### PR TITLE
LMR Simplification

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -959,10 +959,9 @@ moves_loop: // When in check and at SpNode search starts from here
                                         [pos.piece_on(to_sq(move))][to_sq(move)] <= VALUE_ZERO))
               ss->reduction += ONE_PLY;
 
-          if (    move == countermove
-              || (   History[pos.piece_on(to_sq(move))][to_sq(move)] > VALUE_ZERO
+          if (   History[pos.piece_on(to_sq(move))][to_sq(move)] > VALUE_ZERO
                   && CounterMovesHistory[pos.piece_on(prevMoveSq)][prevMoveSq]
-                                        [pos.piece_on(to_sq(move))][to_sq(move)] > VALUE_ZERO))
+                                        [pos.piece_on(to_sq(move))][to_sq(move)] > VALUE_ZERO)
               ss->reduction = std::max(DEPTH_ZERO, ss->reduction - ONE_PLY);
 
           // Decrease reduction for moves that escape a capture


### PR DESCRIPTION
Removed countermove condition for decreasing reduction.

LTC:
LLR: 3.01 (-2.94,2.94) [-3.00,1.00]
Total: 32410 W: 5092 L: 4986 D: 22332

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 24450 W: 4632 L: 4517 D: 15301