### PR TITLE
Apply King Safety later in the endgame

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -219,7 +219,7 @@ namespace {
     ei.attackedBy[Us][ALL_PIECES] = ei.attackedBy[Us][PAWN] = ei.pi->pawn_attacks(Us);
 
     // Init king safety tables only if we are going to use them
-    if (pos.non_pawn_material(Us) > QueenValueMg + PawnValueMg)
+    if (pos.non_pawn_material(Us) >= QueenValueMg)
     {
         ei.kingRing[Them] = b | shift_bb<Down>(b);
         b &= ei.attackedBy[Us][PAWN];


### PR DESCRIPTION
Based on this discussion:
https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/2FPhgpHtefQ

Idea is to apply king safety later in the endgame. Previously, we didn't apply KS in a
RR vs. Q ending for example, which causes poor play. Now we calculate king attacks
when the attacking side has a queen or more.

**STC with 8moves_v3**

```
LLR: 3.06 (-2.94,2.94) [0.00,4.00]
Total: 38481 W: 6228 L: 5952 D: 26301
```

**LTC with 2moves_v1**

```
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 51053 W: 8670 L: 8353 D: 34030
```

bench 7119712
