### PR TITLE
Thread Analysis

### DIFF
--- a/src/uci.h
+++ b/src/uci.h
@@ -70,7 +70,7 @@ void loop(int argc, char* argv[]);
 std::string value(Value v);
 std::string square(Square s);
 std::string move(Move m, bool chess960);
-std::string pv(const Position& pos, Depth depth, Value alpha, Value beta);
+ std::string pv(const Position& pos, Depth depth, Value alpha, Value beta, size_t thread_id = 0);
 Move to_move(const Position& pos, std::string& str);
 
 } // namespace UCI

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -64,6 +64,7 @@ void init(OptionsMap& o) {
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);
+  o["Thread Analysis"]       << Option(false);
   o["Skill Level"]           << Option(20, 0, 20);
   o["Move Overhead"]         << Option(30, 0, 5000);
   o["Minimum Thinking Time"] << Option(20, 0, 5000);


### PR DESCRIPTION
Lazy SMP makes  pvs and evaluations of every thread easily available, and they might be helpful for analysis.
    
This patch provides uci option "Thread Analysis" to use multi pv feature of modern GUIs to display such information.  Thread Analysis mode cause no degradation of performance and functionally equivalent to tournament play.
    
When uci option "Thread Analysis" is set to true,  "MultiPV" uci option is used to select how many threads
 to display.
    
No functional change.