### PR TITLE
MobilityArea

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -701,9 +701,17 @@ namespace {
     ei.attackedBy[WHITE][ALL_PIECES] |= ei.attackedBy[WHITE][KING];
     ei.attackedBy[BLACK][ALL_PIECES] |= ei.attackedBy[BLACK][KING];
 
-    // Do not include in mobility squares protected by enemy pawns or occupied by our pawns or king
-    Bitboard mobilityArea[] = { ~(ei.attackedBy[BLACK][PAWN] | pos.pieces(WHITE, PAWN, KING)),
-                                ~(ei.attackedBy[WHITE][PAWN] | pos.pieces(BLACK, PAWN, KING)) };
+    // Find pawns on rank 4 and above which can move forward
+    Bitboard pmobw = shift_bb<DELTA_S>(~pos.pieces()) & ~(Rank2BB | Rank3BB);
+    Bitboard pmobb = shift_bb<DELTA_N>(~pos.pieces()) & ~(Rank7BB | Rank6BB);
+
+    // Find pawns which can capture
+    pmobw |= shift_bb<DELTA_SW>(pos.pieces(BLACK)) | shift_bb<DELTA_SE>(pos.pieces(BLACK));
+    pmobb |= shift_bb<DELTA_NW>(pos.pieces(WHITE)) | shift_bb<DELTA_NE>(pos.pieces(WHITE));
+
+    // Do not include in mobility squares protected by enemy pawns or occupied by our blocked pawns or king
+    Bitboard mobilityArea[] = { ~(ei.attackedBy[BLACK][PAWN] | (pos.pieces(WHITE, PAWN) & ~pmobw) | pos.pieces(WHITE, KING)) ,  					
+                                ~(ei.attackedBy[WHITE][PAWN] | (pos.pieces(BLACK, PAWN) & ~pmobb) | pos.pieces(BLACK, KING)) }; 					
 
     // Evaluate pieces and mobility
     score += evaluate_pieces<KNIGHT, WHITE, Trace>(pos, ei, mobility, mobilityArea);


### PR DESCRIPTION
Include squares occupied by mobile pawns in the MobilityArea

Bench # 7600729

Passed STC
LLR: 2.95 (-2.94,2.94) [-1.50,4.50]
Total: 8157 W: 1644 L: 1516 D: 4997

And LTC
LLR: 2.97 (-2.94,2.94) [0.00,6.00]
Total: 26086 W: 4274 L: 4051 D: 17761
