### PR TITLE
Fix skill level

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -831,7 +831,8 @@ moves_loop: // When in check and at SpNode search starts from here
       newDepth = depth - ONE_PLY + extension;
 
       // Step 13. Pruning at shallow depth
-      if (   !captureOrPromotion
+      if (   !RootNode
+          && !captureOrPromotion
           && !inCheck
           && !dangerous
           &&  bestValue > VALUE_MATED_IN_MAX_PLY)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,6 +84,7 @@ namespace {
   }
 
   size_t PVIdx;
+  size_t multiPV;
   TimeManager TimeMgr;
   double BestMoveChanges;
   Value DrawValue[COLOR_NB];
@@ -308,7 +309,7 @@ namespace {
     Countermoves.clear();
     Followupmoves.clear();
 
-    size_t multiPV = Options["MultiPV"];
+    multiPV = Options["MultiPV"];
     Skill skill(Options["Skill Level"], RootMoves.size());
 
     // Do we have to play with skill handicap? In this case enable MultiPV search
@@ -831,7 +832,7 @@ moves_loop: // When in check and at SpNode search starts from here
       newDepth = depth - ONE_PLY + extension;
 
       // Step 13. Pruning at shallow depth
-      if (   !RootNode
+      if (  (!RootNode || multiPV == 1) // Don't prune at root while in multipv mode
           && !captureOrPromotion
           && !inCheck
           && !dangerous


### PR DESCRIPTION
Disable pruning in root if MultiPV > 1.
This patch fixes the significant strength drop in comparison to Stockfish 5 while using low skill levels.

STC with Skill Level=1
ELO: 534.29 +-11.7 (95%) LOS: 100.0%
Total: 20000 W: 19098 L: 863 D: 39

Bench: 8080602

No functional change for MultiPV = 1