### PR TITLE
Rotating symmetric patterns with increasing skipsize

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -352,6 +352,33 @@ void MainThread::search() {
   std::cout << sync_endl;
 }
 
+const int halfDensityMap[][9] =
+{
+    {2, 0, 1},
+    {2, 1, 0},
+
+    {4, 0, 0, 1, 1},
+    {4, 0, 1, 1, 0},
+    {4, 1, 1, 0, 0},
+    {4, 1, 0, 0, 1},
+
+    {6, 0, 0, 0, 1, 1, 1},
+    {6, 0, 0, 1, 1, 1, 0},
+    {6, 0, 1, 1, 1, 0, 0},
+    {6, 1, 1, 1, 0, 0, 0},
+    {6, 1, 1, 0, 0, 0, 1},
+    {6, 1, 0, 0, 0, 1, 1},
+
+    {8, 0, 0, 0, 0, 1, 1, 1, 1},
+    {8, 0, 0, 0, 1, 1, 1, 1, 0},
+    {8, 0, 0, 1, 1, 1, 1, 0 ,0},
+    {8, 0, 1, 1, 1, 1, 0, 0 ,0},
+    {8, 1, 1, 1, 1, 0, 0, 0 ,0},
+    {8, 1, 1, 1, 0, 0, 0, 0 ,1},
+    {8, 1, 1, 0, 0, 0, 0, 1 ,1},
+    {8, 1, 0, 0, 0, 0, 1, 1 ,1},
+};
+
 
 // Thread::search() is the main iterative deepening loop. It calls search()
 // repeatedly with increasing depth until the allocated thinking time has been
@@ -393,27 +420,12 @@ void Thread::search() {
   while (++rootDepth < DEPTH_MAX && !Signals.stop && (!Limits.depth || rootDepth <= Limits.depth))
   {
       // Set up the new depths for the helper threads skipping on average every
-      // 2nd ply (using a half-density map similar to a Hadamard matrix).
+      // 2nd ply (using a half-density matrix).
       if (!mainThread)
       {
-          int d = rootDepth + rootPos.game_ply();
-
-          if (idx <= 6 || idx > 24)
-          {
-              if (((d + idx) >> (msb(idx + 1) - 1)) % 2)
-                  continue;
-          }
-          else
-          {
-              // Table of values of 6 bits with 3 of them set
-              static const int HalfDensityMap[] = {
-                0x07, 0x0b, 0x0d, 0x0e, 0x13, 0x16, 0x19, 0x1a, 0x1c,
-                0x23, 0x25, 0x26, 0x29, 0x2c, 0x31, 0x32, 0x34, 0x38
-              };
-
-              if ((HalfDensityMap[idx - 7] >> (d % 6)) & 1)
-                  continue;
-          }
+          int row = (idx - 1) % 20;
+          if (halfDensityMap[row][(rootDepth + rootPos.game_ply()) % halfDensityMap[row][0] + 1])
+             continue;
       }
 
       // Age out PV variability metric


### PR DESCRIPTION
Preamble: the matrix values until thread-idx 6 (= the ones with pattern length 2 and 4) didn't change because I consider them well-proven (therefore also no tests with threads <=7).

For the block with pattern-length 6 to show that the symmetric patterns work better than the mixed heterogeneous ones was test:
http://tests.stockfishchess.org/tests/view/5673b6390ebc592d552a422c
ELO: 5.30 +-4.1 (95%) LOS: 99.4%   games:  8788 @ 5+0.1 th 13
Total: 8788 W: 1482 L: 1348 D: 5958

The last block with pattern-length 8 (and above with modulo operator) indeed was tested with the following tests:
STC:
http://tests.stockfishchess.org/tests/view/5674f7fd0ebc592d552a427b
LLR: 2.95 (-2.94,2.94) [0.00,5.00] sprt @ 5+0.1 th 21
Total: 7068 W: 1121 L: 975 D: 4972

LTC:

http://tests.stockfishchess.org/tests/view/567a4bb30ebc592d552a43d2
LLR: -0.16 (-2.94,2.94) [0.00,4.00] sprt @ 30+0.3 th 15
Total: 7489 W: 872 L: 862 D: 5755
Aborted.

http://tests.stockfishchess.org/tests/view/567bf2b90ebc592d552a4439
LLR: -0.52 (-2.94,2.94) [0.00,5.00] sprt @ 30+0.3 th 31
Total: 6018 W: 635 L: 639 D: 4744
Aborted.

http://tests.stockfishchess.org/tests/view/5684557d0ebc5966b711a9f8
ELO: 3.47 +-4.2 (95%) LOS: 94.8%    Games: 8000 @ 3+0.03 th 31
Total: 8000 W: 1252 L: 1172 D: 5576

http://tests.stockfishchess.org/tests/view/568796af0ebc59265a4acee6
LLR: 0.37 (-2.94,2.94) [0.00,5.00] sprt @ 15+0.15 th 21
Total: 82846 W: 10555 L: 10278 D: 62013
Aborted.

Finally there was a made a test by Peter on its own initiative outside fishtest:
option.Hash=128 -each proto=uci tc=3+0.03 option.Threads=47
Score of stockfish7 vs stockfish7_iter11: 884 - 985 - 3756 [0.491] 5625
ELO difference: -6 

	
	



	


 