### PR TITLE
Simplification to use only one counter move.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -68,12 +68,12 @@ namespace {
 /// ordering is at the current node.
 
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats& h, const CounterMovesHistoryStats& cmh,
-                       Move* cm, Search::Stack* s) : pos(p), history(h), counterMovesHistory(cmh), depth(d) {
+                       Move cm, Search::Stack* s) : pos(p), history(h), counterMovesHistory(cmh), depth(d) {
 
   assert(d > DEPTH_ZERO);
 
   endBadCaptures = moves + MAX_MOVES - 1;
-  countermoves = cm;
+  countermove = cm;
   ss = s;
 
   if (pos.checkers())
@@ -209,16 +209,15 @@ void MovePicker::generate_next_stage() {
 
       killers[0] = ss->killers[0];
       killers[1] = ss->killers[1];
-      killers[2].move = killers[3].move = MOVE_NONE;
+      killers[2].move = MOVE_NONE;
 
       // In SMP case countermoves[] could have duplicated entries
       // in rare cases (less than 1 out of a million). This is harmless.
 
-      // Be sure countermoves and followupmoves are different from killers
-      for (int i = 0; i < 2; ++i)
-          if (   countermoves[i] != killers[0]
-              && countermoves[i] != killers[1])
-              *endMoves++ = countermoves[i];
+      // Be sure countermoves are different from killers
+      if (   countermove != killers[0]
+          && countermove != killers[1])
+          *endMoves++ = countermove;
       break;
 
   case QUIETS_1_S1:
@@ -311,8 +310,7 @@ Move MovePicker::next_move<false>() {
           if (   move != ttMove
               && move != killers[0]
               && move != killers[1]
-              && move != killers[2]
-              && move != killers[3])
+              && move != killers[2])
               return move;
           break;
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -211,9 +211,6 @@ void MovePicker::generate_next_stage() {
       killers[1] = ss->killers[1];
       killers[2].move = MOVE_NONE;
 
-      // In SMP case countermoves[] could have duplicated entries
-      // in rare cases (less than 1 out of a million). This is harmless.
-
       // Be sure countermoves are different from killers
       if (   countermove != killers[0]
           && countermove != killers[1])

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -48,11 +48,8 @@ struct Stats {
 
   void update(Piece pc, Square to, Move m) {
 
-    if (m == table[pc][to].first)
-        return;
-
-    table[pc][to].second = table[pc][to].first;
-    table[pc][to].first = m;
+    if (m != table[pc][to])
+        table[pc][to] = m;
   }
 
   void update(Piece pc, Square to, Value v) {
@@ -70,7 +67,7 @@ private:
 
 typedef Stats< true, Value> GainsStats;
 typedef Stats<false, Value> HistoryStats;
-typedef Stats<false, std::pair<Move, Move> > MovesStats;
+typedef Stats<false, Move> MovesStats;
 typedef Stats<false, HistoryStats> CounterMovesHistoryStats;
 
 
@@ -88,7 +85,7 @@ public:
 
   MovePicker(const Position&, Move, Depth, const HistoryStats&, const CounterMovesHistoryStats&, Square);
   MovePicker(const Position&, Move, const HistoryStats&, const CounterMovesHistoryStats&, PieceType);
-  MovePicker(const Position&, Move, Depth, const HistoryStats&, const CounterMovesHistoryStats&, Move*, Search::Stack*);
+  MovePicker(const Position&, Move, Depth, const HistoryStats&, const CounterMovesHistoryStats&, Move, Search::Stack*);
 
   template<bool SpNode> Move next_move();
 
@@ -102,10 +99,10 @@ private:
   const HistoryStats& history;
   const CounterMovesHistoryStats& counterMovesHistory;
   Search::Stack* ss;
-  Move* countermoves;
+  Move countermove;
   Depth depth;
   Move ttMove;
-  ExtMove killers[4];
+  ExtMove killers[3];
   Square recaptureSquare;
   Value captureThreshold;
   int stage;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -783,10 +783,9 @@ namespace {
 moves_loop: // When in check and at SpNode search starts from here
 
     Square prevMoveSq = to_sq((ss-1)->currentMove);
-    Move countermoves[] = { Countermoves[pos.piece_on(prevMoveSq)][prevMoveSq].first,
-                            Countermoves[pos.piece_on(prevMoveSq)][prevMoveSq].second };
+    Move countermove = Countermoves[pos.piece_on(prevMoveSq)][prevMoveSq];
 
-    MovePicker mp(pos, ttMove, depth, History, CounterMovesHistory, countermoves, ss);
+    MovePicker mp(pos, ttMove, depth, History, CounterMovesHistory, countermove, ss);
     CheckInfo ci(pos);
     value = bestValue; // Workaround a bogus 'uninitialized' warning under gcc
     improving =   ss->staticEval >= (ss-2)->staticEval
@@ -964,7 +963,7 @@ moves_loop: // When in check and at SpNode search starts from here
                 + History[pos.piece_on(to_sq(move))][to_sq(move)] < VALUE_ZERO)
               ss->reduction += ONE_PLY;
 
-          if (move == countermoves[0] || move == countermoves[1])
+          if (move == countermove)
               ss->reduction = std::max(DEPTH_ZERO, ss->reduction - ONE_PLY);
 
           // Decrease reduction for moves that escape a capture


### PR DESCRIPTION
STC http://tests.stockfishchess.org/tests/view/5518dca30ebc5902160ec5d0
LLR: 2.95 (-2.94,2.94) [-3.50,0.50]
Total: 18868 W: 3638 L: 3530 D: 11700

LTC http://tests.stockfishchess.org/tests/view/5518f7ed0ebc5902160ec5d4
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 69767 W: 11019 L: 10973 D: 47775

Extracted from this
http://tests.stockfishchess.org/tests/view/5511028a0ebc5902160ec40b
original patch by hxim.  All credit goes to him.