### PR TITLE
consistent TT

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -87,8 +87,8 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   // Find an entry to be replaced according to the replacement strategy
   TTEntry* replace = tte;
   for (int i = 1; i < ClusterSize; ++i)
-      if (  ((  tte[i].genBound8 & 0xFC) == generation8 ||   tte[i].bound() == BOUND_EXACT)
-          - ((replace->genBound8 & 0xFC) == generation8 || replace->bound() == BOUND_EXACT)
+      if (  ((  tte[i].genBound8 & 0xFC) == generation8)
+          - ((replace->genBound8 & 0xFC) == generation8)
           - (tte[i].depth8 < replace->depth8) < 0)
           replace = &tte[i];
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -87,8 +87,8 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   // Find an entry to be replaced according to the replacement strategy
   TTEntry* replace = tte;
   for (int i = 1; i < ClusterSize; ++i)
-      if (  ((  tte[i].genBound8 & 0xFC) == generation8 || tte[i].bound() == BOUND_EXACT)
-          - ((replace->genBound8 & 0xFC) == generation8)
+      if (  ((  tte[i].genBound8 & 0xFC) == generation8 ||   tte[i].bound() == BOUND_EXACT)
+          - ((replace->genBound8 & 0xFC) == generation8 || replace->bound() == BOUND_EXACT)
           - (tte[i].depth8 < replace->depth8) < 0)
           replace = &tte[i];
 


### PR DESCRIPTION
STC 2MB
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 11301 W: 2176 L: 2038 D: 7087
http://tests.stockfishchess.org/tests/view/55a35cd40ebc590abbe1ba35

LTC 8MB
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 17732 W: 2870 L: 2745 D: 12117
http://tests.stockfishchess.org/tests/view/55a429d10ebc590abbe1ba5a

STC 16MB
LLR: 2.96 (-2.94,2.94) [-4.00,0.00]
Total: 17401 W: 3324 L: 3227 D: 10850
http://tests.stockfishchess.org/tests/view/55a489e60ebc590abbe1ba6a

This fixes an inconsistency bug where TT entries were valued differently depending on which pointer they were accessed through.  It should also qualify as a simplification.