### PR TITLE
Fully yielding locks, no spinning

### DIFF
--- a/src/thread.h
+++ b/src/thread.h
@@ -47,8 +47,8 @@ public:
   Spinlock() { _lock = 1; } // Init here to workaround a bug with MSVC 2013
   void lock() {
       while (_lock.fetch_sub(1, std::memory_order_acquire) != 1)
-          for (int cnt = 0; _lock.load(std::memory_order_relaxed) <= 0; ++cnt)
-              if (cnt >= 10000) std::this_thread::yield(); // Be nice to hyperthreading
+          while(_lock.load(std::memory_order_relaxed) <= 0)
+              std::this_thread::yield(); // Be nice to hyperthreading
   }
   void unlock() { _lock.store(1, std::memory_order_release); }
 };


### PR DESCRIPTION
Fully yielding locks, no spinning

7 threads:

ELO: 2.00 +-2.7 (95%) LOS: 92.4%
Total: 20000 W: 3276 L: 3161 D: 13563