### PR TITLE
Increase depth limit to 249.

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -349,7 +349,7 @@ static ExtMove *add_underprom_caps(Position& pos, ExtMove *stack, ExtMove *end)
 static int probe_ab(Position& pos, int alpha, int beta, int *success)
 {
   int v;
-  ExtMove stack[64];
+  ExtMove stack[MAX_MOVES];
   ExtMove *moves, *end;
   StateInfo st;
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -38,7 +38,7 @@ struct TTEntry {
   Move  move()  const { return (Move )move16; }
   Value value() const { return (Value)value16; }
   Value eval()  const { return (Value)eval16; }
-  Depth depth() const { return (Depth)depth8; }
+  Depth depth() const { return (Depth)depth8 - 6 * ONE_PLY; }
   Bound bound() const { return (Bound)(genBound8 & 0x3); }
 
   void save(Key k, Value v, Bound b, Depth d, Move m, Value ev, uint8_t g) {
@@ -49,7 +49,7 @@ struct TTEntry {
 
     // Don't overwrite more valuable entries
     if (  (k >> 48) != key16
-        || d > depth8 - 2
+        || d + 6 * ONE_PLY > depth8 - 2
      /* || g != (genBound8 & 0xFC) // Matching non-zero keys are already refreshed by probe() */
         || b == BOUND_EXACT)
     {
@@ -57,7 +57,7 @@ struct TTEntry {
         value16   = (int16_t)v;
         eval16    = (int16_t)ev;
         genBound8 = (uint8_t)(g | b);
-        depth8    = (int8_t)d;
+        depth8    = (uint8_t)(d + 6 * ONE_PLY);
     }
   }
 
@@ -69,7 +69,7 @@ private:
   int16_t  value16;
   int16_t  eval16;
   uint8_t  genBound8;
-  int8_t   depth8;
+  uint8_t  depth8;
 };
 
 

--- a/src/types.h
+++ b/src/types.h
@@ -101,7 +101,7 @@ typedef uint64_t Key;
 typedef uint64_t Bitboard;
 
 const int MAX_MOVES = 256;
-const int MAX_PLY   = 128;
+const int MAX_PLY   = 249;
 
 /// A move needs 16 bits to be stored
 ///


### PR DESCRIPTION
With multicore machines and long thinking times, the engine can
sometimes hit the current depth limit. This raises the value to the
maximum we can fit in an unsigned 8 bit integer.

The change in tbprobe.cpp silences a compiler warning.