### PR TITLE
Compute checkers from scratch

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -690,10 +690,10 @@ bool Position::gives_check(Move m, const CheckInfo& ci) const {
 void Position::do_move(Move m, StateInfo& newSt) {
 
   CheckInfo ci(*this);
-  do_move(m, newSt, ci, gives_check(m, ci));
+  do_move(m, newSt, gives_check(m, ci));
 }
 
-void Position::do_move(Move m, StateInfo& newSt, const CheckInfo& ci, bool moveIsCheck) {
+void Position::do_move(Move m, StateInfo& newSt, bool moveIsCheck) {
 
   assert(is_ok(m));
   assert(&newSt != st);
@@ -856,30 +856,8 @@ void Position::do_move(Move m, StateInfo& newSt, const CheckInfo& ci, bool moveI
   // Update the key with the final value
   st->key = k;
 
-  // Update checkers bitboard: piece must be already moved due to attacks_from()
-  st->checkersBB = 0;
-
-  if (moveIsCheck)
-  {
-      if (type_of(m) != NORMAL)
-          st->checkersBB = attackers_to(king_square(them)) & pieces(us);
-      else
-      {
-          // Direct checks
-          if (ci.checkSq[pt] & to)
-              st->checkersBB |= to;
-
-          // Discovered checks
-          if (ci.dcCandidates && (ci.dcCandidates & from))
-          {
-              if (pt != ROOK)
-                  st->checkersBB |= attacks_from<ROOK>(king_square(them)) & pieces(us, QUEEN, ROOK);
-
-              if (pt != BISHOP)
-                  st->checkersBB |= attacks_from<BISHOP>(king_square(them)) & pieces(us, QUEEN, BISHOP);
-          }
-      }
-  }
+  // Calculate checkers bitboard (if move is check)
+  st->checkersBB = moveIsCheck ? attackers_to(king_square(them)) & pieces(us) : 0;
 
   sideToMove = ~sideToMove;
 

--- a/src/position.h
+++ b/src/position.h
@@ -145,7 +145,7 @@ public:
 
   // Doing and undoing moves
   void do_move(Move m, StateInfo& st);
-  void do_move(Move m, StateInfo& st, const CheckInfo& ci, bool moveIsCheck);
+  void do_move(Move m, StateInfo& st, bool moveIsCheck);
   void undo_move(Move m);
   void do_null_move(StateInfo& st);
   void undo_null_move();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -173,7 +173,7 @@ uint64_t Search::perft(Position& pos, Depth depth) {
           cnt = 1, nodes++;
       else
       {
-          pos.do_move(*it, st, ci, pos.gives_check(*it, ci));
+          pos.do_move(*it, st, pos.gives_check(*it, ci));
           cnt = leaf ? MoveList<LEGAL>(pos).size() : perft<false>(pos, depth - ONE_PLY);
           nodes += cnt;
           pos.undo_move(*it);
@@ -702,7 +702,7 @@ namespace {
             if (pos.legal(move, ci.pinned))
             {
                 ss->currentMove = move;
-                pos.do_move(move, st, ci, pos.gives_check(move, ci));
+                pos.do_move(move, st, pos.gives_check(move, ci));
                 value = -search<NonPV, false>(pos, ss+1, -rbeta, -rbeta+1, rdepth, !cutNode);
                 pos.undo_move(move);
                 if (value >= rbeta)
@@ -894,7 +894,7 @@ moves_loop: // When in check and at SpNode search starts from here
           quietsSearched[quietCount++] = move;
 
       // Step 14. Make the move
-      pos.do_move(move, st, ci, givesCheck);
+      pos.do_move(move, st, givesCheck);
 
       // Step 15. Reduced depth search (LMR). If the move fails high it will be
       // re-searched at full depth.
@@ -1255,7 +1255,7 @@ moves_loop: // When in check and at SpNode search starts from here
       ss->currentMove = move;
 
       // Make and search the move
-      pos.do_move(move, st, ci, givesCheck);
+      pos.do_move(move, st, givesCheck);
       value = givesCheck ? -qsearch<NT,  true>(pos, ss+1, -beta, -alpha, depth - ONE_PLY)
                          : -qsearch<NT, false>(pos, ss+1, -beta, -alpha, depth - ONE_PLY);
       pos.undo_move(move);

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -367,7 +367,7 @@ static int probe_ab(Position& pos, int alpha, int beta, int *success)
     if (!pos.capture(capture) || type_of(capture) == ENPASSANT
                         || !pos.legal(capture, ci.pinned))
       continue;
-    pos.do_move(capture, st, ci, pos.gives_check(capture, ci));
+    pos.do_move(capture, st, pos.gives_check(capture, ci));
     v = -probe_ab(pos, -beta, -alpha, success);
     pos.undo_move(capture);
     if (*success == 0) return 0;
@@ -430,7 +430,7 @@ int Tablebases::probe_wdl(Position& pos, int *success)
     if (type_of(capture) != ENPASSANT
           || !pos.legal(capture, ci.pinned))
       continue;
-    pos.do_move(capture, st, ci, pos.gives_check(capture, ci));
+    pos.do_move(capture, st, pos.gives_check(capture, ci));
     int v0 = -probe_ab(pos, -2, 2, success);
     pos.undo_move(capture);
     if (*success == 0) return 0;
@@ -493,7 +493,7 @@ static int probe_dtz_no_ep(Position& pos, int *success)
       if (type_of(pos.moved_piece(move)) != PAWN || pos.capture(move)
                 || !pos.legal(move, ci.pinned))
         continue;
-      pos.do_move(move, st, ci, pos.gives_check(move, ci));
+      pos.do_move(move, st, pos.gives_check(move, ci));
       int v = -probe_ab(pos, -2, -wdl + 1, success);
       pos.undo_move(move);
       if (*success == 0) return 0;
@@ -515,7 +515,7 @@ static int probe_dtz_no_ep(Position& pos, int *success)
       if (pos.capture(move) || type_of(pos.moved_piece(move)) == PAWN
                 || !pos.legal(move, ci.pinned))
         continue;
-      pos.do_move(move, st, ci, pos.gives_check(move, ci));
+      pos.do_move(move, st, pos.gives_check(move, ci));
       int v = -Tablebases::probe_dtz(pos, success);
       pos.undo_move(move);
       if (*success == 0) return 0;
@@ -534,7 +534,7 @@ static int probe_dtz_no_ep(Position& pos, int *success)
       Move move = moves->move;
       if (!pos.legal(move, ci.pinned))
         continue;
-      pos.do_move(move, st, ci, pos.gives_check(move, ci));
+      pos.do_move(move, st, pos.gives_check(move, ci));
       if (st.rule50 == 0) {
         if (wdl == -2) v = -1;
         else {
@@ -610,7 +610,7 @@ int Tablebases::probe_dtz(Position& pos, int *success)
     if (type_of(capture) != ENPASSANT
                 || !pos.legal(capture, ci.pinned))
       continue;
-    pos.do_move(capture, st, ci, pos.gives_check(capture, ci));
+    pos.do_move(capture, st, pos.gives_check(capture, ci));
     int v0 = -probe_ab(pos, -2, 2, success);
     pos.undo_move(capture);
     if (*success == 0) return 0;
@@ -700,7 +700,7 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoveVector& rootMoves, Va
   // Probe each move.
   for (size_t i = 0; i < rootMoves.size(); i++) {
     Move move = rootMoves[i].pv[0];
-    pos.do_move(move, st, ci, pos.gives_check(move, ci));
+    pos.do_move(move, st, pos.gives_check(move, ci));
     int v = 0;
     if (pos.checkers() && dtz > 0) {
       ExtMove s[192];
@@ -810,7 +810,7 @@ bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoveVector& rootMoves
   // Probe each move.
   for (size_t i = 0; i < rootMoves.size(); i++) {
     Move move = rootMoves[i].pv[0];
-    pos.do_move(move, st, ci, pos.gives_check(move, ci));
+    pos.do_move(move, st, pos.gives_check(move, ci));
     int v = -Tablebases::probe_wdl(pos, &success);
     pos.undo_move(move);
     if (!success) return false;


### PR DESCRIPTION
This micro-optimization only complicates the code and provides no benefit.
Removing it is even a speedup on my machine (i7-3770k, linux, gcc 4.9.1):

    stat        test     master    diff
    mean   2,403,118  2,390,904  12,214
    stdev     12,043     10,620   3,677
    
    speedup       0.51%
    P(speedup>0) 100.0%

No functional change.