### PR TITLE
Use "rm -f" instead of "rm" for gcc profiling hack in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -373,9 +373,6 @@ profile-build:
 	@$(PGOBENCH) > /dev/null
 	@echo ""
 	@echo "Step 3/4. Building final executable ..."
-# Deleting corrupt ucioption.gc* profile files is necessary to avoid an 
-# "internal compiler error" for gcc versions 4.7.x
-	@rm ucioption.gc*
 	@touch *.cpp *.h syzygy/*.cpp syzygy/*.h
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_use)
 	@echo ""
@@ -447,6 +444,9 @@ gcc-profile-make:
 	all
 
 gcc-profile-use:
+# Deleting corrupt ucioption.gc* profile files is necessary to avoid an 
+# "internal compiler error" for gcc versions 4.7.x
+	@rm -f ucioption.gc*
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
 	EXTRACXXFLAGS='-fbranch-probabilities' \
 	EXTRALDFLAGS='-lgcov' \


### PR DESCRIPTION
In some UNIX systems "rm" prompts user for confirmation.
However "rm -f" is always a guaranteed forced deletion.

Also move gcc profiling hack under the correct target

No Functional change
