### PR TITLE
size_t cast in TranspositionTable::first_entry()

### DIFF
--- a/src/tt.h
+++ b/src/tt.h
@@ -109,7 +109,7 @@ extern TranspositionTable TT;
 
 inline TTEntry* TranspositionTable::first_entry(const Key key) const {
 
-  return &table[(uint32_t)key & (clusterCount - 1)].entry[0];
+  return &table[(size_t)key & (clusterCount - 1)].entry[0];
 }
 
 #endif // #ifndef TT_H_INCLUDED


### PR DESCRIPTION
32-bit truncation would make this function bogus when clusterCount >= 2^33 (ie. Hash = 2^18 MB =
256 GB).

No function change.
