### PR TITLE
Tune outposts

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -144,8 +144,8 @@ namespace {
   // Outpost[knight/bishop][supported by pawn] contains bonuses for knights and
   // bishops outposts, bigger if outpost piece is supported by a pawn.
   const Score Outpost[][2] = {
-    { S(28, 7), S(42,11) }, // Knights
-    { S(12, 3), S(18, 5) }  // Bishops
+    { S(42,11), S(63,17) }, // Knights
+    { S(18, 5), S(27, 8) }  // Bishops
   };
 
   // Threat[defended/weak][minor/major attacking][attacked PieceType] contains
@@ -296,6 +296,7 @@ namespace {
         {
             // Bonus for outpost square
             if (   relative_rank(Us, s) >= RANK_4
+                && relative_rank(Us, s) <= RANK_6
                 && !(pos.pieces(Them, PAWN) & pawn_attack_span(Us, s)))
                 score += Outpost[Pt == BISHOP][!!(ei.attackedBy[Us][PAWN] & s)];
 


### PR DESCRIPTION
Refine ranks and increase resulting bonus.

STC:
LLR: 2.94 (-2.94,2.94) [0.00,4.00]
Total: 272379 W: 51773 L: 50658 D: 169948

LTC:
LLR: 3.06 (-2.94,2.94) [0.00,4.00]
Total: 41504 W: 6555 L: 6273 D: 28676

bench: 7658406

Resolves #430