### PR TITLE
Remove piece lists

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -161,8 +161,8 @@ Value Endgame<KXK>::operator()(const Position& pos) const {
   if (   pos.count<QUEEN>(strongSide)
       || pos.count<ROOK>(strongSide)
       ||(pos.count<BISHOP>(strongSide) && pos.count<KNIGHT>(strongSide))
-      ||(pos.count<BISHOP>(strongSide) > 1 && opposite_colors(pos.squares<BISHOP>(strongSide)[0],
-                                                              pos.squares<BISHOP>(strongSide)[1])))
+      ||(pos.count<BISHOP>(strongSide) > 1 && opposite_colors(lsb(pos.pieces(strongSide, BISHOP)),
+                                                              msb(pos.pieces(strongSide, BISHOP)))))
       result = std::min(result + VALUE_KNOWN_WIN, VALUE_MATE_IN_MAX_PLY - 1);
 
   return strongSide == pos.side_to_move() ? result : -result;
@@ -589,8 +589,8 @@ ScaleFactor Endgame<KRPPKRP>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, RookValueMg, 2));
   assert(verify_material(pos, weakSide,   RookValueMg, 1));
 
-  Square wpsq1 = pos.squares<PAWN>(strongSide)[0];
-  Square wpsq2 = pos.squares<PAWN>(strongSide)[1];
+  Square wpsq1 = lsb(pos.pieces(strongSide, PAWN));
+  Square wpsq2 = msb(pos.pieces(strongSide, PAWN));
   Square bksq = pos.square<KING>(weakSide);
 
   // Does the stronger side have a passed pawn?
