### PR TITLE
Remove useless optimization

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -534,7 +534,7 @@ namespace {
 
         b = weak & ~ei.attackedBy[Them][ALL_PIECES];
         if (b)
-            score += more_than_one(b) ? Hanging * popcount<Max15>(b) : Hanging;
+            score += Hanging * popcount<Max15>(b);
 
         b = weak & ei.attackedBy[Us][KING];
         if (b)


### PR DESCRIPTION
This optimization is aimed at old hardware only (withouth popcount), and even on
non popcount compile `ARCH=x86-64`, removing this optimization gives no
mesurable slow down:

    stat        test     master     diff
    mean   2,341,779  2,354,699  -12,920
    stdev     12,910     14,770   18,150
    
    speedup      -0.55%
    P(speedup>0)  23.8%

No functional change.