### PR TITLE
Avoid encode/decode madness in init_tb

### DIFF
--- a/src/syzygy/tbcore.cpp
+++ b/src/syzygy/tbcore.cpp
@@ -97,7 +97,7 @@ static char* map_file(const std::string& fname, uint64_t* mapping)
                               MAP_SHARED, fd, 0);
 
     if (data == (char *)(-1)) {
-        std::cerr << "Could not mmap() " << name << '\n';
+        std::cerr << "Could not mmap() " << fname << '\n';
         exit(1);
     }
 
@@ -172,15 +172,12 @@ static void init_tb(const std::vector<PieceType>& pieces)
     uint8_t pcs[PIECE_NB] = {0};
     int num = 0;
 
-    for (PieceType pt : pieces)
-    {
-        if (pt == KING)
-        {
+    for (PieceType pt : pieces) {
+        if (pt == KING) {
             c = ~c;
             if (!fname.empty())
                 fname += 'v';
         }
-
         pcs[make_piece(c, pt)]++;
         num++;
         fname += pchr[pt];

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -67,16 +67,14 @@ static uint64_t calc_key(Position& pos, bool mirror)
 // defined by pcs[16], where pcs[1], ..., pcs[6] is the number of white
 // pawns, ..., kings and pcs[9], ..., pcs[14] is the number of black
 // pawns, ..., kings.
-static uint64_t calc_key_from_pcs(int *pcs, bool mirror)
+static uint64_t calc_key_from_pcs(uint8_t* pcs, bool mirror)
 {
     uint64_t key = 0;
 
-    for (int i = 0; i < 2; i++) {
+    for (Color c = WHITE; c <= BLACK; ++c)
         for (PieceType pt = PAWN; pt <= KING; ++pt)
-            for (int j = 0; j < pcs[8 * (i ^ mirror) + pt]; j++)
-                key ^= Zobrist::psq[i][pt][j];
-    }
-
+            for (int cnt = 0; cnt < pcs[8 * (c ^ mirror) + pt]; ++cnt)
+                key ^= Zobrist::psq[c][pt][cnt];
     return key;
 }
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -54,12 +54,10 @@ static uint64_t calc_key(Position& pos, bool mirror)
 {
     uint64_t key = 0;
 
-    for (int i = 0; i < 2; i++) {
+    for (Color c = WHITE; c <= BLACK; ++c)
         for (PieceType pt = PAWN; pt <= KING; ++pt)
-            for (int j = popcount(pos.pieces(Color(i ^ mirror), pt)); j > 0; j--)
-                key ^= Zobrist::psq[i][pt][j - 1];
-    }
-
+            for (int j = popcount(pos.pieces(Color(c ^ mirror), pt)); j > 0; j--)
+                key ^= Zobrist::psq[c][pt][j - 1];
     return key;
 }
 


### PR DESCRIPTION
We encode pieces in a string passed to init_tb() that
just decodes the exactly same string to get the pieces back!

Sanitize this madness.


