### PR TITLE
SEE prune at higher depths

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -931,7 +931,8 @@ moves_loop: // When in check search starts from here
               continue;
 
           // Prune moves with negative SEE at low depths
-          if (predictedDepth < 4 * ONE_PLY && pos.see_sign(move) < VALUE_ZERO)
+          Value see_v = predictedDepth < 4*ONE_PLY? VALUE_ZERO: -2*PawnValueMg*(int(predictedDepth) - 3);
+          if (predictedDepth < 8 * ONE_PLY && pos.see_sign(move) < see_v)
               continue;
       }
 


### PR DESCRIPTION
Allow SEE pruning at higher depths in shallow depth pruning using a threshold increasing with depth.

STC
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 35366 W: 7011 L: 6724 D: 21631

LTC
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 15578 W: 2243 L: 2070 D: 11265

Bench: 8417887
