### PR TITLE
fix GCC warning

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1043,7 +1043,9 @@ void do_init(Entry& e, T& p, uint8_t* data)
 
     enum { Split = 1, HasPawns = 2 };
 
+#ifndef NDEBUG
     uint8_t flags = *data++;
+#endif
 
     assert(e.hasPawns        == !!(flags & HasPawns));
     assert((e.key != e.key2) == !!(flags & Split));


### PR DESCRIPTION
variable 'flag' is unused, when compiling in "release" mode (ie. NDEBUG = true).