### PR TITLE
Simplify time options

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -78,7 +78,7 @@ void TimeManager::init(const Search::LimitsType& limits, int currentPly, Color u
       increment >  0 && movesToGo == 0 means: x basetime + z increment
       increment >  0 && movesToGo != 0 means: x moves in y minutes + z increment
 
-    Time management is adjusted by following UCI parameters:
+    Time management is adjusted by following parameters:
 
       emergencyMoveHorizon: Be prepared to always play at least this many moves
       emergencyBaseTime   : Always attempt to keep at least this much time (in ms) at clock
@@ -89,9 +89,9 @@ void TimeManager::init(const Search::LimitsType& limits, int currentPly, Color u
   int hypMTG, hypMyTime, t1, t2;
 
   // Read uci parameters
-  int emergencyMoveHorizon = Options["Emergency Move Horizon"];
-  int emergencyBaseTime    = Options["Emergency Base Time"];
-  int emergencyMoveTime    = Options["Emergency Move Time"];
+  int emergencyMoveHorizon = 40;
+  int emergencyBaseTime    = Options["Emergency Time"];
+  int emergencyMoveTime    = emergencyBaseTime / 2;
   int minThinkingTime      = Options["Minimum Thinking Time"];
   int slowMover            = Options["Slow Mover"];
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -63,9 +63,7 @@ void init(OptionsMap& o) {
   o["Ponder"]                   << Option(true);
   o["MultiPV"]                  << Option(1, 1, 500);
   o["Skill Level"]              << Option(20, 0, 20);
-  o["Emergency Move Horizon"]   << Option(40, 0, 50);
-  o["Emergency Base Time"]      << Option(60, 0, 30000);
-  o["Emergency Move Time"]      << Option(30, 0, 5000);
+  o["Emergency Time"]           << Option(60, 0, 30000);
   o["Minimum Thinking Time"]    << Option(20, 0, 5000);
   o["Slow Mover"]               << Option(80, 10, 1000);
   o["UCI_Chess960"]             << Option(false);


### PR DESCRIPTION
These 3 `Emergency` options are not suitable fo end-users. Nobody
understands what they do, apart from those who delved into the code.

For end-users, only one option should be required to adjust for lag. This
is also more consistent with what other engines do.

As for Move Horizon, I see no reason to change its value. Seems better to
hardcode it as 40, and tune the Emergency Move/Base Time instead.

At the `timeman.cpp` level, the full flexibility is kept as it was. The idea is to
not expose the complexity to the end user, while retaining the flexibility for
programmers.

No functional change.
