### PR TITLE
Fix compiling of 32 bit binary on 64-bit Windows AGAIN

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -160,8 +160,6 @@ endif
 
 ifeq ($(COMP),mingw)
 	comp=mingw
-
-	ifeq ($(UNAME),Linux)
 		ifeq ($(bits),64)
 			ifeq ($(shell which x86_64-w64-mingw32-c++-posix),)
 				CXX=x86_64-w64-mingw32-c++
@@ -175,10 +173,6 @@ ifeq ($(COMP),mingw)
 				CXX=i686-w64-mingw32-c++-posix
 			endif
 		endif
-	else
-		CXX=g++
-	endif
-
 	CXXFLAGS += -Wextra -Wshadow
 	LDFLAGS += -static
 endif


### PR DESCRIPTION
This is a resubmission of
https://github.com/official-stockfish/Stockfish/pull/532
by @braich(credit to him) which was already approved and committed here
https://github.com/official-stockfish/Stockfish/commit/1e8836d921b3b508e5d44d2fafab95230bdd03c6
but later reverted here
https://github.com/official-stockfish/Stockfish/commit/90f5937373974adf4ae7216feedf5abc4d62debd
by Marco.  His claim was that his 64 bit compile was broken but the attached log is from a 32 bit
compile. The 32 bit failure was expected because he doesn't have a mingw toolchain targeting Win32 installed.  He has agreed to redo the test.  In the meantime everyone else that tested here
https://groups.google.com/forum/#!topic/fishcooking/g1wIcShQiGY
has reported success and no one has reported any failure.