### PR TITLE
Check Extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -920,7 +920,10 @@ moves_loop: // When in check search starts from here
                   : pos.gives_check(move, ci);
 
       // Step 12. Extend checks
-      if (givesCheck && (moveCount == 1 || (!(depth < 16 && moveCount >= FutilityMoveCounts[improving][depth]) && pos.see_sign(move) >= VALUE_ZERO)))
+      if (   givesCheck
+          && (   moveCount == 1
+              || (   (depth >= 16 * ONE_PLY || moveCount < FutilityMoveCounts[improving][depth])
+                  && pos.see_sign(move) >= VALUE_ZERO)))
           extension = ONE_PLY;
 
       // Singular extension search. If all moves but one fail low on a search of

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -920,7 +920,7 @@ moves_loop: // When in check search starts from here
                   : pos.gives_check(move, ci);
 
       // Step 12. Extend checks
-      if (givesCheck && pos.see_sign(move) >= VALUE_ZERO)
+      if (givesCheck && (moveCount == 1 || (!(depth < 16 && moveCount >= FutilityMoveCounts[improving][depth]) && pos.see_sign(move) >= VALUE_ZERO)))
           extension = ONE_PLY;
 
       // Singular extension search. If all moves but one fail low on a search of


### PR DESCRIPTION
There are two concepts with this patch:

Limit check extensions by using move count.
The idea is to limit search explosion.

Always extend check if the first move gives check.
The idea is to save expensive SEE calls, since the vast majority of first move will have SEE value >= 0, also first move may still be strong even if the SEE is negative.

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 16503 W: 3068 L: 2873 D: 10562

LTC:
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 37202 W: 5261 L: 5014 D: 26927

Bench: 8543372