### PR TITLE
Accurate nps

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -335,15 +335,19 @@ namespace {
             // Sort the PV lines searched so far and update the GUI
             std::stable_sort(RootMoves.begin(), RootMoves.begin() + PVIdx + 1);
 
+            // Print the PV lines, unless a multi-PV search has been interrupted
+            // (which may cause invalid scores to appear)
             Time::point elapsed = Time::now() - SearchTime + 1;
-            if (Signals.stop)
+            if (   (!Signals.stop || multiPV == 1)
+                && (PVIdx + 1 == std::min(multiPV, RootMoves.size()) || elapsed > 3000))
+                sync_cout << uci_pv(pos, depth, alpha, beta) << sync_endl;
+
+            // If search has been interrupted, and we are not printing the PV lines,
+            // we should at least print the final statistics.
+            else if (Signals.stop)
                 sync_cout << "info nodes " << RootPos.nodes_searched()
                           << " nps " << RootPos.nodes_searched() * 1000 / elapsed
                           << " time " << elapsed << sync_endl;
-
-            else if (   PVIdx + 1 == std::min(multiPV, RootMoves.size())
-                     || elapsed > 3000)
-                sync_cout << uci_pv(pos, depth, alpha, beta) << sync_endl;
         }
 
         // If skill levels are enabled and time is up, pick a sub-optimal best move


### PR DESCRIPTION
Since Shredder GUI compatibility improvements, the engine doesn't print any PV lines after the search gets stopped. But in single-PV mode, it is in fact okay to print it. Only multi-PV mode is known to cause bogus "M0 upperbound" scores when interrupted. So the patch relaxes the condition a bit.

Consequently, we can check for the opportunity to print the PV lines _before_ checking for the need to print the nodes/time/nps statistics alone. If PVs have been printed, there is no need to print the terser "info nodes" line, since all that info is already included along the PVs.

No functional change
