### PR TITLE
Profile Build with Hash=16

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -35,7 +35,7 @@ endif
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds
-PGOBENCH = ./$(EXE) bench 32 1 1 default time
+PGOBENCH = ./$(EXE) bench 16 1 1 default time
 
 ### Object files
 OBJS = benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o \


### PR DESCRIPTION
16MB for 1" searches is more comensurate with the average use case.

And 16 is the default used by stockfish bench, so it makes sense to be
consistent, if only to have the same minimum memory requirement for using
SF and compiling it with PGO.

No functional change.
