### PR TITLE
Fix pondering

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1523,7 +1523,11 @@ void check_time() {
       dbg_print();
   }
 
-  if (Limits.use_time_management() && !Limits.ponder)
+  // An engine may not stop pondering until told so by the GUI
+  if (Limits.ponder)
+      return;
+
+  if (Limits.use_time_management())
   {
       bool stillAtFirstMove =    Signals.firstRootMove
                              && !Signals.failedLowAtRoot


### PR DESCRIPTION
The UCI specification states that an engine can never exit the search
while pondering.

No functional change.
