### PR TITLE
Fix a silly warning with Intel compiler

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -63,7 +63,7 @@ namespace {
     double ratio1 = (TMaxRatio * moveImportance) / (TMaxRatio * moveImportance + otherMovesImportance);
     double ratio2 = (moveImportance + TStealRatio * otherMovesImportance) / (moveImportance + otherMovesImportance);
 
-    return myTime * std::min(ratio1, ratio2);
+    return int(myTime * std::min(ratio1, ratio2)); // Intel C++ asks an explicit cast
   }
 
 } // namespace


### PR DESCRIPTION
Intel compiler cries for an explicit cast

warning #2259: non-pointer conversion from "double" to "int"
may lose significant bits

No functional change.