@@ -700,8 +700,8 @@ ScaleFactor Endgame<KBPPKB>::operator()(const Position& pos) const {
       return SCALE_FACTOR_NONE;
 
   Square ksq = pos.square<KING>(weakSide);
-  Square psq1 = pos.squares<PAWN>(strongSide)[0];
-  Square psq2 = pos.squares<PAWN>(strongSide)[1];
+  Square psq1 = lsb(pos.pieces(strongSide, PAWN));
+  Square psq2 = msb(pos.pieces(strongSide, PAWN));
   Rank r1 = rank_of(psq1);
   Rank r2 = rank_of(psq2);
   Square blockSq1, blockSq2;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -259,19 +259,18 @@ namespace {
   Score evaluate_pieces(const Position& pos, EvalInfo& ei, Score* mobility,
                         const Bitboard* mobilityArea) {
     Bitboard b, bb;
-    Square s;
     Score score = SCORE_ZERO;
 
     const PieceType NextPt = (Us == WHITE ? Pt : PieceType(Pt + 1));
     const Color Them = (Us == WHITE ? BLACK : WHITE);
     const Bitboard OutpostRanks = (Us == WHITE ? Rank4BB | Rank5BB | Rank6BB
                                                : Rank5BB | Rank4BB | Rank3BB);
-    const Square* pl = pos.squares<Pt>(Us);
-
     ei.attackedBy[Us][Pt] = 0;
 
-    while ((s = *pl++) != SQ_NONE)
+    for (Bitboard pieces = pos.pieces(Us, Pt); pieces; )
     {
+        const Square s = pop_lsb(&pieces);
+
         // Find attacked squares, including x-ray attacks for bishops and rooks
         b = Pt == BISHOP ? attacks_bb<BISHOP>(s, pos.pieces() ^ pos.pieces(Us, QUEEN))
           : Pt ==   ROOK ? attacks_bb<  ROOK>(s, pos.pieces() ^ pos.pieces(Us, ROOK, QUEEN))

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -228,10 +228,10 @@ namespace {
 
     assert(Pt != KING && Pt != PAWN);
 
-    const Square* pl = pos.squares<Pt>(us);
-
-    for (Square from = *pl; from != SQ_NONE; from = *++pl)
+    for (Bitboard pieces = pos.pieces(us, Pt); pieces; )
     {
+        const Square from = pop_lsb(&pieces);
+
         if (Checks)
         {
             if (    (Pt == BISHOP || Pt == ROOK || Pt == QUEEN)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -106,10 +106,8 @@ namespace {
                   : (FileDBB | FileEBB) & (Rank4BB | Rank3BB | Rank2BB);
 
     Bitboard b, neighbours, doubled, supported, phalanx;
-    Square s;
     bool passed, isolated, opposed, backward, lever, connected;
     Score score = SCORE_ZERO;
-    const Square* pl = pos.squares<PAWN>(Us);
     const Bitboard* pawnAttacksBB = StepAttacksBB[make_piece(Us, PAWN)];
 
     Bitboard ourPawns   = pos.pieces(Us  , PAWN);
@@ -123,8 +121,9 @@ namespace {
     e->pawnsOnSquares[Us][WHITE] = pos.count<PAWN>(Us) - e->pawnsOnSquares[Us][BLACK];
 
     // Loop through all pawns of the current color and score each pawn
-    while ((s = *pl++) != SQ_NONE)
+    for (Bitboard pawns = ourPawns; pawns; )
     {
+        const Square s = pop_lsb(&pawns);
         assert(pos.piece_on(s) == make_piece(Us, PAWN));
 
         File f = file_of(s);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -182,10 +182,6 @@ void Position::clear() {
   std::memset(this, 0, sizeof(Position));
   startState.epSquare = SQ_NONE;
   st = &startState;
-
-  for (int i = 0; i < PIECE_TYPE_NB; ++i)
-      for (int j = 0; j < 16; ++j)
-          pieceList[WHITE][i][j] = pieceList[BLACK][i][j] = SQ_NONE;
 }
 
 
@@ -737,7 +733,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       else
           st->nonPawnMaterial[them] -= PieceValue[MG][captured];
 
-      // Update board and piece lists
+      // Update board
       remove_piece(them, captured, capsq);
 
       // Update material hash key and prefetch access to materialTable
@@ -1124,7 +1120,7 @@ bool Position::pos_is_ok(int* failedStep) const {
 
   const bool Fast = true; // Quick (default) or full check?
 
-  enum { Default, King, Bitboards, State, Lists, Castling };
+  enum { Default, King, Bitboards, State, Castling };
 
   for (int step = Default; step <= (Fast ? Default : Castling); step++)
   {
@@ -1164,19 +1160,6 @@ bool Position::pos_is_ok(int* failedStep) const {
           if (std::memcmp(&si, st, sizeof(StateInfo)))
               return false;
       }
-
-      if (step == Lists)
-          for (Color c = WHITE; c <= BLACK; ++c)
-              for (PieceType pt = PAWN; pt <= KING; ++pt)
-              {
-                  if (pieceCount[c][pt] != popcount<Full>(pieces(c, pt)))
-                      return false;
-
-                  for (int i = 0; i < pieceCount[c][pt];  ++i)
-                      if (   board[pieceList[c][pt][i]] != make_piece(c, pt)
-                          || index[pieceList[c][pt][i]] != i)
-                          return false;
-              }
 
       if (step == Castling)
           for (Color c = WHITE; c <= BLACK; ++c)

--- a/src/position.h
+++ b/src/position.h
@@ -106,7 +106,6 @@ public:
   Square ep_square() const;
   bool empty(Square s) const;
   template<PieceType Pt> int count(Color c) const;
-  template<PieceType Pt> const Square* squares(Color c) const;
   template<PieceType Pt> Square square(Color c) const;
 
   // Castling
@@ -194,8 +193,6 @@ private:
   Bitboard byTypeBB[PIECE_TYPE_NB];
   Bitboard byColorBB[COLOR_NB];
   int pieceCount[COLOR_NB][PIECE_TYPE_NB];
-  Square pieceList[COLOR_NB][PIECE_TYPE_NB][16];
-  int index[SQUARE_NB];
   int castlingRightsMask[SQUARE_NB];
   Square castlingRookSquare[CASTLING_RIGHT_NB];
   Bitboard castlingPath[CASTLING_RIGHT_NB];
@@ -254,13 +251,9 @@ template<PieceType Pt> inline int Position::count(Color c) const {
   return pieceCount[c][Pt];
 }
 
-template<PieceType Pt> inline const Square* Position::squares(Color c) const {
-  return pieceList[c][Pt];
-}
-
 template<PieceType Pt> inline Square Position::square(Color c) const {
   assert(pieceCount[c][Pt] == 1);
-  return pieceList[c][Pt][0];
+  return lsb(pieces(c, Pt));
 }
 
 inline Square Position::ep_square() const {
@@ -397,40 +390,28 @@ inline void Position::put_piece(Color c, PieceType pt, Square s) {
   byTypeBB[ALL_PIECES] |= s;
   byTypeBB[pt] |= s;
   byColorBB[c] |= s;
-  index[s] = pieceCount[c][pt]++;
-  pieceList[c][pt][index[s]] = s;
-  pieceCount[c][ALL_PIECES]++;
+  ++pieceCount[c][pt];
+  ++pieceCount[c][ALL_PIECES];
 }
 
 inline void Position::remove_piece(Color c, PieceType pt, Square s) {
 
-  // WARNING: This is not a reversible operation. If we remove a piece in
-  // do_move() and then replace it in undo_move() we will put it at the end of
-  // the list and not in its original place, it means index[] and pieceList[]
-  // are not guaranteed to be invariant to a do_move() + undo_move() sequence.
   byTypeBB[ALL_PIECES] ^= s;
   byTypeBB[pt] ^= s;
   byColorBB[c] ^= s;
   /* board[s] = NO_PIECE;  Not needed, overwritten by the capturing one */
-  Square lastSquare = pieceList[c][pt][--pieceCount[c][pt]];
-  index[lastSquare] = index[s];
-  pieceList[c][pt][index[lastSquare]] = lastSquare;
-  pieceList[c][pt][pieceCount[c][pt]] = SQ_NONE;
-  pieceCount[c][ALL_PIECES]--;
+  --pieceCount[c][pt];
+  --pieceCount[c][ALL_PIECES];
 }
 
 inline void Position::move_piece(Color c, PieceType pt, Square from, Square to) {
 
-  // index[from] is not updated and becomes stale. This works as long as index[]
-  // is accessed just by known occupied squares.
   Bitboard from_to_bb = SquareBB[from] ^ SquareBB[to];
   byTypeBB[ALL_PIECES] ^= from_to_bb;
   byTypeBB[pt] ^= from_to_bb;
   byColorBB[c] ^= from_to_bb;
   board[from] = NO_PIECE;
   board[to] = make_piece(c, pt);
-  index[to] = index[from];
-  pieceList[c][pt][index[to]] = to;
 }
 
 #endif // #ifndef POSITION_H_INCLUDED


### PR DESCRIPTION
A simplification, and practically a non-functional change. Bench only changes,
because the order of move generation changes.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 51102 W: 9452 L: 9383 D: 32267

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 123190 W: 16586 L: 16603 D: 90001

bench 8584622