### PR TITLE
TTreplace2

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -87,8 +87,8 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   // Find an entry to be replaced according to the replacement strategy
   TTEntry* replace = tte;
   for (int i = 1; i < ClusterSize; ++i)
-      if (    tte[i].depth8 - ((259 + generation8 -   tte[i].genBound8) & 0xFC) * 2 * ONE_PLY
-          < replace->depth8 - ((259 + generation8 - replace->genBound8) & 0xFC) * 2 * ONE_PLY)
+      if (  replace->depth8 - ((259 + generation8 - replace->genBound8) & 0xFC) * 2 * ONE_PLY
+          >   tte[i].depth8 - ((259 + generation8 -   tte[i].genBound8) & 0xFC) * 2 * ONE_PLY)
           replace = &tte[i];
 
   return found = false, replace;

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -64,11 +64,11 @@ void TranspositionTable::clear() {
 
 
 /// TranspositionTable::probe() looks up the current position in the transposition
-/// table. It returns true and a pointer to the TTEntry if the position is found
+/// table. It returns true and a pointer to the TTEntry if the position is found.
 /// Otherwise, it returns false and a pointer to an empty or least valuable TTEntry
 /// to be replaced later. The replace value of an entry is calculated as its depth
 /// minus 8 times its relative age. TTEntry t1 is considered more valuable than
-/// TTEntry t2 if its replace score is greater than that of t2.
+/// TTEntry t2 if its replace value is greater than that of t2.
 
 TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -64,11 +64,11 @@ void TranspositionTable::clear() {
 
 
 /// TranspositionTable::probe() looks up the current position in the transposition
-/// table. It returns true and a pointer to the TTEntry if the position is found.
+/// table. It returns true and a pointer to the TTEntry if the position is found
 /// Otherwise, it returns false and a pointer to an empty or least valuable TTEntry
-/// to be replaced later. A TTEntry t1 is considered to be more valuable than a
-/// TTEntry t2 if t1 is from the current search and t2 is from a previous search,
-/// or if the depth of t1 is bigger than the depth of t2.
+/// to be replaced later. The replace value of an entry is calculated as its depth
+/// minus 8 times its relative age. TTEntry t1 is considered more valuable than
+/// TTEntry t2 if its replace score is greater than that of t2.
 
 TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 
@@ -87,9 +87,8 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   // Find an entry to be replaced according to the replacement strategy
   TTEntry* replace = tte;
   for (int i = 1; i < ClusterSize; ++i)
-      if (  ((  tte[i].genBound8 & 0xFC) == generation8)
-          - ((replace->genBound8 & 0xFC) == generation8)
-          - (tte[i].depth8 < replace->depth8) < 0)
+      if (    tte[i].depth8 - ((259 + generation8 -   tte[i].genBound8) & 0xFC) * 2 * ONE_PLY
+          < replace->depth8 - ((259 + generation8 - replace->genBound8) & 0xFC) * 2 * ONE_PLY)
           replace = &tte[i];
 
   return found = false, replace;


### PR DESCRIPTION
STC 2MB
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 45258 W: 8595 L: 8279 D: 28384
http://tests.stockfishchess.org/tests/view/55c6627b0ebc591b934bd5ed

LTC 8MB
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 56401 W: 8809 L: 8489 D: 39103
http://tests.stockfishchess.org/tests/view/55c713800ebc591b934bd615

STC 16MB
LLR: 2.96 (-2.94,2.94) [-4.00,0.00]
Total: 34764 W: 6565 L: 6529 D: 21670
http://tests.stockfishchess.org/tests/view/55ca5c290ebc591b934bd68f

Calculate TT replace value as depth minus eight times relative age.
For some background on this patch see
https://github.com/official-stockfish/Stockfish/pull/390 