### PR TITLE
Prune PV nodes in qsearch (8852247)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1222,12 +1222,14 @@ moves_loop: // When in check and at SpNode search starts from here
           if (futilityValue <= alpha)
           {
               bestValue = std::max(bestValue, futilityValue);
+              alpha = std::max(alpha, bestValue);
               continue;
           }
 
           if (futilityBase <= alpha && pos.see(move) <= VALUE_ZERO)
           {
               bestValue = std::max(bestValue, futilityBase);
+              alpha = std::max(alpha, bestValue);
               continue;
           }
       }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1222,14 +1222,12 @@ moves_loop: // When in check and at SpNode search starts from here
           if (futilityValue <= alpha)
           {
               bestValue = std::max(bestValue, futilityValue);
-              alpha = std::max(alpha, bestValue);
               continue;
           }
 
           if (futilityBase <= alpha && pos.see(move) <= VALUE_ZERO)
           {
               bestValue = std::max(bestValue, futilityBase);
-              alpha = std::max(alpha, bestValue);
               continue;
           }
       }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1210,8 +1210,7 @@ moves_loop: // When in check and at SpNode search starts from here
                   : pos.gives_check(move, ci);
 
       // Futility pruning
-      if (   !PvNode
-          && !InCheck
+      if (   !InCheck
           && !givesCheck
           &&  futilityBase > -VALUE_KNOWN_WIN
           && !pos.advanced_pawn_push(move))
@@ -1220,13 +1219,13 @@ moves_loop: // When in check and at SpNode search starts from here
 
           futilityValue = futilityBase + PieceValue[EG][pos.piece_on(to_sq(move))];
 
-          if (futilityValue < beta)
+          if (futilityValue <= alpha)
           {
               bestValue = std::max(bestValue, futilityValue);
               continue;
           }
 
-          if (futilityBase < beta && pos.see(move) <= VALUE_ZERO)
+          if (futilityBase <= alpha && pos.see(move) <= VALUE_ZERO)
           {
               bestValue = std::max(bestValue, futilityBase);
               continue;
@@ -1240,8 +1239,7 @@ moves_loop: // When in check and at SpNode search starts from here
                        && !pos.can_castle(pos.side_to_move());
 
       // Don't search moves with negative SEE values
-      if (   !PvNode
-          && (!InCheck || evasionPrunable)
+      if (  (!InCheck || evasionPrunable)
           &&  type_of(move) != PROMOTION
           &&  pos.see_sign(move) < VALUE_ZERO)
           continue;


### PR DESCRIPTION
**STC**

    LLR: 4.20 (-2.94,2.94) [-3.00,1.00]
    Total: 85573 W: 17195 L: 17125 D: 51253

**LTC**

    LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
    Total: 43385 W: 7298 L: 7214 D: 28873

bench 8852247