### PR TITLE
Don't print fail-high or fail-lows in MultiPV mode

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -365,7 +365,8 @@ namespace {
 
                 // When failing high/low give some update (without cluttering
                 // the UI) before a re-search.
-                if (  (bestValue <= alpha || bestValue >= beta)
+                if (   multiPV == 1
+                    && (bestValue <= alpha || bestValue >= beta)
                     && Time::now() - SearchTime > 3000)
                     sync_cout << uci_pv(pos, depth, alpha, beta) << sync_endl;
 


### PR DESCRIPTION
Supposed to give a better user experience when using MultiPV mode

No functional change