### PR TITLE
Do not use piece lists

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -162,8 +162,8 @@ Value Endgame<KXK>::operator()(const Position& pos) const {
   if (   pos.count<QUEEN>(strongSide)
       || pos.count<ROOK>(strongSide)
       ||(pos.count<BISHOP>(strongSide) && pos.count<KNIGHT>(strongSide))
-      ||(pos.count<BISHOP>(strongSide) > 1 && opposite_colors(pos.squares<BISHOP>(strongSide)[0],
-                                                              pos.squares<BISHOP>(strongSide)[1])))
+      ||(pos.count<BISHOP>(strongSide) > 1 && opposite_colors(lsb(pos.pieces(strongSide, BISHOP)),
+                                                              msb(pos.pieces(strongSide, BISHOP)))))
       result = std::min(result + VALUE_KNOWN_WIN, VALUE_MATE_IN_MAX_PLY - 1);
 
   return strongSide == pos.side_to_move() ? result : -result;
@@ -590,8 +590,8 @@ ScaleFactor Endgame<KRPPKRP>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, RookValueMg, 2));
   assert(verify_material(pos, weakSide,   RookValueMg, 1));
 
-  Square wpsq1 = pos.squares<PAWN>(strongSide)[0];
-  Square wpsq2 = pos.squares<PAWN>(strongSide)[1];
+  Square wpsq1 = lsb(pos.pieces(strongSide, PAWN));
+  Square wpsq2 = msb(pos.pieces(strongSide, PAWN));
   Square bksq = pos.square<KING>(weakSide);
 
   // Does the stronger side have a passed pawn?
@@ -701,8 +701,8 @@ ScaleFactor Endgame<KBPPKB>::operator()(const Position& pos) const {
       return SCALE_FACTOR_NONE;
 
   Square ksq = pos.square<KING>(weakSide);
-  Square psq1 = pos.squares<PAWN>(strongSide)[0];
-  Square psq2 = pos.squares<PAWN>(strongSide)[1];
+  Square psq1 = lsb(pos.pieces(strongSide, PAWN));
+  Square psq2 = msb(pos.pieces(strongSide, PAWN));
   Rank r1 = rank_of(psq1);
   Rank r2 = rank_of(psq2);
   Square blockSq1, blockSq2;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -249,19 +249,18 @@ namespace {
   Score evaluate_pieces(const Position& pos, EvalInfo& ei, Score* mobility,
                         const Bitboard* mobilityArea) {
     Bitboard b, bb;
-    Square s;
     Score score = SCORE_ZERO;
 
     const PieceType NextPt = (Us == WHITE ? Pt : PieceType(Pt + 1));
     const Color Them = (Us == WHITE ? BLACK : WHITE);
     const Bitboard OutpostRanks = (Us == WHITE ? Rank4BB | Rank5BB | Rank6BB
                                                : Rank5BB | Rank4BB | Rank3BB);
-    const Square* pl = pos.squares<Pt>(Us);
-
     ei.attackedBy[Us][Pt] = 0;
 
-    while ((s = *pl++) != SQ_NONE)
+    for (Bitboard pieces = pos.pieces(Us, Pt); pieces; )
     {
+        Square s = pop_lsb(&pieces);
+
         // Find attacked squares, including x-ray attacks for bishops and rooks
         b = Pt == BISHOP ? attacks_bb<BISHOP>(s, pos.pieces() ^ pos.pieces(Us, QUEEN))
           : Pt ==   ROOK ? attacks_bb<  ROOK>(s, pos.pieces() ^ pos.pieces(Us, ROOK, QUEEN))

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -101,10 +101,8 @@ namespace {
     const Square Left  = (Us == WHITE ? DELTA_NW : DELTA_SE);
 
     Bitboard b, neighbours, doubled, supported, phalanx;
-    Square s;
     bool passed, isolated, opposed, backward, lever, connected;
     Score score = SCORE_ZERO;
-    const Square* pl = pos.squares<PAWN>(Us);
     const Bitboard* pawnAttacksBB = StepAttacksBB[make_piece(Us, PAWN)];
 
     Bitboard ourPawns   = pos.pieces(Us  , PAWN);
@@ -118,9 +116,9 @@ namespace {
     e->pawnsOnSquares[Us][WHITE] = pos.count<PAWN>(Us) - e->pawnsOnSquares[Us][BLACK];
 
     // Loop through all pawns of the current color and score each pawn
-    while ((s = *pl++) != SQ_NONE)
+    for (Bitboard pawns = ourPawns; pawns; )
     {
-        assert(pos.piece_on(s) == make_piece(Us, PAWN));
+        Square s = pop_lsb(&pawns);
 
         File f = file_of(s);
 

--- a/src/position.h
+++ b/src/position.h
@@ -261,7 +261,7 @@ template<PieceType Pt> inline const Square* Position::squares(Color c) const {
 
 template<PieceType Pt> inline Square Position::square(Color c) const {
   assert(pieceCount[c][Pt] == 1);
-  return pieceList[c][Pt][0];
+  return lsb(pieces(c, Pt));
 }
 
 inline Square Position::ep_square() const {


### PR DESCRIPTION
Remove all usage of piece lists from Stockfish, except in one single place,
where doing so would be a functional change (movegen.cpp).

This patch is the first out of two steps to remove piece list. The next one will
be to remove piece lists completely (functional change).

No significant impact on bench speed:
- i7-6700, gcc 5.1, linux 4.2
- 20x stockfish bench 16 1 14
```
x86-64-bmi2
              nps    +/-
test    2,621,360  2,914
master  2,619,105  2,279
diff        2,255  2,338
diff%       0.09%  0.09%

x86-32
              nps    +/-
test    2,397,055  2,672
master  2,384,067  3,105
diff       12,988  2,363
diff%       0.54%  0.10%
```
No functional change.