### PR TITLE
Speed optimization in TT::probe().

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -78,7 +78,7 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   for (int i = 0; i < ClusterSize; ++i)
       if (!tte[i].key16 || tte[i].key16 == key16)
       {
-          if (tte[i].key16)
+          if ((tte[i].genBound8 & 0xFC) != generation8 && tte[i].key16)
               tte[i].genBound8 = uint8_t(generation8 | tte[i].bound()); // Refresh
 
           return found = (bool)tte[i].key16, &tte[i];


### PR DESCRIPTION
Speed optimization filters out more unnecessary writes during TT::probe(). This is only 0.6% faster for me and not totally significant but since always refreshing has proven slower here
https://github.com/official-stockfish/Stockfish/pull/236 
I think there is a good chance others may get more significant results.
Could a couple of people please run fishbench and post their results?
No functional change.

```
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    799558    804000    -4442     
    StDev   313227    315079    6910      

p-value: 0.74
speedup: 0.006
```