### PR TITLE
Avoid friend

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -118,7 +118,7 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
   }
 
   os << "\nFen: " << pos.fen() << "\nKey: " << std::hex << std::uppercase
-     << std::setfill('0') << std::setw(16) << pos.st->key << std::dec << "\nCheckers: ";
+     << std::setfill('0') << std::setw(16) << pos.key() << std::dec << "\nCheckers: ";
 
   for (Bitboard b = pos.checkers(); b; )
       os << UCI::square(pop_lsb(&b)) << " ";

--- a/src/position.h
+++ b/src/position.h
@@ -82,8 +82,6 @@ struct StateInfo {
 
 class Position {
 
-  friend std::ostream& operator<<(std::ostream&, const Position&);
-
 public:
   static void init();
 
@@ -209,6 +207,8 @@ private:
   StateInfo* st;
   bool chess960;
 };
+
+extern std::ostream& operator<<(std::ostream& os, const Position& pos);
 
 inline Color Position::side_to_move() const {
   return sideToMove;


### PR DESCRIPTION
operator<<(os, pos) does not need to access any private members of pos.

No functional change.