### PR TITLE
Simplify nosleep logic

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -373,7 +373,5 @@ void ThreadPool::start_thinking(const Position& pos, const LimitsType& limits,
           RootMoves.push_back(RootMove(m));
 
   main()->thinking = true;
-
-  for (Thread* th : *this)
-      th->notify_one();
+  main()->notify_one(); // Wake up main thread: 'thinking' must be already set
 }


### PR DESCRIPTION
Avoid redundant 'while' conditions. It is enough to 
check them in the outer loop. 

Moved block at the end so that a master thread starts searching immediately 
after a splitting. 

No functional change.