### PR TITLE
Small Queen simplification

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -348,6 +348,13 @@ namespace {
                     score -= (TrappedRook - make_score(mob * 22, 0)) * (1 + !pos.can_castle(Us));
             }
         }
+        
+        if (Pt == QUEEN)
+        {
+            // Penalty if any relative pin or discovered attack against the queen
+            if (pos.slider_blockers(pos.pieces(), pos.pieces(Them, ROOK, BISHOP), s))
+                score -= WeakQueen;
+        }
     }
 
     if (DoTrace)
@@ -488,13 +495,6 @@ namespace {
     if (   (pos.pieces(Them) ^ pos.pieces(Them, QUEEN, KING))
         & ~(ei.attackedBy[Us][ALL_PIECES] | ei.attackedBy[Them][ALL_PIECES]))
         score += LooseEnemies;
-
-    // Bonus for pin or discovered attack on the opponent queen
-    if (   pos.count<QUEEN>(Them) == 1
-        && pos.slider_blockers(pos.pieces(),
-                               pos.pieces(Us, ROOK, BISHOP),
-                               pos.square<QUEEN>(Them)))
-        score += WeakQueen;
 
     // Non-pawn enemies attacked by a pawn
     weak = (pos.pieces(Them) ^ pos.pieces(Them, PAWN)) & ei.attackedBy[Us][PAWN];


### PR DESCRIPTION
Moving a few lines from evaluate_threats to evaluate_pieces allows to
a) Remove a condition `pos.count<QUEEN>(Them) == 1`
b) use precalculated s instead of pos.square<QUEEN>(Them)
c) do not check the condition at all in queenless endings

Passed STC
http://tests.stockfishchess.org/tests/view/5752e0410ebc59029919b1f4
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 67175 W: 12194 L: 12152 D: 42829

and LTC
http://tests.stockfishchess.org/tests/view/57587b140ebc59029919b2f4
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 20276 W: 2774 L: 2653 D: 14849
