### PR TITLE
Add support for playing in 'nodes as time' mode

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -76,7 +76,7 @@ typedef std::vector<RootMove> RootMoveVector;
 struct LimitsType {
 
   LimitsType() { // Init explicitly due to broken value-initialization of non POD in MSVC
-    nodes = time[WHITE] = time[BLACK] = inc[WHITE] = inc[BLACK] = movestogo =
+    nodes = time[WHITE] = time[BLACK] = inc[WHITE] = inc[BLACK] = npmsec = movestogo =
     depth = movetime = mate = infinite = ponder = 0;
   }
 
@@ -85,7 +85,7 @@ struct LimitsType {
   }
 
   std::vector<Move> searchmoves;
-  int time[COLOR_NB], inc[COLOR_NB], movestogo, depth, movetime, mate, infinite, ponder;
+  int time[COLOR_NB], inc[COLOR_NB], npmsec, movestogo, depth, movetime, mate, infinite, ponder;
   int64_t nodes;
 };
 

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -27,11 +27,13 @@
 
 class TimeManagement {
 public:
-  void init(const Search::LimitsType& limits, Color us, int ply, TimePoint now);
+  void init(Search::LimitsType& limits, Color us, int ply, TimePoint now);
   void pv_instability(double bestMoveChanges) { unstablePvFactor = 1 + bestMoveChanges; }
   int available() const { return int(optimumTime * unstablePvFactor * 0.76); }
   int maximum() const { return maximumTime; }
   int elapsed() const { return now() - start; }
+
+  int64_t availableNodes; // When in 'nodes as time' mode
 
 private:
   TimePoint start;
@@ -39,5 +41,7 @@ private:
   int maximumTime;
   double unstablePvFactor;
 };
+
+extern TimeManagement Time;
 
 #endif // #ifndef TIMEMAN_H_INCLUDED

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -26,6 +26,7 @@
 #include "position.h"
 #include "search.h"
 #include "thread.h"
+#include "timeman.h"
 #include "tt.h"
 #include "uci.h"
 
@@ -178,8 +179,12 @@ void UCI::loop(int argc, char* argv[]) {
                     << "\n"       << Options
                     << "\nuciok"  << sync_endl;
 
+      else if (token == "ucinewgame")
+      {
+          TT.clear();
+          Time.availableNodes = 0;
+      }
       else if (token == "isready")    sync_cout << "readyok" << sync_endl;
-      else if (token == "ucinewgame") TT.clear();
       else if (token == "go")         go(pos, is);
       else if (token == "position")   position(pos, is);
       else if (token == "setoption")  setoption(is);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -67,6 +67,7 @@ void init(OptionsMap& o) {
   o["Move Overhead"]         << Option(30, 0, 5000);
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
   o["Slow Mover"]            << Option(80, 10, 1000);
+  o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);


### PR DESCRIPTION
Tests seem to show that implementation is correct, and the background noise that leads to variable CPU speed is removed when playing in this mode.

Due to its limitations (see log message), this mode is suitable mostly for SPSA tuning, so I'd like to merge this in and allow people experiment with real SPSA sessions (I will explain how to enable it for SPSA in a separated post on the forum).

Eventually I can remove it before official release because I think is not suitable for general consumption, due to the high risk of misusing it, but specifically for a niche but critical application in fishtest.
