### PR TITLE
Fix a warning on Intel C++

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -75,7 +75,7 @@ const TTEntry* TranspositionTable::probe(const Key key) const {
   for (unsigned i = 0; i < TTClusterSize; ++i)
       if (tte[i].key16 == key16)
       {
-          tte[i].genBound8 = generation | (uint8_t)tte[i].bound(); // Refresh
+          tte[i].genBound8 = uint8_t(generation | tte[i].bound()); // Refresh
           return &tte[i];
       }
 


### PR DESCRIPTION
warning #2259: non-pointer conversion from "int" to
"uint8_t={unsigned char}" may lose significant bits

No functional change.
