### PR TITLE
Remove Weights

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -886,13 +886,13 @@ std::string Eval::trace(const Position& pos) {
 
 void Eval::init() {
 
-  const int MaxSlope = 8700;
-  const int Peak = 1280000;
+  const int MaxSlope = 322;
+  const int Peak = 47410;
   int t = 0;
 
   for (int i = 0; i < 400; ++i)
   {
-      t = std::min(Peak, std::min(i * i * 27, t + MaxSlope));
-      KingDanger[i] = make_score((t / 1000) * 330 / 256, 0);
+      t = std::min(Peak, std::min(i * i - 16, t + MaxSlope));
+      KingDanger[i] = make_score(t * 268 / 7700, 0);
   }
 }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -626,7 +626,7 @@ namespace {
 
         score += make_score(mbonus, ebonus) + PassedFile[file_of(s)];
     }
-    
+
     if (DoTrace)
         Trace::add(PASSED, Us, score);
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -670,7 +670,7 @@ namespace {
     int weight =  pos.count<KNIGHT>(Us) + pos.count<BISHOP>(Us)
                 + pos.count<KNIGHT>(Them) + pos.count<BISHOP>(Them);
 
-    return make_score(bonus * weight * weight, 0);
+    return make_score(bonus * weight * weight * 2 / 11, 0);
   }
 
 
@@ -809,8 +809,8 @@ Value Eval::evaluate(const Position& pos) {
 
   // Evaluate space for both sides, only during opening
   if (pos.non_pawn_material(WHITE) + pos.non_pawn_material(BLACK) >= 12222)
-      score += make_score(mg_value(evaluate_space<WHITE>(pos, ei)
-                                 - evaluate_space<BLACK>(pos, ei)) * 47 / 256, 0);
+      score +=  evaluate_space<WHITE>(pos, ei)
+              - evaluate_space<BLACK>(pos, ei);
 
   // Evaluate position potential for the winning side
   score += evaluate_initiative(pos, ei.pi->pawn_asymmetry(), eg_value(score));
@@ -831,8 +831,8 @@ Value Eval::evaluate(const Position& pos) {
       Trace::add(IMBALANCE, ei.me->imbalance());
       Trace::add(PAWN, ei.pi->pawns_score());
       Trace::add(MOBILITY, mobility[WHITE], mobility[BLACK]);
-      Trace::add(SPACE, make_score(mg_value(evaluate_space<WHITE>(pos, ei)) * 47 / 256, 0)
-                      , make_score(mg_value(evaluate_space<BLACK>(pos, ei)) * 47 / 256, 0));
+      Trace::add(SPACE, evaluate_space<WHITE>(pos, ei)
+                      , evaluate_space<BLACK>(pos, ei));
       Trace::add(TOTAL, score);
   }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -168,14 +168,14 @@ namespace {
   // Passed[mg/eg][Rank] contains midgame and endgame bonuses for passed pawns.
   // We don't use a Score because we process the two components independently.
   const Value Passed[][RANK_NB] = {
-    { V(0), V( 1), V(34), V(90), V(214), V(328) },
-    { V(7), V(14), V(37), V(63), V(134), V(189) }
+    { V(0), V( 1), V(26), V(68), V(161), V(247) },
+    { V(7), V(14), V(38), V(64), V(137), V(193) }
   };
 
   // PassedFile[File] contains a bonus according to the file of a passed pawn
   const Score PassedFile[FILE_NB] = {
-    S( 12, 10), S( 3, 10), S( 1, -8), S(-27,-12),
-    S(-27,-12), S( 1, -8), S( 3, 10), S( 12, 10)
+    S(  9, 10), S( 2, 10), S( 1, -8), S(-20,-12),
+    S(-20,-12), S( 1, -8), S( 2, 10), S( 9, 10)
   };
 
   // Assorted bonuses and penalties used by evaluation
@@ -615,10 +615,10 @@ namespace {
                 else if (defendedSquares & blockSq)
                     k += 4;
 
-                mbonus += k * rr, ebonus += k * rr;
+                mbonus += k * rr * 3 / 4, ebonus += k * rr;
             }
             else if (pos.pieces(Us) & blockSq)
-                mbonus += rr * 3 + r * 2 + 3, ebonus += rr + r * 2;
+                mbonus += (rr * 3 + r * 2 + 3) * 3 / 4, ebonus += rr + r * 2;
         } // rr != 0
 
         if (pos.count<PAWN>(Us) < pos.count<PAWN>(Them))
@@ -626,7 +626,6 @@ namespace {
 
         score += make_score(mbonus, ebonus) + PassedFile[file_of(s)];
     }
-    score = make_score(mg_value(score) * 193 / 256, eg_value(score) * 262 / 256);
     
     if (DoTrace)
         Trace::add(PASSED, Us, score);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -232,7 +232,8 @@ Entry* probe(const Position& pos) {
       return e;
 
   e->key = key;
-  e->score = evaluate<WHITE>(pos, e) - evaluate<BLACK>(pos, e);
+  Score score = evaluate<WHITE>(pos, e) - evaluate<BLACK>(pos, e);
+  e->score = make_score(mg_value(score) * 214 / 256, eg_value(score) * 203 / 256);
   e->asymmetry = popcount<Max15>(e->semiopenFiles[WHITE] ^ e->semiopenFiles[BLACK]);
   return e;
 }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -34,30 +34,30 @@ namespace {
 
   // Isolated pawn penalty by opposed flag and file
   const Score Isolated[2][FILE_NB] = {
-    { S(37, 45), S(54, 52), S(60, 52), S(60, 52),
-      S(60, 52), S(60, 52), S(54, 52), S(37, 45) },
-    { S(25, 30), S(36, 35), S(40, 35), S(40, 35),
-      S(40, 35), S(40, 35), S(36, 35), S(25, 30) } };
+    { S(31, 36), S(45, 41), S(50, 41), S(50, 41),
+      S(50, 41), S(50, 41), S(45, 41), S(31, 36) },
+    { S(21, 24), S(30, 28), S(33, 28), S(33, 28),
+      S(33, 28), S(33, 28), S(30, 28), S(21, 24) } };
 
   // Backward pawn penalty by opposed flag
-  const Score Backward[2] = { S(67, 42), S(49, 24) };
+  const Score Backward[2] = { S(56, 33), S(41, 19) };
 
   // Unsupported pawn penalty for pawns which are neither isolated or backward,
   // by number of pawns it supports [less than 2 / exactly 2].
-  const Score Unsupported[2] = { S(20, 10), S(25, 15) };
+  const Score Unsupported[2] = { S(17, 8), S(21, 12) };
 
   // Connected pawn bonus by opposed, phalanx, twice supported and rank
   Score Connected[2][2][2][RANK_NB];
 
   // Doubled pawn penalty by file
   const Score Doubled[FILE_NB] = {
-    S(13, 43), S(20, 48), S(23, 48), S(23, 48),
-    S(23, 48), S(23, 48), S(20, 48), S(13, 43) };
+    S(11, 34), S(17, 38), S(19, 38), S(19, 38),
+    S(19, 38), S(19, 38), S(17, 38), S(11, 34) };
 
   // Lever bonus by rank
   const Score Lever[RANK_NB] = {
     S( 0,  0), S( 0,  0), S(0, 0), S(0, 0),
-    S(20, 20), S(40, 40), S(0, 0), S(0, 0) };
+    S(17, 16), S(33, 32), S(0, 0), S(0, 0) };
 
   // Weakness of our pawn shelter in front of the king by [distance from edge][rank]
   const Value ShelterWeakness[][RANK_NB] = {
@@ -204,7 +204,7 @@ namespace Pawns {
 
 void init()
 {
-  static const int Seed[RANK_NB] = { 0, 6, 15, 10, 57, 75, 135, 258 };
+  static const int Seed[RANK_NB] = { 0, 8, 19, 13, 71, 94, 169, 324 };
 
   for (int opposed = 0; opposed <= 1; ++opposed)
       for (int phalanx = 0; phalanx <= 1; ++phalanx)
@@ -213,7 +213,7 @@ void init()
   {
       int v = (Seed[r] + (phalanx ? (Seed[r + 1] - Seed[r]) / 2 : 0)) >> opposed;
       v += (apex ? v / 2 : 0);
-      Connected[opposed][phalanx][apex][r] = make_score(3 * v / 2, v);
+      Connected[opposed][phalanx][apex][r] = make_score(v, v * 5 / 8);
   }
 }
 
@@ -232,8 +232,7 @@ Entry* probe(const Position& pos) {
       return e;
 
   e->key = key;
-  Score score = evaluate<WHITE>(pos, e) - evaluate<BLACK>(pos, e);
-  e->score = make_score(mg_value(score) * 214 / 256, eg_value(score) * 203 / 256);
+  e->score = evaluate<WHITE>(pos, e) - evaluate<BLACK>(pos, e);
   e->asymmetry = popcount<Max15>(e->semiopenFiles[WHITE] ^ e->semiopenFiles[BLACK]);
   return e;
 }


### PR DESCRIPTION
Removed remaining redundant weights for pawn structure, passed pawns, space and king safety by redistributing into individual evaluation terms.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 15173 W: 2790 L: 2659 D: 9724

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 43433 W: 5936 L: 5846 D: 31651

Bench: 7156237
