### PR TITLE
Use tuned value for PawnsFileSpan

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -58,7 +58,7 @@ namespace {
     S(20,20), S(40,40), S(0, 0), S(0, 0) };
 
   // Bonus for file distance of the two outermost pawns
-  const Score PawnsFileSpan = S(0, 15);
+  const Score PawnsFileSpan = S(0, 8);
 
   // Unsupported pawn penalty
   const Score UnsupportedPawnPenalty = S(20, 10);


### PR DESCRIPTION
Use tuned value for PawnsFileSpan

STC:
LLR: 2.96 (-2.94,2.94) [-1.50,4.50]
Total: 24428 W: 5056 L: 4880 D: 14492

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 26590 W: 4715 L: 4472 D: 17403

Bench : 6615949
