### PR TITLE
Simplify SEE calculation (no X-Ray)

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -54,30 +54,24 @@ const string PieceToChar(" PNBRQK  pnbrqk");
 
 // min_attacker() is a helper function used by see() to locate the least
 // valuable attacker for the side to move, remove the attacker we just found
-// from the bitboards and scan for new X-ray attacks behind it.
+// from the bitboards
 
 template<int Pt>
-PieceType min_attacker(const Bitboard* bb, const Square& to, const Bitboard& stmAttackers,
+PieceType min_attacker(const Bitboard* bb, const Bitboard& stmAttackers,
                        Bitboard& occupied, Bitboard& attackers) {
 
   Bitboard b = stmAttackers & bb[Pt];
   if (!b)
-      return min_attacker<Pt+1>(bb, to, stmAttackers, occupied, attackers);
+      return min_attacker<Pt+1>(bb, stmAttackers, occupied, attackers);
 
-  occupied ^= b & ~(b - 1);
+  occupied ^= b & ~(b - 1); // Remove one attacker from occupied
 
-  //if (Pt == PAWN || Pt == BISHOP || Pt == QUEEN)
-  //    attackers |= attacks_bb<BISHOP>(to, occupied) & (bb[BISHOP] | bb[QUEEN]);
-
-  //if (Pt == ROOK || Pt == QUEEN)
-  //    attackers |= attacks_bb<ROOK>(to, occupied) & (bb[ROOK] | bb[QUEEN]);
-
-  attackers &= occupied; // After X-ray that may add already processed pieces
+  attackers &= occupied;   // ...and synchronize the attackers Bitboard.
   return (PieceType)Pt;
 }
 
 template<>
-PieceType min_attacker<KING>(const Bitboard*, const Square&, const Bitboard&, Bitboard&, Bitboard&) {
+PieceType min_attacker<KING>(const Bitboard*, const Bitboard&, Bitboard&, Bitboard&) {
   return KING; // No need to update bitboards: it is the last cycle
 }
 
@@ -1045,7 +1039,7 @@ Value Position::see(Move m) const {
       swapList[slIndex] = -swapList[slIndex - 1] + PieceValue[MG][captured];
 
       // Locate and remove the next least valuable attacker
-      captured = min_attacker<PAWN>(byTypeBB, to, stmAttackers, occupied, attackers);
+      captured = min_attacker<PAWN>(byTypeBB, stmAttackers, occupied, attackers);
       stm = ~stm;
       stmAttackers = attackers & pieces(stm);
       ++slIndex;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -66,11 +66,11 @@ PieceType min_attacker(const Bitboard* bb, const Square& to, const Bitboard& stm
 
   occupied ^= b & ~(b - 1);
 
-  if (Pt == PAWN || Pt == BISHOP || Pt == QUEEN)
-      attackers |= attacks_bb<BISHOP>(to, occupied) & (bb[BISHOP] | bb[QUEEN]);
+  //if (Pt == PAWN || Pt == BISHOP || Pt == QUEEN)
+  //    attackers |= attacks_bb<BISHOP>(to, occupied) & (bb[BISHOP] | bb[QUEEN]);
 
-  if (Pt == ROOK || Pt == QUEEN)
-      attackers |= attacks_bb<ROOK>(to, occupied) & (bb[ROOK] | bb[QUEEN]);
+  //if (Pt == ROOK || Pt == QUEEN)
+  //    attackers |= attacks_bb<ROOK>(to, occupied) & (bb[ROOK] | bb[QUEEN]);
 
   attackers &= occupied; // After X-ray that may add already processed pieces
   return (PieceType)Pt;


### PR DESCRIPTION
Passed STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 31885 W: 6055 L: 5953 D: 19877

And LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 76309 W: 12017 L: 11981 D: 52311

Bench: 9159664

Same version which passed the tests, but with dead code removed.
See also next pull request for a possibly faster version.