### PR TITLE
Retire Position assignment operator

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -167,7 +167,8 @@ Value Endgame<KXK>::operator()(const Position& pos) const {
   if (   pos.count<QUEEN>(strongSide)
       || pos.count<ROOK>(strongSide)
       ||(pos.count<BISHOP>(strongSide) && pos.count<KNIGHT>(strongSide))
-      || pos.bishop_pair(strongSide))
+      ||(pos.count<BISHOP>(strongSide) > 1 && opposite_colors(pos.list<BISHOP>(strongSide)[0],
+                                                              pos.list<BISHOP>(strongSide)[1])))
       result += VALUE_KNOWN_WIN;
 
   return strongSide == pos.side_to_move() ? result : -result;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -129,21 +129,6 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
 }
 
 
-/// Position c'tor creates a copy of 'pos' but detaching the state pointer from
-/// the source to be self-consistent and not depending on any external data.
-
-Position::Position(const Position& pos, Thread* th) {
-
-  std::memcpy(this, &pos, sizeof(Position));
-  startState = *st;
-  st = &startState;
-  nodes = 0;
-  thisThread = th;
-
-  assert(pos_is_ok());
-}
-
-
 /// Position::init() initializes at startup the various arrays used to compute
 /// hash keys and the piece square tables. The latter is a two-step operation:
 /// Firstly, the white halves of the tables are copied from PSQT[] tables.
@@ -188,6 +173,22 @@ void Position::init() {
          psq[BLACK][pt][~s] = -(v + PSQT[pt][s]);
       }
   }
+}
+
+
+/// Position::operator=() creates a copy of 'pos' but detaching the state pointer
+/// from the source to be self-consistent and not depending on any external data.
+
+Position& Position::operator=(const Position& pos) {
+
+  std::memcpy(this, &pos, sizeof(Position));
+  startState = *st;
+  st = &startState;
+  nodes = 0;
+
+  assert(pos_is_ok());
+
+  return *this;
 }
 
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -129,6 +129,21 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
 }
 
 
+/// Position c'tor creates a copy of 'pos' but detaching the state pointer from
+/// the source to be self-consistent and not depending on any external data.
+
+Position::Position(const Position& pos, Thread* th) {
+
+  std::memcpy(this, &pos, sizeof(Position));
+  startState = *st;
+  st = &startState;
+  nodes = 0;
+  thisThread = th;
+
+  assert(pos_is_ok());
+}
+
+
 /// Position::init() initializes at startup the various arrays used to compute
 /// hash keys and the piece square tables. The latter is a two-step operation:
 /// Firstly, the white halves of the tables are copied from PSQT[] tables.
@@ -173,23 +188,6 @@ void Position::init() {
          psq[BLACK][pt][~s] = -(v + PSQT[pt][s]);
       }
   }
-}
-
-
-/// Position::operator=() creates a copy of 'pos'. We want the new born Position
-/// object to not depend on any external data so we detach state pointer from
-/// the source one.
-
-Position& Position::operator=(const Position& pos) {
-
-  std::memcpy(this, &pos, sizeof(Position));
-  startState = *st;
-  st = &startState;
-  nodes = 0;
-
-  assert(pos_is_ok());
-
-  return *this;
 }
 
 

--- a/src/position.h
+++ b/src/position.h
@@ -87,8 +87,9 @@ public:
   static void init();
 
   Position() {} // To define the global object RootPos
-  Position(const Position& pos, Thread* th);
+  Position(const Position& pos, Thread* th) { *this = pos; thisThread = th; }
   Position(const std::string& f, bool c960, Thread* th) { set(f, c960, th); }
+  Position& operator=(const Position&); // To assign RootPos from UCI
 
   // FEN string input/output
   void set(const std::string& fenStr, bool isChess960, Thread* th);

--- a/src/position.h
+++ b/src/position.h
@@ -21,16 +21,16 @@
 #define POSITION_H_INCLUDED
 
 #include <cassert>
