### PR TITLE
LMR reduction parameter tweak

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1010,7 +1010,7 @@ moves_loop: // When in check search starts from here
 
           // Increase reduction for cut nodes
           if (!PvNode && cutNode)
-              r += ONE_PLY;
+              r += 2 * ONE_PLY;
 
           // Decrease reduction for moves that escape a capture. Filter out
           // castling moves, because they are coded as "king captures rook" and
@@ -1019,7 +1019,7 @@ moves_loop: // When in check search starts from here
           else if (   type_of(move) == NORMAL
                    && type_of(pos.piece_on(to_sq(move))) != PAWN
                    && pos.see(make_move(to_sq(move), from_sq(move))) < VALUE_ZERO)
-              r -= ONE_PLY;
+              r -= 2 * ONE_PLY;
 
           // Decrease/increase reduction for moves with a good/bad history
           int rHist = (val - 10000) / 20000;


### PR DESCRIPTION
More reduction for cut nodes, less for moves that escape a capture:

STC (http://tests.stockfishchess.org/tests/view/57548c1e0ebc59029919b247):
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 60165 W: 11519 L: 11149 D: 37497

LTC (http://tests.stockfishchess.org/tests/view/57555b570ebc59029919b260):
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 10353 W: 1493 L: 1317 D: 7543

Bench: 8902859