### PR TITLE
Simplify and optimize the eg_value() extractor.

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -273,11 +273,11 @@ inline Score make_score(int mg, int eg) {
 /// according to the standard a simple cast to short is implementation defined
 /// and so is a right shift of a signed integer.
 inline Value mg_value(Score s) {
-  return Value(((s + 0x8000) & ~0xFFFF) / 0x10000);
+  return Value(int16_t(uint16_t(unsigned(s + 0x8000) >> 16)));
 }
 
 inline Value eg_value(Score s) {
-  return Value(int16_t(uint16_t(uint32_t(s))));
+  return Value(int16_t(uint16_t(unsigned(s))));
 }
 
 #define ENABLE_BASE_OPERATORS_ON(T)                             \

--- a/src/types.h
+++ b/src/types.h
@@ -273,11 +273,13 @@ inline Score make_score(int mg, int eg) {
 /// according to the standard a simple cast to short is implementation defined
 /// and so is a right shift of a signed integer.
 inline Value mg_value(Score s) {
-  return Value(int16_t(uint16_t(unsigned(s + 0x8000) >> 16)));
+  const union us16 { uint16_t u; int16_t s; } mg = { uint16_t(unsigned(s + 0x8000) >> 16) };
+  return Value(mg.s);
 }
 
 inline Value eg_value(Score s) {
-  return Value(int16_t(uint16_t(unsigned(s))));
+  const union us16 { uint16_t u; int16_t s; } eg = { uint16_t(unsigned(s)) };
+  return Value(eg.s);
 }
 
 #define ENABLE_BASE_OPERATORS_ON(T)                             \

--- a/src/types.h
+++ b/src/types.h
@@ -277,7 +277,7 @@ inline Value mg_value(Score s) {
 }
 
 inline Value eg_value(Score s) {
-  return Value(int16_t(uint16_t(uint32_t(s) & 0xFFFFU)));
+  return Value(int16_t(uint16_t(uint32_t(s))));
 }
 
 #define ENABLE_BASE_OPERATORS_ON(T)                             \

--- a/src/types.h
+++ b/src/types.h
@@ -273,12 +273,12 @@ inline Score make_score(int mg, int eg) {
 /// according to the standard a simple cast to short is implementation defined
 /// and so is a right shift of a signed integer.
 inline Value mg_value(Score s) {
-  const union us16 { uint16_t u; int16_t s; } mg = { uint16_t(unsigned(s + 0x8000) >> 16) };
+  const union { uint16_t u; int16_t s; } mg = { uint16_t(unsigned(s + 0x8000) >> 16) };
   return Value(mg.s);
 }
 
 inline Value eg_value(Score s) {
-  const union us16 { uint16_t u; int16_t s; } eg = { uint16_t(unsigned(s)) };
+  const union { uint16_t u; int16_t s; } eg = { uint16_t(unsigned(s)) };
   return Value(eg.s);
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -277,7 +277,7 @@ inline Value mg_value(Score s) {
 }
 
 inline Value eg_value(Score s) {
-  return Value((int)(unsigned(s) & 0x7FFFU) - (int)(unsigned(s) & 0x8000U));
+  return Value(int16_t(uint16_t(uint32_t(s) & 0xFFFFU)));
 }
 
 #define ENABLE_BASE_OPERATORS_ON(T)                             \


### PR DESCRIPTION
Speedups vary depending on gcc version but never slower.

i7 mobile, Windows7-64

gcc 4.7.4
Results for 20 tests for each version:

            Base      Test      Diff
    Mean    1145602   1145932   -330
    StDev   26686     24296     4889

p-value: 0.527

gcc 4.8.2
Results for 20 tests for each version:

            Base      Test      Diff
    Mean    1118372   1136727   -18355
    StDev   11992     14562     3831

p-value: 1

gcc 4.9.2
Results for 20 tests for each version:

            Base      Test      Diff
    Mean    1089072   1091734   -2662
    StDev   11955     12205     2827

p-value: 0.827

No functional change.