### PR TITLE
Rearrange check_time()

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1561,7 +1561,7 @@ void check_time() {
   {
       Threads.mutex.lock();
 
-      int nodes = RootPos.nodes_searched();
+      int64_t nodes = RootPos.nodes_searched();
 
       // Loop across all split points and sum accumulated SplitPoint nodes plus
       // all the currently active positions nodes.

--- a/src/search.h
+++ b/src/search.h
@@ -78,13 +78,14 @@ struct RootMove {
 struct LimitsType {
 
   LimitsType() { // Using memset on a std::vector is undefined behavior
-    time[WHITE] = time[BLACK] = inc[WHITE] = inc[BLACK] = movestogo =
-    depth = nodes = movetime = mate = infinite = ponder = 0;
+    nodes = time[WHITE] = time[BLACK] = inc[WHITE] = inc[BLACK] = movestogo =
+    depth = movetime = mate = infinite = ponder = 0;
   }
   bool use_time_management() const { return !(mate | movetime | depth | nodes | infinite); }
 
   std::vector<Move> searchmoves;
-  int time[COLOR_NB], inc[COLOR_NB], movestogo, depth, nodes, movetime, mate, infinite, ponder;
+  int time[COLOR_NB], inc[COLOR_NB], movestogo, depth, movetime, mate, infinite, ponder;
+  int64_t nodes;
 };
 
 


### PR DESCRIPTION
Remove an ugly workaround for a gcc
warning while there.

No functional change.
