### PR TITLE
Fix compiling of 32 bit binary on 64-bit Windows

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -160,7 +160,6 @@ endif
 ifeq ($(COMP),mingw)
 	comp=mingw
 
-	ifeq ($(UNAME),Linux)
 		ifeq ($(bits),64)
 			ifeq ($(shell which x86_64-w64-mingw32-c++-posix),)
 				CXX=x86_64-w64-mingw32-c++
@@ -174,9 +173,6 @@ ifeq ($(COMP),mingw)
 				CXX=i686-w64-mingw32-c++-posix
 			endif
 		endif
-	else
-		CXX=g++
-	endif
 
 	CXXFLAGS += -Wextra -Wshadow
 	LDFLAGS += -static


### PR DESCRIPTION
Two versions of mingw-w64 (targeting Win64 and Win32) 
can be installed on Windows too.