### PR TITLE
History gravity, version 2

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -39,7 +39,7 @@
 template<typename T>
 struct Stats {
 
-  static const Value Max = Value(250);
+  static const Value Max = Value(1<<28);
 
   const T* operator[](Piece pc) const { return table[pc]; }
   T* operator[](Piece pc) { return table[pc]; }
@@ -53,8 +53,8 @@ struct Stats {
 
   void update(Piece pc, Square to, Value v) {
 
-    if (abs(table[pc][to] + v) < Max)
-        table[pc][to] += v;
+    table[pc][to] -= table[pc][to] * std::min(abs(int(v)), 512) / 512;
+    table[pc][to] += int(v) * 64;
   }
 
 private:


### PR DESCRIPTION
There seems to be something good in this idea. I prefer the second version as it's somewhat safer at high depths...

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 47270 W: 9083 L: 8748 D: 29439

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 16933 W: 2685 L: 2501 D: 11747



