### PR TITLE
Retire __popcnt64 intrinsic

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -272,10 +272,6 @@ inline int popcount(Bitboard b) {
 
   return (int)_mm_popcnt_u64(b);
 
-#elif defined(_MSC_VER)
-
-  return (int)__popcnt64(b);
-
 #else // Assumed gcc or compatible compiler
 
   return __builtin_popcountll(b);

--- a/src/types.h
+++ b/src/types.h
@@ -60,12 +60,12 @@
 /// _WIN64             Building on Windows 64 bit
 
 #if defined(_WIN64) && defined(_MSC_VER) // No Makefile used
-#  include <intrin.h> // MSVC popcnt and bsfq instrinsics
+#  include <intrin.h> // Microsoft header for _BitScanForward64()
 #  define IS_64BIT
 #endif
 
 #if defined(USE_POPCNT) && (defined(__INTEL_COMPILER) || defined(_MSC_VER))
-#  include <nmmintrin.h> // Intel header for _mm_popcnt_u64() intrinsic
+#  include <nmmintrin.h> // Intel and Microsoft header for _mm_popcnt_u64()
 #endif
 
 #if !defined(NO_PREFETCH) && (defined(__INTEL_COMPILER) || defined(_MSC_VER))


### PR DESCRIPTION
Just use _mm_popcnt_u64() that is available
both for MSVC and Intel compiler.

Verified on MSVC that the produced assembly
has the hardware 'popcnt' instruction.

No functional change.