### PR TITLE
Make verification search more accurate

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -57,7 +57,7 @@ void init(OptionsMap& o) {
   o["Write Debug Log"]          << Option(false, on_logger);
   o["Write Search Log"]         << Option(false);
   o["Search Log Filename"]      << Option("SearchLog.txt");
-  o["Contempt Factor"]          << Option(0, -50,  50);
+  o["Contempt Factor"]          << Option(0, -100,  100);
   o["Min Split Depth"]          << Option(0, 0, 12, on_threads);
   o["Threads"]                  << Option(1, 1, MAX_THREADS, on_threads);
   o["Hash"]                     << Option(32, 1, 1024 * 1024, on_hash_size);


### PR DESCRIPTION
Now following position gets solved at depth 79, while
verification search is still noticeably reduced.

8/8/8/2p5/1pp5/brpp4/1pprp2P/qnkbK3 w - - 0 1
info depth 79 seldepth 30 score mate 15 nodes 5672950 nps 2511266 time 2259 multipv 1 pv h2h3 a1a2 h3h4 a2a1 h4h5 a1a2 h5h6 a2a1 h6h7 a1a2 h7h8n a2a1 h8g6 a1a2 g6e5 a2a1 e5d7 a1a2 d7c5 a2a1 c5d7 a1a2 d7e5 a2a1 e5c4 a1a2 c4a5 a2a1 a5b3

Chessquaker reports a significant boost in solving tactical/zugzwang positions, as well.

Neutral at both, STC
ELO: 0.15 +-2.0 (95%) LOS: 55.8%
Total: 40000 W: 6686 L: 6669 D: 26645

and LTC
ELO: 0.38 +-1.8 (95%) LOS: 66.2%
Total: 40000 W: 5576 L: 5532 D: 28892

bench: 7430277
