### PR TITLE
Attacked By SpeedUp

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -195,7 +195,7 @@ enum Value : int {
 
 enum PieceType {
   NO_PIECE_TYPE, PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING,
-  ALL_PIECES = 0,
+  ALL_PIECES = 0, ALL_BUT_KQ = 7,
   PIECE_TYPE_NB = 8
 };
 


### PR DESCRIPTION
No functional change
Same bench: 8075202

Reporting a 0.8% speed up on my WIndows 7 running in safe mode.

Results for 10 tests for each version:

Base      Test      Diff
Mean    1334392   1345530   -11138
StDev   18730     16175     2695

p-value: 1
speedup: 0.008

------------------------------------------
And also passed 99.5% confidence test on the excellent build tester
http://software.farseer.org/

This author recommends running tests in safe mode, 
and with bench which last at least 30s
bench 256 1 18 default depth

Build Tester: 1.4.6.0
Windows 7 Service Pack 1 (Version 6.1, Build 7601, 64-bit Edition)
Intel(R) Core(TM) i5-2410M CPU @ 2.30GHz
SafeMode: Yes
Running In VM: No
HyperThreading Enabled: No
CPU Warmup: Yes
Command Line: bench 256 1 18 default depth
Tests per Build: 12

Engine# (NPS)                     Speedup     Sp     Conf. 99.5%  S.S.
2  (1,265,614.1   ) ---> 1  (1,254,707.2   ) --->  0.869%  1,558.0
Yes       No