### PR TITLE
Eval tempo speed up

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -26,7 +26,9 @@ class Position;
 
 namespace Eval {
 
-const Value Tempo = Value(34); // Must be visible to search
+const Value Tempo = Value(17); // Must be visible to search
+const Value doubleTempo = 2*Tempo; // Must be visible to search
+
 
 void init();
 Value evaluate(const Position& pos);

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -26,7 +26,7 @@ class Position;
 
 namespace Eval {
 
-const Value Tempo = Value(17); // Must be visible to search
+const Value Tempo = Value(34); // Must be visible to search
 
 void init();
 Value evaluate(const Position& pos);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -595,7 +595,7 @@ namespace {
     else
     {
         eval = ss->staticEval =
-        (ss-1)->currentMove != MOVE_NULL ? evaluate(pos) : -(ss-1)->staticEval + 2 * Eval::Tempo;
+        (ss-1)->currentMove != MOVE_NULL ? evaluate(pos) : -(ss-1)->staticEval + Eval::Tempo;
 
         tte->save(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE, ss->staticEval, TT.generation());
     }
@@ -1175,7 +1175,7 @@ moves_loop: // When in check and at SpNode search starts from here
         }
         else
             ss->staticEval = bestValue =
-            (ss-1)->currentMove != MOVE_NULL ? evaluate(pos) : -(ss-1)->staticEval + 2 * Eval::Tempo;
+            (ss-1)->currentMove != MOVE_NULL ? evaluate(pos) : -(ss-1)->staticEval + Eval::Tempo;
 
         // Stand pat. Return immediately if static value is at least beta
         if (bestValue >= beta)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -595,7 +595,7 @@ namespace {
     else
     {
         eval = ss->staticEval =
-        (ss-1)->currentMove != MOVE_NULL ? evaluate(pos) : -(ss-1)->staticEval + Eval::Tempo;
+        (ss-1)->currentMove != MOVE_NULL ? evaluate(pos) : -(ss-1)->staticEval + Eval::doubleTempo;
 
         tte->save(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE, ss->staticEval, TT.generation());
     }
@@ -1175,7 +1175,7 @@ moves_loop: // When in check and at SpNode search starts from here
         }
         else
             ss->staticEval = bestValue =
-            (ss-1)->currentMove != MOVE_NULL ? evaluate(pos) : -(ss-1)->staticEval + Eval::Tempo;
+            (ss-1)->currentMove != MOVE_NULL ? evaluate(pos) : -(ss-1)->staticEval + Eval::doubleTempo;
 
         // Stand pat. Return immediately if static value is at least beta
         if (bestValue >= beta)


### PR DESCRIPTION
Speed-up by precomputing 2*Eval::Tempo in eval.h. Gave 2.5/1000 speed-up (50 benches, delta > 0 over 6 sigma) on my machine.

No functional change.