### PR TITLE
Adjust time used for move based on previous score

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -186,6 +186,8 @@ void Search::clear() {
       th->history.clear();
       th->counterMoves.clear();
   }
+
+  PreviousMoveValue = VALUE_INFINITE;
 }
 
 
@@ -335,8 +337,8 @@ void MainThread::search() {
               && th->rootMoves[0].score > bestThread->rootMoves[0].score)
               bestThread = th;
   }
+  mainThread->previousMoveScore = bestThread->rootMoves[0].score;
 
-  // Send new PV when needed
   if (bestThread != this)
       sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
 
@@ -535,10 +537,12 @@ void Thread::search() {
               // of the available time has been used or we matched an easyMove
               // from the previous search and just did a fast verification.
               if (   rootMoves.size() == 1
-                  || Time.elapsed() > Time.available() * (mainThread->failedLow ? 641 : 315) / 640
-                  || (mainThread->easyMovePlayed = (   rootMoves[0].pv[0] == easyMove
-                                                    && mainThread->bestMoveChanges < 0.03
-                                                    && Time.elapsed() > Time.available() / 8)))
+                  || Time.elapsed() > Time.available() * ( 640  - 160 * !mainThread->failedLow 
+                     - 126 * (bestValue >= mainThread->previousMoveScore)  
+                     - 124 * (bestValue >= mainThread->previousMoveScore && !mainThread->failedLow))/640
+                  || ( mainThread->easyMovePlayed = ( rootMoves[0].pv[0] == easyMove
+                                                     && mainThread->bestMoveChanges < 0.03
+                                                     && Time.elapsed() > Time.available() * 25/206)))
               {
                   // If we are allowed to ponder do not stop the search now but
                   // keep pondering until the GUI sends "ponderhit" or "stop".

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -127,7 +127,7 @@ namespace {
   };
 
   EasyMoveManager EasyMove;
-  Value PreviousMoveScore, DrawValue[COLOR_NB];
+  Value DrawValue[COLOR_NB];
   CounterMovesHistoryStats CounterMovesHistory;
 
   template <NodeType NT>
@@ -187,7 +187,7 @@ void Search::clear() {
       th->counterMoves.clear();
   }
 
-  PreviousMoveScore = VALUE_INFINITE;
+  Threads.main()->previousMoveScore = VALUE_INFINITE;
 }
 
 
@@ -338,7 +338,7 @@ void MainThread::search() {
               bestThread = th;
   }
 
-  PreviousMoveScore = bestThread->rootMoves[0].score;
+  previousMoveScore = bestThread->rootMoves[0].score;
 
   // Send new PV when needed
   if (bestThread != this)
@@ -540,8 +540,8 @@ void Thread::search() {
               // from the previous search and just did a fast verification.
               if (   rootMoves.size() == 1
                   || Time.elapsed() > Time.available() * ( 640  - 160 * !mainThread->failedLow 
-                     - 126 * (bestValue >= PreviousMoveScore)  
-                     - 124 * (bestValue >= PreviousMoveScore && !mainThread->failedLow))/640
+                     - 126 * (bestValue >= mainThread->previousMoveScore)  
+                     - 124 * (bestValue >= mainThread->previousMoveScore && !mainThread->failedLow))/640
                   || ( mainThread->easyMovePlayed = ( rootMoves[0].pv[0] == easyMove
                                                      && mainThread->bestMoveChanges < 0.03
                                                      && Time.elapsed() > Time.available() * 25/206)))

--- a/src/thread.h
+++ b/src/thread.h
@@ -79,6 +79,7 @@ struct MainThread : public Thread {
 
   bool easyMovePlayed, failedLow;
   double bestMoveChanges;
+  Value previousMoveScore;
 };
 
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -79,7 +79,6 @@ struct MainThread : public Thread {
 
   bool easyMovePlayed, failedLow;
   double bestMoveChanges;
-  Value previousMoveScore;
 };
 
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -32,8 +32,8 @@ namespace {
   enum TimeType { OptimumTime, MaxTime };
 
   const int MoveHorizon   = 50;   // Plan time management at most this many moves ahead
-  const double MaxRatio   = 6.93;  // When in trouble, we can step over reserved time with this ratio
-  const double StealRatio = 0.36; // However we must not steal time from remaining moves over this ratio
+  const double MaxRatio   = 7.09;  // When in trouble, we can step over reserved time with this ratio
+  const double StealRatio = 0.35; // However we must not steal time from remaining moves over this ratio
 
 
   // move_importance() is a skew-logistic function based on naive statistical
@@ -43,9 +43,9 @@ namespace {
 
   double move_importance(int ply) {
 
-    const double XScale = 8.27;
-    const double XShift = 59.;
-    const double Skew   = 0.179;
+    const double XScale = 7.64;
+    const double XShift = 58.4;
+    const double Skew   = 0.183;
 
     return pow((1 + exp((ply - XShift) / XScale)), -Skew) + DBL_MIN; // Ensure non-zero
   }

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -31,7 +31,7 @@ class TimeManagement {
 public:
   void init(Search::LimitsType& limits, Color us, int ply);
   void pv_instability(double bestMoveChanges) { unstablePvFactor = 1 + bestMoveChanges; }
-  int available() const { return int(optimumTime * unstablePvFactor * 1.016); }
+  int available() const { return int(optimumTime * unstablePvFactor * 0.968); }
   int maximum() const { return maximumTime; }
   int elapsed() const { return int(Search::Limits.npmsec ? Threads.nodes_searched() : now() - startTime); }
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -66,7 +66,7 @@ void init(OptionsMap& o) {
   o["Skill Level"]           << Option(20, 0, 20);
   o["Move Overhead"]         << Option(30, 0, 5000);
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
-  o["Slow Mover"]            << Option(84, 10, 1000);
+  o["Slow Mover"]            << Option(89, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);


### PR DESCRIPTION
Use less time if evaluation is not worse than for previous move and even less time if in addition no fail low encountered for current iteration.

STC: 10+0.1
ELO: 5.37 +-2.9 (95%) LOS: 100.0%
Total: 20000 W: 3832 L: 3523 D: 12645

STC: 10+0.1
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 17527 W: 3334 L: 3132 D: 11061

LTC: 60+0.6
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 28233 W: 3939 L: 3725 D: 20569

LTC: 60+0.6
ELO: 2.43 +-1.4 (95%) LOS: 100.0%
Total: 60000 W: 8266 L: 7847 D: 43887

LTC: 60+0.06
LLR: 2.95 (-2.94,2.94) [-1.00,3.00]
Total: 38932 W: 5408 L: 5207 D: 28317