### PR TITLE
Always use "rm -f" instead of "rm" in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -375,7 +375,7 @@ profile-build:
 	@echo "Step 3/4. Building final executable ..."
 # Deleting corrupt ucioption.gc* profile files is necessary to avoid an 
 # "internal compiler error" for gcc versions 4.7.x
-	@rm ucioption.gc*
+	@rm -f ucioption.gc*
 	@touch *.cpp *.h syzygy/*.cpp syzygy/*.h
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_use)
 	@echo ""


### PR DESCRIPTION
This is the standard practice.
In some UNIX systems "rm" prompts user for confirmation.
However "rm -f" is always a guaranteed forced deletion.

No Functional change
