### PR TITLE
Convert TT depth to int8_t

### DIFF
--- a/src/tt.h
+++ b/src/tt.h
@@ -38,7 +38,7 @@ struct TTEntry {
   Move  move()  const      { return (Move )move16; }
   Value value() const      { return (Value)value16; }
   Value eval_value() const { return (Value)evalValue; }
-  Depth depth() const      { return (Depth)(depth8) + DEPTH_NONE; }
+  Depth depth() const      { return (Depth)(depth8); }
   Bound bound() const      { return (Bound)(genBound8 & 0x3); }
 
 private:
@@ -50,7 +50,7 @@ private:
     move16    = (uint16_t)m;
     value16   = (int16_t)v;
     evalValue = (int16_t)ev;
-    depth8    = (uint8_t)(d - DEPTH_NONE);
+    depth8    = (int8_t)(d);
     genBound8 = g | (uint8_t)b;
   }
 
@@ -59,7 +59,7 @@ private:
   int16_t  value16;
   int16_t  evalValue;
   uint8_t  genBound8;
-  uint8_t  depth8;
+  int8_t  depth8;
 };
 
 /// TTCluster is a 32 bytes cluster of TT entries consisting of:


### PR DESCRIPTION
Now that half plies have been removed from the engine, we can encode
TT depth into an int8_t.

Range is -128 to +127, so it goes still further than the previous
limit of 121 plies (with ONE_PLY == 2 where depth - DEPTH_NONE was
encoded as an uint8_t).

No functional change.
