### PR TITLE
apply_weight() optimization

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -91,7 +91,7 @@ namespace {
   // Evaluation weights, indexed by evaluation term
   enum { Mobility, PawnStructure, PassedPawns, Space, KingSafety };
   const struct Weight { int mg, eg; } Weights[] = {
-    {289, 344}, {233, 201}, {221, 273}, {46, 0}, {322, 0}
+      {73984, 88064}, {59648, 51456}, {56576, 69888}, {11776, 0}, {82432, 0}
   };
 
   #define V(v) Value(v)
@@ -203,7 +203,7 @@ namespace {
 
   // apply_weight() weighs score 's' by weight 'w' trying to prevent overflow
   Score apply_weight(Score s, const Weight& w) {
-    return make_score(mg_value(s) * w.mg / 256, eg_value(s) * w.eg / 256);
+    return make_score(mg_value(s) * w.mg / 65536, eg_value(s) * w.eg / 65536);
   }
 
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -91,7 +91,7 @@ namespace {
   // Evaluation weights, indexed by evaluation term
   enum { Mobility, PawnStructure, PassedPawns, Space, KingSafety };
   const struct Weight { int mg, eg; } Weights[] = {
-      {73984, 88064}, {59648, 51456}, {56576, 69888}, {11776, 0}, {82432, 0}
+    {73984, 88064}, {59648, 51456}, {56576, 69888}, {11776, 0}, {82432, 0}
   };
 
   #define V(v) Value(v)


### PR DESCRIPTION
No functional change.
This is 0.5% faster with gcc 4.9.2 and about the same with gcc 4.8.2 and 4.7.4
I suspect the speedup is because when dividing a 32bit value by 256 the result comes from the 
high 24 bits which is not an integral type but when dividing by 65536 the result is the 
high 16 bits which is an integral type allowing the compiler to be more clever.
Could someone please bench and include which gcc version you used?

4.9.2  
0.5% faster
```
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    872314    877241    -4927     
    StDev   292757    294158    2125      

p-value: 0.99
```

4.8.2
same
```
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    933051    933140    -89       
    StDev   240657    240418    1688      

p-value: 0.521
```

4.7.4
0.1% faster
```
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    949005    950143    -1138     
    StDev   281440    282200    2323      

p-value: 0.688
```
