### PR TITLE
Tweak gcc/mingw inline parameters.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -245,6 +245,8 @@ ifeq ($(optimize),yes)
 
 	ifeq ($(comp),gcc)
 
+		CXXFLAGS += --param max-inline-insns-auto=100 --param inline-min-speedup=25
+
 		ifeq ($(UNAME),Darwin)
 			ifeq ($(arch),i386)
 				CXXFLAGS += -mdynamic-no-pic
@@ -257,6 +259,10 @@ ifeq ($(optimize),yes)
 		ifeq ($(arch),armv7)
 			CXXFLAGS += -fno-gcse -mthumb -march=armv7-a -mfloat-abi=softfp
 		endif
+	endif
+
+	ifeq ($(comp),mingw)
+		CXXFLAGS += --param max-inline-insns-auto=100 --param inline-min-speedup=25
 	endif
 
 	ifeq ($(comp),icc)


### PR DESCRIPTION
Win7 i7 mobile x86-64-modern mingw 5.3.0
```
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    828043    864829    -36786    
    StDev   303530    314444    12195     

p-value: 0.999
speedup: 0.044
```

Can someone please verify?
Docs and source for more ideas can be found here
https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html