### PR TITLE
Fix a possible overflow in TT resize

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -32,9 +32,9 @@ TranspositionTable TT; // Our global transposition table
 
 void TranspositionTable::resize(size_t mbSize) {
 
-  assert(sizeof(TTCluster) == CacheLineSize / 2);
+  assert(sizeof(Cluster) == CacheLineSize / 2);
 
-  size_t newClusterCount = size_t(1) << msb((mbSize * 1024 * 1024) / sizeof(TTCluster));
+  size_t newClusterCount = size_t(1) << msb((mbSize * 1024 * 1024) / sizeof(Cluster));
 
   if (newClusterCount == clusterCount)
       return;
@@ -42,7 +42,7 @@ void TranspositionTable::resize(size_t mbSize) {
   clusterCount = newClusterCount;
 
   free(mem);
-  mem = calloc(clusterCount * sizeof(TTCluster) + CacheLineSize - 1, 1);
+  mem = calloc(clusterCount * sizeof(Cluster) + CacheLineSize - 1, 1);
 
   if (!mem)
   {
@@ -51,7 +51,7 @@ void TranspositionTable::resize(size_t mbSize) {
       exit(EXIT_FAILURE);
   }
 
-  table = (TTCluster*)((uintptr_t(mem) + CacheLineSize - 1) & ~(CacheLineSize - 1));
+  table = (Cluster*)((uintptr_t(mem) + CacheLineSize - 1) & ~(CacheLineSize - 1));
 }
 
 
@@ -61,7 +61,7 @@ void TranspositionTable::resize(size_t mbSize) {
 
 void TranspositionTable::clear() {
 
-  std::memset(table, 0, clusterCount * sizeof(TTCluster));
+  std::memset(table, 0, clusterCount * sizeof(Cluster));
 }
 
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -76,7 +76,7 @@ class TranspositionTable {
   static const int CacheLineSize = 64;
   static const int TTClusterSize = 3;
 
-  struct TTCluster {
+  struct Cluster {
     TTEntry entry[TTClusterSize];
     char padding[2]; // Align to the cache line size
   };
@@ -96,7 +96,7 @@ public:
 
 private:
   size_t clusterCount;
-  TTCluster* table;
+  Cluster* table;
   void* mem;
   uint8_t generation8; // Size must be not bigger than TTEntry::genBound8
 };

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -54,11 +54,13 @@ bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const 
 
 void init(OptionsMap& o) {
 
+  const int MaxHashMB = Is64Bit ? 1024 * 1024 : 2048;
+
   o["Write Debug Log"]       << Option(false, on_logger);
   o["Contempt"]              << Option(0, -100, 100);
   o["Min Split Depth"]       << Option(0, 0, 12, on_threads);
   o["Threads"]               << Option(1, 1, MAX_THREADS, on_threads);
-  o["Hash"]                  << Option(16, 1, 1024 * 1024, on_hash_size);
+  o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(true);
   o["MultiPV"]               << Option(1, 1, 500);


### PR DESCRIPTION
On platforms where size_t is 32 bit, we
can have an overflow in this expression:

(mbSize * 1024 * 1024)

Fix it explicitly defining mbSize as 64bit.

Also set correct max hash size for platforms
where size_t is 32 bit.

A small rename while there: now struct Cluster
is definied inside class TranspositionTable so
we should drop the redundant TT prefix.

No functional change.