### PR TITLE
use -ftree-loop-distribution and -mavx when available

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -145,7 +145,7 @@ endif
 ifeq ($(COMP),gcc)
 	comp=gcc
 	CXX=g++
-	CXXFLAGS += -pedantic -Wextra -Wshadow -m$(bits)
+	CXXFLAGS += -ftree-loop-distribution -pedantic -Wextra -Wshadow -m$(bits)
 	ifneq ($(UNAME),Darwin)
 	   LDFLAGS += -Wl,--no-as-needed
 	endif
@@ -172,7 +172,7 @@ ifeq ($(COMP),mingw)
 		CXX=g++
 	endif
 
-	CXXFLAGS += -Wextra -Wshadow
+	CXXFLAGS += -ftree-loop-distribution -Wextra -Wshadow
 	LDFLAGS += -static
 endif
 
@@ -301,7 +301,7 @@ ifeq ($(popcnt),yes)
 	ifeq ($(comp),icc)
 		CXXFLAGS += -msse3 -DUSE_POPCNT
 	else
-		CXXFLAGS += -msse3 -mpopcnt -DUSE_POPCNT
+		CXXFLAGS += -mavx -msse3 -mpopcnt -DUSE_POPCNT
 	endif
 endif
 


### PR DESCRIPTION
These optimizations options give me a small but consistent speedup:

```
Result of  30 runs
==================
base =    1336460  +/- 3156
test =    1342001  +/- 3965
diff =      +5541  +/- 1117

speedup        = +0.0041
P(speedup > 0) =  1.0000

CPU: Intel(R) Core(TM) i3-2330M CPU @ 2.20GHz
```
Of course optimization may depend on the exact processor architecture, therefore I would appreciate if other people could verify this effect.