### PR TITLE
Remove SquareBB lookup table

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -36,7 +36,6 @@ Bitboard  BishopMagics [SQUARE_NB];
 Bitboard* BishopAttacks[SQUARE_NB];
 unsigned  BishopShifts [SQUARE_NB];
 
-Bitboard SquareBB[SQUARE_NB];
 Bitboard FileBB[FILE_NB];
 Bitboard RankBB[RANK_NB];
 Bitboard AdjacentFilesBB[FILE_NB];
@@ -155,10 +154,7 @@ void Bitboards::init() {
       PopCnt16[i] = (uint8_t) popcount16(i);
 
   for (Square s = SQ_A1; s <= SQ_H8; ++s)
-  {
-      SquareBB[s] = 1ULL << s;
-      BSFTable[bsf_index(SquareBB[s])] = s;
-  }
+      BSFTable[bsf_index(make_bb(s))] = s;
 
   for (Bitboard b = 2; b < 256; ++b)
       MSBTable[b] = MSBTable[b - 1] + !more_than_one(b);
@@ -223,7 +219,7 @@ void Bitboards::init() {
                   continue;
 
               LineBB[s1][s2] = (attacks_bb(pc, s1, 0) & attacks_bb(pc, s2, 0)) | s1 | s2;
-              BetweenBB[s1][s2] = attacks_bb(pc, s1, SquareBB[s2]) & attacks_bb(pc, s2, SquareBB[s1]);
+              BetweenBB[s1][s2] = attacks_bb(pc, s1, make_bb(s2)) & attacks_bb(pc, s2, make_bb(s1));
           }
   }
 }

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -61,7 +61,6 @@ const Bitboard Rank8BB = Rank1BB << (8 * 7);
 
 extern int SquareDistance[SQUARE_NB][SQUARE_NB];
 
-extern Bitboard SquareBB[SQUARE_NB];
 extern Bitboard FileBB[FILE_NB];
 extern Bitboard RankBB[RANK_NB];
 extern Bitboard AdjacentFilesBB[FILE_NB];
@@ -79,24 +78,28 @@ extern Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 /// Overloads of bitwise operators between a Bitboard and a Square for testing
 /// whether a given bit is set in a bitboard, and for setting and clearing bits.
 
+inline Bitboard make_bb(Square s) {
+    return 1ULL << s;
+}
+
 inline Bitboard operator&(Bitboard b, Square s) {
-  return b & SquareBB[s];
+  return b & make_bb(s);
 }
 
 inline Bitboard operator|(Bitboard b, Square s) {
-  return b | SquareBB[s];
+  return b | make_bb(s);
 }
 
 inline Bitboard operator^(Bitboard b, Square s) {
-  return b ^ SquareBB[s];
+  return b ^ make_bb(s);
 }
 
 inline Bitboard& operator|=(Bitboard& b, Square s) {
-  return b |= SquareBB[s];
+  return b |= make_bb(s);
 }
 
 inline Bitboard& operator^=(Bitboard& b, Square s) {
-  return b ^= SquareBB[s];
+  return b ^= make_bb(s);
 }
 
 inline bool more_than_one(Bitboard b) {

--- a/src/position.h
+++ b/src/position.h
@@ -426,7 +426,7 @@ inline void Position::move_piece(Color c, PieceType pt, Square from, Square to) 
 
   // index[from] is not updated and becomes stale. This works as long as index[]
   // is accessed just by known occupied squares.
-  Bitboard from_to_bb = SquareBB[from] ^ SquareBB[to];
+  Bitboard from_to_bb = make_bb(from) ^ make_bb(to);
   byTypeBB[ALL_PIECES] ^= from_to_bb;
   byTypeBB[pt] ^= from_to_bb;
   byColorBB[c] ^= from_to_bb;


### PR DESCRIPTION
Simplify away the SquareBB lookup table.  Also maybe a small speedup.
No functional change.

x86-64-modern
```
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    867335    870897    -3562     
    StDev   333883    334686    3964      

p-value: 0.816
speedup: 0.004
```
x86-32 (using CXX=i686-w64-mingw32-c++)
```
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    637592    638673    -1081     
    StDev   223514    224426    2833      

p-value: 0.649
speedup: 0.002
```
Can someone please verify.