### PR TITLE
Replace MVV/LVA by MVV

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -148,7 +148,7 @@ void MovePicker::score<CAPTURES>() {
   // has been picked up in pick_move_from_list(). This way we save some SEE
   // calls in case we get a cutoff.
   for (auto& m : *this)
-      m.value =  Value(int(pos.piece_on(to_sq(m));
+      m.value =  Value(int(pos.piece_on(to_sq(m))));
 }
 
 template<>

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -134,10 +134,10 @@ MovePicker::MovePicker(const Position& p, Move ttm, const HistoryStats& h, const
 /// highest values will be picked first.
 template<>
 void MovePicker::score<CAPTURES>() {
-  // Winning and equal captures in the main search are ordered by MVV/LVA.
-  // Suprisingly, this appears to perform slightly better than SEE based
+  // Winning and equal captures in the main search are ordered by MVV.
+  // Suprisingly, this appears to perform slightly better than SEE or MVV/LVA based
   // move ordering. The reason is probably that in a position with a winning
-  // capture, capturing a more valuable (but sufficiently defended) piece
+  // capture, capturing a valuable (but sufficiently defended) piece
   // first usually doesn't hurt. The opponent will have to recapture, and
   // the hanging piece will still be hanging (except in the unusual cases
   // where it is possible to recapture with the hanging piece). Exchanging

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -148,19 +148,7 @@ void MovePicker::score<CAPTURES>() {
   // has been picked up in pick_move_from_list(). This way we save some SEE
   // calls in case we get a cutoff.
   for (auto& m : *this)
-<<<<<<< HEAD
       m.value =  Value(int(pos.piece_on(to_sq(m))));
-=======
-      if (type_of(m) == ENPASSANT)
-          m.value = PieceValue[MG][PAWN] - Value(PAWN);
-
-      else if (type_of(m) == PROMOTION)
-          m.value =  PieceValue[MG][pos.piece_on(to_sq(m))] - Value(PAWN)
-                   + PieceValue[MG][promotion_type(m)] - PieceValue[MG][PAWN];
-      else
-          m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
-                   - Value(type_of(pos.moved_piece(m)));
->>>>>>> parent of c2ab84a... Switch to pure MVV logic
 }
 
 template<>

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -148,15 +148,7 @@ void MovePicker::score<CAPTURES>() {
   // has been picked up in pick_move_from_list(). This way we save some SEE
   // calls in case we get a cutoff.
   for (auto& m : *this)
-      if (type_of(m) == ENPASSANT)
-          m.value = PieceValue[MG][PAWN] - Value(PAWN);
-
-      else if (type_of(m) == PROMOTION)
-          m.value =  PieceValue[MG][pos.piece_on(to_sq(m))] - Value(PAWN)
-                   + PieceValue[MG][promotion_type(m)] - PieceValue[MG][PAWN];
-      else
-          m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
-                   - Value(type_of(pos.moved_piece(m)));
+      m.value =  Value(int(pos.piece_on(to_sq(m));
 }
 
 template<>

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -148,7 +148,19 @@ void MovePicker::score<CAPTURES>() {
   // has been picked up in pick_move_from_list(). This way we save some SEE
   // calls in case we get a cutoff.
   for (auto& m : *this)
+<<<<<<< HEAD
       m.value =  Value(int(pos.piece_on(to_sq(m))));
+=======
+      if (type_of(m) == ENPASSANT)
+          m.value = PieceValue[MG][PAWN] - Value(PAWN);
+
+      else if (type_of(m) == PROMOTION)
+          m.value =  PieceValue[MG][pos.piece_on(to_sq(m))] - Value(PAWN)
+                   + PieceValue[MG][promotion_type(m)] - PieceValue[MG][PAWN];
+      else
+          m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
+                   - Value(type_of(pos.moved_piece(m)));
+>>>>>>> parent of c2ab84a... Switch to pure MVV logic
 }
 
 template<>

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1057,7 +1057,8 @@ moves_loop: // When in check and at SpNode search starts from here
               // We record how often the best move has been changed in each
               // iteration. This information is used for time management: When
               // the best move changes frequently, we allocate some more time.
-              BestMoveChanges += moveCount - 1;
+              if (moveCount > 1)
+                  ++BestMoveChanges;
           }
           else
               // All other moves but the PV are set to the lowest value: this is

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1057,8 +1057,7 @@ moves_loop: // When in check and at SpNode search starts from here
               // We record how often the best move has been changed in each
               // iteration. This information is used for time management: When
               // the best move changes frequently, we allocate some more time.
-              if (moveCount > 1)
-                  ++BestMoveChanges;
+              BestMoveChanges += moveCount - 1;
           }
           else
               // All other moves but the PV are set to the lowest value: this is


### PR DESCRIPTION
Passed STC

LLR: 3.71 (-2.94,2.94) [-3.00,1.00]
Total: 64363 W: 12299 L: 12214 D: 39850

and LTC

LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 69976 W: 11056 L: 11011 D: 47909

Reasons to commit the patch:

1) In the MVV/LVA paradigm the LVA part does add very little ELO
2) Removing LVA reduces both code line count and code complexity

Regarding 1)
- Simplification test passed with positive score, both in at [STC] (http://tests.stockfishchess.org/tests/view/55320f6d0ebc596367ee9a85) and [LTC] (http://tests.stockfishchess.org/tests/view/5535e1740ebc596367ee9b55). Comparing with results with different sprt simulators it should be something between -1 and -0.5 ELO.
- [Tabled] (http://tests.stockfishchess.org/tests/view/552d33d80ebc596367ee990b) and [tuned] (http://tests.stockfishchess.org/tests/view/5530a47b0ebc596367ee9a03) MVV/LVA failed STC with identical run length, tuned MVV/LVA being practically identical to MVV/LVA + some random walk of parameters
- LVA alone failed STC [miserably] (http://tests.stockfishchess.org/tests/view/5535582c0ebc596367ee9b32)
- Nevertheless, there must be some part of LVA which is useful (or which correlates with something useful), since [MVV/MVA] (http://tests.stockfishchess.org/tests/view/553113590ebc596367ee9a42) failed more clearly than tabled or tuned MVV/LVA. 