### PR TITLE
TT replace speed optimization.  Replaces some algebra with logic.  Idea ...

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -88,10 +88,14 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   // Find an entry to be replaced according to the replacement strategy
   TTEntry* replace = tte;
   for (unsigned i = 1; i < TTClusterSize; ++i)
-      if (  ((  tte[i].genBound8 & 0xFC) == generation || tte[i].bound() == BOUND_EXACT)
-          - ((replace->genBound8 & 0xFC) == generation)
-          - (tte[i].depth8 < replace->depth8) < 0)
+  {
+      const bool A = (  tte[i].genBound8 & 0xFC) == generation || tte[i].bound() == BOUND_EXACT;
+      const bool B = (replace->genBound8 & 0xFC) == generation;
+      const bool C = tte[i].depth8 < replace->depth8;
+
+      if ((!A && (B || C)) || (B && C))
           replace = &tte[i];
+  }
 
   found = false;
   return replace;


### PR DESCRIPTION
...came from

https://github.com/mcostalba/Stockfish/pull/187

Interestingly changing
if ((!A && (B || C)) || (B && C))
to
if ((!A & (B | C)) | (B & C))
is also possible but maybe a tiny tiny bit slower.

gcc 4.9.1
build ARCH=x86-64-modern
i7 mobile Windows7-64

Results for 50 tests for each version:

```
        Base      Test      Diff
Mean    511309    516602    -5293
StDev   12016     12075     2359
```

p-value: 0.988

No functional change.

Can someone else please run fishbench?
