### PR TITLE
Improve compatibility with Shredder Classic GUI

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -342,7 +342,9 @@ namespace {
             // Sort the PV lines searched so far and update the GUI
             std::stable_sort(RootMoves.begin(), RootMoves.begin() + PVIdx + 1);
 
-            if (PVIdx + 1 == std::min(multiPV, RootMoves.size()) || Time::now() - SearchTime > 3000)
+            if (   !Signals.stop
+                && (   PVIdx + 1 == std::min(multiPV, RootMoves.size())
+                    || Time::now() - SearchTime > 3000))
                 sync_cout << uci_pv(pos, depth, alpha, beta) << sync_endl;
         }
 


### PR DESCRIPTION
Shredder Classic GUI has a couple of issues with the UCI emitted by Stockfish, as opposed to other engines. They manifest themselves when analyzing a game move by move with multi-PV on: the eval graph goes all over the place. These 2 very simple revisions fix them.

(There is a third issue, which is IMHO a bug in the GUI, and doesn't deserve a workaround in Stockfish: when scrolling too fast through the moves, Shredder gives the engine no time to think, issuing both `go infinite` and `stop` at the same time. SF has no time to print any PV, causing the move to be displayed as 0.00)
