### PR TITLE
Implementing fmh2 (follow up move2) and adding CMS pointer to the Search::Stack

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -68,10 +68,8 @@ namespace {
 /// ordering is at the current node.
 
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats& h,
-                       const CounterMoveStats& cmh, const CounterMoveStats& fmh,
                        Move cm, Search::Stack* s)
-           : pos(p), history(h), counterMoveHistory(&cmh),
-             followupMoveHistory(&fmh), ss(s), countermove(cm), depth(d) {
+           : pos(p), history(h),  ss(s), countermove(cm), depth(d) {
 
   assert(d > DEPTH_ZERO);
 
@@ -142,10 +140,14 @@ void MovePicker::score<CAPTURES>() {
 template<>
 void MovePicker::score<QUIETS>() {
 
+  const CounterMoveStats* cmh  = (ss-1)->cms;
+  const CounterMoveStats* fmh  = (ss-2)->cms;
+  const CounterMoveStats* fmh2 = (ss-4)->cms;
   for (auto& m : *this)
       m.value =  history[pos.moved_piece(m)][to_sq(m)]
-               + (*counterMoveHistory )[pos.moved_piece(m)][to_sq(m)]
-               + (*followupMoveHistory)[pos.moved_piece(m)][to_sq(m)];
+               + (cmh  ? (*cmh )[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
+               + (fmh  ? (*fmh )[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
+               + (fmh2 ? (*fmh2)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO);
 }
 
 template<>

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -67,20 +67,21 @@ namespace {
 /// search captures, promotions, and some checks) and how important good move
 /// ordering is at the current node.
 
-MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const HistoryStats& h,
-                       Move cm, Search::Stack* s)
-           : pos(p), history(h),  ss(s), countermove(cm), depth(d) {
+MovePicker::MovePicker(const Position& p, Move ttm, Depth d, Search::Stack* s)
+           : pos(p), ss(s), depth(d) {
 
   assert(d > DEPTH_ZERO);
+
+  Square prevSq = to_sq((ss-1)->currentMove);
+  countermove = pos.this_thread()->counterMoves[pos.piece_on(prevSq)][prevSq];
 
   stage = pos.checkers() ? EVASION : MAIN_SEARCH;
   ttMove = ttm && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE;
   endMoves += (ttMove != MOVE_NONE);
 }
 
-MovePicker::MovePicker(const Position& p, Move ttm, Depth d,
-                       const HistoryStats& h, Square s)
-           : pos(p), history(h) {
+MovePicker::MovePicker(const Position& p, Move ttm, Depth d, Square s)
+           : pos(p) {
 
   assert(d <= DEPTH_ZERO);
 
@@ -104,8 +105,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d,
   endMoves += (ttMove != MOVE_NONE);
 }
 
-MovePicker::MovePicker(const Position& p, Move ttm, const HistoryStats& h, Value th)
-           : pos(p), history(h), threshold(th) {
+MovePicker::MovePicker(const Position& p, Move ttm, Value th)
+           : pos(p), threshold(th) {
 
   assert(!pos.checkers());
 
@@ -140,14 +141,17 @@ void MovePicker::score<CAPTURES>() {
 template<>
 void MovePicker::score<QUIETS>() {
 
-  const CounterMoveStats* cmh  = (ss-1)->cms;
-  const CounterMoveStats* fmh  = (ss-2)->cms;
-  const CounterMoveStats* fmh2 = (ss-4)->cms;
+  const HistoryStats& history = pos.this_thread()->history;
+
+  const CounterMoveStats* cm = (ss-1)->counterMoves;
+  const CounterMoveStats* fm = (ss-2)->counterMoves;
+  const CounterMoveStats* f2 = (ss-4)->counterMoves;
+
   for (auto& m : *this)
-      m.value =  history[pos.moved_piece(m)][to_sq(m)]
-               + (cmh  ? (*cmh )[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
-               + (fmh  ? (*fmh )[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
-               + (fmh2 ? (*fmh2)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO);
+      m.value =      history[pos.moved_piece(m)][to_sq(m)]
+               + (cm ? (*cm)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
+               + (fm ? (*fm)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
+               + (f2 ? (*f2)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO);
 }
 
 template<>
@@ -155,6 +159,7 @@ void MovePicker::score<EVASIONS>() {
   // Try winning and equal captures ordered by MVV/LVA, then non-captures ordered
   // by history value, then bad captures and quiet moves with a negative SEE ordered
   // by SEE value.
+  const HistoryStats& history = pos.this_thread()->history;
   Value see;
 
   for (auto& m : *this)

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -81,8 +81,7 @@ public:
 
   MovePicker(const Position&, Move, const HistoryStats&, Value);
   MovePicker(const Position&, Move, Depth, const HistoryStats&, Square);
-  MovePicker(const Position&, Move, Depth, const HistoryStats&,
-             const CounterMoveStats&, const CounterMoveStats&, Move, Search::Stack*);
+  MovePicker(const Position&, Move, Depth, const HistoryStats&, Move, Search::Stack*);
 
   Move next_move();
 
@@ -94,8 +93,6 @@ private:
 
   const Position& pos;
   const HistoryStats& history;
-  const CounterMoveStats* counterMoveHistory;
-  const CounterMoveStats* followupMoveHistory;
   Search::Stack* ss;
   Move countermove;
   Depth depth;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -79,9 +79,9 @@ public:
   MovePicker(const MovePicker&) = delete;
   MovePicker& operator=(const MovePicker&) = delete;
 
-  MovePicker(const Position&, Move, const HistoryStats&, Value);
-  MovePicker(const Position&, Move, Depth, const HistoryStats&, Square);
-  MovePicker(const Position&, Move, Depth, const HistoryStats&, Move, Search::Stack*);
+  MovePicker(const Position&, Move, Value);
+  MovePicker(const Position&, Move, Depth, Square);
+  MovePicker(const Position&, Move, Depth, Search::Stack*);
 
   Move next_move();
 
@@ -92,8 +92,7 @@ private:
   ExtMove* end() { return endMoves; }
 
   const Position& pos;
-  const HistoryStats& history;
-  Search::Stack* ss;
+  const Search::Stack* ss;
   Move countermove;
   Depth depth;
   Move ttMove;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -665,7 +665,7 @@ namespace {
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
     ss->currentMove = (ss+1)->excludedMove = bestMove = MOVE_NONE;
-    ss->cms = nullptr;
+    ss->counterMoves = nullptr;
     (ss+1)->skipEarlyPruning = false;
     (ss+2)->killers[0] = (ss+2)->killers[1] = MOVE_NONE;
 
@@ -789,7 +789,7 @@ namespace {
         &&  pos.non_pawn_material(pos.side_to_move()))
     {
         ss->currentMove = MOVE_NULL;
-        ss->cms = nullptr;
+        ss->counterMoves = nullptr;
 
         assert(eval - beta >= 0);
 
@@ -838,14 +838,14 @@ namespace {
         assert((ss-1)->currentMove != MOVE_NONE);
         assert((ss-1)->currentMove != MOVE_NULL);
 
-        MovePicker mp(pos, ttMove, thisThread->history, PieceValue[MG][pos.captured_piece_type()]);
+        MovePicker mp(pos, ttMove, PieceValue[MG][pos.captured_piece_type()]);
         CheckInfo ci(pos);
 
         while ((move = mp.next_move()) != MOVE_NONE)
             if (pos.legal(move, ci.pinned))
             {
                 ss->currentMove = move;
-                ss->cms = &CounterMoveHistory[pos.moved_piece(move)][to_sq(move)];
+                ss->counterMoves = &CounterMoveHistory[pos.moved_piece(move)][to_sq(move)];
                 pos.do_move(move, st, pos.gives_check(move, ci));
                 value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, rdepth, !cutNode);
                 pos.undo_move(move);
@@ -871,10 +871,9 @@ namespace {
 moves_loop: // When in check search starts from here
 
     Square prevSq = to_sq((ss-1)->currentMove);
-    Move cm = thisThread->counterMoves[pos.piece_on(prevSq)][prevSq];
-    const CounterMoveStats * cmh = &CounterMoveHistory[pos.piece_on(prevSq)][prevSq];
+    const CounterMoveStats& cmh = CounterMoveHistory[pos.piece_on(prevSq)][prevSq];
 
-    MovePicker mp(pos, ttMove, depth, thisThread->history, cm, ss);
+    MovePicker mp(pos, ttMove, depth, ss);
     CheckInfo ci(pos);
     value = bestValue; // Workaround a bogus 'uninitialized' warning under gcc
     improving =   ss->staticEval >= (ss-2)->staticEval
@@ -968,8 +967,7 @@ moves_loop: // When in check search starts from here
           if (   depth <= 4 * ONE_PLY
               && move != ss->killers[0]
               && thisThread->history[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO
-              && cmh
-              && (*cmh)[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO)
+              && cmh[pos.moved_piece(move)][to_sq(move)] < VALUE_ZERO)
               continue;
 
           predictedDepth = std::max(newDepth - reduction<PvNode>(improving, depth, moveCount), DEPTH_ZERO);
@@ -1002,7 +1000,7 @@ moves_loop: // When in check search starts from here
       }
 
       ss->currentMove = move;
-      ss->cms = &CounterMoveHistory[pos.moved_piece(move)][to_sq(move)];
+      ss->counterMoves = &CounterMoveHistory[pos.moved_piece(move)][to_sq(move)];
 
       // Step 14. Make the move
       pos.do_move(move, st, givesCheck);
@@ -1015,7 +1013,7 @@ moves_loop: // When in check search starts from here
       {
           Depth r = reduction<PvNode>(improving, depth, moveCount);
           Value hValue = thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)];
-          Value cmhValue = cmh ? (*cmh)[pos.piece_on(to_sq(move))][to_sq(move)] : VALUE_ZERO;
+          Value cmhValue = cmh[pos.piece_on(to_sq(move))][to_sq(move)];
 
           // Increase reduction for cut nodes and moves with a bad history
           if (   (!PvNode && cutNode)
@@ -1164,17 +1162,17 @@ moves_loop: // When in check search starts from here
              && !bestMove
              && !inCheck
              && !pos.captured_piece_type()
-             && is_ok((ss - 1)->currentMove))
+             && is_ok((ss-1)->currentMove))
     {
         Value bonus = Value((depth / ONE_PLY) * (depth / ONE_PLY) + depth / ONE_PLY - 1);
-        if ((ss-2)->cms) // prevCmh
-            (ss-2)->cms->update(pos.piece_on(prevSq), prevSq, bonus);
+        if ((ss-2)->counterMoves)
+            (ss-2)->counterMoves->update(pos.piece_on(prevSq), prevSq, bonus);
 
-        if ((ss-3)->cms) // prevFmh
-            (ss-3)->cms->update(pos.piece_on(prevSq), prevSq, bonus);
+        if ((ss-3)->counterMoves)
+            (ss-3)->counterMoves->update(pos.piece_on(prevSq), prevSq, bonus);
 
-        if ((ss-5)->cms) // prevFmh2
-            (ss-5)->cms->update(pos.piece_on(prevSq), prevSq, bonus);
+        if ((ss-5)->counterMoves)
+            (ss-5)->counterMoves->update(pos.piece_on(prevSq), prevSq, bonus);
     }
 
     tte->save(posKey, value_to_tt(bestValue, ss->ply),
@@ -1295,7 +1293,7 @@ moves_loop: // When in check search starts from here
     // to search the moves. Because the depth is <= 0 here, only captures,
     // queen promotions and checks (only if depth >= DEPTH_QS_CHECKS) will
     // be generated.
-    MovePicker mp(pos, ttMove, depth, pos.this_thread()->history, to_sq((ss-1)->currentMove));
+    MovePicker mp(pos, ttMove, depth, to_sq((ss-1)->currentMove));
     CheckInfo ci(pos);
 
     // Loop through the moves until no moves remain or a beta cutoff occurs
@@ -1449,9 +1447,9 @@ moves_loop: // When in check search starts from here
     Value bonus = Value((depth / ONE_PLY) * (depth / ONE_PLY) + depth / ONE_PLY - 1);
 
     Square prevSq = to_sq((ss-1)->currentMove);
-    CounterMoveStats * cmh  = (ss-1)->cms;
-    CounterMoveStats * fmh  = (ss-2)->cms;
-    CounterMoveStats * fmh2 = (ss-4)->cms;
+    CounterMoveStats* cmh  = (ss-1)->counterMoves;
+    CounterMoveStats* fmh  = (ss-2)->counterMoves;
+    CounterMoveStats* fmh2 = (ss-4)->counterMoves;
     Thread* thisThread = pos.this_thread();
 
     thisThread->history.update(pos.moved_piece(move), to_sq(move), bonus);
@@ -1484,17 +1482,16 @@ moves_loop: // When in check search starts from here
     }
 
     // Extra penalty for a quiet TT move in previous ply when it gets refuted
-    if (   (ss-1)->moveCount == 1
-        && !pos.captured_piece_type())
+    if ((ss-1)->moveCount == 1 && !pos.captured_piece_type())
     {
-        if ((ss-2)->cms) // prevCmh
-            (ss-2)->cms->update(pos.piece_on(prevSq), prevSq, -bonus - 2 * (depth + 1) / ONE_PLY);
+        if ((ss-2)->counterMoves)
+            (ss-2)->counterMoves->update(pos.piece_on(prevSq), prevSq, -bonus - 2 * (depth + 1) / ONE_PLY);
 
-        if ((ss-3)->cms) // prevFmh
-            (ss-3)->cms->update(pos.piece_on(prevSq), prevSq, -bonus - 2 * (depth + 1) / ONE_PLY);
+        if ((ss-3)->counterMoves)
+            (ss-3)->counterMoves->update(pos.piece_on(prevSq), prevSq, -bonus - 2 * (depth + 1) / ONE_PLY);
 
-        if ((ss-5)->cms) // prevFmh2
-            (ss-5)->cms->update(pos.piece_on(prevSq), prevSq, -bonus - 2 * (depth + 1) / ONE_PLY);
+        if ((ss-5)->counterMoves)
+            (ss-5)->counterMoves->update(pos.piece_on(prevSq), prevSq, -bonus - 2 * (depth + 1) / ONE_PLY);
     }
   }
 

--- a/src/search.h
+++ b/src/search.h
@@ -30,6 +30,10 @@
 #include "position.h"
 #include "types.h"
 
+template<typename T, bool CM>
+struct Stats;
+typedef Stats<Value,  true> CounterMoveStats;
+
 namespace Search {
 
 /// Stack struct keeps track of the information we need to remember from nodes
@@ -45,6 +49,7 @@ struct Stack {
   Value staticEval;
   bool skipEarlyPruning;
   int moveCount;
+  CounterMoveStats * cms;
 };
 
 /// RootMove struct is used for moves at the root of the tree. For each root move

--- a/src/search.h
+++ b/src/search.h
@@ -30,9 +30,8 @@
 #include "position.h"
 #include "types.h"
 
-template<typename T, bool CM>
-struct Stats;
-typedef Stats<Value,  true> CounterMoveStats;
+template<typename T, bool CM> struct Stats;
+typedef Stats<Value, true> CounterMoveStats;
 
 namespace Search {
 
@@ -49,7 +48,7 @@ struct Stack {
   Value staticEval;
   bool skipEarlyPruning;
   int moveCount;
-  CounterMoveStats * cms;
+  CounterMoveStats* counterMoves;
 };
 
 /// RootMove struct is used for moves at the root of the tree. For each root move


### PR DESCRIPTION
There are two main points for this patch:
a) Keeping a pointer to the CounterMoveStats (CMS) history on the Search::Stack: 
     The reason is that we loose information of the moved piece from previous move, and
      trying to guess it from the current position cause problems (e.g. captures, castle, promotion,
      multiple move by the same piece, etc)
b) Adding  a variation of @locutus2 idea to incorporate a second level followup move (fmh2).


STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 6438 W: 1229 L: 1077 D: 4132

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 4000 W: 605 L: 473 D: 2922

bench: 7378965
