### PR TITLE
Retire CACHE_LINE_ALIGNMENT

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -24,8 +24,6 @@
 #include "bitcount.h"
 #include "rkiss.h"
 
-CACHE_LINE_ALIGNMENT
-
 Bitboard RMasks[SQUARE_NB];
 Bitboard RMagics[SQUARE_NB];
 Bitboard* RAttacks[SQUARE_NB];
@@ -57,8 +55,6 @@ namespace {
   // De Bruijn sequences. See chessprogramming.wikispaces.com/BitScan
   const uint64_t DeBruijn_64 = 0x3F79D71B4CB0A89ULL;
   const uint32_t DeBruijn_32 = 0x783A9B23;
-
-  CACHE_LINE_ALIGNMENT
 
   int MS1BTable[256];
   Square BSFTable[SQUARE_NB];

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -57,8 +57,6 @@ const Bitboard Rank6BB = Rank1BB << (8 * 5);
 const Bitboard Rank7BB = Rank1BB << (8 * 6);
 const Bitboard Rank8BB = Rank1BB << (8 * 7);
 
-CACHE_LINE_ALIGNMENT
-
 extern Bitboard RMasks[SQUARE_NB];
 extern Bitboard RMagics[SQUARE_NB];
 extern Bitboard* RAttacks[SQUARE_NB];

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -34,8 +34,6 @@
 
 using std::string;
 
-CACHE_LINE_ALIGNMENT
-
 Value PieceValue[PHASE_NB][PIECE_NB] = {
 { VALUE_ZERO, PawnValueMg, KnightValueMg, BishopValueMg, RookValueMg, QueenValueMg },
 { VALUE_ZERO, PawnValueEg, KnightValueEg, BishopValueEg, RookValueEg, QueenValueEg } };

--- a/src/types.h
+++ b/src/types.h
@@ -65,11 +65,6 @@
 #  endif
 
 #define CACHE_LINE_SIZE 64
-#if defined(_MSC_VER) || defined(__INTEL_COMPILER)
-#  define CACHE_LINE_ALIGNMENT __declspec(align(CACHE_LINE_SIZE))
-#else
-#  define CACHE_LINE_ALIGNMENT  __attribute__ ((aligned(CACHE_LINE_SIZE)))
-#endif
 
 #ifdef _MSC_VER
 #  define FORCE_INLINE  __forceinline
@@ -325,8 +320,6 @@ inline Score operator*(Score s1, Score s2);
 inline Score operator/(Score s, int i) {
   return make_score(mg_value(s) / i, eg_value(s) / i);
 }
-
-CACHE_LINE_ALIGNMENT
 
 extern Value PieceValue[PHASE_NB][PIECE_NB];
 


### PR DESCRIPTION
It is useless. The only thing that should be aligned is the TT.

No functional change.
