### PR TITLE
Retire one implementation of pop_lsb()

### DIFF
--- a/src/bitbase.cpp
+++ b/src/bitbase.cpp
@@ -71,7 +71,7 @@ namespace {
 } // namespace
 
 
-bool Bitbases::probe_kpk(Square wksq, Square wpsq, Square bksq, Color us) {
+bool Bitbases::probe(Square wksq, Square wpsq, Square bksq, Color us) {
 
   assert(file_of(wpsq) <= FILE_D);
 
@@ -80,7 +80,7 @@ bool Bitbases::probe_kpk(Square wksq, Square wpsq, Square bksq, Color us) {
 }
 
 
-void Bitbases::init_kpk() {
+void Bitbases::init() {
 
   unsigned idx, repeat = 1;
   std::vector<KPKPosition> db;

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -217,7 +217,7 @@ Value Endgame<KPK>::operator()(const Position& pos) const {
 
   Color us = strongSide == pos.side_to_move() ? WHITE : BLACK;
 
-  if (!Bitbases::probe_kpk(wksq, psq, bksq, us))
+  if (!Bitbases::probe(wksq, psq, bksq, us))
       return VALUE_DRAW;
 
   Value result = VALUE_KNOWN_WIN + PawnValueEg + Value(rank_of(psq));
@@ -852,5 +852,5 @@ ScaleFactor Endgame<KPKP>::operator()(const Position& pos) const {
 
   // Probe the KPK bitbase with the weakest side's pawn removed. If it's a draw,
   // it's probably at least a draw even with the pawn.
-  return Bitbases::probe_kpk(wksq, psq, bksq, us) ? SCALE_FACTOR_NONE : SCALE_FACTOR_DRAW;
+  return Bitbases::probe(wksq, psq, bksq, us) ? SCALE_FACTOR_NONE : SCALE_FACTOR_DRAW;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char* argv[]) {
   UCI::init(Options);
   Bitboards::init();
   Position::init();
-  Bitbases::init_kpk();
+  Bitbases::init();
   Search::init();
   Eval::init();
   Pawns::init();

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -288,7 +288,7 @@ Score Entry::do_king_safety(const Position& pos, Square ksq) {
 
   Bitboard pawns = pos.pieces(Us, PAWN);
   if (pawns)
-      while (!(DistanceRingsBB[ksq][minKingPawnDistance[Us]++] & pawns)) {}
+      while (!(DistanceRingBB[ksq][minKingPawnDistance[Us]++] & pawns)) {}
 
   if (relative_rank(Us, ksq) > RANK_4)
       return make_score(0, -16 * minKingPawnDistance[Us]);


### PR DESCRIPTION
We have two implementations that are equivalent,
so retire one.

Plus usual tidy up of comments and code reshuffle.

No functional change.