### PR TITLE
5.5% Speedup.  Early Return for move generation.

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -317,6 +317,9 @@ ExtMove* generate(const Position& pos, ExtMove* moveList) {
                    : Type == QUIETS       ? ~pos.pieces()
                    : Type == NON_EVASIONS ? ~pos.pieces(us) : 0;
 
+  if (!target)
+      return moveList;
+
   return us == WHITE ? generate_all<WHITE, Type>(pos, moveList, target)
                      : generate_all<BLACK, Type>(pos, moveList, target);
 }


### PR DESCRIPTION
Results for 10 tests for each version:

            Base      Test      Diff      
    Mean    2186238   2307344   -121106   
    StDev   119640    88442     139449    

p-value: 0.807
speedup: 0.055