### PR TITLE
Improve time management when playing on increment

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -84,8 +84,8 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
 {
   int minThinkingTime = Options["Minimum Thinking Time"];
   int moveOverhead    = Options["Move Overhead"];
-  int slowMover       = Options["Slow Mover"];
   int npmsec          = Options["nodestime"];
+  int slowMover       = Options["Slow Mover"] * (limits.time[us] < 3*limits.inc[us] ? 5 : 7)/7;
 
   // If we have to play in 'nodes as time' mode, then convert from time
   // to nodes, and use resulting values in time management formulas.


### PR DESCRIPTION
Decrease average time spent when time left is comparable to increment.
This allows time management to function in more normal manner when best
move is changing.

Passed 0.25+0.25:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 8816 W: 1961 L: 1788 D: 5067

Passed 1+1:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 6772 W: 1204 L: 1054 D: 4514

Passed no regression test at 10+0.1:
LLR: 3.33 (-2.94,2.94) [-3.00,1.00]
Total: 49343 W: 9449 L: 9358 D: 30536

bench: 8004751