### PR TITLE
Use quiet ttMove in qsearch() (7962287)

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -103,15 +103,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats&
       stage = QSEARCH_0;
 
   else if (d > DEPTH_QS_RECAPTURES)
-  {
       stage = QSEARCH_1;
 
-      // Skip TT move if is not a capture or a promotion. This avoids qsearch
-      // tree explosion due to a possible perpetual check or similar rare cases
-      // when TT table is full.
-      if (ttm && !pos.capture_or_promotion(ttm))
-          ttm = MOVE_NONE;
-  }
   else
   {
       stage = RECAPTURE;


### PR DESCRIPTION
Idea from Daniel Jose:
http://www.talkchess.com/forum/viewtopic.php?t=54290

**STC: Hash=16**

```
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 33067 W: 6670 L: 6571 D: 19826
```

**LTC: Hash=64**

```
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 41181 W: 7008 L: 6920 D: 27253
```

And another one to verify no regression with hash pressure:

**STC: Hash=4**

```
LLR: 2.96 (-2.94,2.94) [-4.00,0.00]
Total: 25085 W: 5059 L: 4991 D: 15035
```

There is a comment that claims this would trigger qsearch explosion with perpetual checks. But I doubt this because:
- of the QS recapture logic
- of the fact that perpet get pruned at the first repetition

If anyone can find an example of such a qsearch explosion, I am interested.

bench 7962287
