### PR TITLE
Use minimumSplitDepth = 5

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -323,7 +323,7 @@ void ThreadPool::read_uci_options() {
 
   // If zero (default) then set best minimum split depth automatically
   if (!minimumSplitDepth)
-      minimumSplitDepth = requested < 8 ? 4 * ONE_PLY : 7 * ONE_PLY;
+      minimumSplitDepth =  5 * ONE_PLY ;
 
   while (size() < requested)
       push_back(new_thread<Thread>());


### PR DESCRIPTION
After the reduction of the split overhead last month, we can afford to try splitting nodes at lower depths in the game tree. Using minimumSplitDepth = 5 seems to be the best compromise in the current SMP alpha-beta implementation.

No functional change in single-thread mode.

Bench: 7664249