### PR TITLE
Evaluate d5-d7 passers like d6-d7

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -147,10 +147,9 @@ namespace {
             assert(!backward || !(pawn_attack_span(Them, s + Up) & neighbours));
         }
 
-        // Passed pawns will be properly scored in evaluation because we need
-        // full attack info to evaluate them. Only the frontmost passed
-        // pawn on each file is considered a true passed pawn.
-        if (!(stoppers | doubled)) // FIXME this is just doubled by adjacent pawn
+        // Passed pawns will be scored in evaluation because we need full attack
+        // info to evaluate them properly.
+        if (!stoppers)
             e->passedPawns[Us] |= s;
 
         // Score this pawn


### PR DESCRIPTION
Simplify a condition in pawns.cpp: before this patch, only the frontmost passed pawn of each adjacent doubled pawns pair was scored in evaluation.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 60960 W: 11060 L: 11007 D: 38893

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 174924 W: 23508 L: 23594 D: 127822

Bench: 8067218