### PR TITLE
Allow Bitbases::init() to be called more than once

### DIFF
--- a/src/bitbase.cpp
+++ b/src/bitbase.cpp
@@ -85,9 +85,10 @@ bool Bitbases::probe(Square wksq, Square wpsq, Square bksq, Color us) {
 void Bitbases::init() {
 
   std::vector<KPKPosition> db(MAX_INDEX);
+  unsigned id = 0;
 
   // Initialize db with known win / draw positions
-  std::generate(db.begin(), db.end(), [](){ static unsigned id; return KPKPosition(id++); });
+  std::generate(db.begin(), db.end(), [&id](){ return KPKPosition(id++); });
 
   // Iterate through the positions until none of the unknown positions can be
   // changed to either wins or draws (15 cycles needed).

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -299,9 +299,12 @@ void ThreadPool::init() {
 void ThreadPool::exit() {
 
   delete_thread(timer); // As first because check_time() accesses threads data
+  timer = nullptr;
 
   for (Thread* th : *this)
       delete_thread(th);
+
+  clear(); // Get rid of stale pointers
 }
 
 


### PR DESCRIPTION
Currently if we call it more than once, we crash.

This is not a real problem, because this function is
indeed called just once. Nevertheless with this small fix,
that gets rid of a hidden 'static' variable, we cleanly
resolve the issue.

While there, fix also ThreadPool::exit to return in a
consistent state. Now all the init() functions but
UCI::init() are reentrant and can be called multiple
times.

No functional change.