### PR TITLE
Reformat and rename hash_after_move()

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -139,7 +139,6 @@ public:
   void undo_move(Move m);
   void do_null_move(StateInfo& st);
   void undo_null_move();
-  Key hash_after_move(Move m) const;
 
   // Static exchange evaluation
   Value see(Move m) const;
@@ -147,6 +146,7 @@ public:
 
   // Accessing hash keys
   Key key() const;
+  Key key_after(Move m) const;
   Key exclusion_key() const;
   Key pawn_key() const;
   Key material_key() const;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -788,8 +788,8 @@ moves_loop: // When in check and at SpNode search starts from here
           }
       }
 
-      // Speculative prefetch
-      prefetch((char*)TT.first_entry(pos.hash_after_move(move)));
+      // Speculative prefetch as early as possible
+      prefetch((char*)TT.first_entry(pos.key_after(move)));
 
       // Check for legality just before making the move
       if (!RootNode && !SpNode && !pos.legal(move, ci.pinned))
@@ -1140,8 +1140,8 @@ moves_loop: // When in check and at SpNode search starts from here
           &&  pos.see_sign(move) < VALUE_ZERO)
           continue;
 
-      // Speculative prefetch
-      prefetch((char*)TT.first_entry(pos.hash_after_move(move)));
+      // Speculative prefetch as early as possible
+      prefetch((char*)TT.first_entry(pos.key_after(move)));
 
       // Check for legality just before making the move
       if (!pos.legal(move, ci.pinned))


### PR DESCRIPTION
Align to standard coding style and properly use
enum types. Rename while there.

No functional change.
