### PR TITLE
Move stats

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -146,7 +146,7 @@ void MovePicker::score<QUIETS>() {
 
   for (auto& m : *this)
       m.value =  history[pos.moved_piece(m)][to_sq(m)]
-               + cmh[pos.moved_piece(m)][to_sq(m)] * 3;
+               + cmh[pos.moved_piece(m)][to_sq(m)];
 }
 
 template<>

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -39,7 +39,7 @@
 template<typename T>
 struct Stats {
 
-  static const Value Max = Value(1 << 28);
+  static const Value Max = Value(1<<28);
 
   const T* operator[](Piece pc) const { return table[pc]; }
   T* operator[](Piece pc) { return table[pc]; }
@@ -51,10 +51,20 @@ struct Stats {
         table[pc][to] = m;
   }
 
-  void update(Piece pc, Square to, Value v) {
+  void updateH(Piece pc, Square to, Value v) {
 
-    table[pc][to] -= table[pc][to] * std::min(abs(v), 512) / 512;
-    table[pc][to] += v * 64;
+    if (abs(int(v)) >= 324) 
+        return;
+    table[pc][to] -= table[pc][to] * abs(int(v)) / 324;
+    table[pc][to] += int(v) * 32;
+  }
+
+  void updateCMH(Piece pc, Square to, Value v) {
+
+    if (abs(int(v)) >= 324) 
+        return;
+    table[pc][to] -= table[pc][to] * abs(int(v)) / 512;
+    table[pc][to] += int(v) * 64;
   }
 
 private:

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1418,21 +1418,21 @@ moves_loop: // When in check and at SpNode search starts from here
     Square prevSq = to_sq((ss-1)->currentMove);
     HistoryStats& cmh = CounterMovesHistory[pos.piece_on(prevSq)][prevSq];
 
-    History.update(pos.moved_piece(move), to_sq(move), bonus);
+    History.updateH(pos.moved_piece(move), to_sq(move), bonus);
 
     if (is_ok((ss-1)->currentMove))
     {
         Countermoves.update(pos.piece_on(prevSq), prevSq, move);
-        cmh.update(pos.moved_piece(move), to_sq(move), bonus);
+        cmh.updateCMH(pos.moved_piece(move), to_sq(move), bonus);
     }
 
     // Decrease all the other played quiet moves
     for (int i = 0; i < quietsCnt; ++i)
     {
-        History.update(pos.moved_piece(quiets[i]), to_sq(quiets[i]), -bonus);
+        History.updateH(pos.moved_piece(quiets[i]), to_sq(quiets[i]), -bonus);
 
         if (is_ok((ss-1)->currentMove))
-            cmh.update(pos.moved_piece(quiets[i]), to_sq(quiets[i]), -bonus);
+            cmh.updateCMH(pos.moved_piece(quiets[i]), to_sq(quiets[i]), -bonus);
     }
 
     // Extra penalty for PV move in previous ply when it gets refuted
@@ -1440,7 +1440,7 @@ moves_loop: // When in check and at SpNode search starts from here
     {
         Square prevPrevSq = to_sq((ss-2)->currentMove);
         HistoryStats& ttMoveCmh = CounterMovesHistory[pos.piece_on(prevPrevSq)][prevPrevSq];
-        ttMoveCmh.update(pos.piece_on(prevSq), prevSq, -bonus - 2 * depth / ONE_PLY - 1);
+        ttMoveCmh.updateCMH(pos.piece_on(prevSq), prevSq, -bonus - 2 * depth / ONE_PLY - 1);
     }
   }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1132,6 +1132,19 @@ moves_loop: // When in check and at SpNode search starts from here
     else if (bestMove && !pos.capture_or_promotion(bestMove))
         update_stats(pos, ss, bestMove, depth, quietsSearched, quietCount);
 
+    // Bonus for prior countermove that caused the fail low
+    else if (!bestMove)
+    {
+        if (is_ok((ss - 2)->currentMove) && is_ok((ss - 1)->currentMove) && !pos.captured_piece_type() && !inCheck && depth>=3*ONE_PLY)
+        {
+            Value bonus = Value((depth / ONE_PLY) * (depth / ONE_PLY));
+            Square prevSq = to_sq((ss - 1)->currentMove);
+            Square prevPrevSq = to_sq((ss - 2)->currentMove);
+            HistoryStats& flMoveCmh = CounterMovesHistory[pos.piece_on(prevPrevSq)][prevPrevSq];
+            flMoveCmh.updateCMH(pos.piece_on(prevSq), prevSq, bonus);
+        }
+    }
+
     tte->save(posKey, value_to_tt(bestValue, ss->ply),
               bestValue >= beta ? BOUND_LOWER :
               PvNode && bestMove ? BOUND_EXACT : BOUND_UPPER,


### PR DESCRIPTION
Combination of two ideas:

Apply bonus for the prior CMH that caused a fail low.

Balance Stats: CMH and History bonuses are updated differently.
This eliminates the "fudge" factor weight when scoring moves. Also eliminated discontinuity in the gravity history stat formula. (i.e. stat scores will no longer inverse when depth exceeds 22)

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 21802 W: 4107 L: 3887 D: 13808

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 46036 W: 7046 L: 6756 D: 32234

Bench:  7677367