### PR TITLE
Fix a bug in LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -973,7 +973,7 @@ moves_loop: // When in check and at SpNode search starts from here
 
           value = -search<NonPV, false>(pos, ss+1, -(alpha+1), -alpha, d, true);
 
-          doFullDepthSearch = (value > alpha && ss->reduction != DEPTH_ZERO);
+          doFullDepthSearch = (value > alpha && d != newDepth);
           ss->reduction = DEPTH_ZERO;
       }
       else


### PR DESCRIPTION
The problem comes from:

    d = std::max(newDepth - ss->reduction, ONE_PLY);

Because of this max(), it means that the equation:

    d = newDepth - ss->reduction;

is not always verified. In such cases where, it means that ss->reduction is
incorrect, and we should be testing instead:

    d != newDepth

to find out if the search was reduced.

bench 8020484