### PR TITLE
Retire support for Haiku installation directory from Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -28,10 +28,6 @@ EXE = stockfish
 
 ### Installation dir definitions
 PREFIX = /usr/local
-# Haiku has a non-standard filesystem layout
-ifeq ($(UNAME),Haiku)
-	PREFIX=/boot/system/non-packaged
-endif
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds


### PR DESCRIPTION
- It is out of the scope of the project.
- It is the responsibility of Haiku package maintainer to
  configure this.

No functional change
