### PR TITLE
Changes to support dynamic material values

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -172,25 +172,25 @@ enum Bound {
   BOUND_EXACT = BOUND_UPPER | BOUND_LOWER
 };
 
-enum Value : int {
-  VALUE_ZERO      = 0,
-  VALUE_DRAW      = 0,
-  VALUE_KNOWN_WIN = 10000,
-  VALUE_MATE      = 32000,
-  VALUE_INFINITE  = 32001,
-  VALUE_NONE      = 32002,
-
-  VALUE_MATE_IN_MAX_PLY  =  VALUE_MATE - 2 * MAX_PLY,
-  VALUE_MATED_IN_MAX_PLY = -VALUE_MATE + 2 * MAX_PLY,
-
-  PawnValueMg   = 198,   PawnValueEg   = 258,
-  KnightValueMg = 817,   KnightValueEg = 846,
-  BishopValueMg = 836,   BishopValueEg = 857,
-  RookValueMg   = 1270,  RookValueEg   = 1281,
-  QueenValueMg  = 2521,  QueenValueEg  = 2558,
-
-  MidgameLimit  = 15581, EndgameLimit  = 3998
-};
+// Value of various pieces and postions.
+// Declared as external so they can be modified at runtime.
+// Actual values are in uci.cpp
+typedef int Value;
+extern Value
+  VALUE_ZERO,
+  VALUE_DRAW,
+  VALUE_KNOWN_WIN,
+  VALUE_MATE,
+  VALUE_INFINITE,
+  VALUE_NONE,
+  VALUE_MATE_IN_MAX_PLY,
+  VALUE_MATED_IN_MAX_PLY,
+  PawnValueMg   ,   PawnValueEg   ,
+  KnightValueMg ,   KnightValueEg ,
+  BishopValueMg ,   BishopValueEg ,
+  RookValueMg   ,  RookValueEg  ,
+  QueenValueMg  ,  QueenValueEg ,
+  MidgameLimit  , EndgameLimit  ;
 
 enum PieceType {
   NO_PIECE_TYPE, PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING,
@@ -295,7 +295,7 @@ inline T operator/(T d, int i) { return T(int(d) / i); }        \
 inline int operator/(T d1, T d2) { return int(d1) / int(d2); }  \
 inline T& operator/=(T& d, int i) { return d = T(int(d) / i); }
 
-ENABLE_FULL_OPERATORS_ON(Value)
+//ENABLE_FULL_OPERATORS_ON(Value)
 ENABLE_FULL_OPERATORS_ON(PieceType)
 ENABLE_FULL_OPERATORS_ON(Piece)
 ENABLE_FULL_OPERATORS_ON(Color)
@@ -310,10 +310,10 @@ ENABLE_BASE_OPERATORS_ON(Score)
 #undef ENABLE_BASE_OPERATORS_ON
 
 /// Additional operators to add integers to a Value
-inline Value operator+(Value v, int i) { return Value(int(v) + i); }
-inline Value operator-(Value v, int i) { return Value(int(v) - i); }
-inline Value& operator+=(Value& v, int i) { return v = v + i; }
-inline Value& operator-=(Value& v, int i) { return v = v - i; }
+//inline Value operator+(Value v, int i) { return Value(int(v) + i); }
+//inline Value operator-(Value v, int i) { return Value(int(v) - i); }
+//inline Value& operator+=(Value& v, int i) { return v = v + i; }
+//inline Value& operator-=(Value& v, int i) { return v = v - i; }
 
 /// Only declared but not defined. We don't want to multiply two scores due to
 /// a very high risk of overflow. So user should explicitly convert to integer.

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -33,6 +33,25 @@ using namespace std;
 
 extern void benchmark(const Position& pos, istream& is);
 
+// Instantiate the material values. These are global and used to
+// compute the value of a position. They are here as this is also where
+// the code to set them is. They are declared external in types.h
+Value
+  VALUE_ZERO      = 0,
+  VALUE_DRAW      = 0,
+  VALUE_KNOWN_WIN = 10000,
+  VALUE_MATE      = 32000,
+  VALUE_INFINITE  = 32001,
+  VALUE_NONE      = 32002,
+  VALUE_MATE_IN_MAX_PLY  =  VALUE_MATE - 2 * MAX_PLY,
+  VALUE_MATED_IN_MAX_PLY = -VALUE_MATE + 2 * MAX_PLY,
+  PawnValueMg   = 198,   PawnValueEg   = 258,
+  KnightValueMg = 817,   KnightValueEg = 846,
+  BishopValueMg = 836,   BishopValueEg = 857,
+  RookValueMg   = 1270,  RookValueEg   = 1281,
+  QueenValueMg  = 2521,  QueenValueEg  = 2558,
+  MidgameLimit  = 15581, EndgameLimit  = 3998;
+
 namespace {
 
   // FEN string of the initial position, normal chess
@@ -100,6 +119,29 @@ namespace {
         Options[name] = value;
     else
         sync_cout << "No such option: " << name << sync_endl;
+
+    // For material value options, also set the global integer that is used
+    // within the code for calculating position value.
+    if (name == "PawnValueMg")
+        PawnValueMg = std::stoi(value);
+    else if (name == "PawnValueEg")
+        PawnValueEg = std::stoi(value);
+    else if (name == "KnightValueMg")
+        KnightValueMg = std::stoi(value);
+    else if (name == "KnightValueEg")
+        KnightValueEg = std::stoi(value);
+    else if (name == "BishopValueMg")
+        BishopValueMg = std::stoi(value);
+    else if (name == "BishopValueEg")
+        BishopValueEg = std::stoi(value);
+    else if (name == "RookValueMg")
+        RookValueMg = std::stoi(value);
+    else if (name == "RookValueEg")
+        RookValueEg = std::stoi(value);
+    else if (name == "QueenValueMg")
+        QueenValueMg = std::stoi(value);
+    else if (name == "QueenValueEg")
+        QueenValueEg = std::stoi(value);
   }
 
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -49,6 +49,29 @@ bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const 
          [](char c1, char c2) { return tolower(c1) < tolower(c2); });
 }
 
