### PR TITLE
Optimize TranspositionTable::store() and TranspositionTable::probe() for...

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -69,14 +69,14 @@ void TranspositionTable::clear() {
 
 const TTEntry* TranspositionTable::probe(const Key key) const {
 
-  TTEntry* const tte = first_entry(key);
-  const uint16_t key16 = key >> 48;
+  TTEntry* tte = first_entry(key);
+  uint16_t key16 = key >> 48;
 
-  for (unsigned i = 0; i < TTClusterSize; ++i)
-      if (tte[i].key16 == key16)
+  for (unsigned i = 0; i < TTClusterSize; ++i, ++tte)
+      if (tte->key16 == key16)
       {
-          tte[i].genBound8 = generation | (uint8_t)tte[i].bound(); // Refresh
-          return &tte[i];
+          tte->genBound8 = uint8_t(generation | tte->bound()); // Refresh
+          return tte;
       }
 
   return NULL;
@@ -93,27 +93,29 @@ const TTEntry* TranspositionTable::probe(const Key key) const {
 
 void TranspositionTable::store(const Key key, Value v, Bound b, Depth d, Move m, Value statV) {
 
-  TTEntry* const tte = first_entry(key);
-  const uint16_t key16 = key >> 48; // Use the high 16 bits as key inside the cluster
+  TTEntry *tte, *replace;
+  uint16_t key16 = key >> 48; // Use the high 16 bits as key inside the cluster
 
-  for (unsigned i = 0; i < TTClusterSize; ++i)
+  tte = replace = first_entry(key);
+
+  for (unsigned i = 0; i < TTClusterSize; ++i, ++tte)
   {
-      if (!tte[i].key16 || tte[i].key16 == key16) // Empty or overwrite old
+      if (!tte->key16 || tte->key16 == key16) // Empty or overwrite old
       {
-          // Save preserving any existing ttMove
-          tte[i].save(key16, v, b, d, m ? m : tte[i].move(), generation, statV);
+          // Preserve any existing ttMove
+          tte->save(key16, v, b, d, m ? m : tte->move(), generation, statV);
           return;
       }
   }
 
   // Implement replace strategy
-  TTEntry* replace = tte;
-  for (unsigned i = 1; i < TTClusterSize; ++i)
+  tte = replace + 1;
+  for (unsigned i = 1; i < TTClusterSize; ++i, ++tte)
   {
-      if (  ((  tte[i].genBound8 & 0xFC) == generation || tte[i].bound() == BOUND_EXACT)
+      if (  ((    tte->genBound8 & 0xFC) == generation || tte->bound() == BOUND_EXACT)
           - ((replace->genBound8 & 0xFC) == generation)
-          - (tte[i].depth8 < replace->depth8) < 0)
-          replace = &tte[i];
+          - (tte->depth8 < replace->depth8) < 0)
+          replace = tte;
   }
 
   replace->save(key16, v, b, d, m, generation, statV);


### PR DESCRIPTION
... speed.

No functional change.

AMD Phenom II 3.6GHz, gcc 4.9.1, build ARCH=x86-64-modern
start /B /REALTIME /AFFINITY 0x1 stockfish.exe bench 1>nul

Master
4134
4118
4134
4134
4118

Patch
4025
4024
4009
4025
4009

Approximately 2.5% speedup
