### PR TITLE
Link with -static in mingw

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -162,7 +162,7 @@ ifeq ($(COMP),mingw)
 	comp=mingw
 	CXX=g++
 	CXXFLAGS += -Wextra -Wshadow
-	LDFLAGS += -static-libstdc++ -static-libgcc
+	LDFLAGS += -static
 endif
 
 ifeq ($(COMP),icc)


### PR DESCRIPTION
Fixes reported startup error about missing libwinpthread-1.dll
when the dll is not in the path.

The current -static-xxxx flags, introduced with:

https://github.com/official-stockfish/Stockfish/commit/373503f4a9a990054b5

Only take in account standard libraries, but not thread
library.

No functional change.