### PR TITLE
Reduce variation in rootDepth between different threads

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -376,7 +376,7 @@ void Thread::search(bool isMainThread) {
   {
       // Set up the new depth for the helper threads
       if (!isMainThread)
-          depth = Threads.main()->depth + Depth(int(3 * log(1 + this->idx)));
+          depth = Threads.main()->depth + Depth(int(2.3 * log(1 + this->idx)));
 
       // Age out PV variability metric
       if (isMainThread)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -376,7 +376,7 @@ void Thread::search(bool isMainThread) {
   {
       // Set up the new depth for the helper threads
       if (!isMainThread)
-          depth = Threads.main()->depth + Depth(int(2.3 * log(1 + this->idx)));
+          depth = Threads.main()->depth + Depth(int(2.2 * log(1 + this->idx)));
 
       // Age out PV variability metric
       if (isMainThread)


### PR DESCRIPTION
Reduce the variation in Root Depth between different threads. This prevents threads from searching at a depth much higher than Main Thread. 

Performed well at STC 24 Threads:
ELO: 3.44 +-3.8 (95%) LOS: 96.1%
Total: 10000 W: 1627 L: 1528 D: 6845

And LTC 24 Threads
LLR: 1.43 (-2.94,2.94) [0.00,4.00]
Total: 3804 W: 500 L: 420 D: 2884
ELO : +7.31
p-value: 73.16%

Passed no regression at STC 3 Threads:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 40457 W: 7148 L: 7060 D: 26249

And LTC 3 Threads:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 17704 W: 2489 L: 2364 D: 12851

Raising a pull request early as 24 Thread tests are very expensive and this is clearly a positive gain at high thread counts and high time controls. The change is a small parameter tweak with no additional logic.