### PR TITLE
Probcut speedup

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -821,6 +821,7 @@ namespace {
     // safely prune the previous move.
     if (   !PvNode
         &&  depth >= 5 * ONE_PLY
+        &&  pos.captured_piece_type() != QUEEN
         &&  abs(beta) < VALUE_MATE_IN_MAX_PLY)
     {
         Value rbeta = std::min(beta + 200, VALUE_INFINITE);


### PR DESCRIPTION
Avoid probcut if last captured piece is a queen because the condition SEE > queen value in movepicker can't be true so never a cutoff is triggered. Gives a small speedup. 

No functional change.