### PR TITLE
Introduction of followup moves history for move ordering

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -68,8 +68,8 @@ namespace {
 /// ordering is at the current node.
 
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats& h,
-                       const CounterMoveStats& cmh, Move cm, Search::Stack* s)
-           : pos(p), history(h), counterMoveHistory(&cmh), ss(s), countermove(cm), depth(d) {
+                       const CounterMoveStats& cmh, const CounterMoveStats& fmh, Move cm, Search::Stack* s)
+           : pos(p), history(h), counterMoveHistory(&cmh), followupMoveHistory(&fmh), ss(s), countermove(cm), depth(d) {
 
   assert(d > DEPTH_ZERO);
 
@@ -80,7 +80,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats&
 
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d,
                        const HistoryStats& h, Square s)
-           : pos(p), history(h), counterMoveHistory(nullptr) {
+           : pos(p), history(h), counterMoveHistory(nullptr), followupMoveHistory(nullptr) {
 
   assert(d <= DEPTH_ZERO);
 
@@ -105,7 +105,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d,
 }
 
 MovePicker::MovePicker(const Position& p, Move ttm, const HistoryStats& h, Value th)
-           : pos(p), history(h), counterMoveHistory(nullptr), threshold(th) {
+           : pos(p), history(h), counterMoveHistory(nullptr), followupMoveHistory(nullptr), threshold(th) {
 
   assert(!pos.checkers());
 
@@ -142,7 +142,8 @@ void MovePicker::score<QUIETS>() {
 
   for (auto& m : *this)
       m.value =  history[pos.moved_piece(m)][to_sq(m)]
-               + (*counterMoveHistory)[pos.moved_piece(m)][to_sq(m)];
+               + (*counterMoveHistory)[pos.moved_piece(m)][to_sq(m)]
+               + (*followupMoveHistory)[pos.moved_piece(m)][to_sq(m)];
 }
 
 template<>

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -85,7 +85,7 @@ public:
 
   MovePicker(const Position&, Move, Depth, const HistoryStats&, Square);
   MovePicker(const Position&, Move, const HistoryStats&, Value);
-  MovePicker(const Position&, Move, Depth, const HistoryStats&, const CounterMoveStats&, Move, Search::Stack*);
+  MovePicker(const Position&, Move, Depth, const HistoryStats&, const CounterMoveStats&, const CounterMoveStats&, Move, Search::Stack*);
 
   Move next_move();
 
@@ -98,6 +98,7 @@ private:
   const Position& pos;
   const HistoryStats& history;
   const CounterMoveStats* counterMoveHistory;
+  const CounterMoveStats* followupMoveHistory;
   Search::Stack* ss;
   Move countermove;
   Depth depth;


### PR DESCRIPTION
Analog to counter move history collect stats for follow up moves in relation to the last own move and use them for quiet move ordering. Because the CounterMoveHistoryStats array utilize only one half of the entries we can collect followup moves stats there too.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 7955 W: 1538 L: 1378 D: 5039

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 5323 W: 778 L: 642 D: 3903

Bench: 8261839