### PR TITLE
Retire -Wno-long-long

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -151,7 +151,7 @@ endif
 ifeq ($(COMP),gcc)
 	comp=gcc
 	CXX=g++
-	CXXFLAGS += -pedantic -Wno-long-long -Wextra -Wshadow
+	CXXFLAGS += -pedantic -Wextra -Wshadow
 	ifneq ($(UNAME),Darwin)
 	   LDFLAGS += -Wl,--no-as-needed
 	endif
@@ -173,7 +173,7 @@ endif
 ifeq ($(COMP),clang)
 	comp=clang
 	CXX=clang++
-	CXXFLAGS += -pedantic -Wno-long-long -Wextra -Wshadow
+	CXXFLAGS += -pedantic -Wextra -Wshadow
 	ifeq ($(UNAME),Darwin)
 		CXXFLAGS += -std=c++0x -stdlib=libc++
 		DEPENDFLAGS += -std=c++0x -stdlib=libc++


### PR DESCRIPTION
`long long` is part of the `C++11` standard.

No functional change.