### PR TITLE
Don't use _pext_u64() directly

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -275,7 +275,7 @@ namespace {
             reference[size] = sliding_attack(deltas, s, b);
 
             if (HasPext)
-                attacks[s][_pext_u64(b, masks[s])] = reference[size];
+                attacks[s][pext(b, masks[s])] = reference[size];
 
             size++;
             b = (b - masks[s]) & masks[s];

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -238,7 +238,7 @@ FORCE_INLINE unsigned magic_index(Square s, Bitboard occupied) {
   unsigned* const Shifts = Pt == ROOK ? RookShifts : BishopShifts;
 
   if (HasPext)
-      return unsigned(_pext_u64(occupied, Masks[s]));
+      return unsigned(pext(occupied, Masks[s]));
 
   if (Is64Bit)
       return unsigned(((occupied & Masks[s]) * Magics[s]) >> Shifts[s]);

--- a/src/types.h
+++ b/src/types.h
@@ -65,8 +65,9 @@
 
 #if defined(USE_PEXT)
 #  include <immintrin.h> // Header for _pext_u64() intrinsic
+#  define pext(b, m) _pext_u64(b, m)
 #else
-#  define _pext_u64(b, m) (0)
+#  define pext(b, m) (0)
 #endif
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Backported from C++11 branch.

See also this one:
https://github.com/official-stockfish/Stockfish/commit/f54c44e6be0deaadefcb428af8d288e75955aa20#commitcomment-9373566