### PR TITLE
Do futility pruning before razoring in main search.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -733,7 +733,15 @@ namespace {
     if (ss->skipEarlyPruning)
         goto moves_loop;
 
-    // Step 6. Razoring (skipped when in check)
+    // Step 6. Futility pruning: child node (skipped when in check)
+    if (   !RootNode
+        &&  depth < 7 * ONE_PLY
+        &&  eval - futility_margin(depth) >= beta
+        &&  eval < VALUE_KNOWN_WIN  // Do not return unproven wins
+        &&  pos.non_pawn_material(pos.side_to_move()))
+        return eval - futility_margin(depth);
+
+    // Step 7. Razoring (skipped when in check)
     if (   !PvNode
         &&  depth < 4 * ONE_PLY
         &&  eval + razor_margin[depth] <= alpha
@@ -748,14 +756,6 @@ namespace {
         if (v <= ralpha)
             return v;
     }
-
-    // Step 7. Futility pruning: child node (skipped when in check)
-    if (   !RootNode
-        &&  depth < 7 * ONE_PLY
-        &&  eval - futility_margin(depth) >= beta
-        &&  eval < VALUE_KNOWN_WIN  // Do not return unproven wins
-        &&  pos.non_pawn_material(pos.side_to_move()))
-        return eval - futility_margin(depth);
 
     // Step 8. Null move search with verification search (is omitted in PV nodes)
     if (   !PvNode


### PR DESCRIPTION
This little rearranging gives a tiny speedup on my machine.
```
Engine                          | Nodes/second
sf-fut-first                    | 1686954.0 +- 4480.48
sf-master                       | 1685933.0 +- 3760.28

Differences                     | 2046.0 +- 1198.0
Variance of the mean            | 169.42 ( 8.28 %)
Speed up                        | 0.12 %
```
Can others confirm, please?

No functional change.