### PR TITLE
Fix MultiPv and Skill in SMP.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -327,10 +327,11 @@ void MainThread::search() {
 
   // Check if there are threads with a better score than main thread.
   Thread* bestThread = this;
-  for (Thread* th : Threads)
-      if (   th->completedDepth > bestThread->completedDepth
-          && th->rootMoves[0].score > bestThread->rootMoves[0].score)
-        bestThread = th;
+  if (Options["MultiPV"] == 1 && !Skill(Options["Skill Level"]).enabled())
+      for (Thread* th : Threads)
+          if (   th->completedDepth > bestThread->completedDepth
+              && th->rootMoves[0].score > bestThread->rootMoves[0].score)
+            bestThread = th;
 
   // Send new PV when needed.
   // FIXME: Breaks multiPV, and skill levels


### PR DESCRIPTION
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 55460 W: 9665 L: 9601 D: 36194
http://tests.stockfishchess.org/tests/view/5666006b0ebc5902cdc089e9

See https://github.com/official-stockfish/Stockfish/pull/519