### PR TITLE
SEE

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -986,7 +986,7 @@ Value Position::see_sign(Move m) const {
   // Early return if SEE cannot be negative because captured piece value
   // is not less then capturing one. Note that king moves always return
   // here because king midgame value is set to 0.
-  if (PieceValue[MG][moved_piece(m)] <= PieceValue[MG][piece_on(to_sq(m))])
+  if (PieceValue[MG][moved_piece(m)] <= PieceValue[MG][piece_on(to_sq(m))] || type_of(m) == ENPASSANT)
       return VALUE_KNOWN_WIN;
 
   return see(m);


### PR DESCRIPTION
For enpassants the piece_on(to_sq) will be NONE.
So it will always skip the early return and run the very expensive see() call.
This tweak will make sure enpassants return early, which should prove to be a small speed up.