### PR TITLE
Reduce tt looping

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -76,18 +76,17 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   TTEntry* const tte = first_entry(key);
   const uint16_t key16 = key >> 48;  // Use the high 16 bits as key inside the cluster
 
+  // Find an entry to be replaced according to the replacement strategy
+  TTEntry* replace = tte;
   for (int i = 0; i < ClusterSize; ++i)
-      if (!tte[i].key16 || tte[i].key16 == key16)
+  {
+	  if (!tte[i].key16 || tte[i].key16 == key16)
       {
           if ((tte[i].genBound8 & 0xFC) != generation8 && tte[i].key16)
               tte[i].genBound8 = uint8_t(generation8 | tte[i].bound()); // Refresh
 
           return found = (bool)tte[i].key16, &tte[i];
       }
-
-  // Find an entry to be replaced according to the replacement strategy
-  TTEntry* replace = tte;
-  for (int i = 1; i < ClusterSize; ++i)
       // Due to our packed storage format for generation and its cyclic
       // nature we add 259 (256 is the modulus plus 3 to keep the lowest
       // two bound bits from affecting the result) to calculate the entry
@@ -95,6 +94,7 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
       if (  replace->depth8 - ((259 + generation8 - replace->genBound8) & 0xFC) * 2 * ONE_PLY
           >   tte[i].depth8 - ((259 + generation8 -   tte[i].genBound8) & 0xFC) * 2 * ONE_PLY)
           replace = &tte[i];
+  }
 
   return found = false, replace;
 }


### PR DESCRIPTION
Consolidate tt probe work into a single loop.

Results for 50 tests for each version:

            Base      Test      Diff      
    Mean    1737887   1745378   -7491     
    StDev   17466     17606     2638      

p-value: 0.998

No functional change.

Resolves #642 