### PR TITLE
Remove intermediate re-search in LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -975,13 +975,6 @@ moves_loop: // When in check and at SpNode search starts from here
 
           value = -search<NonPV, false>(pos, ss+1, -(alpha+1), -alpha, d, true);
 
-          // Re-search at intermediate depth if reduction is very high
-          if (value > alpha && ss->reduction >= 4 * ONE_PLY)
-          {
-              Depth d2 = std::max(newDepth - 2 * ONE_PLY, ONE_PLY);
-              value = -search<NonPV, false>(pos, ss+1, -(alpha+1), -alpha, d2, true);
-          }
-
           doFullDepthSearch = (value > alpha && ss->reduction != DEPTH_ZERO);
           ss->reduction = DEPTH_ZERO;
       }


### PR DESCRIPTION
Removing intermediate re-search on LMR fail high as a simplification. See thread https://groups.google.com/d/msg/fishcooking/QtzXr8Jb5d0/0SwSIsSg7VMJ for details and discussion.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 20149 W: 3830 L: 3707 D: 12612

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 45384 W: 7089 L: 7006 D: 31289

The theory is that since this step was introduced in 2013, the basic search has improved, so that the fail-highs from the LMR search are more reliable and thus more time is wasted confirming them than is gained by refuting them. But in the end, it's about the numbers, not the theories.