### PR TITLE
Removing unused field ttMove in Stats struct.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -641,7 +641,7 @@ namespace {
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
-    ss->currentMove = ss->ttMove = (ss+1)->excludedMove = bestMove = MOVE_NONE;
+    ss->currentMove = (ss+1)->excludedMove = bestMove = MOVE_NONE;
     (ss+1)->skipEarlyPruning = false; (ss+1)->reduction = DEPTH_ZERO;
     (ss+2)->killers[0] = (ss+2)->killers[1] = MOVE_NONE;
 
@@ -652,8 +652,8 @@ namespace {
     posKey = excludedMove ? pos.exclusion_key() : pos.key();
     tte = TT.probe(posKey, ttHit);
     ttValue = ttHit ? value_from_tt(tte->value(), ss->ply) : VALUE_NONE;
-    ss->ttMove = ttMove =  RootNode ? thisThread->rootMoves[thisThread->PVIdx].pv[0]
-                         : ttHit    ? tte->move() : MOVE_NONE;
+    ttMove =  RootNode ? thisThread->rootMoves[thisThread->PVIdx].pv[0]
+            : ttHit    ? tte->move() : MOVE_NONE;
 
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode

--- a/src/search.h
+++ b/src/search.h
@@ -39,7 +39,6 @@ struct Stack {
   Move* pv;
   int ply;
   Move currentMove;
-  Move ttMove;
   Move excludedMove;
   Move killers[2];
   Depth reduction;

--- a/tmp.tmp
+++ b/tmp.tmp
@@ -1,5 +1,0 @@
-AUTHORS
-Copying.txt
-Readme.md
-src
-tmp.tmp

--- a/tmp.tmp
+++ b/tmp.tmp
@@ -1,0 +1,5 @@
+AUTHORS
+Copying.txt
+Readme.md
+src
+tmp.tmp


### PR DESCRIPTION
This is a not functional change that slightly improve the nodes per second speed (in my local machine by 0.4%)
