### PR TITLE
Retire KNNK

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -111,7 +111,6 @@ namespace {
 Endgames::Endgames() {
 
   add<KPK>("KPK");
-  add<KNNK>("KNNK");
   add<KBNK>("KBNK");
   add<KRKP>("KRKP");
   add<KRKB>("KRKB");
@@ -165,6 +164,9 @@ Value Endgame<KXK>::operator()(const Position& pos) const {
       ||(pos.count<BISHOP>(strongSide) > 1 && opposite_colors(pos.squares<BISHOP>(strongSide)[0],
                                                               pos.squares<BISHOP>(strongSide)[1])))
       result = std::min(result + VALUE_KNOWN_WIN, VALUE_MATE_IN_MAX_PLY - 1);
+
+  else
+      result = VALUE_DRAW;
 
   return strongSide == pos.side_to_move() ? result : -result;
 }
@@ -340,10 +342,6 @@ Value Endgame<KQKR>::operator()(const Position& pos) const {
 
   return strongSide == pos.side_to_move() ? result : -result;
 }
-
-
-/// Some cases of trivial draws
-template<> Value Endgame<KNNK>::operator()(const Position&) const { return VALUE_DRAW; }
 
 
 /// KB and one or more pawns vs K. It checks for draws with rook pawns and

--- a/src/endgame.h
+++ b/src/endgame.h
@@ -37,7 +37,6 @@ enum EndgameType {
 
   // Evaluation functions
 
-  KNNK,  // KNN vs K
   KXK,   // Generic "mate lone king" eval
   KBNK,  // KBN vs K
   KPK,   // KP vs K


### PR DESCRIPTION
Useless once you teach KXK to return DRAW_VALUE when X is insufficient to mate.
```
$ position fen knn5/8/8/8/8/8/8/K7 w - - 0 1
$ eval
[...]
Total Evaluation: 0.00 (white side)
```
As a benefic side effect, now KBBK returns a zero score when both bishops are on
the same color:

**new**
```
$ position fen kb1b4/8/8/8/8/8/8/K7 w - - 0 1
$ eval
[...]
Total Evaluation: 0.00 (white side)
```
**master**
```
$ position fen kb1b4/8/8/8/8/8/8/K7 w - - 0 1
[...]
Total Evaluation: -6.91 (white side)
```
bench 8091289