### PR TITLE
Rename Position::list

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -71,7 +71,7 @@ namespace {
 
     assert(pos.count<PAWN>(strongSide) == 1);
 
-    if (file_of(pos.list<PAWN>(strongSide)[0]) >= FILE_E)
+    if (file_of(pos.square<PAWN>(strongSide)) >= FILE_E)
         sq = Square(sq ^ 7); // Mirror SQ_H1 -> SQ_A1
 
     if (strongSide == BLACK)
@@ -147,8 +147,8 @@ Value Endgame<KXK>::operator()(const Position& pos) const {
   if (pos.side_to_move() == weakSide && !MoveList<LEGAL>(pos).size())
       return VALUE_DRAW;
 
-  Square winnerKSq = pos.king_square(strongSide);
-  Square loserKSq = pos.king_square(weakSide);
+  Square winnerKSq = pos.square<KING>(strongSide);
+  Square loserKSq = pos.square<KING>(weakSide);
 
   Value result =  pos.non_pawn_material(strongSide)
                 + pos.count<PAWN>(strongSide) * PawnValueEg
@@ -158,8 +158,8 @@ Value Endgame<KXK>::operator()(const Position& pos) const {
   if (   pos.count<QUEEN>(strongSide)
       || pos.count<ROOK>(strongSide)
       ||(pos.count<BISHOP>(strongSide) && pos.count<KNIGHT>(strongSide))
-      ||(pos.count<BISHOP>(strongSide) > 1 && opposite_colors(pos.list<BISHOP>(strongSide)[0],
-                                                              pos.list<BISHOP>(strongSide)[1])))
+      ||(pos.count<BISHOP>(strongSide) > 1 && opposite_colors(pos.squares<BISHOP>(strongSide)[0],
+                                                              pos.squares<BISHOP>(strongSide)[1])))
       result += VALUE_KNOWN_WIN;
 
   return strongSide == pos.side_to_move() ? result : -result;
@@ -174,9 +174,9 @@ Value Endgame<KBNK>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, KnightValueMg + BishopValueMg, 0));
   assert(verify_material(pos, weakSide, VALUE_ZERO, 0));
 
-  Square winnerKSq = pos.king_square(strongSide);
-  Square loserKSq = pos.king_square(weakSide);
-  Square bishopSq = pos.list<BISHOP>(strongSide)[0];
+  Square winnerKSq = pos.square<KING>(strongSide);
+  Square loserKSq = pos.square<KING>(weakSide);
+  Square bishopSq = pos.square<BISHOP>(strongSide);
 
   // kbnk_mate_table() tries to drive toward corners A1 or H8. If we have a
   // bishop that cannot reach the above squares, we flip the kings in order
@@ -203,9 +203,9 @@ Value Endgame<KPK>::operator()(const Position& pos) const {
   assert(verify_material(pos, weakSide, VALUE_ZERO, 0));
 
   // Assume strongSide is white and the pawn is on files A-D
-  Square wksq = normalize(pos, strongSide, pos.king_square(strongSide));
-  Square bksq = normalize(pos, strongSide, pos.king_square(weakSide));
-  Square psq  = normalize(pos, strongSide, pos.list<PAWN>(strongSide)[0]);
+  Square wksq = normalize(pos, strongSide, pos.square<KING>(strongSide));
+  Square bksq = normalize(pos, strongSide, pos.square<KING>(weakSide));
+  Square psq  = normalize(pos, strongSide, pos.square<PAWN>(strongSide));
 
   Color us = strongSide == pos.side_to_move() ? WHITE : BLACK;
 
@@ -228,10 +228,10 @@ Value Endgame<KRKP>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, RookValueMg, 0));
   assert(verify_material(pos, weakSide, VALUE_ZERO, 1));
 
-  Square wksq = relative_square(strongSide, pos.king_square(strongSide));
-  Square bksq = relative_square(strongSide, pos.king_square(weakSide));
-  Square rsq  = relative_square(strongSide, pos.list<ROOK>(strongSide)[0]);
-  Square psq  = relative_square(strongSide, pos.list<PAWN>(weakSide)[0]);
+  Square wksq = relative_square(strongSide, pos.square<KING>(strongSide));
+  Square bksq = relative_square(strongSide, pos.square<KING>(weakSide));
+  Square rsq  = relative_square(strongSide, pos.square<ROOK>(strongSide));
+  Square psq  = relative_square(strongSide, pos.square<PAWN>(weakSide));
 
   Square queeningSq = make_square(file_of(psq), RANK_1);
   Value result;
