### PR TITLE
Fix LazySMP when searching to a fixed depth.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -350,6 +350,7 @@ void MainThread::search() {
   Thread* bestThread = this;
   if (   !this->easyMovePlayed
       &&  Options["MultiPV"] == 1
+      && !Limits.depth
       && !Skill(Options["Skill Level"]).enabled()
       &&  rootMoves[0].pv[0] != MOVE_NONE)
   {
@@ -411,7 +412,7 @@ void Thread::search() {
   multiPV = std::min(multiPV, rootMoves.size());
 
   // Iterative deepening loop until requested to stop or the target depth is reached.
-  while (++rootDepth < DEPTH_MAX && !Signals.stop && (!Limits.depth || rootDepth <= Limits.depth))
+  while (++rootDepth < DEPTH_MAX && !Signals.stop && (!Limits.depth || Threads.main()->rootDepth <= Limits.depth))
   {
       // Set up the new depths for the helper threads skipping on average every
       // 2nd ply (using a half-density matrix).


### PR DESCRIPTION
Currently, helper threads will only search up to the specified depth limit.
Now let them search until the main thread has finished the specified depth.

On the other hand, we don't want to pick a thread with a higher search depth.
This may be considered cheating. ;-)

Bench unchanged.