### PR TITLE
Retire Material::space_weight()

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -223,15 +223,6 @@ Entry* probe(const Position& pos, Table& entries, Endgames& endgames) {
   if (pos.count<PAWN>(BLACK) == 1 && npm_b - npm_w <= BishopValueMg)
       e->factor[BLACK] = (uint8_t) SCALE_FACTOR_ONEPAWN;
 
-  // Compute the space weight
-  if (npm_w + npm_b >= 2 * QueenValueMg + 4 * RookValueMg + 2 * KnightValueMg)
-  {
-      int minorPieceCount =  pos.count<KNIGHT>(WHITE) + pos.count<BISHOP>(WHITE)
-                           + pos.count<KNIGHT>(BLACK) + pos.count<BISHOP>(BLACK);
-
-      e->spaceWeight = make_score(minorPieceCount * minorPieceCount, 0);
-  }
-
   // Evaluate the material imbalance. We use PIECE_TYPE_NONE as a place holder
   // for the bishop pair "extended piece", which allows us to be more flexible
   // in defining bishop pair bonuses.

--- a/src/material.h
+++ b/src/material.h
@@ -39,7 +39,6 @@ namespace Material {
 struct Entry {
 
   Score imbalance() const { return make_score(value, value); }
-  Score space_weight() const { return spaceWeight; }
   Phase game_phase() const { return gamePhase; }
   bool specialized_eval_exists() const { return evaluationFunction != NULL; }
   Value evaluate(const Position& pos) const { return (*evaluationFunction)(pos); }
@@ -61,7 +60,6 @@ struct Entry {
   uint8_t factor[COLOR_NB];
   EndgameBase<Value>* evaluationFunction;
   EndgameBase<ScaleFactor>* scalingFunction[COLOR_NB];
-  Score spaceWeight;
   Phase gamePhase;
 };
 


### PR DESCRIPTION
This is a nice simplification but could potentially introduce a speed regression so I run a test on it.

Speed bench is not enough IMO because space is computed only in the opening so bench is not representative enough of what really happens.