### PR TITLE
Simplify attackUnits formula

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -414,10 +414,10 @@ namespace {
         // attacked and undefended squares around our king and the quality of
         // the pawn shelter (current 'score' value).
         attackUnits =  std::min(74, ei.kingAttackersCount[Them] * ei.kingAttackersWeight[Them])
-                     + 8 * ei.kingAdjacentZoneAttacksCount[Them]
+                     +  8 * ei.kingAdjacentZoneAttacksCount[Them]
                      + 25 * popcount<Max15>(undefended)
-                     +  11 * (ei.pinnedPieces[Us] != 0)
-                     - mg_value(score) * 31 / 256
+                     + 11 * (ei.pinnedPieces[Us] != 0)
+                     - mg_value(score) / 8
                      - !pos.count<QUEEN>(Them) * 60;
 
         // Analyse the enemy's safe queen contact checks. Firstly, find the


### PR DESCRIPTION
Use '/ 8' instead of '* 31 / 256'

Passed STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 55077 W: 10999 L: 10940 D: 33138

And LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 14751 W: 2530 L: 2400 D: 9821

bench: 7911944