### PR TITLE
Tuned weights

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -107,10 +107,10 @@ namespace {
 
 
   // Evaluation weights, indexed by the corresponding evaluation term
-  enum { Mobility, PawnStructure, PassedPawns, Space, KingSafety };
+  enum { Mobility, PawnStructure, PassedPawns, Space, KingSafety, Threats};
 
   const struct Weight { int mg, eg; } Weights[] = {
-    {289, 344}, {233, 201}, {221, 273}, {46, 0}, {322, 0}
+    {266, 334}, {214, 203}, {193, 262}, {47, 0}, {330, 0}, {404, 241}
   };
 
   Score operator*(Score s, const Weight& w) {
@@ -566,9 +566,9 @@ namespace {
         score += popcount<Max15>(b) * PawnAttackThreat;
 
     if (DoTrace)
-        Trace::add(THREAT, Us, score);
+        Trace::add(THREAT, Us, score * Weights[Threats]);
 
-    return score;
+    return score * Weights[Threats];
   }
 
 


### PR DESCRIPTION
More accurate evaluation weights

Performed better at STC

LLR: 1.32 (-2.94,2.94) [0.00,4.00]
Total: 190043 W: 37433 L: 36675 D: 115935

Passed LTC

LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 30157 W: 4540 L: 4303 D: 21314