### PR TITLE
Calculate CheckInfo once per position

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -99,6 +99,24 @@ CheckInfo::CheckInfo(const Position& pos) {
   checkSquares[KING]   = 0;
 }
 
+CheckInfo::CheckInfo() {
+  checkSquares[KING]   = 1;
+}
+
+void CheckInfo::setState(CheckInfo ci) {
+    ksq = ci.ksq;
+    pinned = ci.pinned;
+    dcCandidates = ci.dcCandidates;
+
+    checkSquares[PAWN]   = ci.checkSquares[PAWN];
+    checkSquares[KNIGHT] = ci.checkSquares[KNIGHT];
+    checkSquares[BISHOP] = ci.checkSquares[BISHOP];
+    checkSquares[ROOK]   = ci.checkSquares[ROOK];
+    checkSquares[QUEEN]  = ci.checkSquares[QUEEN];
+    checkSquares[KING]   = 0;
+}
+
+
 
 /// operator<<(Position) returns an ASCII representation of the position
 

--- a/src/position.h
+++ b/src/position.h
@@ -44,6 +44,9 @@ namespace PSQT {
 struct CheckInfo {
 
   explicit CheckInfo(const Position&);
+  explicit CheckInfo();
+
+  void setState(CheckInfo ci);
 
   Bitboard dcCandidates;
   Bitboard pinned;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -617,6 +617,7 @@ namespace {
     bool ttHit, inCheck, givesCheck, singularExtensionNode, improving;
     bool captureOrPromotion, doFullDepthSearch;
     int moveCount, quietCount;
+    CheckInfo ci;
 
     // Step 1. Initialize node
     Thread* thisThread = pos.this_thread();
@@ -837,8 +838,8 @@ namespace {
         assert((ss-1)->currentMove != MOVE_NULL);
 
         MovePicker mp(pos, ttMove, thisThread->history, PieceValue[MG][pos.captured_piece_type()]);
-        CheckInfo ci(pos);
-
+        CheckInfo cip(pos);
+        ci.setState(cip);
         while ((move = mp.next_move()) != MOVE_NONE)
             if (pos.legal(move, ci.pinned))
             {
@@ -874,7 +875,10 @@ moves_loop: // When in check search starts from here
     const CounterMoveStats& fmh = CounterMoveHistory[pos.piece_on(ownPrevSq)][ownPrevSq];
 
     MovePicker mp(pos, ttMove, depth, thisThread->history, cmh, fmh, cm, ss);
-    CheckInfo ci(pos);
+    if (ci.checkSquares[KING]) {
+      CheckInfo cit(pos);
+      ci.setState(cit);
+    }
     value = bestValue; // Workaround a bogus 'uninitialized' warning under gcc
     improving =   ss->staticEval >= (ss-2)->staticEval
                || ss->staticEval == VALUE_NONE


### PR DESCRIPTION
CheckInfo construction is rather expensive and often we do it twice to no purpose:
one time for probcut and another time for the normal move-loop.
With this patch I try to make it once. The implementation is quite ugly (sorry for that).
I just created this pullrequest to show that there's a possible speedup.
The speedup I measured is following:

Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    2049763   2061147   -11384    
    StDev   8910      9743      2840      

p-value: 1
speedup: 0,006

bench 7482426 (Hide global visibility when not needed )