### PR TITLE
Cap evaluation based null move extra reduction to three plies

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -567,8 +567,7 @@ namespace {
         // Null move dynamic reduction based on depth and value
         Depth R =  3 * ONE_PLY
                  + depth / 4
-                 + (abs(beta) < VALUE_KNOWN_WIN ? int(eval - beta) / PawnValueMg * ONE_PLY
-                                                : DEPTH_ZERO);
+                 + std::min(int(eval - beta) / PawnValueMg, 3) * ONE_PLY;
 
         pos.do_null_move(st);
         (ss+1)->skipNullMove = true;


### PR DESCRIPTION
Lucas: It's a zero elo patch, and a reasonable safeguard against uncontrolled extreme reductions.
