### PR TITLE
Added King of the Hill variant support (based on SCIDB 3-checks variant code)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -207,6 +207,7 @@ ifneq ($(comp),mingw)
 endif
 
 ### 3.4 Debugging
+CXXFLAGS += -DKOTH
 ifeq ($(debug),no)
 	CXXFLAGS += -DNDEBUG
 else

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -133,7 +133,11 @@ void benchmark(const Position& current, istream& is) {
 
   for (size_t i = 0; i < fens.size(); ++i)
   {
+#ifdef KOTH
+      Position pos(fens[i], Options["UCI_Chess960"], Options["UCI_VariantKOTH"], Threads.main());
+#else
       Position pos(fens[i], Options["UCI_Chess960"], Threads.main());
+#endif
 
       cerr << "\nPosition: " << i + 1 << '/' << fens.size() << endl;
 

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -96,7 +96,11 @@ namespace {
     string fen =  sides[0] + char(8 - sides[0].length() + '0') + "/8/8/8/8/8/8/"
                 + sides[1] + char(8 - sides[1].length() + '0') + " w - - 0 10";
 
+#ifdef KOTH
+    return Position(fen, NULL).material_key();
+#else
     return Position(fen, false, NULL).material_key();
+#endif
   }
 
   template<typename M>

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -153,6 +153,15 @@ namespace {
   // Hanging contains a bonus for each enemy hanging piece
   const Score Hanging = S(23, 20);
 
+#ifdef KOTH
+  const Score KOTHDistanceBonus[4] = {
+    S(9*PawnValueMg + PawnValueMg/2, 9*PawnValueEg),
+    S(4*PawnValueMg + PawnValueMg/2, 4*PawnValueEg),
+    S(2*PawnValueMg + PawnValueMg/2, 2*PawnValueEg),
+    S(0, 0)
+  };
+#endif
+
   #undef S
 
   const Score RookOnPawn       = make_score(10, 28);
@@ -393,6 +402,15 @@ namespace {
 
     // King shelter and enemy pawns storm
     Score score = ei.pi->king_safety<Us>(pos, ksq);
+
+#ifdef KOTH
+    if (pos.is_koth())
+    {
+        // Initial attempt to adjust score based on KOTH distance
+        score += KOTHDistanceBonus[pos.koth_distance(Us)];
+        score -= KOTHDistanceBonus[pos.koth_distance(Them)];
+    }
+#endif
 
     // Main king safety evaluation
     if (ei.kingAttackersCount[Them])
@@ -679,6 +697,17 @@ namespace {
     // in the position object (material + piece square tables).
     // Score is computed from the point of view of white.
     score = pos.psq_score();
+
+#ifdef KOTH
+    if (pos.is_koth())
+    {
+        // TODO: Do we need or want both conditions here?
+        if (pos.is_koth_win())
+            return VALUE_MATE;
+        if (pos.is_koth_loss())
+            return -VALUE_MATE;
+    }
+#endif
 
     // Probe the material hash table
     ei.mi = Material::probe(pos, thisThread->materialTable, thisThread->endgames);

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -302,6 +302,14 @@ void MovePicker::generate_next_stage() {
 template<>
 Move MovePicker::next_move<false>() {
 
+#ifdef KOTH
+  assert(!pos.is_koth_win());
+
+  // Best move can only be MOVE_NONE when searching on a lost KOTH position
+  if (pos.is_koth_loss())
+      return MOVE_NONE;
+#endif
+
   Move move;
 
   while (true)

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -191,7 +191,11 @@ void Position::clear() {
 /// This function is not very robust - make sure that input FENs are correct,
 /// this is assumed to be the responsibility of the GUI.
 
+#ifdef KOTH
+void Position::set(const string& fenStr, bool isChess960, bool isKOTH, Thread* th) {
+#else
 void Position::set(const string& fenStr, bool isChess960, Thread* th) {
+#endif
 /*
    A FEN string defines a particular position using only the ASCII character set.
 
@@ -300,6 +304,9 @@ void Position::set(const string& fenStr, bool isChess960, Thread* th) {
   gamePly = std::max(2 * (gamePly - 1), 0) + (sideToMove == BLACK);
 
   chess960 = isChess960;
+#ifdef KOTH
+  koth = isKOTH;
+#endif
   thisThread = th;
   set_state(st);
 
@@ -712,6 +719,10 @@ void Position::do_move(Move m, StateInfo& newSt, const CheckInfo& ci, bool moveI
 
   assert(is_ok(m));
   assert(&newSt != st);
+#ifdef KOTH
+  assert(!is_koth_win());
+  assert(!is_koth_loss());
+#endif
 
   ++nodes;
   Key k = st->key;
@@ -1178,7 +1189,11 @@ void Position::flip() {
   std::getline(ss, token); // Half and full moves
   f += token;
 
+#ifdef KOTH
+  set(f, is_chess960(), is_koth(), this_thread());
+#else
   set(f, is_chess960(), this_thread());
+#endif
 
   assert(pos_is_ok());
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -250,6 +250,12 @@ finalize:
       RootPos.this_thread()->wait_for(Signals.stop);
   }
 
+#ifdef KOTH
+  // Best move can only be MOVE_NONE when searching on a lost KOTH position
+  if (RootPos.is_koth() && RootPos.is_koth_loss())
+      sync_cout << "bestmove " << "(none) ponder (none)" << sync_endl;
+  else
+#endif
   // Best move could be MOVE_NONE when searching on a stalemate position
   sync_cout << "bestmove " << move_to_uci(RootMoves[0].pv[0], RootPos.is_chess960())
             << " ponder "  << move_to_uci(RootMoves[0].pv[1], RootPos.is_chess960())

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -68,7 +68,11 @@ namespace {
     else
         return;
 
+#ifdef KOTH
+    pos.set(fen, Options["UCI_Chess960"], Options["UCI_VariantKOTH"], Threads.main());
+#else
     pos.set(fen, Options["UCI_Chess960"], Threads.main());
+#endif
     SetupStates = Search::StateStackPtr(new std::stack<StateInfo>());
 
     // Parse move list (if any)
@@ -145,7 +149,11 @@ namespace {
 
 void UCI::loop(int argc, char* argv[]) {
 
+#ifdef KOTH
+  Position pos(StartFEN, Threads.main()); // The root position
+#else
   Position pos(StartFEN, false, Threads.main()); // The root position
+#endif
   string token, cmd;
 
   for (int i = 1; i < argc; ++i)

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -71,6 +71,9 @@ void init(OptionsMap& o) {
   o["Minimum Thinking Time"]    << Option(20, 0, 5000);
   o["Slow Mover"]               << Option(80, 10, 1000);
   o["UCI_Chess960"]             << Option(false);
+#ifdef KOTH
+  o["UCI_VariantKOTH"]          << Option(false);
+#endif
 }
 
 


### PR DESCRIPTION
I'm looking for a good way to test this change (whereby moving a king to the center wins).

So far I have tested from these positions (and similar positions):
position startpos moves e2e3 e7e6 e1e2 e8e7 e2d3 e7d6 and Stockfish finds 4. Kd4#
position fen k7/p7/8/8/8/8/8/7K w - - 0 1 and Stockfish finds 1. Kg2 a5 2. Kf3 a4 3. Ke4#
