### PR TITLE
V pawns

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -108,10 +108,10 @@ namespace {
 
 
   // Evaluation weights, indexed by the corresponding evaluation term
-  enum { PassedPawns, Space, KingSafety };
+  enum { PawnStructure, PassedPawns, Space, KingSafety };
 
   const struct Weight { int mg, eg; } Weights[] = {
-    {193, 262}, {47, 0}, {330, 0}
+    {214, 203}, {193, 262}, {47, 0}, {330, 0}
   };
 
   Score operator*(Score s, const Weight& w) {
@@ -769,7 +769,7 @@ Value Eval::evaluate(const Position& pos) {
 
   // Probe the pawn hash table
   ei.pi = Pawns::probe(pos);
-  score += ei.pi->pawns_score();
+  score += ei.pi->pawns_score() * Weights[PawnStructure];
 
   // Initialize attack and king safety bitboards
   ei.attackedBy[WHITE][ALL_PIECES] = ei.attackedBy[BLACK][ALL_PIECES] = 0;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -108,10 +108,10 @@ namespace {
 
 
   // Evaluation weights, indexed by the corresponding evaluation term
-  enum { PawnStructure, PassedPawns, Space, KingSafety };
+  enum { PassedPawns, Space, KingSafety };
 
   const struct Weight { int mg, eg; } Weights[] = {
-    {214, 203}, {193, 262}, {47, 0}, {330, 0}
+    {193, 262}, {47, 0}, {330, 0}
   };
 
   Score operator*(Score s, const Weight& w) {
@@ -769,7 +769,7 @@ Value Eval::evaluate(const Position& pos) {
 
   // Probe the pawn hash table
   ei.pi = Pawns::probe(pos);
-  score += ei.pi->pawns_score() * Weights[PawnStructure];
+  score += ei.pi->pawns_score();
 
   // Initialize attack and king safety bitboards
   ei.attackedBy[WHITE][ALL_PIECES] = ei.attackedBy[BLACK][ALL_PIECES] = 0;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -54,7 +54,8 @@ namespace {
     S( 0, 0), S( 0, 0), S(0, 0), S(0, 0),
     S(20,20), S(40,40), S(0, 0), S(0, 0) };
 
-  // Unsupported pawn penalty by twice supporting
+  // Unsupported pawn penalty by twice supporting.
+  // This applies only to pawns which are neither isolated or backward.
   const Score Unsupported[2] = { S(20, 10), S(25, 15) };
 
   const Score CenterBind = S(16, 0);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -33,18 +33,18 @@ namespace {
 
   // Doubled pawn penalty by file
   const Score Doubled[FILE_NB] = {
-    S(11, 35), S(17, 39), S(20, 39), S(20, 39),
-    S(20, 39), S(20, 39), S(17, 39), S(11, 35) };
+    S(13, 43), S(20, 48), S(23, 48), S(23, 48),
+    S(23, 48), S(23, 48), S(20, 48), S(13, 43) };
 
   // Isolated pawn penalty by opposed flag and file
   const Score Isolated[2][FILE_NB] = {
-  { S(32, 37), S(46, 42), S(51, 42), S(51, 42),
-    S(51, 42), S(51, 42), S(46, 42), S(32, 37) },
-  { S(22, 24), S(31, 29), S(34, 29), S(34, 29),
-    S(34, 29), S(34, 29), S(31, 29), S(22, 24) } };
+  { S(37, 45), S(54, 52), S(60, 52), S(60, 52),
+    S(60, 52), S(60, 52), S(54, 52), S(37, 45) },
+  { S(25, 30), S(36, 35), S(40, 35), S(40, 35),
+    S(40, 35), S(40, 35), S(36, 35), S(25, 30) } };
 
   // Backward pawn penalty by opposed flag
-  const Score Backward[2] = { S(57, 34), S(43, 21) };
+  const Score Backward[2] = { S(67, 42), S(49, 24) };
 
   // Connected pawn bonus by opposed, phalanx, twice supported and rank
   Score Connected[2][2][2][RANK_NB];
@@ -52,16 +52,12 @@ namespace {
   // Levers bonus by rank
   const Score Lever[RANK_NB] = {
     S( 0, 0), S( 0, 0), S(0, 0), S(0, 0),
-    S(16, 16), S(32, 32), S(0, 0), S(0, 0) };
+    S(20,20), S(40,40), S(0, 0), S(0, 0) };
 
-  // Unsupported pawn penalty
-  // for pawns which are neither backward or isolated.
-  const Score Unsupported = S(18, 8);
+  // Unsupported pawn penalty by twice supporting
+  const Score Unsupported[2] = { S(20, 10), S(25, 15) };
 
-  // Unsupported pawn which protects 2 other pawns
-  const Score VPawn = S(4, 4);
-
-  const Score CenterBind = S(13, 0);
+  const Score CenterBind = S(16, 0);
 
   // Weakness of our pawn shelter in front of the king by [distance from edge][rank]
   const Value ShelterWeakness[][RANK_NB] = {
@@ -108,7 +104,7 @@ namespace {
       Us == WHITE ? (FileDBB | FileEBB) & (Rank5BB | Rank6BB | Rank7BB)
                   : (FileDBB | FileEBB) & (Rank4BB | Rank3BB | Rank2BB);
 
-    Bitboard b, neighbours, doubled, supported, phalanx, supporting;
+    Bitboard b, neighbours, doubled, supported, phalanx;
     Square s;
     bool passed, isolated, opposed, backward, lever, connected;
     Score score = SCORE_ZERO;
@@ -143,7 +139,6 @@ namespace {
         lever       =   theirPawns & pawnAttacksBB[s];
         phalanx     =   neighbours & rank_bb(s);
         supported   =   neighbours & rank_bb(s - Up);
-        supporting  =   neighbours & rank_bb(s + Up);
         connected   =   supported | phalanx;
         isolated    =  !neighbours;
 
@@ -185,10 +180,7 @@ namespace {
             score -= Backward[opposed];
 
         else if (!supported)
-            score -= Unsupported;
-        
-        if (!supported & more_than_one(supporting))
-            score -= VPawn;
+            score -= Unsupported[more_than_one(neighbours & rank_bb(s + Up))];
 
         if (connected)
             score += Connected[opposed][!!phalanx][more_than_one(supported)][relative_rank(Us, s)];
@@ -205,7 +197,7 @@ namespace {
 
     // Center binds: Two pawns controlling the same central square
     b = shift_bb<Right>(ourPawns) & shift_bb<Left>(ourPawns) & CenterBindMask;
-    score += CenterBind * popcount<Max15>(b);
+    score += popcount<Max15>(b) * CenterBind;
 
     return score;
   }
@@ -220,7 +212,7 @@ namespace Pawns {
 
 void init()
 {
-  static const int Seed[RANK_NB] = { 0, 5, 12, 8, 46, 61, 110, 210 };
+  static const int Seed[RANK_NB] = { 0, 6, 15, 10, 57, 75, 135, 258 };
 
   for (int opposed = 0; opposed <= 1; ++opposed)
       for (int phalanx = 0; phalanx <= 1; ++phalanx)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -54,8 +54,8 @@ namespace {
     S( 0, 0), S( 0, 0), S(0, 0), S(0, 0),
     S(20,20), S(40,40), S(0, 0), S(0, 0) };
 
-  // Unsupported pawn penalty
-  const Score UnsupportedPawnPenalty = S(20, 10);
+  // Unsupported pawn penalty by twice supporting
+  const Score Unsupported[2] = { S(20, 10), S(25, 15) };
 
   const Score CenterBind = S(16, 0);
 
@@ -180,7 +180,7 @@ namespace {
             score -= Backward[opposed];
 
         else if (!supported)
-            score -= UnsupportedPawnPenalty;
+            score -= Unsupported[more_than_one(neighbours & rank_bb(s + Up))];
 
         if (connected)
             score += Connected[opposed][!!phalanx][more_than_one(supported)][relative_rank(Us, s)];

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -54,8 +54,8 @@ namespace {
     S( 0, 0), S( 0, 0), S(0, 0), S(0, 0),
     S(20,20), S(40,40), S(0, 0), S(0, 0) };
 
-  // Unsupported pawn penalty by twice supporting.
-  // This applies only to pawns which are neither isolated or backward.
+  // Unsupported pawn penalty for pawns which are neither isolated or backward,
+  // by number of pawns it supports [less than 2 / exactly 2].
   const Score Unsupported[2] = { S(20, 10), S(25, 15) };
 
   const Score CenterBind = S(16, 0);


### PR DESCRIPTION
Adjust the unsupported pawn penalty when the pawn is supporting 2 pawns 
(for example g7 in f6-g7-h6)

Passed STC
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 23833 W: 4384 L: 4158 D: 15291

Passed LTC
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 42711 W: 5918 L: 5655 D: 31138

Attempt to extend the small extra also to backward pawns (and simplify the PawnStructure weight at the same time) did not worked, and was reverted
http://tests.stockfishchess.org/tests/view/5680c7de0ebc5966b711a924

And 30M game tuning did not show any significant improvement probably not worth testing.
http://tests.stockfishchess.org/tests/view/5681be360ebc5966b711a95f
