### PR TITLE
Makefile fix

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -145,7 +145,7 @@ endif
 ifeq ($(COMP),gcc)
 	comp=gcc
 	CXX=g++
-	CXXFLAGS += -pedantic -Wextra -Wshadow
+	CXXFLAGS += -pedantic -Wextra -Wshadow -m$(bits)
 	ifneq ($(UNAME),Darwin)
 	   LDFLAGS += -Wl,--no-as-needed
 	endif
@@ -185,7 +185,7 @@ endif
 ifeq ($(COMP),clang)
 	comp=clang
 	CXX=clang++
-	CXXFLAGS += -pedantic -Wextra -Wshadow
+	CXXFLAGS += -pedantic -Wextra -Wshadow -m$(bits)
 	ifeq ($(UNAME),Darwin)
 		CXXFLAGS += -stdlib=libc++
 		DEPENDFLAGS += -stdlib=libc++

--- a/src/Makefile
+++ b/src/Makefile
@@ -186,6 +186,7 @@ ifeq ($(COMP),clang)
 	comp=clang
 	CXX=clang++
 	CXXFLAGS += -pedantic -Wextra -Wshadow -m$(bits)
+	LDFLAGS += -m$(bits)
 	ifeq ($(UNAME),Darwin)
 		CXXFLAGS += -stdlib=libc++
 		DEPENDFLAGS += -stdlib=libc++


### PR DESCRIPTION
Counter intuitively, `ARCH=x86-32` does NOT produce a 32-bit compile when running
on a 64-bit OS. Nor would `ARCH=x86-64` produce a 64-bit compile when running a
32-bit OS (assuming it would compile w/o errors with IS_64BIT defined, which is another
story).

No functional change.