### PR TITLE
Adjust time used for move based on previous score

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -127,9 +127,9 @@ namespace {
   };
 
   EasyMoveManager EasyMove;
-  bool easyPlayed, failedLow;
+  bool easyPlayed, failedLow, FirstSearchOfGame;
   double BestMoveChanges;
-  Value DrawValue[COLOR_NB];
+  Value PreviousMoveValue, DrawValue[COLOR_NB];
   CounterMovesHistoryStats CounterMovesHistory;
 
   template <NodeType NT>
@@ -188,6 +188,9 @@ void Search::clear() {
       th->history.clear();
       th->counterMoves.clear();
   }
+
+  PreviousMoveValue = VALUE_ZERO;
+  FirstSearchOfGame = true;
 }
 
 
@@ -333,6 +336,9 @@ void MainThread::search() {
           if (   th->completedDepth > bestThread->completedDepth
               && th->rootMoves[0].score > bestThread->rootMoves[0].score)
             bestThread = th;
+
+  PreviousMoveValue = bestThread->rootMoves[0].score;
+  FirstSearchOfGame = false;
 
   // Send new PV when needed.
   // FIXME: Breaks multiPV, and skill levels
@@ -534,10 +540,11 @@ void Thread::search() {
               // of the available time has been used or we matched an easyMove
               // from the previous search and just did a fast verification.
               if (   rootMoves.size() == 1
-                  || Time.elapsed() > Time.available() * (failedLow? 641 : 315)/640
-		  || ( easyPlayed = (   rootMoves[0].pv[0] == easyMove
+                  || Time.elapsed() > Time.available(1 + !failedLow 
+		      + 2*(bestValue >= PreviousMoveValue && !FirstSearchOfGame))
+                  || ( easyPlayed = (   rootMoves[0].pv[0] == easyMove
                       && BestMoveChanges < 0.03
-                      && Time.elapsed() > Time.available() / 8)))
+                      && Time.elapsed() > Time.available(0))))
               {
                   // If we are allowed to ponder do not stop the search now but
                   // keep pondering until the GUI sends "ponderhit" or "stop".

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -32,9 +32,11 @@ namespace {
   enum TimeType { OptimumTime, MaxTime };
 
   const int MoveHorizon   = 50;   // Plan time management at most this many moves ahead
-  const double MaxRatio   = 6.93;  // When in trouble, we can step over reserved time with this ratio
+  const double MaxRatio   = 7.48;  // When in trouble, we can step over reserved time with this ratio
   const double StealRatio = 0.36; // However we must not steal time from remaining moves over this ratio
 
+  // Easy move, fail low + eval drop, no fail low, no eval drop, no fail low + no eval drop 
+  const double searchFactor[5] = {0.12, 0.968, 0.743, 0.791, 0.383};
 
   // move_importance() is a skew-logistic function based on naive statistical
   // analysis of "how many games are still undecided after n half-moves". Game
@@ -43,9 +45,9 @@ namespace {
 
   double move_importance(int ply) {
 
-    const double XScale = 8.27;
-    const double XShift = 59.;
-    const double Skew   = 0.179;
+    const double XScale = 7.28;
+    const double XShift = 60.5;
+    const double Skew   = 0.188;
 
     return pow((1 + exp((ply - XShift) / XScale)), -Skew) + DBL_MIN; // Ensure non-zero
   }
@@ -129,4 +131,8 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
 
   if (Options["Ponder"])
       optimumTime += optimumTime / 4;
+}
+
+int TimeManagement::available(int mask){
+   return int(optimumTime * unstablePvFactor * searchFactor[mask]);
 }

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -32,11 +32,11 @@ namespace {
   enum TimeType { OptimumTime, MaxTime };
 
   const int MoveHorizon   = 50;   // Plan time management at most this many moves ahead
-  const double MaxRatio   = 7.48;  // When in trouble, we can step over reserved time with this ratio
-  const double StealRatio = 0.36; // However we must not steal time from remaining moves over this ratio
+  const double MaxRatio   = 7.09;  // When in trouble, we can step over reserved time with this ratio
+  const double StealRatio = 0.35; // However we must not steal time from remaining moves over this ratio
 
   // Easy move, fail low + eval drop, no fail low, no eval drop, no fail low + no eval drop 
-  const double searchFactor[5] = {0.12, 0.968, 0.743, 0.791, 0.383};
+  const double searchFactor[5] = {0.117, 0.968, 0.726, 0.777, 0.348};
 
   // move_importance() is a skew-logistic function based on naive statistical
   // analysis of "how many games are still undecided after n half-moves". Game
@@ -45,9 +45,9 @@ namespace {
 
   double move_importance(int ply) {
 
-    const double XScale = 7.28;
-    const double XShift = 60.5;
-    const double Skew   = 0.188;
+    const double XScale = 7.64;
+    const double XShift = 58.4;
+    const double Skew   = 0.183;
 
     return pow((1 + exp((ply - XShift) / XScale)), -Skew) + DBL_MIN; // Ensure non-zero
   }

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -30,8 +30,8 @@
 class TimeManagement {
 public:
   void init(Search::LimitsType& limits, Color us, int ply);
+  int available(int mask); 
   void pv_instability(double bestMoveChanges) { unstablePvFactor = 1 + bestMoveChanges; }
-  int available() const { return int(optimumTime * unstablePvFactor * 1.016); }
   int maximum() const { return maximumTime; }
   int elapsed() const { return int(Search::Limits.npmsec ? Threads.nodes_searched() : now() - startTime); }
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -66,7 +66,7 @@ void init(OptionsMap& o) {
   o["Skill Level"]           << Option(20, 0, 20);
   o["Move Overhead"]         << Option(30, 0, 5000);
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
-  o["Slow Mover"]            << Option(84, 10, 1000);
+  o["Slow Mover"]            << Option(86, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -66,7 +66,7 @@ void init(OptionsMap& o) {
   o["Skill Level"]           << Option(20, 0, 20);
   o["Move Overhead"]         << Option(30, 0, 5000);
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
-  o["Slow Mover"]            << Option(86, 10, 1000);
+  o["Slow Mover"]            << Option(89, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);


### PR DESCRIPTION
Use less time if evaluation is not worse than for previous move and even less time if in addition no fail low encountered for current iteration. 

STC: 10+0.1
ELO: 5.37 +-2.9 (95%) LOS: 100.0%
Total: 20000 W: 3832 L: 3523 D: 12645

STC: 10+0.1
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 17527 W: 3334 L: 3132 D: 11061

LTC: 60+0.6
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 28233 W: 3939 L: 3725 D: 20569