### PR TITLE
Correctly describe POPCNT compile

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -52,7 +52,7 @@ const string engine_info(bool to_uci) {
   }
 
   ss << (Is64Bit ? " 64" : "")
-     << (HasPext ? " BMI2" : (HasPopCnt ? " SSE4.2" : ""))
+     << (HasPext ? " BMI2" : (HasPopCnt ? " POPCNT" : ""))
      << (to_uci  ? "\nid author ": " by ")
      << "Tord Romstad, Marco Costalba and Joona Kiiski";
 


### PR DESCRIPTION
SSE4.2 has nothing to do with POPCNT. We must dispell this myth, because
Stockfish is a reference and many will copy this mistake if they see it in
Stockfish:
- SSE is an SIMD instruction set, relative to vectorization (using special
  128-bit registers).
- POPCNT/LZCNT work on normal registers (eg. AL, AX, EAX, RAX).

The confusion comes from the fact that, in the Intel product line, it just
so happens that SSE4.2 and POPCNT/LZCNT came out at the same time. But this
is not true for AMD. For example, all AMD Pheniom II have SSE3 but no
POPCNT/LZCNT, and that is why the modern compile uses `-msse3 -popcnt` and
not `-msse4.2`.

No functional change.
