### PR TITLE
TTRefresh

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -80,8 +80,7 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   for (int i = 0; i < ClusterSize; ++i)
       if (!tte[i].key16 || tte[i].key16 == key16)
       {
-          if (tte[i].key16)
-              tte[i].genBound8 = uint8_t(generation8 | tte[i].bound()); // Refresh
+          tte[i].genBound8 = uint8_t(generation8 | tte[i].bound()); // Refresh
 
           return found = (bool)tte[i].key16, &tte[i];
       }


### PR DESCRIPTION
It makes no functional difference whether we refresh the generation of an empty entry.
We can therefore simplify away the useless condition guarding against it.
No functional change.

The bench results are just to verify there is no speed
regression.

Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    995675    995895    -220      
    StDev   158210    156793    4512      

p-value: 0.519
