### PR TITLE
Icc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -231,18 +231,19 @@ ifneq ($(comp),mingw)
 	endif
 endif
 
-### 3.4 Debugging
+### 3.2 Debugging
 ifeq ($(debug),no)
 	CXXFLAGS += -DNDEBUG
 else
 	CXXFLAGS += -g
 endif
 
-### 3.5 Optimization
+### 3.3 Optimization
 ifeq ($(optimize),yes)
 
+	CXXFLAGS += -O3
+
 	ifeq ($(comp),gcc)
-		CXXFLAGS += -O3
 
 		ifeq ($(UNAME),Darwin)
 			ifeq ($(arch),i386)
@@ -258,21 +259,11 @@ ifeq ($(optimize),yes)
 		endif
 	endif
 
-	ifeq ($(comp),mingw)
-		CXXFLAGS += -O3
-	endif
-
 	ifeq ($(comp),icc)
-		ifeq ($(UNAME),Darwin)
-			CXXFLAGS += -fast -mdynamic-no-pic
-		else
-			CXXFLAGS += -fast
-		endif
+		CXXFLAGS += -mdynamic-no-pic
 	endif
 
 	ifeq ($(comp),clang)
-		CXXFLAGS += -O3
-
 		ifeq ($(UNAME),Darwin)
 			ifeq ($(pext),no)
 				CXXFLAGS += -flto
@@ -288,12 +279,12 @@ ifeq ($(optimize),yes)
 	endif
 endif
 
-### 3.6. Bits
+### 3.4 Bits
 ifeq ($(bits),64)
 	CXXFLAGS += -DIS_64BIT
 endif
 
-### 3.7 prefetch
+### 3.5 prefetch
 ifeq ($(prefetch),yes)
 	ifeq ($(sse),yes)
 		CXXFLAGS += -msse
@@ -303,7 +294,7 @@ else
 	CXXFLAGS += -DNO_PREFETCH
 endif
 
-### 3.9 popcnt
+### 3.6 popcnt
 ifeq ($(popcnt),yes)
 	ifeq ($(comp),icc)
 		CXXFLAGS += -msse3 -DUSE_POPCNT
@@ -312,7 +303,7 @@ ifeq ($(popcnt),yes)
 	endif
 endif
 
-### 3.10 pext
+### 3.7 pext
 ifeq ($(pext),yes)
 	CXXFLAGS += -DUSE_PEXT
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
@@ -320,7 +311,7 @@ ifeq ($(pext),yes)
 	endif
 endif
 
-### 3.11 Link Time Optimization, it works since gcc 4.5 but not on mingw under Windows.
+### 3.8 Link Time Optimization, it works since gcc 4.5 but not on mingw under Windows.
 ### This is a mix of compile and link time options because the lto link phase
 ### needs access to the optimization flags.
 ifeq ($(comp),gcc)
@@ -343,7 +334,7 @@ ifeq ($(comp),mingw)
 	endif
 endif
 
-### 3.12 Android 5 can only run position independent executables. Note that this
+### 3.9 Android 5 can only run position independent executables. Note that this
 ### breaks Android 4.0 and earlier.
 ifeq ($(arch),armv7)
 	CXXFLAGS += -fPIE

--- a/src/Makefile
+++ b/src/Makefile
@@ -260,7 +260,9 @@ ifeq ($(optimize),yes)
 	endif
 
 	ifeq ($(comp),icc)
-		CXXFLAGS += -mdynamic-no-pic
+		ifeq ($(UNAME),Darwin)
+			CXXFLAGS += -mdynamic-no-pic
+		endif
 	endif
 
 	ifeq ($(comp),clang)


### PR DESCRIPTION
There seems to be no benefit from using -fast over -O3 with icc. So use -O3 everywhere.

uname -r
4.5.1-1-ARCH

make profile-build ARCH=x86-64-bmi2 COMP=icc
icc version 16.0.2

20 runs each:

./stockfish-intel-master 2168837 +- 23989	
./stockfish-intel-O3 2173845 +- 24755	