### PR TITLE
Let material probing to access per-thread table

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -18,7 +18,7 @@
 */
 
 #include <algorithm>
-#include <cstring> // For memset
+#include <cstring>   // For std::memset
 
 #include "bitboard.h"
 #include "bitcount.h"

--- a/src/endgame.h
+++ b/src/endgame.h
@@ -76,7 +76,7 @@ template<typename T>
 struct EndgameBase {
 
   virtual ~EndgameBase() {}
-  virtual Color color() const = 0;
+  virtual Color strong_side() const = 0;
   virtual T operator()(const Position&) const = 0;
 };
 
@@ -85,7 +85,7 @@ template<EndgameType E, typename T = typename eg_fun<(E > SCALE_FUNS)>::type>
 struct Endgame : public EndgameBase<T> {
 
   explicit Endgame(Color c) : strongSide(c), weakSide(~c) {}
-  Color color() const { return strongSide; }
+  Color strong_side() const { return strongSide; }
   T operator()(const Position&) const;
 
 private:

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstring>   // For std::memset
 #include <iomanip>
 #include <sstream>
 
@@ -26,7 +27,6 @@
 #include "evaluate.h"
 #include "material.h"
 #include "pawns.h"
-#include "thread.h"
 
 namespace {
 
@@ -676,7 +676,6 @@ namespace {
 
     EvalInfo ei;
     Score score, mobility[2] = { SCORE_ZERO, SCORE_ZERO };
-    Thread* thisThread = pos.this_thread();
 
     // Initialize score by reading the incrementally updated scores included
     // in the position object (material + piece square tables).
@@ -684,7 +683,7 @@ namespace {
     score = pos.psq_score();
 
     // Probe the material hash table
-    ei.mi = Material::probe(pos, thisThread->materialTable, thisThread->endgames);
+    ei.mi = Material::probe(pos);
     score += ei.mi->imbalance();
 
     // If we have a specialized evaluation function for the current material
@@ -693,7 +692,7 @@ namespace {
         return ei.mi->evaluate(pos);
 
     // Probe the pawn hash table
-    ei.pi = Pawns::probe(pos, thisThread->pawnsTable);
+    ei.pi = Pawns::probe(pos);
     score += apply_weight(ei.pi->pawns_score(), Weights[PawnStructure]);
 
     // Initialize attack and king safety bitboards

--- a/src/material.h
+++ b/src/material.h
@@ -30,11 +30,11 @@ namespace Material {
 /// Material::Entry contains various information about a material configuration.
 /// It contains a material imbalance evaluation, a function pointer to a special
 /// endgame evaluation function (which in most cases is NULL, meaning that the
-/// standard evaluation function will be used), and "scale factors".
+/// standard evaluation function will be used), and scale factors.
 ///
-/// The scale factors are used to scale the evaluation score up or down.
-/// For instance, in KRB vs KR endgames, the score is scaled down by a factor
-/// of 4, which will result in scores of absolute value less than one pawn.
+/// The scale factors are used to scale the evaluation score up or down. For
+/// instance, in KRB vs KR endgames, the score is scaled down by a factor of 4,
+/// which will result in scores of absolute value less than one pawn.
 
 struct Entry {
 
@@ -43,12 +43,11 @@ struct Entry {
   bool specialized_eval_exists() const { return evaluationFunction != NULL; }
   Value evaluate(const Position& pos) const { return (*evaluationFunction)(pos); }
 
-  // scale_factor takes a position and a color as input, and returns a scale factor
-  // for the given color. We have to provide the position in addition to the color,
-  // because the scale factor need not be a constant: It can also be a function
-  // which should be applied to the position. For instance, in KBP vs K endgames,
-  // a scaling function for draws with rook pawns and wrong-colored bishops.
-
+  // scale_factor takes a position and a color as input and returns a scale factor
+  // for the given color. We have to provide the position in addition to the color
+  // because the scale factor may also be a function which should be applied to
+  // the position. For instance, in KBP vs K endgames, the scaling function looks
+  // for rook pawns and wrong-colored bishops.
   ScaleFactor scale_factor(const Position& pos, Color c) const {
 
     return !scalingFunction[c] || (*scalingFunction[c])(pos) == SCALE_FACTOR_NONE
@@ -59,13 +58,14 @@ struct Entry {
   int16_t value;
   uint8_t factor[COLOR_NB];
   EndgameBase<Value>* evaluationFunction;
-  EndgameBase<ScaleFactor>* scalingFunction[COLOR_NB];
+  EndgameBase<ScaleFactor>* scalingFunction[COLOR_NB]; // Could be one for each
+                                                       // side (e.g. KPKP, KBPsKs)
   Phase gamePhase;
 };
 
 typedef HashTable<Entry, 8192> Table;
 
-Entry* probe(const Position& pos, Table& entries, Endgames& endgames);
+Entry* probe(const Position& pos);
 
 } // namespace Material
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -24,6 +24,7 @@
 #include "bitcount.h"
 #include "pawns.h"
 #include "position.h"
+#include "thread.h"
 
 namespace {
 
@@ -202,9 +203,9 @@ namespace {
 
 namespace Pawns {
 
-/// init() initializes some tables used by evaluation. Instead of hard-coded
-/// tables, when makes sense, we prefer to calculate them with a formula to
-/// reduce independent parameters and to allow easier tuning and better insight.
+/// Pawns::init() initializes some tables needed by evaluation. Instead of using
+/// hard-coded tables, when makes sense, we prefer to calculate them with a formula
+/// to reduce independent parameters and to allow easier tuning and better insight.
 
 void init()
 {
@@ -220,14 +221,15 @@ void init()
 }
 
 
-/// probe() takes a position as input, computes a Entry object, and returns a
-/// pointer to it. The result is also stored in a hash table, so we don't have
-/// to recompute everything when the same pawn structure occurs again.
+/// Pawns::probe() looks up the current position's pawns configuration in
+/// the pawns hash table. It returns a pointer to the Entry if the position
+/// is found. Otherwise a new Entry is computed and stored there, so we don't
+/// have to recompute all when the same pawns configuration occurs again.
 
-Entry* probe(const Position& pos, Table& entries) {
+Entry* probe(const Position& pos) {
 
   Key key = pos.pawn_key();
-  Entry* e = entries[key];
+  Entry* e = pos.this_thread()->pawnsTable[key];
 
   if (e->key == key)
       return e;

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -80,7 +80,7 @@ struct Entry {
 typedef HashTable<Entry, 16384> Table;
 
 void init();
-Entry* probe(const Position& pos, Table& entries);
+Entry* probe(const Position& pos);
 
 } // namespace Pawns
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -19,7 +19,7 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cstring>
+#include <cstring>   // For std::memset
 #include <iomanip>
 #include <sstream>
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -20,7 +20,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <cstring>
+#include <cstring>   // For std::memset
 #include <iostream>
 #include <sstream>
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <cstring>
+#include <cstring>   // For std::memset
 #include <iostream>
 
 #include "bitboard.h"


### PR DESCRIPTION
It was a while I didn't touch this part of code and it needed a small refresh.

Although interesting, this is not one of the parts typically tweaked by our friends on fishtest, possibly because is a bit technical and obscure. I hope now is more clear what SF does in material.cpp
