### PR TITLE
Remove useless code in Position::pretty()

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -25,7 +25,6 @@
 
 #include "bitcount.h"
 #include "movegen.h"
-#include "notation.h"
 #include "position.h"
 #include "psqtab.h"
 #include "rkiss.h"
@@ -430,16 +429,11 @@ const string Position::fen() const {
 }
 
 
-/// Position::pretty() returns an ASCII representation of the position to be
-/// printed to the standard output together with the move's san notation.
+/// Position::pretty() returns an ASCII representation of the position
 
-const string Position::pretty(Move m) const {
+const string Position::pretty() const {
 
   std::ostringstream ss;
-
-  if (m)
-      ss << "\nMove: " << (sideToMove == BLACK ? ".." : "")
-         << move_to_san(*const_cast<Position*>(this), m);
 
   ss << "\n +---+---+---+---+---+---+---+---+\n";
 
@@ -456,10 +450,6 @@ const string Position::pretty(Move m) const {
 
   for (Bitboard b = checkers(); b; )
       ss << to_string(pop_lsb(&b)) << " ";
-
-  ss << "\nLegal moves: ";
-  for (MoveList<LEGAL> it(*this); *it; ++it)
-      ss << move_to_san(*const_cast<Position*>(this), *it) << " ";
 
   return ss.str();
 }

--- a/src/position.h
+++ b/src/position.h
@@ -83,7 +83,7 @@ public:
   // Text input/output
   void set(const std::string& fenStr, bool isChess960, Thread* th);
   const std::string fen() const;
-  const std::string pretty(Move m = MOVE_NONE) const;
+  const std::string pretty() const;
 
   // Position representation
   Bitboard pieces() const;


### PR DESCRIPTION
First, remove some dead code (function never called with a Move argument).

Then, remove printing of legal moves, which does not belong here. Let's keep commands orthogonal and minimal:
- the "d" command should display the board, nothing more, or less.
- "perft 1" will display the list of legal moves.

No functional change.
