### PR TITLE
Optimize code in LMR search

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -144,14 +144,14 @@ namespace {
   // KnightOutpost[supported by pawn] contains bonuses for
   // knight outposts, bigger if outpost piece is supported by a pawn.
   const Score KnightOutpost[2] = {
-    { S(42,11), S(63,17) }
+     S(42,11), S(63,17)
   };
-  
+
   // BishopOutpost[supported by pawn] contains bonuses for
   // bishops outposts, bigger if outpost piece is supported by a pawn.
   const Score BishopOutpost[2] = {
-    { S(18, 5), S(27, 8) }
-  }
+     S(18, 5), S(27, 8)
+  };
 
   // Threat[defended/weak][minor/major attacking][attacked PieceType] contains
   // bonuses according to which piece type attacks which one.
@@ -326,7 +326,7 @@ namespace {
                                                                               : TrappedBishopA1H1;
             }
         }
-        
+
         else if (Pt == KNIGHT)
         {
           // Bonus for outpost square

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -141,16 +141,11 @@ namespace {
       S( 94, 99), S( 96,100), S(99,111), S(99,112) }
   };
 
-  // KnightOutpost[supported by pawn] contains bonuses for
-  // knight outposts, bigger if outpost piece is supported by a pawn.
-  const Score KnightOutpost[2] = {
-     S(42,11), S(63,17)
-  };
-
-  // BishopOutpost[supported by pawn] contains bonuses for
+  // Outpost[knight/bishop][supported by pawn] contains bonuses for knights and
   // bishops outposts, bigger if outpost piece is supported by a pawn.
-  const Score BishopOutpost[2] = {
-     S(18, 5), S(27, 8)
+  const Score Outpost[][2] = {
+    { S(42,11), S(63,17) }, // Knights
+    { S(18, 5), S(27, 8) }  // Bishops
   };
 
   // Threat[defended/weak][minor/major attacking][attacked PieceType] contains
@@ -297,13 +292,13 @@ namespace {
 
         mobility[Us] += MobilityBonus[Pt][mob];
 
-        if (Pt == BISHOP)
+        if (Pt == BISHOP || Pt == KNIGHT)
         {
             // Bonus for outpost square
             if (   relative_rank(Us, s) >= RANK_4
                 && relative_rank(Us, s) <= RANK_6
                 && !(pos.pieces(Them, PAWN) & pawn_attack_span(Us, s)))
-                score += BishopOutpost[!!(ei.attackedBy[Us][PAWN] & s)];
+                score += Outpost[Pt == BISHOP][!!(ei.attackedBy[Us][PAWN] & s)];
 
             // Bonus when behind a pawn
             if (    relative_rank(Us, s) < RANK_5
@@ -311,12 +306,14 @@ namespace {
                 score += MinorBehindPawn;
 
             // Penalty for pawns on same color square of bishop
-            score -= BishopPawns * ei.pi->pawns_on_same_color_squares(Us, s);
+            if (Pt == BISHOP)
+                score -= BishopPawns * ei.pi->pawns_on_same_color_squares(Us, s);
 
             // An important Chess960 pattern: A cornered bishop blocked by a friendly
             // pawn diagonally in front of it is a very serious problem, especially
             // when that pawn is also blocked.
-            if (   pos.is_chess960()
+            if (   Pt == BISHOP
+                && pos.is_chess960()
                 && (s == relative_square(Us, SQ_A1) || s == relative_square(Us, SQ_H1)))
             {
                 Square d = pawn_push(Us) + (file_of(s) == FILE_A ? DELTA_E : DELTA_W);
@@ -327,21 +324,7 @@ namespace {
             }
         }
 
-        else if (Pt == KNIGHT)
-        {
-          // Bonus for outpost square
-            if (   relative_rank(Us, s) >= RANK_4
-                && relative_rank(Us, s) <= RANK_6
-                && !(pos.pieces(Them, PAWN) & pawn_attack_span(Us, s)))
-                score += KnightOutpost[!!(ei.attackedBy[Us][PAWN] & s)];
-
-            // Bonus when behind a pawn
-            if (    relative_rank(Us, s) < RANK_5
-                && (pos.pieces(PAWN) & (s + pawn_push(Us))))
-                score += MinorBehindPawn;
-        }
-
-        else if (Pt == ROOK)
+        if (Pt == ROOK)
         {
             // Bonus for aligning with enemy pawns on the same rank/file
             if (relative_rank(Us, s) >= RANK_5)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1011,8 +1011,10 @@ moves_loop: // When in check search starts from here
           && !captureOrPromotion)
       {
           Depth r = reduction<PvNode>(improving, depth, moveCount);
-          Value hValue = thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)];
-          Value cmhValue = cmh[pos.piece_on(to_sq(move))][to_sq(move)];
+          Square toSq = to_sq(move);
+          Piece toPc = pos.piece_on(toSq);
+          Value hValue = thisThread->history[toPc][toSq];
+          Value cmhValue = cmh[toPc][toSq];
 
           // Increase reduction for cut nodes and moves with a bad history
           if (   (!PvNode && cutNode)
@@ -1029,8 +1031,8 @@ moves_loop: // When in check search starts from here
           // because the destination square is empty.
           if (   r
               && type_of(move) == NORMAL
-              && type_of(pos.piece_on(to_sq(move))) != PAWN
-              && pos.see(make_move(to_sq(move), from_sq(move))) < VALUE_ZERO)
+              && type_of(toPc) != PAWN
+              && pos.see(make_move(toSq, from_sq(move))) < VALUE_ZERO)
               r = std::max(DEPTH_ZERO, r - ONE_PLY);
 
           Depth d = std::max(newDepth - r, ONE_PLY);


### PR DESCRIPTION
The code in LMR search can be optimized. Besides making the code more readable, it also prevents unnecessary calls to the to_sq and pos.piece_on functions. On my machine this results in a speedup of about 0.9%:

Results for 25 tests for each version:

            Base      Test      Diff      
    Mean    2178541   2198456   -19915    
    StDev   16711     16621     2639      

p-value: 1
speedup: 0.009

No functional change.


