### PR TITLE
Update search.cpp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -960,7 +960,6 @@ moves_loop: // When in check and at SpNode search starts from here
           ss->reduction = reduction<PvNode>(improving, depth, moveCount);
 
           if (   (!PvNode && cutNode)
-              ||  History[pos.piece_on(to_sq(move))][to_sq(move)] < VALUE_ZERO
               || (  History[pos.piece_on(to_sq(move))][to_sq(move)]
                   + CounterMovesHistory[pos.piece_on(prevMoveSq)][prevMoveSq]
                                        [pos.piece_on(to_sq(move))][to_sq(move)] < VALUE_ZERO))


### PR DESCRIPTION
Removed extra condition(history<0) in LMR...to help sync up with move ordering.
LMR condition is now cmh+history<0
Instead of history<0 OR cmh+history<0

STC: 
LLR: 2.96 (-2.94,2.94) [-3.00, 1.00] 
Total: 26446 W: 5092 L: 4980 D: 16374

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00, 1.00] 
Total: 14129 W: 2340 L: 2209 D: 9580

Bench: 7815183