### PR TITLE
Do not output position number to cerr in bench

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -149,7 +149,7 @@ void benchmark(const Position& current, istream& is) {
   {
       Position pos(fens[i], Options["UCI_Chess960"], Threads.main());
 
-      cerr << "\nPosition: " << i + 1 << '/' << fens.size() << endl;
+      cout << "\nPosition: " << i + 1 << '/' << fens.size() << endl;
 
       if (limitType == "perft")
           nodes += Search::perft(pos, limits.depth * ONE_PLY);
@@ -168,7 +168,7 @@ void benchmark(const Position& current, istream& is) {
 
   dbg_print(); // Just before exiting
 
-  cerr << "\n==========================="
+  cerr << "==========================="
        << "\nTotal time (ms) : " << elapsed
        << "\nNodes searched  : " << nodes
        << "\nNodes/second    : " << 1000 * nodes / elapsed << endl;


### PR DESCRIPTION
This is necessary for syzygy unit test, and also easier for normal benching.

Usual bench:
Bench is to verify correctness (node count), but also performance, and this is
where it is critical to reduce stdout spamming, to avoid measuring noise.
```
$ ./stockfish bench 1>/dev/null
=> final result only: no spamming.
```
Syzygy unit test:
Same thing, but it cannot be run directly from the command line, as SyzygyPath
must be loaded, before bench can run with a specific input file (syzygy.epd).
```
$ ./stockfish 1>/dev/null
$ setoption name SyzygyPath value [...]
$ bench 16 1 10 [...]/syzygy.epd
=> final result only: no spamming.
```
No functional change.