### PR TITLE
Fixed futility pruning bug.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -967,7 +967,7 @@ moves_loop: // When in check search starts from here
               && cmh[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO)
               continue;
 
-          predictedDepth = std::max(newDepth - reduction<PvNode>(improving, depth, moveCount), DEPTH_NONE);
+          predictedDepth = std::max(newDepth - reduction<PvNode>(improving, depth, moveCount), DEPTH_ZERO);
 
           // Futility pruning: parent node
           if (predictedDepth < 7 * ONE_PLY)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -967,7 +967,7 @@ moves_loop: // When in check search starts from here
               && cmh[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO)
               continue;
 
-          predictedDepth = newDepth - reduction<PvNode>(improving, depth, moveCount);
+          predictedDepth = std::max(newDepth - reduction<PvNode>(improving, depth, moveCount), DEPTH_NONE);
 
           // Futility pruning: parent node
           if (predictedDepth < 7 * ONE_PLY)


### PR DESCRIPTION
PredictedDepth can be negative, causing the futility_margin to be negative.
It will be very difficult to tweak moveCount pruning and reduction formula, as they are tuned to prevent this behavior.