### PR TITLE
Atomic signals

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -126,19 +126,19 @@ namespace {
   // friendly pieces.
   const Score MobilityBonus[][32] = {
     {}, {},
-    { S(-68,-49), S(-46,-33), S(-3,-12), S( 5, -4), S( 9, 11), S(15, 16), // Knights
-      S( 23, 27), S( 33, 28), S(37, 29) },
-    { S(-49,-44), S(-23,-16), S(16,  1), S(29, 16), S(40, 25), S(51, 34), // Bishops
-      S( 55, 43), S( 61, 49), S(64, 51), S(68, 52), S(73, 55), S(75, 60),
-      S( 80, 65), S( 86, 66) },
-    { S(-50,-57), S(-28,-22), S(-11, 7), S(-1, 29), S( 0, 39), S( 1, 46), // Rooks
-      S( 10, 66), S( 16, 79), S(22, 86), S(23,103), S(30,109), S(33,111),
-      S( 37,115), S( 38,119), S(48,124) },
-    { S(-43,-30), S(-27,-15), S( 1, -5), S( 2, -3), S(14, 10), S(18, 24), // Queens
-      S( 20, 27), S( 33, 37), S(33, 38), S(34, 43), S(40, 46), S(43, 56),
-      S( 46, 61), S( 52, 63), S(52, 63), S(57, 65), S(60, 70), S(61, 74),
-      S( 67, 80), S( 76, 82), S(77, 88), S(82, 94), S(86, 95), S(90, 96),
-      S( 94, 99), S( 96,100), S(99,111), S(99,112) }
+    { S(-70,-52), S(-52,-37), S( -7,-17), S(  0, -6), S(  8,  5), S( 16,  9), // Knights
+      S( 23, 20), S( 31, 21), S( 36, 22) },
+    { S(-49,-44), S(-22,-13), S( 16,  0), S( 27, 11), S( 38, 19), S( 52, 34), // Bishops
+      S( 56, 44), S( 65, 47), S( 67, 51), S( 73, 56), S( 81, 59), S( 83, 69),
+      S( 95, 72), S(100, 75) },
+    { S(-49,-57), S(-22,-14), S(-10, 18), S( -5, 39), S( -4, 50), S( -2, 58), // Rooks
+      S(  6, 78), S( 11, 86), S( 17, 92), S( 19,103), S( 26,111), S( 27,115),
+      S( 36,119), S( 41,121), S( 50,122) },
+    { S(-41,-24), S(-26, -8), S(  0,  6), S(  2, 14), S( 12, 27), S( 21, 40), // Queens
+      S( 22, 45), S( 37, 55), S( 40, 57), S( 43, 63), S( 50, 68), S( 52, 74),
+      S( 56, 80), S( 66, 84), S( 68, 85), S( 69, 88), S( 71, 92), S( 72, 94),
+      S( 80, 96), S( 89, 98), S( 94,101), S(102,113), S(106,114), S(107,116),
+      S(112,125), S(113,127), S(117,137), S(122,143) }
   };
 
   // Outpost[knight/bishop][supported by pawn] contains bonuses for knights and
@@ -172,8 +172,8 @@ namespace {
 
   // PassedFile[File] contains a bonus according to the file of a passed pawn.
   const Score PassedFile[] = {
-    S( 14,  13), S( 2,  5), S(-3, -4), S(-19, -14),
-    S(-19, -14), S(-3, -4), S( 2,  5), S( 14,  13)
+    S( 12,  10), S( 3,  10), S( 1, -8), S(-27, -12),
+    S(-27, -12), S( 1, -8),  S( 3, 10), S( 12,  10)
   };
 
   const Score ThreatenedByHangingPawn = S(40, 60);
@@ -414,7 +414,8 @@ namespace {
         {
             // ...and then remove squares not supported by another enemy piece
             b &=  ei.attackedBy[Them][PAWN]   | ei.attackedBy[Them][KNIGHT]
-                | ei.attackedBy[Them][BISHOP] | ei.attackedBy[Them][ROOK];
+                | ei.attackedBy[Them][BISHOP] | ei.attackedBy[Them][ROOK]
+                | ei.attackedBy[Them][KING];
 
             if (b)
                 attackUnits += QueenContactCheck * popcount<Max15>(b);

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -28,7 +28,7 @@ class Position;
 
 namespace Eval {
 
-const Value Tempo = Value(17); // Must be visible to search
+const Value Tempo = Value(20); // Must be visible to search
 
 void init();
 std::string trace(const Position& pos);

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -31,28 +31,28 @@ namespace {
   // Polynomial material imbalance parameters
 
   //                      pair  pawn knight bishop rook queen
-  const int Linear[6] = { 1756, -164, -1067, -160,  234, -137 };
+  const int Linear[6] = { 1667, -168, -1027, -166,  238, -138 };
 
   const int QuadraticOurs[][PIECE_TYPE_NB] = {
     //            OUR PIECES
     // pair pawn knight bishop rook queen
     {   0                               }, // Bishop pair
-    {  39,    2                         }, // Pawn
-    {  35,  271,  -4                    }, // Knight      OUR PIECES
-    {   0,  105,   4,    0              }, // Bishop
-    { -27,   -2,  46,   100,  -141      }, // Rook
-    {-177,   25, 129,   142,  -137,   0 }  // Queen
+    {  40,    2                         }, // Pawn
+    {  32,  255,  -3                    }, // Knight      OUR PIECES
+    {   0,  104,   4,    0              }, // Bishop
+    { -26,   -2,  47,   105,  -149      }, // Rook
+    {-185,   24, 122,   137,  -134,   0 }  // Queen
   };
 
   const int QuadraticTheirs[][PIECE_TYPE_NB] = {
     //           THEIR PIECES
     // pair pawn knight bishop rook queen
     {   0                               }, // Bishop pair
-    {  37,    0                         }, // Pawn
-    {  10,   62,   0                    }, // Knight      OUR PIECES
-    {  57,   64,  39,     0             }, // Bishop
-    {  50,   40,  23,   -22,    0       }, // Rook
-    {  98,  105, -39,   141,  274,    0 }  // Queen
+    {  36,    0                         }, // Pawn
+    {   9,   63,   0                    }, // Knight      OUR PIECES
+    {  59,   65,  42,     0             }, // Bishop
+    {  46,   39,  24,   -24,    0       }, // Rook
+    { 101,  100, -37,   141,  268,    0 }  // Queen
   };
 
   // Endgame evaluation and scaling functions are accessed directly and not through

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -113,7 +113,7 @@ const string engine_info(bool to_uci) {
   ss << (Is64Bit ? " 64" : "")
      << (HasPext ? " BMI2" : (HasPopCnt ? " POPCNT" : ""))
      << (to_uci  ? "\nid author ": " by ")
-     << "Tord Romstad, Marco Costalba and Joona Kiiski";
+     << "T. Romstad, M. Costalba, J. Kiiski, G. Linscott";
 
   return ss.str();
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -64,7 +64,7 @@ namespace {
   enum NodeType { Root, PV, NonPV };
 
   // Razoring and futility margin based on depth
-  Value razor_margin(Depth d) { return Value(512 + 32 * d); }
+  int razor_margin[4] = {483, 570, 603, 554};
   Value futility_margin(Depth d) { return Value(200 * d); }
 
   // Futility and reductions lookup tables, initialized at startup
@@ -149,7 +149,7 @@ namespace {
 
 void Search::init() {
 
-  const double K[][2] = {{ 0.83, 2.25 }, { 0.50, 3.00 }};
+  const double K[][2] = {{ 0.799, 2.281 }, { 0.484, 3.023 }};
 
   for (int pv = 0; pv <= 1; ++pv)
       for (int imp = 0; imp <= 1; ++imp)
@@ -393,7 +393,7 @@ void Thread::search(bool isMainThread) {
           // Reset aspiration window starting size
           if (depth >= 5 * ONE_PLY)
           {
-              delta = Value(16);
+              delta = Value(18);
               alpha = std::max(rootMoves[PVIdx].previousScore - delta,-VALUE_INFINITE);
               beta  = std::min(rootMoves[PVIdx].previousScore + delta, VALUE_INFINITE);
           }
@@ -453,7 +453,7 @@ void Thread::search(bool isMainThread) {
               else
                   break;
 
-              delta += delta / 2;
+              delta += delta / 4 + 5;
 
               assert(alpha >= -VALUE_INFINITE && beta <= VALUE_INFINITE);
           }
@@ -690,14 +690,14 @@ namespace {
     // Step 6. Razoring (skipped when in check)
     if (   !PvNode
         &&  depth < 4 * ONE_PLY
-        &&  eval + razor_margin(depth) <= alpha
+        &&  eval + razor_margin[depth] <= alpha
         &&  ttMove == MOVE_NONE)
     {
         if (   depth <= ONE_PLY
-            && eval + razor_margin(3 * ONE_PLY) <= alpha)
+            && eval + razor_margin[3 * ONE_PLY] <= alpha)
             return qsearch<NonPV, false>(pos, ss, alpha, beta, DEPTH_ZERO);
 
-        Value ralpha = alpha - razor_margin(depth);
+        Value ralpha = alpha - razor_margin[depth];
         Value v = qsearch<NonPV, false>(pos, ss, ralpha, ralpha+1, DEPTH_ZERO);
         if (v <= ralpha)
             return v;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -37,7 +37,7 @@
 
 namespace Search {
 
-  volatile SignalsType Signals;
+  SignalsType Signals;
   LimitsType Limits;
   StateStackPtr SetupStates;
 }
@@ -581,7 +581,7 @@ namespace {
     if (!RootNode)
     {
         // Step 2. Check for aborted search and immediate draw
-        if (Signals.stop || pos.is_draw() || ss->ply >= MAX_PLY)
+        if (Signals.stop.load(std::memory_order_acquire) || pos.is_draw() || ss->ply >= MAX_PLY)
             return ss->ply >= MAX_PLY && !inCheck ? evaluate(pos) : DrawValue[pos.side_to_move()];
 
         // Step 3. Mate distance pruning. Even if we mate at the next move our score
@@ -835,7 +835,7 @@ moves_loop: // When in check search starts from here
 
       if (RootNode && thisThread == Threads.main())
       {
-          Signals.firstRootMove = (moveCount == 1);
+          Signals.firstRootMove.store(moveCount == 1, std::memory_order_release);
 
           if (Time.elapsed() > 3000)
               sync_cout << "info depth " << depth / ONE_PLY
@@ -996,7 +996,7 @@ moves_loop: // When in check search starts from here
       // Finished searching the move. If a stop occurred, the return value of
       // the search cannot be trusted, and we return immediately without
       // updating best move, PV and TT.
-      if (Signals.stop)
+      if (Signals.stop.load(std::memory_order_acquire))
           return VALUE_ZERO;
 
       if (RootNode)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -581,7 +581,7 @@ namespace {
     if (!RootNode)
     {
         // Step 2. Check for aborted search and immediate draw
-        if (Signals.stop.load(std::memory_order_acquire) || pos.is_draw() || ss->ply >= MAX_PLY)
+        if (Signals.stop.load(std::memory_order_relaxed) || pos.is_draw() || ss->ply >= MAX_PLY)
             return ss->ply >= MAX_PLY && !inCheck ? evaluate(pos) : DrawValue[pos.side_to_move()];
 
         // Step 3. Mate distance pruning. Even if we mate at the next move our score
@@ -835,7 +835,7 @@ moves_loop: // When in check search starts from here
 
       if (RootNode && thisThread == Threads.main())
       {
-          Signals.firstRootMove.store(moveCount == 1, std::memory_order_release);
+          Signals.firstRootMove = moveCount == 1;
 
           if (Time.elapsed() > 3000)
               sync_cout << "info depth " << depth / ONE_PLY
@@ -996,7 +996,7 @@ moves_loop: // When in check search starts from here
       // Finished searching the move. If a stop occurred, the return value of
       // the search cannot be trusted, and we return immediately without
       // updating best move, PV and TT.
-      if (Signals.stop.load(std::memory_order_acquire))
+      if (Signals.stop.load(std::memory_order_relaxed))
           return VALUE_ZERO;
 
       if (RootNode)
@@ -1559,7 +1559,7 @@ void check_time() {
   {
       bool stillAtFirstMove =    Signals.firstRootMove
                              && !Signals.failedLowAtRoot
-                             &&  elapsed > Time.available() * 75 / 100;
+                             &&  elapsed > Time.available() * 3 / 4;
 
       if (   stillAtFirstMove
           || elapsed > Time.maximum() - 2 * TimerThread::Resolution)

--- a/src/search.h
+++ b/src/search.h
@@ -20,7 +20,8 @@
 #ifndef SEARCH_H_INCLUDED
 #define SEARCH_H_INCLUDED
 
-#include <memory>  // For std::auto_ptr
+#include <atomic>
+#include <memory>  // For std::unique_ptr
 #include <stack>
 #include <vector>
 
@@ -91,16 +92,16 @@ struct LimitsType {
   TimePoint startTime;
 };
 
-/// The SignalsType struct stores volatile flags updated during the search
+/// The SignalsType struct stores atomic flags updated during the search
 /// typically in an async fashion e.g. to stop the search by the GUI.
 
 struct SignalsType {
-  bool stop, stopOnPonderhit, firstRootMove, failedLowAtRoot;
+  std::atomic<bool> stop, stopOnPonderhit, firstRootMove, failedLowAtRoot;
 };
 
 typedef std::unique_ptr<std::stack<StateInfo>> StateStackPtr;
 
-extern volatile SignalsType Signals;
+extern SignalsType Signals;
 extern LimitsType Limits;
 extern StateStackPtr SetupStates;
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -68,16 +68,16 @@ void ThreadBase::notify_one() {
 
 // ThreadBase::wait() set the thread to sleep until 'condition' turns true
 
-void ThreadBase::wait(volatile const bool& condition) {
+void ThreadBase::wait(std::atomic<bool>& condition) {
 
   std::unique_lock<Mutex> lk(mutex);
-  sleepCondition.wait(lk, [&]{ return condition; });
+  sleepCondition.wait(lk, [&]{ return condition.load(std::memory_order_acquire); });
 }
 
 
 // ThreadBase::wait_while() set the thread to sleep until 'condition' turns false
 
-void ThreadBase::wait_while(volatile const bool& condition) {
+void ThreadBase::wait_while(std::atomic<bool>& condition) {
 
   std::unique_lock<Mutex> lk(mutex);
   sleepCondition.wait(lk, [&]{ return !condition; });
@@ -87,7 +87,7 @@ void ThreadBase::wait_while(volatile const bool& condition) {
 // Thread c'tor makes some init but does not launch any execution thread that
 // will be started only when c'tor returns.
 
-Thread::Thread() /* : splitPoints() */ { // Initialization of non POD broken in MSVC
+Thread::Thread() {
 
   searching = false;
   maxPly = 0;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -76,7 +76,6 @@ void ThreadBase::wait(std::atomic<bool>& condition) {
 
 
 // ThreadBase::wait_while() set the thread to sleep until 'condition' turns false
-
 void ThreadBase::wait_while(std::atomic<bool>& condition) {
 
   std::unique_lock<Mutex> lk(mutex);

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -71,7 +71,7 @@ void ThreadBase::notify_one() {
 void ThreadBase::wait(std::atomic<bool>& condition) {
 
   std::unique_lock<Mutex> lk(mutex);
-  sleepCondition.wait(lk, [&]{ return condition.load(std::memory_order_acquire); });
+  sleepCondition.wait(lk, [&]{ return bool(condition); });
 }
 
 


### PR DESCRIPTION
Rely on well defined behaviour for message passing, instead of volatile. Two
versions have been tested, to make sure this wouldn't cause a slowdown on any
platform.

**v1: Sequentially consistent atomics**

No mesurable regression, despite the extra memory barriers on x86. Even with 15
threads and extreme time pressure, both acting as a magnifying glass:
```
threads=15, tc=2+0.02
ELO: 2.59 +-3.4 (95%) LOS: 93.3%
Total: 18132 W: 4113 L: 3978 D: 10041

threads=7, tc=2+0.02
ELO: -1.64 +-3.6 (95%) LOS: 18.8%
Total: 16914 W: 4053 L: 4133 D: 8728
```
**v2: Acquire/Release semantics**

This version generates no extra barriers for x86 (on the hot path). As expected,
no regression either, under the same conditions:
```
threads=15, tc=2+0.02
ELO: 2.85 +-3.3 (95%) LOS: 95.4%
Total: 19661 W: 4640 L: 4479 D: 10542

threads=7, tc=2+0.02
ELO: 0.23 +-3.5 (95%) LOS: 55.1%
Total: 18108 W: 4326 L: 4314 D: 9468
```
As suggested by Joona, another test at LTC:
```
threads=15, tc=20+0.05
ELO: 0.64 +-2.6 (95%) LOS: 68.3%
Total: 20000 W: 3053 L: 3016 D: 13931
```
Note that, on ARM and PPC, acquire/release will generate barriers, unlike x86.
And we don't have ARM and PPC machines on fishtest. This is one of the reson for
testing version 1 as well. The theoretical cost of these barriers is not
mesurable, as shown by v1 tests.

Obviously, we go with v2.

No functional change.