### PR TITLE
Revert "Remove unnecessary generation check"

### DIFF
--- a/src/tt.h
+++ b/src/tt.h
@@ -50,7 +50,7 @@ struct TTEntry {
     // Don't overwrite more valuable entries
     if (  (k >> 48) != key16
         || d > depth8 - 2
-     /* || g != (genBound8 & 0xFC) // Any matching keys are already refreshed by probe() */
+        || g != (genBound8 & 0xFC)
         || b == BOUND_EXACT)
     {
         key16     = (uint16_t)(k >> 48);


### PR DESCRIPTION
Comment is wrong!

Indeed it is easy to find with dbg_hit

    // Don't overwrite more valuable entries
    if (  (k >> 48) != key16
        || d > depth8 - 2
     /* || g != (genBound8 & 0xFC) // Any matching keys are already refreshed by probe() */
        || (dbg_hit_on(g != (genBound8 & 0xFC)), false)
        || b == BOUND_EXACT)
    {
        .....

Running a bench we have 6 hits on 128171 cases, not enough to change anything
but the comment is wrong and we have replaced correct code by incorrectly
commented code. So better to revert and have consistent code.

bench: 7658406 (even if bench does not change it _is_ a functional change)