### PR TITLE
Cleanup available()

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -393,7 +393,7 @@ void Thread::search(bool isMainThread) {
 
       // Age out PV variability metric
       if (isMainThread)
-          BestMoveChanges *= 0.5;
+          BestMoveChanges *= 0.503;
 
       // Save the last iteration's scores before first PV line is searched and
       // all the move scores except the (new) PV are set to -VALUE_INFINITE.

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -31,7 +31,7 @@ class TimeManagement {
 public:
   void init(Search::LimitsType& limits, Color us, int ply);
   void pv_instability(double bestMoveChanges) { unstablePvFactor = 1 + bestMoveChanges; }
-  int available() const { return int(optimumTime * unstablePvFactor * 0.76); }
+  int available() const { return std::min(maximumTime, int(optimumTime * unstablePvFactor)); }
   int maximum() const { return maximumTime; }
   int elapsed() const { return int(Search::Limits.npmsec ? Threads.nodes_searched() : now() - startTime); }
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -66,7 +66,7 @@ void init(OptionsMap& o) {
   o["Skill Level"]           << Option(20, 0, 20);
   o["Move Overhead"]         << Option(30, 0, 5000);
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
-  o["Slow Mover"]            << Option(80, 10, 1000);
+  o["Slow Mover"]            << Option(55, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);


### PR DESCRIPTION
1/ Make sure that available() never returns more than maximum(). Tested
individually, passed SPRT(-3,1) in 10+0.1 but failed in 15+0. So we can't just
fix that standalone.

2/ Remove the fudge factor 0.76. Obviously that cannot be done standalone as
well, because it creates a significant biais which needs to be corrected.

3/ Retune BestMoveChanges factor, and -- more importantly -- Slow Mover, without
the fudge factor 0.76. Indeed the fudge factor is very inelegant, and makes the
data model overspecified (several redundant parameters).

Passed 3 SPRT(-3,1) tests:

**10+0.1: STC, standard increment**
```
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 54139 W: 10347 L: 10285 D: 33507
```

**15+0: STC, no increment**
```
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 29479 W: 5980 L: 5874 D: 17625
```

**40+0.4: LTC, standard increment**
```
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 20672 W: 3194 L: 3073 D: 14405
```

bench 8639247