### PR TITLE
Apex bonus

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -198,7 +198,7 @@ namespace {
             if (more_than_one(supported))
                 //a connected pawn is either a phalanx and/or a supported pawn
                 //apex bonus: when s is supported twice (so phalanx is certainly false)
-                score += Connected[opposed][phalanx][relative_rank(Us, s)] / 2;
+                score += 5 * Connected[opposed][phalanx][relative_rank(Us, s)] / 8;
         }
 
         if (lever)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -140,11 +140,10 @@ namespace {
         // Previous rank
         p = rank_bb(s - Up);
 
-        // Flag the pawn as passed, isolated, doubled,
-        // unsupported or connected (but not the backward one).
+        // Flag the pawn
         connected   =   ourPawns   & adjacent_files_bb(f) & (rank_bb(s) | p);
         phalanx     =   connected  & rank_bb(s);
-        supported   = (ourPawns   & adjacent_files_bb(f) & p);
+        supported   =   connected  & p;
         isolated    = !(ourPawns   & adjacent_files_bb(f));
         doubled     =   ourPawns   & forward_bb(Us, s);
         opposed     =   theirPawns & forward_bb(Us, s);
@@ -160,7 +159,7 @@ namespace {
             backward = false;
         else
         {
-            // We now know that there are no friendly pawns beside or behind this
+            // We now know there are no friendly pawns beside or behind this
             // pawn on adjacent files. We now check whether the pawn is
             // backward by looking in the forward direction on the adjacent
             // files, and picking the closest pawn there.
@@ -195,10 +194,10 @@ namespace {
 
         if (connected) {
             score += Connected[opposed][phalanx][relative_rank(Us, s)];
-            if (more_than_one(supported))
-                //a connected pawn is either a phalanx and/or a supported pawn
-                //apex bonus: when s is supported twice (so phalanx is certainly false)
-                score += 5 * Connected[opposed][phalanx][relative_rank(Us, s)] / 8;
+            if (more_than_one(supported)) {
+                //apex bonus: pawn on s is supported twice
+                score += Connected[opposed][phalanx][relative_rank(Us, s)] / 2;
+            }
         }
 
         if (lever)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -198,7 +198,7 @@ namespace {
             if (more_than_one(supported))
                 //a connected pawn is either a phalanx and/or a supported pawn
                 //apex bonus: when s is supported twice (so phalanx is certainly false)
-                score += Connected[opposed][phalanx][relative_rank(Us, s)] / 3;
+                score += Connected[opposed][phalanx][relative_rank(Us, s)] / 2;
         }
 
         if (lever)


### PR DESCRIPTION
This passed STC and LTC test.
Small edits to code, inspired by mcostalba small changes in his c++11 branch,
but exact same bench.

Note: The new line
score += Connected[opposed][phalanx][relative_rank(Us, s)] / 2;
is not equivalent to 
score += Connected[opposed][0][relative_rank(Us, s)] / 2;

Because a pawn can be supported twice, AND still be part of a phalanx.
Exemple: c3 c4 d4 e3  
d4 is supported twice, and part of a phalanx. 
      