### PR TITLE
Make kingdanger array smaller

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -198,7 +198,7 @@ namespace {
 
   // KingDanger[attackUnits] contains the actual king danger weighted
   // scores, indexed by a calculated integer number.
-  Score KingDanger[128];
+  Score KingDanger[64];
 
   // apply_weight() weighs score 's' by weight 'w' trying to prevent overflow
   Score apply_weight(Score s, const Weight& w) {
@@ -475,7 +475,7 @@ namespace {
 
         // Finally, extract the king danger score from the KingDanger[]
         // array and subtract the score from evaluation.
-        score -= KingDanger[std::max(std::min(attackUnits, 99), 0)];
+        score -= KingDanger[std::max(std::min(attackUnits, 63), 0)];
     }
 
     if (Trace)
@@ -894,7 +894,7 @@ namespace Eval {
     const double MaxSlope = 30;
     const double Peak = 1280;
 
-    for (int t = 0, i = 1; i < 100; ++i)
+    for (int t = 0, i = 0; i < 64; ++i)
     {
         t = int(std::min(Peak, std::min(0.4 * i * i, t + MaxSlope)));
         KingDanger[i] = apply_weight(make_score(t, 0), Weights[KingSafety]);


### PR DESCRIPTION
Make KingDanger array size 64, Previously KingDanger array was 128 items of which 99 items was initialized. But only 62 items had useful values because:
KingDanger[0] == KingDanger[1] == 0
and
KingDanger[62] == KingDanger[63] == KingDanger[64] ==  ... == KingDanger[99]
In addition to this it seems KingDanger[0] was uninitialized.

No functional change.