### PR TITLE
Remove check for normal moves in LMR and replace see by see_sign

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -989,6 +989,7 @@ moves_loop: // When in check search starts from here
       // Step 15. Reduced depth search (LMR). If the move fails high it will be
       // re-searched at full depth.
       if (    depth >= 3 * ONE_PLY
+          &&  moveCount > 1
           && !captureOrPromotion)
       {
           Depth r = reduction<PvNode>(improving, depth, moveCount);
@@ -1006,7 +1007,6 @@ moves_loop: // When in check search starts from here
 
           // Decrease reduction for moves that escape a capture
           if (   r
-              && type_of(move) == NORMAL
               && type_of(pos.piece_on(to_sq(move))) != PAWN
               && pos.see(make_move(to_sq(move), from_sq(move))) < VALUE_ZERO)
               r = std::max(DEPTH_ZERO, r - ONE_PLY);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1008,7 +1008,7 @@ moves_loop: // When in check search starts from here
           // Decrease reduction for moves that escape a capture
           if (   r
               && type_of(pos.piece_on(to_sq(move))) != PAWN
-              && pos.see(make_move(to_sq(move), from_sq(move))) < VALUE_ZERO)
+              && pos.see_sign(make_move(to_sq(move), from_sq(move))) < VALUE_ZERO)
               r = std::max(DEPTH_ZERO, r - ONE_PLY);
 
           Depth d = std::max(newDepth - r, ONE_PLY);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -989,7 +989,6 @@ moves_loop: // When in check search starts from here
       // Step 15. Reduced depth search (LMR). If the move fails high it will be
       // re-searched at full depth.
       if (    depth >= 3 * ONE_PLY
-          &&  moveCount > 1
           && !captureOrPromotion)
       {
           Depth r = reduction<PvNode>(improving, depth, moveCount);


### PR DESCRIPTION
Remove non necessary condition in LMR step and replace see by see_sign.

Bench is unchanged also as higher depth.

original:  			bench/15: 23329380 bench/20: 170471032  start/25: 112078091
branch (see_sign): 	bench/15: 23329380 bench/20: 170471032  start/25: 112078091
branch (see): 		bench/15: 23329380 bench/20: 170471032  start/25: 112078091

Benches were run with debug=yes: no assert firing. Please confirm in view of comment by @DU-jdto.

see version passed a sanity SPRT 10+0.1 [-3, 1]

LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 54439 W: 9983 L: 9920 D: 34536

see_sign version did not actually pass SPRT 10+0.1 [-3, 1] but must be better than see version

LLR: -2.96 (-2.94,2.94) [-3.00,1.00]
Total: 81751 W: 14892 L: 15191 D: 51668