### PR TITLE
Update Makefile remove -mbmi 

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -309,7 +309,7 @@ endif
 ifeq ($(pext),yes)
 	CXXFLAGS += -DUSE_PEXT
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
-		CXXFLAGS += -mbmi -mbmi2
+		CXXFLAGS += -mbmi2
 	endif
 endif
 


### PR DESCRIPTION
Gives a slight speedup  (Base = Master  and Test = no -mbmi)
Results for 50 tests for each version:

            Base      Test      Diff      
    Mean    2831300   2843891   -12591    
    StDev   5683      7326      12220     

p-value: 0.849
speedup: 0.004