### PR TITLE
Simplify Reduction Formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -183,16 +183,17 @@ void Search::init() {
       for (int d = 1; d < 64; ++d)
           for (int mc = 1; mc < 64; ++mc)
           {
+              bool pv=true;
               double r = log(d) * log(mc) / 2;
               if (r < 0.80)
                 continue;
 
-              Reductions[0][imp][d][mc] = int(std::round(r)) * ONE_PLY;
-              Reductions[1][imp][d][mc] = std::max(Reductions[0][imp][d][mc] - 1, 0) * ONE_PLY;
-
-              // Increase reduction when eval is not improving
-              if (!imp && Reductions[0][imp][d][mc] >= 2 * ONE_PLY)
-                Reductions[0][imp][d][mc] += ONE_PLY;
+              Reductions[!pv][imp][d][mc] = int(std::round(r)) * ONE_PLY;
+              Reductions[pv][imp][d][mc] = std::max(Reductions[!pv][imp][d][mc] - ONE_PLY, DEPTH_ZERO);
+              
+              // Increase reduction for non-pv nodes when eval is not improving
+              if (!imp && Reductions[!pv][imp][d][mc] >= 2 * ONE_PLY)
+                Reductions[!pv][imp][d][mc] += ONE_PLY;
           }
 
   for (int d = 0; d < 16; ++d)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -179,11 +179,12 @@ namespace {
 
 void Search::init() {
 
+  const bool pv=true;
+
   for (int imp = 0; imp <= 1; ++imp)
       for (int d = 1; d < 64; ++d)
           for (int mc = 1; mc < 64; ++mc)
           {
-              bool pv=true;
               double r = log(d) * log(mc) / 2;
               if (r < 0.80)
                 continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -179,22 +179,21 @@ namespace {
 
 void Search::init() {
 
-  const double K[][2] = {{ 0.799, 2.281 }, { 0.484, 3.023 }};
+  for (int imp = 0; imp <= 1; ++imp)
+      for (int d = 1; d < 64; ++d)
+          for (int mc = 1; mc < 64; ++mc)
+          {
+              double r = log(d) * log(mc) / 2;
+              if (r < 0.80)
+                continue;
 
-  for (int pv = 0; pv <= 1; ++pv)
-      for (int imp = 0; imp <= 1; ++imp)
-          for (int d = 1; d < 64; ++d)
-              for (int mc = 1; mc < 64; ++mc)
-              {
-                  double r = K[pv][0] + log(d) * log(mc) / K[pv][1];
+              Reductions[0][imp][d][mc] = int(std::round(r)) * ONE_PLY;
+              Reductions[1][imp][d][mc] = std::max(Reductions[0][imp][d][mc] - 1, 0) * ONE_PLY;
 
-                  if (r >= 1.5)
-                      Reductions[pv][imp][d][mc] = int(r) * ONE_PLY;
-
-                  // Increase reduction when eval is not improving
-                  if (!pv && !imp && Reductions[pv][imp][d][mc] >= 2 * ONE_PLY)
-                      Reductions[pv][imp][d][mc] += ONE_PLY;
-              }
+              // Increase reduction when eval is not improving
+              if (!imp && Reductions[0][imp][d][mc] >= 2 * ONE_PLY)
+                Reductions[0][imp][d][mc] += ONE_PLY;
+          }
 
   for (int d = 0; d < 16; ++d)
   {


### PR DESCRIPTION
Simplify Reduction Formula

Formula now only contains one coefficient.  Making it much easier to tune.
STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 187443 W: 34858 L: 35028 D: 117557

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 88329 W: 11982 L: 11953 D: 64394

Bench:  7521394