### PR TITLE
Optimize the TT replacement policy implementation for speed.

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -86,11 +86,16 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 
   // Find an entry to be replaced according to the replacement strategy
   TTEntry* replace = tte;
+  int ev1 = ((tte->genBound8 & 0xFC) == generation8) * 256 + tte->depth8;
   for (int i = 1; i < ClusterSize; ++i)
-      if (  ((  tte[i].genBound8 & 0xFC) == generation8 || tte[i].bound() == BOUND_EXACT)
-          - ((replace->genBound8 & 0xFC) == generation8)
-          - (tte[i].depth8 < replace->depth8) < 0)
+  {
+      int ev2 = ((tte[i].genBound8 & 0xFC) == generation8 || tte[i].bound() == BOUND_EXACT) * 256 + tte[i].depth8;
+      if (ev2 < ev1)
+      {
+          ev1 = ev2;
           replace = &tte[i];
+      }
+  }
 
   return found = false, replace;
 }

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -86,13 +86,13 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 
   // Find an entry to be replaced according to the replacement strategy
   TTEntry* replace = tte;
-  int ev1 = ((tte->genBound8 & 0xFC) == generation8) * 256 + tte->depth8;
+  int minScore = ((tte->genBound8 & 0xFC) == generation8) * 256 + tte->depth8;
   for (int i = 1; i < ClusterSize; ++i)
   {
-      int ev2 = ((tte[i].genBound8 & 0xFC) == generation8 || tte[i].bound() == BOUND_EXACT) * 256 + tte[i].depth8;
-      if (ev2 < ev1)
+      int score = ((tte[i].genBound8 & 0xFC) == generation8 || tte[i].bound() == BOUND_EXACT) * 256 + tte[i].depth8;
+      if (score < minScore)
       {
-          ev1 = ev2;
+          minScore = score;
           replace = &tte[i];
       }
   }


### PR DESCRIPTION
No functional change.

gcc 4.9.2 
make profile-build ARCH=x86-64-modern COMP=mingw

```
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    1037545   1045727   -8182     
    StDev   304161    306417    3512      

p-value: 0.99
```
0.8% faster

Can someone please verify?