### PR TITLE
Do not probe syzygy when castling is possible

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -111,7 +111,6 @@ public:
   template<PieceType Pt> Square square(Color c) const;
 
   // Castling
-  int can_castle() const;
   int can_castle(Color c) const;
   int can_castle(CastlingRight cr) const;
   bool castling_impeded(CastlingRight cr) const;
@@ -267,10 +266,6 @@ template<PieceType Pt> inline Square Position::square(Color c) const {
 
 inline Square Position::ep_square() const {
   return st->epSquare;
-}
-
-inline int Position::can_castle() const {
-  return st->castlingRights;
 }
 
 inline int Position::can_castle(CastlingRight cr) const {

--- a/src/position.h
+++ b/src/position.h
@@ -111,6 +111,7 @@ public:
   template<PieceType Pt> Square square(Color c) const;
 
   // Castling
+  int can_castle() const;
   int can_castle(Color c) const;
   int can_castle(CastlingRight cr) const;
   bool castling_impeded(CastlingRight cr) const;
@@ -266,6 +267,10 @@ template<PieceType Pt> inline Square Position::square(Color c) const {
 
 inline Square Position::ep_square() const {
   return st->epSquare;
+}
+
+inline int Position::can_castle() const {
+  return st->castlingRights;
 }
 
 inline int Position::can_castle(CastlingRight cr) const {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -258,7 +258,7 @@ void MainThread::search() {
   {
       if (    TB::Cardinality >=  rootPos.count<ALL_PIECES>(WHITE)
                                 + rootPos.count<ALL_PIECES>(BLACK)
-          && !rootPos.can_castle())
+          && !rootPos.can_castle(ANY_CASTLING))
       {
           // If the current root position is in the tablebases, then RootMoves
           // contains only moves that preserve the draw or the win.
@@ -688,7 +688,7 @@ namespace {
         if (    piecesCnt <= TB::Cardinality
             && (piecesCnt <  TB::Cardinality || depth >= TB::ProbeDepth)
             &&  pos.rule50_count() == 0
-            && !pos.can_castle())
+            && !pos.can_castle(ANY_CASTLING))
         {
             int found, v = Tablebases::probe_wdl(pos, &found);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -256,8 +256,9 @@ void MainThread::search() {
   }
   else
   {
-      if (TB::Cardinality >=  rootPos.count<ALL_PIECES>(WHITE)
-                            + rootPos.count<ALL_PIECES>(BLACK))
+      if (    TB::Cardinality >=  rootPos.count<ALL_PIECES>(WHITE)
+                                + rootPos.count<ALL_PIECES>(BLACK)
+          && !rootPos.can_castle())
       {
           // If the current root position is in the tablebases, then RootMoves
           // contains only moves that preserve the draw or the win.
@@ -686,7 +687,8 @@ namespace {
 
         if (    piecesCnt <= TB::Cardinality
             && (piecesCnt <  TB::Cardinality || depth >= TB::ProbeDepth)
-            &&  pos.rule50_count() == 0)
+            &&  pos.rule50_count() == 0
+            && !pos.can_castle())
         {
             int found, v = Tablebases::probe_wdl(pos, &found);
 


### PR DESCRIPTION
- Verified that this resolves issue #230.
- Verified that it's a non-functional change with and without syzygy bases when castling is not possible.
- Verified that it's not a speed regression

---

setoption name SyzygyPath value /data/tb/tables5
position fen 2k5/3P4/8/8/8/8/1r5p/R3K3 b Q - 0 1
go depth 20

master:

info depth 20 seldepth 3 multipv 1 score cp 12352 nodes 15901 nps 45045 tbhits 536 time 353 pv c8d7

syzygy_castling:

info depth 20 seldepth 10 multipv 1 score cp 12350 nodes 10559 nps 621117 tbhits 311 time 17 pv c8d8 e1c1 b2g2 c1b1 g2g1 b1a2 g1d1

---

master bench (no TBs): 8076724
syzygy_castling bench (no TBs): 8076724

---

master bench (5-men TBs): 7571929
syzygy_castling bench (5-men TBs): 7571929

---

master benchmark (5-men TBs):

Time (Mean: 4535.875, Trimmed mean: 4528.5625, Std: 32.0732528501101)
Nodes (Mean: 7571929, Trimmed mean: 7571929, Std: 0)
Speed (Mean: 1669.42292921062, Trimmed mean: 1672.06613657052, Std: 11.7388239676667)

syzygy_castling benchmark (5-men TBs):

Time (Mean: 4518.53125, Trimmed mean: 4515.5, Std: 12.0080198335354)
Nodes (Mean: 7571929, Trimmed mean: 7571929, Std: 0)
Speed (Mean: 1675.76145442115, Trimmed mean: 1676.87535625764, Std: 4.4271360333097)
