### PR TITLE
Update stats at pv nodes.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -945,8 +945,6 @@ moves_loop: // When in check and at SpNode search starts from here
       }
 
       ss->currentMove = move;
-      if (!SpNode && !captureOrPromotion && quietCount < 64)
-          quietsSearched[quietCount++] = move;
 
       // Step 14. Make the move
       pos.do_move(move, st, givesCheck);
@@ -1070,6 +1068,7 @@ moves_loop: // When in check and at SpNode search starts from here
               rm.score = -VALUE_INFINITE;
       }
 
+      bool goodMove = false;
       if (value > bestValue)
       {
           bestValue = SpNode ? splitPoint->bestValue = value : value;
@@ -1082,6 +1081,7 @@ moves_loop: // When in check and at SpNode search starts from here
                   && (move != EasyMove.get(pos.key()) || moveCount > 1))
                   EasyMove.clear();
 
+              goodMove = true;
               bestMove = SpNode ? splitPoint->bestMove = move : move;
 
               if (PvNode && !RootNode) // Update pv even in fail-high case
@@ -1100,6 +1100,9 @@ moves_loop: // When in check and at SpNode search starts from here
               }
           }
       }
+
+      if (!SpNode && !captureOrPromotion && !goodMove && quietCount < 64)
+          quietsSearched[quietCount++] = move;
 
       // Step 19. Check for splitting the search
       if (   !SpNode
@@ -1144,8 +1147,8 @@ moves_loop: // When in check and at SpNode search starts from here
                    :     inCheck ? mated_in(ss->ply) : DrawValue[pos.side_to_move()];
 
     // Quiet best move: update killers, history and countermoves
-    else if (bestValue >= beta && !pos.capture_or_promotion(bestMove))
-        update_stats(pos, ss, bestMove, depth, quietsSearched, quietCount - 1);
+    else if (bestMove != MOVE_NONE && !pos.capture_or_promotion(bestMove))
+        update_stats(pos, ss, bestMove, depth, quietsSearched, quietCount);
 
     tte->save(posKey, value_to_tt(bestValue, ss->ply),
               bestValue >= beta ? BOUND_LOWER :

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1405,8 +1405,7 @@ moves_loop: // When in check and at SpNode search starts from here
     *pv = MOVE_NONE;
   }
 
-  // update_stats() updates killers, history and countermoves stats after a fail-high
-  // of a quiet move.
+  // update_stats() updates killers, history, countermove history and countermoves stats for a quiet best move.
 
   void update_stats(const Position& pos, Stack* ss, Move move, Depth depth, Move* quiets, int quietsCnt) {
 


### PR DESCRIPTION
If a quiet best move is found at a pv node always update stats.

STC:
LLR: 2.96 (-2.94,2.94) [-1.50,4.50]
Total: 41485 W: 8047 L: 7830 D: 25608

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,6.00]
Total: 14351 W: 2420 L: 2250 D: 9681

Bench: 6948938