### PR TITLE
Realign stack on 32-bit compiles

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -284,6 +284,8 @@ endif
 ### 3.4 Bits
 ifeq ($(bits),64)
 	CXXFLAGS += -DIS_64BIT
+else
+	CXXFLAGS += -mstackrealign
 endif
 
 ### 3.5 prefetch

--- a/src/Makefile
+++ b/src/Makefile
@@ -231,6 +231,17 @@ ifneq ($(comp),mingw)
 	endif
 endif
 
+### Stack misalignment bug fix for SSE 32-bit compiles
+ifeq ($(ARCH),x86-32)
+	ifeq ($(COMP),gcc)
+		CXXFLAGS += -mstackrealign
+	else
+		ifeq ($(COMP),mingw)
+		CXXFLAGS += -mstackrealign
+		endif
+	endif
+endif
+
 ### 3.2 Debugging
 ifeq ($(debug),no)
 	CXXFLAGS += -DNDEBUG
@@ -284,8 +295,6 @@ endif
 ### 3.4 Bits
 ifeq ($(bits),64)
 	CXXFLAGS += -DIS_64BIT
-else
-	CXXFLAGS += -mstackrealign
 endif
 
 ### 3.5 prefetch

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -498,7 +498,7 @@ namespace {
     const Bitboard CenterFiles = TheirCamp & (FileCBB | FileDBB | FileEBB | FileFBB);
     const Bitboard KingSide    = TheirCamp & (FileEBB | FileFBB | FileGBB | FileHBB);
 
-    const Bitboard KingFlank[FILE_NB] = {
+    static const Bitboard KingFlank[FILE_NB] = {
       QueenSide, QueenSide, QueenSide, CenterFiles,
       CenterFiles, KingSide, KingSide, KingSide
     };


### PR DESCRIPTION
GCC uses SSE instructions to move data but in 32-bit GCC the stack is not 16-byte aligned for some reason. This adds a flag -mstackrealign which realigns stack in each object file.
Additionally the const KingFlank was made static to avoid copying the array on the stack at every function call.

Fixes issue #721.