### PR TITLE
Removing slowMover

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -44,9 +44,9 @@ namespace {
 
   double move_importance(int ply) {
 
-    const double XScale = 0.0000007;
+    const double XScale = 0.000000007;
 
-    return exp(-XScale * ply * ply * ply) + DBL_MIN; // Ensure non-zero
+    return exp(-XScale * ply * ply * ply * ply) + DBL_MIN; // Ensure non-zero
   }
 
   template<TimeType T>

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -44,9 +44,9 @@ namespace {
 
   double move_importance(int ply) {
 
-    const double XScale = 0.00004;
+    const double XScale = 0.0000007;
 
-    return exp(-XScale * ply * ply) + DBL_MIN; // Ensure non-zero
+    return exp(-XScale * ply * ply * ply) + DBL_MIN; // Ensure non-zero
   }
 
   template<TimeType T>

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -43,10 +43,10 @@ namespace {
 
   double move_importance(int ply) {
 
-    const double XScale = 7.0e-9;
-    const double XPower = 4.0;
+    const double PlyScale = 109.3265;
+    const double PlyGrowth = 4.0;
 
-    return exp(-XScale * pow(ply, XPower)) + DBL_MIN; // Ensure non-zero
+    return exp(-pow(ply / PlyScale, PlyGrowth)) + DBL_MIN; // Ensure non-zero
   }
 
   template<TimeType T>

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -44,7 +44,7 @@ namespace {
 
   double move_importance(int ply) {
 
-    const double XScale = 0.00003;
+    const double XScale = 0.00004;
 
     return exp(-XScale * ply * ply) + DBL_MIN; // Ensure non-zero
   }

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -44,20 +44,18 @@ namespace {
 
   double move_importance(int ply) {
 
-    const double XScale = 7.64;
-    const double XShift = 58.4;
-    const double Skew   = 0.183;
+    const double XScale = 0.00003;
 
-    return pow((1 + exp((ply - XShift) / XScale)), -Skew) + DBL_MIN; // Ensure non-zero
+    return exp(-XScale * ply * ply) + DBL_MIN; // Ensure non-zero
   }
 
   template<TimeType T>
-  int remaining(int myTime, int movesToGo, int ply, int slowMover)
+  int remaining(int myTime, int movesToGo, int ply)
   {
     const double TMaxRatio   = (T == OptimumTime ? 1 : MaxRatio);
     const double TStealRatio = (T == OptimumTime ? 0 : StealRatio);
 
-    double moveImportance = (move_importance(ply) * slowMover) / 100;
+    double moveImportance = move_importance(ply);
     double otherMovesImportance = 0;
 
     for (int i = 1; i < movesToGo; ++i)
@@ -85,7 +83,6 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
 {
   int minThinkingTime = Options["Minimum Thinking Time"];
   int moveOverhead    = Options["Move Overhead"];
-  int slowMover       = Options["Slow Mover"];
   int npmsec          = Options["nodestime"];
 
   // If we have to play in 'nodes as time' mode, then convert from time
@@ -120,8 +117,8 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
 
       hypMyTime = std::max(hypMyTime, 0);
 
-      int t1 = minThinkingTime + remaining<OptimumTime>(hypMyTime, hypMTG, ply, slowMover);
-      int t2 = minThinkingTime + remaining<MaxTime    >(hypMyTime, hypMTG, ply, slowMover);
+      int t1 = minThinkingTime + remaining<OptimumTime>(hypMyTime, hypMTG, ply);
+      int t2 = minThinkingTime + remaining<MaxTime    >(hypMyTime, hypMTG, ply);
 
       optimumTime = std::min(t1, optimumTime);
       maximumTime = std::min(t2, maximumTime);

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -37,16 +37,16 @@ namespace {
   const double StealRatio = 0.35; // However we must not steal time from remaining moves over this ratio
 
 
-  // move_importance() is a skew-logistic function based on naive statistical
-  // analysis of "how many games are still undecided after n half-moves". Game
-  // is considered "undecided" as long as neither side has >275cp advantage.
-  // Data was extracted from the CCRL game database with some simple filtering criteria.
+  // move_importance() is an exponential function based on naive observation
+  // that a game is closer to be decided after each half-move. This function
+  // should be decreasing and with "nice" convexity properties.
 
   double move_importance(int ply) {
 
-    const double XScale = 0.000000007;
+    const double XScale = 7.0e-9;
+    const double XPower = 4.0;
 
-    return exp(-XScale * ply * ply * ply * ply) + DBL_MIN; // Ensure non-zero
+    return exp(-XScale * pow(ply, XPower)) + DBL_MIN; // Ensure non-zero
   }
 
   template<TimeType T>

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -67,7 +67,6 @@ void init(OptionsMap& o) {
   o["Skill Level"]           << Option(20, 0, 20);
   o["Move Overhead"]         << Option(30, 0, 5000);
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
-  o["Slow Mover"]            << Option(89, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);


### PR DESCRIPTION
This patch removes a slowMover and one paramater from move_importance function.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 77023 W: 14456 L: 14433 D: 48134

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 37175 W: 5190 L: 5092 D: 26893