### PR TITLE
Fix extract_ponder_from_tt

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1568,7 +1568,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
 bool RootMove::extract_ponder_from_tt(Position& pos)
 {
     StateInfo st;
-    bool ttHit, success;
+    bool ttHit;
 
     assert(pv.size() == 1);
 
@@ -1579,15 +1579,11 @@ bool RootMove::extract_ponder_from_tt(Position& pos)
     {
         Move m = tte->move(); // Local copy to be SMP safe
         if (MoveList<LEGAL>(pos).contains(m))
-        {
             pv.push_back(m);
-            success = true;
-        }
     }
 
     pos.undo_move(pv[0]);
-
-    return success;
+    return pv.size() > 1;
 }
 
 void Tablebases::filter_root_moves(Position& pos, Search::RootMoves& rootMoves) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1568,22 +1568,26 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
 bool RootMove::extract_ponder_from_tt(Position& pos)
 {
     StateInfo st;
-    bool ttHit;
+    bool ttHit, success;
 
     assert(pv.size() == 1);
 
     pos.do_move(pv[0], st, pos.gives_check(pv[0], CheckInfo(pos)));
     TTEntry* tte = TT.probe(pos.key(), ttHit);
-    pos.undo_move(pv[0]);
 
     if (ttHit)
     {
         Move m = tte->move(); // Local copy to be SMP safe
         if (MoveList<LEGAL>(pos).contains(m))
-           return pv.push_back(m), true;
+        {
+            pv.push_back(m);
+            success = true;
+        }
     }
 
-    return false;
+    pos.undo_move(pv[0]);
+
+    return success;
 }
 
 void Tablebases::filter_root_moves(Position& pos, Search::RootMoves& rootMoves) {


### PR DESCRIPTION
Checking for legality of a possible ponder move
must be done before we undo the first pv move, of course.
(spotted by mohammed li.)

This obviously only has any effect when playing in ponder mode.