### PR TITLE
Retire ConditionVariable

### DIFF
--- a/src/thread_win32.h
+++ b/src/thread_win32.h
@@ -57,29 +57,7 @@ private:
   CRITICAL_SECTION cs;
 };
 
-struct ConditionVariable {
-  ConditionVariable() { hn = CreateEvent(0, FALSE, FALSE, 0); }
- ~ConditionVariable() { CloseHandle(hn); }
-  void notify_one() { SetEvent(hn); }
-
-  void wait(std::unique_lock<Mutex>& lk) {
-    lk.unlock();
-    WaitForSingleObject(hn, INFINITE);
-    lk.lock();
-  }
-
-  void wait_for(std::unique_lock<Mutex>& lk, const std::chrono::milliseconds& ms) {
-    lk.unlock();
-    WaitForSingleObject(hn, ms.count());
-    lk.lock();
-  }
-
-  template<class Predicate>
-  void wait(std::unique_lock<Mutex>& lk, Predicate p) { while (!p()) this->wait(lk); }
-
-private:
-  HANDLE hn;
-};
+typedef std::condition_variable_any ConditionVariable;
 
 #else // Default case: use STL classes
 


### PR DESCRIPTION
Now that we use spinlocks everywhere and don't put
threads to sleep while idle, we can use the slower
(but no more in hot path) std::condition_variable_any
instead of our homwgrown ConditionVariable struct.

Verified fo rno regression at STC with 7 threads:
ELO: -0.66 +-2.7 (95%) LOS: 31.8%
Total: 20000 W: 3210 L: 3248 D: 13542

bench: 8567402