### PR TITLE
Fix compile for Android 5

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -310,6 +310,14 @@ ifeq ($(comp),gcc)
 	endif
 endif
 
+### 3.12 Android 5 can only run position independent executables. Note that this
+### breaks Android 4.0 and earlier.
+ifeq ($(arch),armv7)
+	CXXFLAGS += -fPIE
+	LDFLAGS += -fPIE -pie
+endif
+
+
 ### ==========================================================================
 ### Section 4. Public targets
 ### ==========================================================================


### PR DESCRIPTION
Android 5 can only run position independent executables.

Note that this breaks Android 4.0 and earlier.

See here for more info:
http://stackoverflow.com/questions/24818902/running-a-native-library-on-android-l-error-only-position-independent-executab

Thanks to Peter Osterlund for the support.

No functional change