+// Initialize the value of a chess piece.
+// The default value is hardcoded in uci.cpp and external in types.h
+// These can be overridden with system environment variables of the same
+// name as below... They can be further overridden with the 'setoption'
+// command during runtime.
+static int initMaterialValue(OptionsMap& o, const char *key, int defaultValue) {
+  int value = defaultValue;
+
+  // Look for an environment variable...
+  char *sValue = getenv(key);
+  if (sValue != NULL) {
+    value = std::stoi(sValue);
+  }
+
+  // Set default values in options map -- for reference only
+  // these are not the values used by the program. The global
+  // variables are what the code actually uses.
+  Option op = Option(std::to_string(defaultValue).c_str());
+  op = std::to_string(value);
+  o[key] << op;
+
+  return value;
+}
 
 /// init() initializes the UCI options to their hard-coded default values
 
@@ -73,6 +96,18 @@ void init(OptionsMap& o) {
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(6, 0, 6);
+
+  // Initliaze default and current material values
+  PawnValueMg = initMaterialValue(o, "PawnValueMg", PawnValueMg);
+  PawnValueEg = initMaterialValue(o, "PawnValueEg", PawnValueEg);
+  KnightValueMg = initMaterialValue(o, "KnightValueMg", KnightValueMg);
+  KnightValueEg = initMaterialValue(o, "KnightValueEg", KnightValueEg);
+  BishopValueMg = initMaterialValue(o, "BishopValueMg", BishopValueMg);
+  BishopValueEg = initMaterialValue(o, "BishopValueEg", BishopValueEg);
+  RookValueMg = initMaterialValue(o, "RookValueMg", RookValueMg);
+  RookValueEg = initMaterialValue(o, "RookValueEg", RookValueEg);
+  QueenValueMg = initMaterialValue(o, "QueenValueMg", QueenValueMg);
+  QueenValueEg = initMaterialValue(o, "QueenValueEg", QueenValueEg);
 }
 
 
@@ -89,7 +124,7 @@ std::ostream& operator<<(std::ostream& os, const OptionsMap& om) {
               os << "\noption name " << it.first << " type " << o.type;
 
               if (o.type != "button")
-                  os << " default " << o.defaultValue;
+                  os << " default " << o.defaultValue << " current " << o.currentValue;
 
               if (o.type == "spin")
                   os << " min " << o.min << " max " << o.max;


### PR DESCRIPTION
These changes allow for setting material values either as an option (setoption command) or via environment variables. The original purpose for these changes was to enable the use of stockfish in a machine learning environment and evaluate the "best" material values by experimentation and iteration. It changes material values from an enumeration to first-class integer variables. They can then be modified at runtime.

There may be performance implications to this change. Compiler optimizations will by necessity work differently with non-constant integers vs constant enums.