### PR TITLE
Bonus for reachable outpost

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -318,7 +318,7 @@ namespace {
             else
             {
                 bb &= b & ~pos.pieces(Us);
-                if(bb)
+                if (bb)
                    score += ReachableOutpost[Pt == BISHOP][!!(ei.attackedBy[Us][PAWN] & bb)];
             }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -154,7 +154,7 @@ namespace {
   };
 
   // PossibleOutpost[knight/bishop][supported by pawn] contains bonuses for knights and
-  // bishops which can reach in one move a outpost square, bigger if outpost square is supported by a pawn.
+  // bishops which can reach a outpost square in one move, bigger if outpost square is supported by a pawn.
   const Score PossibleOutpost[][2] = {
     { S(21, 5), S(31, 8) }, // Knights
     { S( 8, 2), S(13, 4) }  // Bishops

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -153,9 +153,9 @@ namespace {
     { S(18, 5), S(27, 8) }  // Bishops
   };
 
-  // PossibleOutpost[knight/bishop][supported by pawn] contains bonuses for knights and
+  // ReachableOutpost[knight/bishop][supported by pawn] contains bonuses for knights and
   // bishops which can reach a outpost square in one move, bigger if outpost square is supported by a pawn.
-  const Score PossibleOutpost[][2] = {
+  const Score ReachableOutpost[][2] = {
     { S(21, 5), S(31, 8) }, // Knights
     { S( 8, 2), S(13, 4) }  // Bishops
   };
@@ -319,7 +319,7 @@ namespace {
             {
                 bb &= b & ~pos.pieces(Us);
                 if(bb)
-                   score += PossibleOutpost[Pt == BISHOP][!!(ei.attackedBy[Us][PAWN] & bb)];
+                   score += ReachableOutpost[Pt == BISHOP][!!(ei.attackedBy[Us][PAWN] & bb)];
             }
 
             // Bonus when behind a pawn

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -142,7 +142,9 @@ namespace {
   };
 
   // Mask of allowed outpost squares indexed by color
-  const Bitboard OutpostMask[COLOR_NB] = { Rank4BB | Rank5BB | Rank6BB, Rank5BB | Rank4BB | Rank3BB };
+  const Bitboard OutpostMask[COLOR_NB] = {
+    Rank4BB | Rank5BB | Rank6BB, Rank5BB | Rank4BB | Rank3BB
+  };
 
   // Outpost[knight/bishop][supported by pawn] contains bonuses for knights and
   // bishops outposts, bigger if outpost piece is supported by a pawn.

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -154,7 +154,7 @@ namespace {
   };
 
   // PossibleOutpost[knight/bishop][supported by pawn] contains bonuses for knights and
-  // bishops possible outpost squares, bigger if outpost square is supported by a pawn.
+  // bishops which can reach in one move a outpost square, bigger if outpost square is supported by a pawn.
   const Score PossibleOutpost[][2] = {
     { S(21, 5), S(31, 8) }, // Knights
     { S( 8, 2), S(13, 4) }  // Bishops
@@ -311,7 +311,7 @@ namespace {
 
         if (Pt == BISHOP || Pt == KNIGHT)
         {
-            // Bonus for outpost square
+            // Bonus for outpost squares
             bb = OutpostMask[Us] & ~ei.pi->pawn_attacks_span(Them);
             if (bb & s)
                 score += Outpost[Pt == BISHOP][!!(ei.attackedBy[Us][PAWN] & s)];

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -116,7 +116,7 @@ namespace {
     Bitboard ourPawns   = pos.pieces(Us  , PAWN);
     Bitboard theirPawns = pos.pieces(Them, PAWN);
 
-    e->passedPawns[Us] = 0;
+    e->passedPawns[Us] = e->pawnAttacksSpan[Us] = 0;
     e->kingSquares[Us] = SQ_NONE;
     e->semiopenFiles[Us] = 0xFF;
     e->pawnAttacks[Us] = shift_bb<Right>(ourPawns) | shift_bb<Left>(ourPawns);
@@ -132,6 +132,8 @@ namespace {
 
         // This file cannot be semi-open
         e->semiopenFiles[Us] &= ~(1 << f);
+
+        e->pawnAttacksSpan[Us] |= pawn_attack_span(Us, s);
 
         // Flag the pawn
         neighbours  =   ourPawns   & adjacent_files_bb(f);

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -35,6 +35,7 @@ struct Entry {
   Score pawns_score() const { return score; }
   Bitboard pawn_attacks(Color c) const { return pawnAttacks[c]; }
   Bitboard passed_pawns(Color c) const { return passedPawns[c]; }
+  Bitboard pawn_attacks_span(Color c) const { return pawnAttacksSpan[c]; }
   int pawn_span(Color c) const { return pawnSpan[c]; }
   int pawn_asymmetry() const { return asymmetry; }
 
@@ -66,6 +67,7 @@ struct Entry {
   Score score;
   Bitboard passedPawns[COLOR_NB];
   Bitboard pawnAttacks[COLOR_NB];
+  Bitboard pawnAttacksSpan[COLOR_NB];
   Square kingSquares[COLOR_NB];
   Score kingSafety[COLOR_NB];
   int castlingRights[COLOR_NB];


### PR DESCRIPTION
Give a bonus for outpost squares which in reach of a bishop or knight.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 22725 W: 4570 L: 4339 D: 13816

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 15019 W: 2333 L: 2157 D: 10529

Bench: 8503181