### PR TITLE
Clear token before reading from input

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -157,6 +157,7 @@ void UCI::loop(int argc, char* argv[]) {
 
       istringstream is(cmd);
 
+      token.clear(); // getline() could return empty or blank line
       is >> skipws >> token;
 
       if (token == "quit" || token == "stop" || token == "ponderhit")


### PR DESCRIPTION
Previously token would keep its value from the previous line when an empty
line was input, leading to unexpected behaviour.
