### PR TITLE
Benchmark Clear Stats

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -161,6 +161,8 @@ void benchmark(const Position& current, istream& is) {
           Threads.main()->join();
           nodes += Threads.nodes_searched();
       }
+
+      Search::clear();
   }
 
   elapsed = now() - elapsed + 1; // Ensure positivity to avoid a 'divide by zero'


### PR DESCRIPTION
Clear Search stats for each bench positions.

Reason:
1/  Bench # may help developers find correlation with their tweaks.  The current bench # is not reliable as bench positions are dramatically different.

2/  Bench # will change when compressing large array such as CMH, by indexing the first entry as PieceType.  Since the Bench positions have both white and black to play this will cause a bench changed.  By clearing the stats between each bench position this will not change the bench #.

No Functional Change
Bench #:  8204062   
