### PR TITLE
Do not conceal the invocation command of the benchmark program

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -387,7 +387,7 @@ profile-build:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_make)
 	@echo ""
 	@echo "Step 2/4. Running benchmark for pgo-build ..."
-	@$(PGOBENCH) > /dev/null
+	$(PGOBENCH) > /dev/null
 	@echo ""
 	@echo "Step 3/4. Building final executable ..."
 	@touch *.cpp *.h syzygy/*.cpp syzygy/*.h


### PR DESCRIPTION
Make visible the command line with which the benchmark program was invoked for a profile-guided-optimization build.  This is useful for recording in automated compilations what arguments were used for the benchmarking run.
