### PR TITLE
Sf7 status

### DIFF
--- a/STATUS
+++ b/STATUS
@@ -78,8 +78,8 @@ At minimum 2000 games at minimum 10+0.1 time control. SF7 vs. SF6.
 Expect no crashes and no losses on time.
 
 Ponder On: TODO
-Chess960: TODO
-Syzygy tables: TODO
+Chess960: PASS (lucasart)
+Syzygy tables: PASS (lucasart)
 
 (add more if required...)
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -31,7 +31,7 @@ namespace {
 
 /// Version number. If Version is left empty, then compile date in the format
 /// DD-MM-YY and show in engine_info.
-const string Version = "";
+const string Version = "7Beta1";
 
 /// Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 /// cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We

--- a/src/thread.h
+++ b/src/thread.h
@@ -76,6 +76,9 @@ public:
 
 struct MainThread : public Thread {
   virtual void search();
+
+  bool easyMovePlayed, failedLow;
+  double bestMoveChanges;
 };
 
 


### PR DESCRIPTION
Ran the following test, SF7 vs. SF6. No crashes or time losses:
```
./cutechess-cli \
  -each proto=uci tc=20+0.2 option.Contempt=10 option.Hash=32 \
  option.SyzygyPath='/home/lucas/Chess/syzygy' option.SyzygyProbeLimit=5 \
  -openings file='./chess960.epd' format=epd order='sequential' \
  -engine cmd=$1 name=$1 \
  -engine cmd=$2 name=$2 \
  -pgnout $3 \
  -concurrency 7 -repeat \
  -rounds 1920 \
  -variant 'fischerandom' \
  -ratinginterval 25
```
Note, in particular:
* No adjudication + Contempt: This leads to some very long games, where SF plays
  stubbornly and tries to delay the draw as much as possible, hence increases
  the likelyhood of time losses (or crashes).
* 1920 = 2x960 games: All Chess960 starting positions played twice (SF7 plays
  both white and black in each position).
* concurrency=7: My machine is an i7-3770k, with 4 physical cores, and 8 HT
  cores. Using HT again increases the pressure, and the likelyhood of time
  losses.

This validates both Chess960 and Syzygy.