### PR TITLE
Passed pawns

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -171,7 +171,10 @@ namespace {
   };
 
   // PassedFile[File] contains a bonus according to the file of a passed pawn.
-  const Score PassedFile[] = {S(15,15), S(5,5), S(-5,-5), S(-15, -15), S(-15, -15), S(-5, -5), S(5, 5), S(15, 15)};
+  const Score PassedFile[] = {
+    S(-15, -15), S(-5, -5), S( 5,  5), S( 15,  15),
+    S( 15,  15), S( 5,  5), S(-5, -5), S(-15, -15)
+  };
 
   const Score ThreatenedByHangingPawn = S(40, 60);
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -172,8 +172,8 @@ namespace {
 
   // PassedFile[File] contains a bonus according to the file of a passed pawn.
   const Score PassedFile[] = {
-    S(-15, -15), S(-5, -5), S( 5,  5), S( 15,  15),
-    S( 15,  15), S( 5,  5), S(-5, -5), S(-15, -15)
+    S( 30,  30), S( 10,  10), S(-10, -10), S(-30, -30),
+    S(-30, -30), S(-10, -10), S( 10,  10), S( 30,  30)
   };
 
   const Score ThreatenedByHangingPawn = S(40, 60);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -170,6 +170,9 @@ namespace {
     { V(7), V(14), V(37), V(63), V(134), V(189) }
   };
 
+  // PassedFile[File] contains a bonus according to the file of a passed pawn.
+  const Score PassedFile[] = {S(15,15), S(5,5), S(-5,-5), S(-15, -15), S(-15, -15), S(-5, -5), S(5, 5), S(15, 15)};
+
   const Score ThreatenedByHangingPawn = S(40, 60);
 
   // Assorted bonuses and penalties used by evaluation
@@ -639,7 +642,7 @@ namespace {
         if (pos.count<PAWN>(Us) < pos.count<PAWN>(Them))
             ebonus += ebonus / 4;
 
-        score += make_score(mbonus, ebonus);
+        score += make_score(mbonus, ebonus) + PassedFile[file_of(s)];
     }
 
     if (DoTrace)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -172,8 +172,8 @@ namespace {
 
   // PassedFile[File] contains a bonus according to the file of a passed pawn.
   const Score PassedFile[] = {
-    S( 30,  30), S( 10,  10), S(-10, -10), S(-30, -30),
-    S(-30, -30), S(-10, -10), S( 10,  10), S( 30,  30)
+    S( 14,  13), S( 2,  5), S(-3, -4), S(-19, -14),
+    S(-19, -14), S(-3, -4), S( 2,  5), S( 14,  13)
   };
 
   const Score ThreatenedByHangingPawn = S(40, 60);


### PR DESCRIPTION
Add file based bonus for passed pawns. Values tuned by SPSA.

STC:
LLR: 3.33 (-2.94,2.94) [0.00,5.00]
Total: 36889 W: 6805 L: 6507 D: 23577

LTC:
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 32301 W: 5101 L: 4858 D: 22342

bench: 8690843
