### PR TITLE
Improve ordering of good captures using rank term

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -19,6 +19,7 @@
 */
 
 #include <cassert>
+#include <iostream>
 
 #include "movepick.h"
 #include "thread.h"
@@ -147,8 +148,9 @@ void MovePicker::score<CAPTURES>() {
   // badCaptures[] array, but instead of doing it now we delay until the move
   // has been picked up in pick_move_from_list(). This way we save some SEE
   // calls in case we get a cutoff.
-  for (auto& m : *this)
-      m.value =  Value(int(pos.piece_on(to_sq(m))));
+  for (auto& m : *this){
+      m.value = PieceValue[MG][pos.piece_on(to_sq(m))] - 200*relative_rank(pos.side_to_move(), to_sq(m));
+  }
 }
 
 template<>

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -19,7 +19,6 @@
 */
 
 #include <cassert>
-#include <iostream>
 
 #include "movepick.h"
 #include "thread.h"


### PR DESCRIPTION
Rank based term improved approximation of pos.see() for scoring good captures.

Passed STC

LLR: 2.95 (-2.94,2.94) [-1.50,4.50]
Total: 4632 W: 945 L: 827 D: 2860

and LTC

LLR: 2.95 (-2.94,2.94) [0.00,6.00]
Total: 25770 W: 4184 L: 3964 D: 17622