### PR TITLE
Reduce think time for PGO optimization

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,7 @@ PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds
-PGOBENCH = ./$(EXE) bench 16 1 1000 default time
+PGOBENCH = ./$(EXE) bench 16 1 300 default time
 
 ### Object files
 OBJS = benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o \


### PR DESCRIPTION
In the forum, somebody hinted that faster think in PGO build makes faster compiles. I cannot reconstruct who. I tried it out by setting time = 300 ms. I got following results:

Depth 13, 50 samples

Engine                                       | Nodes/second
stockfish_profile_branch        | 2195015.5 +- 3933.6
stockfish_profile_master        | 2185190.0 +- 3010.52

Differences                               | 10108.0 +- 626.0
Variance of the mean             | 88.53 ( 0.88 %)
Speed up                                  | 0.46 %

Depth 16, 5 samples

Depth 16

Engine                          | Nodes/second
stockfish_profile_branch        | 2227159.0 +- 8811.64
stockfish_profile_master        | 2214783.0 +- 10765.08

Differences                     | 12376.0 +- 1953.0
Variance of the mean            | 873.41 ( 7.06 %)
Speed up                        | 0.56 %

TTD 30 from starting position, one sample 

branch:
info depth 30 seldepth 43 multipv 1 score cp 17 nodes 443679765 nps 1692516
master:
info depth 30 seldepth 43 multipv 1 score cp 17 nodes 443679765 nps 1694151
Speed up: -0.10%

Can anybody (dis)confirm?