### PR TITLE
Retire rook contact checks

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -222,7 +222,7 @@ namespace {
   const int QueenContactCheck = 89;
   const int RookContactCheck  = 71;
   const int QueenCheck        = 50;
-  const int RookCheck         = 37;
+  const int RookCheck         = 45;
   const int BishopCheck       = 6;
   const int KnightCheck       = 14;
 
@@ -419,23 +419,6 @@ namespace {
 
             if (b)
                 attackUnits += QueenContactCheck * popcount<Max15>(b);
-        }
-
-        // Analyse the enemy's safe rook contact checks. Firstly, find the
-        // undefended squares around the king reachable by the enemy rooks...
-        b = undefended & ei.attackedBy[Them][ROOK] & ~pos.pieces(Them);
-
-        // Consider only squares where the enemy's rook gives check
-        b &= PseudoAttacks[ROOK][ksq];
-
-        if (b)
-        {
-            // ...and then remove squares not supported by another enemy piece
-            b &= (  ei.attackedBy[Them][PAWN]   | ei.attackedBy[Them][KNIGHT]
-                  | ei.attackedBy[Them][BISHOP]);
-
-            if (b)
-                attackUnits += RookContactCheck * popcount<Max15>(b);
         }
 
         // Analyse the enemy's safe distance checks for sliders and knights


### PR DESCRIPTION
Remove rook contact check bonus and in return increase rook checks

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 34114 W: 6363 L: 6265 D: 21486

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 61776 W: 9349 L: 9289 D: 43138

bench: 7681680

Resolves #442 