### PR TITLE
Fix a MSVC warning at W4

### DIFF
--- a/src/endgame.h
+++ b/src/endgame.h
@@ -89,7 +89,7 @@ struct Endgame : public EndgameBase<T> {
   T operator()(const Position&) const;
 
 private:
-  const Color strongSide, weakSide;
+  Color strongSide, weakSide;
 };
 
 


### PR DESCRIPTION
Warning is C4512 (assignment operator could not be generated)

Now, apart the foreign syzygy code, everything compiles
without warnings at warning level 4.

Backported from C++11 branch.

No functional change.