### PR TITLE
Update comments in LMR step

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1005,7 +1005,9 @@ moves_loop: // When in check search starts from here
               && cmh[pos.piece_on(to_sq(move))][to_sq(move)] > VALUE_ZERO)
               r = std::max(DEPTH_ZERO, r - ONE_PLY);
 
-          // Decrease reduction for moves that escape a capture
+          // Decrease reduction for moves that escape a capture. Explicitly filter out castling moves
+          // and use see() instead of see_sign() to avoid any possible surprise.
+
           if (   r
               && type_of(move) == NORMAL
               && type_of(pos.piece_on(to_sq(move))) != PAWN

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1005,8 +1005,9 @@ moves_loop: // When in check search starts from here
               && cmh[pos.piece_on(to_sq(move))][to_sq(move)] > VALUE_ZERO)
               r = std::max(DEPTH_ZERO, r - ONE_PLY);
 
-          // Decrease reduction for moves that escape a capture. Explicitly filter out castling moves
-          // and use see() instead of see_sign() to avoid any possible surprise.
+          // Decrease reduction for moves that escape a capture. Filter out castling
+          // moves because are coded as "king captures rook" and break make_move().
+          // Also use see() instead of see_sign() because destination square is empty.
 
           if (   r
               && type_of(move) == NORMAL


### PR DESCRIPTION
Update comments in the LMR step of search.

see_sign() was replaced by see() and filtering out of castling moves in https://github.com/official-stockfish/Stockfish/commit/187a9fe5e7b8349b9eacf23e11cb801a32bb6b12. Comment code accordingly as discussed in https://github.com/official-stockfish/Stockfish/pull/560.

No functional change. 