### PR TITLE
High res bench

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,7 @@ PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds
-PGOBENCH = ./$(EXE) bench 16 1 1 default time
+PGOBENCH = ./$(EXE) bench 16 1 1000 default time
 
 ### Object files
 OBJS = benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o \

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -108,7 +108,7 @@ void benchmark(const Position& current, istream& is) {
   TT.clear();
 
   if (limitType == "time")
-      limits.movetime = 1000 * atoi(limit.c_str()); // movetime is in ms
+      limits.movetime = atoi(limit.c_str()); // movetime is in ms
 
   else if (limitType == "nodes")
       limits.nodes = atoi(limit.c_str());

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -88,7 +88,7 @@ const char* Defaults[] = {
 /// be used, the limit value spent for each position (optional, default is
 /// depth 13), an optional file name where to look for positions in FEN
 /// format (defaults are the positions defined above) and the type of the
-/// limit value: depth (default), time in secs or number of nodes.
+/// limit value: depth (default), time in millisecs or number of nodes.
 
 void benchmark(const Position& current, istream& is) {
 


### PR DESCRIPTION
At the moment the command "bench 16 1 X default time" let the default fen file be analysed with X seconds for position. Is there a reason for this? I searched UCI specifications without success.

It seems much more reasonable to use milliseconds for resolution (in particular if one want to analyse automatically database of positions for tuning purposes).
