### PR TITLE
PGO + LTO + static

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -159,7 +159,11 @@ endif
 
 ifeq ($(COMP),mingw)
 	comp=mingw
-	CXX=g++
+        ifeq ($(UNAME),Linux)
+            CXX=x86_64-w64-mingw32-g++-posix
+        else
+	    CXX=g++
+        endif
 	CXXFLAGS += -Wextra -Wshadow
 	LDFLAGS += -static
 endif
@@ -307,7 +311,7 @@ ifeq ($(pext),yes)
 	endif
 endif
 
-### 3.11 Link Time Optimization, it works since gcc 4.5 but not on mingw.
+### 3.11 Link Time Optimization, it works since gcc 4.5 but not on mingw under windows.
 ### This is a mix of compile and link time options because the lto link phase
 ### needs access to the optimization flags.
 ifeq ($(comp),gcc)
@@ -317,6 +321,17 @@ ifeq ($(comp),gcc)
 		LDFLAGS += $(CXXFLAGS)
 	endif
 	endif
+endif
+
+ifeq ($(UNAME),Linux)
+ifeq ($(comp),mingw)
+        ifeq ($(optimize),yes)
+        ifeq ($(debug),no)
+                CXXFLAGS += -flto
+                LDFLAGS += $(CXXFLAGS)
+        endif
+        endif
+endif
 endif
 
 ### 3.12 Android 5 can only run position independent executables. Note that this

--- a/src/Makefile
+++ b/src/Makefile
@@ -159,11 +159,23 @@ endif
 
 ifeq ($(COMP),mingw)
 	comp=mingw
-        ifeq ($(UNAME),Linux)
-            CXX=x86_64-w64-mingw32-g++-posix
-        else
-	    CXX=g++
-        endif
+		ifeq ($(UNAME),Linux)
+			ifeq ($(bits),64)
+				ifeq ($(shell which x86_64-w64-mingw32-c++-posix),)
+					CXX=x86_64-w64-mingw32-c++
+				else
+					CXX=x86_64-w64-mingw32-c++-posix
+				endif
+			else
+				ifeq ($(shell which i686-w64-mingw32-c++-posix),)
+					CXX=i686-w64-mingw32-c++
+				else
+					CXX=i686-w64-mingw32-c++-posix
+				endif
+			endif
+		else
+			CXX=g++
+		endif
 	CXXFLAGS += -Wextra -Wshadow
 	LDFLAGS += -static
 endif
@@ -311,7 +323,7 @@ ifeq ($(pext),yes)
 	endif
 endif
 
-### 3.11 Link Time Optimization, it works since gcc 4.5 but not on mingw under windows.
+### 3.11 Link Time Optimization, it works since gcc 4.5 but not on mingw under Windows.
 ### This is a mix of compile and link time options because the lto link phase
 ### needs access to the optimization flags.
 ifeq ($(comp),gcc)
@@ -323,15 +335,15 @@ ifeq ($(comp),gcc)
 	endif
 endif
 
-ifeq ($(UNAME),Linux)
 ifeq ($(comp),mingw)
-        ifeq ($(optimize),yes)
-        ifeq ($(debug),no)
-                CXXFLAGS += -flto
-                LDFLAGS += $(CXXFLAGS)
-        endif
-        endif
-endif
+	ifeq ($(UNAME),Linux)
+	ifeq ($(optimize),yes)
+	ifeq ($(debug),no)
+		CXXFLAGS += -flto
+		LDFLAGS += $(CXXFLAGS)
+	endif
+	endif
+	endif
 endif
 
 ### 3.12 Android 5 can only run position independent executables. Note that this


### PR DESCRIPTION
Allow cross compilation of Windows binaries on a Linux system that are PGO, LTO, and statically linked.
This is the only way to produce such binaries I know of.  If we could also convince abrok to install mingw-w64 and wine 
$ sudo apt-get install mingw-w64
$ sudo apt-get install wine1.6
after this we would not have to make custom binaries for special purposes any more.

Full credit goes to: pasquale....@gmail.com
who posted the instructions here
https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/B4RMSEbm1C0[1-25]
