### PR TITLE
Run PVS-STUDIO analyzer

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,4 +47,5 @@ int main(int argc, char* argv[]) {
   UCI::loop(argc, argv);
 
   Threads.exit();
+  return 0;
 }

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -58,10 +58,11 @@ namespace {
 
     if (Checks && !pos.gives_check(m, *ci))
         return moveList;
+    else
+        (void)ci; // Silence a warning under MSVC
 
     *moveList++ = m;
-
-    return (void)ci, moveList; // Silence a warning under MSVC
+    return moveList;
   }
 
 
@@ -82,8 +83,10 @@ namespace {
     // that's not already included in the queen promotion.
     if (Type == QUIET_CHECKS && (StepAttacksBB[W_KNIGHT][to] & ci->ksq))
         *moveList++ = make<PROMOTION>(to - Delta, to, KNIGHT);
+    else
+        (void)ci; // Silence a warning under MSVC
 
-    return (void)ci, moveList; // Silence a warning under MSVC
+    return moveList;
   }
 
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -39,7 +39,7 @@
 template<typename T>
 struct Stats {
 
-  static const Value Max = Value(1<<28);
+  static const Value Max = Value(1 << 28);
 
   const T* operator[](Piece pc) const { return table[pc]; }
   T* operator[](Piece pc) { return table[pc]; }
@@ -53,8 +53,8 @@ struct Stats {
 
   void update(Piece pc, Square to, Value v) {
 
-    table[pc][to] -= table[pc][to] * std::min(abs(int(v)), 512) / 512;
-    table[pc][to] += int(v) * 64;
+    table[pc][to] -= table[pc][to] * std::min(abs(v), 512) / 512;
+    table[pc][to] += v * 64;
   }
 
 private:

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -341,7 +341,7 @@ namespace {
     Move easyMove = EasyMove.get(pos.key());
     EasyMove.clear();
 
-    std::memset(stack, 0, 5 * sizeof(Stack));
+    std::memset(ss-2, 0, 5 * sizeof(Stack));
 
     depth = DEPTH_ZERO;
     BestMoveChanges = 0;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -90,11 +90,11 @@ namespace {
 
     // Read option name (can contain spaces)
     while (is >> token && token != "value")
-        name += string(" ", !name.empty()) + token;
+        name += string(" ", name.empty() ? 0 : 1) + token;
 
     // Read option value (can contain spaces)
     while (is >> token)
-        value += string(" ", !value.empty()) + token;
+        value += string(" ", value.empty() ? 0 : 1) + token;
 
     if (Options.count(name))
         Options[name] = value;
@@ -126,8 +126,8 @@ namespace {
         else if (token == "nodes")     is >> limits.nodes;
         else if (token == "movetime")  is >> limits.movetime;
         else if (token == "mate")      is >> limits.mate;
-        else if (token == "infinite")  limits.infinite = true;
-        else if (token == "ponder")    limits.ponder = true;
+        else if (token == "infinite")  limits.infinite = 1;
+        else if (token == "ponder")    limits.ponder = 1;
 
     Threads.start_thinking(pos, limits, SetupStates);
   }
@@ -171,7 +171,7 @@ void UCI::loop(int argc, char* argv[]) {
           Threads.main()->notify_one(); // Could be sleeping
       }
       else if (token == "ponderhit")
-          Search::Limits.ponder = false; // Switch to normal search
+          Search::Limits.ponder = 0; // Switch to normal search
 
       else if (token == "uci")
           sync_cout << "id name " << engine_info(true)


### PR DESCRIPTION
Fix issues after a run of PVS-STUDIO analyzer.
Mainly false positives but warnings are anyhow
useful to point out not very readable code.

Noteworthy is the memset() one, where PVS prefers ss-2
instead of stack. This is because memeset() could
be optimized away by the compiler when using 'stack',
due to stack being a local variable no more used after
memset. This should normally not happen, but when
it happens it leads to very sublte and difficult
to find bug, so better to be safe than sorry.

No functional change.