### PR TITLE
Init thread local memory in idle loop for NUMA first touch policy.

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -84,17 +84,6 @@ void ThreadBase::wait_while(volatile const bool& condition) {
 }
 
 
-// Thread c'tor makes some init but does not launch any execution thread that
-// will be started only when c'tor returns.
-
-Thread::Thread() /* : splitPoints() */ { // Initialization of non POD broken in MSVC
-
-  searching = false;
-  maxPly = 0;
-  idx = Threads.size(); // Starts from 0
-}
-
-
 // TimerThread::idle_loop() is where the timer thread waits Resolution milliseconds
 // and then calls check_time(). When not searching, thread sleeps until it's woken up.
 
@@ -118,6 +107,12 @@ void TimerThread::idle_loop() {
 // Thread::idle_loop() is where the thread is parked when it has no work to do
 
 void Thread::idle_loop() {
+
+  std::memset(this, 0, sizeof(*this)); // Touch memory for NUMA allocation
+
+  //searching = false; maxPly = 0; // Done by memset
+
+  idx = Threads.size(); // Starts from 0
 
   while (!exit)
   {

--- a/src/thread.h
+++ b/src/thread.h
@@ -63,7 +63,6 @@ struct ThreadBase : public std::thread {
 
 struct Thread : public ThreadBase {
 
-  Thread();
   virtual void idle_loop();
   void search(bool isMainThread = false);
 


### PR DESCRIPTION
Currently thread local memory is first touched by the main thread.

In the thread constructor and by calling History and CounterMoves reset() from the main thread.
This patch moves the init code to the idle loop, so NUMA first touch policy will attempt to allocate it locally.

Non functional change.