### PR TITLE
Update Makefile for Mac OS X compilation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -151,7 +151,11 @@ ifeq ($(COMP),gcc)
 	comp=gcc
 	CXX=g++
 	CXXFLAGS += -pedantic -Wno-long-long -Wextra -Wshadow
-	LDFLAGS += -Wl,--no-as-needed
+	ifneq ($(UNAME),Darwin)
+	   LDFLAGS += -Wl,--no-as-needed
+	else
+	   LDFLAGS += -Wl
+	endif
 endif
 
 ifeq ($(COMP),mingw)
@@ -189,8 +193,8 @@ else
 endif
 
 ifeq ($(UNAME),Darwin)
-	CXXFLAGS += -arch $(arch) -mmacosx-version-min=10.10
-	LDFLAGS += -arch $(arch) -mmacosx-version-min=10.10
+	CXXFLAGS += -arch $(arch) -mmacosx-version-min=10.9
+	LDFLAGS += -arch $(arch) -mmacosx-version-min=10.9
 endif
 
 ### On mingw use Windows threads, otherwise POSIX


### PR DESCRIPTION
This change in the Makefile restores the possibility to compile Stockfish
on Mac OS X 10.9 and 10.10 after the C++11 has been merged.

To use the default (fastest) settings, compile with:

make build ARCH=x86-64-modern

To test the clang settings, compile with

make build ARCH=x86-64-modern COMP=clang

Beware that the clang settings may provide a slightly slower (6%) executable.

------------------

Note : it is also possible to compile Stockfish for Mac OS X 10.7 and 10.8
using the clang setting. For instructions on how to do that, see the thread 
named "Compiling C++11 code on Mac OS X" in the FishCooking forum :
https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/9Ze_Qokel-M