### PR TITLE
King Threats Tuned

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -151,8 +151,8 @@ namespace {
   };
 
   // Assorted bonuses and penalties used by evaluation
-  const Score KingOnPawnOne    = S(0 , 64);
-  const Score KingOnPawnMany   = S(0 ,128);
+  const Score KingThreatOne    = S(2 , 58);
+  const Score KingThreatMany   = S(6 ,125);
   const Score RookOnPawn       = S(10, 28);
   const Score RookOpenFile     = S(43, 21);
   const Score RookSemiOpenFile = S(19, 10);
@@ -530,9 +530,9 @@ namespace {
         if (b)
             score += more_than_one(b) ? Hanging * popcount<Max15>(b) : Hanging;
 
-        b = weakEnemies & pos.pieces(Them, PAWN) & ei.attackedBy[Us][KING];
+        b = weakEnemies & ei.attackedBy[Us][KING];
         if (b)
-            score += more_than_one(b) ? KingOnPawnMany : KingOnPawnOne;
+            score += more_than_one(b) ? KingThreatMany : KingThreatOne;
     }
 
     if (Trace)


### PR DESCRIPTION
Extend King Threats to other pieces(other than pawns).

The patch passed STC
LLR: 2.99 (-2.94,2.94) [-1.50,4.50]
Total: 20559 W: 4261 L: 4095 D: 12203

and LTC
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 75232 W: 13097 L: 12696 D: 49439
