### PR TITLE
Retire #ifdef SYZYGY macro

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -40,7 +40,7 @@ PGOBENCH = ./$(EXE) bench 16 1 1 default time
 ### Object files
 OBJS = benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o \
 	material.o misc.o movegen.o movepick.o pawns.o position.o \
-	search.o thread.o timeman.o tt.o uci.o ucioption.o
+	search.o thread.o timeman.o tt.o uci.o ucioption.o syzygy/tbprobe.o
 
 ### ==========================================================================
 ### Section 2. High-level Configuration
@@ -75,12 +75,6 @@ bsfq = no
 popcnt = no
 sse = no
 pext = no
-syzygy = yes
-
-ifeq ($(syzygy),yes)
-	OBJS += syzygy/tbprobe.o
-	CXXFLAGS += -DSYZYGY
-endif
 
 ### 2.2 Architecture specific
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,10 +26,7 @@
 #include "thread.h"
 #include "tt.h"
 #include "uci.h"
-
-#ifdef SYZYGY
 #include "syzygy/tbprobe.h"
-#endif
 
 int main(int argc, char* argv[]) {
 
@@ -43,10 +40,8 @@ int main(int argc, char* argv[]) {
   Eval::init();
   Pawns::init();
   Threads.init();
-  TT.resize(Options["Hash"]);
-#ifdef SYZYGY
   Tablebases::init(Options["SyzygyPath"]);
-#endif
+  TT.resize(Options["Hash"]);
 
   UCI::loop(argc, argv);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -33,10 +33,7 @@
 #include "thread.h"
 #include "tt.h"
 #include "uci.h"
-
-#ifdef SYZYGY
 #include "syzygy/tbprobe.h"
-#endif
 
 namespace Search {
 
@@ -207,7 +204,6 @@ void Search::think() {
   }
   else
   {
-#ifdef SYZYGY
       // Check Tablebases at root
       int piecesCnt = RootPos.total_piece_count();
       TBCardinality = Options["SyzygyProbeLimit"];
@@ -259,7 +255,6 @@ void Search::think() {
                       : TBScore;
           }
       }
-#endif
 
       for (size_t i = 0; i < Threads.size(); ++i)
           Threads[i]->maxPly = 0;
@@ -552,7 +547,6 @@ namespace {
         return ttValue;
     }
 
-#ifdef SYZYGY
     // Step 4a. Tablebase probe
     if (   !RootNode
         && pos.total_piece_count() <= TBCardinality
@@ -583,7 +577,6 @@ namespace {
             return value;
         }
     }
-#endif
 
     // Step 5. Evaluate the position statically and update parent's gain statistics
     if (inCheck)

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -26,10 +26,7 @@
 #include "thread.h"
 #include "tt.h"
 #include "uci.h"
-
-#ifdef SYZYGY
 #include "syzygy/tbprobe.h"
-#endif
 
 using std::string;
 
@@ -38,13 +35,11 @@ UCI::OptionsMap Options; // Global object
 namespace UCI {
 
 /// 'On change' actions, triggered by an option's value change
+void on_clear_hash(const Option&) { TT.clear(); }
+void on_hash_size(const Option& o) { TT.resize(o); }
 void on_logger(const Option& o) { start_logger(o); }
 void on_threads(const Option&) { Threads.read_uci_options(); }
-void on_hash_size(const Option& o) { TT.resize(o); }
-void on_clear_hash(const Option&) { TT.clear(); }
-#ifdef SYZYGY
 void on_tb_path(const Option& o) { Tablebases::init(o); }
-#endif
 
 
 /// Our case insensitive less() function as required by UCI protocol
@@ -72,12 +67,10 @@ void init(OptionsMap& o) {
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
   o["Slow Mover"]            << Option(80, 10, 1000);
   o["UCI_Chess960"]          << Option(false);
-#ifdef SYZYGY
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(6, 0, 6);
-#endif
 }
 
 


### PR DESCRIPTION
It just clutters the code for no
real reason.

No functional change.
