### PR TITLE
History Pruning Tweak

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -924,7 +924,7 @@ moves_loop: // When in check search starts from here
 
           // History based pruning
           if (   depth <= 4 * ONE_PLY
-			  &&  move != ss->killers[0]
+              &&  move != ss->killers[0]
               && thisThread->history[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO
               && cmh[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO)
               continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -924,7 +924,7 @@ moves_loop: // When in check search starts from here
 
           // History based pruning
           if (   depth <= 4 * ONE_PLY
-              &&  move != ss->killers[0]
+              && move != ss->killers[0]
               && thisThread->history[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO
               && cmh[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO)
               continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -923,7 +923,7 @@ moves_loop: // When in check search starts from here
               continue;
 
           // History based pruning
-          if (   depth <= 3 * ONE_PLY
+          if (   depth <= 4 * ONE_PLY
               && thisThread->history[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO
               && cmh[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO)
               continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -924,6 +924,7 @@ moves_loop: // When in check search starts from here
 
           // History based pruning
           if (   depth <= 4 * ONE_PLY
+			  &&  move != ss->killers[0]
               && thisThread->history[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO
               && cmh[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO)
               continue;


### PR DESCRIPTION
Don't prune main killer move.
Increased pruned depth to 4.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 23380 W: 4581 L: 4350 D: 14449

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 28934 W: 4329 L: 4105 D: 20500

Bench:  8642100