### PR TITLE
King separation bonus in endgame

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -719,7 +719,7 @@ namespace {
     // Now apply the bonus: note that we find the attacking side by extracting the sign 
     // of the endgame value of "positional_score", and that we carefully cap the bonus so
     // that the endgame score with the correction will never be divided by more than two.
-    int eg = eg_value(positionnal_score);
+    int eg = eg_value(positional_score);
     int value = ((eg > 0) - (eg < 0)) * std::max( attacker_bonus , -abs( eg / 2 ) );
 
     return make_score( 0 , value ) ; 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -705,9 +705,9 @@ namespace {
   }
 
 
-  // evaluate_initiative() computes the initiative correction values for the position, i.e. 
+  // evaluate_initiative() computes the initiative correction value for the position, i.e. 
   // second order bonus/malus based on the known attacking/defending status of the players. 
-  Score evaluate_initiative(const Position& pos, const Score positionnal_score) {
+  Score evaluate_initiative(const Position& pos, const Score positional_score) {
 
     int pawns           =   pos.count<PAWN>(WHITE) + pos.count<PAWN>(BLACK);
     int king_separation =   distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
@@ -717,9 +717,8 @@ namespace {
                          +  8 * king_separation ;
 
     // Now apply the bonus: note that we find the attacking side by extracting the sign 
-    // of the endgame value of "positionnal_score", and that we carefully cap the bonus 
-    // to be at most half that value (in other words, the endgame score with the correction
-    // will never be divided by more than two).
+    // of the endgame value of "positional_score", and that we carefully cap the bonus so
+    // that the endgame score with the correction will never be divided by more than two.
     int eg = eg_value(positionnal_score);
     int value = ((eg > 0) - (eg < 0)) * std::max( attacker_bonus , -abs( eg / 2 ) );
 


### PR DESCRIPTION
King separation bonus in endgame for the attacker side: idea is that king separation is an important feature in endgame, helping to outflank the defense and showing that the defensive king had to stay at the other wing to protect other weaknesses.

A first test showed that rewriting Stefan's Geschwentner "Scales the endgame score by the number of pawns" patch using an additive formulation in evaluate_initiative() was neutral: http://tests.stockfishchess.org/tests/view/55f6421f0ebc5976a2d6dc72

Then we have this patch, which adds king separation in the attacker bonus formula, and passed STC and LTC:

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 116153 W: 21616 L: 20990 D: 73547

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 115087 W: 17578 L: 17034 D: 80475

bench: 8768361