### PR TITLE
Easy fix SMP

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -327,10 +327,11 @@ void MainThread::search() {
 
   // Check if there are threads with a better score than main thread.
   Thread* bestThread = this;
-  for (Thread* th : Threads)
-      if (   th->completedDepth > bestThread->completedDepth
-          && th->rootMoves[0].score > bestThread->rootMoves[0].score)
-        bestThread = th;
+  if (!Limits.use_time_management() || Time.elapsed() > Time.available())
+      for (Thread* th : Threads)
+          if (   th->completedDepth > bestThread->completedDepth
+              && th->rootMoves[0].score > bestThread->rootMoves[0].score)
+            bestThread = th;
 
   // Send new PV when needed.
   // FIXME: Breaks multiPV, and skill levels


### PR DESCRIPTION
Fix a bug where we could stop the search after only 10% of time used due to a matching easy move but later switch to a different move that was never pre-screened as easy due to SMP thread select.

STC http://tests.stockfishchess.org/tests/view/565f87e60ebc5902cdc08865
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 27227 W: 4910 L: 4800 D: 17517

LTC http://tests.stockfishchess.org/tests/view/5660c5000ebc5902cdc08895
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 40368 W: 5826 L: 5733 D: 28809
