### PR TITLE
Auto detect CPU cores and set default Threads value respectively

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -21,6 +21,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <thread>
 
 #include "misc.h"
 #include "thread.h"
@@ -101,6 +102,8 @@ const string engine_info(bool to_uci) {
   const string months("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec");
   string month, day, year;
   stringstream ss, date(__DATE__); // From compiler, format is "Sep 21 2008"
+  
+  unsigned int n = std::thread::hardware_concurrency(); // Get quantity of CPU cores (C++ 11)
 
   ss << "Stockfish " << Version << setfill('0');
 
@@ -110,10 +113,13 @@ const string engine_info(bool to_uci) {
       ss << setw(2) << day << setw(2) << (1 + months.find(month) / 4) << year.substr(2);
   }
 
-  ss << (Is64Bit ? " 64" : "")
+  ss << (Is64Bit ? " x64" : "")
      << (HasPext ? " BMI2" : (HasPopCnt ? " POPCNT" : ""))
      << (to_uci  ? "\nid author ": " by ")
-     << "Tord Romstad, Marco Costalba and Joona Kiiski";
+     << "Tord Romstad, Marco Costalba and Joona Kiiski"
+     << (to_uci ? "" : "\n\ninfo string ")
+     << (to_uci ? "" : std::to_string(n))
+     << (to_uci ? "" : " processor(s) found");
 
   return ss.str();
 }

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cassert>
 #include <ostream>
+#include <thread>
 
 #include "misc.h"
 #include "search.h"
@@ -55,11 +56,14 @@ bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const 
 void init(OptionsMap& o) {
 
   const int MaxHashMB = Is64Bit ? 1024 * 1024 : 2048;
+  
+  unsigned int n = std::thread::hardware_concurrency(); // Get quantity of CPU cores (C++ 11)
+  if (!n) n = 1; // If something was wrong, set default to one thread
 
   o["Write Debug Log"]       << Option(false, on_logger);
   o["Contempt"]              << Option(0, -100, 100);
   o["Min Split Depth"]       << Option(5, 0, 12, on_threads);
-  o["Threads"]               << Option(1, 1, MAX_THREADS, on_threads);
+  o["Threads"]               << Option(n, 1, MAX_THREADS, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(true);


### PR DESCRIPTION
Hello.
This is a small addition, so now we can see at the start screen of engine how many CPU cores we have.
And we can set default value of Threads to quantity of real CPU cores. In such way SF will use maximum his power...

I see some Chess GUI that does not provide change of using threads, so SF sometimes lose weak engines (with greater default threads) with engine matches.

Also small cosmetic fix: 64 -> x64 at the main screen of engine.

Regards,
Eugene.
