### PR TITLE
Use only one ConditionVariable to sync UI

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -158,7 +158,7 @@ void benchmark(const Position& current, istream& is) {
       else
       {
           Threads.start_thinking(pos, limits, st);
-          Threads.wait_for_think_finished();
+          Threads.main()->join();
           nodes += Search::RootPos.nodes_searched();
       }
   }

--- a/src/thread.h
+++ b/src/thread.h
@@ -137,6 +137,7 @@ struct Thread : public ThreadBase {
 
 struct MainThread : public Thread {
   virtual void idle_loop();
+  void join();
   volatile bool thinking = true; // Avoid a race with start_thinking()
 };
 
@@ -162,11 +163,9 @@ struct ThreadPool : public std::vector<Thread*> {
   MainThread* main() { return static_cast<MainThread*>(at(0)); }
   void read_uci_options();
   Thread* available_slave(const SplitPoint* sp) const;
-  void wait_for_think_finished();
   void start_thinking(const Position&, const Search::LimitsType&, Search::StateStackPtr&);
 
   Depth minimumSplitDepth;
-  ConditionVariable sleepCondition;
   TimerThread* timer;
 };
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -205,7 +205,7 @@ void UCI::loop(int argc, char* argv[]) {
 
   } while (token != "quit" && argc == 1); // Passed args have one-shot behaviour
 
-  Threads.wait_for_think_finished(); // Cannot quit whilst the search is running
+  Threads.main()->join(); // Cannot quit whilst the search is running
 }
 
 


### PR DESCRIPTION
To sync UI with main thread it is enough a single
condition variable because here we have a single
producer / single consumer design pattern.

Two condition variables are strictly needed just for
many producers / many consumers case.

The natural consequence is to retire wait_for_think_finished()
and move all the logic under MainThread class, yielding the
rename of teh function to join()

No functional change.