### PR TITLE
Simplify doubled pawn

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -124,7 +124,7 @@ namespace {
         opposed    = theirPawns & forward_bb(Us, s);
         stoppers   = theirPawns & passed_pawn_mask(Us, s);
         lever      = theirPawns & pawnAttacksBB[s];
-        doubled    = ourPawns   & forward_bb(Us, s);
+        doubled    = ourPawns   & (s + Up);
         neighbours = ourPawns   & adjacent_files_bb(f);
         phalanx    = neighbours & rank_bb(s);
         supported  = neighbours & rank_bb(s - Up);
@@ -167,7 +167,7 @@ namespace {
             score += Connected[opposed][!!phalanx][more_than_one(supported)][relative_rank(Us, s)];
 
         if (doubled)
-            score -= Doubled / distance<Rank>(s, frontmost_sq(Us, doubled));
+            score -= Doubled;
 
         if (lever)
             score += Lever[relative_rank(Us, s)];


### PR DESCRIPTION
Only use doubled pawn malus when the doubled pawns are on consecutive squares.

Passed STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 7678 W: 1469 L: 1325 D: 4884

And LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 26739 W: 3562 L: 3449 D: 19728

Bench: 8211685

Resolves https://github.com/official-stockfish/Stockfish/pull/677
