### PR TITLE
Hide global visibility when not needed

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -78,7 +78,7 @@ namespace {
 
   // popcount16() counts the non-zero bits using SWAR-Popcount algorithm
 
-  uint8_t popcount16(uint16_t u) {
+  unsigned popcount16(unsigned u) {
     u -= (u >> 1) & 0x5555U;
     u = ((u >> 2) & 0x3333U) + (u & 0x3333U);
     u = ((u >> 4) + u) & 0x0F0FU;
@@ -152,7 +152,7 @@ const std::string Bitboards::pretty(Bitboard b) {
 void Bitboards::init() {
 
   for (unsigned i = 0; i < (1 << 16); ++i)
-      PopCnt16[i] = popcount16(i);
+      PopCnt16[i] = (uint8_t) popcount16(i);
 
   for (Square s = SQ_A1; s <= SQ_H8; ++s)
   {

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -61,16 +61,6 @@ const Bitboard Rank8BB = Rank1BB << (8 * 7);
 
 extern int SquareDistance[SQUARE_NB][SQUARE_NB];
 
-extern Bitboard  RookMasks  [SQUARE_NB];
-extern Bitboard  RookMagics [SQUARE_NB];
-extern Bitboard* RookAttacks[SQUARE_NB];
-extern unsigned  RookShifts [SQUARE_NB];
-
-extern Bitboard  BishopMasks  [SQUARE_NB];
-extern Bitboard  BishopMagics [SQUARE_NB];
-extern Bitboard* BishopAttacks[SQUARE_NB];
-extern unsigned  BishopShifts [SQUARE_NB];
-
 extern Bitboard SquareBB[SQUARE_NB];
 extern Bitboard FileBB[FILE_NB];
 extern Bitboard RankBB[RANK_NB];
@@ -225,6 +215,13 @@ template<> inline int distance<Rank>(Square x, Square y) { return distance(rank_
 template<PieceType Pt>
 inline unsigned magic_index(Square s, Bitboard occupied) {
 
+  extern Bitboard RookMasks[SQUARE_NB];
+  extern Bitboard RookMagics[SQUARE_NB];
+  extern unsigned RookShifts[SQUARE_NB];
+  extern Bitboard BishopMasks[SQUARE_NB];
+  extern Bitboard BishopMagics[SQUARE_NB];
+  extern unsigned BishopShifts[SQUARE_NB];
+
   Bitboard* const Masks  = Pt == ROOK ? RookMasks  : BishopMasks;
   Bitboard* const Magics = Pt == ROOK ? RookMagics : BishopMagics;
   unsigned* const Shifts = Pt == ROOK ? RookShifts : BishopShifts;
@@ -242,6 +239,10 @@ inline unsigned magic_index(Square s, Bitboard occupied) {
 
 template<PieceType Pt>
 inline Bitboard attacks_bb(Square s, Bitboard occupied) {
+
+  extern Bitboard* RookAttacks[SQUARE_NB];
+  extern Bitboard* BishopAttacks[SQUARE_NB];
+
   return (Pt == ROOK ? RookAttacks : BishopAttacks)[s][magic_index<Pt>(s, occupied)];
 }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -392,8 +392,8 @@ namespace {
                         | ei.attackedBy[Us][QUEEN]);
 
         // ... and those which are not defended at all in the larger king ring
-        b =   ei.attackedBy[Them][ALL_PIECES] & ~ei.attackedBy[Us][ALL_PIECES] 
-            & ei.kingRing[Us] & ~pos.pieces(Them);
+        b =  ei.attackedBy[Them][ALL_PIECES] & ~ei.attackedBy[Us][ALL_PIECES]
+           & ei.kingRing[Us] & ~pos.pieces(Them);
 
         // Initialize the 'attackUnits' variable, which is used later on as an
         // index into the KingDanger[] array. The initial value is based on the

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -34,10 +34,6 @@
 
 using std::string;
 
-Value PieceValue[PHASE_NB][PIECE_NB] = {
-{ VALUE_ZERO, PawnValueMg, KnightValueMg, BishopValueMg, RookValueMg, QueenValueMg },
-{ VALUE_ZERO, PawnValueEg, KnightValueEg, BishopValueEg, RookValueEg, QueenValueEg } };
-
 namespace Zobrist {
 
   Key psq[COLOR_NB][PIECE_TYPE_NB][SQUARE_NB];

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -18,7 +18,13 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
+
 #include "types.h"
+
+Value PieceValue[PHASE_NB][PIECE_NB] = {
+{ VALUE_ZERO, PawnValueMg, KnightValueMg, BishopValueMg, RookValueMg, QueenValueMg },
+{ VALUE_ZERO, PawnValueEg, KnightValueEg, BishopValueEg, RookValueEg, QueenValueEg } };
 
 namespace PSQT {
 
@@ -96,7 +102,7 @@ const Score Bonus[][RANK_NB][int(FILE_NB) / 2] = {
 
 Score psq[COLOR_NB][PIECE_TYPE_NB][SQUARE_NB];
 
-// init() initializes piece square tables: the white halves of the tables are
+// init() initializes piece-square tables: the white halves of the tables are
 // copied from Bonus[] adding the piece value, then the black halves of the
 // tables are initialized by flipping and changing the sign of the white scores.
 void init() {
@@ -110,8 +116,9 @@ void init() {
 
       for (Square s = SQ_A1; s <= SQ_H8; ++s)
       {
-          int edgeDistance = file_of(s) < FILE_E ? file_of(s) : FILE_H - file_of(s);
-          psq[BLACK][pt][~s] = -(psq[WHITE][pt][s] = v + Bonus[pt][rank_of(s)][edgeDistance]);
+          File f = std::min(file_of(s), FILE_H - file_of(s));
+          psq[WHITE][pt][ s] = v + Bonus[pt][rank_of(s)][f];
+          psq[BLACK][pt][~s] = -psq[WHITE][pt][s];
       }
   }
 }


### PR DESCRIPTION
Also move PieceValue definition in psqt.cpp,
where it is initialized.

Fix a warning in popcount16() with Intel compiler

No functional change.