### PR TITLE
Realign stack on 32-bit compiles

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -82,6 +82,7 @@ ifeq ($(ARCH),x86-32)
 	arch = i386
 	prefetch = yes
 	sse = yes
+	CXXFLAGS += -mstackrealign
 endif
 
 ifeq ($(ARCH),general-64)


### PR DESCRIPTION
GCC uses SSE instructions to move data but in 32-bit GCC the stack is not 16-byte aligned for some reason. This adds a flag -mstackrealign which realigns stack in each object file.

Fixes issue #721.