### PR TITLE
Fix a bogus use of mutex

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1599,7 +1599,7 @@ void Thread::idle_loop() {
             && !(this_sp && this_sp->slavesMask.none())
             && !searching)
       {
-          if (   !this_sp 
+          if (   !this_sp
               && !Threads.main()->thinking)
           {
               std::unique_lock<Mutex> lk(mutex);
@@ -1613,12 +1613,12 @@ void Thread::idle_loop() {
       // If this thread has been assigned work, launch a search
       while (searching)
       {
-          mutex.lock();
+          spinlock.acquire();
 
           assert(activeSplitPoint);
           SplitPoint* sp = activeSplitPoint;
 
-          mutex.unlock();
+          spinlock.release();
 
           Stack stack[MAX_PLY+4], *ss = stack+2; // To allow referencing (ss-2) and (ss+2)
           Position pos(*sp->pos, this);


### PR DESCRIPTION
Fix a bogus use of mutex
    
    Spinlock must be used instead.
    
    Tested for no regression at 15+0.05 th 4:
    
    LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
    Total: 25928 W: 4303 L: 4190 D: 17435
    
    No functional change.
