### PR TITLE
Simplify safe checks

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -427,7 +427,7 @@ namespace {
         b = (b1 | b2) & ei.attackedBy[Them][QUEEN];
         if (b)
         {
-            attackUnits += QueenCheck * popcount<Max15>(b);
+            attackUnits += QueenCheck;
             score -= Checked;
         }
 
@@ -435,7 +435,7 @@ namespace {
         b = b1 & ei.attackedBy[Them][ROOK];
         if (b)
         {
-            attackUnits += RookCheck * popcount<Max15>(b);
+            attackUnits += RookCheck;
             score -= Checked;
         }
 
@@ -443,7 +443,7 @@ namespace {
         b = b2 & ei.attackedBy[Them][BISHOP];
         if (b)
         {
-            attackUnits += BishopCheck * popcount<Max15>(b);
+            attackUnits += BishopCheck;
             score -= Checked;
         }
 
@@ -451,7 +451,7 @@ namespace {
         b = pos.attacks_from<KNIGHT>(ksq) & ei.attackedBy[Them][KNIGHT] & safe;
         if (b)
         {
-            attackUnits += KnightCheck * popcount<Max15>(b);
+            attackUnits += KnightCheck;
             score -= Checked;
         }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -372,9 +372,6 @@ namespace {
   Score evaluate_king(const Position& pos, const EvalInfo& ei) {
 
     const Color Them = (Us == WHITE ? BLACK : WHITE);
-
-    Bitboard undefended, b, b1, b2, safe;
-    int attackUnits;
     const Square ksq = pos.square<KING>(Us);
 
     // King shelter and enemy pawns storm
@@ -385,27 +382,27 @@ namespace {
     {
         // Find the attacked squares around the king which have no defenders
         // apart from the king itself.
-        undefended =  ei.attackedBy[Them][ALL_PIECES]
-                    & ei.attackedBy[Us][KING]
-                    & ~(  ei.attackedBy[Us][PAWN]   | ei.attackedBy[Us][KNIGHT]
-                        | ei.attackedBy[Us][BISHOP] | ei.attackedBy[Us][ROOK]
-                        | ei.attackedBy[Us][QUEEN]);
+        Bitboard undefended =  ei.attackedBy[Them][ALL_PIECES]
+                             & ei.attackedBy[Us][KING]
+                             & ~(  ei.attackedBy[Us][PAWN]   | ei.attackedBy[Us][KNIGHT]
+                                 | ei.attackedBy[Us][BISHOP] | ei.attackedBy[Us][ROOK]
+                                 | ei.attackedBy[Us][QUEEN]);
 
         // Initialize the 'attackUnits' variable, which is used later on as an
         // index into the KingDanger[] array. The initial value is based on the
         // number and types of the enemy's attacking pieces, the number of
         // attacked and undefended squares around our king and the quality of
         // the pawn shelter (current 'score' value).
-        attackUnits =  std::min(72, ei.kingAttackersCount[Them] * ei.kingAttackersWeight[Them])
-                     +  9 * ei.kingAdjacentZoneAttacksCount[Them]
-                     + 27 * popcount<Max15>(undefended)
-                     + 11 * !!ei.pinnedPieces[Us]
-                     - 64 * !pos.count<QUEEN>(Them)
-                     - mg_value(score) / 8;
+        int attackUnits =  std::min(72, ei.kingAttackersCount[Them] * ei.kingAttackersWeight[Them])
+                         +  9 * ei.kingAdjacentZoneAttacksCount[Them]
+                         + 27 * popcount<Max15>(undefended)
+                         + 11 * !!ei.pinnedPieces[Us]
+                         - 64 * !pos.count<QUEEN>(Them)
+                         - mg_value(score) / 8;
 
         // Analyse the enemy's safe queen contact checks. Firstly, find the
         // undefended squares around the king reachable by the enemy queen...
-        b = undefended & ei.attackedBy[Them][QUEEN] & ~pos.pieces(Them);
+        Bitboard b = undefended & ei.attackedBy[Them][QUEEN] & ~pos.pieces(Them);
         if (b)
         {
             // ...and then remove squares not supported by another enemy piece
@@ -418,10 +415,10 @@ namespace {
         }
 
         // Analyse the enemy's safe distance checks for sliders and knights
-        safe = ~(ei.attackedBy[Us][ALL_PIECES] | pos.pieces(Them));
+        Bitboard safe = ~(ei.attackedBy[Us][ALL_PIECES] | pos.pieces(Them));
 
-        b1 = pos.attacks_from<ROOK  >(ksq) & safe;
-        b2 = pos.attacks_from<BISHOP>(ksq) & safe;
+        Bitboard b1 = pos.attacks_from<ROOK  >(ksq) & safe;
+        Bitboard b2 = pos.attacks_from<BISHOP>(ksq) & safe;
 
         // Enemy queen safe checks
         if ((b1 | b2) & ei.attackedBy[Them][QUEEN])

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -372,6 +372,9 @@ namespace {
   Score evaluate_king(const Position& pos, const EvalInfo& ei) {
 
     const Color Them = (Us == WHITE ? BLACK : WHITE);
+
+    Bitboard undefended, b, b1, b2, safe;
+    int attackUnits;
     const Square ksq = pos.square<KING>(Us);
 
     // King shelter and enemy pawns storm
@@ -382,27 +385,27 @@ namespace {
     {
         // Find the attacked squares around the king which have no defenders
         // apart from the king itself.
-        Bitboard undefended =  ei.attackedBy[Them][ALL_PIECES]
-                             & ei.attackedBy[Us][KING]
-                             & ~(  ei.attackedBy[Us][PAWN]   | ei.attackedBy[Us][KNIGHT]
-                                 | ei.attackedBy[Us][BISHOP] | ei.attackedBy[Us][ROOK]
-                                 | ei.attackedBy[Us][QUEEN]);
+        undefended =  ei.attackedBy[Them][ALL_PIECES]
+                    & ei.attackedBy[Us][KING]
+                    & ~(  ei.attackedBy[Us][PAWN]   | ei.attackedBy[Us][KNIGHT]
+                        | ei.attackedBy[Us][BISHOP] | ei.attackedBy[Us][ROOK]
+                        | ei.attackedBy[Us][QUEEN]);
 
         // Initialize the 'attackUnits' variable, which is used later on as an
         // index into the KingDanger[] array. The initial value is based on the
         // number and types of the enemy's attacking pieces, the number of
         // attacked and undefended squares around our king and the quality of
         // the pawn shelter (current 'score' value).
-        int attackUnits =  std::min(72, ei.kingAttackersCount[Them] * ei.kingAttackersWeight[Them])
-                         +  9 * ei.kingAdjacentZoneAttacksCount[Them]
-                         + 27 * popcount<Max15>(undefended)
-                         + 11 * !!ei.pinnedPieces[Us]
-                         - 64 * !pos.count<QUEEN>(Them)
-                         - mg_value(score) / 8;
+        attackUnits =  std::min(72, ei.kingAttackersCount[Them] * ei.kingAttackersWeight[Them])
+                     +  9 * ei.kingAdjacentZoneAttacksCount[Them]
+                     + 27 * popcount<Max15>(undefended)
+                     + 11 * !!ei.pinnedPieces[Us]
+                     - 64 * !pos.count<QUEEN>(Them)
+                     - mg_value(score) / 8;
 
         // Analyse the enemy's safe queen contact checks. Firstly, find the
         // undefended squares around the king reachable by the enemy queen...
-        Bitboard b = undefended & ei.attackedBy[Them][QUEEN] & ~pos.pieces(Them);
+        b = undefended & ei.attackedBy[Them][QUEEN] & ~pos.pieces(Them);
         if (b)
         {
             // ...and then remove squares not supported by another enemy piece
@@ -415,10 +418,10 @@ namespace {
         }
 
         // Analyse the enemy's safe distance checks for sliders and knights
-        Bitboard safe = ~(ei.attackedBy[Us][ALL_PIECES] | pos.pieces(Them));
+        safe = ~(ei.attackedBy[Us][ALL_PIECES] | pos.pieces(Them));
 
-        Bitboard b1 = pos.attacks_from<ROOK  >(ksq) & safe;
-        Bitboard b2 = pos.attacks_from<BISHOP>(ksq) & safe;
+        b1 = pos.attacks_from<ROOK  >(ksq) & safe;
+        b2 = pos.attacks_from<BISHOP>(ksq) & safe;
 
         // Enemy queen safe checks
         if ((b1 | b2) & ei.attackedBy[Them][QUEEN])

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -424,36 +424,20 @@ namespace {
         b2 = pos.attacks_from<BISHOP>(ksq) & safe;
 
         // Enemy queen safe checks
-        b = (b1 | b2) & ei.attackedBy[Them][QUEEN];
-        if (b)
-        {
-            attackUnits += QueenCheck;
-            score -= Checked;
-        }
+        if ((b1 | b2) & ei.attackedBy[Them][QUEEN])
+            attackUnits += QueenCheck, score -= Checked;
 
         // Enemy rooks safe checks
-        b = b1 & ei.attackedBy[Them][ROOK];
-        if (b)
-        {
-            attackUnits += RookCheck;
-            score -= Checked;
-        }
+        if (b1 & ei.attackedBy[Them][ROOK])
+            attackUnits += RookCheck, score -= Checked;
 
         // Enemy bishops safe checks
-        b = b2 & ei.attackedBy[Them][BISHOP];
-        if (b)
-        {
-            attackUnits += BishopCheck;
-            score -= Checked;
-        }
+        if (b2 & ei.attackedBy[Them][BISHOP])
+            attackUnits += BishopCheck, score -= Checked;
 
         // Enemy knights safe checks
-        b = pos.attacks_from<KNIGHT>(ksq) & ei.attackedBy[Them][KNIGHT] & safe;
-        if (b)
-        {
-            attackUnits += KnightCheck;
-            score -= Checked;
-        }
+        if (pos.attacks_from<KNIGHT>(ksq) & ei.attackedBy[Them][KNIGHT] & safe)
+            attackUnits += KnightCheck, score -= Checked;
 
         // Finally, extract the king danger score from the KingDanger[]
         // array and subtract the score from the evaluation.


### PR DESCRIPTION
STC http://tests.stockfishchess.org/tests/view/56e1f7ad0ebc59301a353b25
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 11796 W: 2211 L: 2074 D: 7511

LTC http://tests.stockfishchess.org/tests/view/56e2191e0ebc59301a353b2b
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 14324 W: 1935 L: 1806 D: 10583

based on idea of @jcalovski from
http://tests.stockfishchess.org/tests/view/56e12c3d0ebc59301a353b01

Maybe QueenCheck, RookCheck, BishopCheck, and KnightCheck can now be retuned if anyone has time.