### PR TITLE
Fix broken UCI 'wait for stop'

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -300,14 +300,6 @@ void MainThread::think() {
       }
 
       search(true); // Let's start searching!
-
-      // Stop the threads
-      Signals.stop = true;
-
-      // Wait until all threads have finished
-      for (Thread* th : Threads)
-          if (th != this)
-              th->wait_while(th->searching);
   }
 
   // When playing in 'nodes as time' mode, subtract the searched nodes from
@@ -325,6 +317,14 @@ void MainThread::think() {
       Signals.stopOnPonderhit = true;
       wait(Signals.stop);
   }
+
+  // Stop the threads if not already stopped
+  Signals.stop = true;
+
+  // Wait until all threads have finished
+  for (Thread* th : Threads)
+      if (th != this)
+          th->wait_while(th->searching);
 
   // Check if there are threads with a better score than main thread.
   Thread* bestThread = this;


### PR DESCRIPTION
When we reach the maximum depth, we can finish the
search without a raise of Signals.stop. However, if
we are pondering or in an infinite search, the UCI
protocol states that we shouldn't print the best move
before the GUI sends a "stop" or "ponderhit" command.

It was broken by lazy smp. Fix it by moving the stopping
of the threads after waiting for GUI.

No functional change.