### PR TITLE
Speed-up lsb on 32-bit

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -259,11 +259,16 @@ inline Bitboard attacks_bb(Piece pc, Square s, Bitboard occupied) {
 
 /// lsb() and msb() return the least/most significant bit in a non-zero bitboard
 
-#if defined(__GNUC__)
+#ifdef __GNUC__
 
 inline Square lsb(Bitboard b) {
   assert(b);
+#  ifdef IS_64BIT
   return Square(__builtin_ctzll(b));
+#  else
+  uint32_t low = uint32_t(b), high = uint32_t(b >> 32);
+  return Square(low ? __builtin_ctz(low) : 32 + __builtin_ctz(high));
+#  endif
 }
 
 inline Square msb(Bitboard b) {


### PR DESCRIPTION
It seems that db4b0d8b regresses on 32-bit, because GCC produces some poor
32-bit code for `__builtin_ctzll()`.

So we simply use 2 x ctz (32-bit), instead of ctzll (64-bit).

Unfortunately, I cannot do 32-bit compiles to speed this, so I had to use
fishtest. This is not an ideal measure, because we get a random blend of 32 and
64 bit workers.

However, despite 32 bit workers being in minority, the patch passed with flying
colors, which implies a very significant speedup on 32-bit.

SPRT(0,4) in 4+0.04 (fast tc to increase sensitivity of the measure):
```
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 9066 W: 2015 L: 1818 D: 5233
```

No functional change.