### PR TITLE
Gradually relax the NMP staticEval check for higher depths

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -731,7 +731,7 @@ namespace {
     if (   !PvNode
         &&  depth >= 2 * ONE_PLY
         &&  eval >= beta
-        && (ss->staticEval >= beta || depth >= 12 * ONE_PLY)
+        && ((ss->staticEval >= beta - ((int) depth - 6) * 35) || depth >= 13 * ONE_PLY)
         &&  pos.non_pawn_material(pos.side_to_move()))
     {
         ss->currentMove = MOVE_NULL;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -731,7 +731,7 @@ namespace {
     if (   !PvNode
         &&  depth >= 2 * ONE_PLY
         &&  eval >= beta
-        && ((ss->staticEval >= beta - ((int) depth - 6) * 35) || depth >= 13 * ONE_PLY)
+        && ((ss->staticEval >= beta - ((depth / ONE_PLY) - 6) * 35) || depth >= 13 * ONE_PLY)
         &&  pos.non_pawn_material(pos.side_to_move()))
     {
         ss->currentMove = MOVE_NULL;


### PR DESCRIPTION
Gradually relax the NMP staticEval check as we go to higher depths.
Use tuned values.

STC
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 16745 W: 3371 L: 3168 D: 10206

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 5906 W: 875 L: 736 D: 4295

