### PR TITLE
Small rearranging in KXK endgame

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -150,17 +150,18 @@ Value Endgame<KXK>::operator()(const Position& pos) const {
   Square winnerKSq = pos.square<KING>(strongSide);
   Square loserKSq = pos.square<KING>(weakSide);
 
-  Value result =  pos.non_pawn_material(strongSide)
-                + pos.count<PAWN>(strongSide) * PawnValueEg
+  Value result =  pos.count<PAWN>(strongSide) * PawnValueEg
                 + PushToEdges[loserKSq]
                 + PushClose[distance(winnerKSq, loserKSq)];
 
   if (   pos.count<QUEEN>(strongSide)
       || pos.count<ROOK>(strongSide)
       ||(pos.count<BISHOP>(strongSide) && pos.count<KNIGHT>(strongSide))
+      || pos.count<KNIGHT>(strongSide) > 2
       ||(pos.count<BISHOP>(strongSide) > 1 && opposite_colors(pos.squares<BISHOP>(strongSide)[0],
                                                               pos.squares<BISHOP>(strongSide)[1])))
-      result += VALUE_KNOWN_WIN;
+      result +=  pos.non_pawn_material(strongSide)
+               + VALUE_KNOWN_WIN;
 
   return strongSide == pos.side_to_move() ? result : -result;
 }


### PR DESCRIPTION
to output drawish scores in cases of 2 or more bishops of the same color.
(Of course, with the known limitation this code
```
opposite_colors(pos.squares<BISHOP>(strongSide)[0],
                pos.squares<BISHOP>(strongSide)[1])
```
offers)

For example bench position 33
8/3k4/8/8/8/4B3/4KB2/2B5 w - - 0 1

default SF
info depth 13 seldepth 14 multipv 1 score cp 1030 nodes 60505 nps 2521041 tbhits 0 time 24 pv e2d3 d7d6 d3d4 d6e6 d4e4 e6d6 c1a3 d6e6 f2e1 e6f6 e4d5 f6f5 a3e7 f5g4

KXK_fix
info depth 13 seldepth 16 multipv 1 score cp 65 nodes 105111 nps 2563682 tbhits 0 time 41 pv e2f3 d7d6 f2g3 d6d7 f3e4 d7e6 e3g5 e6f7 e4f5 f7g7 f5e6 g7g6 g3e5 g6h5 e6f6

Also add
```
      || pos.count<KNIGHT>(strongSide) > 2
```
condition, to cover KNNNK endgame and output a winning score here, too.

Example 8/3k4/8/8/8/4N3/4KN2/2N5 w - - 0 1

default SF
info depth 13 seldepth 13 multipv 1 score cp 1008 nodes 100654 nps 2648789 tbhits 0 time 38 pv e2d3 d7e7 d3d4 e7e6 f2e4 e6e7 d4e5 e7d7 e5d5 d7e7 c1e2 e7d7 e4f2
bestmove e2d3 ponder d7e7

KXK_fix
info depth 13 seldepth 16 multipv 1 score cp 4884 nodes 93789 nps 2534837 tbhits 0 time 37 pv e2d3 d7e7 d3d4 e7d6 f2e4 d6e6 c1e2 e6d7 d4e5 d7c6 e2d4 c6d7 e3d1 d7e7 d4c6 e7d7
bestmove e2d3 ponder d7e7

bench: 8125919