### PR TITLE
Futility Simplification

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -970,6 +970,7 @@ moves_loop: // When in check search starts from here
 
           predictedDepth = std::max(newDepth - reduction<PvNode>(improving, depth, moveCount), DEPTH_ZERO);
 
+          // Futility pruning: parent node
           if (   predictedDepth < 7 * ONE_PLY
               && ss->staticEval + futility_margin(predictedDepth) + 256 <= alpha)
               continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -606,7 +606,7 @@ namespace {
     Key posKey;
     Move ttMove, move, excludedMove, bestMove;
     Depth extension, newDepth, predictedDepth;
-    Value bestValue, value, ttValue, eval, nullValue, futilityValue;
+    Value bestValue, value, ttValue, eval, nullValue;
     bool ttHit, inCheck, givesCheck, singularExtensionNode, improving;
     bool captureOrPromotion, doFullDepthSearch;
     Piece moved_piece;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -970,17 +970,9 @@ moves_loop: // When in check search starts from here
 
           predictedDepth = std::max(newDepth - reduction<PvNode>(improving, depth, moveCount), DEPTH_ZERO);
 
-          // Futility pruning: parent node
-          if (predictedDepth < 7 * ONE_PLY)
-          {
-              futilityValue = ss->staticEval + futility_margin(predictedDepth) + 256;
-
-              if (futilityValue <= alpha)
-              {
-                  bestValue = std::max(bestValue, futilityValue);
-                  continue;
-              }
-          }
+          if (   predictedDepth < 7 * ONE_PLY
+              && ss->staticEval + futility_margin(predictedDepth) + 256 <= alpha)
+              continue;
 
           // Prune moves with negative SEE at low depths
           if (predictedDepth < 4 * ONE_PLY && pos.see_sign(move) < VALUE_ZERO)


### PR DESCRIPTION
Futility Simplification:
Don't update bestValue when futility pruning.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 21933 W: 4031 L: 3912 D: 13990

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 46225 W: 6115 L: 6028 D: 34082

Bench:  7226540

Note:
I consider updating the bestValue at futility pruning a bug.  Since we use futility pruning far away from the leaves and the move that updates the bestValue may even be illegal.

