### PR TITLE
Revert "Remove slowMover"

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -67,6 +67,7 @@ void init(OptionsMap& o) {
   o["Skill Level"]           << Option(20, 0, 20);
   o["Move Overhead"]         << Option(30, 0, 5000);
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
+  o["Slow Mover"]            << Option(89, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);


### PR DESCRIPTION
This reverts commit 77fa960f8923ca83ba0391835d50f4230ac6a345, which regresses at sudden death time control

15sec/game: 
ELO: -3.04 +-3.0 (95%) LOS: 2.3%
Total: 20000 W: 3776 L: 3951 D: 12273

60sec/game:
LLR: -2.95 (-2.94,2.94) [-4.00,0.00]
Total: 12457 W: 1771 L: 1958 D: 8728
