### PR TITLE
Move pruning at PV nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -839,8 +839,12 @@ moves_loop: // When in check and at SpNode search starts from here
       {
           // Move count based pruning
           if (   depth < 16 * ONE_PLY
-              && ss->distanceToPv > 2
-              && moveCount >= FutilityMoveCounts[improving][depth])
+              && moveCount >= FutilityMoveCounts[improving][depth]
+              && (   ss->distanceToPv > 1
+                  || (   move != ss->killers[0] && move != ss->killers[1]
+                      && move != countermoves[0] && move != countermoves[1]
+                      && move != followupmoves[0] && move != followupmoves[1]
+                     )))
           {
               if (SpNode)
                   splitPoint->mutex.lock();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -632,7 +632,7 @@ namespace {
     }
 
     // Step 7. Futility pruning: child node (skipped when in check)
-    if (   !PvNode
+    if (   !RootNode
         &&  depth < 7 * ONE_PLY
         &&  eval - futility_margin(depth) >= beta
         &&  eval < VALUE_KNOWN_WIN  // Do not return unproven wins

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -618,6 +618,7 @@ namespace {
     // Step 6. Razoring (skipped when in check)
     if (   !PvNode
         &&  depth < 4 * ONE_PLY
+        &&  ss->distanceToPv > 1
         &&  eval + razor_margin(depth) <= alpha
         &&  ttMove == MOVE_NONE
         && !pos.pawn_on_7th(pos.side_to_move()))
@@ -839,12 +840,7 @@ moves_loop: // When in check and at SpNode search starts from here
       {
           // Move count based pruning
           if (   depth < 16 * ONE_PLY
-              && moveCount >= FutilityMoveCounts[improving][depth]
-              && (   ss->distanceToPv > 1
-                  || (   move != ss->killers[0] && move != ss->killers[1]
-                      && move != countermoves[0] && move != countermoves[1]
-                      && move != followupmoves[0] && move != followupmoves[1]
-                     )))
+              && moveCount >= FutilityMoveCounts[improving][depth])
           {
               if (SpNode)
                   splitPoint->mutex.lock();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -839,7 +839,7 @@ moves_loop: // When in check and at SpNode search starts from here
       {
           // Move count based pruning
           if (   depth < 16 * ONE_PLY
-              && ss->distanceToPv > 1
+              && ss->distanceToPv > 2
               && moveCount >= FutilityMoveCounts[improving][depth])
           {
               if (SpNode)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -489,6 +489,7 @@ namespace {
     moveCount = quietCount = 0;
     bestValue = -VALUE_INFINITE;
     ss->ply = (ss-1)->ply + 1;
+    ss->distanceToPv = PvNode ? 0 : (ss-1)->distanceToPv + 1;
 
     // Used to send selDepth info to GUI
     if (PvNode && thisThread->maxPly < ss->ply)
@@ -838,6 +839,7 @@ moves_loop: // When in check and at SpNode search starts from here
       {
           // Move count based pruning
           if (   depth < 16 * ONE_PLY
+              && ss->distanceToPv > 1
               && moveCount >= FutilityMoveCounts[improving][depth])
           {
               if (SpNode)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -489,7 +489,6 @@ namespace {
     moveCount = quietCount = 0;
     bestValue = -VALUE_INFINITE;
     ss->ply = (ss-1)->ply + 1;
-    ss->distanceToPv = PvNode ? 0 : (ss-1)->distanceToPv + 1;
 
     // Used to send selDepth info to GUI
     if (PvNode && thisThread->maxPly < ss->ply)
@@ -618,7 +617,6 @@ namespace {
     // Step 6. Razoring (skipped when in check)
     if (   !PvNode
         &&  depth < 4 * ONE_PLY
-        &&  ss->distanceToPv > 1
         &&  eval + razor_margin(depth) <= alpha
         &&  ttMove == MOVE_NONE
         && !pos.pawn_on_7th(pos.side_to_move()))
@@ -831,9 +829,8 @@ moves_loop: // When in check and at SpNode search starts from here
       // Update the current move (this must be done after singular extension search)
       newDepth = depth - ONE_PLY + extension;
 
-      // Step 13. Pruning at shallow depth (exclude PV nodes)
-      if (   !PvNode
-          && !captureOrPromotion
+      // Step 13. Pruning at shallow depth
+      if (   !captureOrPromotion
           && !inCheck
           && !dangerous
           &&  bestValue > VALUE_MATED_IN_MAX_PLY)

--- a/src/search.h
+++ b/src/search.h
@@ -40,7 +40,6 @@ struct Stack {
   SplitPoint* splitPoint;
   Move* pv;
   int ply;
-  int distanceToPv;
   Move currentMove;
   Move ttMove;
   Move excludedMove;

--- a/src/search.h
+++ b/src/search.h
@@ -40,6 +40,7 @@ struct Stack {
   SplitPoint* splitPoint;
   Move* pv;
   int ply;
+  int distanceToPv;
   Move currentMove;
   Move ttMove;
   Move excludedMove;


### PR DESCRIPTION
Allow move pruning in search at PV nodes.
Futility pruning in step 7 is included too (Thanks to Lucas for point out this to me).

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 21553 W: 4342 L: 4221 D: 12990

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 7675 W: 1351 L: 1209 D: 5115

Bench: 8668014