### PR TITLE
simplification

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -531,10 +531,6 @@ void Thread::search() {
       {
           if (!Signals.stop && !Signals.stopOnPonderhit)
           {
-              // Take some extra time if the best move has changed
-              if (rootDepth > 4 * ONE_PLY && multiPV == 1)
-                  Time.pv_instability(mainThread->bestMoveChanges);
-
               // Stop the search if only one legal move is available, or if all
               // of the available time has been used, or if we matched an easyMove
               // from the previous search and just did a fast verification.
@@ -542,13 +538,14 @@ void Thread::search() {
                                  bestValue >= mainThread->previousScore };
 
               int improvingFactor = 640 - 160*F[0] - 126*F[1] - 124*F[0]*F[1];
+              double unstablePvFactor = 1 + mainThread->bestMoveChanges;
 
               bool doEasyMove =   rootMoves[0].pv[0] == easyMove
                                && mainThread->bestMoveChanges < 0.03
-                               && Time.elapsed() > Time.available() * 25 / 206;
+                               && Time.elapsed() > Time.optimum() * 25 / 204;
 
               if (   rootMoves.size() == 1
-                  || Time.elapsed() > Time.available() * improvingFactor / 640
+                  || Time.elapsed() > Time.optimum() * unstablePvFactor * improvingFactor / 634
                   || (mainThread->easyMovePlayed = doEasyMove))
               {
                   // If we are allowed to ponder do not stop the search now but

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -104,7 +104,6 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
   }
 
   startTime = limits.startTime;
-  unstablePvFactor = 1;
   optimumTime = maximumTime = std::max(limits.time[us], minThinkingTime);
 
   const int MaxMTG = limits.movestogo ? std::min(limits.movestogo, MoveHorizon) : MoveHorizon;

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -31,8 +31,7 @@
 class TimeManagement {
 public:
   void init(Search::LimitsType& limits, Color us, int ply);
-  void pv_instability(double bestMoveChanges) { unstablePvFactor = 1 + bestMoveChanges; }
-  int available() const { return int(optimumTime * unstablePvFactor * 1.01); }
+  int optimum() const { return optimumTime; }
   int maximum() const { return maximumTime; }
   int elapsed() const { return int(Search::Limits.npmsec ? Threads.nodes_searched() : now() - startTime); }
 
@@ -42,7 +41,6 @@ private:
   TimePoint startTime;
   int optimumTime;
   int maximumTime;
-  double unstablePvFactor;
 };
 
 extern TimeManagement Time;


### PR DESCRIPTION
Time management simplification. Checked for non-regression both at STC and LTC.

10+0.1:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 41963 W: 7967 L: 7883 D: 26113

60+0.6:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 132314 W: 17939 L: 17969 D: 96406
