### PR TITLE
Remove dead code

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -27,7 +27,6 @@
 #include "material.h"
 #include "pawns.h"
 #include "thread.h"
-#include "uci.h"
 
 namespace {
 
@@ -905,8 +904,7 @@ namespace Eval {
   }
 
 
-  /// init() computes evaluation weights from the corresponding UCI parameters
-  /// and setup king tables.
+  /// init() computes evaluation weights
 
   void init() {
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -22,7 +22,6 @@
 #include <cstdlib>
 #include <sstream>
 
-#include "evaluate.h"
 #include "misc.h"
 #include "thread.h"
 #include "tt.h"
@@ -36,7 +35,6 @@ namespace UCI {
 
 /// 'On change' actions, triggered by an option's value change
 void on_logger(const Option& o) { start_logger(o); }
-void on_eval(const Option&) { Eval::init(); }
 void on_threads(const Option&) { Threads.read_uci_options(); }
 void on_hash_size(const Option& o) { TT.resize(o); }
 void on_clear_hash(const Option&) { TT.clear(); }


### PR DESCRIPTION
Remove this dead code, which became obsolete with e4fc9d84d7bf854c07b791573a0c5377e8393279.

No functional change.
