### PR TITLE
Retire dangerous

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -531,7 +531,7 @@ namespace {
     Depth extension, newDepth, predictedDepth;
     Value bestValue, value, ttValue, eval, nullValue, futilityValue;
     bool ttHit, inCheck, givesCheck, singularExtensionNode, improving;
-    bool captureOrPromotion, dangerous, doFullDepthSearch;
+    bool captureOrPromotion, doFullDepthSearch;
     int moveCount, quietCount;
 
     // Step 1. Initialize node
@@ -847,10 +847,6 @@ moves_loop: // When in check and at SpNode search starts from here
                   ? ci.checkSquares[type_of(pos.piece_on(from_sq(move)))] & to_sq(move)
                   : pos.gives_check(move, ci);
 
-      dangerous =   givesCheck
-                 || type_of(move) != NORMAL
-                 || pos.advanced_pawn_push(move);
-
       // Step 12. Extend checks
       if (givesCheck && pos.see_sign(move) >= VALUE_ZERO)
           extension = ONE_PLY;
@@ -883,7 +879,9 @@ moves_loop: // When in check and at SpNode search starts from here
       if (   !RootNode
           && !captureOrPromotion
           && !inCheck
-          && !dangerous
+          && !givesCheck
+          &&  type_of(move) == NORMAL
+          && !pos.advanced_pawn_push(move)
           &&  bestValue > VALUE_MATED_IN_MAX_PLY)
       {
           // Move count based pruning


### PR DESCRIPTION
Replace by its value where it is used. Code is more clear that way.

No functional change.