### PR TITLE
Remove followupmoves.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -68,13 +68,12 @@ namespace {
 /// ordering is at the current node.
 
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats& h, const CounterMovesHistoryStats& cmh,
-                       Move* cm, Move* fm, Search::Stack* s) : pos(p), history(h), counterMovesHistory(cmh), depth(d) {
+                       Move* cm, Search::Stack* s) : pos(p), history(h), counterMovesHistory(cmh), depth(d) {
 
   assert(d > DEPTH_ZERO);
 
   endBadCaptures = moves + MAX_MOVES - 1;
   countermoves = cm;
-  followupmoves = fm;
   ss = s;
 
   if (pos.checkers())
@@ -211,9 +210,8 @@ void MovePicker::generate_next_stage() {
       killers[0] = ss->killers[0];
       killers[1] = ss->killers[1];
       killers[2].move = killers[3].move = MOVE_NONE;
-      killers[4].move = killers[5].move = MOVE_NONE;
 
-      // In SMP case countermoves[] and followupmoves[] could have duplicated entries
+      // In SMP case countermoves[]could have duplicated entries
       // in rare cases (less than 1 out of a million). This is harmless.
 
       // Be sure countermoves and followupmoves are different from killers
@@ -221,13 +219,6 @@ void MovePicker::generate_next_stage() {
           if (   countermoves[i] != killers[0]
               && countermoves[i] != killers[1])
               *endMoves++ = countermoves[i];
-
-      for (int i = 0; i < 2; ++i)
-          if (   followupmoves[i] != killers[0]
-              && followupmoves[i] != killers[1]
-              && followupmoves[i] != killers[2]
-              && followupmoves[i] != killers[3])
-              *endMoves++ = followupmoves[i];
       break;
 
   case QUIETS_1_S1:
@@ -321,9 +312,7 @@ Move MovePicker::next_move<false>() {
               && move != killers[0]
               && move != killers[1]
               && move != killers[2]
-              && move != killers[3]
-              && move != killers[4]
-              && move != killers[5])
+              && move != killers[3])
               return move;
           break;
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -88,7 +88,7 @@ public:
 
   MovePicker(const Position&, Move, Depth, const HistoryStats&, const CounterMovesHistoryStats&, Square);
   MovePicker(const Position&, Move, const HistoryStats&, const CounterMovesHistoryStats&, PieceType);
-  MovePicker(const Position&, Move, Depth, const HistoryStats&, const CounterMovesHistoryStats&, Move*, Move*, Search::Stack*);
+  MovePicker(const Position&, Move, Depth, const HistoryStats&, const CounterMovesHistoryStats&, Move*, Search::Stack*);
 
   template<bool SpNode> Move next_move();
 
@@ -103,10 +103,9 @@ private:
   const CounterMovesHistoryStats& counterMovesHistory;
   Search::Stack* ss;
   Move* countermoves;
-  Move* followupmoves;
   Depth depth;
   Move ttMove;
-  ExtMove killers[6];
+  ExtMove killers[4];
   Square recaptureSquare;
   Value captureThreshold;
   int stage;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -97,7 +97,7 @@ namespace {
   HistoryStats History;
   CounterMovesHistoryStats CounterMovesHistory;
   GainsStats Gains;
-  MovesStats Countermoves, Followupmoves;
+  MovesStats Countermoves;
 
   template <NodeType NT, bool SpNode>
   Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, bool cutNode);
@@ -293,8 +293,7 @@ namespace {
     CounterMovesHistory.clear();
     Gains.clear();
     Countermoves.clear();
-    Followupmoves.clear();
-
+    
     size_t multiPV = Options["MultiPV"];
     Skill skill(Options["Skill Level"]);
 
@@ -532,7 +531,7 @@ namespace {
     {
         ss->currentMove = ttMove; // Can be MOVE_NONE
 
-        // If ttMove is quiet, update killers, history, counter move and followup move on TT hit
+        // If ttMove is quiet, update killers, history, counter move on TT hit
         if (ttValue >= beta && ttMove && !pos.capture_or_promotion(ttMove) && !inCheck)
             update_stats(pos, ss, ttMove, depth, nullptr, 0);
 
@@ -724,11 +723,7 @@ moves_loop: // When in check and at SpNode search starts from here
     Move countermoves[] = { Countermoves[pos.piece_on(prevMoveSq)][prevMoveSq].first,
                             Countermoves[pos.piece_on(prevMoveSq)][prevMoveSq].second };
 
-    Square prevOwnMoveSq = to_sq((ss-2)->currentMove);
-    Move followupmoves[] = { Followupmoves[pos.piece_on(prevOwnMoveSq)][prevOwnMoveSq].first,
-                             Followupmoves[pos.piece_on(prevOwnMoveSq)][prevOwnMoveSq].second };
-
-    MovePicker mp(pos, ttMove, depth, History, CounterMovesHistory, countermoves, followupmoves, ss);
+    MovePicker mp(pos, ttMove, depth, History, CounterMovesHistory, countermoves, ss);
     CheckInfo ci(pos);
     value = bestValue; // Workaround a bogus 'uninitialized' warning under gcc
     improving =   ss->staticEval >= (ss-2)->staticEval
@@ -1073,7 +1068,7 @@ moves_loop: // When in check and at SpNode search starts from here
         bestValue = excludedMove ? alpha
                    :     inCheck ? mated_in(ss->ply) : DrawValue[pos.side_to_move()];
 
-    // Quiet best move: update killers, history, countermoves and followupmoves
+    // Quiet best move: update killers, history and countermoves
     else if (bestValue >= beta && !pos.capture_or_promotion(bestMove) && !inCheck)
         update_stats(pos, ss, bestMove, depth, quietsSearched, quietCount - 1);
 
@@ -1333,7 +1328,7 @@ moves_loop: // When in check and at SpNode search starts from here
     *pv = MOVE_NONE;
   }
 
-  // update_stats() updates killers, history, countermoves and followupmoves stats after a fail-high
+  // update_stats() updates killers, history and countermoves stats after a fail-high
   // of a quiet move.
 
   void update_stats(const Position& pos, Stack* ss, Move move, Depth depth, Move* quiets, int quietsCnt) {
@@ -1368,12 +1363,6 @@ moves_loop: // When in check and at SpNode search starts from here
             Move m = quiets[i];
             cmh.update(pos.moved_piece(m), to_sq(m), -bonus);
         }
-    }
-
-    if (is_ok((ss-2)->currentMove) && (ss-1)->currentMove == (ss-1)->ttMove)
-    {
-        Square prevOwnMoveSq = to_sq((ss-2)->currentMove);
-        Followupmoves.update(pos.piece_on(prevOwnMoveSq), prevOwnMoveSq, move);
     }
   }
 


### PR DESCRIPTION
STC: http://tests.stockfishchess.org/tests/view/5501d0f30ebc5902160ec0fd
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 34891 W: 6904 L: 6808 D: 21179

LTC: http://tests.stockfishchess.org/tests/view/550328540ebc5902160ec133
LLR: 3.10 (-2.94,2.94) [-3.00,1.00]
Total: 182653 W: 29866 L: 29993 D: 122794
