### PR TITLE
one single sort call

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -178,6 +178,7 @@ void MovePicker::score<EVASIONS>() {
 /// when there are no more moves to try for the current stage.
 
 void MovePicker::generate_next_stage() {
+  ExtMove* endMovesToSort;
 
   assert(stage != STOP);
 
@@ -200,15 +201,12 @@ void MovePicker::generate_next_stage() {
       break;
 
   case QUIET:
-      endMoves = generate<QUIETS>(pos, moves);
+      endMovesToSort = endMoves = generate<QUIETS>(pos, moves);
       score<QUIETS>();
       if (depth < 3 * ONE_PLY)
-      {
-          ExtMove* goodQuiet = std::partition(cur, endMoves, [](const ExtMove& m)
-                                             { return m.value > VALUE_ZERO; });
-          insertion_sort(cur, goodQuiet);
-      } else
-          insertion_sort(cur, endMoves);
+          endMovesToSort = std::partition(cur, endMoves, [](const ExtMove& m)
+                                          { return m.value > VALUE_ZERO; });
+      insertion_sort(cur, endMovesToSort);
       break;
 
   case BAD_CAPTURES:


### PR DESCRIPTION
I tested this change locally and it is slightly  faster.

  Each version 200 benchs:

              Average Nodes/Second
  Master 1375701.7
  Patch   1377468.8		0.13%

Anyway this seem to me as a simplification.

Note: Does not change Bench.