### PR TITLE
Optimize TTEntry::save()

### DIFF
--- a/src/tt.h
+++ b/src/tt.h
@@ -44,7 +44,7 @@ struct TTEntry {
   void save(Key k, Value v, Bound b, Depth d, Move m, Value ev, uint8_t g) {
 
     // Preserve any existing move for the same position
-    if (m || (k >> 48) != key16)
+    if ((k >> 48) != key16 || m)
         move16 = (uint16_t)m;
 
     // Don't overwrite more valuable entries


### PR DESCRIPTION
Since (k >> 48) != key16 always gets computed later anyway move it first so sometimes we can skip testing m.

gcc 4.9.2
make build ARCH=x86-64-modern COMP=mingw
```
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    876165    882852    -6687     
    StDev   314228    314813    2942      

p-value: 0.988
```
.75% faster

make profile-build ARCH=x86-64-modern COMP=mingw
```
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    1019161   1023413   -4252     
    StDev   306245    306768    2923      

p-value: 0.927
```
.4% faster

Can someone please verify?

