### PR TITLE
History Pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -894,16 +894,12 @@ moves_loop: // When in check search starts from here
               && moveCount >= FutilityMoveCounts[improving][depth])
               continue;
 
-		  //History Score Pruning
-		  if (depth <=3
-			  && thisThread->History[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO
-			  && CounterMovesHistory[pos.piece_on(prevMoveSq)][prevMoveSq]
-			  [pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO)
-			  continue;
-
-
-
-
+          // History Score Pruning
+          if ( depth <= 3 * ONE_PLY
+              && thisThread->History[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO
+              && CounterMovesHistory[pos.piece_on(prevMoveSq)][prevMoveSq]
+                                    [pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO)
+              continue;
 
           predictedDepth = newDepth - reduction<PvNode>(improving, depth, moveCount);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -894,6 +894,17 @@ moves_loop: // When in check search starts from here
               && moveCount >= FutilityMoveCounts[improving][depth])
               continue;
 
+		  //History Score Pruning
+		  if (depth <=3
+			  && thisThread->History[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO
+			  && CounterMovesHistory[pos.piece_on(prevMoveSq)][prevMoveSq]
+			  [pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO)
+			  continue;
+
+
+
+
+
           predictedDepth = newDepth - reduction<PvNode>(improving, depth, moveCount);
 
           // Futility pruning: parent node


### PR DESCRIPTION
Prune moves with negative History and CMH scores at low depth.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 24182 W: 4672 L: 4439 D: 15071

LTC:
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 12579 W: 1959 L: 1792 D: 8828