### PR TITLE
Fix doubled pawns asymmetry

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -165,7 +165,7 @@ namespace {
             value -= UnsupportedPawnPenalty;
 
         if (doubled)
-            value -= Doubled[f] / distance<Rank>(s, Square(lsb(doubled)));
+            value -= Doubled[f] / distance<Rank>(s, frontmost_sq(Us, doubled));
 
         if (backward)
             value -= Backward[opposed][f];


### PR DESCRIPTION
When evaluating double pawns we use always
lsb() to extract the frontmost square.

This breaks evaluation color symmetry as is
possible to verify with an instrumented evaluate()

  Value evaluate(const Position& pos) {

```
Value v = do_evaluate<false>(pos);
Position p = pos;
p.flip();
assert(v == do_evaluate<false>(p));
return v;
```

  }

bench: 8255966
