### PR TITLE
Bitbase index() from ADD to OR.  No functional change.

### DIFF
--- a/src/bitbase.cpp
+++ b/src/bitbase.cpp
@@ -41,7 +41,7 @@ namespace {
   // bit 13-14: white pawn file (from FILE_A to FILE_D)
   // bit 15-17: white pawn RANK_7 - rank (from RANK_7 - RANK_7 to RANK_7 - RANK_2)
   unsigned index(Color us, Square bksq, Square wksq, Square psq) {
-    return wksq + (bksq << 6) + (us << 12) + (file_of(psq) << 13) + ((RANK_7 - rank_of(psq)) << 15);
+    return wksq | (bksq << 6) | (us << 12) | (file_of(psq) << 13) | ((RANK_7 - rank_of(psq)) << 15);
   }
 
   enum Result {


### PR DESCRIPTION
I initially wrote this as a speed optimization but because Intel has done a great job making the ADD instruction with carry as fast as a bitwise OR it is exactly the same speed.  I'm submitting it anyway because from a purist point of view the bitwise OR better reflects that the index is a series of bitfields as documented in the comment section instead of a number arrived at through an algebraic expression.  Also it might still be faster on more primitive architectures.  I realize this is very nit picky so if you don't like it just close the pull request.  No functional change.
