### PR TITLE
Filter root moves filter before copy to threads

### DIFF
--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -12,6 +12,7 @@ int probe_wdl(Position& pos, int *success);
 int probe_dtz(Position& pos, int *success);
 bool root_probe(Position& pos, Search::RootMoves& rootMoves, Value& score);
 bool root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, Value& score);
+void filter_root_moves(Position& pos, Search::RootMoves& rootMoves);
 
 }
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -25,6 +25,7 @@
 #include "search.h"
 #include "thread.h"
 #include "uci.h"
+#include "syzygy/tbprobe.h"
 
 ThreadPool Threads; // Global object
 
@@ -169,7 +170,7 @@ int64_t ThreadPool::nodes_searched() {
 /// ThreadPool::start_thinking() wakes up the main thread sleeping in idle_loop()
 /// and starts a new search, then returns immediately.
 
-void ThreadPool::start_thinking(const Position& pos, StateListPtr& states,
+void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
                                 const Search::LimitsType& limits) {
 
   main()->wait_for_search_finished();
@@ -182,6 +183,8 @@ void ThreadPool::start_thinking(const Position& pos, StateListPtr& states,
       if (   limits.searchmoves.empty()
           || std::count(limits.searchmoves.begin(), limits.searchmoves.end(), m))
           rootMoves.push_back(Search::RootMove(m));
+
+  Tablebases::filter_root_moves(pos, rootMoves);
 
   // After ownership transfer 'states' becomes empty, so if we stop the search
   // and call 'go' again without setting a new position states.get() == NULL.

--- a/src/thread.h
+++ b/src/thread.h
@@ -94,7 +94,7 @@ struct ThreadPool : public std::vector<Thread*> {
   void exit(); // be initialized and valid during the whole thread lifetime.
 
   MainThread* main() { return static_cast<MainThread*>(at(0)); }
-  void start_thinking(const Position&, StateListPtr&, const Search::LimitsType&);
+  void start_thinking(Position&, StateListPtr&, const Search::LimitsType&);
   void read_uci_options();
   int64_t nodes_searched();
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -108,7 +108,7 @@ namespace {
   // the thinking time and other parameters from the input string, then starts
   // the search.
 
-  void go(const Position& pos, istringstream& is) {
+  void go(Position& pos, istringstream& is) {
 
     Search::LimitsType limits;
     string token;


### PR DESCRIPTION
Currently root moves are copied to all the threads
but are DTZ filtered only in main thread at the
beginning of the search.

This patch moves the TB filtering before the
copy of root moves fixing issue #658 

https://github.com/official-stockfish/Stockfish/issues/658

No bench change.