### PR TITLE
Use compiler intrinsic instead of inline assembly for popcnt

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -285,7 +285,7 @@ endif
 
 ### 3.9 popcnt
 ifeq ($(popcnt),yes)
-	CXXFLAGS += -msse3 -DUSE_POPCNT
+	CXXFLAGS += -msse3 -mpopcnt -DUSE_POPCNT
 endif
 
 ### 3.10 pext

--- a/src/bitcount.h
+++ b/src/bitcount.h
@@ -96,8 +96,7 @@ inline int popcount<CNT_HW_POPCNT>(Bitboard b) {
 
 #else
 
-  __asm__("popcnt %1, %0" : "=r" (b) : "r" (b));
-  return b;
+  return __builtin_popcountll(b);
 
 #endif
 }


### PR DESCRIPTION
This time, do not break compatibility with some AMD machines that have SSE3 and popcnt, but do
not have SSE4.2.

No functional change.
