### PR TITLE
Ressurrect hashfull patch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1447,8 +1447,12 @@ moves_loop: // When in check and at SpNode search starts from here
               ss << (v >= beta ? " lowerbound" : v <= alpha ? " upperbound" : "");
 
         ss << " nodes "     << pos.nodes_searched()
-           << " nps "       << pos.nodes_searched() * 1000 / elapsed
-           << " tbhits "    << TB::Hits
+           << " nps "       << pos.nodes_searched() * 1000 / elapsed;
+
+        if (elapsed > 1000) // Earlier makes little sense
+           ss << " hashfull "  << TT.hashfull();
+
+        ss << " tbhits "    << TB::Hits
            << " time "      << elapsed
            << " pv";
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -96,3 +96,20 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 
   return found = false, replace;
 }
+
+
+/// Returns an approximation of the hashtable occupation during a search. The
+/// hash is x permill full, as per UCI protocol.
+
+int TranspositionTable::hashfull() const
+{
+  int cnt = 0;
+  for (int i = 0; i < 1000 / ClusterSize; i++)
+  {
+      const TTEntry* tte = &table[i].entry[0];
+      for (int j = 0; j < ClusterSize; j++)
+          if ((tte[j].genBound8 & 0xFC) == generation8)
+              cnt++;
+  }
+  return cnt;
+}

--- a/src/tt.h
+++ b/src/tt.h
@@ -86,6 +86,7 @@ public:
   void new_search() { generation8 += 4; } // Lower 2 bits are used by Bound
   uint8_t generation() const { return generation8; }
   TTEntry* probe(const Key key, bool& found) const;
+  int hashfull() const;
   void resize(size_t mbSize);
   void clear();
 


### PR DESCRIPTION
This is an old patch from Jean-Francois Romang to send
UCI hashfull info to the GUI:
https://github.com/mcostalba/Stockfish/pull/60/files

It was wrongly judged as a slowdown, but it takes much
less than 1 ms to run, indeed on my core i5 2.6Ghz it
takes about 2 microsecs to run!

Regression test is good:

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 7352 W: 1548 L: 1401 D: 4403

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 61432 W: 10307 L: 10251 D: 40874

I have set the name of the author to the original
one.

No functional change.