### PR TITLE
Assorted work in uci.cpp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1446,8 +1446,12 @@ moves_loop: // When in check and at SpNode search starts from here
         ss << "info depth " << d / ONE_PLY
            << " seldepth "  << selDepth
            << " multipv "   << i + 1
-           << " score "     << ((!tb && i == PVIdx) ? UCI::value(v, alpha, beta) : UCI::value(v))
-           << " nodes "     << pos.nodes_searched()
+           << " score "     << UCI::value(v);
+
+        if (!tb && i == PVIdx)
+              ss << (v >= beta ? " lowerbound" : v <= alpha ? " upperbound" : "");
+
+        ss << " nodes "     << pos.nodes_searched()
            << " nps "       << pos.nodes_searched() * 1000 / elapsed
            << " tbhits "    << TB::Hits
            << " time "      << elapsed

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -17,7 +17,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -39,9 +38,9 @@ namespace {
   // FEN string of the initial position, normal chess
   const char* StartFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
-  // Keep a track of the position keys along the setup moves (from the start position
-  // to the position just before the search starts). This is needed by the repetition
-  // draw detection code.
+  // Stack to keep track of the position states along the setup moves (from the
+  // start position to the position just before the search starts). Needed by
+  // 'draw by repetition' detection.
   Search::StateStackPtr SetupStates;
 
 
@@ -105,7 +104,7 @@ namespace {
 
 
   // go() is called when engine receives the "go" UCI command. The function sets
-  // the thinking time and other parameters from the input string, and starts
+  // the thinking time and other parameters from the input string, then starts
   // the search.
 
   void go(const Position& pos, istringstream& is) {
@@ -114,7 +113,6 @@ namespace {
     string token;
 
     while (is >> token)
-    {
         if (token == "searchmoves")
             while (is >> token)
                 limits.searchmoves.push_back(UCI::to_move(pos, token));
@@ -130,7 +128,6 @@ namespace {
         else if (token == "mate")      is >> limits.mate;
         else if (token == "infinite")  limits.infinite = true;
         else if (token == "ponder")    limits.ponder = true;
-    }
 
     Threads.start_thinking(pos, limits, SetupStates);
   }
@@ -138,10 +135,11 @@ namespace {
 } // namespace
 
 
-/// Wait for a command from the user, parse this text string as an UCI command,
-/// and call the appropriate functions. Also intercepts EOF from stdin to ensure
-/// that we exit gracefully if the GUI dies unexpectedly. In addition to the UCI
-/// commands, the function also supports a few debug commands.
+/// UCI::loop() waits for a command from stdin, parses it and calls the appropriate
+/// function. Also intercepts EOF from stdin to ensure gracefully exiting if the
+/// GUI dies unexpectedly. When called with some command line arguments, e.g. to
+/// run 'bench', once the command is executed the function returns immediately.
+/// In addition to the UCI ones, also some additional debug commands are supported.
 
 void UCI::loop(int argc, char* argv[]) {
 
@@ -152,7 +150,7 @@ void UCI::loop(int argc, char* argv[]) {
       cmd += std::string(argv[i]) + " ";
 
   do {
-      if (argc == 1 && !getline(cin, cmd)) // Block here waiting for input
+      if (argc == 1 && !getline(cin, cmd)) // Block here waiting for input or EOF
           cmd = "quit";
 
       istringstream is(cmd);
@@ -160,21 +158,37 @@ void UCI::loop(int argc, char* argv[]) {
       token.clear(); // getline() could return empty or blank line
       is >> skipws >> token;
 
-      if (token == "quit" || token == "stop" || token == "ponderhit")
+      // The GUI sends 'ponderhit' to tell us to ponder on the same move the
+      // opponent has played. In case Signals.stopOnPonderhit is set we are
+      // waiting for 'ponderhit' to stop the search (for instance because we
+      // already ran out of time), otherwise we should continue searching but
+      // switching from pondering to normal search.
+      if (    token == "quit"
+          ||  token == "stop"
+          || (token == "ponderhit" && Search::Signals.stopOnPonderhit))
       {
-          // The GUI sends 'ponderhit' to tell us to ponder on the same move the
-          // opponent has played. In case Signals.stopOnPonderhit is set we are
-          // waiting for 'ponderhit' to stop the search (for instance because we
-          // already ran out of time), otherwise we should continue searching but
-          // switch from pondering to normal search.
-          if (token != "ponderhit" || Search::Signals.stopOnPonderhit)
-          {
-              Search::Signals.stop = true;
-              Threads.main()->notify_one(); // Could be sleeping
-          }
-          else
-              Search::Limits.ponder = false;
+          Search::Signals.stop = true;
+          Threads.main()->notify_one(); // Could be sleeping
       }
+      else if (token == "ponderhit")
+          Search::Limits.ponder = false; // Switch to normal search
+
+      else if (token == "uci")
+          sync_cout << "id name " << engine_info(true)
+                    << "\n"       << Options
+                    << "\nuciok"  << sync_endl;
+
+      else if (token == "isready")    sync_cout << "readyok" << sync_endl;
+      else if (token == "ucinewgame") TT.clear();
+      else if (token == "go")         go(pos, is);
+      else if (token == "position")   position(pos, is);
+      else if (token == "setoption")  setoption(is);
+
+      // Additional custom non-UCI commands, useful for debugging
+      else if (token == "flip")       pos.flip();
+      else if (token == "bench")      benchmark(pos, is);
+      else if (token == "d")          sync_cout << pos << sync_endl;
+      else if (token == "eval")       sync_cout << Eval::trace(pos) << sync_endl;
       else if (token == "perft")
       {
           int depth;
@@ -182,31 +196,10 @@ void UCI::loop(int argc, char* argv[]) {
 
           is >> depth;
           ss << Options["Hash"]    << " "
-             << Options["Threads"] << " " << depth << " current " << token;
+             << Options["Threads"] << " " << depth << " current perft";
 
           benchmark(pos, ss);
       }
-      else if (token == "key")
-          sync_cout << hex << uppercase << setfill('0')
-                    << "position key: "   << setw(16) << pos.key()
-                    << "\nmaterial key: " << setw(16) << pos.material_key()
-                    << "\npawn key:     " << setw(16) << pos.pawn_key()
-                    << dec << nouppercase << setfill(' ') << sync_endl;
-
-      else if (token == "uci")
-          sync_cout << "id name " << engine_info(true)
-                    << "\n"       << Options
-                    << "\nuciok"  << sync_endl;
-
-      else if (token == "ucinewgame") TT.clear();
-      else if (token == "go")         go(pos, is);
-      else if (token == "position")   position(pos, is);
-      else if (token == "setoption")  setoption(is);
-      else if (token == "flip")       pos.flip();
-      else if (token == "bench")      benchmark(pos, is);
-      else if (token == "d")          sync_cout << pos << sync_endl;
-      else if (token == "isready")    sync_cout << "readyok" << sync_endl;
-      else if (token == "eval")       sync_cout << Eval::trace(pos) << sync_endl;
       else
           sync_cout << "Unknown command: " << cmd << sync_endl;
 
@@ -216,14 +209,14 @@ void UCI::loop(int argc, char* argv[]) {
 }
 
 
-/// Convert a Value to a string suitable for use with the UCI protocol
-/// specifications:
+/// UCI::value() converts a Value to a string suitable for use with the UCI
+/// protocol specification:
 ///
-/// cp <x>     The score from the engine's point of view in centipawns.
-/// mate <y>   Mate in y moves, not plies. If the engine is getting mated
-///            use negative values for y.
+/// cp <x>    The score from the engine's point of view in centipawns.
+/// mate <y>  Mate in y moves, not plies. If the engine is getting mated
+///           use negative values for y.
 
-string UCI::value(Value v, Value alpha, Value beta) {
+string UCI::value(Value v) {
 
   stringstream ss;
 
@@ -232,25 +225,23 @@ string UCI::value(Value v, Value alpha, Value beta) {
   else
       ss << "mate " << (v > 0 ? VALUE_MATE - v + 1 : -VALUE_MATE - v) / 2;
 
-  ss << (v >= beta ? " lowerbound" : v <= alpha ? " upperbound" : "");
-
   return ss.str();
 }
 
 
-/// Convert a Square to a string in algebraic notation (g1, a7, etc.)
+/// UCI::square() converts a Square to a string in algebraic notation (g1, a7, etc.)
 
 std::string UCI::square(Square s) {
 
-  char sq[] = { char('a' + file_of(s)), char('1' + rank_of(s)), 0 };
+  char sq[] = { char('a' + file_of(s)), char('1' + rank_of(s)), 0 }; // NULL terminated
   return sq;
 }
 
 
-/// Convert a Move to a string in pure coordinate notation (g1f3, a7a8q). The
-/// only special case is castling moves, where we print in the e1g1 notation in
-/// normal chess mode, and in e1h1 notation in chess960 mode. Internally
-/// castling moves are always encoded as "king captures rook".
+/// UCI::move() converts a Move to a string in coordinate notation (g1f3, a7a8q).
+/// The only special case is castling, where we print in the e1g1 notation in
+/// normal chess mode, and in e1h1 notation in chess960 mode. Internally all
+/// castling moves are always encoded as 'king captures rook'.
 
 string UCI::move(Move m, bool chess960) {
 
@@ -275,8 +266,8 @@ string UCI::move(Move m, bool chess960) {
 }
 
 
-/// Convert a string representing a move in pure coordinate notation to the
-/// corresponding legal Move, if any.
+/// UCI::to_move() converts a string representing a move in coordinate notation
+/// (g1f3, a7a8q) to the corresponding legal Move, if any.
 
 Move UCI::to_move(const Position& pos, string& str) {
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -67,7 +67,7 @@ private:
 void init(OptionsMap&);
 void loop(int argc, char* argv[]);
 
-std::string value(Value v, Value alpha = -VALUE_INFINITE, Value beta = VALUE_INFINITE);
+std::string value(Value v);
 std::string square(Square s);
 std::string move(Move m, bool chess960);
 Move to_move(const Position& pos, std::string& str);


### PR DESCRIPTION
- Change UCI::value() signature

This function should only return the value,
lowerbound and upperbound info is up to the
caller because it requires external knowledge,
out of the scope of this little helper.

- Retire 'key' command

It is not an UCI command and is absolutely
useless: never used.

- Comments fixing and other trivia

No functional change.