### PR TITLE
PawnSafePush Simplification

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -519,12 +519,14 @@ namespace {
             score += more_than_one(b) ? KingOnMany : KingOnOne;
     }
 
-    // Bonus if the pawn push safely attacks an enemy piece
+    // Bonus if some pawns can safely push and attack an enemy piece
     b = pos.pieces(Us, PAWN) & ~TRank7BB;
     b = shift_bb<Up>(b | (shift_bb<Up>(b & TRank2BB) & ~pos.pieces()));
+
     b &=  ~pos.pieces()
         & ~ei.attackedBy[Them][PAWN]
         & (ei.attackedBy[Us][ALL_PIECES] | ~ei.attackedBy[Them][ALL_PIECES]);
+
     b =  (shift_bb<Left>(b) | shift_bb<Right>(b))
        &  pos.pieces(Them)
        & ~ei.attackedBy[Us][PAWN];

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -160,7 +160,6 @@ namespace {
   const Score Unstoppable        = S( 0, 20);
   const Score Hanging            = S(31, 26);
   const Score PawnAttackThreat   = S(20, 20);
-  //const Score PawnSafePush       = S( 5,  5);
 
   // Penalty for a bishop on a1/h1 (a8/h8 for black) which is trapped by
   // a friendly pawn on b2/g2 (b7/g7 for black). This can obviously only
@@ -520,18 +519,12 @@ namespace {
             score += more_than_one(b) ? KingOnMany : KingOnOne;
     }
 
-    // Add a small bonus for safe pawn pushes
+    // Bonus if the pawn push safely attacks an enemy piece
     b = pos.pieces(Us, PAWN) & ~TRank7BB;
     b = shift_bb<Up>(b | (shift_bb<Up>(b & TRank2BB) & ~pos.pieces()));
-
     b &=  ~pos.pieces()
         & ~ei.attackedBy[Them][PAWN]
         & (ei.attackedBy[Us][ALL_PIECES] | ~ei.attackedBy[Them][ALL_PIECES]);
-
-    //if (b)
-    //   score += popcount<Full>(b) * PawnSafePush;
-
-    // Add another bonus if the pawn push attacks an enemy piece
     b =  (shift_bb<Left>(b) | shift_bb<Right>(b))
        &  pos.pieces(Them)
        & ~ei.attackedBy[Us][PAWN];

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -160,7 +160,7 @@ namespace {
   const Score Unstoppable        = S( 0, 20);
   const Score Hanging            = S(31, 26);
   const Score PawnAttackThreat   = S(20, 20);
-  const Score PawnSafePush       = S( 5,  5);
+  //const Score PawnSafePush       = S( 5,  5);
 
   // Penalty for a bishop on a1/h1 (a8/h8 for black) which is trapped by
   // a friendly pawn on b2/g2 (b7/g7 for black). This can obviously only
@@ -528,8 +528,8 @@ namespace {
         & ~ei.attackedBy[Them][PAWN]
         & (ei.attackedBy[Us][ALL_PIECES] | ~ei.attackedBy[Them][ALL_PIECES]);
 
-    if (b)
-        score += popcount<Full>(b) * PawnSafePush;
+    //if (b)
+    //   score += popcount<Full>(b) * PawnSafePush;
 
     // Add another bonus if the pawn push attacks an enemy piece
     b =  (shift_bb<Left>(b) | shift_bb<Right>(b))


### PR DESCRIPTION
PawnSafePush, with the value S(5,5) proved not "necessary"
possibly due to recent changes to MobilityArea and other changes to Connected bonus.

STC: http://tests.stockfishchess.org/tests/view/55b98e060ebc590abbe1bdc8
LLR: 3.22 (-2.94,2.94) [-3.00,1.00]
Total: 98528 W: 18757 L: 18759 D: 61012

Lucas ran the LTC:
LTC: http://tests.stockfishchess.org/tests/view/55c54e1a0ebc591b934bd5af
LLR: 5.30 (-2.94,2.94) [-3.00,1.00]
Total: 204194 W: 31698 L: 31734 D: 140762

Lucas also verified if the older PawnAttackThreat (20,20) could be removed altogether
http://tests.stockfishchess.org/tests/view/55bd63070ebc590abbe1be63
http://tests.stockfishchess.org/tests/view/55bd623b0ebc590abbe1be5f
http://tests.stockfishchess.org/tests/view/55bdc3990ebc590abbe1be6e