### PR TITLE
Depth margin parameter-tweak in TT#save

### DIFF
--- a/src/tt.h
+++ b/src/tt.h
@@ -50,7 +50,7 @@ struct TTEntry {
 
     // Don't overwrite more valuable entries
     if (  (k >> 48) != key16
-        || d > depth8 - 2
+        || d > depth8 - 4
      /* || g != (genBound8 & 0xFC) // Matching non-zero keys are already refreshed by probe() */
         || b == BOUND_EXACT)
     {


### PR DESCRIPTION
http://tests.stockfishchess.org/tests/view/569695c10ebc594a0871d818
Low hash pressure, hashsize: 128 MB
ELO: 6.25 +-4.6 (95%) LOS: 99.6%  8000 games @ 2+0.1 th 7
Total: 8000 W: 1537 L: 1393 D: 5070

http://tests.stockfishchess.org/tests/view/5697b6a70ebc594a0871d853
Retry with hash pressure, hashsize: 8 MB
ELO: 1.35 +-4.5 (95%) LOS: 72.2% 8000 @ 2+0.1 th 7
Total: 8000 W: 1395 L: 1364 D: 5241
(with increasing hash-pressure the benefit of the patch get mitigated)

http://tests.stockfishchess.org/tests/view/569898c80ebc594a0871d884
Quick check if we benefit also on low number of threads (3). Low hash pressure.
ELO: 5.39 +-4.7 (95%) LOS: 98.8% @ 2+0.1 th 3 	
Total: 8000 W: 1592 L: 1468 D: 4940

LTC:
http://tests.stockfishchess.org/tests/view/569a99190ebc594a0871d8f4
LLR: 2.95 (-2.94,2.94) [0.00,4.00] sprt @ 30+0.3 th 3
Total: 14817 W: 2103 L: 1915 D: 10799    Elo +4,39 

http://tests.stockfishchess.org/tests/view/569a998b0ebc594a0871d8f7
LLR: 2.96 (-2.94,2.94) [0.00,4.00] sprt @ 15+0.15 th 7
Total: 10264 W: 1498 L: 1321 D: 7445      Elo +5,96

http://tests.stockfishchess.org/tests/view/569bbf5b0ebc594a0871d943
LLR: 2.96 (-2.94,2.94) [-4.00,0.00] sprt @ 60+0.6 th 1
Total: 23975 W: 3294 L: 3210 D: 17471

Explanation:
As proved with tests:
http://tests.stockfishchess.org/tests/view/5698ef7e0ebc594a0871d892
http://tests.stockfishchess.org/tests/view/5699fcc20ebc594a0871d8cc
in lazy SMP threads deliver results with different quality, we have:
-main th.with skip-size 0  : best quality
-helpers with skip-size 1  : good quality
-helpers with skip-size 2  : medium quality
-helpers with skip-size 3  : medium-low quality
-helpers with skip-size 4  : low quality

Since the main-thread is usually searching behind the helpers root-depth,
we benefit from generally distrusting a little bit more what it's stored in TT even if it was analyzed with higher depth. 