### PR TITLE
Remove bias when choosing a TT entry to replace

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -93,14 +93,15 @@ const TTEntry* TranspositionTable::probe(const Key key) const {
 
 void TranspositionTable::store(const Key key, Value v, Bound b, Depth d, Move m, Value statV) {
 
-  TTEntry *tte, *replace;
+  TTEntry *cluster, *tte, *replace;
   uint16_t key16 = key >> 48; // Use the high 16 bits as key inside the cluster
 
-  tte = replace = first_entry(key);
+  cluster = tte = replace = first_entry(key);
 
-  for (unsigned i = 0; i < TTClusterSize; ++i, ++tte)
+  for (unsigned i = 0; i < TTClusterSize; ++i)
   {
-      if (!tte->key16 || tte->key16 == key16) // Empty or overwrite old
+      tte = cluster + ((i + key16) % TTClusterSize);
+      if (!tte->genBound8 || tte->key16 == key16) // Empty or overwrite old
       {
           if (!m)
               m = tte->move(); // Preserve any existing ttMove


### PR DESCRIPTION
When saving an entry to a TT cluster, the previous logic
would only overwrite the last cluster entry if it proved
less valuable than the previous ones, in addition to being
less valuable than the new entry. This bias caused the
first entry in a cluster to be overwritten and lost more
often that the last. Any bias here is detrimental to the
search: it reduces the effective size of the TT.

 Entry 1: replaced 39.5 % of the time
 Entry 2: 32.8 %
 Entry 3: 27.6 %

From this, we deduce that the TT operates at 84.3% efficiency.

The patch removes the bias by scanning the cluster's entries
starting with any of them, pseudo-randomly (using key16 as
the sole source of randomness).

Another source of bias covered by the patch is the
identification of 'empty' slots. Previous code systematically
replaced entries with key16 = 0, which means that 1 entry
out of 65536 had a much shorter lifetime in the TT than the
others. This is solved by using genBound8 instead, as it
is never equal to 0 for non-empty entries.
