### PR TITLE
Enable sse4 instead of sse3 when Pext is on

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -304,7 +304,7 @@ ifeq ($(popcnt),yes)
 	    else
 	    CXXFLAGS += -msse3 -DUSE_POPCNT
 	    endif
-        endif
+       endif
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
 	    ifeq ($(pext),yes)
 	    CXXFLAGS += -msse4 -mpopcnt -DUSE_POPCNT

--- a/src/Makefile
+++ b/src/Makefile
@@ -298,20 +298,20 @@ endif
 
 ### 3.6 popcnt
 ifeq ($(popcnt),yes)
-   	ifeq ($(comp),icc)
-	    ifeq ($(pext),yes)
-	    CXXFLAGS += -msse4 -DUSE_POPCNT
-	    else
-	    CXXFLAGS += -msse3 -DUSE_POPCNT
-	    endif
-       endif
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
-	    ifeq ($(pext),yes)
-	    CXXFLAGS += -msse4 -mpopcnt -DUSE_POPCNT
-	    else
-	    CXXFLAGS += -msse3 -mpopcnt -DUSE_POPCNT
+        ifeq ($(comp),icc)
+            ifeq ($(pext),yes)
+            CXXFLAGS += -msse4 -DUSE_POPCNT
+            else
+            CXXFLAGS += -msse3 -DUSE_POPCNT
             endif
-	endif	
+        endif
+        ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+            ifeq ($(pext),yes)
+            CXXFLAGS += -msse4 -mpopcnt -DUSE_POPCNT
+            else
+            CXXFLAGS += -msse3 -mpopcnt -DUSE_POPCNT
+            endif
+        endif	
 endif
 
 ### 3.7 pext


### PR DESCRIPTION
All the bmi2 enabled CPUs have sse4. Using sse4 instead of sse3 seems beneficial and also gives 0.4% speedup :

Results for 50 tests for each version:

            Base      Test      Diff      
    Mean    2742112   2752359   -10247    
    StDev   5400      4026      6893      

p-value: 0.931
speedup: 0.004