@@ -271,7 +271,7 @@ Value Endgame<KRKB>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, RookValueMg, 0));
   assert(verify_material(pos, weakSide, BishopValueMg, 0));
 
-  Value result = Value(PushToEdges[pos.king_square(weakSide)]);
+  Value result = Value(PushToEdges[pos.square<KING>(weakSide)]);
   return strongSide == pos.side_to_move() ? result : -result;
 }
 
@@ -284,8 +284,8 @@ Value Endgame<KRKN>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, RookValueMg, 0));
   assert(verify_material(pos, weakSide, KnightValueMg, 0));
 
-  Square bksq = pos.king_square(weakSide);
-  Square bnsq = pos.list<KNIGHT>(weakSide)[0];
+  Square bksq = pos.square<KING>(weakSide);
+  Square bnsq = pos.square<KNIGHT>(weakSide);
   Value result = Value(PushToEdges[bksq] + PushAway[distance(bksq, bnsq)]);
   return strongSide == pos.side_to_move() ? result : -result;
 }
@@ -301,9 +301,9 @@ Value Endgame<KQKP>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, QueenValueMg, 0));
   assert(verify_material(pos, weakSide, VALUE_ZERO, 1));
 
-  Square winnerKSq = pos.king_square(strongSide);
-  Square loserKSq = pos.king_square(weakSide);
-  Square pawnSq = pos.list<PAWN>(weakSide)[0];
+  Square winnerKSq = pos.square<KING>(strongSide);
+  Square loserKSq = pos.square<KING>(weakSide);
+  Square pawnSq = pos.square<PAWN>(weakSide);
 
   Value result = Value(PushClose[distance(winnerKSq, loserKSq)]);
 
@@ -326,8 +326,8 @@ Value Endgame<KQKR>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, QueenValueMg, 0));
   assert(verify_material(pos, weakSide, RookValueMg, 0));
 
-  Square winnerKSq = pos.king_square(strongSide);
-  Square loserKSq = pos.king_square(weakSide);
+  Square winnerKSq = pos.square<KING>(strongSide);
+  Square loserKSq = pos.square<KING>(weakSide);
 
   Value result =  QueenValueEg
                 - RookValueEg
@@ -356,15 +356,15 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
   // be detected even when the weaker side has some pawns.
 
   Bitboard pawns = pos.pieces(strongSide, PAWN);
-  File pawnFile = file_of(pos.list<PAWN>(strongSide)[0]);
+  File pawnsFile = file_of(lsb(pawns));
 
-  // All pawns are on a single rook file ?
-  if (    (pawnFile == FILE_A || pawnFile == FILE_H)
-      && !(pawns & ~file_bb(pawnFile)))
+  // All pawns are on a single rook file?
+  if (    (pawnsFile == FILE_A || pawnsFile == FILE_H)
+      && !(pawns & ~file_bb(pawnsFile)))
   {
-      Square bishopSq = pos.list<BISHOP>(strongSide)[0];
-      Square queeningSq = relative_square(strongSide, make_square(pawnFile, RANK_8));
-      Square kingSq = pos.king_square(weakSide);
+      Square bishopSq = pos.square<BISHOP>(strongSide);
+      Square queeningSq = relative_square(strongSide, make_square(pawnsFile, RANK_8));
+      Square kingSq = pos.square<KING>(weakSide);
 
       if (   opposite_colors(queeningSq, bishopSq)
           && distance(queeningSq, kingSq) <= 1)
@@ -372,17 +372,17 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
   }
 
   // If all the pawns are on the same B or G file, then it's potentially a draw
