### PR TITLE
Tuned individual threats + eg 10%.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -108,10 +108,10 @@ namespace {
 
 
   // Evaluation weights, indexed by the corresponding evaluation term
-  enum { Mobility, PawnStructure, PassedPawns, Space, KingSafety, Threats };
+  enum { Mobility, PawnStructure, PassedPawns, Space, KingSafety }; //, Threats
 
   const struct Weight { int mg, eg; } Weights[] = {
-    {266, 334}, {214, 203}, {193, 262}, {47, 0}, {330, 0}, {404, 241}
+    {266, 334}, {214, 203}, {193, 262}, {47, 0}, {330, 0} //, {256, 256}
   };
 
   Score operator*(Score s, const Weight& w) {
@@ -161,14 +161,14 @@ namespace {
   // bonuses according to which piece type attacks which one.
   // Attacks on lesser pieces which are pawn defended are not considered.
   const Score Threat[2][PIECE_TYPE_NB] = {
-   { S(0, 0), S(0, 32), S(25, 39), S(28, 44), S(42, 98), S(35,105) }, // Minor attacks
-   { S(0, 0), S(0, 27), S(26, 57), S(26, 57), S( 0, 30), S(23, 51) }  // Rook attacks
+   { S(0, 0), S(0, 29), S(44, 39), S(46, 44), S(72, 94), S(47,106) }, // Minor attacks
+   { S(0, 0), S(0, 24), S(40, 55), S(39, 52), S( 0, 31), S(36, 44) }  // Rook attacks
   };
 
   // ThreatenedByPawn[PieceType] contains a penalty according to which piece
   // type is attacked by a pawn.
   const Score ThreatenedByPawn[PIECE_TYPE_NB] = {
-    S(0, 0), S(0, 0), S(107, 138), S(84, 122), S(114, 203), S(121, 217)
+    S(0, 0), S(0, 0), S(171, 126), S(123, 118), S(217, 204), S(208, 199)
   };
 
   // Passed[mg/eg][Rank] contains midgame and endgame bonuses for passed pawns.
@@ -184,11 +184,11 @@ namespace {
     S(-27, -12), S( 1, -8), S( 3, 10), S( 12,  10)
   };
 
-  const Score ThreatenedByHangingPawn = S(40, 60);
+  const Score ThreatenedByHangingPawn = S(69, 58);
 
   // Assorted bonuses and penalties used by evaluation
-  const Score KingOnOne          = S( 2, 58);
-  const Score KingOnMany         = S( 6,125);
+  const Score KingOnOne          = S( 3, 54);
+  const Score KingOnMany         = S( 8,122);
   const Score RookOnPawn         = S( 7, 27);
   const Score RookOnOpenFile     = S(43, 21);
   const Score RookOnSemiOpenFile = S(19, 10);
@@ -196,8 +196,8 @@ namespace {
   const Score MinorBehindPawn    = S(16,  0);
   const Score TrappedRook        = S(92,  0);
   const Score Unstoppable        = S( 0, 20);
-  const Score Hanging            = S(31, 26);
-  const Score PawnAttackThreat   = S(20, 20);
+  const Score Hanging            = S(49, 25);
+  const Score PawnAttackThreat   = S(31, 19);
   const Score Checked            = S(20, 20);
 
   // Penalty for a bishop on a1/h1 (a8/h8 for black) which is trapped by
@@ -557,9 +557,9 @@ namespace {
         score += popcount<Max15>(b) * PawnAttackThreat;
 
     if (DoTrace)
-        Trace::add(THREAT, Us, score * Weights[Threats]);
+        Trace::add(THREAT, Us, score);// * Weights[Threats]);
 
-    return score * Weights[Threats];
+    return score;// * Weights[Threats];
   }
 
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -161,14 +161,14 @@ namespace {
   // bonuses according to which piece type attacks which one.
   // Attacks on lesser pieces which are pawn defended are not considered.
   const Score Threat[2][PIECE_TYPE_NB] = {
-   { S(0, 0), S(0, 29), S(44, 39), S(46, 44), S(72, 94), S(47,106) }, // Minor attacks
-   { S(0, 0), S(0, 24), S(40, 55), S(39, 52), S( 0, 31), S(36, 44) }  // Rook attacks
+   { S(0, 0), S(0, 30), S(45, 39), S(46, 43), S(72, 97), S(48,107) }, // Minor attacks
+   { S(0, 0), S(0, 23), S(40, 56), S(40, 53), S( 0, 31), S(35, 44) }  // Rook attacks
   };
 
   // ThreatenedByPawn[PieceType] contains a penalty according to which piece
   // type is attacked by a pawn.
   const Score ThreatenedByPawn[PIECE_TYPE_NB] = {
-    S(0, 0), S(0, 0), S(171, 126), S(123, 118), S(217, 204), S(208, 199)
+    S(0, 0), S(0, 0), S(176, 127), S(131, 115), S(217, 199), S(203, 195)
   };
 
   // Passed[mg/eg][Rank] contains midgame and endgame bonuses for passed pawns.
@@ -184,11 +184,11 @@ namespace {
     S(-27, -12), S( 1, -8), S( 3, 10), S( 12,  10)
   };
 
-  const Score ThreatenedByHangingPawn = S(69, 58);
+  const Score ThreatenedByHangingPawn = S(70, 58);
 
   // Assorted bonuses and penalties used by evaluation
-  const Score KingOnOne          = S( 3, 54);
-  const Score KingOnMany         = S( 8,122);
+  const Score KingOnOne          = S( 3, 56);
+  const Score KingOnMany         = S( 9,126);
   const Score RookOnPawn         = S( 7, 27);
   const Score RookOnOpenFile     = S(43, 21);
   const Score RookOnSemiOpenFile = S(19, 10);
@@ -196,7 +196,7 @@ namespace {
   const Score MinorBehindPawn    = S(16,  0);
   const Score TrappedRook        = S(92,  0);
   const Score Unstoppable        = S( 0, 20);
-  const Score Hanging            = S(49, 25);
+  const Score Hanging            = S(48, 24);
   const Score PawnAttackThreat   = S(31, 19);
   const Score Checked            = S(20, 20);
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -161,14 +161,14 @@ namespace {
   // bonuses according to which piece type attacks which one.
   // Attacks on lesser pieces which are pawn defended are not considered.
   const Score Threat[2][PIECE_TYPE_NB] = {
-   { S(0, 0), S(0, 30), S(45, 39), S(46, 43), S(72, 97), S(48,107) }, // Minor attacks
-   { S(0, 0), S(0, 23), S(40, 56), S(40, 53), S( 0, 31), S(35, 44) }  // Rook attacks
+   { S(0, 0), S(0, 33), S(45, 43), S(46, 47), S(72, 107), S(48,118) }, // Minor attacks
+   { S(0, 0), S(0, 25), S(40, 62), S(40, 59), S( 0,  34), S(35, 48) }  // Rook attacks
   };
 
   // ThreatenedByPawn[PieceType] contains a penalty according to which piece
   // type is attacked by a pawn.
   const Score ThreatenedByPawn[PIECE_TYPE_NB] = {
-    S(0, 0), S(0, 0), S(176, 127), S(131, 115), S(217, 199), S(203, 195)
+    S(0, 0), S(0, 0), S(176, 139), S(131, 127), S(217, 218), S(203, 215)
   };
 
   // Passed[mg/eg][Rank] contains midgame and endgame bonuses for passed pawns.
@@ -184,11 +184,11 @@ namespace {
     S(-27, -12), S( 1, -8), S( 3, 10), S( 12,  10)
   };
 
-  const Score ThreatenedByHangingPawn = S(70, 58);
+  const Score ThreatenedByHangingPawn = S(70, 63);
 
   // Assorted bonuses and penalties used by evaluation
-  const Score KingOnOne          = S( 3, 56);
-  const Score KingOnMany         = S( 9,126);
+  const Score KingOnOne          = S( 3, 62);
+  const Score KingOnMany         = S( 9,138);
   const Score RookOnPawn         = S( 7, 27);
   const Score RookOnOpenFile     = S(43, 21);
   const Score RookOnSemiOpenFile = S(19, 10);
@@ -196,7 +196,7 @@ namespace {
   const Score MinorBehindPawn    = S(16,  0);
   const Score TrappedRook        = S(92,  0);
   const Score Unstoppable        = S( 0, 20);
-  const Score Hanging            = S(48, 24);
+  const Score Hanging            = S(48, 28);
   const Score PawnAttackThreat   = S(31, 19);
   const Score Checked            = S(20, 20);
 


### PR DESCRIPTION
After Threat Weights had been successfully changed from {256, 256} to {350, 256} (after a bold test by snicolet) and major weights were successfully retuned by absimaldata (with new weight {404. 241}, 
nperson tried {450, 241} which passed STC but was yellow (neutral) at LTC.

It could be observed that some mg values which were originally much lower than eg values were now higher. So it was time to retune the individual threats.

I tuned using default magic SPSA tuner parameters, 
but run 120000 @ 10+0.1 th 1 using hash 128 and nodestime=600
(the recommended time control is however 20+0.2)

The tuned values passed STC 
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 13189 W: 2595 L: 2390 D: 8204

but struggled LTC.
LLR: -1.49 (-2.94,2.94) [0.00,4.00]
Total: 109058 W: 15765 L: 15532 D: 77761


Meanwhile I made another attempt, keeping the tuned mg values, 
but manually raising the tuned eg values by 10%.

It passed STC
http://tests.stockfishchess.org/tests/view/5669019a0ebc592d552a3f58
sprt @ 10+0.1 th 1
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 45239 W: 8913 L: 8591 D: 27735

and LTC
http://tests.stockfishchess.org/tests/view/566d88120ebc592d552a406d
sprt @ 60+0.6 th 1
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 21046 W: 3200 L: 2989 D: 14857

Compared to current master, mg values were raised on average by 5 %, 
and eg values by (2+10) %

Conclusion:

More tuning at a longer time control than 10+0.1 will eventually be useful to stabilize those individual threats,
and possibly there is still some room to tune our global weights.