### PR TITLE
Reformat trace code

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -143,7 +143,6 @@ void benchmark(const Position& current, istream& is) {
   }
 
   uint64_t nodes = 0;
-  Search::StateStackPtr st;
   TimePoint elapsed = now();
 
   for (size_t i = 0; i < fens.size(); ++i)
@@ -157,6 +156,7 @@ void benchmark(const Position& current, istream& is) {
 
       else
       {
+          Search::StateStackPtr st;
           Threads.start_thinking(pos, limits, st);
           Threads.main()->join();
           nodes += Search::RootPos.nodes_searched();

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -31,9 +31,10 @@ namespace Eval {
 const Value Tempo = Value(17); // Must be visible to search
 
 void init();
-Value evaluate(const Position& pos);
 std::string trace(const Position& pos);
 
+template<bool DoTrace = false>
+Value evaluate(const Position& pos);
 }
 
 #endif // #ifndef EVALUATE_H_INCLUDED


### PR DESCRIPTION
Apart from usual renaiming, take advantage of
C++11 function template default parmeter to
get rid of Eval trampoline functions.

Some triviality fixes while there.

No functional change.