### PR TITLE
TTreplace

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -66,9 +66,9 @@ void TranspositionTable::clear() {
 /// TranspositionTable::probe() looks up the current position in the transposition
 /// table. It returns true and a pointer to the TTEntry if the position is found.
 /// Otherwise, it returns false and a pointer to an empty or least valuable TTEntry
-/// to be replaced later. A TTEntry t1 is considered to be more valuable than a
-/// TTEntry t2 if the depth of t1 is bigger than the depth of t2 after adding 8 to
-/// each depth that is from the current search.
+/// to be replaced later. TTEntry t1 is considered more valuable than TTEntry t2 if
+/// both are from the current search and the depth of t1 is greater than the depth of t2,
+/// or if t1 is from a previous search but its depth is at least 8 ply deeper than t2.
 
 TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 
@@ -87,8 +87,8 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   // Find an entry to be replaced according to the replacement strategy
   TTEntry* replace = tte;
   for (int i = 1; i < ClusterSize; ++i)
-      if (  ((  tte[i].genBound8 & 0xFC) == generation8) * 8 +   tte[i].depth8
-          < ((replace->genBound8 & 0xFC) == generation8) * 8 + replace->depth8)
+      if (  ((  tte[i].genBound8 & 0xFC) == generation8) * 8 * ONE_PLY +   tte[i].depth8
+          < ((replace->genBound8 & 0xFC) == generation8) * 8 * ONE_PLY + replace->depth8)
           replace = &tte[i];
 
   return found = false, replace;

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -67,8 +67,8 @@ void TranspositionTable::clear() {
 /// table. It returns true and a pointer to the TTEntry if the position is found.
 /// Otherwise, it returns false and a pointer to an empty or least valuable TTEntry
 /// to be replaced later. A TTEntry t1 is considered to be more valuable than a
-/// TTEntry t2 if t1 is from the current search and t2 is from a previous search,
-/// or if the depth of t1 is bigger than the depth of t2.
+/// TTEntry t2 if the depth of t1 is bigger than the depth of t2 after adding 8 to
+/// each depth that is from the current search.
 
 TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -87,9 +87,8 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   // Find an entry to be replaced according to the replacement strategy
   TTEntry* replace = tte;
   for (int i = 1; i < ClusterSize; ++i)
-      if (  ((  tte[i].genBound8 & 0xFC) == generation8)
-          - ((replace->genBound8 & 0xFC) == generation8)
-          - (tte[i].depth8 < replace->depth8) < 0)
+      if (  ((  tte[i].genBound8 & 0xFC) == generation8) * 8 +   tte[i].depth8
+          < ((replace->genBound8 & 0xFC) == generation8) * 8 + replace->depth8)
           replace = &tte[i];
 
   return found = false, replace;


### PR DESCRIPTION
STC 2MB
LLR: 2.96 (-2.94,2.94) [-1.50,4.50]
Total: 16353 W: 3216 L: 3066 D: 10071
http://tests.stockfishchess.org/tests/view/55a6d0630ebc590abbe1babd

LTC 8MB
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 134618 W: 21276 L: 20716 D: 92626
http://tests.stockfishchess.org/tests/view/55a74d760ebc590abbe1bad6

STC 16MB
LLR: 2.96 (-2.94,2.94) [-4.00,0.00]
Total: 22549 W: 4257 L: 4178 D: 14114
http://tests.stockfishchess.org/tests/view/55a9a2f90ebc590abbe1bb16

Tuned version of TT replacement policy. (Note if the used multiplier of 8 was any number larger than DEPTH_MAX this would be a non functional patch.)