### PR TITLE
Restore previous order

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1333,8 +1333,8 @@ moves_loop: // When in check and at SpNode search starts from here
 
         ss << "info depth " << d
            << " seldepth "  << selDepth
-           << " multipv "   << i + 1
            << " score "     << (i == PVIdx ? UCI::format_value(v, alpha, beta) : UCI::format_value(v))
+           << " multipv "   << i + 1
            << " nodes "     << pos.nodes_searched()
            << " nps "       << pos.nodes_searched() * 1000 / elapsed
            << " time "      << elapsed


### PR DESCRIPTION
Joona's PERL script is broken by a recent display reordering:
https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/uCq8EJcbuXo

And who knows how many external tools or GUIs are broken by this reordering?
UCI protocol does not forbid to reshuffle, but some external programs are
cheap and dirty and may have hard-wired assumptions on the order of the order
here. No reason to break compatibility, so restore the previous order.

No functional change.