-#include <cstddef>
+#include <cstddef>  // For offsetof()
 
 #include "bitboard.h"
 #include "types.h"
 
-
-/// The checkInfo struct is initialized at c'tor time and keeps info used
-/// to detect if a move gives check.
 class Position;
 struct Thread;
+
+/// CheckInfo struct is initialized at c'tor time and keeps info used to detect
+/// if a move gives check.
 
 struct CheckInfo {
 
@@ -39,52 +39,56 @@ struct CheckInfo {
   Bitboard dcCandidates;
   Bitboard pinned;
   Bitboard checkSq[PIECE_TYPE_NB];
-  Square ksq;
+  Square   ksq;
 };
 
 
-/// The StateInfo struct stores information needed to restore a Position
-/// object to its previous state when we retract a move. Whenever a move
-/// is made on the board (by calling Position::do_move), a StateInfo
-/// object must be passed as a parameter.
+/// StateInfo struct stores information needed to restore a Position object to
+/// its previous state when we retract a move. Whenever a move is made on the
+/// board (by calling Position::do_move), a StateInfo object must be passed.
 
 struct StateInfo {
-  Key pawnKey, materialKey;
-  Value nonPawnMaterial[COLOR_NB];
-  int castlingRights, rule50, pliesFromNull;
-  Score psq;
+
+  // Copied when making a move
+  Key    pawnKey;
+  Key    materialKey;
+  Value  nonPawnMaterial[COLOR_NB];
+  int    castlingRights;
+  int    rule50;
+  int    pliesFromNull;
+  Score  psq;
   Square epSquare;
 
-  Key key;
-  Bitboard checkersBB;
-  PieceType capturedType;
+  // Not copied when making a move
+  Key        key;
+  Bitboard   checkersBB;
+  PieceType  capturedType;
   StateInfo* previous;
 };
 
 
 /// When making a move the current StateInfo up to 'key' excluded is copied to
-/// the new one. Here we calculate the quad words (64bits) needed to be copied.
+/// the new one. Here we calculate the quad words (64 bit) needed to be copied.
 const size_t StateCopySize64 = offsetof(StateInfo, key) / sizeof(uint64_t) + 1;
 
 
-/// The Position class stores the information regarding the board representation
-/// like pieces, side to move, hash keys, castling info, etc. The most important
-/// methods are do_move() and undo_move(), used by the search to update node info
-/// when traversing the search tree.
+/// Position class stores information regarding the board representation as
+/// pieces, side to move, hash keys, castling info, etc. Important methods are
+/// do_move() and undo_move(), used by the search to update node info when
+/// traversing the search tree.
 
 class Position {
 
   friend std::ostream& operator<<(std::ostream&, const Position&);
 
-  // Disable the default copy constructor
-  Position(const Position&); 
+  Position(const Position&); // Disable the default copy constructor
 
 public:
-  Position() {}
-  Position(const Position& pos, Thread* th) { *this = pos; thisThread = th; }
-  Position(const std::string& f, bool c960, Thread* th) { set(f, c960, th); }
-  Position& operator=(const Position&);
   static void init();
+
+  Position() {} // To define the global object RootPos
+  Position(const Position& pos, Thread* th);
+  Position(const std::string& f, bool c960, Thread* th) { set(f, c960, th); }
 
   // FEN string input/output
   void set(const std::string& fenStr, bool isChess960, Thread* th);
@@ -128,14 +132,12 @@ public:
   bool capture(Move m) const;
   bool capture_or_promotion(Move m) const;
   bool gives_check(Move m, const CheckInfo& ci) const;
-  bool advanced_pawn_push(Move m) const;
   Piece moved_piece(Move m) const;
   PieceType captured_piece_type() const;
 
   // Piece specific
   bool pawn_passed(Color c, Square s) const;
   bool pawn_on_7th(Color c) const;
-  bool bishop_pair(Color c) const;
   bool opposite_bishops() const;
 
   // Doing and undoing moves
@@ -153,12 +155,8 @@ public:
   Key key() const;
   Key key_after(Move m) const;
   Key exclusion_key() const;
-  Key pawn_key() const;
   Key material_key() const;
-
-  // Incremental piece-square evaluation
-  Score psq_score() const;
-  Value non_pawn_material(Color c) const;
+  Key pawn_key() const;
 
   // Other properties of the position
   Color side_to_move() const;
@@ -170,6 +168,8 @@ public:
   void set_nodes_searched(uint64_t n);
   bool is_draw() const;
   int rule50_count() const;
+  Score psq_score() const;
+  Value non_pawn_material(Color c) const;
 
   // Position consistency check, for debugging
   bool pos_is_ok(int* step = NULL) const;
@@ -181,7 +181,7 @@ private:
   void set_castling_right(Color c, Square rfrom);
   void set_state(StateInfo* si) const;
 
-  // Helper functions
+  // Other helpers
   Bitboard check_blockers(Color c, Color kingColor) const;
   void put_piece(Square s, Color c, PieceType pt);
   void remove_piece(Square s, Color c, PieceType pt);
@@ -189,15 +189,13 @@ private:
   template<bool Do>
   void do_castling(Square from, Square& to, Square& rfrom, Square& rto);
 
-  // Board and pieces
+  // Data members
   Piece board[SQUARE_NB];
   Bitboard byTypeBB[PIECE_TYPE_NB];
   Bitboard byColorBB[COLOR_NB];
   int pieceCount[COLOR_NB][PIECE_TYPE_NB];
   Square pieceList[COLOR_NB][PIECE_TYPE_NB][16];
   int index[SQUARE_NB];
-
-  // Other info
   int castlingRightsMask[SQUARE_NB];
   Square castlingRookSquare[CASTLING_RIGHT_NB];
   Bitboard castlingPath[CASTLING_RIGHT_NB];
@@ -210,12 +208,12 @@ private:
   bool chess960;
 };
 
-inline uint64_t Position::nodes_searched() const {
-  return nodes;
+inline Color Position::side_to_move() const {
+  return sideToMove;
 }
 
-inline void Position::set_nodes_searched(uint64_t n) {
-  nodes = n;
+inline bool Position::empty(Square s) const {
+  return board[s] == NO_PIECE;
 }
 
 inline Piece Position::piece_on(Square s) const {
@@ -224,14 +222,6 @@ inline Piece Position::piece_on(Square s) const {
 
 inline Piece Position::moved_piece(Move m) const {
   return board[from_sq(m)];
-}
-
-inline bool Position::empty(Square s) const {
-  return board[s] == NO_PIECE;
-}
-
-inline Color Position::side_to_move() const {
-  return sideToMove;
 }
 
 inline Bitboard Position::pieces() const {
@@ -266,12 +256,12 @@ template<PieceType Pt> inline const Square* Position::list(Color c) const {
   return pieceList[c][Pt];
 }
 
-inline Square Position::ep_square() const {
-  return st->epSquare;
-}
-
 inline Square Position::king_square(Color c) const {
   return pieceList[c][KING][0];
+}
+
+inline Square Position::ep_square() const {
+  return st->epSquare;
 }
 
 inline int Position::can_castle(CastlingRight cr) const {
@@ -292,7 +282,6 @@ inline Square Position::castling_rook_square(CastlingRight cr) const {
 
 template<PieceType Pt>
 inline Bitboard Position::attacks_from(Square s) const {
-
   return  Pt == BISHOP || Pt == ROOK ? attacks_bb<Pt>(s, byTypeBB[ALL_PIECES])
         : Pt == QUEEN  ? attacks_from<ROOK>(s) | attacks_from<BISHOP>(s)
         : StepAttacksBB[Pt][s];
@@ -327,11 +316,6 @@ inline bool Position::pawn_passed(Color c, Square s) const {
   return !(pieces(~c, PAWN) & passed_pawn_mask(c, s));
 }
 
-inline bool Position::advanced_pawn_push(Move m) const {
-  return   type_of(moved_piece(m)) == PAWN
-        && relative_rank(sideToMove, from_sq(m)) > RANK_4;
-}
-
 inline Key Position::key() const {
   return st->key;
 }
@@ -360,17 +344,18 @@ inline int Position::rule50_count() const {
   return st->rule50;
 }
 
-inline bool Position::opposite_bishops() const {
+inline uint64_t Position::nodes_searched() const {
+  return nodes;
+}
 
+inline void Position::set_nodes_searched(uint64_t n) {
+  nodes = n;
+}
+
+inline bool Position::opposite_bishops() const {
   return   pieceCount[WHITE][BISHOP] == 1
         && pieceCount[BLACK][BISHOP] == 1
         && opposite_colors(pieceList[WHITE][BISHOP][0], pieceList[BLACK][BISHOP][0]);
-}
-
-inline bool Position::bishop_pair(Color c) const {
-
-  return   pieceCount[c][BISHOP] >= 2
-        && opposite_colors(pieceList[c][BISHOP][0], pieceList[c][BISHOP][1]);
 }
 
 inline bool Position::pawn_on_7th(Color c) const {
@@ -389,7 +374,7 @@ inline bool Position::capture_or_promotion(Move m) const {
 
 inline bool Position::capture(Move m) const {
 
-  // Note that castling is encoded as "king captures the rook"
+  // Castling is encoded as "king captures the rook"
   assert(is_ok(m));
   return (!empty(to_sq(m)) && type_of(m) != CASTLING) || type_of(m) == ENPASSANT;
 }
@@ -415,8 +400,8 @@ inline void Position::put_piece(Square s, Color c, PieceType pt) {
 
 inline void Position::move_piece(Square from, Square to, Color c, PieceType pt) {
 
-  // index[from] is not updated and becomes stale. This works as long
-  // as index[] is accessed just by known occupied squares.
+  // index[from] is not updated and becomes stale. This works as long as index[]
+  // is accessed just by known occupied squares.
   Bitboard from_to_bb = SquareBB[from] ^ SquareBB[to];
   byTypeBB[ALL_PIECES] ^= from_to_bb;
   byTypeBB[pt] ^= from_to_bb;
@@ -436,7 +421,7 @@ inline void Position::remove_piece(Square s, Color c, PieceType pt) {
   byTypeBB[ALL_PIECES] ^= s;
   byTypeBB[pt] ^= s;
   byColorBB[c] ^= s;
-  /* board[s] = NO_PIECE; */ // Not needed, will be overwritten by capturing
+  /* board[s] = NO_PIECE;  Not needed, overwritten by the capturing one */
   Square lastSquare = pieceList[c][pt][--pieceCount[c][pt]];
   index[lastSquare] = index[s];
   pieceList[c][pt][index[lastSquare]] = lastSquare;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -799,7 +799,8 @@ moves_loop: // When in check and at SpNode search starts from here
 
       dangerous =   givesCheck
                  || type_of(move) != NORMAL
-                 || pos.advanced_pawn_push(move);
+                 || (   type_of(pos.moved_piece(move)) == PAWN
+                     && relative_rank(pos.side_to_move(), from_sq(move)) > RANK_4);
 
       // Step 12. Extend checks
       if (givesCheck && pos.see_sign(move) >= VALUE_ZERO)
@@ -1214,7 +1215,8 @@ moves_loop: // When in check and at SpNode search starts from here
           && !InCheck
           && !givesCheck
           &&  futilityBase > -VALUE_KNOWN_WIN
-          && !pos.advanced_pawn_push(move))
+          && !(   type_of(pos.moved_piece(move)) == PAWN
+               && relative_rank(pos.side_to_move(), from_sq(move)) > RANK_4))
       {
           assert(type_of(move) != ENPASSANT); // Due to !pos.advanced_pawn_push
 


### PR DESCRIPTION
Assorted formatting and comment tweaks in position.h

Also retired advanced_pawn_push(), it just hides the logic in
the only two places where it is used: better to make the rule
explicit to allow easier tweaks and tests.

No functional change.