### PR TITLE
Minor threats b

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -43,6 +43,7 @@ namespace {
     // attacked by a given color and piece type, attackedBy[color][ALL_PIECES]
     // contains all squares attacked by the given color.
     Bitboard attackedBy[COLOR_NB][PIECE_TYPE_NB];
+    Bitboard attackedByMinors[COLOR_NB];
 
     // kingRing[color] is the zone around the king which is considered
     // by the king safety evaluation. This consists of the squares directly
@@ -401,8 +402,8 @@ namespace {
         // apart from the king itself
         undefended =  ei.attackedBy[Them][ALL_PIECES]
                     & ei.attackedBy[Us][KING]
-                    & ~(  ei.attackedBy[Us][PAWN]   | ei.attackedBy[Us][KNIGHT]
-                        | ei.attackedBy[Us][BISHOP] | ei.attackedBy[Us][ROOK]
+                    & ~(  ei.attackedBy[Us][PAWN]
+                        | ei.attackedByMinors[Us] | ei.attackedBy[Us][ROOK]
                         | ei.attackedBy[Us][QUEEN]);
 
         // Initialize the 'attackUnits' variable, which is used later on as an
@@ -422,8 +423,8 @@ namespace {
         if (b)
         {
             // ...and then remove squares not supported by another enemy piece
-            b &= (  ei.attackedBy[Them][PAWN]   | ei.attackedBy[Them][KNIGHT]
-                  | ei.attackedBy[Them][BISHOP] | ei.attackedBy[Them][ROOK]);
+            b &= (  ei.attackedBy[Them][PAWN]   | ei.attackedByMinors[Them]
+                   | ei.attackedBy[Them][ROOK]);
 
             if (b)
                 attackUnits +=  QueenContactCheck * popcount<Max15>(b);
@@ -440,8 +441,8 @@ namespace {
         if (b)
         {
             // ...and then remove squares not supported by another enemy piece
-            b &= (  ei.attackedBy[Them][PAWN]   | ei.attackedBy[Them][KNIGHT]
-                  | ei.attackedBy[Them][BISHOP] | ei.attackedBy[Them][QUEEN]);
+            b &= (  ei.attackedBy[Them][PAWN]   | ei.attackedByMinors[Them]
+                   | ei.attackedBy[Them][QUEEN]);
 
             if (b)
                 attackUnits +=  RookContactCheck * popcount<Max15>(b);
@@ -501,7 +502,7 @@ namespace {
     // Protected enemies
     protectedEnemies = (pos.pieces(Them) ^ pos.pieces(Them,PAWN))
                  & ei.attackedBy[Them][PAWN]
-                 & (ei.attackedBy[Us][BISHOP] | ei.attackedBy[Us][KNIGHT]);
+                 & ei.attackedByMinors[Us];
 
     if(protectedEnemies)
       score += Threat[0][type_of(pos.piece_on(lsb(protectedEnemies)))];
@@ -514,7 +515,7 @@ namespace {
     // Add a bonus according if the attacking pieces are minor or major
     if (weakEnemies)
     {
-        b = weakEnemies & (ei.attackedBy[Us][KNIGHT] | ei.attackedBy[Us][BISHOP]);
+        b = weakEnemies & ei.attackedByMinors[Us];
         if (b)
             score += Threat[0][type_of(pos.piece_on(lsb(b)))];
 
@@ -707,6 +708,9 @@ namespace {
     // Evaluate pieces and mobility
     score += evaluate_pieces<KNIGHT, WHITE, Trace>(pos, ei, mobility, mobilityArea);
     score += apply_weight(mobility[WHITE] - mobility[BLACK], Weights[Mobility]);
+
+    ei.attackedByMinors[WHITE] = ei.attackedBy[WHITE][KNIGHT] | ei.attackedBy[WHITE][BISHOP];
+    ei.attackedByMinors[BLACK] = ei.attackedBy[BLACK][KNIGHT] | ei.attackedBy[BLACK][BISHOP];
 
     // Evaluate kings after all other pieces because we need complete attack
     // information when computing the king safety evaluation.


### PR DESCRIPTION
Add bonuses for Minors attacking enemy pieces(except pawns) even when they are protected by enemy pawns.

Patch has passed both STC
LLR: 2.95 (-2.94,2.94) [-1.50,4.50]
Total: 8206 W: 1426 L: 1304 D: 5476

and LTC
LLR: 2.97 (-2.94,2.94) [0.00,6.00]
Total: 19534 W: 2821 L: 2640 D: 14073

Note: LTC was run at SPRT [0,6] as it is not a complicated change.
