### PR TITLE
Backward simplication

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -139,7 +139,7 @@ namespace {
 
         // A pawn is backward when it is behind all pawns of the same color on the
         // adjacent files and cannot be safely advanced.
-        if (connected || !neighbours || relative_rank(Us, s) >= RANK_5 || lever)
+        if (connected || !neighbours || lever || relative_rank(Us, s) >= RANK_5)
             backward = false;
         else
         {

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -139,7 +139,7 @@ namespace {
 
         // A pawn is backward when it is behind all pawns of the same color on the
         // adjacent files and cannot be safely advanced.
-        if (connected || !neighbours || lever || relative_rank(Us, s) >= RANK_5)
+        if (!neighbours || lever || relative_rank(Us, s) >= RANK_5)
             backward = false;
         else
         {
@@ -150,6 +150,8 @@ namespace {
             // either there is a stopper in the way on this rank, or there is a
             // stopper on adjacent file which controls the way to that rank.
             backward = (b | shift_bb<Up>(b & adjacent_files_bb(f))) & stoppers;
+            
+            assert(!backward || !(pawn_attack_span(Them, s + Up) & neighbours));
         }
 
         // Passed pawns will be properly scored in evaluation because we need

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -100,9 +100,9 @@ namespace {
     const Square Right = (Us == WHITE ? DELTA_NE : DELTA_SW);
     const Square Left  = (Us == WHITE ? DELTA_NW : DELTA_SE);
 
-    Bitboard b, neighbours, doubled, supported, phalanx;
+    Bitboard b, neighbours, stoppers, doubled, supported, phalanx;
     Square s;
-    bool passed, isolated, opposed, backward, lever, connected;
+    bool isolated, opposed, lever, connected, backward;
     Score score = SCORE_ZERO;
     const Square* pl = pos.squares<PAWN>(Us);
     const Bitboard* pawnAttacksBB = StepAttacksBB[make_piece(Us, PAWN)];
@@ -131,7 +131,7 @@ namespace {
         neighbours  =   ourPawns   & adjacent_files_bb(f);
         doubled     =   ourPawns   & forward_bb(Us, s);
         opposed     =   theirPawns & forward_bb(Us, s);
-        passed      = !(theirPawns & passed_pawn_mask(Us, s));
+        stoppers    =   theirPawns & passed_pawn_mask(Us, s);
         lever       =   theirPawns & pawnAttacksBB[s];
         phalanx     =   neighbours & rank_bb(s);
         supported   =   neighbours & rank_bb(s - Up);
@@ -142,7 +142,7 @@ namespace {
         // If the pawn is passed, isolated, lever or connected it cannot be
         // backward. If there are friendly pawns behind on adjacent files
         // or if it is sufficiently advanced, it cannot be backward either.
-        if (   (passed | isolated | lever | connected)
+        if (   (!stoppers | isolated | lever | connected)
             || (ourPawns & pawn_attack_span(Them, s))
             || (relative_rank(Us, s) >= RANK_5))
             backward = false;
@@ -151,21 +151,21 @@ namespace {
             // We now know there are no friendly pawns beside or behind this
             // pawn on adjacent files. We now check whether the pawn is
             // backward by looking in the forward direction on the adjacent
-            // files, and picking the closest pawn there.
-            b = pawn_attack_span(Us, s) & (ourPawns | theirPawns);
-            b = pawn_attack_span(Us, s) & rank_bb(backmost_sq(Us, b));
+            // files and the front file, and picking the closest pawn there.
+            b = rank_bb(backmost_sq(Us, neighbours | stoppers));
 
             // If we have an enemy pawn in the same or next rank, the pawn is
-            // backward because it cannot advance without being captured.
-            backward = (b | shift_bb<Up>(b)) & theirPawns;
+            // backward because it is opposed or it can be captured before 
+            // making a phalanx with closest neighbour.
+            backward = (b | shift_bb<Up>(b & adjacent_files_bb(f))) & stoppers;
         }
 
-        assert(opposed | passed | (pawn_attack_span(Us, s) & theirPawns));
+        assert(opposed | !stoppers | (pawn_attack_span(Us, s) & theirPawns));
 
         // Passed pawns will be properly scored in evaluation because we need
         // full attack info to evaluate them. Only the frontmost passed
         // pawn on each file is considered a true passed pawn.
-        if (passed && !doubled)
+        if (!(stoppers | doubled))
             e->passedPawns[Us] |= s;
 
         // Score this pawn

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -128,18 +128,18 @@ namespace {
         e->pawnAttacksSpan[Us] |= pawn_attack_span(Us, s);
 
         // Flag the pawn
-        opposed     =   theirPawns & forward_bb(Us, s);
-        stoppers    =   theirPawns & passed_pawn_mask(Us, s);
-        lever       =   theirPawns & pawnAttacksBB[s];
+        opposed    = theirPawns & forward_bb(Us, s);
+        stoppers   = theirPawns & passed_pawn_mask(Us, s);
+        lever      = theirPawns & pawnAttacksBB[s];
         doubled    = ourPawns   & forward_bb(Us, s);
         neighbours = ourPawns   & adjacent_files_bb(f);
-        phalanx     =   neighbours & rank_bb(s);
-        supported   =   neighbours & rank_bb(s - Up);
-        connected   =   supported | phalanx;
+        phalanx    = neighbours & rank_bb(s);
+        supported  = neighbours & rank_bb(s - Up);
+        connected  = supported | phalanx;
 
-        // A pawn is backward when is behind all pawns of the same color on the
+        // A pawn is backward when it is behind all pawns of the same color on the
         // adjacent files and cannot be safely advanced.
-        if (!neighbours || lever || connected || relative_rank(Us, s) >= RANK_5)
+        if (connected || !neighbours || relative_rank(Us, s) >= RANK_5 || lever)
             backward = false;
         else
         {
@@ -148,7 +148,7 @@ namespace {
 
             // The pawn is backward when it cannot safely progress to that rank:
             // either there is a stopper in the way on this rank, or there is a
-            // stopper on adjacent file which control the way to that rank.
+            // stopper on adjacent file which controls the way to that rank.
             backward = (b | shift_bb<Up>(b & adjacent_files_bb(f))) & stoppers;
         }
 
@@ -166,7 +166,7 @@ namespace {
             score -= Backward[opposed];
 
         else if (!supported)
-            score -= Unsupported[more_than_one(neighbours & rank_bb(s + Up))];
+            score -= Unsupported[more_than_one(neighbours & pawnAttacksBB[s])];
 
         if (connected)
             score += Connected[opposed][!!phalanx][more_than_one(supported)][relative_rank(Us, s)];

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -139,24 +139,16 @@ namespace {
         isolated    =  !neighbours;
 
         // Test for backward pawn.
-        // If the pawn is passed, isolated, lever or connected it cannot be
-        // backward. If there are friendly pawns behind on adjacent files
-        // or if it is sufficiently advanced, it cannot be backward either.
-        if (   (!stoppers | isolated | lever | connected)
-            || (ourPawns & pawn_attack_span(Them, s))
-            || (relative_rank(Us, s) >= RANK_5))
+        if ( (isolated | lever | connected) || (relative_rank(Us, s) >= RANK_5))
             backward = false;
         else
         {
-            // We now know there are no friendly pawns beside or behind this
-            // pawn on adjacent files. We now check whether the pawn is
-            // backward by looking in the forward direction on the adjacent
-            // files and the front file, and picking the closest pawn there.
+            // Find the backmost rank with neighbours or stoppers
             b = rank_bb(backmost_sq(Us, neighbours | stoppers));
 
-            // If we have an enemy pawn in the same or next rank, the pawn is
-            // backward because it is opposed or it can be captured before 
-            // making a phalanx with closest neighbour.
+            // The pawn is backward when it cannot safely progress to that rank:
+            // either there is a stopper in the way on this rank,
+            // or there is a stopper on adjacent file which control the way to that rank
             backward = (b | shift_bb<Up>(b & adjacent_files_bb(f))) & stoppers;
         }
 


### PR DESCRIPTION
Rewrite of Stefan Geschwentner idea for a more natural backward definition which led to a small simplification to the master code.

On top of the usual conditions 
a) some opponent in front (but no lever)
b) some neighbours (in front) (but no neighbour behind or same rank)
c) < rank_5

to find out if a pawn is backward we look at the squares in front of this pawn to reach the same rank as the next neighbour.

In current master, a pawn is backward if any of those squares is controlled by an enemy pawn on an adjacent file

In this version, a pawn is ALSO backward if any of those squares is occupied by an enemy pawn.

STC: 
http://tests.stockfishchess.org/tests/view/56fe7efd0ebc59301a3541f1
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 19051 W: 3557 L: 3433 D: 12061

LTC:
http://tests.stockfishchess.org/tests/view/56febc2d0ebc59301a354209 
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 40810 W: 5619 L: 5526 D: 29665
