### PR TITLE
Change profile-build options to produce 1% to 2% faster executables.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -373,6 +373,8 @@ profile-build:
 	@$(PGOBENCH) > /dev/null
 	@echo ""
 	@echo "Step 3/4. Building final executable ..."
+# Deleting corrupt ucioption.gc* profile files is necessary to avoid an 
+# "internal compiler error" for gcc versions 4.7.x
 	@rm ucioption.gc*
 	@touch *.cpp *.h syzygy/*.cpp syzygy/*.h
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_use)


### PR DESCRIPTION
The "@rm ucioption.gc*" line is necessary to avoid a gcc 4.7.x bug.
Confirmed for gcc 4.7.4, 4.8.1, and 4.9.1
Suggested by Kiran Panditrao on fishcooking forum.
https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/AY8gN53nG18
