### PR TITLE
Prune castling and en-passant

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -880,7 +880,6 @@ moves_loop: // When in check and at SpNode search starts from here
           && !captureOrPromotion
           && !inCheck
           && !givesCheck
-          &&  type_of(move) == NORMAL
           && !pos.advanced_pawn_push(move)
           &&  bestValue > VALUE_MATED_IN_MAX_PLY)
       {


### PR DESCRIPTION
Align the behaviour with reductions. Initially en-passant and castling had to be
treated differently, because the SEE did not handle them correctly. But now it
does.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 83750 W: 15722 L: 15711 D: 52317

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 97183 W: 15120 L: 15115 D: 66948

bench 7759837