### PR TITLE
Change the install prefix for Haiku

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,7 +30,7 @@ EXE = stockfish
 PREFIX = /usr/local
 # Haiku has a non-standard filesystem layout
 ifeq ($(UNAME),Haiku)
-	PREFIX=/boot/common
+	PREFIX=/boot/system/non-packaged
 endif
 BINDIR = $(PREFIX)/bin
 


### PR DESCRIPTION
- /boot/common was removed from Haiku
- The equivalent path now that package management has been implemented is /boot/system/non-packaged
