### PR TITLE
MobilityArea (simplified)

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -701,17 +701,17 @@ namespace {
     ei.attackedBy[WHITE][ALL_PIECES] |= ei.attackedBy[WHITE][KING];
     ei.attackedBy[BLACK][ALL_PIECES] |= ei.attackedBy[BLACK][KING];
 
-    // Find pawns on rank 4 and above which can move forward
-    Bitboard pmobw = shift_bb<DELTA_S>(~pos.pieces()) & ~(Rank2BB | Rank3BB);
-    Bitboard pmobb = shift_bb<DELTA_N>(~pos.pieces()) & ~(Rank7BB | Rank6BB);
+    // Blocked pawns, and also pawns on rank 2 and 3 will be excluded from the mobility area
+    Bitboard blockedPawns[] = {
+        pos.pieces(WHITE, PAWN) & (shift_bb<DELTA_S>(pos.pieces()) | Rank2BB | Rank3BB),
+        pos.pieces(BLACK, PAWN) & (shift_bb<DELTA_N>(pos.pieces()) | Rank7BB | Rank6BB)
+    };
 
-    // Find pawns which can capture
-    //pmobw |= shift_bb<DELTA_SW>(pos.pieces(BLACK)) | shift_bb<DELTA_SE>(pos.pieces(BLACK));
-    //pmobb |= shift_bb<DELTA_NW>(pos.pieces(WHITE)) | shift_bb<DELTA_NE>(pos.pieces(WHITE));
-
-    // Do not include in mobility squares protected by enemy pawns or occupied by our blocked pawns or king
-    Bitboard mobilityArea[] = { ~(ei.attackedBy[BLACK][PAWN] | (pos.pieces(WHITE, PAWN) & ~pmobw) | pos.pieces(WHITE, KING)) ,  					
-                                ~(ei.attackedBy[WHITE][PAWN] | (pos.pieces(BLACK, PAWN) & ~pmobb) | pos.pieces(BLACK, KING)) }; 					
+    // Do not include in mobility squares protected by enemy pawns, or occupied by our blocked pawns or king
+    Bitboard mobilityArea[] = { 
+        ~(ei.attackedBy[BLACK][PAWN] | blockedPawns[WHITE] | pos.king_square(WHITE)),
+        ~(ei.attackedBy[WHITE][PAWN] | blockedPawns[BLACK] | pos.king_square(BLACK))
+    };
 
     // Evaluate pieces and mobility
     score += evaluate_pieces<KNIGHT, WHITE, Trace>(pos, ei, mobility, mobilityArea);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -701,9 +701,17 @@ namespace {
     ei.attackedBy[WHITE][ALL_PIECES] |= ei.attackedBy[WHITE][KING];
     ei.attackedBy[BLACK][ALL_PIECES] |= ei.attackedBy[BLACK][KING];
 
-    // Do not include in mobility squares protected by enemy pawns or occupied by our pawns or king
-    Bitboard mobilityArea[] = { ~(ei.attackedBy[BLACK][PAWN] | pos.pieces(WHITE, PAWN, KING)),
-                                ~(ei.attackedBy[WHITE][PAWN] | pos.pieces(BLACK, PAWN, KING)) };
+    // Find pawns on rank 4 and above which can move forward
+    Bitboard pmobw = shift_bb<DELTA_S>(~pos.pieces()) & ~(Rank2BB | Rank3BB);
+    Bitboard pmobb = shift_bb<DELTA_N>(~pos.pieces()) & ~(Rank7BB | Rank6BB);
+
+    // Find pawns which can capture
+    pmobw |= shift_bb<DELTA_SW>(pos.pieces(BLACK)) | shift_bb<DELTA_SE>(pos.pieces(BLACK));
+    pmobb |= shift_bb<DELTA_NW>(pos.pieces(WHITE)) | shift_bb<DELTA_NE>(pos.pieces(WHITE));
+
+    // Do not include in mobility squares protected by enemy pawns or occupied by our blocked pawns or king
+    Bitboard mobilityArea[] = { ~(ei.attackedBy[BLACK][PAWN] | (pos.pieces(WHITE, PAWN) & ~pmobw) | pos.pieces(WHITE, KING)) ,  					
+                                ~(ei.attackedBy[WHITE][PAWN] | (pos.pieces(BLACK, PAWN) & ~pmobb) | pos.pieces(BLACK, KING)) }; 					
 
     // Evaluate pieces and mobility
     score += evaluate_pieces<KNIGHT, WHITE, Trace>(pos, ei, mobility, mobilityArea);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -701,16 +701,17 @@ namespace {
     ei.attackedBy[WHITE][ALL_PIECES] |= ei.attackedBy[WHITE][KING];
     ei.attackedBy[BLACK][ALL_PIECES] |= ei.attackedBy[BLACK][KING];
 
-    // Blocked pawns, and also pawns on rank 2 and 3 will be excluded from the mobility area
+    // Pawns blocked or on ranks 2 and 3. Will be excluded from the mobility area
     Bitboard blockedPawns[] = {
-        pos.pieces(WHITE, PAWN) & (shift_bb<DELTA_S>(pos.pieces()) | Rank2BB | Rank3BB),
-        pos.pieces(BLACK, PAWN) & (shift_bb<DELTA_N>(pos.pieces()) | Rank7BB | Rank6BB)
+      pos.pieces(WHITE, PAWN) & (shift_bb<DELTA_S>(pos.pieces()) | Rank2BB | Rank3BB),
+      pos.pieces(BLACK, PAWN) & (shift_bb<DELTA_N>(pos.pieces()) | Rank7BB | Rank6BB)
     };
 
-    // Do not include in mobility squares protected by enemy pawns, or occupied by our blocked pawns or king
-    Bitboard mobilityArea[] = { 
-        ~(ei.attackedBy[BLACK][PAWN] | blockedPawns[WHITE] | pos.king_square(WHITE)),
-        ~(ei.attackedBy[WHITE][PAWN] | blockedPawns[BLACK] | pos.king_square(BLACK))
+    // Do not include in mobility squares protected by enemy pawns, or occupied
+    // by our blocked pawns or king.
+    Bitboard mobilityArea[] = {
+      ~(ei.attackedBy[BLACK][PAWN] | blockedPawns[WHITE] | pos.king_square(WHITE)),
+      ~(ei.attackedBy[WHITE][PAWN] | blockedPawns[BLACK] | pos.king_square(BLACK))
     };
 
     // Evaluate pieces and mobility

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -706,8 +706,8 @@ namespace {
     Bitboard pmobb = shift_bb<DELTA_N>(~pos.pieces()) & ~(Rank7BB | Rank6BB);
 
     // Find pawns which can capture
-    pmobw |= shift_bb<DELTA_SW>(pos.pieces(BLACK)) | shift_bb<DELTA_SE>(pos.pieces(BLACK));
-    pmobb |= shift_bb<DELTA_NW>(pos.pieces(WHITE)) | shift_bb<DELTA_NE>(pos.pieces(WHITE));
+    //pmobw |= shift_bb<DELTA_SW>(pos.pieces(BLACK)) | shift_bb<DELTA_SE>(pos.pieces(BLACK));
+    //pmobb |= shift_bb<DELTA_NW>(pos.pieces(WHITE)) | shift_bb<DELTA_NE>(pos.pieces(WHITE));
 
     // Do not include in mobility squares protected by enemy pawns or occupied by our blocked pawns or king
     Bitboard mobilityArea[] = { ~(ei.attackedBy[BLACK][PAWN] | (pos.pieces(WHITE, PAWN) & ~pmobw) | pos.pieces(WHITE, KING)) ,  					


### PR DESCRIPTION
Initial test (pull request #383 ) was

Include squares occupied by some pawns in the MobilityArea
a) not blocked
b) on rank 4 and above
c) or captures

Passed STC
 LLR: 2.95 (-2.94,2.94) [-1.50,4.50]
 Total: 8157 W: 1644 L: 1516 D: 4997

And LTC
 LLR: 2.97 (-2.94,2.94) [0.00,6.00]
 Total: 26086 W: 4274 L: 4051 D: 17761

Then, a simplification test failed, trying to remove b and c)
  LLR: -2.95 (-2.94,2.94) [-3.00,1.00]
  Total: 6048 W: 1117 L: 1288 D: 3643

Another simplification test, was run to remove just (c)
Passed STC
  LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
  Total: 28073 W: 5364 L: 5255 D: 17454

And LTC
  LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
  Total: 34652 W: 5448 L: 5348 D: 23856

A parameter tweak test showed that changing b) for "on rank 3 and above"
does not work
  LLR: -2.95 (-2.94,2.94) [0.00,4.00]
  Total: 5233 W: 937 L: 1077 D: 3219

Finally, a small rewrite, and we have this version

Include squares occupied by some pawns in the MobilityArea which are
a) not blocked
b) on rank 4 and above

Bench # 8977899
