### PR TITLE
Separate Threads from Position

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -146,7 +146,7 @@ void benchmark(const Position& current, istream& is) {
 
   for (size_t i = 0; i < fens.size(); ++i)
   {
-      Position pos(fens[i], Options["UCI_Chess960"], Threads.main());
+      Position pos(fens[i], Options["UCI_Chess960"]);
 
       cerr << "\nPosition: " << i + 1 << '/' << fens.size() << endl;
 

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -99,7 +99,7 @@ namespace {
     string fen =  sides[0] + char(8 - sides[0].length() + '0') + "/8/8/8/8/8/8/"
                 + sides[1] + char(8 - sides[1].length() + '0') + " w - - 0 10";
 
-    return Position(fen, false, nullptr).material_key();
+    return Position(fen, false).material_key();
   }
 
 } // namespace

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -123,7 +123,7 @@ namespace Material {
 Entry* probe(const Position& pos) {
 
   Key key = pos.material_key();
-  Entry* e = pos.this_thread()->materialTable[key];
+  Entry* e = ThisThread->materialTable[key];
 
   if (e->key == key)
       return e;
@@ -136,7 +136,7 @@ Entry* probe(const Position& pos) {
   // Let's look if we have a specialized evaluation function for this particular
   // material configuration. Firstly we look for a fixed configuration one, then
   // for a generic one if the previous search failed.
-  if ((e->evaluationFunction = pos.this_thread()->endgames.probe<Value>(key)) != nullptr)
+  if ((e->evaluationFunction = ThisThread->endgames.probe<Value>(key)) != nullptr)
       return e;
 
   for (Color c = WHITE; c <= BLACK; ++c)
@@ -150,7 +150,7 @@ Entry* probe(const Position& pos) {
   // configuration. Is there a suitable specialized scaling function?
   EndgameBase<ScaleFactor>* sf;
 
-  if ((sf = pos.this_thread()->endgames.probe<ScaleFactor>(key)) != nullptr)
+  if ((sf = ThisThread->endgames.probe<ScaleFactor>(key)) != nullptr)
   {
       e->scalingFunction[sf->strong_side()] = sf; // Only strong color assigned
       return e;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -23,7 +23,7 @@
 #include <sstream>
 
 #include "misc.h"
-#include "thread.h"
+#include "thread_win32.h"
 
 using namespace std;
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -234,7 +234,7 @@ void init()
 Entry* probe(const Position& pos) {
 
   Key key = pos.pawn_key();
-  Entry* e = pos.this_thread()->pawnsTable[key];
+  Entry* e = ThisThread->pawnsTable[key];
 
   if (e->key == key)
       return e;

--- a/src/position.h
+++ b/src/position.h
@@ -28,7 +28,6 @@
 #include "types.h"
 
 class Position;
-class Thread;
 
 namespace PSQT {
 
@@ -86,13 +85,11 @@ public:
   static void init();
 
   Position() = default; // To define the global object RootPos
-  Position(const Position&) = delete;
-  Position(const Position& pos, Thread* th) { *this = pos; thisThread = th; }
-  Position(const std::string& f, bool c960, Thread* th) { set(f, c960, th); }
+  Position(const std::string& f, bool c960) { set(f, c960); }
   Position& operator=(const Position&); // To assign RootPos from UCI
 
   // FEN string input/output
-  void set(const std::string& fenStr, bool isChess960, Thread* th);
+  void set(const std::string& fenStr, bool isChess960);
   const std::string fen() const;
 
   // Position representation
@@ -163,7 +160,6 @@ public:
   Phase game_phase() const;
   int game_ply() const;
   bool is_chess960() const;
-  Thread* this_thread() const;
   uint64_t nodes_searched() const;
   void set_nodes_searched(uint64_t n);
   bool is_draw() const;
@@ -203,7 +199,6 @@ private:
   uint64_t nodes;
   int gamePly;
   Color sideToMove;
-  Thread* thisThread;
   StateInfo* st;
   bool chess960;
 };
@@ -385,10 +380,6 @@ inline bool Position::capture(Move m) const {
 
 inline PieceType Position::captured_piece_type() const {
   return st->capturedType;
-}
-
-inline Thread* Position::this_thread() const {
-  return thisThread;
 }
 
 inline void Position::put_piece(Color c, PieceType pt, Square s) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -596,6 +596,8 @@ namespace {
     int moveCount, quietCount;
 
     // Step 1. Initialize node
+    prefetch(ThisThread->materialTable[pos.material_key()]);
+    prefetch(ThisThread->pawnsTable[pos.material_key()]);
     inCheck = pos.checkers();
     moveCount = quietCount =  ss->moveCount = 0;
     bestValue = -VALUE_INFINITE;
@@ -1174,6 +1176,9 @@ moves_loop: // When in check search starts from here
     Value bestValue, value, ttValue, futilityValue, futilityBase, oldAlpha;
     bool ttHit, givesCheck, evasionPrunable;
     Depth ttDepth;
+
+    prefetch(ThisThread->materialTable[pos.material_key()]);
+    prefetch(ThisThread->pawnsTable[pos.material_key()]);
 
     if (PvNode)
     {

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -27,7 +27,8 @@
 
 using namespace Search;
 
-ThreadPool Threads; // Global object
+ThreadPool Threads;
+thread_local Thread *ThisThread;
 
 /// Thread constructor launch the thread and then wait until it goes to sleep
 /// in idle_loop().
@@ -93,6 +94,8 @@ void Thread::start_searching(bool resume) {
 /// Thread::idle_loop() is where the thread is parked when it has no work to do
 
 void Thread::idle_loop() {
+
+  ThisThread = this;
 
   while (!exit)
   {

--- a/src/thread.h
+++ b/src/thread.h
@@ -95,5 +95,6 @@ struct ThreadPool : public std::vector<Thread*> {
 };
 
 extern ThreadPool Threads;
+extern thread_local Thread *ThisThread;
 
 #endif // #ifndef THREAD_H_INCLUDED

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -67,7 +67,7 @@ namespace {
     else
         return;
 
-    pos.set(fen, Options["UCI_Chess960"], Threads.main());
+    pos.set(fen, Options["UCI_Chess960"]);
     SetupStates = Search::StateStackPtr(new std::stack<StateInfo>);
 
     // Parse move list (if any)
@@ -145,7 +145,7 @@ namespace {
 
 void UCI::loop(int argc, char* argv[]) {
 
-  Position pos(StartFEN, false, Threads.main()); // The root position
+  Position pos(StartFEN, false); // The root position
   string token, cmd;
 
   for (int i = 1; i < argc; ++i)


### PR DESCRIPTION
Threads don't belong in Position. This simplifies the Position API, and makes more easily separable from the rest of Stockfish (for those using the Position API it in other programs or experiments).

The "trick" is to make ThisThread a thread_local variable. That makes it a lot easier to access from anywhere in the code (you don't need a Position object).

No functional change.

On my configuration (i7-3770k, GCC 5.2.1, Linux 4.2.0), this is actually a small speed-up:
```
stat       test     master    diff
mean  2,600,002  2,589,240  12,490
stdev    15,077     14,466   6,771

speedup       0.48%
P(speedup>0) 100.0%
```