### PR TITLE
Fix a crash of syzygy on Android

### DIFF
--- a/src/syzygy/tbcore.cpp
+++ b/src/syzygy/tbcore.cpp
@@ -370,7 +370,7 @@ void Tablebases::init(const std::string& path)
   printf("info string Found %d tablebases.\n", TBnum_piece + TBnum_pawn);
 }
 
-static const char offdiag[] = {
+static const signed char offdiag[] = {
   0,-1,-1,-1,-1,-1,-1,-1,
   1, 0,-1,-1,-1,-1,-1,-1,
   1, 1, 0,-1,-1,-1,-1,-1,


### PR DESCRIPTION
On Android-ARM current TB code crashes at
random times even in single thread mode.

Reported, debugged, fixed and verified
by Peter Osterlund.

No functional change.