### PR TITLE
Remove globals taht are main thread related

### DIFF
--- a/src/thread.h
+++ b/src/thread.h
@@ -76,6 +76,9 @@ public:
 
 struct MainThread : public Thread {
   virtual void search();
+
+  bool easyMovePlayed, failedLow;
+  double bestMoveChanges;
 };
 
 


### PR DESCRIPTION
And move them under main thread scope, where they belong.

Make it explicit that those variables are not globals, but
are used only by main thread. I think it is a sensible
clarification because easy move is already tricky enough
and current patch makes the involved actors explicit.

No functional change.