### PR TITLE
Retire FakeSplit

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -52,9 +52,6 @@ using namespace Search;
 
 namespace {
 
-  // Set to true to force running with one thread. Used for debugging
-  const bool FakeSplit = false;
-
   // Different node types, used as template parameter
   enum NodeType { Root, PV, NonPV };
 
@@ -987,8 +984,8 @@ moves_loop: // When in check and at SpNode search starts from here
       {
           assert(bestValue > -VALUE_INFINITE && bestValue < beta);
 
-          thisThread->split<FakeSplit>(pos, ss, alpha, beta, &bestValue, &bestMove,
-                                       depth, moveCount, &mp, NT, cutNode);
+          thisThread->split(pos, ss, alpha, beta, &bestValue, &bestMove,
+                            depth, moveCount, &mp, NT, cutNode);
 
           if (Signals.stop || thisThread->cutoff_occurred())
               return VALUE_ZERO;

--- a/src/thread.h
+++ b/src/thread.h
@@ -117,7 +117,6 @@ struct Thread : public ThreadBase {
   bool cutoff_occurred() const;
   bool available_to(const Thread* master) const;
 
-  template <bool Fake>
   void split(Position& pos, const Search::Stack* ss, Value alpha, Value beta, Value* bestValue, Move* bestMove,
              Depth depth, int moveCount, MovePicker* movePicker, int nodeType, bool cutNode);
 


### PR DESCRIPTION
```
- Currently broken
- Never been really useful
- Does not work well with new splitting model
```

No functional change
