### PR TITLE
Fix multi PV and skill levels

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -482,7 +482,8 @@ void Thread::search() {
               sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
       }
 
-      if (!Signals.stop)
+      // Picking best thread is not compatible with skill level or multipv
+      if (!Signals.stop && multiPV == 1 && !skill.enabled())
           completedDepth = rootDepth;
 
       if (!isMainThread)


### PR DESCRIPTION
Not very elegant but effective.

Verfied for no regression:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 9759 W: 1734 L: 1595 D: 6430

No functional change.