### PR TITLE
obfuscated code

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -341,7 +341,7 @@ namespace {
     Move easyMove = EasyMove.get(pos.key());
     EasyMove.clear();
 
-    std::memset(ss-2, 0, 5 * sizeof(Stack));
+    std::memset(stack, 0, 5 * sizeof(Stack));
 
     depth = DEPTH_ZERO;
     BestMoveChanges = 0;


### PR DESCRIPTION
Stack stack[MAX_PLY+4], *ss = stack+2; // To allow referencing (ss-2) and (ss+2)
std::memset(ss-2, 0, 5 * sizeof(Stack));

is same

Stack stack[MAX_PLY+4], *ss = stack+2; // To allow referencing (ss-2) and (ss+2)
std::memset(stack, 0, 5 * sizeof(Stack));