### PR TITLE
En passant bonus

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -61,6 +61,9 @@ namespace {
   // Unsupported pawn penalty
   const Score UnsupportedPawnPenalty = S(20, 10);
 
+  // En Passant bonus
+  const Score EnPassantBonus = S(7, 5);
+
   // Center bind bonus: Two pawns controlling the same central square
   const Bitboard CenterBindMask[COLOR_NB] = {
     (FileDBB | FileEBB) & (Rank5BB | Rank6BB | Rank7BB),
@@ -170,6 +173,13 @@ namespace {
             // If we have an enemy pawn in the same or next rank, the pawn is
             // backward because it cannot advance without being captured.
             backward = (b | shift_bb<Up>(b)) & theirPawns;
+        }
+
+        if (!backward && relative_rank(Us, s) == 4)
+        {
+            if (pawn_attack_span(Us, s + pawn_push(Us)) & theirPawns)
+                score += EnPassantBonus;
+
         }
 
         assert(opposed | passed | (pawn_attack_span(Us, s) & theirPawns));

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -112,10 +112,11 @@ namespace {
     const Square Up    = (Us == WHITE ? DELTA_N  : DELTA_S);
     const Square Right = (Us == WHITE ? DELTA_NE : DELTA_SW);
     const Square Left  = (Us == WHITE ? DELTA_NW : DELTA_SE);
+    const Bitboard TRank7BB = Rank2BB | Rank7BB;
 
     Bitboard b, p, doubled, connected;
     Square s;
-    bool passed, isolated, opposed, phalanx, backward, unsupported, lever;
+    bool passed, isolated, opposed, phalanx, backward, unsupported, lever, enpassant;
     Score score = SCORE_ZERO;
     const Square* pl = pos.list<PAWN>(Us);
     const Bitboard* pawnAttacksBB = StepAttacksBB[make_piece(Us, PAWN)];
@@ -153,6 +154,7 @@ namespace {
         opposed     =   theirPawns & forward_bb(Us, s);
         passed      = !(theirPawns & passed_pawn_mask(Us, s));
         lever       =   theirPawns & pawnAttacksBB[s];
+        enpassant   =   theirPawns & pawnAttacksBB[s + pawn_push(Us)] & TRank7BB;
 
         // Test for backward pawn.
         // If the pawn is passed, isolated, connected or a lever it cannot be
@@ -202,7 +204,7 @@ namespace {
         if (lever)
             score += Lever[relative_rank(Us, s)];
 
-        if (!backward && (relative_rank(Us, s) == RANK_5) && (pawn_attack_span(Us, s + pawn_push(Us)) & theirPawns))
+        if (enpassant && !backward)
             score += EnPassantBonus;
 
     }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -175,7 +175,7 @@ namespace {
             backward = (b | shift_bb<Up>(b)) & theirPawns;
         }
 
-        if (!backward && relative_rank(Us, s) == 4)
+        if (!backward && relative_rank(Us, s) == RANK_5)
         {
             if (pawn_attack_span(Us, s + pawn_push(Us)) & theirPawns)
                 score += EnPassantBonus;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -62,7 +62,7 @@ namespace {
   const Score UnsupportedPawnPenalty = S(20, 10);
 
   // En Passant bonus
-  const Score EnPassantBonus = S(7, 5);
+  const Score EnPassantBonus = S(15, 10);
 
   // Center bind bonus: Two pawns controlling the same central square
   const Bitboard CenterBindMask[COLOR_NB] = {

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -62,7 +62,7 @@ namespace {
   const Score UnsupportedPawnPenalty = S(20, 10);
 
   // En Passant bonus
-  const Score EnPassantBonus = S(15, 10);
+  const Score EnPassantBonus = S(11, 6);
 
   // Center bind bonus: Two pawns controlling the same central square
   const Bitboard CenterBindMask[COLOR_NB] = {

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -175,13 +175,6 @@ namespace {
             backward = (b | shift_bb<Up>(b)) & theirPawns;
         }
 
-        if (!backward && relative_rank(Us, s) == RANK_5)
-        {
-            if (pawn_attack_span(Us, s + pawn_push(Us)) & theirPawns)
-                score += EnPassantBonus;
-
-        }
-
         assert(opposed | passed | (pawn_attack_span(Us, s) & theirPawns));
 
         // Passed pawns will be properly scored in evaluation because we need
@@ -208,6 +201,10 @@ namespace {
 
         if (lever)
             score += Lever[relative_rank(Us, s)];
+
+        if (!backward && (relative_rank(Us, s) == RANK_5) && (pawn_attack_span(Us, s + pawn_push(Us)) & theirPawns))
+            score += EnPassantBonus;
+
     }
 
     b = e->semiopenFiles[Us] ^ 0xFF;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -112,7 +112,6 @@ namespace {
     const Square Up    = (Us == WHITE ? DELTA_N  : DELTA_S);
     const Square Right = (Us == WHITE ? DELTA_NE : DELTA_SW);
     const Square Left  = (Us == WHITE ? DELTA_NW : DELTA_SE);
-    const Bitboard TRank7BB = Rank2BB | Rank7BB;
 
     Bitboard b, p, doubled, connected;
     Square s;
@@ -154,7 +153,7 @@ namespace {
         opposed     =   theirPawns & forward_bb(Us, s);
         passed      = !(theirPawns & passed_pawn_mask(Us, s));
         lever       =   theirPawns & pawnAttacksBB[s];
-        enpassant   =   theirPawns & pawnAttacksBB[s + pawn_push(Us)] & TRank7BB;
+        enpassant   =   theirPawns & pawnAttacksBB[s + pawn_push(Us)] & (Rank2BB | Rank7BB);
 
         // Test for backward pawn.
         // If the pawn is passed, isolated, connected or a lever it cannot be


### PR DESCRIPTION
Idea from Lyudmil Tsvetkov, adding small bonus to 5th rank pawns versus opponent 2nd rank potential en passant pawns. Talkchess thread: http://talkchess.com/forum/viewtopic.php?topic_view=threads&p=608498&t=55290&sid=211a8dfeb22c14b23652b82785a7ec1b

Test runs with SPSA tuned values:

TC: 15+0.05 th 1
LLR: 2.96 (-2.94,2.94) [-1.50,4.50]
Total: 11769 W: 2443 L: 2303 D: 7023  

TC: 60+0.05 th 1 
LLR: 2.95 (-2.94,2.94) [0.00,6.00] 
Total: 43724 W: 7469 L: 7156 D: 29099 
