### PR TITLE
Also pass endgame value to the evaluate_scale_factor() function.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -695,9 +695,9 @@ namespace {
 
 
   // evaluate_scale_factor() computes the scale factor for the winning side
-  ScaleFactor evaluate_scale_factor(const Position& pos, const EvalInfo& ei, Score score) {
+  ScaleFactor evaluate_scale_factor(const Position& pos, const EvalInfo& ei, Value eg) {
 
-    Color strongSide = eg_value(score) > VALUE_DRAW ? WHITE : BLACK;
+    Color strongSide = eg > VALUE_DRAW ? WHITE : BLACK;
     ScaleFactor sf = ei.me->scale_factor(pos, strongSide);
 
     // If we don't already have an unusual scale factor, check for certain
@@ -720,7 +720,7 @@ namespace {
         }
         // Endings where weaker side can place his king in front of the opponent's
         // pawns are drawish.
-        else if (    abs(eg_value(score)) <= BishopValueEg
+        else if (    abs(eg) <= BishopValueEg
                  &&  ei.pi->pawn_span(strongSide) <= 1
                  && !pos.pawn_passed(~strongSide, pos.square<KING>(~strongSide)))
             sf = ei.pi->pawn_span(strongSide) ? ScaleFactor(51) : ScaleFactor(37);
@@ -816,7 +816,7 @@ Value Eval::evaluate(const Position& pos) {
   score += evaluate_initiative(pos, ei.pi->pawn_asymmetry(), eg_value(score));
 
   // Evaluate scale factor for the winning side
-  ScaleFactor sf = evaluate_scale_factor(pos, ei, score);
+  ScaleFactor sf = evaluate_scale_factor(pos, ei, eg_value(score));
 
   // Interpolate between a middlegame and a (scaled by 'sf') endgame score
   Value v =  mg_value(score) * int(ei.me->game_phase())


### PR DESCRIPTION
Just like we do in the evaluate_initiative() function.

It's also a tiny speedup for me.
Normal builds:
```
Engine                          | Nodes/second
sf5                             | 1664783.0 +- 2188.72
sf1                             | 1660193.0 +- 1360.74

Differences                     | 4264.0 +- 825.0
Variance of the mean            | 165.0 ( 3.87 %)
Speed up                        | 0.26 %
```

PGO builds:
```
Engine                          | Nodes/second
sf5-pgo                         | 1913839.0 +- 2921.1
sf1-pgo                         | 1910370.0 +- 2632.22

Differences                     | 3473.0 +- 831.0
Variance of the mean            | 166.2 ( 4.79 %)
Speed up                        | 0.18 %
```
No functional change.