### PR TITLE
Compute SplitPoint::spLevel on the fly

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1589,7 +1589,7 @@ void Thread::idle_loop() {
           // Try to late join to another split point if none of its slaves has
           // already finished.
           SplitPoint* bestSp = NULL;
-          int bestThread = 0;
+          Thread* bestThread = NULL;
           int bestScore = INT_MAX;
 
           for (size_t i = 0; i < Threads.size(); ++i)
@@ -1615,7 +1615,7 @@ void Thread::idle_loop() {
                   if (score < bestScore)
                   {
                       bestSp = sp;
-                      bestThread = i;
+                      bestThread = Threads[i];
                       bestScore = score;
                   }
               }
@@ -1631,7 +1631,7 @@ void Thread::idle_loop() {
 
               if (   sp->allSlavesSearching
                   && sp->slavesCount < MAX_SLAVES_PER_SPLITPOINT
-                  && available_to(Threads[bestThread]))
+                  && available_to(bestThread))
               {
                   sp->slavesMask.set(idx);
                   sp->slavesCount++;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1602,6 +1602,9 @@ void Thread::idle_loop() {
                   && sp->slavesCount < MAX_SLAVES_PER_SPLITPOINT
                   && available_to(Threads[i]))
               {
+                  assert(this != Threads[i]);
+                  assert(!(this_sp && this_sp->slavesMask.none()));
+
                   // Compute the recursive split points chain size
                   int level = -1;
                   for (SplitPoint* spp = Threads[i]->activeSplitPoint; spp; spp = spp->parentSplitPoint)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1604,7 +1604,12 @@ void Thread::idle_loop() {
                       && sp->slavesCount < MAX_SLAVES_PER_SPLITPOINT
                       && available_to(Threads[i]))
                   {
-                      int score = sp->spLevel * 256 * 256 + sp->slavesCount * 256 - sp->depth * 1;
+                      // Compute the recursive split points chain size
+                      int level = -1;
+                      for (SplitPoint* spp = Threads[i]->activeSplitPoint; spp; spp = spp->parentSplitPoint)
+                          level++;
+
+                      int score = level * 256 * 256 + sp->slavesCount * 256 - sp->depth * 1;
 
                       if (score < bestScore)
                       {
@@ -1618,7 +1623,7 @@ void Thread::idle_loop() {
               if (bestSp)
               {
                   sp = bestSp;
- 
+
                   // Recheck the conditions under lock protection
                   Threads.mutex.lock();
                   sp->mutex.lock();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1604,8 +1604,10 @@ void Thread::idle_loop() {
               {
                   assert(this != Threads[i]);
                   assert(!(this_sp && this_sp->slavesMask.none()));
+                  assert(Threads.size() > 2);
 
-                  // Compute the recursive split points chain size
+                  // Prefer to join to SP with few parents to reduce the probability
+                  // that a cut-off occurs above us, and hence we waste our work.
                   int level = -1;
                   for (SplitPoint* spp = Threads[i]->activeSplitPoint; spp; spp = spp->parentSplitPoint)
                       level++;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1594,7 +1594,7 @@ void Thread::idle_loop() {
 
           for (size_t i = 0; i < Threads.size(); ++i)
           {
-              const int size = Threads[i]->splitPointsSize; // Local copy
+              const size_t size = Threads[i]->splitPointsSize; // Local copy
               sp = size ? &Threads[i]->splitPoints[size - 1] : NULL;
 
               if (   sp
@@ -1705,7 +1705,7 @@ void check_time() {
       // Loop across all split points and sum accumulated SplitPoint nodes plus
       // all the currently active positions nodes.
       for (size_t i = 0; i < Threads.size(); ++i)
-          for (int j = 0; j < Threads[i]->splitPointsSize; ++j)
+          for (size_t j = 0; j < Threads[i]->splitPointsSize; ++j)
           {
               SplitPoint& sp = Threads[i]->splitPoints[j];
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -154,7 +154,6 @@ void Thread::split(Position& pos, Stack* ss, Value alpha, Value beta, Value* bes
 
   sp.masterThread = this;
   sp.parentSplitPoint = activeSplitPoint;
-  sp.spLevel = activeSplitPoint ? activeSplitPoint->spLevel + 1 : 0;
   sp.slavesMask = 0, sp.slavesMask.set(idx);
   sp.slavesCount = 1;
   sp.depth = depth;
@@ -184,7 +183,7 @@ void Thread::split(Position& pos, Stack* ss, Value alpha, Value beta, Value* bes
 
   Thread* slave;
 
-  while (    sp.slavesCount < MAX_SLAVES_PER_SPLITPOINT 
+  while (    sp.slavesCount < MAX_SLAVES_PER_SPLITPOINT
          && (slave = Threads.available_slave(this)) != NULL)
   {
       sp.slavesMask.set(slave->idx);

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -89,7 +89,8 @@ void ThreadBase::wait_for(volatile const bool& condition) {
 Thread::Thread() /* : splitPoints() */ { // Initialization of non POD broken in MSVC
 
   searching = false;
-  maxPly = splitPointsSize = 0;
+  maxPly = 0;
+  splitPointsSize = 0;
   activeSplitPoint = NULL;
   activePosition = NULL;
   idx = Threads.size(); // Starts from 0
@@ -123,7 +124,7 @@ bool Thread::available_to(const Thread* master) const {
 
   // Make a local copy to be sure it doesn't become zero under our feet while
   // testing next condition and so leading to an out of bounds access.
-  const int size = splitPointsSize;
+  const size_t size = splitPointsSize;
 
   // No split points means that the thread is available as a slave for any
   // other thread otherwise apply the "helpful master" concept if possible.

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -155,7 +155,6 @@ void Thread::split(Position& pos, Stack* ss, Value alpha, Value beta, Value* bes
   sp.masterThread = this;
   sp.parentSplitPoint = activeSplitPoint;
   sp.slavesMask = 0, sp.slavesMask.set(idx);
-  sp.slavesCount = 1;
   sp.depth = depth;
   sp.bestValue = *bestValue;
   sp.bestMove = *bestMove;
@@ -183,11 +182,10 @@ void Thread::split(Position& pos, Stack* ss, Value alpha, Value beta, Value* bes
 
   Thread* slave;
 
-  while (    sp.slavesCount < MAX_SLAVES_PER_SPLITPOINT
+  while (    sp.slavesMask.count() < MAX_SLAVES_PER_SPLITPOINT
          && (slave = Threads.available_slave(this)) != NULL)
   {
       sp.slavesMask.set(slave->idx);
-      sp.slavesCount++;
       slave->activeSplitPoint = &sp;
       slave->searching = true; // Slave leaves idle_loop()
       slave->notify_one(); // Could be sleeping

--- a/src/thread.h
+++ b/src/thread.h
@@ -73,7 +73,6 @@ struct SplitPoint {
   const Position* pos;
   Search::Stack* ss;
   Thread* masterThread;
-  int spLevel;
   Depth depth;
   Value beta;
   int nodeType;

--- a/src/thread.h
+++ b/src/thread.h
@@ -33,7 +33,7 @@ struct Thread;
 
 const int MAX_THREADS = 128;
 const int MAX_SPLITPOINTS_PER_THREAD = 8;
-const int MAX_SLAVES_PER_SPLITPOINT = 4;
+const size_t MAX_SLAVES_PER_SPLITPOINT = 4;
 
 /// Mutex and ConditionVariable struct are wrappers of the low level locking
 /// machinery and are modeled after the corresponding C++11 classes.
@@ -85,7 +85,6 @@ struct SplitPoint {
   // Shared variable data
   Mutex mutex;
   std::bitset<MAX_THREADS> slavesMask;
-  int slavesCount;
   volatile bool allSlavesSearching;
   volatile uint64_t nodes;
   volatile Value alpha;

--- a/src/thread.h
+++ b/src/thread.h
@@ -31,8 +31,8 @@
 
 struct Thread;
 
-const int MAX_THREADS = 128;
-const int MAX_SPLITPOINTS_PER_THREAD = 8;
+const size_t MAX_THREADS = 128;
+const size_t MAX_SPLITPOINTS_PER_THREAD = 8;
 const size_t MAX_SLAVES_PER_SPLITPOINT = 4;
 
 /// Mutex and ConditionVariable struct are wrappers of the low level locking
@@ -136,7 +136,7 @@ struct Thread : public ThreadBase {
   size_t idx;
   int maxPly;
   SplitPoint* volatile activeSplitPoint;
-  volatile int splitPointsSize;
+  volatile size_t splitPointsSize;
   volatile bool searching;
 };
 


### PR DESCRIPTION
And retire a redundant field. This is important also
from a concept point of view becuase we want to keep
SMP structures as simple as possible with the only
strictly necessary data.

Verified with

dbg_hit_on(sp->spLevel != level)

that the values are 100% the same out of more 50K samples.

No functional change.

P.S: I am possibly confident that 'level' is the only metric that really counts, after this get merged I will try to prove this with a test series, dropping one by one all the others terms in 'score' computation.

