### PR TITLE
Allow Position::init() to be called more than once

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -149,6 +149,7 @@ void Position::init() {
 
   for (int cr = NO_CASTLING; cr <= ANY_CASTLING; ++cr)
   {
+      Zobrist::castling[cr] = 0;
       Bitboard b = cr;
       while (b)
       {

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -19,7 +19,7 @@
 
 #include <algorithm>
 #include <cassert>
-#include <sstream>
+#include <ostream>
 
 #include "misc.h"
 #include "thread.h"


### PR DESCRIPTION
Currently Zobrist::castling[] are not properly zeroed
and rely on the compiler to do this at startup, but this
makes Position::init() to set different values every time
it is called!

This is a bit odd, and although not impacting normal usage,
can yield to subtle misbehavior, very difficult to track
down, in case we happen to call it more than once for some
reason. I found this while developing tuning support and
it took me a while to track it down.

So properly init Zobrist::castling[]

No functional change.