### PR TITLE
Time management: Use the score from previous search to resolve fail l…

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -66,7 +66,7 @@ void init(OptionsMap& o) {
   o["Skill Level"]           << Option(20, 0, 20);
   o["Move Overhead"]         << Option(30, 0, 5000);
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
-  o["Slow Mover"]            << Option(80, 10, 1000);
+  o["Slow Mover"]            << Option(84, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);


### PR DESCRIPTION
Need some advice on what to do with this patch. I made a blunder when rescheduling the test with another value for Slow Mover.

With default Slow mover (80) we got STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 4651 W: 961 L: 814 D: 2876
http://tests.stockfishchess.org/tests/view/564cb3140ebc5902cdc082a6

And LTC was yellow, with a positive score:
LLR: -2.95 (-2.94,2.94) [0.00,5.00]
Total: 57444 W: 8367 L: 8282 D: 40795
http://tests.stockfishchess.org/tests/view/564cc7590ebc5902cdc082b0

Then I recheduled with Slow Mover=84, STC:
LLR: 2.94 (-2.94,2.94) [0.00,5.00]
Total: 14495 W: 2903 L: 2711 D: 8881
http://tests.stockfishchess.org/tests/view/564ed8260ebc5902cdc0830c

Ongoing LTC  with Slow Mover=84:
LLR: 1.77 (-2.94,2.94) [0.00,5.00]
Total: 69421 W: 10766 L: 10435 D: 48220
http://tests.stockfishchess.org/tests/view/564efc4c0ebc5902cdc08314

The blunder is that LTC with default Slow mover was run with 60+0.4, the LTC for Slow Mover=84 is run with 40+0.4. The second test seems to do better, but this could be because of shorter time control, and not because of the modified Slow Mover value.
Is there any hope for first green+yellow patch to be committed? If there is, I'll schedule a test with default Slow Mover for 7 threads 5+05 because this patch is dependent on bestThread score.