### PR TITLE
Remove Countermove update function...

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -46,8 +46,6 @@ struct Stats {
   T* operator[](Piece pc) { return table[pc]; }
   void clear() { std::memset(table, 0, sizeof(table)); }
 
-  void update(Piece pc, Square to, Move m) { table[pc][to] = m; }
-
   void update(Piece pc, Square to, Value v) {
 
     if (abs(int(v)) >= 324)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1408,7 +1408,7 @@ moves_loop: // When in check search starts from here
 
     if (cmh)
     {
-        thisThread->counterMoves.update(pos.piece_on(prevSq), prevSq, move);
+        thisThread->counterMoves[pos.piece_on(prevSq)][prevSq] = move;
         cmh->update(pos.moved_piece(move), to_sq(move), bonus);
     }
 


### PR DESCRIPTION
No point in having a function to simply update an array.  This was needed in the past when special logic was needed to handle more than one cm.

One less call and function that SF have to take...

Non-functional change.