### PR TITLE
Use yielding spinlocks

### DIFF
--- a/src/thread.h
+++ b/src/thread.h
@@ -39,7 +39,7 @@ const size_t MAX_THREADS = 128;
 const size_t MAX_SPLITPOINTS_PER_THREAD = 8;
 const size_t MAX_SLAVES_PER_SPLITPOINT = 4;
 
-#if 0
+#if 1
 /// Spinlock class wraps low level atomic operations to provide a spin lock
 
 class Spinlock {
@@ -49,8 +49,9 @@ class Spinlock {
 public:
   Spinlock() { lock = 1; } // Init here to workaround a bug with MSVC 2013
   void acquire() {
-    while (lock.fetch_sub(1, std::memory_order_acquire) != 1)
-        while (lock.load(std::memory_order_relaxed) <= 0) {}
+      while (lock.fetch_sub(1, std::memory_order_acquire) != 1)
+          for (int cnt= 0; lock.load(std::memory_order_relaxed) <= 0; ++cnt)
+        	  if (cnt >= 10000) std::this_thread::yield();
   }
   void release() { lock.store(1, std::memory_order_release); }
 };


### PR DESCRIPTION
Use yielding spinlocks : we spin a little bit, then begin yielding to
the operating system if there seems to be contention on this lock.