### PR TITLE
Remove depth for best thread

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -334,8 +334,7 @@ void MainThread::search() {
       && !Skill(Options["Skill Level"]).enabled())
   {
       for (Thread* th : Threads)
-          if (   th->completedDepth > bestThread->completedDepth
-              && th->rootMoves[0].score > bestThread->rootMoves[0].score)
+          if (th->rootMoves[0].score > bestThread->rootMoves[0].score)
               bestThread = th;
   }
 


### PR DESCRIPTION
STC 3 threads:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 25206 W: 4135 L: 4021 D: 17050
http://tests.stockfishchess.org/tests/view/569f6e340ebc595aa8e28c48 

LTC 7 threads: 
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 40639 W: 5555 L: 5461 D: 29623
http://tests.stockfishchess.org/tests/view/56a313350ebc590247cdf7e8

Resolves #583