### PR TITLE
Try hard to retrieve a ponder move

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -60,6 +60,7 @@ struct RootMove {
   bool operator<(const RootMove& m) const { return score > m.score; } // Ascending sort
   bool operator==(const Move& m) const { return pv[0] == m; }
   void insert_pv_in_tt(Position& pos);
+  Move extract_ponder_from_tt(Position& pos);
 
   Value score;
   Value previousScore;


### PR DESCRIPTION
In case we stop the search during a fail-high
it is possible we return to GUI without a ponder
move. This patch try harder to find a ponder move
retrieving it from TT. This is important in games
played with 'ponder on'.

bench: 8080602