### PR TITLE
Profile build options

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -452,11 +452,8 @@ gcc-profile-make:
 	all
 
 gcc-profile-use:
-# Deleting corrupt ucioption.gc* profile files is necessary to avoid an 
-# "internal compiler error" for gcc versions 4.7.x
-	@rm -f ucioption.gc*
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-use' \
+	EXTRACXXFLAGS='-fprofile-use -fno-peel-loops -fno-tracer' \
 	EXTRALDFLAGS='-lgcov' \
 	all
 


### PR DESCRIPTION
I went through all the individual compile options that differ between
-fprofile-generate/-fprofile-use  and  -fprofile-arcs/-fbranch-probabilities
and distilled the speed difference down to only turning off
-fno-peel-loops and -fno-tracer.  Using this we still get the full speedup
(maybe a bit more because other optimizations stay on) and it's also much cleaner
because we can get rid of the "@rm -f ucioption.gc*" hack for all versions of gcc.

Unfortunately, I don't know the exact Mac OSX problem referred to in
https://github.com/official-stockfish/Stockfish/pull/219
so I would like to ask someone with OSX to please test this patch
first before it can be considered for approval.
(Other related pull request was https://github.com/official-stockfish/Stockfish/pull/160 )


gcc492: 2.7%
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    1165550   1197407   -31857    
    StDev   16699     17016     2203      

p-value: 1


gcc482: 2.0%
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    1167248   1191230   -23982    
    StDev   155164    155898    2839      

p-value: 1


gcc474: 0.7%
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    1240153   1249024   -8871     
    StDev   19558     18655     3103      

p-value: 0.998

