### PR TITLE
Minsplitdepth2 maxslaves7 fix

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1091,11 +1091,16 @@ moves_loop: // When in check and at SpNode search starts from here
       if (   !SpNode
           &&  Threads.size() >= 2
           &&  depth >= Threads.minimumSplitDepth
+          &&  thisThread->splitPointsSize < MAX_SPLITPOINTS_PER_THREAD
           &&  (   !thisThread->activeSplitPoint
                || !thisThread->activeSplitPoint->allSlavesSearching
-               || (   Threads.size() > Threads.max_slaves_per_splitpoint(thisThread->activeSplitPoint->depth)
-                   && thisThread->activeSplitPoint->slavesMask.count() == Threads.max_slaves_per_splitpoint(thisThread->activeSplitPoint->depth)))
-	  &&  thisThread->splitPointsSize < MAX_SPLITPOINTS_PER_THREAD)
+
+                  // Try to split again if previous split was limited due to
+                  // hit max_slaves_per_splitpoint.
+               || [&]() {
+                  SplitPoint* sp = thisThread->activeSplitPoint;
+                  size_t oldMax = Threads.max_slaves_per_splitpoint(sp->depth);
+                  return Threads.size() > oldMax && sp->slavesMask.count() == oldMax; }()))
       {
           assert(bestValue > -VALUE_INFINITE && bestValue < beta);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1094,13 +1094,9 @@ moves_loop: // When in check and at SpNode search starts from here
           &&  thisThread->splitPointsSize < MAX_SPLITPOINTS_PER_THREAD
           &&  (   !thisThread->activeSplitPoint
                || !thisThread->activeSplitPoint->allSlavesSearching
-
-                  // Try to split again if previous split was limited due to
-                  // hit max_slaves_per_splitpoint.
-               || [&]() {
-                  SplitPoint* sp = thisThread->activeSplitPoint;
-                  size_t oldMax = Threads.max_slaves_per_splitpoint(sp->depth);
-                  return Threads.size() > oldMax && sp->slavesMask.count() == oldMax; }()))
+               // Try to split again if previous split was limited due to
+               // hit max_slaves_per_splitpoint.
+               || thisThread->can_split_again()))
       {
           assert(bestValue > -VALUE_INFINITE && bestValue < beta);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1093,9 +1093,9 @@ moves_loop: // When in check and at SpNode search starts from here
           &&  depth >= Threads.minimumSplitDepth
           &&  (   !thisThread->activeSplitPoint
                || !thisThread->activeSplitPoint->allSlavesSearching
-               || (   Threads.size() > MAX_SLAVES_PER_SPLITPOINT
-                   && thisThread->activeSplitPoint->slavesMask.count() == MAX_SLAVES_PER_SPLITPOINT))
-          &&  thisThread->splitPointsSize < MAX_SPLITPOINTS_PER_THREAD)
+               || (   Threads.size() > Threads.max_slaves_per_splitpoint(thisThread->activeSplitPoint->depth)
+                   && thisThread->activeSplitPoint->slavesMask.count() == Threads.max_slaves_per_splitpoint(thisThread->activeSplitPoint->depth)))
+	  &&  thisThread->splitPointsSize < MAX_SPLITPOINTS_PER_THREAD)
       {
           assert(bestValue > -VALUE_INFINITE && bestValue < beta);
 
@@ -1648,7 +1648,7 @@ void Thread::idle_loop() {
 
               if (   sp
                   && sp->allSlavesSearching
-                  && sp->slavesMask.count() < MAX_SLAVES_PER_SPLITPOINT
+                  && sp->slavesMask.count() < Threads.max_slaves_per_splitpoint(sp->depth)
                   && can_join(sp))
               {
                   assert(this != th);
@@ -1677,7 +1677,7 @@ void Thread::idle_loop() {
               sp->spinlock.acquire();
 
               if (   sp->allSlavesSearching
-                  && sp->slavesMask.count() < MAX_SLAVES_PER_SPLITPOINT)
+                  && sp->slavesMask.count() < Threads.max_slaves_per_splitpoint(sp->depth))
               {
                   spinlock.acquire();
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -295,7 +295,7 @@ void ThreadPool::init() {
 size_t ThreadPool::max_slaves_per_splitpoint(Depth depth)
 {
 
-  return 1 + depth / (2 * ONE_PLY);
+  return std::min((1 + depth / (2 * ONE_PLY)), 5);
 }
 
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -102,6 +102,13 @@ bool Thread::cutoff_occurred() const {
 }
 
 
+bool Thread::can_split_again() const {
+
+  SplitPoint* sp = activeSplitPoint;
+  size_t oldMax = Threads.max_slaves_per_splitpoint(sp->depth);
+ 
+  return (Threads.size() > oldMax && sp->slavesMask.count() == oldMax);
+}
 // Thread::can_join() checks whether the thread is available to join the split
 // point 'sp'. An obvious requirement is that thread must be idle. With more than
 // two threads, this is not sufficient: If the thread is the master of some split

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -295,7 +295,7 @@ void ThreadPool::init() {
 size_t ThreadPool::max_slaves_per_splitpoint(Depth depth)
 {
 
-  return std::min((1 + depth / (2 * ONE_PLY)), 5);
+  return std::min(depth/ONE_PLY - 1, 16);
 }
 
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -171,7 +171,7 @@ void Thread::split(Position& pos, Stack* ss, Value alpha, Value beta, Value* bes
   // Try to allocate available threads
   Thread* slave;
 
-  while (    sp.slavesMask.count() < MAX_SLAVES_PER_SPLITPOINT
+  while (    sp.slavesMask.count() < Threads.max_slaves_per_splitpoint(depth)
          && (slave = Threads.available_slave(&sp)) != nullptr)
   {
      slave->spinlock.acquire();
@@ -292,6 +292,10 @@ void ThreadPool::init() {
   read_uci_options();
 }
 
+unsigned int ThreadPool::max_slaves_per_splitpoint(Depth depth)
+{
+    return(1 + (depth/(2 * ONE_PLY)));
+}
 
 // ThreadPool::exit() terminates the threads before the program exits. Cannot be
 // done in d'tor because threads must be terminated before freeing us.

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -292,10 +292,13 @@ void ThreadPool::init() {
   read_uci_options();
 }
 
-unsigned int ThreadPool::max_slaves_per_splitpoint(Depth depth)
+size_t ThreadPool::max_slaves_per_splitpoint(Depth depth)
 {
-    return(1 + (depth/(2 * ONE_PLY)));
+
+  return 1 + depth / (2 * ONE_PLY);
 }
+
+
 
 // ThreadPool::exit() terminates the threads before the program exits. Cannot be
 // done in d'tor because threads must be terminated before freeing us.

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -295,7 +295,7 @@ void ThreadPool::init() {
 size_t ThreadPool::max_slaves_per_splitpoint(Depth depth)
 {
 
-  return std::min(depth/ONE_PLY - 1, 16);
+  return std::min((1 + depth / (2 * ONE_PLY)), MAX_SLAVES_PER_SPLITPOINT); 
 }
 
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -163,7 +163,7 @@ struct ThreadPool : public std::vector<Thread*> {
   void read_uci_options();
   Thread* available_slave(const SplitPoint* sp) const;
   void start_thinking(const Position&, const Search::LimitsType&, Search::StateStackPtr&);
-
+  unsigned int  max_slaves_per_splitpoint(Depth depth);
   Depth minimumSplitDepth;
   TimerThread* timer;
 };

--- a/src/thread.h
+++ b/src/thread.h
@@ -114,6 +114,7 @@ struct Thread : public ThreadBase {
   virtual void idle_loop();
   bool cutoff_occurred() const;
   bool can_join(const SplitPoint* sp) const;
+  bool can_split_again() const;
 
   void split(Position& pos, Search::Stack* ss, Value alpha, Value beta, Value* bestValue, Move* bestMove,
              Depth depth, int moveCount, MovePicker* movePicker, int nodeType, bool cutNode);

--- a/src/thread.h
+++ b/src/thread.h
@@ -38,6 +38,7 @@ struct Thread;
 
 const size_t MAX_THREADS = 128;
 const size_t MAX_SPLITPOINTS_PER_THREAD = 8;
+const int    MAX_SLAVES_PER_SPLITPOINT = 7;
 
 class Spinlock {
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -38,7 +38,6 @@ struct Thread;
 
 const size_t MAX_THREADS = 128;
 const size_t MAX_SPLITPOINTS_PER_THREAD = 8;
-const size_t MAX_SLAVES_PER_SPLITPOINT = 4;
 
 class Spinlock {
 
@@ -163,7 +162,7 @@ struct ThreadPool : public std::vector<Thread*> {
   void read_uci_options();
   Thread* available_slave(const SplitPoint* sp) const;
   void start_thinking(const Position&, const Search::LimitsType&, Search::StateStackPtr&);
-  unsigned int  max_slaves_per_splitpoint(Depth depth);
+  size_t  max_slaves_per_splitpoint(Depth depth);
   Depth minimumSplitDepth;
   TimerThread* timer;
 };

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -58,7 +58,7 @@ void init(OptionsMap& o) {
 
   o["Write Debug Log"]       << Option(false, on_logger);
   o["Contempt"]              << Option(0, -100, 100);
-  o["Min Split Depth"]       << Option(5, 0, 12, on_threads);
+  o["Min Split Depth"]       << Option(2, 0, 12, on_threads);
   o["Threads"]               << Option(1, 1, MAX_THREADS, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -58,7 +58,7 @@ void init(OptionsMap& o) {
 
   o["Write Debug Log"]       << Option(false, on_logger);
   o["Contempt"]              << Option(0, -100, 100);
-  o["Min Split Depth"]       << Option(2, 0, 12, on_threads);
+  o["Min Split Depth"]       << Option(3, 0, 12, on_threads);
   o["Threads"]               << Option(1, 1, MAX_THREADS, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -58,7 +58,7 @@ void init(OptionsMap& o) {
 
   o["Write Debug Log"]       << Option(false, on_logger);
   o["Contempt"]              << Option(0, -100, 100);
-  o["Min Split Depth"]       << Option(3, 0, 12, on_threads);
+  o["Min Split Depth"]       << Option(2, 0, 12, on_threads);
   o["Threads"]               << Option(1, 1, MAX_THREADS, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);


### PR DESCRIPTION
Reduce minimumSplitDepth to 2. But use fewer slaves while splitting at lower depths. Test passed

STC 3 Threads:
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 11351 W: 2008 L: 1838 D: 7505

STC 7 Threads:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 2587 W: 485 L: 353 D: 1749

LTC 7 Threads:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 20538 W: 2769 L: 2584 D: 15185
