### PR TITLE
Rename dbg_hit_on_c() to dbg_hit_on()

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -559,7 +559,7 @@ namespace {
        &  pos.pieces(Them)
        & ~ei.attackedBy[Us][PAWN];
 
-    if(b)
+    if (b)
         score += popcount<Max15>(b) * PawnAttackThreat;
 
     if (Trace)

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -126,7 +126,7 @@ const string engine_info(bool to_uci) {
 /// Debug functions used mainly to collect run-time statistics
 
 void dbg_hit_on(bool b) { ++hits[0]; if (b) ++hits[1]; }
-void dbg_hit_on_c(bool c, bool b) { if (c) dbg_hit_on(b); }
+void dbg_hit_on(bool c, bool b) { if (c) dbg_hit_on(b); }
 void dbg_mean_of(int v) { ++means[0]; means[1] += v; }
 
 void dbg_print() {

--- a/src/misc.h
+++ b/src/misc.h
@@ -33,7 +33,7 @@ void prefetch(char* addr);
 void start_logger(bool b);
 
 void dbg_hit_on(bool b);
-void dbg_hit_on_c(bool c, bool b);
+void dbg_hit_on(bool c, bool b);
 void dbg_mean_of(int v);
 void dbg_print();
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -47,7 +47,7 @@ namespace Zobrist {
   Key exclusion;
 }
 
-Key Position::exclusion_key() const { return st->key ^ Zobrist::exclusion;}
+Key Position::exclusion_key() const { return st->key ^ Zobrist::exclusion; }
 
 namespace {
 
@@ -1060,8 +1060,8 @@ Value Position::see(Move m) const {
   stm = color_of(piece_on(from));
   occupied = pieces() ^ from;
 
-  // Castling moves are implemented as king capturing the rook so cannot be
-  // handled correctly. Simply return 0 that is always the correct value
+  // Castling moves are implemented as king capturing the rook so cannot
+  // be handled correctly. Simply return VALUE_ZERO that is always correct
   // unless in the rare case the rook ends up under attack.
   if (type_of(m) == CASTLING)
       return VALUE_ZERO;


### PR DESCRIPTION
Use an overload instead of a new named function.

I have found this handier and easier when adding
some quick debug code.

No functional change.

Ported from C++11 branch
