### PR TITLE
Use only 'level' as late join metric

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1590,7 +1590,7 @@ void Thread::idle_loop() {
           // Try to late join to another split point if none of its slaves has
           // already finished.
           SplitPoint* bestSp = NULL;
-          int bestScore = INT_MAX;
+          int minLevel = INT_MAX;
 
           for (size_t i = 0; i < Threads.size(); ++i)
           {
@@ -1608,16 +1608,14 @@ void Thread::idle_loop() {
 
                   // Prefer to join to SP with few parents to reduce the probability
                   // that a cut-off occurs above us, and hence we waste our work.
-                  int level = -1;
-                  for (SplitPoint* spp = Threads[i]->activeSplitPoint; spp; spp = spp->parentSplitPoint)
+                  int level = 0;
+                  for (SplitPoint* p = Threads[i]->activeSplitPoint; p; p = p->parentSplitPoint)
                       level++;
 
-                  int score = level * 256 * 256 + (int)sp->slavesMask.count() * 256 - sp->depth * 1;
-
-                  if (score < bestScore)
+                  if (level < minLevel)
                   {
                       bestSp = sp;
-                      bestScore = score;
+                      minLevel = level;
                   }
               }
           }


### PR DESCRIPTION
It seems other metric are useless, this allow us
to simplify the code and to prune useless stuff.

STC 20K games 4 threads
ELO: -0.76 +-2.8 (95%) LOS: 29.9%
Total: 20000 W: 3477 L: 3521 D: 13002

STC 10K games 16 threads
ELO: 1.36 +-3.9 (95%) LOS: 75.0%
Total: 10000 W: 1690 L: 1651 D: 6659

bench: 8253813