### PR TITLE
Undefended King Ring 

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -383,13 +383,17 @@ namespace {
     // Main king safety evaluation
     if (ei.kingAttackersCount[Them])
     {
-        // apart from the king itself...
+        // Find the attacked squares which are defended only by the king...
         undefended =  ei.attackedBy[Them][ALL_PIECES]
                     & ei.attackedBy[Us][KING]
                     & ~(  ei.attackedBy[Us][PAWN]   | ei.attackedBy[Us][KNIGHT]
                         | ei.attackedBy[Us][BISHOP] | ei.attackedBy[Us][ROOK]
                         | ei.attackedBy[Us][QUEEN]);
 
+        // ... and those which are not defended at all in the larger king ring
+        // (excluding our pieces, since we already score the hanging bonus elsewhere)
+        b =   ei.attackedBy[Them][ALL_PIECES] & ~ei.attackedBy[Us][ALL_PIECES] 
+            & ei.kingRing[Us] & ~pos.pieces(Us);
 
         // Initialize the 'attackUnits' variable, which is used later on as an
         // index into the KingDanger[] array. The initial value is based on the

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -391,9 +391,8 @@ namespace {
                         | ei.attackedBy[Us][QUEEN]);
 
         // ... and those which are not defended at all in the larger king ring
-        // (excluding our pieces, since we already score the hanging bonus elsewhere)
         b =   ei.attackedBy[Them][ALL_PIECES] & ~ei.attackedBy[Us][ALL_PIECES] 
-            & ei.kingRing[Us] & ~pos.pieces(Us);
+            & ei.kingRing[Us] & ~pos.pieces(Them);
 
         // Initialize the 'attackUnits' variable, which is used later on as an
         // index into the KingDanger[] array. The initial value is based on the

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -383,7 +383,6 @@ namespace {
     // Main king safety evaluation
     if (ei.kingAttackersCount[Them])
     {
-        // Find the attacked squares around the king which have no defenders
         // apart from the king itself...
         undefended =  ei.attackedBy[Them][ALL_PIECES]
                     & ei.attackedBy[Us][KING]
@@ -391,8 +390,6 @@ namespace {
                         | ei.attackedBy[Us][BISHOP] | ei.attackedBy[Us][ROOK]
                         | ei.attackedBy[Us][QUEEN]);
 
-        // and those which are not defended at all in the larger kingring 
-        b = ei.attackedBy[Them][ALL_PIECES] & ~ei.attackedBy[Us][ALL_PIECES] & ei.kingRing[Us];
 
         // Initialize the 'attackUnits' variable, which is used later on as an
         // index into the KingDanger[] array. The initial value is based on the

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -384,12 +384,15 @@ namespace {
     if (ei.kingAttackersCount[Them])
     {
         // Find the attacked squares around the king which have no defenders
-        // apart from the king itself.
+        // apart from the king itself...
         undefended =  ei.attackedBy[Them][ALL_PIECES]
                     & ei.attackedBy[Us][KING]
                     & ~(  ei.attackedBy[Us][PAWN]   | ei.attackedBy[Us][KNIGHT]
                         | ei.attackedBy[Us][BISHOP] | ei.attackedBy[Us][ROOK]
                         | ei.attackedBy[Us][QUEEN]);
+
+        // and those which are not defended at all in the larger kingring 
+        b = ei.attackedBy[Them][ALL_PIECES] & ~ei.attackedBy[Us][ALL_PIECES] & ei.kingRing[Us];
 
         // Initialize the 'attackUnits' variable, which is used later on as an
         // index into the KingDanger[] array. The initial value is based on the
@@ -399,7 +402,7 @@ namespace {
         attackUnits =  std::min(72, ei.kingAttackersCount[Them] * ei.kingAttackersWeight[Them])
                      +  9 * ei.kingAdjacentZoneAttacksCount[Them]
                      + 27 * popcount<Max15>(undefended)
-                     + 11 * !!ei.pinnedPieces[Us]
+                     + 11 * (popcount<Max15>(b) + !!ei.pinnedPieces[Us])
                      - 64 * !pos.count<QUEEN>(Them)
                      - mg_value(score) / 8;
 


### PR DESCRIPTION
There was already a penalty for squares only defended by King (undefended)

This test records a penalty for completely undefended squares in the so called extended king-ring
(so if we exclude squares defended by a Kg8 for example, we only look at h6 g6 and f6)

Was yellow at STC
http://tests.stockfishchess.org/tests/view/56f6a5170ebc59301a35407e
LLR: -2.97 (-2.94,2.94) [0.00,5.00]
Total: 112499 W: 20649 L: 20293 D: 71557

and passed LTC
http://tests.stockfishchess.org/tests/view/57019f280ebc59301a3542ab
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 36805 W: 5100 L: 4857 D: 26848

We also exclude squares occupied by opponent pieces in this computation,
based on the following results
no piece exclusion
http://tests.stockfishchess.org/tests/view/56f4819f0ebc59301a354006
excluding our pieces
http://tests.stockfishchess.org/tests/view/56f5ef210ebc59301a35405b
excluding all pieces
http://tests.stockfishchess.org/tests/view/56f533330ebc59301a35402c