### PR TITLE
Makefile: Remove redundant -std=c++0x flag

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -194,8 +194,8 @@ ifeq ($(COMP),clang)
 	CXX=clang++
 	CXXFLAGS += -pedantic -Wextra -Wshadow
 	ifeq ($(UNAME),Darwin)
-		CXXFLAGS += -std=c++0x -stdlib=libc++
-		DEPENDFLAGS += -std=c++0x -stdlib=libc++
+		CXXFLAGS += -stdlib=libc++
+		DEPENDFLAGS += -stdlib=libc++
 	endif
 endif
 


### PR DESCRIPTION
This flag is functionally identical to '-std=c++11' flag which is part of standard flags.

Can someone with Mac to confirm that this doesn't break the build, please?