### PR TITLE
Add copy constructor for Position so that it behaves correctly in std co...

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -76,6 +76,11 @@ class Position {
 
   friend std::ostream& operator<<(std::ostream&, const Position&);
 
+  // Disable the default copy constructor
+  // Copying Position would require making a copy of *st (for example, by using
+  // the assignment operator)
+  Position(const Position&);
+
 public:
   Position() {}
   Position(const Position& pos, Thread* th) { *this = pos; thisThread = th; }


### PR DESCRIPTION
The rule of 3 in C++ says we should have all 3 of - destructor, copy constructor, and assignment operator, if we have any of the 3.

Our design of the Position class is a little strange and there's not really a sensible way to implement a dtor.

However, we can implement the copy ctor using assignment operator, and that makes it behave correctly in std containers.

I discovered this working on my own stuff based on Stockfish. Not sure if the default copy ctor is currently used anywhere in Stockfish, but even if it doesn't fix a bug right now, it may prevent a hard-to-find bug in the future.

If it's not used right now, it will just be optimized out by the compiler.