### PR TITLE
Add UCI_LimitStrength and UCI_Elo features

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -351,7 +351,12 @@ namespace {
     TT.new_search();
 
     size_t multiPV = Options["MultiPV"];
-    Skill skill(Options["Skill Level"]);
+	  int skillLevel = Options["Skill Level"];
+
+	  if (Options["UCI_LimitStrength"])
+		    skillLevel = (Options["UCI_Elo"] - 1000) / 100;
+
+    Skill skill(skillLevel);
 
     // When playing with strength handicap enable MultiPV search that we will
     // use behind the scenes to retrieve a set of possible moves.

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -69,6 +69,8 @@ void init(OptionsMap& o) {
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
   o["Slow Mover"]            << Option(80, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
+  o["UCI_LimitStrength"]     << Option(false);
+  o["UCI_Elo"]               << Option(3000, 1000, 3000);
   o["UCI_Chess960"]          << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);


### PR DESCRIPTION
Hello.

UCI protocol has standard options to change chess engine strength with Elo value. These options let such GUI as Shredder, Aquarium and Fritz to auto change chess engine strength after finish any rated game with human.

Reagrds,
Eugene.