### PR TITLE
Simplify skill level and reduce ELO

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1393,10 +1393,6 @@ moves_loop: // When in check and at SpNode search starts from here
     {
         int score = RootMoves[i].score;
 
-        // Don't allow crazy blunders even at very low skills
-        if (i > 0 && RootMoves[i - 1].score > score + 2 * PawnValueMg)
-            break;
-
         // This is our magic formula
         score += (  weakness * int(RootMoves[0].score - score)
                   + variance * (rng.rand<unsigned>() % weakness)) / 128;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -106,7 +106,7 @@ namespace {
 
   struct Skill {
     Skill(int l, size_t rootSize) : level(l),
-                                    candidates(l < 40 ? std::min(4, (int)rootSize) : 0),
+                                    candidates(l < 20 ? std::min(4, (int)rootSize) : 0),
                                     best(MOVE_NONE) {}
    ~Skill() {
       if (candidates) // Swap best PV line with the sub-optimal one
@@ -115,7 +115,7 @@ namespace {
     }
 
     size_t candidates_size() const { return candidates; }
-    bool time_to_pick(Depth depth) const { return depth / ONE_PLY == 1 + level / 2; }
+    bool time_to_pick(Depth depth) const { return depth / ONE_PLY == 1 + level; }
     Move pick_move();
 
     int level;
@@ -1382,7 +1382,7 @@ moves_loop: // When in check and at SpNode search starts from here
 
     // RootMoves are already sorted by score in descending order
     int variance = std::min(RootMoves[0].score - RootMoves[candidates - 1].score, PawnValueMg);
-    int weakness = 120 - level;
+    int weakness = 120 - 2 * level;
     int maxScore = -VALUE_INFINITE;
     best = MOVE_NONE;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -106,7 +106,7 @@ namespace {
 
   struct Skill {
     Skill(int l, size_t rootSize) : level(l),
-                                    candidates(l < 20 ? std::min(4, (int)rootSize) : 0),
+                                    candidates(l < 40 ? std::min(4, (int)rootSize) : 0),
                                     best(MOVE_NONE) {}
    ~Skill() {
       if (candidates) // Swap best PV line with the sub-optimal one
@@ -115,7 +115,7 @@ namespace {
     }
 
     size_t candidates_size() const { return candidates; }
-    bool time_to_pick(Depth depth) const { return depth / ONE_PLY == 1 + level; }
+    bool time_to_pick(Depth depth) const { return depth / ONE_PLY == 1 + level / 2; }
     Move pick_move();
 
     int level;
@@ -1382,7 +1382,7 @@ moves_loop: // When in check and at SpNode search starts from here
 
     // RootMoves are already sorted by score in descending order
     int variance = std::min(RootMoves[0].score - RootMoves[candidates - 1].score, PawnValueMg);
-    int weakness = 120 - 2 * level;
+    int weakness = 120 - level;
     int maxScore = -VALUE_INFINITE;
     best = MOVE_NONE;
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -64,7 +64,7 @@ void init(OptionsMap& o) {
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(true);
   o["MultiPV"]               << Option(1, 1, 500);
-  o["Skill Level"]           << Option(40, 0, 40);
+  o["Skill Level"]           << Option(20, 0, 20);
   o["Move Overhead"]         << Option(30, 0, 5000);
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
   o["Slow Mover"]            << Option(80, 10, 1000);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -64,7 +64,7 @@ void init(OptionsMap& o) {
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(true);
   o["MultiPV"]               << Option(1, 1, 500);
-  o["Skill Level"]           << Option(20, 0, 20);
+  o["Skill Level"]           << Option(40, 0, 40);
   o["Move Overhead"]         << Option(30, 0, 5000);
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
   o["Slow Mover"]            << Option(80, 10, 1000);


### PR DESCRIPTION
This patch has two positive effects:

- Retire a hackish formula and leave
  just a natural, simple and plain one.

- Reduce strenght at very low level, but
  don't impact medium/high levels.

Actually even at level 0, SF is still too
strong for many beginners (this was reported
many times for instance on Droidfish user
comments on Google Play).

Test on fishtest shows that ELO drop is around
170 ELO at level 0 (good!), 130 ELO at level 1
and smoothly reduces (as expected) until level
10 where the drop is just of 8 ELO.

No functional change.