### PR TITLE
Revert "Check for an available slave early on"

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -978,8 +978,8 @@ moves_loop: // When in check and at SpNode search starts from here
 
       // Step 19. Check for splitting the search
       if (   !SpNode
+          &&  Threads.size() >= 2
           &&  depth >= Threads.minimumSplitDepth
-          &&  Threads.available_slave(thisThread)
           &&  (   !thisThread->activeSplitPoint
                || !thisThread->activeSplitPoint->allSlavesSearching)
           &&  thisThread->splitPointsSize < MAX_SPLITPOINTS_PER_THREAD)


### PR DESCRIPTION
fastgm from fishcooking spotted a regression in performance after this patch.
