### PR TITLE
Use FMHs to assist with LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1006,6 +1006,11 @@ moves_loop: // When in check search starts from here
           Depth r = reduction<PvNode>(improving, depth, moveCount);
           Value hValue = thisThread->history[pos.piece_on(to_sq(move))][to_sq(move)];
           Value cmhValue = cmh[pos.piece_on(to_sq(move))][to_sq(move)];
+          
+          const CounterMoveStats* fm = (ss - 2)->counterMoves;
+          const CounterMoveStats* fm2 = (ss - 4)->counterMoves;
+          Value fmValue = (fm ? (*fm)[pos.piece_on(to_sq(move))][to_sq(move)] : VALUE_ZERO);
+          Value fm2Value = (fm2 ? (*fm2)[pos.piece_on(to_sq(move))][to_sq(move)] : VALUE_ZERO);
 
           // Increase reduction for cut nodes and moves with a bad history
           if (   (!PvNode && cutNode)
@@ -1013,7 +1018,7 @@ moves_loop: // When in check search starts from here
               r += ONE_PLY;
 
           // Decrease/increase reduction for moves with a good/bad history
-          int rHist = (hValue + cmhValue) / 14980;
+          int rHist = (hValue + cmhValue + fmValue + fm2Value) / 20000;
           r = std::max(DEPTH_ZERO, r - rHist * ONE_PLY);
 
           // Decrease reduction for moves that escape a capture. Filter out


### PR DESCRIPTION
Use FMHs to assist with LMR formula.

STC:
LLR: 2.99 (-2.94,2.94) [0.00,5.00]
Total: 52232 W: 9654 L: 9304 D: 33274

LTC:
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 115988 W: 15550 L: 15049 D: 85389

Bench:  7890808

Link for hidden LTC results
http://tests.stockfishchess.org/tests/view/5714d0f40ebc59301a35466b