### PR TITLE
Prefer operator<<() to pretty()

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -108,6 +108,30 @@ CheckInfo::CheckInfo(const Position& pos) {
 }
 
 
+/// operator<<(Position) returns an ASCII representation of the position
+
+std::ostream& operator<<(std::ostream& os, const Position& pos) {
+
+  os << "\n +---+---+---+---+---+---+---+---+\n";
+
+  for (Rank r = RANK_8; r >= RANK_1; --r)
+  {
+      for (File f = FILE_A; f <= FILE_H; ++f)
+          os << " | " << PieceToChar[pos.piece_on(make_square(f, r))];
+
+      os << " |\n +---+---+---+---+---+---+---+---+\n";
+  }
+
+  os << "\nFen: " << pos.fen() << "\nKey: " << std::hex << std::uppercase
+     << std::setfill('0') << std::setw(16) << pos.st->key << "\nCheckers: ";
+
+  for (Bitboard b = pos.checkers(); b; )
+      os << UCI::format_square(pop_lsb(&b)) << " ";
+
+  return os;
+}
+
+
 /// Position::init() initializes at startup the various arrays used to compute
 /// hash keys and the piece square tables. The latter is a two-step operation:
 /// Firstly, the white halves of the tables are copied from PSQT[] tables.
@@ -425,32 +449,6 @@ const string Position::fen() const {
 
   ss << (ep_square() == SQ_NONE ? " - " : " " + UCI::format_square(ep_square()) + " ")
      << st->rule50 << " " << 1 + (gamePly - (sideToMove == BLACK)) / 2;
-
-  return ss.str();
-}
-
-
-/// Position::pretty() returns an ASCII representation of the position
-
-const string Position::pretty() const {
-
-  std::ostringstream ss;
-
-  ss << "\n +---+---+---+---+---+---+---+---+\n";
-
-  for (Rank r = RANK_8; r >= RANK_1; --r)
-  {
-      for (File f = FILE_A; f <= FILE_H; ++f)
-          ss << " | " << PieceToChar[piece_on(make_square(f, r))];
-
-      ss << " |\n +---+---+---+---+---+---+---+---+\n";
-  }
-
-  ss << "\nFen: " << fen() << "\nKey: " << std::hex << std::uppercase
-     << std::setfill('0') << std::setw(16) << st->key << "\nCheckers: ";
-
-  for (Bitboard b = checkers(); b; )
-      ss << UCI::format_square(pop_lsb(&b)) << " ";
 
   return ss.str();
 }

--- a/src/position.h
+++ b/src/position.h
@@ -73,6 +73,9 @@ const size_t StateCopySize64 = offsetof(StateInfo, key) / sizeof(uint64_t) + 1;
 /// when traversing the search tree.
 
 class Position {
+
+  friend std::ostream& operator<<(std::ostream&, const Position&);
+
 public:
   Position() {}
   Position(const Position& pos, Thread* t) { *this = pos; thisThread = t; }
@@ -80,10 +83,9 @@ public:
   Position& operator=(const Position&);
   static void init();
 
-  // Text input/output
+  // FEN string input/output
   void set(const std::string& fenStr, bool isChess960, Thread* th);
   const std::string fen() const;
-  const std::string pretty() const;
 
   // Position representation
   Bitboard pieces() const;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -203,7 +203,7 @@ void UCI::loop(int argc, char* argv[]) {
       else if (token == "setoption")  setoption(is);
       else if (token == "flip")       pos.flip();
       else if (token == "bench")      benchmark(pos, is);
-      else if (token == "d")          sync_cout << pos.pretty() << sync_endl;
+      else if (token == "d")          sync_cout << pos << sync_endl;
       else if (token == "isready")    sync_cout << "readyok" << sync_endl;
       else if (token == "eval")       sync_cout << Eval::trace(pos) << sync_endl;
       else


### PR DESCRIPTION
It is more idiomatic, we didn't used it
in the past because Position::pretty(Move)
had a calling argument, but now we can.

As an added benefit, we avoid a lot of string
copies in the process because now we avoid
std::ostringstream ss.

No functional change.
