### PR TITLE
Retire total_piece_count()

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -24,8 +24,8 @@
 #include <cstddef>
 
 #include "bitboard.h"
-#include "bitcount.h"
 #include "types.h"
+
 
 /// The checkInfo struct is initialized at c'tor time and keeps info used
 /// to detect if a move gives check.
@@ -100,7 +100,6 @@ public:
   bool empty(Square s) const;
   template<PieceType Pt> int count(Color c) const;
   template<PieceType Pt> const Square* list(Color c) const;
-  int total_piece_count() const;
 
   // Castling
   int can_castle(Color c) const;
@@ -358,10 +357,6 @@ inline int Position::rule50_count() const {
   return st->rule50;
 }
 
-inline int Position::total_piece_count() const {
-  return HasPopCnt ? popcount<Full>(pieces()) : pieceCount[WHITE][ALL_PIECES];
-}
-
 inline bool Position::opposite_bishops() const {
 
   return   pieceCount[WHITE][BISHOP] == 1
@@ -412,8 +407,7 @@ inline void Position::put_piece(Square s, Color c, PieceType pt) {
   byColorBB[c] |= s;
   index[s] = pieceCount[c][pt]++;
   pieceList[c][pt][index[s]] = s;
-  if (!HasPopCnt)
-      pieceCount[WHITE][ALL_PIECES]++;
+  pieceCount[c][ALL_PIECES]++;
 }
 
 inline void Position::move_piece(Square from, Square to, Color c, PieceType pt) {
@@ -444,8 +438,7 @@ inline void Position::remove_piece(Square s, Color c, PieceType pt) {
   index[lastSquare] = index[s];
   pieceList[c][pt][index[lastSquare]] = lastSquare;
   pieceList[c][pt][pieceCount[c][pt]] = SQ_NONE;
-  if (!HasPopCnt)
-      pieceCount[WHITE][ALL_PIECES]--;
+  pieceCount[c][ALL_PIECES]--;
 }
 
 #endif // #ifndef POSITION_H_INCLUDED

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -209,7 +209,7 @@ void Search::think() {
   {
 #ifdef SYZYGY
       // Check Tablebases at root
-      int piecesCnt = RootPos.total_piece_count();
+      int piecesCnt = RootPos.count<ALL_PIECES>(WHITE) + RootPos.count<ALL_PIECES>(BLACK);
       TBCardinality = Options["SyzygyProbeLimit"];
       TBProbeDepth = Options["SyzygyProbeDepth"] * ONE_PLY;
       if (TBCardinality > Tablebases::TBLargest)
@@ -554,10 +554,12 @@ namespace {
 
 #ifdef SYZYGY
     // Step 4a. Tablebase probe
+    int piecesCnt = pos.count<ALL_PIECES>(WHITE) + pos.count<ALL_PIECES>(BLACK);
+
     if (   !RootNode
-        && pos.total_piece_count() <= TBCardinality
-        && ( pos.total_piece_count() < TBCardinality || depth >= TBProbeDepth )
-        && pos.rule50_count() == 0)
+        &&  piecesCnt <= TBCardinality
+        && (piecesCnt < TBCardinality || depth >= TBProbeDepth)
+        &&  pos.rule50_count() == 0)
     {
         int found, v = Tablebases::probe_wdl(pos, &found);
 


### PR DESCRIPTION
We really don't need to uglify in this way
our nice count() API with this ad-hoc hack.

So remove the hack and use the already
existing infrastructure.

No functional change.
