### PR TITLE
All safe pawn pushes

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -163,6 +163,7 @@ namespace {
   const Score Unstoppable        = S( 0, 20);
   const Score Hanging            = S(31, 26);
   const Score PawnAttackThreat   = S(20, 20);
+  const Score PawnSafePush       = S( 5 , 5);
 
   // Penalty for a bishop on a1/h1 (a8/h8 for black) which is trapped by
   // a friendly pawn on b2/g2 (b7/g7 for black). This can obviously only
@@ -547,14 +548,18 @@ namespace {
             score += more_than_one(b) ? KingOnMany : KingOnOne;
     }
 
-    // Add bonus for safe pawn pushes which attacks an enemy piece
+    // Add a small bonus for safe pawn pushes
     b = pos.pieces(Us, PAWN) & ~TRank7BB;
     b = shift_bb<Up>(b | (shift_bb<Up>(b & TRank2BB) & ~pos.pieces()));
 
     b &=  ~pos.pieces()
         & ~ei.attackedBy[Them][PAWN]
-        & (ei.attackedBy[Us][PAWN] | ~ei.attackedBy[Them][ALL_PIECES]);
+        & (ei.attackedBy[Us][ALL_PIECES] | ~ei.attackedBy[Them][ALL_PIECES]);
+    
+    if (b)
+        score += popcount<Max15>(b) * PawnSafePush;
 
+    // Add another bonus if the pawn push attacks an enemy piece
     b =  (shift_bb<Left>(b) | shift_bb<Right>(b))
        &  pos.pieces(Them)
        & ~ei.attackedBy[Us][PAWN];

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -557,7 +557,7 @@ namespace {
         & (ei.attackedBy[Us][ALL_PIECES] | ~ei.attackedBy[Them][ALL_PIECES]);
     
     if (b)
-        score += popcount<Max15>(b) * PawnSafePush;
+        score += popcount<Full>(b) * PawnSafePush;
 
     // Add another bonus if the pawn push attacks an enemy piece
     b =  (shift_bb<Left>(b) | shift_bb<Right>(b))


### PR DESCRIPTION
Pawn flexibility: add a small bonus for all safe pawn pushes

STC:
LLR: 2.70 (-2.94,2.94) [-1.50,4.50]
Total: 18233 W: 3705 L: 3557 D: 10971

LTC:
LLR: 2.97 (-2.94,2.94) [0.00,6.00]
Total: 17684 W: 3042 L: 2854 D: 11788

Bench: 7369224