### PR TITLE
Remove PvNode condition from LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -963,7 +963,7 @@ moves_loop: // When in check search starts from here
                      +    (fmh2 ? (*fmh2)[moved_piece][to_sq(move)] : VALUE_ZERO);
 
           // Increase reduction for cut nodes
-          if (!PvNode && cutNode)
+          if (cutNode)
               r += 2 * ONE_PLY;
 
           // Decrease reduction for moves that escape a capture. Filter out


### PR DESCRIPTION
Because of the change in https://github.com/official-stockfish/Stockfish/pull/703 the condition in LMR for cut nodes can be simplified, because the check for !PvNode is no longer needed.
No functional change (same bench: 7977279) and on my machine it gives a negligable speedup of 0.3 % (it may be different on other machines):

Results for 25 tests for each version:

            Base      Test      Diff      
    Mean    2066132   2072285   -6153     
    StDev   20982     15694     8447      

p-value: 0.767
speedup: 0.003
