### PR TITLE
Additional tidy up in timeman.cpp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -193,7 +193,7 @@ template uint64_t Search::perft<true>(Position& pos, Depth depth);
 
 void Search::think() {
 
-  TimeMgr.init(Limits, RootPos.game_ply(), RootPos.side_to_move());
+  TimeMgr.init(Limits, RootPos.side_to_move(), RootPos.game_ply());
 
   int contempt = Options["Contempt"] * PawnValueEg / 100; // From centipawns
   DrawValue[ RootPos.side_to_move()] = VALUE_DRAW - Value(contempt);

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -33,10 +33,6 @@ namespace {
   const double MaxRatio   = 7.0;  // When in trouble, we can step over reserved time with this ratio
   const double StealRatio = 0.33; // However we must not steal time from remaining moves over this ratio
 
-  const double xscale     = 9.3;
-  const double xshift     = 59.8;
-  const double skewfactor = 0.172;
-
 
   // move_importance() is a skew-logistic function based on naive statistical
   // analysis of "how many games are still undecided after n half-moves". Game
@@ -45,72 +41,76 @@ namespace {
 
   double move_importance(int ply) {
 
-    return pow((1 + exp((ply - xshift) / xscale)), -skewfactor) + DBL_MIN; // Ensure non-zero
+    const double XScale = 9.3;
+    const double XShift = 59.8;
+    const double Skew   = 0.172;
+
+    return pow((1 + exp((ply - XShift) / XScale)), -Skew) + DBL_MIN; // Ensure non-zero
   }
 
   template<TimeType T>
-  int remaining(int myTime, int movesToGo, int currentPly, int slowMover)
+  int remaining(int myTime, int movesToGo, int ply, int slowMover)
   {
     const double TMaxRatio   = (T == OptimumTime ? 1 : MaxRatio);
     const double TStealRatio = (T == OptimumTime ? 0 : StealRatio);
 
-    double thisMoveImportance = (move_importance(currentPly) * slowMover) / 100;
+    double moveImportance = (move_importance(ply) * slowMover) / 100;
     double otherMovesImportance = 0;
 
     for (int i = 1; i < movesToGo; ++i)
-        otherMovesImportance += move_importance(currentPly + 2 * i);
+        otherMovesImportance += move_importance(ply + 2 * i);
 
-    double ratio1 = (TMaxRatio * thisMoveImportance) / (TMaxRatio * thisMoveImportance + otherMovesImportance);
-    double ratio2 = (thisMoveImportance + TStealRatio * otherMovesImportance) / (thisMoveImportance + otherMovesImportance);
+    double ratio1 = (TMaxRatio * moveImportance) / (TMaxRatio * moveImportance + otherMovesImportance);
+    double ratio2 = (moveImportance + TStealRatio * otherMovesImportance) / (moveImportance + otherMovesImportance);
 
-    return int(myTime * std::min(ratio1, ratio2));
+    return myTime * std::min(ratio1, ratio2);
   }
 
 } // namespace
 
 
-void TimeManager::init(const Search::LimitsType& limits, int currentPly, Color us)
+/// init() is called at the beginning of the search and calculates the allowed
+/// thinking time out of the time control and current game ply. We support four
+/// different kinds of time controls, passed in 'limits':
+///
+///  inc == 0 && movestogo == 0 means: x basetime  [sudden death!]
+///  inc == 0 && movestogo != 0 means: x moves in y minutes
+///  inc >  0 && movestogo == 0 means: x basetime + z increment
+///  inc >  0 && movestogo != 0 means: x moves in y minutes + z increment
+
+void TimeManager::init(const Search::LimitsType& limits, Color us, int ply)
 {
-  /* We support four different kinds of time controls:
-
-      increment == 0 && movesToGo == 0 means: x basetime  [sudden death!]
-      increment == 0 && movesToGo != 0 means: x moves in y minutes
-      increment >  0 && movesToGo == 0 means: x basetime + z increment
-      increment >  0 && movesToGo != 0 means: x moves in y minutes + z increment
-  */
-
-  int hypMTG, hypMyTime, t1, t2;
-
-  // Read uci parameters
-  int moveOverhead    = Options["Move Overhead"];
   int minThinkingTime = Options["Minimum Thinking Time"];
+  int moveOverhead    = Options["Move Overhead"];
   int slowMover       = Options["Slow Mover"];
 
   // Initialize unstablePvFactor to 1 and search times to maximum values
   unstablePvFactor = 1;
   optimumSearchTime = maximumSearchTime = std::max(limits.time[us], minThinkingTime);
 
-  // We calculate optimum time usage for different hypothetical "moves to go"-values and choose the
-  // minimum of calculated search time values. Usually the greatest hypMTG gives the minimum values.
-  for (hypMTG = 1; hypMTG <= (limits.movestogo ? std::min(limits.movestogo, MoveHorizon) : MoveHorizon); ++hypMTG)
+  const int MaxMTG = limits.movestogo ? std::min(limits.movestogo, MoveHorizon) : MoveHorizon;
+
+  // We calculate optimum time usage for different hypothetical "moves to go"-values
+  // and choose the minimum of calculated search time values. Usually the greatest
+  // hypMTG gives the minimum values.
+  for (int hypMTG = 1; hypMTG <= MaxMTG; ++hypMTG)
   {
       // Calculate thinking time for hypothetical "moves to go"-value
-      hypMyTime =  limits.time[us]
-                 + limits.inc[us] * (hypMTG - 1)
-                 - moveOverhead * (2 + std::min(hypMTG, 40));
+      int hypMyTime =  limits.time[us]
+                     + limits.inc[us] * (hypMTG - 1)
+                     - moveOverhead * (2 + std::min(hypMTG, 40));
 
       hypMyTime = std::max(hypMyTime, 0);
 
-      t1 = minThinkingTime + remaining<OptimumTime>(hypMyTime, hypMTG, currentPly, slowMover);
-      t2 = minThinkingTime + remaining<MaxTime>(hypMyTime, hypMTG, currentPly, slowMover);
+      int t1 = minThinkingTime + remaining<OptimumTime>(hypMyTime, hypMTG, ply, slowMover);
+      int t2 = minThinkingTime + remaining<MaxTime    >(hypMyTime, hypMTG, ply, slowMover);
 
-      optimumSearchTime = std::min(optimumSearchTime, t1);
-      maximumSearchTime = std::min(maximumSearchTime, t2);
+      optimumSearchTime = std::min(t1, optimumSearchTime);
+      maximumSearchTime = std::min(t2, maximumSearchTime);
   }
 
   if (Options["Ponder"])
       optimumSearchTime += optimumSearchTime / 4;
 
-  // Make sure that maxSearchTime is not over absoluteMaxSearchTime
   optimumSearchTime = std::min(optimumSearchTime, maximumSearchTime);
 }

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -25,7 +25,7 @@
 
 class TimeManager {
 public:
-  void init(const Search::LimitsType& limits, int currentPly, Color us);
+  void init(const Search::LimitsType& limits, Color us, int ply);
   void pv_instability(double bestMoveChanges) { unstablePvFactor = 1 + bestMoveChanges; }
   int available_time() const { return int(optimumSearchTime * unstablePvFactor * 0.71); }
   int maximum_time() const { return maximumSearchTime; }


### PR DESCRIPTION
Simplified the ratio formulas and verified
that after int conversion there is no difference:

assert(int(myTime \* ratio_old) == int(myTime \* ratio_new));

With big numbers of myTime. Actually the difference
(ratio_old - ratio_new) is on the order of 0.1e-15
and all due to rounding errors.

Also fixed some comments and moved/renamed some
variables.

No functional change.
