### PR TITLE
Cosmetics in KRPPKRP scaling function

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -59,7 +59,7 @@ namespace {
   const int PushClose[8] = { 0, 0, 100, 80, 60, 40, 20, 10 };
   const int PushAway [8] = { 0, 5, 20, 40, 60, 80, 90, 100 };
 
-  // Assorted values
+  // Rank-based scaling factors used in KRPPKRP endgame
   const int KRPPKRPvalues[RANK_NB] = {0, 9, 10, 14, 21, 44, 0, 0};
 
 #ifndef NDEBUG
@@ -602,8 +602,10 @@ ScaleFactor Endgame<KRPPKRP>::operator()(const Position& pos) const {
   if (   distance<File>(bksq, wpsq1) <= 1
       && distance<File>(bksq, wpsq2) <= 1
       && relative_rank(strongSide, bksq) > r)
+  {
+      assert(r > RANK_1 && r < RANK_7);
       return ScaleFactor(KRPPKRPvalues[r]);
-
+  }
   return SCALE_FACTOR_NONE;
 }
 

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -59,6 +59,9 @@ namespace {
   const int PushClose[8] = { 0, 0, 100, 80, 60, 40, 20, 10 };
   const int PushAway [8] = { 0, 5, 20, 40, 60, 80, 90, 100 };
 
+  // Assorted values
+  const int KRPPKRPvalues[RANK_NB] = {0, 9, 10, 14, 21, 44, 0, 0};
+
 #ifndef NDEBUG
   bool verify_material(const Position& pos, Color c, Value npm, int pawnsCnt) {
     return pos.non_pawn_material(c) == npm && pos.count<PAWN>(c) == pawnsCnt;
@@ -599,16 +602,8 @@ ScaleFactor Endgame<KRPPKRP>::operator()(const Position& pos) const {
   if (   distance<File>(bksq, wpsq1) <= 1
       && distance<File>(bksq, wpsq2) <= 1
       && relative_rank(strongSide, bksq) > r)
-  {
-      switch (r) {
-      case RANK_2: return ScaleFactor(9);
-      case RANK_3: return ScaleFactor(10);
-      case RANK_4: return ScaleFactor(14);
-      case RANK_5: return ScaleFactor(21);
-      case RANK_6: return ScaleFactor(44);
-      default: assert(false);
-      }
-  }
+      return ScaleFactor(KRPPKRPvalues[r]);
+
   return SCALE_FACTOR_NONE;
 }
 


### PR DESCRIPTION
Remove an ugly, verbose switch statement in the scaling function for KRPPKRP endgame and replace it by retrieving values in an array.

No functional change.