### PR TITLE
Account for Move Overhead in emergency stop

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -104,7 +104,7 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
 
   startTime = limits.startTime;
   unstablePvFactor = 1;
-  optimumTime = maximumTime = std::max(limits.time[us], minThinkingTime);
+  optimumTime = maximumTime = std::max(limits.time[us] - moveOverhead, minThinkingTime);
 
   const int MaxMTG = limits.movestogo ? std::min(limits.movestogo, MoveHorizon) : MoveHorizon;
 


### PR DESCRIPTION
`Time.maximum()` forgets to take into account "Move Overhead", which I believe
to be a bug. Indeed, this code is supposed to be a safety net, for when the time
manager goes rogue:

    if (stillAtFirstMove || elapsed > Time.maximum() - 2 * TimerThread::Resolution)
        Signals.stop = true;

But `2 * TimerThread::Resolution = 10ms` is too optimistic. We need to account for
various sources of lag, and that's what "Move Overhead" is designed to do.

No functional change.