### PR TITLE
connected should be bool, not Bitboard

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -110,9 +110,9 @@ namespace {
     const Square Right = (Us == WHITE ? DELTA_NE : DELTA_SW);
     const Square Left  = (Us == WHITE ? DELTA_NW : DELTA_SE);
 
-    Bitboard b, neighbours, doubled, connected, supported, phalanx;
+    Bitboard b, neighbours, doubled, supported, phalanx;
     Square s;
-    bool passed, isolated, opposed, backward, lever;
+    bool passed, isolated, opposed, backward, lever, connected;
     Score score = SCORE_ZERO;
     const Square* pl = pos.list<PAWN>(Us);
     const Bitboard* pawnAttacksBB = StepAttacksBB[make_piece(Us, PAWN)];


### PR DESCRIPTION
There's no reason to define it as a Bitboard, so for consistency, use bool.

This is even a speedup on my machine: i7-3770k, using gcc 4.9.1 (linux):

    stat        test     master    diff
    mean   2,341,338  2,327,998  13,134
    stdev     15,765     14,717   5,405

    speedup       0.56%
    P(speedup>0) 100.0%

No functional change.