### PR TITLE
Fix MSVC 2013 error

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -9,6 +9,10 @@
 
 #define NOMINMAX
 
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include <algorithm>
 
 #include "../position.h"


### PR DESCRIPTION
tbcore.cpp(67): error C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead.
To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\include\string.h(112) : see declaration of 'strcpy'

Note: For some this might only have been a warning depending on SDL settings described here
https://stackoverflow.com/questions/20448102/why-does-visual-studio-2013-error-on-c4996