### PR TITLE
Precompute clusterMask to speed up TranspositionTable::first_entry() whi...

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -38,6 +38,7 @@ void TranspositionTable::resize(size_t mbSize) {
       return;
 
   clusterCount = newClusterCount;
+  clusterMask = clusterCount - 1;
 
   free(mem);
   mem = calloc(clusterCount * sizeof(TTCluster) + CACHE_LINE_SIZE - 1, 1);

--- a/src/tt.h
+++ b/src/tt.h
@@ -95,6 +95,7 @@ public:
 
 private:
   size_t clusterCount;
+  size_t clusterMask;
   TTCluster* table;
   void* mem;
   uint8_t generation; // Size must be not bigger than TTEntry::genBound8
@@ -109,7 +110,7 @@ extern TranspositionTable TT;
 
 inline TTEntry* TranspositionTable::first_entry(const Key key) const {
 
-  return &table[(size_t)key & (clusterCount - 1)].entry[0];
+  return &table[(size_t)key & clusterMask].entry[0];
 }
 
 #endif // #ifndef TT_H_INCLUDED


### PR DESCRIPTION
...ch is on he hot path.

Timings:
gcc 4.9.1
AMD Phenom II
x86-64-modern

Master
4274
4259
4274
4275
4274
Average w/o min & max: 4274

Patch
4243
4243
4227
4228
4228
Average w/o min & max: 4233

1% speedup
