### PR TITLE
Speedup reduced depth search

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -144,14 +144,14 @@ namespace {
   // KnightOutpost[supported by pawn] contains bonuses for
   // knight outposts, bigger if outpost piece is supported by a pawn.
   const Score KnightOutpost[2] = {
-    { S(42,11), S(63,17) }
+     S(42,11), S(63,17)
   };
-  
+
   // BishopOutpost[supported by pawn] contains bonuses for
   // bishops outposts, bigger if outpost piece is supported by a pawn.
   const Score BishopOutpost[2] = {
-    { S(18, 5), S(27, 8) }
-  }
+     S(18, 5), S(27, 8)
+  };
 
   // Threat[defended/weak][minor/major attacking][attacked PieceType] contains
   // bonuses according to which piece type attacks which one.
@@ -326,7 +326,7 @@ namespace {
                                                                               : TrappedBishopA1H1;
             }
         }
-        
+
         else if (Pt == KNIGHT)
         {
           // Bonus for outpost square

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -141,16 +141,11 @@ namespace {
       S( 94, 99), S( 96,100), S(99,111), S(99,112) }
   };
 
-  // KnightOutpost[supported by pawn] contains bonuses for
-  // knight outposts, bigger if outpost piece is supported by a pawn.
-  const Score KnightOutpost[2] = {
-     S(42,11), S(63,17)
-  };
-
-  // BishopOutpost[supported by pawn] contains bonuses for
+  // Outpost[knight/bishop][supported by pawn] contains bonuses for knights and
   // bishops outposts, bigger if outpost piece is supported by a pawn.
-  const Score BishopOutpost[2] = {
-     S(18, 5), S(27, 8)
+  const Score Outpost[][2] = {
+    { S(42,11), S(63,17) }, // Knights
+    { S(18, 5), S(27, 8) }  // Bishops
   };
 
   // Threat[defended/weak][minor/major attacking][attacked PieceType] contains
@@ -297,13 +292,13 @@ namespace {
 
         mobility[Us] += MobilityBonus[Pt][mob];
 
-        if (Pt == BISHOP)
+        if (Pt == BISHOP || Pt == KNIGHT)
         {
             // Bonus for outpost square
             if (   relative_rank(Us, s) >= RANK_4
                 && relative_rank(Us, s) <= RANK_6
                 && !(pos.pieces(Them, PAWN) & pawn_attack_span(Us, s)))
-                score += BishopOutpost[!!(ei.attackedBy[Us][PAWN] & s)];
+                score += Outpost[Pt == BISHOP][!!(ei.attackedBy[Us][PAWN] & s)];
 
             // Bonus when behind a pawn
             if (    relative_rank(Us, s) < RANK_5
@@ -311,12 +306,14 @@ namespace {
                 score += MinorBehindPawn;
 
             // Penalty for pawns on same color square of bishop
-            score -= BishopPawns * ei.pi->pawns_on_same_color_squares(Us, s);
+            if (Pt == BISHOP)
+                score -= BishopPawns * ei.pi->pawns_on_same_color_squares(Us, s);
 
             // An important Chess960 pattern: A cornered bishop blocked by a friendly
             // pawn diagonally in front of it is a very serious problem, especially
             // when that pawn is also blocked.
-            if (   pos.is_chess960()
+            if (   Pt == BISHOP
+                && pos.is_chess960()
                 && (s == relative_square(Us, SQ_A1) || s == relative_square(Us, SQ_H1)))
             {
                 Square d = pawn_push(Us) + (file_of(s) == FILE_A ? DELTA_E : DELTA_W);
@@ -327,21 +324,7 @@ namespace {
             }
         }
 
-        else if (Pt == KNIGHT)
-        {
-          // Bonus for outpost square
-            if (   relative_rank(Us, s) >= RANK_4
-                && relative_rank(Us, s) <= RANK_6
-                && !(pos.pieces(Them, PAWN) & pawn_attack_span(Us, s)))
-                score += KnightOutpost[!!(ei.attackedBy[Us][PAWN] & s)];
-
-            // Bonus when behind a pawn
-            if (    relative_rank(Us, s) < RANK_5
-                && (pos.pieces(PAWN) & (s + pawn_push(Us))))
-                score += MinorBehindPawn;
-        }
-
-        else if (Pt == ROOK)
+        if (Pt == ROOK)
         {
             // Bonus for aligning with enemy pawns on the same rank/file
             if (relative_rank(Us, s) >= RANK_5)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1010,16 +1010,16 @@ moves_loop: // When in check search starts from here
           && !captureOrPromotion)
       {
           Depth r = reduction<PvNode>(improving, depth, moveCount);
+          Value hValue = thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)];
+          Value cmhValue = cmh[pos.piece_on(to_sq(move))][to_sq(move)];
 
           // Increase reduction for cut nodes and moves with a bad history
           if (   (!PvNode && cutNode)
-              || (   thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)] < VALUE_ZERO
-                  && cmh[pos.piece_on(to_sq(move))][to_sq(move)] <= VALUE_ZERO))
+              || (hValue < VALUE_ZERO && cmhValue <= VALUE_ZERO))
               r += ONE_PLY;
 
           // Decrease/increase reduction for moves with a good/bad history
-          int rHist = (  thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)]
-                       + cmh[pos.piece_on(to_sq(move))][to_sq(move)]) / 14980;
+          int rHist = (hValue + cmhValue) / 14980;
           r = std::max(DEPTH_ZERO, r - rHist * ONE_PLY);
 
           // Decrease reduction for moves that escape a capture. Filter out


### PR DESCRIPTION
Instead of accessing the history and countermovehistory tables twice, we can do this just once. This gives a small but noticeable speedup (0,7 % on my machine) when compiling with MinGW, according to FishBench:

Results for 100 tests for each version:

            Base      Test      Diff      
    Mean    2089989   2103634   -13645    
    StDev   14707     14799     4576      

p-value: 0.999
speedup: 0.007

No functional change.
Bench: 7156237