### PR TITLE
MovePicker::score<QUIETS>()

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -167,7 +167,7 @@ void MovePicker::score<QUIETS>() {
 
   for (auto& m : *this)
       m.value =  history[pos.moved_piece(m)][to_sq(m)]
-               + cmh[pos.moved_piece(m)][to_sq(m)] * 2;
+               + cmh[pos.moved_piece(m)][to_sq(m)] * 3;
 }
 
 template<>

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -167,7 +167,7 @@ void MovePicker::score<QUIETS>() {
 
   for (auto& m : *this)
       m.value =  history[pos.moved_piece(m)][to_sq(m)]
-               + cmh[pos.moved_piece(m)][to_sq(m)];
+               + cmh[pos.moved_piece(m)][to_sq(m)] * 2;
 }
 
 template<>


### PR DESCRIPTION
STC http://tests.stockfishchess.org/tests/view/5522f48f0ebc590d172268c2
LLR: 2.97 (-2.94,2.94) [-1.50,4.50]
Total: 45363 W: 8759 L: 8532 D: 28072

LTC http://tests.stockfishchess.org/tests/view/552417320ebc590d172268ee
LLR: 3.51 (-2.94,2.94) [0.00,4.00]
Total: 125092 W: 20032 L: 19468 D: 85592

Tuned history/cmh relative weights in MovePicker::score().  Idea from VoyagerOne Tuna patch.