### PR TITLE
Rook support checks

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -427,7 +427,7 @@ namespace {
                 attackUnits += QueenContactCheck * popcount<Max15>(b);
         }
 
-if (false) {
+//if (false) {
         // Analyse the enemy's safe rook contact checks. Firstly, find the
         // undefended squares around the king reachable by the enemy rooks...
         b = undefended & ei.attackedBy[Them][ROOK] & ~pos.pieces(Them);
@@ -439,12 +439,12 @@ if (false) {
         {
             // ...and then remove squares not supported by another enemy piece
             b &= (  ei.attackedBy[Them][PAWN]   | ei.attackedBy[Them][KNIGHT]
-                  | ei.attackedBy[Them][BISHOP] | ei.attackedBy[Them][QUEEN]);
+                  | ei.attackedBy[Them][BISHOP]); // | ei.attackedBy[Them][QUEEN]);
 
             if (b)
                 attackUnits += RookContactCheck * popcount<Max15>(b);
         }
-}
+//}
 
         // Analyse the enemy's safe distance checks for sliders and knights
         safe = ~(ei.attackedBy[Us][ALL_PIECES] | pos.pieces(Them));

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -427,6 +427,7 @@ namespace {
                 attackUnits += QueenContactCheck * popcount<Max15>(b);
         }
 
+if (false) {
         // Analyse the enemy's safe rook contact checks. Firstly, find the
         // undefended squares around the king reachable by the enemy rooks...
         b = undefended & ei.attackedBy[Them][ROOK] & ~pos.pieces(Them);
@@ -443,6 +444,7 @@ namespace {
             if (b)
                 attackUnits += RookContactCheck * popcount<Max15>(b);
         }
+}
 
         // Analyse the enemy's safe distance checks for sliders and knights
         safe = ~(ei.attackedBy[Us][ALL_PIECES] | pos.pieces(Them));


### PR DESCRIPTION
// [QUEEN] is not needed in the Rook Contact Check computation since already done in the Queen Contact Checks with a large bonus
// example: if Rook can attack g7 supported by Queen, then Queen can also move to g7 supported by Rook (since there are no x-ray on Queens) so it was already computed.

@9+0.05
ELO: 1.11 +-2.8 (95%) LOS: 78.4%
Total: 25000 W: 5210 L: 5130 D: 14660

@15+0.05 
LLR: 2.96 (-2.94,2.94) [-1.50,4.50]
Total: 8095 W: 1597 L: 1470 D: 5028

@60+0.05  as a parameter tweak
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 29133 W: 4755 L: 4513 D: 19865