### PR TITLE
Simpler TT save()

### DIFF
--- a/src/tt.h
+++ b/src/tt.h
@@ -50,7 +50,6 @@ struct TTEntry {
     // Don't overwrite more valuable entries
     if (  (k >> 48) != key16
         || d > depth8 - 2
-        || g != (genBound8 & 0xFC)
         || b == BOUND_EXACT)
     {
         key16     = (uint16_t)(k >> 48);

--- a/src/tt.h
+++ b/src/tt.h
@@ -50,6 +50,7 @@ struct TTEntry {
     // Don't overwrite more valuable entries
     if (  (k >> 48) != key16
         || d > depth8 - 2
+     /* || g != (genBound8 & 0xFC) // Any matching keys are already refreshed by probe() */
         || b == BOUND_EXACT)
     {
         key16     = (uint16_t)(k >> 48);


### PR DESCRIPTION
Checking for generation is useless because if the key matches then the entry was already probed and refreshed earlier.  Therefore this is effectively a non functional patch but was tested just to be sure.

STC 2MB
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 57391 W: 10671 L: 10613 D: 36107
http://tests.stockfishchess.org/tests/view/55ef59fa0ebc5976a2d6da5d

LTC 8MB
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 60732 W: 9260 L: 9199 D: 42273
http://tests.stockfishchess.org/tests/view/55ef8fe60ebc5976a2d6da6b

STC 16MB
LLR: 2.95 (-2.94,2.94) [-4.00,0.00]
Total: 23443 W: 4369 L: 4293 D: 14781
http://tests.stockfishchess.org/tests/view/55ef8fe60ebc5976a2d6da6b
