### PR TITLE
Don't account for Tempo in specialized endgames

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -702,7 +702,7 @@ namespace {
     // If we have a specialized evaluation function for the current material
     // configuration, call it and return.
     if (ei.mi->specialized_eval_exists())
-        return ei.mi->evaluate(pos) + Eval::Tempo;
+        return ei.mi->evaluate(pos);
 
     // Probe the pawn hash table
     ei.pi = Pawns::probe(pos, thisThread->pawnsTable);


### PR DESCRIPTION
The evaluation is already done by the specialized
function, don't need to add something else later.

With this patch following positions are evaluated
correctly as draws:

8/6p1/1Pkp1p1p/2nNn2P/2P1K1P1/8/8/3B4 w - - 7
8/1k4p1/1P1p1p1p/3NnK1P/2P3P1/1n6/4B3/8 w - -

Verified it not regress with an STC test:
LLR: 3.15 (-2.94,2.94) [-3.00,1.00]
Total: 49812 W: 10095 L: 10016 D: 29701

Reported by Arjun Temurnikar.

bench: 8289983
