### PR TITLE
PawnSpeedUpV1

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -218,7 +218,7 @@ namespace {
     ei.pinnedPieces[Us] = pos.pinned_pieces(Us);
 
     Bitboard b = ei.attackedBy[Them][KING] = pos.attacks_from<KING>(pos.king_square(Them));
-    ei.attackedBy[Us][ALL_PIECES] = ei.attackedBy[Us][PAWN] = ei.pi->pawn_attacks(Us);
+    ei.attackedBy[Us][PAWN] = ei.pi->pawn_attacks(Us);
 
     // Init king safety tables only if we are going to use them
     if (pos.non_pawn_material(Us) >= QueenValueMg)
@@ -314,7 +314,7 @@ namespace {
         if (Pt == BISHOP || Pt == KNIGHT)
         {
             // Bonus for outpost square
-            if (!(pos.pieces(Them, PAWN) & pawn_attack_span(Us, s)))
+            if (!(ei.pi->pawns(Them) & pawn_attack_span(Us, s)))
                 score += evaluate_outpost<Pt, Us>(pos, ei, s);
 
             // Bonus when behind a pawn
@@ -346,7 +346,7 @@ namespace {
             // Bonus for aligning with enemy pawns on the same rank/file
             if (relative_rank(Us, s) >= RANK_5)
             {
-                Bitboard alignedPawns = pos.pieces(Them, PAWN) & PseudoAttacks[ROOK][s];
+                Bitboard alignedPawns = ei.pi->pawns(Them) & PseudoAttacks[ROOK][s];
                 if (alignedPawns)
                     score += popcount<Max15>(alignedPawns) * RookOnPawn;
             }
@@ -501,7 +501,7 @@ namespace {
     Score score = SCORE_ZERO;
 
     // Non-pawn enemies defended by a pawn
-    defended =  (pos.pieces(Them) ^ pos.pieces(Them, PAWN))
+    defended =  (pos.pieces(Them) ^ ei.pi->pawns(Them))
               &  ei.attackedBy[Them][PAWN];
 
     // Add a bonus according to the kind of attacking pieces
@@ -647,12 +647,12 @@ namespace {
     // SpaceMask[]. A square is unsafe if it is attacked by an enemy
     // pawn, or if it is undefended and attacked by an enemy piece.
     Bitboard safe =   SpaceMask[Us]
-                   & ~pos.pieces(Us, PAWN)
+                   & ~ei.pi->pawns(Us)
                    & ~ei.attackedBy[Them][PAWN]
                    & (ei.attackedBy[Us][ALL_PIECES] | ~ei.attackedBy[Them][ALL_PIECES]);
 
     // Find all squares which are at most three squares behind some friendly pawn
-    Bitboard behind = pos.pieces(Us, PAWN);
+    Bitboard behind = ei.pi->pawns(Us);
     behind |= (Us == WHITE ? behind >>  8 : behind <<  8);
     behind |= (Us == WHITE ? behind >> 16 : behind << 16);
 
@@ -700,8 +700,8 @@ namespace {
     init_eval_info<WHITE>(pos, ei);
     init_eval_info<BLACK>(pos, ei);
 
-    ei.attackedBy[WHITE][ALL_PIECES] |= ei.attackedBy[WHITE][KING];
-    ei.attackedBy[BLACK][ALL_PIECES] |= ei.attackedBy[BLACK][KING];
+    ei.attackedBy[WHITE][ALL_PIECES] = ei.attackedBy[WHITE][KING] | ei.attackedBy[WHITE][PAWN];
+    ei.attackedBy[BLACK][ALL_PIECES] = ei.attackedBy[BLACK][KING] | ei.attackedBy[BLACK][PAWN];
 
     // Do not include in mobility squares protected by enemy pawns or occupied by our pawns or king
     Bitboard mobilityArea[] = { ~(ei.attackedBy[BLACK][PAWN] | pos.pieces(WHITE, PAWN, KING)),

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -109,7 +109,8 @@ namespace {
     const Square* pl = pos.list<PAWN>(Us);
     const Bitboard* pawnAttacksBB = StepAttacksBB[make_piece(Us, PAWN)];
 
-    Bitboard ourPawns   = pos.pieces(Us  , PAWN);
+    Bitboard ourPawns   = e->pawnsAr[Us] 
+                        = pos.pieces(Us  , PAWN);
     Bitboard theirPawns = pos.pieces(Them, PAWN);
 
     e->passedPawns[Us] = 0;
@@ -284,11 +285,11 @@ Score Entry::do_king_safety(const Position& pos, Square ksq) {
 
   kingSquares[Us] = ksq;
   castlingRights[Us] = pos.can_castle(Us);
-  minKingPawnDistance[Us] = 0;
 
-  Bitboard pawns = pos.pieces(Us, PAWN);
-  if (pawns)
-      while (!(DistanceRingBB[ksq][minKingPawnDistance[Us]++] & pawns)) {}
+  minKingPawnDistance[Us] = 0;
+  Bitboard b = pawnsAr[Us];
+  if (b)
+      while (!(DistanceRingBB[ksq][minKingPawnDistance[Us]++] & b)) {}
 
   if (relative_rank(Us, ksq) > RANK_4)
       return make_score(0, -16 * minKingPawnDistance[Us]);

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -35,6 +35,7 @@ struct Entry {
   Score pawns_score() const { return score; }
   Bitboard pawn_attacks(Color c) const { return pawnAttacks[c]; }
   Bitboard passed_pawns(Color c) const { return passedPawns[c]; }
+  Bitboard pawns(Color c) const { return pawnsAr[c]; }
   int pawn_span(Color c) const { return pawnSpan[c]; }
 
   int semiopen_file(Color c, File f) const {
@@ -64,6 +65,7 @@ struct Entry {
   Key key;
   Score score;
   Bitboard passedPawns[COLOR_NB];
+  Bitboard pawnsAr[COLOR_NB];
   Bitboard pawnAttacks[COLOR_NB];
   Square kingSquares[COLOR_NB];
   Score kingSafety[COLOR_NB];


### PR DESCRIPTION
tests were done on RC3.

It is faster to use a call to ei->pi.pawns(Us) then making a call to
pos.pieces(Us, PAWN)

Also small tweak when initializing ei.attackedby[Us][ALL_PIECES]

Note: in latest master, please also replace
b = pos.pieces(Us, PAWN) & ~TRank7BB;
with
b = ei.pi->pawns(Us) & ~TRank7BB;

compiled with mingcc 4.7 on Windows 7 64 bit.
Results for 10 tests for each version:

RC3            Test            Diff
Mean    1233409   1247903   -14494
StDev       17594       16397       2295

p-value: 1
speedup: 0.012