### PR TITLE
RootMove less operator

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -56,7 +56,7 @@ struct RootMove {
 
   explicit RootMove(Move m) : pv(1, m) {}
 
-  bool operator<(const RootMove& m) const { return score > m.score; } // Ascending sort
+  bool operator<(const RootMove& m) const { return m.score < score; } // Descending sort
   bool operator==(const Move& m) const { return pv[0] == m; }
   void insert_pv_in_tt(Position& pos);
   bool extract_ponder_from_tt(Position& pos);


### PR DESCRIPTION
This is used by std::stable_sort() to sort moves from highest score to lowest score.
1) The comment is incorrect since highest to lowest means descending.
2) It's more natural to implement a less operator using another less operator rather than a greater operator.
No functional change.