### PR TITLE
Fix dependency generation for MacOSX

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -177,6 +177,7 @@ ifeq ($(COMP),clang)
 	CXXFLAGS += -pedantic -Wno-long-long -Wextra -Wshadow
 	ifeq ($(UNAME),Darwin)
 		CXXFLAGS += -std=c++0x -stdlib=libc++
+		DEPENDFLAGS += -std=c++0x -stdlib=libc++
 	endif
 endif
 


### PR DESCRIPTION
The auto-generation of the dependencies by the Makefile was broken for MacOSX by the C++11 changes. (At least it was for the clang compiler). It wasn't immediately obvious because errors from the dependency generation run are redirected to /dev/null.

DEPENDFLAGS needs the C++11 bits added so that the right places are looked at for the standard header files during dependency parsing. WIthout this the operation fails with many "can't find file" type messages.