### PR TITLE
Remove another unnecessary Search::Stack field

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -984,31 +984,31 @@ moves_loop: // When in check search starts from here
           &&  moveCount > 1
           && !captureOrPromotion)
       {
-          Depth r = reduction<PvNode>(improving, depth, moveCount);
+          Depth reduce = reduction<PvNode>(improving, depth, moveCount);
 
           // Increase reduction for cut nodes and moves with a bad history
           if (   (!PvNode && cutNode)
               || (   thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] < VALUE_ZERO
                   && cmh[pos.piece_on(to_sq(move))][to_sq(move)] <= VALUE_ZERO))
-              r += ONE_PLY;
+              reduce += ONE_PLY;
 
           // Decrease reduction for moves with a good history
           if (   thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] > VALUE_ZERO
               && cmh[pos.piece_on(to_sq(move))][to_sq(move)] > VALUE_ZERO)
-              r = std::max(DEPTH_ZERO, r - ONE_PLY);
+              reduce = std::max(DEPTH_ZERO, reduce - ONE_PLY);
 
           // Decrease reduction for moves that escape a capture
-          if (   r
+          if (   reduce
               && type_of(move) == NORMAL
               && type_of(pos.piece_on(to_sq(move))) != PAWN
               && pos.see(make_move(to_sq(move), from_sq(move))) < VALUE_ZERO)
-              r = std::max(DEPTH_ZERO, r - ONE_PLY);
+              reduce = std::max(DEPTH_ZERO, reduce - ONE_PLY);
 
-          Depth d = std::max(newDepth - r, ONE_PLY);
+          Depth d = std::max(newDepth - reduce, ONE_PLY);
 
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, d, true);
 
-          doFullDepthSearch = (value > alpha && r != DEPTH_ZERO);
+          doFullDepthSearch = (value > alpha && reduce != DEPTH_ZERO);
       }
       else
           doFullDepthSearch = !PvNode || moveCount > 1;

--- a/src/search.h
+++ b/src/search.h
@@ -41,7 +41,6 @@ struct Stack {
   Move currentMove;
   Move excludedMove;
   Move killers[2];
-  Depth reduction;
   Value staticEval;
   bool skipEarlyPruning;
   int moveCount;


### PR DESCRIPTION
Removed reduction from the Search::Stack structure and replaced it with a local variable.