### PR TITLE
Detempletize Material

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -65,45 +65,45 @@ namespace {
   Endgame<KPKP>   ScaleKPKP[]   = { Endgame<KPKP>(WHITE),   Endgame<KPKP>(BLACK) };
 
   // Helper used to detect a given material distribution
-  bool is_KXK(const Position& pos, Color Us) {
-    return  !more_than_one(pos.pieces(~Us))
-          && pos.non_pawn_material(Us) >= RookValueMg;
+  bool is_KXK(const Position& pos, Color us) {
+    return  !more_than_one(pos.pieces(~us))
+          && pos.non_pawn_material(us) >= RookValueMg;
   }
 
-  bool is_KBPsKs(const Position& pos, Color Us) {
-    return   pos.non_pawn_material(Us) == BishopValueMg
-          && pos.count<BISHOP>(Us) == 1
-          && pos.count<PAWN  >(Us) >= 1;
+  bool is_KBPsKs(const Position& pos, Color us) {
+    return   pos.non_pawn_material(us) == BishopValueMg
+          && pos.count<BISHOP>(us) == 1
+          && pos.count<PAWN  >(us) >= 1;
   }
 
-  bool is_KQKRPs(const Position& pos, Color Us) {
-    return  !pos.count<PAWN>(Us)
-          && pos.non_pawn_material(Us) == QueenValueMg
-          && pos.count<QUEEN>(Us)  == 1
-          && pos.count<ROOK>(~Us) == 1
-          && pos.count<PAWN>(~Us) >= 1;
+  bool is_KQKRPs(const Position& pos, Color us) {
+    return  !pos.count<PAWN>(us)
+          && pos.non_pawn_material(us) == QueenValueMg
+          && pos.count<QUEEN>(us)  == 1
+          && pos.count<ROOK>(~us) == 1
+          && pos.count<PAWN>(~us) >= 1;
   }
 
   /// imbalance() calculates the imbalance by comparing the piece count of each
   /// piece type for both colors.
 
-  int imbalance(Color Us, const int pieceCount[][PIECE_TYPE_NB]) {
+  int imbalance(Color us, const int pieceCount[][PIECE_TYPE_NB]) {
 
     int bonus = 0;
 
     // Second-degree polynomial material imbalance by Tord Romstad
     for (int pt1 = NO_PIECE_TYPE; pt1 <= QUEEN; ++pt1)
     {
-        if (!pieceCount[Us][pt1])
+        if (!pieceCount[us][pt1])
             continue;
 
         int v = Linear[pt1];
 
         for (int pt2 = NO_PIECE_TYPE; pt2 <= pt1; ++pt2)
-            v +=  QuadraticOurs[pt1][pt2] * pieceCount[Us][pt2]
-                + QuadraticTheirs[pt1][pt2] * pieceCount[~Us][pt2];
+            v +=  QuadraticOurs[pt1][pt2] * pieceCount[us][pt2]
+                + QuadraticTheirs[pt1][pt2] * pieceCount[~us][pt2];
 
-        bonus += pieceCount[Us][pt1] * v;
+        bonus += pieceCount[us][pt1] * v;
     }
 
     return bonus;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -87,11 +87,9 @@ namespace {
   /// imbalance() calculates the imbalance by comparing the piece count of each
   /// piece type for both colors.
 
-  template<Color Us>
-  int imbalance(const int pieceCount[][PIECE_TYPE_NB]) {
+  int imbalance(Color Us, const int pieceCount[][PIECE_TYPE_NB]) {
 
-    const Color Them = (Us == WHITE ? BLACK : WHITE);
-
+    const Color Them = ~Us;
     int bonus = 0;
 
     // Second-degree polynomial material imbalance by Tord Romstad
@@ -221,7 +219,7 @@ Entry* probe(const Position& pos) {
   { pos.count<BISHOP>(BLACK) > 1, pos.count<PAWN>(BLACK), pos.count<KNIGHT>(BLACK),
     pos.count<BISHOP>(BLACK)    , pos.count<ROOK>(BLACK), pos.count<QUEEN >(BLACK) } };
 
-  e->value = int16_t((imbalance<WHITE>(PieceCount) - imbalance<BLACK>(PieceCount)) / 16);
+  e->value = int16_t((imbalance(WHITE, PieceCount) - imbalance(BLACK, PieceCount)) / 16);
   return e;
 }
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -66,8 +66,7 @@ namespace {
 
   // Helper templates used to detect a given material distribution
   bool is_KXK(const Position& pos, Color Us) {
-    const Color Them = ~Us;
-    return  !more_than_one(pos.pieces(Them))
+    return  !more_than_one(pos.pieces(~Us))
           && pos.non_pawn_material(Us) >= RookValueMg;
   }
 
@@ -78,12 +77,11 @@ namespace {
   }
 
   bool is_KQKRPs(const Position& pos, Color Us) {
-    const Color Them = ~Us;
     return  !pos.count<PAWN>(Us)
           && pos.non_pawn_material(Us) == QueenValueMg
           && pos.count<QUEEN>(Us)  == 1
-          && pos.count<ROOK>(Them) == 1
-          && pos.count<PAWN>(Them) >= 1;
+          && pos.count<ROOK>(~Us) == 1
+          && pos.count<PAWN>(~Us) >= 1;
   }
 
   /// imbalance() calculates the imbalance by comparing the piece count of each

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -64,7 +64,7 @@ namespace {
   Endgame<KPsK>   ScaleKPsK[]   = { Endgame<KPsK>(WHITE),   Endgame<KPsK>(BLACK) };
   Endgame<KPKP>   ScaleKPKP[]   = { Endgame<KPKP>(WHITE),   Endgame<KPKP>(BLACK) };
 
-  // Helper templates used to detect a given material distribution
+  // Helper used to detect a given material distribution
   bool is_KXK(const Position& pos, Color Us) {
     return  !more_than_one(pos.pieces(~Us))
           && pos.non_pawn_material(Us) >= RookValueMg;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -89,7 +89,6 @@ namespace {
 
   int imbalance(Color Us, const int pieceCount[][PIECE_TYPE_NB]) {
 
-    const Color Them = ~Us;
     int bonus = 0;
 
     // Second-degree polynomial material imbalance by Tord Romstad
@@ -102,7 +101,7 @@ namespace {
 
         for (int pt2 = NO_PIECE_TYPE; pt2 <= pt1; ++pt2)
             v +=  QuadraticOurs[pt1][pt2] * pieceCount[Us][pt2]
-                + QuadraticTheirs[pt1][pt2] * pieceCount[Them][pt2];
+                + QuadraticTheirs[pt1][pt2] * pieceCount[~Us][pt2];
 
         bonus += pieceCount[Us][pt1] * v;
     }


### PR DESCRIPTION
Removes useless templates, some of which lead to code duplication (`is_K*()`).

This is even a **speedup** on my machine (i7-3770k, lunix, gcc 4.9.1):

    stat        test     master    diff
    mean   2,360,796  2,348,259  12,537
    stdev      9,692      9,194   3,576

    speedup        0.53%
    P(speedup>0)  100.0%

No functional change.