### PR TITLE
Avoid 'double assigments' tricks

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -149,7 +149,10 @@ const std::string Bitboards::pretty(Bitboard b) {
 void Bitboards::init() {
 
   for (Square s = SQ_A1; s <= SQ_H8; ++s)
-      BSFTable[bsf_index(SquareBB[s] = 1ULL << s)] = s;
+      SquareBB[s] = 1ULL << s;
+
+  for (Square s = SQ_A1; s <= SQ_H8; ++s)
+      BSFTable[bsf_index(s)] = s;
 
   for (Bitboard b = 1; b < 256; ++b)
       MS1BTable[b] = more_than_one(b) ? MS1BTable[b - 1] : lsb(b);
@@ -301,7 +304,8 @@ namespace {
         // Find a magic for square 's' picking up an (almost) random number
         // until we find the one that passes the verification test.
         do {
-            do magics[s] = rk.magic_rand<Bitboard>(booster);
+            do
+                magics[s] = rk.magic_rand<Bitboard>(booster);
             while (popcount<Max15>((magics[s] * masks[s]) >> 56) < 6);
 
             std::memset(attacks[s], 0, size * sizeof(Bitboard));


### PR DESCRIPTION
fix from Marco's repo.

I was doing some modifications in bitboard, and spent some painful debugging time, thanks to these clever tricks. I dissectred the problem to narrow it down to a simple commit, and Marco saved my day and found the problem in this commit :+1: 

The reason is that if you remove or displace initialization of BSFTable (which is only useful on PPC compiles anyway), you will get a very subtile bug. By doing so you remove the initialization of `SquaresBB[]`, which causes `sliding_attack()` to always return `0`, due to `operator |= (bitboard, square)`, which will cause `masks[s] = 0` in `init_magics()`,  and an infinite loop here:

```
do
    magics[s] = rk.magic_rand<Bitboard>(booster);
while (popcount<Max15>((magics[s] * masks[s]) >> 56) < 6);
```

Also the loop was indented in an unstandard way which caused me a little WTF moment when looking at this line in isolation:

```
while (popcount<Max15>((magics[s] * masks[s]) >> 56) < 6);
```

which seems equivalent to an assert!
