### PR TITLE
Clarify when forcing the moves loop

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -46,7 +46,7 @@ struct Stack {
   Move killers[2];
   Depth reduction;
   Value staticEval;
-  bool skipNullMove;
+  bool skipEarlyPruning;
 };
 
 


### PR DESCRIPTION
In some cases we want to go direcly to the moves loop
without checking for early return. The patch make this
logic more clear and consistent.

Tested for no regression, passed STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 25282 W: 5136 L: 5022 D: 15124

and LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 72007 W: 12133 L: 12095 D: 47779

bench: 9316798
