### PR TITLE
Allow Bitbases::init() to be called more than once

### DIFF
--- a/src/bitbase.cpp
+++ b/src/bitbase.cpp
@@ -85,9 +85,10 @@ bool Bitbases::probe(Square wksq, Square wpsq, Square bksq, Color us) {
 void Bitbases::init() {
 
   std::vector<KPKPosition> db(MAX_INDEX);
+  unsigned id = 0;
 
   // Initialize db with known win / draw positions
-  std::generate(db.begin(), db.end(), [](){ static unsigned id; return KPKPosition(id++); });
+  std::generate(db.begin(), db.end(), [&id](){ return KPKPosition(id++); });
 
   // Iterate through the positions until none of the unknown positions can be
   // changed to either wins or draws (15 cycles needed).

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -249,7 +249,9 @@ namespace {
                              {  728, 10316, 55013, 32803, 12281, 15100,  16645,   255 } };
 
     Bitboard occupancy[4096], reference[4096], edges, b;
-    int i, size;
+    int age[4096], current = 0, i, size;
+
+    std::memset(age, 0, sizeof(age));
 
     // attacks[s] is a pointer to the beginning of the attacks table for square 's'
     attacks[SQ_A1] = table;
@@ -298,22 +300,21 @@ namespace {
                 magics[s] = rng.sparse_rand<Bitboard>();
             while (popcount<Max15>((magics[s] * masks[s]) >> 56) < 6);
 
-            std::memset(attacks[s], 0, size * sizeof(Bitboard));
-
             // A good magic must map every possible occupancy to an index that
             // looks up the correct sliding attack in the attacks[s] database.
             // Note that we build up the database for square 's' as a side
             // effect of verifying the magic.
-            for (i = 0; i < size; ++i)
+            for (++current, i = 0; i < size; ++i)
             {
-                Bitboard& attack = attacks[s][index(s, occupancy[i])];
+                unsigned idx = index(s, occupancy[i]);
 
-                if (attack && attack != reference[i])
+                if (age[idx] < current)
+                {
+                    age[idx] = current;
+                    attacks[s][idx] = reference[i];
+                }
+                else if (attacks[s][idx] != reference[i])
                     break;
-
-                assert(reference[i]);
-
-                attack = reference[i];
             }
         } while (i < size);
     }

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -299,9 +299,12 @@ void ThreadPool::init() {
 void ThreadPool::exit() {
 
   delete_thread(timer); // As first because check_time() accesses threads data
+  timer = nullptr;
 
   for (Thread* th : *this)
       delete_thread(th);
+
+  clear(); // Get rid of stale pointers
 }
 
 


### PR DESCRIPTION
    Currently if we call it more than once, we crash.
    
    This is not a real problem, because this function is
    indeed called just once. Nevertheless with this small fix,
    that gets rid of a hidden 'static' variable, we cleanly
    resolve the issue.
    
    While there, fix also ThreadPool::exit to return in a
    consistent state. Now all the init() functions but
    UCI::init() are reentrant and can be called multiple
    times.
    
    No functional change.