### PR TITLE
Calculate pawnSpan on the fly

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -314,7 +314,7 @@ namespace {
         {
             // Penalty for bishop with same colored pawns
             if (Pt == BISHOP)
-                score -= BishopPawns * ei.pi->pawns_on_same_color_squares(Us, s);
+                score -= BishopPawns * ei.pi->pawns_num_on_same_color_squares(Us, s);
 
             // Bishop and knight outpost square
             if (!(pos.pieces(Them, PAWN) & pawn_attack_span(Us, s)))

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -100,8 +100,8 @@ namespace {
     e->kingSquares[Us] = SQ_NONE;
     e->semiopenFiles[Us] = 0xFF;
     e->pawnAttacks[Us] = shift_bb<Right>(ourPawns) | shift_bb<Left>(ourPawns);
-    e->pawnsOnSquares[Us][BLACK] = popcount<Max15>(ourPawns & DarkSquares);
-    e->pawnsOnSquares[Us][WHITE] = pos.count<PAWN>(Us) - e->pawnsOnSquares[Us][BLACK];
+    e->pawnsNumOnSquares[Us][BLACK] = popcount<Max15>(ourPawns & DarkSquares);
+    e->pawnsNumOnSquares[Us][WHITE] = pos.count<PAWN>(Us) - e->pawnsNumOnSquares[Us][BLACK];
 
     // Loop through all pawns of the current color and score each pawn
     while ((s = *pl++) != SQ_NONE)
@@ -176,9 +176,6 @@ namespace {
         if (lever)
             value += Lever[relative_rank(Us, s)];
     }
-
-    b = e->semiopenFiles[Us] ^ 0xFF;
-    e->pawnSpan[Us] = b ? int(msb(b) - lsb(b)) : 0;
 
     return value;
   }

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -45,11 +45,12 @@ struct Entry {
   }
 
   int pawn_span(Color c) const {
-    return pawnSpan[c];
+    return semiopenFiles[c] ^ 0xFF ? int(  msb(semiopenFiles[c] ^ 0xFF)
+                                         - lsb(semiopenFiles[c] ^ 0xFF)) : 0;
   }
 
-  int pawns_on_same_color_squares(Color c, Square s) const {
-    return pawnsOnSquares[c][!!(DarkSquares & s)];
+  int pawns_num_on_same_color_squares(Color c, Square s) const {
+    return pawnsNumOnSquares[c][!!(DarkSquares & s)];
   }
 
   template<Color Us>
@@ -73,8 +74,7 @@ struct Entry {
   int minKPdistance[COLOR_NB];
   int castlingRights[COLOR_NB];
   int semiopenFiles[COLOR_NB];
-  int pawnSpan[COLOR_NB];
-  int pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
+  int pawnsNumOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
 };
 
 typedef HashTable<Entry, 16384> Table;


### PR DESCRIPTION
Avoid storing it in pawns hash entry but
calculate it when needed (only in bishop
ending logic).

It is also immediately clear what pawn_span()
does.

While there, renamed pawnsOnSquares to make
it clear is a counter.

No measurable speed difference.

No functional change.
