### PR TITLE
Use a scalable logic for reduction modifications based on history.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1002,7 +1002,7 @@ moves_loop: // When in check search starts from here
 
           // Decrease reduction for moves with a good history
           int reductionHistoryDecrease =
-                  (19*thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + 18*cmh[pos.piece_on(to_sq(move))][to_sq(move)])/262144;
+                  (18*thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + 17*cmh[pos.piece_on(to_sq(move))][to_sq(move)] + 11)/262144;
           r = std::max(DEPTH_ZERO, r - reductionHistoryDecrease*ONE_PLY);
 
           // Decrease reduction for moves that escape a capture

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1001,7 +1001,7 @@ moves_loop: // When in check search starts from here
               r += ONE_PLY;
 
           // Decrease reduction for moves with a good history
-          int reductionHistoryDecrease = (thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + cmh[pos.piece_on(to_sq(move))][to_sq(move)])/10000;
+          int reductionHistoryDecrease = std::max(Value(0), thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + cmh[pos.piece_on(to_sq(move))][to_sq(move)])/25000;
           r = std::max(DEPTH_ZERO, r - reductionHistoryDecrease*ONE_PLY);
 
           // Decrease reduction for moves that escape a capture

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1001,7 +1001,7 @@ moves_loop: // When in check search starts from here
               r += ONE_PLY;
 
           // Decrease reduction for moves with a good history
-          int reductionHistoryDecrease = (thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + cmh[pos.piece_on(to_sq(move))][to_sq(move)])/25000;
+          int reductionHistoryDecrease = (thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + cmh[pos.piece_on(to_sq(move))][to_sq(move)])/10000;
           r = std::max(DEPTH_ZERO, r - reductionHistoryDecrease*ONE_PLY);
 
           // Decrease reduction for moves that escape a capture

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1002,7 +1002,7 @@ moves_loop: // When in check search starts from here
 
           // Decrease reduction for moves with a good history
           int reductionHistoryDecrease =
-                  (18*thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + 17*cmh[pos.piece_on(to_sq(move))][to_sq(move)] + 11)/262144;
+                  (thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + cmh[pos.piece_on(to_sq(move))][to_sq(move)])/14980;
           r = std::max(DEPTH_ZERO, r - reductionHistoryDecrease*ONE_PLY);
 
           // Decrease reduction for moves that escape a capture

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1002,7 +1002,7 @@ moves_loop: // When in check search starts from here
 
           // Decrease reduction for moves with a good history
           int reductionHistoryDecrease =
-                  (18*thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + 17*cmh[pos.piece_on(to_sq(move))][to_sq(move)] + 11)/262144;
+                  (18*thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + 17*cmh[pos.piece_on(to_sq(move))][to_sq(move)] + 30000)/262144;
           r = std::max(DEPTH_ZERO, r - reductionHistoryDecrease*ONE_PLY);
 
           // Decrease reduction for moves that escape a capture

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1001,9 +1001,8 @@ moves_loop: // When in check search starts from here
               r += ONE_PLY;
 
           // Decrease reduction for moves with a good history
-          if (   thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] > VALUE_ZERO
-              && cmh[pos.piece_on(to_sq(move))][to_sq(move)] > VALUE_ZERO)
-              r = std::max(DEPTH_ZERO, r - ONE_PLY);
+          int reductionHistoryDecrease = (thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + cmh[pos.piece_on(to_sq(move))][to_sq(move)])/25000;
+          r = std::max(DEPTH_ZERO, r - reductionHistoryDecrease*ONE_PLY);
 
           // Decrease reduction for moves that escape a capture
           if (   r

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1002,7 +1002,7 @@ moves_loop: // When in check search starts from here
 
           // Decrease reduction for moves with a good history
           int reductionHistoryDecrease =
-                  (18*thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + 17*cmh[pos.piece_on(to_sq(move))][to_sq(move)] + 30000)/262144;
+                  (18*thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + 17*cmh[pos.piece_on(to_sq(move))][to_sq(move)] - 30000)/262144;
           r = std::max(DEPTH_ZERO, r - reductionHistoryDecrease*ONE_PLY);
 
           // Decrease reduction for moves that escape a capture

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1001,7 +1001,8 @@ moves_loop: // When in check search starts from here
               r += ONE_PLY;
 
           // Decrease reduction for moves with a good history
-          int reductionHistoryDecrease = std::max(Value(0), thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + cmh[pos.piece_on(to_sq(move))][to_sq(move)])/25000;
+          int reductionHistoryDecrease =
+                  (19*thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + 18*cmh[pos.piece_on(to_sq(move))][to_sq(move)])/262144;
           r = std::max(DEPTH_ZERO, r - reductionHistoryDecrease*ONE_PLY);
 
           // Decrease reduction for moves that escape a capture

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1002,7 +1002,7 @@ moves_loop: // When in check search starts from here
 
           // Decrease reduction for moves with a good history
           int reductionHistoryDecrease =
-                  (18*thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + 17*cmh[pos.piece_on(to_sq(move))][to_sq(move)] - 30000)/262144;
+                  (18*thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] + 17*cmh[pos.piece_on(to_sq(move))][to_sq(move)] + 11)/262144;
           r = std::max(DEPTH_ZERO, r - reductionHistoryDecrease*ONE_PLY);
 
           // Decrease reduction for moves that escape a capture


### PR DESCRIPTION
Use a scalable logic for reduction modifications based on history.

Replace the current logic in which reductions can be only decreased by one ply for moves with a good history. Modify reductions based on the sum of thread and countermoves history multiplied by a factor tuned per SPSA. Further tuning of the current very small offset could lead to further ELO gain.

Passed STC:

LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 11140 W: 2117 L: 1944 D: 7079

and LTC:

LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 11155 W: 1572 L: 1416 D: 8167

Bench: 7822264