### PR TITLE
Use DEPTH_MAX instead of MAX_PLY

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -255,7 +255,7 @@ namespace {
     multiPV = std::max(multiPV, skill.candidates_size());
 
     // Iterative deepening loop until requested to stop or target depth reached
-    while (++depth < MAX_PLY && !Signals.stop && (!Limits.depth || depth <= Limits.depth))
+    while (++depth < DEPTH_MAX && !Signals.stop && (!Limits.depth || depth <= Limits.depth))
     {
         // Age out PV variability metric
         BestMoveChanges *= 0.5;

--- a/src/types.h
+++ b/src/types.h
@@ -212,7 +212,8 @@ enum Depth {
   DEPTH_QS_NO_CHECKS  = -1,
   DEPTH_QS_RECAPTURES = -5,
 
-  DEPTH_NONE = -6
+  DEPTH_NONE = -6,
+  DEPTH_MAX  = MAX_PLY
 };
 
 enum Square {


### PR DESCRIPTION
When comparing to a Depth it is more
consistent to use DEPTH_MAX instead
of a int.

This is a subtle difference because we use
ply and depth almost interchangably in SF,
but they are different. For counting plies
make sense to continue using ints, while
for Depth we have our specific enum.

This cleanly fixes a new Clang 3.5 warning:

No functional change.
