### PR TITLE
Counter move history

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -67,8 +67,8 @@ namespace {
 /// search captures, promotions and some checks) and how important good move
 /// ordering is at the current node.
 
-MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats& h,
-                       Move* cm, Move* fm, Search::Stack* s) : pos(p), history(h), depth(d) {
+MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats& h, const DoubleHistoryStats& dh,
+                       Move* cm, Move* fm, Search::Stack* s) : pos(p), history(h), double_history(dh), depth(d) {
 
   assert(d > DEPTH_ZERO);
 
@@ -87,8 +87,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats&
   endMoves += (ttMove != MOVE_NONE);
 }
 
-MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats& h,
-                       Square s) : pos(p), history(h) {
+MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats& h, const DoubleHistoryStats& dh,
+                       Square s) : pos(p), history(h), double_history(dh) {
 
   assert(d <= DEPTH_ZERO);
 
@@ -112,8 +112,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats&
   endMoves += (ttMove != MOVE_NONE);
 }
 
-MovePicker::MovePicker(const Position& p, Move ttm, const HistoryStats& h, PieceType pt)
-                       : pos(p), history(h) {
+MovePicker::MovePicker(const Position& p, Move ttm, const HistoryStats& h, const DoubleHistoryStats& dh, PieceType pt)
+                       : pos(p), history(h), double_history(dh) {
 
   assert(!pos.checkers());
 
@@ -162,8 +162,12 @@ void MovePicker::score<CAPTURES>() {
 
 template<>
 void MovePicker::score<QUIETS>() {
+  Square prevMoveSq = to_sq((ss-1)->currentMove);
+  Piece prevMovePiece = pos.piece_on(prevMoveSq);
+
   for (auto& m : *this)
-      m.value = history[pos.moved_piece(m)][to_sq(m)];
+      m.value =  history[pos.moved_piece(m)][to_sq(m)]
+               + double_history[prevMovePiece][prevMoveSq][pos.moved_piece(m)][to_sq(m)];
 }
 
 template<>

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -67,8 +67,8 @@ namespace {
 /// search captures, promotions and some checks) and how important good move
 /// ordering is at the current node.
 
-MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats& h, const DoubleHistoryStats& dh,
-                       Move* cm, Move* fm, Search::Stack* s) : pos(p), history(h), double_history(dh), depth(d) {
+MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats& h, const CounterMovesHistoryStats& cmh,
+                       Move* cm, Move* fm, Search::Stack* s) : pos(p), history(h), counterMovesHistory(cmh), depth(d) {
 
   assert(d > DEPTH_ZERO);
 
@@ -87,8 +87,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats&
   endMoves += (ttMove != MOVE_NONE);
 }
 
-MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats& h, const DoubleHistoryStats& dh,
-                       Square s) : pos(p), history(h), double_history(dh) {
+MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats& h, const CounterMovesHistoryStats& cmh,
+                       Square s) : pos(p), history(h), counterMovesHistory(cmh) {
 
   assert(d <= DEPTH_ZERO);
 
@@ -112,8 +112,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats&
   endMoves += (ttMove != MOVE_NONE);
 }
 
-MovePicker::MovePicker(const Position& p, Move ttm, const HistoryStats& h, const DoubleHistoryStats& dh, PieceType pt)
-                       : pos(p), history(h), double_history(dh) {
+MovePicker::MovePicker(const Position& p, Move ttm, const HistoryStats& h, const CounterMovesHistoryStats& cmh, PieceType pt)
+                       : pos(p), history(h), counterMovesHistory(cmh) {
 
   assert(!pos.checkers());
 
@@ -164,10 +164,11 @@ template<>
 void MovePicker::score<QUIETS>() {
   Square prevMoveSq = to_sq((ss-1)->currentMove);
   Piece prevMovePiece = pos.piece_on(prevMoveSq);
+  const HistoryStats &cmh = counterMovesHistory[prevMovePiece][prevMoveSq];
 
   for (auto& m : *this)
       m.value =  history[pos.moved_piece(m)][to_sq(m)]
-               + double_history[prevMovePiece][prevMoveSq][pos.moved_piece(m)][to_sq(m)];
+               + cmh[pos.moved_piece(m)][to_sq(m)];
 }
 
 template<>

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -75,7 +75,7 @@ template<bool Gain, typename T>
 struct DoubleStats {
 
   static const Value Max = Value(250);
-  typedef T (Table)[SQUARE_NB][PIECE_NB][SQUARE_NB];
+  typedef T Table[SQUARE_NB][PIECE_NB][SQUARE_NB];
 
   const Table& operator[](Piece pc) const { return (table[pc]); }
   void clear() { std::memset(table, 0, sizeof(table)); }

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -71,6 +71,39 @@ typedef Stats< true, Value> GainsStats;
 typedef Stats<false, Value> HistoryStats;
 typedef Stats<false, std::pair<Move, Move> > MovesStats;
 
+template<bool Gain, typename T>
+struct DoubleStats {
+
+  static const Value Max = Value(250);
+  typedef T (Table)[SQUARE_NB][PIECE_NB][SQUARE_NB];
+
+  const Table& operator[](Piece pc) const { return (table[pc]); }
+  void clear() { std::memset(table, 0, sizeof(table)); }
+
+  void update(Piece pc1, Square to1, Piece pc2, Square to2, Move m) {
+
+    if (m == table[pc1][to1][pc2][to2].first)
+        return;
+
+    table[pc1][to1][pc2][to2].second = table[pc1][to1][pc2][to2].first;
+    table[pc1][to1][pc2][to2].first = m;
+  }
+
+  void update(Piece pc1, Square to1, Piece pc2, Square to2, Value v) {
+
+    if (Gain)
+        table[pc1][to1][pc2][to2] = std::max(v, table[pc1][to1][pc2][to2] - 1);
+
+    else if (abs(table[pc1][to1][pc2][to2] + v) < Max)
+        table[pc1][to1][pc2][to2] +=  v;
+  }
+
+private:
+  T table[PIECE_NB][SQUARE_NB][PIECE_NB][SQUARE_NB];
+};
+
+typedef DoubleStats<false, Value> DoubleHistoryStats;
+
 
 /// MovePicker class is used to pick one pseudo legal move at a time from the
 /// current position. The most important method is next_move(), which returns a
@@ -84,9 +117,9 @@ public:
   MovePicker(const MovePicker&) = delete;
   MovePicker& operator=(const MovePicker&) = delete;
 
-  MovePicker(const Position&, Move, Depth, const HistoryStats&, Square);
-  MovePicker(const Position&, Move, const HistoryStats&, PieceType);
-  MovePicker(const Position&, Move, Depth, const HistoryStats&, Move*, Move*, Search::Stack*);
+  MovePicker(const Position&, Move, Depth, const HistoryStats&, const DoubleHistoryStats&, Square);
+  MovePicker(const Position&, Move, const HistoryStats&, const DoubleHistoryStats&, PieceType);
+  MovePicker(const Position&, Move, Depth, const HistoryStats&, const DoubleHistoryStats&, Move*, Move*, Search::Stack*);
 
   template<bool SpNode> Move next_move();
 
@@ -98,6 +131,7 @@ private:
 
   const Position& pos;
   const HistoryStats& history;
+  const DoubleHistoryStats& double_history;
   Search::Stack* ss;
   Move* countermoves;
   Move* followupmoves;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -95,7 +95,7 @@ namespace {
   double BestMoveChanges;
   Value DrawValue[COLOR_NB];
   HistoryStats History;
-  DoubleHistoryStats DoubleHistory;
+  CounterMovesHistoryStats CounterMovesHistory;
   GainsStats Gains;
   MovesStats Countermoves, Followupmoves;
 
@@ -290,7 +290,7 @@ namespace {
 
     TT.new_search();
     History.clear();
-    DoubleHistory.clear();
+    CounterMovesHistory.clear();
     Gains.clear();
     Countermoves.clear();
     Followupmoves.clear();
@@ -689,7 +689,7 @@ namespace {
         assert((ss-1)->currentMove != MOVE_NONE);
         assert((ss-1)->currentMove != MOVE_NULL);
 
-        MovePicker mp(pos, ttMove, History, DoubleHistory, pos.captured_piece_type());
+        MovePicker mp(pos, ttMove, History, CounterMovesHistory, pos.captured_piece_type());
         CheckInfo ci(pos);
 
         while ((move = mp.next_move<false>()) != MOVE_NONE)
@@ -728,7 +728,7 @@ moves_loop: // When in check and at SpNode search starts from here
     Move followupmoves[] = { Followupmoves[pos.piece_on(prevOwnMoveSq)][prevOwnMoveSq].first,
                              Followupmoves[pos.piece_on(prevOwnMoveSq)][prevOwnMoveSq].second };
 
-    MovePicker mp(pos, ttMove, depth, History, DoubleHistory, countermoves, followupmoves, ss);
+    MovePicker mp(pos, ttMove, depth, History, CounterMovesHistory, countermoves, followupmoves, ss);
     CheckInfo ci(pos);
     value = bestValue; // Workaround a bogus 'uninitialized' warning under gcc
     improving =   ss->staticEval >= (ss-2)->staticEval
@@ -1194,7 +1194,7 @@ moves_loop: // When in check and at SpNode search starts from here
     // to search the moves. Because the depth is <= 0 here, only captures,
     // queen promotions and checks (only if depth >= DEPTH_QS_CHECKS) will
     // be generated.
-    MovePicker mp(pos, ttMove, depth, History, DoubleHistory, to_sq((ss-1)->currentMove));
+    MovePicker mp(pos, ttMove, depth, History, CounterMovesHistory, to_sq((ss-1)->currentMove));
     CheckInfo ci(pos);
 
     // Loop through the moves until no moves remain or a beta cutoff occurs
@@ -1359,13 +1359,14 @@ moves_loop: // When in check and at SpNode search starts from here
     {
         Square prevMoveSq = to_sq((ss-1)->currentMove);
         Piece prevMovePiece = pos.piece_on(prevMoveSq);
-        Countermoves.update(pos.piece_on(prevMoveSq), prevMoveSq, move);
+        Countermoves.update(prevMovePiece, prevMoveSq, move);
 
-        DoubleHistory.update(prevMovePiece, prevMoveSq, pos.moved_piece(move), to_sq(move), bonus);
+        HistoryStats& cmh = CounterMovesHistory[prevMovePiece][prevMoveSq];
+        cmh.update(pos.moved_piece(move), to_sq(move), bonus);
         for (int i = 0; i < quietsCnt; ++i)
         {
             Move m = quiets[i];
-            DoubleHistory.update(prevMovePiece, prevMoveSq, pos.moved_piece(m), to_sq(m), -bonus);
+            cmh.update(pos.moved_piece(m), to_sq(m), -bonus);
         }
     }
 


### PR DESCRIPTION
Introduce a counter move history table which additionally is indexed by the last move's piece and target square.
For quiet move ordering use now the sum of standard and counter move history table.

STC:
LLR: 2.96 (-2.94,2.94) [-1.50,4.50]
Total: 4747 W: 1005 L: 885 D: 2857

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,6.00]
Total: 5726 W: 1001 L: 872 D: 3853

Because of reported low NPS on multi core test
STC (7 threads):
ELO: 7.26 +-3.3 (95%) LOS: 100.0%
Total: 14937 W: 2710 L: 2398 D: 9829

Bench: 7725341