### PR TITLE
Insufficient

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1126,12 +1126,6 @@ Value Position::see(Move m) const {
 
 bool Position::is_draw() const {
 
-  if (   !pieces(PAWN)
-      &&  non_pawn_material(WHITE) <= BishopValueMg
-      &&  non_pawn_material(BLACK) <= BishopValueMg
-      && !opposite_bishops())
-      return true;
-
   if (st->rule50 > 99 && (!checkers() || MoveList<LEGAL>(*this).size()))
       return true;
 


### PR DESCRIPTION
Remove check for insufficient mating material from Position::is_draw().
Kicks only in rather rare (0.00114% in bench 17), and draw evaluation for KK, KNK and KBK is handled by material.cpp.

Passed LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 33023 W: 4613 L: 4509 D: 23901

and STC, but then test was purged.
STC after 128k games: (after test was purged)
LLR: 0.05 (-2.94,2.94) [-3.00,1.00]
Total: 128000 W: 21357 L: 21560 D: 85083
