### PR TITLE
retire divide command

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -138,7 +138,7 @@ void benchmark(const Position& current, istream& is) {
 
       cerr << "\nPosition: " << i + 1 << '/' << fens.size() << endl;
 
-      if (limitType == "divide")
+      if (limitType == "perft")
           for (MoveList<LEGAL> it(pos); *it; ++it)
           {
               StateInfo si;
@@ -148,12 +148,6 @@ void benchmark(const Position& current, istream& is) {
               cerr << move_to_uci(*it, pos.is_chess960()) << ": " << cnt << endl;
               nodes += cnt;
           }
-      else if (limitType == "perft")
-      {
-          uint64_t cnt = Search::perft(pos, limits.depth * ONE_PLY);
-          cerr << "\nPerft " << limits.depth  << " leaf nodes: " << cnt << endl;
-          nodes += cnt;
-      }
       else
       {
           Threads.start_thinking(pos, limits, st);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -174,7 +174,7 @@ void UCI::loop(int argc, char* argv[]) {
           else
               Search::Limits.ponder = false;
       }
-      else if (token == "perft" || token == "divide")
+      else if (token == "perft")
       {
           int depth;
           stringstream ss;


### PR DESCRIPTION
This command is redundant with perft. Or, rather, it is what perft should always have been. The main purpose of perft is to be a debugging tool, so if we can't see the sum of perft(N-1), it's completely useless.

Note that the usual `2>/dev/null` can be used to trash the unwanted display and do perft speed measurements (when indulging in micro-optimizations).

No functional change.
