### PR TITLE
Checking for rook color when setting castling

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -266,14 +266,15 @@ void Position::set(const string& fenStr, bool isChess960, Thread* th) {
   {
       Square rsq;
       Color c = islower(token) ? BLACK : WHITE;
+      Piece rook = make_piece(c, ROOK);
 
       token = char(toupper(token));
 
       if (token == 'K')
-          for (rsq = relative_square(c, SQ_H1); type_of(piece_on(rsq)) != ROOK; --rsq) {}
+          for (rsq = relative_square(c, SQ_H1); piece_on(rsq) != rook; --rsq) {}
 
       else if (token == 'Q')
-          for (rsq = relative_square(c, SQ_A1); type_of(piece_on(rsq)) != ROOK; ++rsq) {}
+          for (rsq = relative_square(c, SQ_A1); piece_on(rsq) != rook; ++rsq) {}
 
       else if (token >= 'A' && token <= 'H')
           rsq = make_square(File(token - 'A'), relative_rank(c, RANK_1));


### PR DESCRIPTION
In Chess960 we can have legal positions with
opponent rook in A or H file and with castling
available, for instance:

4k3/pppppppp/8/8/8/8/PPPPPPPP/rR2K3 w Q - 0 1

In those cases we pick up the wrong rook when
setting castling.

Fix it by checking the color of the rook.

Bug reported by Matthew Lai.

No functional change.