### PR TITLE
Only Quiets

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1428,7 +1428,7 @@ moves_loop: // When in check and at SpNode search starts from here
     }
 
     // Extra penalty for TT move in previous ply when it gets refuted
-    if (is_ok((ss-2)->currentMove) && (ss-1)->currentMove == (ss-1)->ttMove)
+    if (is_ok((ss-2)->currentMove) && (ss-1)->currentMove == (ss-1)->ttMove && !pos.captured_piece_type())
     {
         Square prevPrevSq = to_sq((ss-2)->currentMove);
         HistoryStats& ttMoveCmh = CounterMovesHistory[pos.piece_on(prevPrevSq)][prevPrevSq];


### PR DESCRIPTION
This will make sure we store only quiet moves for TT Penalty.


STC:
LLR: 2.96 (-2.94,2.94) [-1.50,4.50]
Total: 34748 W: 6617 L: 6420 D: 21711

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 19975 W: 3259 L: 3137 D: 13579

Bench:  8063826