### PR TITLE
Loose pieces

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -471,10 +471,9 @@ namespace {
     Score score = SCORE_ZERO;
 
     // Small bonus if the opponent has loose pawns or pieces
-    if (    (pos.pieces(Them, PAWN, ROOK) | pos.pieces(Them, KNIGHT, BISHOP))
-    	 & ~ei.attackedBy[Us][ALL_PIECES] 
-    	 & ~ei.attackedBy[Them][ALL_PIECES])
-    	score += LooseEnemies;
+    if (   (pos.pieces(Them) ^ pos.pieces(Them, QUEEN, KING))
+        & ~(ei.attackedBy[Us][ALL_PIECES] | ei.attackedBy[Them][ALL_PIECES]))
+        score += LooseEnemies;
 
     // Non-pawn enemies attacked by a pawn
     weak = (pos.pieces(Them) ^ pos.pieces(Them, PAWN)) & ei.attackedBy[Us][PAWN];

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -185,6 +185,7 @@ namespace {
   const Score TrappedRook         = S(92,  0);
   const Score Checked             = S(20, 20);
   const Score ThreatByHangingPawn = S(70, 63);
+  const Score LooseEnemies        = S( 0, 25);
   const Score Hanging             = S(48, 28);
   const Score ThreatByPawnPush    = S(31, 19);
   const Score Unstoppable         = S( 0, 20);
@@ -468,6 +469,12 @@ namespace {
 
     Bitboard b, weak, defended, safeThreats;
     Score score = SCORE_ZERO;
+    
+    // Loose enemies
+    if (    (pos.pieces(Them, PAWN, ROOK) | pos.pieces(Them, KNIGHT, BISHOP))
+    	 & ~ei.attackedBy[Us][ALL_PIECES] 
+    	 & ~ei.attackedBy[Them][ALL_PIECES])
+    	score += LooseEnemies;
 
     // Non-pawn enemies attacked by a pawn
     weak = (pos.pieces(Them) ^ pos.pieces(Them, PAWN)) & ei.attackedBy[Us][PAWN];

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -469,8 +469,8 @@ namespace {
 
     Bitboard b, weak, defended, safeThreats;
     Score score = SCORE_ZERO;
-    
-    // Loose enemies
+
+    // Small bonus if the opponent has loose pawns or pieces
     if (    (pos.pieces(Them, PAWN, ROOK) | pos.pieces(Them, KNIGHT, BISHOP))
     	 & ~ei.attackedBy[Us][ALL_PIECES] 
     	 & ~ei.attackedBy[Them][ALL_PIECES])


### PR DESCRIPTION
Small endgame bonus if the opponent has loose pawns or pieces.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 30504 W: 5743 L: 5485 D: 19276

LTC:
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 11936 W: 1651 L: 1493 D: 8792

Bench: 8885091