### PR TITLE
Fix out-of-bound array access printing ponder move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -218,8 +218,10 @@ void Search::think() {
   }
 
   sync_cout << "bestmove " << UCI::format_move(RootMoves[0].pv[0], RootPos.is_chess960());
+
   if (RootMoves[0].pv.size() > 1)
       std::cout << " ponder " << UCI::format_move(RootMoves[0].pv[1], RootPos.is_chess960());
+
   std::cout << sync_endl;
 }
 


### PR DESCRIPTION
It is possible that we won't have a ponder move if our PV
is too short.  In that case, just don't print a ponder move.

No functional change
