### PR TITLE
Assert

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -174,8 +174,8 @@ void Search::init() {
 
   for (int d = 0; d < 16; ++d)
   {
-    FutilityMoveCounts[0][d] = int(2.4  + (Options["Threads"] - 1) + 0.773 * pow(d + 0.00, 1.8) );
-    FutilityMoveCounts[1][d] = int(2.9  + (Options["Threads"] - 1) + 1.045 * pow(d + 0.49, 1.8) );
+    FutilityMoveCounts[0][d] = int(2.4  + (2*Options["Threads"] - 2) + 0.773 * pow(d + 0.00, 1.8) );
+    FutilityMoveCounts[1][d] = int(2.9  + (2*Options["Threads"] - 2) + 1.045 * pow(d + 0.49, 1.8) );
   }
 }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -174,8 +174,8 @@ void Search::init() {
 
   for (int d = 0; d < 16; ++d)
   {
-    FutilityMoveCounts[0][d] = int(2.4  + (2*Options["Threads"] - 2) + 0.773 * pow(d + 0.00, 1.8) );
-    FutilityMoveCounts[1][d] = int(2.9  + (2*Options["Threads"] - 2) + 1.045 * pow(d + 0.49, 1.8) );
+      FutilityMoveCounts[0][d] = int(2.4 + 0.773 * pow(d + 0.00, 1.8));
+      FutilityMoveCounts[1][d] = int(2.9 + 1.045 * pow(d + 0.49, 1.8));
   }
 }
 
@@ -1657,7 +1657,6 @@ void Thread::idle_loop() {
               {
                   assert(this != th);
                   assert(!(this_sp && this_sp->slavesMask.none()));
-                  assert(Threads.size() > 2);
 
                   // Prefer to join to SP with few parents to reduce the probability
                   // that a cut-off occurs above us, and hence we waste our work.

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -174,8 +174,8 @@ void Search::init() {
 
   for (int d = 0; d < 16; ++d)
   {
-      FutilityMoveCounts[0][d] = int(2.4 + 0.773 * pow(d + 0.00, 1.8));
-      FutilityMoveCounts[1][d] = int(2.9 + 1.045 * pow(d + 0.49, 1.8));
+    FutilityMoveCounts[0][d] = int(2.4  + (Options["Threads"] - 1) + 0.773 * pow(d + 0.00, 1.8) );
+    FutilityMoveCounts[1][d] = int(2.9  + (Options["Threads"] - 1) + 1.045 * pow(d + 0.49, 1.8) );
   }
 }
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -58,7 +58,7 @@ void init(OptionsMap& o) {
 
   o["Write Debug Log"]       << Option(false, on_logger);
   o["Contempt"]              << Option(0, -100, 100);
-  o["Min Split Depth"]       << Option(5, 0, 12, on_threads);
+  o["Min Split Depth"]       << Option(2, 0, 12, on_threads);
   o["Threads"]               << Option(1, 1, MAX_THREADS, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -58,8 +58,8 @@ void init(OptionsMap& o) {
 
   o["Write Debug Log"]       << Option(false, on_logger);
   o["Contempt"]              << Option(0, -100, 100);
-  o["Min Split Depth"]       << Option(2, 0, 12, on_threads);
-  o["Threads"]               << Option(2, 1, MAX_THREADS, on_threads);
+  o["Min Split Depth"]       << Option(5, 0, 12, on_threads);
+  o["Threads"]               << Option(1, 1, MAX_THREADS, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(true);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -59,7 +59,7 @@ void init(OptionsMap& o) {
   o["Write Debug Log"]       << Option(false, on_logger);
   o["Contempt"]              << Option(0, -100, 100);
   o["Min Split Depth"]       << Option(2, 0, 12, on_threads);
-  o["Threads"]               << Option(1, 1, MAX_THREADS, on_threads);
+  o["Threads"]               << Option(2, 1, MAX_THREADS, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(true);


### PR DESCRIPTION
Remove an assert that is technically incorrect:
Technically it's possible that:

1. thread1 & thread2 are searching at the same split point
2. thread1finishes searching in splitpoint and sets allSlavesSearching = false in idle_loop()
3. Immediately after this OS terminates thread1 execution for a very long time, and starts executing thread2
4. thread2 is now eligible to split() and it does the whole split operation.
5. execution of thread1is resumed, and now latejoin is evaluated in idle_loop. thread1 can now legally latejoin and assert fires.

So there is a legal extremely rare way that this can happen... And it's likely dependent on hardware that you are running. I think that in fact this is most likely to occur on 1CPU machine...

So technically the assert is incorrect. There is an SMP race that triggers it...

No functional change.