### PR TITLE
History Stat Formula Simplification

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -57,8 +57,8 @@ struct Stats {
     if (abs(int(v)) >= 324)
         return;
 
-    table[pc][to] -= table[pc][to] * abs(int(v)) / (CM ? 512 : 324);
-    table[pc][to] += int(v) * (CM ? 64 : 32);
+    table[pc][to] -= table[pc][to] * abs(int(v)) / (CM ? 936 : 324);
+    table[pc][to] += int(v) * 32;
   }
 
 private:


### PR DESCRIPTION
Simplified formula by getting rid of a parameter.

It will now be significantly easier to tweak/tune history stat formula.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 67476 W: 12561 L: 12521 D: 42394

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 111923 W: 15147 L: 15149 D: 81627

Bench:  8430465

