### PR TITLE
Color-From-To History Stat

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -147,11 +147,14 @@ void MovePicker::score<QUIETS>() {
   const CounterMoveStats* fm = (ss-2)->counterMoves;
   const CounterMoveStats* f2 = (ss-4)->counterMoves;
 
+  Color c = pos.side_to_move();
+
   for (auto& m : *this)
-      m.value =      history[pos.moved_piece(m)][to_sq(m)]
-               + (cm ? (*cm)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
-               + (fm ? (*fm)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
-               + (f2 ? (*f2)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO);
+	  m.value = history[pos.moved_piece(m)][to_sq(m)]
+	  + (cm ? (*cm)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
+	  + (fm ? (*fm)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
+	  + (f2 ? (*f2)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
+	  + Search::fromTo[c][from_sq(m)][to_sq(m)];
 }
 
 template<>

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -163,6 +163,7 @@ void MovePicker::score<EVASIONS>() {
   // by history value, then bad captures and quiet moves with a negative SEE ordered
   // by SEE value.
   const HistoryStats& history = pos.this_thread()->history;
+  Color c = pos.side_to_move();
   Value see;
 
   for (auto& m : *this)
@@ -173,7 +174,7 @@ void MovePicker::score<EVASIONS>() {
           m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
                    - Value(type_of(pos.moved_piece(m))) + HistoryStats::Max;
       else
-          m.value = history[pos.moved_piece(m)][to_sq(m)];
+          m.value = history[pos.moved_piece(m)][to_sq(m)]+Search::fromTo[c][from_sq(m)][to_sq(m)];;
 }
 
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1463,7 +1463,7 @@ moves_loop: // When in check search starts from here
 	  Square f = from_sq(m);
 
 	  fromTo[c][f][t] -= fromTo[c][f][t] * abs(int(v)) / 324;
-	  fromTo[c][f][t] += int(v) * 16;
+	  fromTo[c][f][t] += int(v) * 32;
   }
 
 

--- a/src/search.h
+++ b/src/search.h
@@ -36,6 +36,7 @@ namespace Search {
 /// Stack struct keeps track of the information we need to remember from nodes
 /// shallower and deeper in the tree during the search. Each search thread has
 /// its own array of Stack objects, indexed by the current ply.
+extern Value fromTo[COLOR_NB][SQUARE_NB][SQUARE_NB];
 
 struct Stack {
   Move* pv;


### PR DESCRIPTION
Use Color-From-To history stats to help sort moves:

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 33502 W: 6498 L: 6223 D: 20781
http://tests.stockfishchess.org/tests/view/578abb940ebc5972faa169e2

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 50782 W: 7124 L: 6832 D: 36826
http://tests.stockfishchess.org/tests/view/578b8e5d0ebc5972faa169fd

Bench:  8114703