-  if (    (pawnFile == FILE_B || pawnFile == FILE_G)
-      && !(pos.pieces(PAWN) & ~file_bb(pawnFile))
+  if (    (pawnsFile == FILE_B || pawnsFile == FILE_G)
+      && !(pos.pieces(PAWN) & ~file_bb(pawnsFile))
       && pos.non_pawn_material(weakSide) == 0
       && pos.count<PAWN>(weakSide) >= 1)
   {
       // Get weakSide pawn that is closest to the home rank
       Square weakPawnSq = backmost_sq(weakSide, pos.pieces(weakSide, PAWN));
 
-      Square strongKingSq = pos.king_square(strongSide);
-      Square weakKingSq = pos.king_square(weakSide);
-      Square bishopSq = pos.list<BISHOP>(strongSide)[0];
+      Square strongKingSq = pos.square<KING>(strongSide);
+      Square weakKingSq = pos.square<KING>(weakSide);
+      Square bishopSq = pos.square<BISHOP>(strongSide);
 
       // There's potential for a draw if our pawn is blocked on the 7th rank,
       // the bishop cannot attack it or they only have one pawn left
@@ -419,11 +419,11 @@ ScaleFactor Endgame<KQKRPs>::operator()(const Position& pos) const {
   assert(pos.count<ROOK>(weakSide) == 1);
   assert(pos.count<PAWN>(weakSide) >= 1);
 
-  Square kingSq = pos.king_square(weakSide);
-  Square rsq = pos.list<ROOK>(weakSide)[0];
+  Square kingSq = pos.square<KING>(weakSide);
+  Square rsq = pos.square<ROOK>(weakSide);
 
   if (    relative_rank(weakSide, kingSq) <= RANK_2
-      &&  relative_rank(weakSide, pos.king_square(strongSide)) >= RANK_4
+      &&  relative_rank(weakSide, pos.square<KING>(strongSide)) >= RANK_4
       &&  relative_rank(weakSide, rsq) == RANK_3
       && (  pos.pieces(weakSide, PAWN)
           & pos.attacks_from<KING>(kingSq)
@@ -447,11 +447,11 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
   assert(verify_material(pos, weakSide,   RookValueMg, 0));
 
   // Assume strongSide is white and the pawn is on files A-D
-  Square wksq = normalize(pos, strongSide, pos.king_square(strongSide));
-  Square bksq = normalize(pos, strongSide, pos.king_square(weakSide));
-  Square wrsq = normalize(pos, strongSide, pos.list<ROOK>(strongSide)[0]);
-  Square wpsq = normalize(pos, strongSide, pos.list<PAWN>(strongSide)[0]);
-  Square brsq = normalize(pos, strongSide, pos.list<ROOK>(weakSide)[0]);
+  Square wksq = normalize(pos, strongSide, pos.square<KING>(strongSide));
+  Square bksq = normalize(pos, strongSide, pos.square<KING>(weakSide));
+  Square wrsq = normalize(pos, strongSide, pos.square<ROOK>(strongSide));
+  Square wpsq = normalize(pos, strongSide, pos.square<PAWN>(strongSide));
+  Square brsq = normalize(pos, strongSide, pos.square<ROOK>(weakSide));
 
   File f = file_of(wpsq);
   Rank r = rank_of(wpsq);
@@ -543,9 +543,9 @@ ScaleFactor Endgame<KRPKB>::operator()(const Position& pos) const {
   // Test for a rook pawn
   if (pos.pieces(PAWN) & (FileABB | FileHBB))
   {
-      Square ksq = pos.king_square(weakSide);
-      Square bsq = pos.list<BISHOP>(weakSide)[0];
-      Square psq = pos.list<PAWN>(strongSide)[0];
+      Square ksq = pos.square<KING>(weakSide);
+      Square bsq = pos.square<BISHOP>(weakSide);
+      Square psq = pos.square<PAWN>(strongSide);
       Rank rk = relative_rank(strongSide, psq);
       Square push = pawn_push(strongSide);
 
@@ -558,7 +558,7 @@ ScaleFactor Endgame<KRPKB>::operator()(const Position& pos) const {
       {
           int d = distance(psq + 3 * push, ksq);
 
-          if (d <= 2 && !(d == 0 && ksq == pos.king_square(strongSide) + 2 * push))
+          if (d <= 2 && !(d == 0 && ksq == pos.square<KING>(strongSide) + 2 * push))
               return ScaleFactor(24);
           else
               return ScaleFactor(48);
@@ -586,9 +586,9 @@ ScaleFactor Endgame<KRPPKRP>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, RookValueMg, 2));
   assert(verify_material(pos, weakSide,   RookValueMg, 1));
 
-  Square wpsq1 = pos.list<PAWN>(strongSide)[0];
-  Square wpsq2 = pos.list<PAWN>(strongSide)[1];
-  Square bksq = pos.king_square(weakSide);
+  Square wpsq1 = pos.squares<PAWN>(strongSide)[0];
+  Square wpsq2 = pos.squares<PAWN>(strongSide)[1];
+  Square bksq = pos.square<KING>(weakSide);
 
   // Does the stronger side have a passed pawn?
   if (pos.pawn_passed(strongSide, wpsq1) || pos.pawn_passed(strongSide, wpsq2))
@@ -622,15 +622,14 @@ ScaleFactor Endgame<KPsK>::operator()(const Position& pos) const {
   assert(pos.count<PAWN>(strongSide) >= 2);
   assert(verify_material(pos, weakSide, VALUE_ZERO, 0));
 
-  Square ksq = pos.king_square(weakSide);
+  Square ksq = pos.square<KING>(weakSide);
   Bitboard pawns = pos.pieces(strongSide, PAWN);
-  Square psq = pos.list<PAWN>(strongSide)[0];
 
   // If all pawns are ahead of the king, on a single rook file and
   // the king is within one file of the pawns, it's a draw.
   if (   !(pawns & ~in_front_bb(weakSide, rank_of(ksq)))
       && !((pawns & ~FileABB) && (pawns & ~FileHBB))
-      &&  distance<File>(ksq, psq) <= 1)
+      &&  distance<File>(ksq, lsb(pawns)) <= 1)
       return SCALE_FACTOR_DRAW;
 
   return SCALE_FACTOR_NONE;
@@ -647,10 +646,10 @@ ScaleFactor Endgame<KBPKB>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, BishopValueMg, 1));
   assert(verify_material(pos, weakSide,   BishopValueMg, 0));
 
-  Square pawnSq = pos.list<PAWN>(strongSide)[0];
-  Square strongBishopSq = pos.list<BISHOP>(strongSide)[0];
-  Square weakBishopSq = pos.list<BISHOP>(weakSide)[0];
-  Square weakKingSq = pos.king_square(weakSide);
+  Square pawnSq = pos.square<PAWN>(strongSide);
+  Square strongBishopSq = pos.square<BISHOP>(strongSide);
+  Square weakBishopSq = pos.square<BISHOP>(weakSide);
+  Square weakKingSq = pos.square<KING>(weakSide);
 
   // Case 1: Defending king blocks the pawn, and cannot be driven away
   if (   file_of(weakKingSq) == file_of(pawnSq)
@@ -697,15 +696,15 @@ ScaleFactor Endgame<KBPPKB>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, BishopValueMg, 2));
   assert(verify_material(pos, weakSide,   BishopValueMg, 0));
 
-  Square wbsq = pos.list<BISHOP>(strongSide)[0];
-  Square bbsq = pos.list<BISHOP>(weakSide)[0];
+  Square wbsq = pos.square<BISHOP>(strongSide);
+  Square bbsq = pos.square<BISHOP>(weakSide);
 
   if (!opposite_colors(wbsq, bbsq))
       return SCALE_FACTOR_NONE;
 
-  Square ksq = pos.king_square(weakSide);
-  Square psq1 = pos.list<PAWN>(strongSide)[0];
-  Square psq2 = pos.list<PAWN>(strongSide)[1];
+  Square ksq = pos.square<KING>(weakSide);
+  Square psq1 = pos.squares<PAWN>(strongSide)[0];
+  Square psq2 = pos.squares<PAWN>(strongSide)[1];
   Rank r1 = rank_of(psq1);
   Rank r2 = rank_of(psq2);
   Square blockSq1, blockSq2;
@@ -768,9 +767,9 @@ ScaleFactor Endgame<KBPKN>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, BishopValueMg, 1));
   assert(verify_material(pos, weakSide, KnightValueMg, 0));
 
-  Square pawnSq = pos.list<PAWN>(strongSide)[0];
-  Square strongBishopSq = pos.list<BISHOP>(strongSide)[0];
-  Square weakKingSq = pos.king_square(weakSide);
+  Square pawnSq = pos.square<PAWN>(strongSide);
+  Square strongBishopSq = pos.square<BISHOP>(strongSide);
+  Square weakKingSq = pos.square<KING>(weakSide);
 
   if (   file_of(weakKingSq) == file_of(pawnSq)
       && relative_rank(strongSide, pawnSq) < relative_rank(strongSide, weakKingSq)
@@ -791,8 +790,8 @@ ScaleFactor Endgame<KNPK>::operator()(const Position& pos) const {
   assert(verify_material(pos, weakSide, VALUE_ZERO, 0));
 
   // Assume strongSide is white and the pawn is on files A-D
-  Square pawnSq     = normalize(pos, strongSide, pos.list<PAWN>(strongSide)[0]);
-  Square weakKingSq = normalize(pos, strongSide, pos.king_square(weakSide));
+  Square pawnSq     = normalize(pos, strongSide, pos.square<PAWN>(strongSide));
+  Square weakKingSq = normalize(pos, strongSide, pos.square<KING>(weakSide));
 
   if (pawnSq == SQ_A7 && distance(SQ_A8, weakKingSq) <= 1)
       return SCALE_FACTOR_DRAW;
@@ -806,9 +805,9 @@ ScaleFactor Endgame<KNPK>::operator()(const Position& pos) const {
 template<>
 ScaleFactor Endgame<KNPKB>::operator()(const Position& pos) const {
 
-  Square pawnSq = pos.list<PAWN>(strongSide)[0];
-  Square bishopSq = pos.list<BISHOP>(weakSide)[0];
-  Square weakKingSq = pos.king_square(weakSide);
+  Square pawnSq = pos.square<PAWN>(strongSide);
+  Square bishopSq = pos.square<BISHOP>(weakSide);
+  Square weakKingSq = pos.square<KING>(weakSide);
 
   // King needs to get close to promoting pawn to prevent knight from blocking.
   // Rules for this are very tricky, so just approximate.
@@ -831,9 +830,9 @@ ScaleFactor Endgame<KPKP>::operator()(const Position& pos) const {
   assert(verify_material(pos, weakSide,   VALUE_ZERO, 1));
 
   // Assume strongSide is white and the pawn is on files A-D
-  Square wksq = normalize(pos, strongSide, pos.king_square(strongSide));
-  Square bksq = normalize(pos, strongSide, pos.king_square(weakSide));
-  Square psq  = normalize(pos, strongSide, pos.list<PAWN>(strongSide)[0]);
+  Square wksq = normalize(pos, strongSide, pos.square<KING>(strongSide));
+  Square bksq = normalize(pos, strongSide, pos.square<KING>(weakSide));
+  Square psq  = normalize(pos, strongSide, pos.square<PAWN>(strongSide));
 
   Color us = strongSide == pos.side_to_move() ? WHITE : BLACK;
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -208,7 +208,7 @@ namespace {
 
     ei.pinnedPieces[Us] = pos.pinned_pieces(Us);
     ei.attackedBy[Us][ALL_PIECES] = ei.attackedBy[Us][PAWN] = ei.pi->pawn_attacks(Us);
-    Bitboard b = ei.attackedBy[Them][KING] = pos.attacks_from<KING>(pos.king_square(Them));
+    Bitboard b = ei.attackedBy[Them][KING] = pos.attacks_from<KING>(pos.square<KING>(Them));
 
     // Init king safety tables only if we are going to use them
     if (pos.non_pawn_material(Us) >= QueenValueMg)
@@ -234,7 +234,7 @@ namespace {
 
     const PieceType NextPt = (Us == WHITE ? Pt : PieceType(Pt + 1));
     const Color Them = (Us == WHITE ? BLACK : WHITE);
-    const Square* pl = pos.list<Pt>(Us);
+    const Square* pl = pos.squares<Pt>(Us);
 
     ei.attackedBy[Us][Pt] = 0;
 
@@ -246,7 +246,7 @@ namespace {
                          : pos.attacks_from<Pt>(s);
 
         if (ei.pinnedPieces[Us] & s)
-            b &= LineBB[pos.king_square(Us)][s];
+            b &= LineBB[pos.square<KING>(Us)][s];
 
         ei.attackedBy[Us][ALL_PIECES] |= ei.attackedBy[Us][Pt] |= b;
 
@@ -316,7 +316,7 @@ namespace {
             // Penalize when trapped by the king, even more if king cannot castle
             if (mob <= 3 && !ei.pi->semiopen_file(Us, file_of(s)))
             {
-                Square ksq = pos.king_square(Us);
+                Square ksq = pos.square<KING>(Us);
 
                 if (   ((file_of(ksq) < FILE_E) == (file_of(s) < file_of(ksq)))
                     && (rank_of(ksq) == rank_of(s) || relative_rank(Us, ksq) == RANK_1)
@@ -348,7 +348,7 @@ namespace {
 
     Bitboard undefended, b, b1, b2, safe;
     int attackUnits;
-    const Square ksq = pos.king_square(Us);
+    const Square ksq = pos.square<KING>(Us);
 
     // King shelter and enemy pawns storm
     Score score = ei.pi->king_safety<Us>(pos, ksq);
@@ -575,12 +575,12 @@ namespace {
             Square blockSq = s + pawn_push(Us);
 
             // Adjust bonus based on the king's proximity
-            ebonus +=  distance(pos.king_square(Them), blockSq) * 5 * rr
-                     - distance(pos.king_square(Us  ), blockSq) * 2 * rr;
+            ebonus +=  distance(pos.square<KING>(Them), blockSq) * 5 * rr
+                     - distance(pos.square<KING>(Us  ), blockSq) * 2 * rr;
 
             // If blockSq is not the queening square then consider also a second push
             if (relative_rank(Us, blockSq) != RANK_8)
-                ebonus -= distance(pos.king_square(Us), blockSq + pawn_push(Us)) * rr;
+                ebonus -= distance(pos.square<KING>(Us), blockSq + pawn_push(Us)) * rr;
 
             // If the pawn is free to advance, then increase the bonus
             if (pos.empty(blockSq))
@@ -710,8 +710,8 @@ namespace {
     // Do not include in mobility squares protected by enemy pawns, or occupied
     // by our blocked pawns or king.
     Bitboard mobilityArea[] = {
-      ~(ei.attackedBy[BLACK][PAWN] | blockedPawns[WHITE] | pos.king_square(WHITE)),
-      ~(ei.attackedBy[WHITE][PAWN] | blockedPawns[BLACK] | pos.king_square(BLACK))
+      ~(ei.attackedBy[BLACK][PAWN] | blockedPawns[WHITE] | pos.square<KING>(WHITE)),
+      ~(ei.attackedBy[WHITE][PAWN] | blockedPawns[BLACK] | pos.square<KING>(BLACK))
     };
 
     // Evaluate pieces and mobility
@@ -772,7 +772,7 @@ namespace {
         // pawns are drawish.
         else if (    abs(eg_value(score)) <= BishopValueEg
                  &&  ei.pi->pawn_span(strongSide) <= 1
-                 && !pos.pawn_passed(~strongSide, pos.king_square(~strongSide)))
+                 && !pos.pawn_passed(~strongSide, pos.square<KING>(~strongSide)))
                  sf = ei.pi->pawn_span(strongSide) ? ScaleFactor(56) : ScaleFactor(38);
     }
 

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -34,7 +34,7 @@ namespace {
 
     // After castling, the rook and king final positions are the same in Chess960
     // as they would be in standard chess.
-    Square kfrom = pos.king_square(us);
+    Square kfrom = pos.square<KING>(us);
     Square rfrom = pos.castling_rook_square(Cr);
     Square kto = relative_square(us, KingSide ? SQ_G1 : SQ_C1);
     Bitboard enemies = pos.pieces(~us);
@@ -225,7 +225,7 @@ namespace {
 
     assert(Pt != KING && Pt != PAWN);
 
-    const Square* pl = pos.list<Pt>(us);
+    const Square* pl = pos.squares<Pt>(us);
 
     for (Square from = *pl; from != SQ_NONE; from = *++pl)
     {
@@ -266,7 +266,7 @@ namespace {
 
     if (Type != QUIET_CHECKS && Type != EVASIONS)
     {
-        Square ksq = pos.king_square(Us);
+        Square ksq = pos.square<KING>(Us);
         Bitboard b = pos.attacks_from<KING>(ksq) & target;
         while (b)
             *moveList++ = make_move(ksq, pop_lsb(&b));
@@ -364,7 +364,7 @@ ExtMove* generate<EVASIONS>(const Position& pos, ExtMove* moveList) {
   assert(pos.checkers());
 
   Color us = pos.side_to_move();
-  Square ksq = pos.king_square(us);
+  Square ksq = pos.square<KING>(us);
   Bitboard sliderAttacks = 0;
   Bitboard sliders = pos.checkers() & ~pos.pieces(KNIGHT, PAWN);
 
@@ -400,7 +400,7 @@ template<>
 ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
 
   Bitboard pinned = pos.pinned_pieces(pos.side_to_move());
-  Square ksq = pos.king_square(pos.side_to_move());
+  Square ksq = pos.square<KING>(pos.side_to_move());
   ExtMove* cur = moveList;
 
   moveList = pos.checkers() ? generate<EVASIONS    >(pos, moveList)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -110,7 +110,7 @@ namespace {
     Square s;
     bool passed, isolated, opposed, backward, lever, connected;
     Score score = SCORE_ZERO;
-    const Square* pl = pos.list<PAWN>(Us);
+    const Square* pl = pos.squares<PAWN>(Us);
     const Bitboard* pawnAttacksBB = StepAttacksBB[make_piece(Us, PAWN)];
 
     Bitboard ourPawns   = pos.pieces(Us  , PAWN);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -89,7 +89,7 @@ PieceType min_attacker<KING>(const Bitboard*, const Square&, const Bitboard&, Bi
 CheckInfo::CheckInfo(const Position& pos) {
 
   Color them = ~pos.side_to_move();
-  ksq = pos.king_square(them);
+  ksq = pos.square<KING>(them);
 
   pinned = pos.pinned_pieces(pos.side_to_move());
   dcCandidates = pos.discovered_check_candidates();
@@ -315,7 +315,7 @@ void Position::set(const string& fenStr, bool isChess960, Thread* th) {
 
 void Position::set_castling_right(Color c, Square rfrom) {
 
-  Square kfrom = king_square(c);
+  Square kfrom = square<KING>(c);
   CastlingSide cs = kfrom < rfrom ? KING_SIDE : QUEEN_SIDE;
   CastlingRight cr = (c | cs);
 
@@ -348,7 +348,7 @@ void Position::set_state(StateInfo* si) const {
   si->nonPawnMaterial[WHITE] = si->nonPawnMaterial[BLACK] = VALUE_ZERO;
   si->psq = SCORE_ZERO;
 
-  si->checkersBB = attackers_to(king_square(sideToMove)) & pieces(~sideToMove);
+  si->checkersBB = attackers_to(square<KING>(sideToMove)) & pieces(~sideToMove);
 
   for (Bitboard b = pieces(); b; )
   {
@@ -456,7 +456,7 @@ Phase Position::game_phase() const {
 Bitboard Position::check_blockers(Color c, Color kingColor) const {
 
   Bitboard b, pinners, result = 0;
-  Square ksq = king_square(kingColor);
+  Square ksq = square<KING>(kingColor);
 
   // Pinners are sliders that give check when a pinned piece is removed
   pinners = (  (pieces(  ROOK, QUEEN) & PseudoAttacks[ROOK  ][ksq])
@@ -498,14 +498,14 @@ bool Position::legal(Move m, Bitboard pinned) const {
   Square from = from_sq(m);
 
   assert(color_of(moved_piece(m)) == us);
-  assert(piece_on(king_square(us)) == make_piece(us, KING));
+  assert(piece_on(square<KING>(us)) == make_piece(us, KING));
 
   // En passant captures are a tricky special case. Because they are rather
   // uncommon, we do it simply by testing whether the king is attacked after
   // the move is made.
   if (type_of(m) == ENPASSANT)
   {
-      Square ksq = king_square(us);
+      Square ksq = square<KING>(us);
       Square to = to_sq(m);
       Square capsq = to - pawn_push(us);
       Bitboard occupied = (pieces() ^ from ^ capsq) | to;
@@ -529,7 +529,7 @@ bool Position::legal(Move m, Bitboard pinned) const {
   // is moving along the ray towards or away from the king.
   return   !pinned
         || !(pinned & from)
-        ||  aligned(from, to_sq(m), king_square(us));
+        ||  aligned(from, to_sq(m), square<KING>(us));
 }
 
 
@@ -592,7 +592,7 @@ bool Position::pseudo_legal(const Move m) const {
               return false;
 
           // Our move must be a blocking evasion or a capture of the checking piece
-          if (!((between_bb(lsb(checkers()), king_square(us)) | checkers()) & to))
+          if (!((between_bb(lsb(checkers()), square<KING>(us)) | checkers()) & to))
               return false;
       }
       // In case of king moves under check we have to remove king so as to catch
@@ -826,7 +826,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   st->key = k;
 
   // Calculate checkers bitboard (if move gives check)
-  st->checkersBB = givesCheck ? attackers_to(king_square(them)) & pieces(us) : 0;
+  st->checkersBB = givesCheck ? attackers_to(square<KING>(them)) & pieces(us) : 0;
 
   sideToMove = ~sideToMove;
 
@@ -1133,8 +1133,8 @@ bool Position::pos_is_ok(int* failedStep) const {
 
       if (step == Default)
           if (   (sideToMove != WHITE && sideToMove != BLACK)
-              || piece_on(king_square(WHITE)) != W_KING
-              || piece_on(king_square(BLACK)) != B_KING
+              || piece_on(square<KING>(WHITE)) != W_KING
+              || piece_on(square<KING>(BLACK)) != B_KING
               || (   ep_square() != SQ_NONE
                   && relative_rank(sideToMove, ep_square()) != RANK_6))
               return false;
@@ -1142,7 +1142,7 @@ bool Position::pos_is_ok(int* failedStep) const {
       if (step == King)
           if (   std::count(board, board + SQUARE_NB, W_KING) != 1
               || std::count(board, board + SQUARE_NB, B_KING) != 1
-              || attackers_to(king_square(~sideToMove)) & pieces(sideToMove))
+              || attackers_to(square<KING>(~sideToMove)) & pieces(sideToMove))
               return false;
 
       if (step == Bitboards)
@@ -1187,7 +1187,7 @@ bool Position::pos_is_ok(int* failedStep) const {
 
                   if (   piece_on(castlingRookSquare[c | s]) != make_piece(c, ROOK)
                       || castlingRightsMask[castlingRookSquare[c | s]] != (c | s)
-                      ||(castlingRightsMask[king_square(c)] & (c | s)) != (c | s))
+                      ||(castlingRightsMask[square<KING>(c)] & (c | s)) != (c | s))
                       return false;
               }
   }

--- a/src/position.h
+++ b/src/position.h
@@ -105,11 +105,11 @@ public:
   Bitboard pieces(Color c, PieceType pt) const;
   Bitboard pieces(Color c, PieceType pt1, PieceType pt2) const;
   Piece piece_on(Square s) const;
-  Square king_square(Color c) const;
   Square ep_square() const;
   bool empty(Square s) const;
   template<PieceType Pt> int count(Color c) const;
-  template<PieceType Pt> const Square* list(Color c) const;
+  template<PieceType Pt> const Square* squares(Color c) const;
+  template<PieceType Pt> Square square(Color c) const;
 
   // Castling
   int can_castle(Color c) const;
@@ -254,12 +254,13 @@ template<PieceType Pt> inline int Position::count(Color c) const {
   return pieceCount[c][Pt];
 }
 
-template<PieceType Pt> inline const Square* Position::list(Color c) const {
+template<PieceType Pt> inline const Square* Position::squares(Color c) const {
   return pieceList[c][Pt];
 }
 
-inline Square Position::king_square(Color c) const {
-  return pieceList[c][KING][0];
+template<PieceType Pt> inline Square Position::square(Color c) const {
+  assert(pieceCount[c][Pt] == 1);
+  return pieceList[c][Pt][0];
 }
 
 inline Square Position::ep_square() const {
@@ -362,7 +363,7 @@ inline void Position::set_nodes_searched(uint64_t n) {
 inline bool Position::opposite_bishops() const {
   return   pieceCount[WHITE][BISHOP] == 1
         && pieceCount[BLACK][BISHOP] == 1
-        && opposite_colors(pieceList[WHITE][BISHOP][0], pieceList[BLACK][BISHOP][0]);
+        && opposite_colors(square<BISHOP>(WHITE), square<BISHOP>(BLACK));
 }
 
 inline bool Position::is_chess960() const {


### PR DESCRIPTION
Use Position::square and Position::squares instead.

This allow us to remove king_square(), simplify
endgames and to have more naming uniformity.

Moreover, this is a prerequisite step in case
in the future we decide to retire piece lists
altoghter and use pop_lsb() to loop across
pieces and serialize the moves. In this way
we just need to change definition of Position::square
to something like:

template<PieceType Pt> inline
Square Position::square(Color c) const {
  return lsb(byColorBB[c]);
}

No functional change.