### PR TITLE
Another max_piece_type() cleanup.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -499,12 +499,11 @@ namespace {
 
     assert(target & (pos.pieces(C) ^ pos.pieces(C, KING)));
 
-    PieceType pt;
-    for (pt = QUEEN; pt > PAWN; --pt)
+    for (PieceType pt = QUEEN; pt > PAWN; --pt)
         if (target & pos.pieces(C, pt))
             return pt;
 
-    return pt;
+    return PAWN;
   }
 
 


### PR DESCRIPTION
Since this is already getting the pedantic treatment here is my submission.

Timings using AMD Phenom II, gcc 4.9.1, build ARCH=x86-64-modern
start /B /REALTIME /AFFINITY 0x1 stockfish.exe bench 1>nul

Master
4134
4134
4134
4134
4134  (yes I really did get exactly 4134 5 times in a row)

Patch
4119
4119
4118
4118
4118

Very minor speedup but it also removes a line.
