### PR TITLE
Move allocation of EvalInfo from evaluate to (q)search

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -69,48 +69,7 @@ namespace {
 
   using namespace Trace;
 
-  // Struct EvalInfo contains various information computed and collected
-  // by the evaluation functions.
-  struct EvalInfo {
 
-    // attackedBy[color][piece type] is a bitboard representing all squares
-    // attacked by a given color and piece type (can be also ALL_PIECES).
-    Bitboard attackedBy[COLOR_NB][PIECE_TYPE_NB];
-
-    // attackedBy2[color] are the squares attacked by 2 pieces of a given color,
-    // possibly via x-ray or by one pawn and one piece. Diagonal x-ray through
-    // pawn or squares attacked by 2 pawns are not explicitly added.
-    Bitboard attackedBy2[COLOR_NB];
-
-    // kingRing[color] is the zone around the king which is considered
-    // by the king safety evaluation. This consists of the squares directly
-    // adjacent to the king, and the three (or two, for a king on an edge file)
-    // squares two ranks in front of the king. For instance, if black's king
-    // is on g8, kingRing[BLACK] is a bitboard containing the squares f8, h8,
-    // f7, g7, h7, f6, g6 and h6.
-    Bitboard kingRing[COLOR_NB];
-
-    // kingAttackersCount[color] is the number of pieces of the given color
-    // which attack a square in the kingRing of the enemy king.
-    int kingAttackersCount[COLOR_NB];
-
-    // kingAttackersWeight[color] is the sum of the "weights" of the pieces of the
-    // given color which attack a square in the kingRing of the enemy king. The
-    // weights of the individual piece types are given by the elements in the
-    // KingAttackWeights array.
-    int kingAttackersWeight[COLOR_NB];
-
-    // kingAdjacentZoneAttacksCount[color] is the number of attacks by the given
-    // color to squares directly adjacent to the enemy king. Pieces which attack
-    // more than one square are counted multiple times. For instance, if there is
-    // a white knight on g5 and black's king is on g8, this white knight adds 2
-    // to kingAdjacentZoneAttacksCount[WHITE].
-    int kingAdjacentZoneAttacksCount[COLOR_NB];
-
-    Bitboard pinnedPieces[COLOR_NB];
-    Material::Entry* me;
-    Pawns::Entry* pi;
-  };
 
   #define V(v) Value(v)
   #define S(mg, eg) make_score(mg, eg)
@@ -773,11 +732,11 @@ namespace {
 /// of the position from the point of view of the side to move.
 
 template<bool DoTrace>
-Value Eval::evaluate(const Position& pos) {
+Value Eval::evaluate(const Position& pos, EvalInfo& ei) {
 
   assert(!pos.checkers());
 
-  EvalInfo ei;
+
   Score score, mobility[COLOR_NB] = { SCORE_ZERO, SCORE_ZERO };
 
   // Initialize score by reading the incrementally updated scores included in
@@ -879,8 +838,8 @@ Value Eval::evaluate(const Position& pos) {
 }
 
 // Explicit template instantiations
-template Value Eval::evaluate<true >(const Position&);
-template Value Eval::evaluate<false>(const Position&);
+template Value Eval::evaluate<true >(const Position&, EvalInfo&);
+template Value Eval::evaluate<false>(const Position&, EvalInfo&);
 
 
 /// trace() is like evaluate(), but instead of returning a value, it returns
@@ -890,8 +849,8 @@ template Value Eval::evaluate<false>(const Position&);
 std::string Eval::trace(const Position& pos) {
 
   std::memset(scores, 0, sizeof(scores));
-
-  Value v = evaluate<true>(pos);
+  EvalInfo ei;
+  Value v = evaluate<true>(pos, ei);
   v = pos.side_to_move() == WHITE ? v : -v; // White's point of view
 
   std::stringstream ss;

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -24,8 +24,53 @@
 #include <string>
 
 #include "types.h"
+#include "material.h"
+#include "pawns.h"
 
 class Position;
+
+// Struct EvalInfo contains various information computed and collected
+  // by the evaluation functions.
+  struct EvalInfo {
+
+    // attackedBy[color][piece type] is a bitboard representing all squares
+    // attacked by a given color and piece type (can be also ALL_PIECES).
+    Bitboard attackedBy[COLOR_NB][PIECE_TYPE_NB];
+
+    // attackedBy2[color] are the squares attacked by 2 pieces of a given color,
+    // possibly via x-ray or by one pawn and one piece. Diagonal x-ray through
+    // pawn or squares attacked by 2 pawns are not explicitly added.
+    Bitboard attackedBy2[COLOR_NB];
+
+    // kingRing[color] is the zone around the king which is considered
+    // by the king safety evaluation. This consists of the squares directly
+    // adjacent to the king, and the three (or two, for a king on an edge file)
+    // squares two ranks in front of the king. For instance, if black's king
+    // is on g8, kingRing[BLACK] is a bitboard containing the squares f8, h8,
+    // f7, g7, h7, f6, g6 and h6.
+    Bitboard kingRing[COLOR_NB];
+
+    // kingAttackersCount[color] is the number of pieces of the given color
+    // which attack a square in the kingRing of the enemy king.
+    int kingAttackersCount[COLOR_NB];
+
+    // kingAttackersWeight[color] is the sum of the "weights" of the pieces of the
+    // given color which attack a square in the kingRing of the enemy king. The
+    // weights of the individual piece types are given by the elements in the
+    // KingAttackWeights array.
+    int kingAttackersWeight[COLOR_NB];
+
+    // kingAdjacentZoneAttacksCount[color] is the number of attacks by the given
+    // color to squares directly adjacent to the enemy king. Pieces which attack
+    // more than one square are counted multiple times. For instance, if there is
+    // a white knight on g5 and black's king is on g8, this white knight adds 2
+    // to kingAdjacentZoneAttacksCount[WHITE].
+    int kingAdjacentZoneAttacksCount[COLOR_NB];
+
+    Bitboard pinnedPieces[COLOR_NB];
+    Material::Entry* me;
+    Pawns::Entry* pi;
+  };
 
 namespace Eval {
 
@@ -35,7 +80,9 @@ void init();
 std::string trace(const Position& pos);
 
 template<bool DoTrace = false>
-Value evaluate(const Position& pos);
+Value evaluate(const Position& pos, EvalInfo& ei);
 }
+
+
 
 #endif // #ifndef EVALUATE_H_INCLUDED

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -35,6 +35,7 @@
 #include "tt.h"
 #include "uci.h"
 #include "syzygy/tbprobe.h"
+#include "evaluate.h"
 
 namespace Search {
 
@@ -562,6 +563,7 @@ namespace {
     bool captureOrPromotion, doFullDepthSearch, moveCountPruning;
     Piece moved_piece;
     int moveCount, quietCount;
+    EvalInfo ei;
 
     // Step 1. Initialize node
     Thread* thisThread = pos.this_thread();
@@ -592,7 +594,7 @@ namespace {
     {
         // Step 2. Check for aborted search and immediate draw
         if (Signals.stop.load(std::memory_order_relaxed) || pos.is_draw() || ss->ply >= MAX_PLY)
-            return ss->ply >= MAX_PLY && !inCheck ? evaluate(pos)
+            return ss->ply >= MAX_PLY && !inCheck ? evaluate(pos, ei)
                                                   : DrawValue[pos.side_to_move()];
 
         // Step 3. Mate distance pruning. Even if we mate at the next move our score
@@ -683,7 +685,7 @@ namespace {
     {
         // Never assume anything on values stored in TT
         if ((ss->staticEval = eval = tte->eval()) == VALUE_NONE)
-            eval = ss->staticEval = evaluate(pos);
+            eval = ss->staticEval = evaluate(pos, ei);
 
         // Can ttValue be used as a better position evaluation?
         if (ttValue != VALUE_NONE)
@@ -693,7 +695,7 @@ namespace {
     else
     {
         eval = ss->staticEval =
-        (ss-1)->currentMove != MOVE_NULL ? evaluate(pos)
+        (ss-1)->currentMove != MOVE_NULL ? evaluate(pos, ei)
                                          : -(ss-1)->staticEval + 2 * Eval::Tempo;
 
         tte->save(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE,
@@ -1160,6 +1162,7 @@ moves_loop: // When in check search starts from here
     Value bestValue, value, ttValue, futilityValue, futilityBase, oldAlpha;
     bool ttHit, givesCheck, evasionPrunable;
     Depth ttDepth;
+    EvalInfo ei;
 
     if (PvNode)
     {
@@ -1173,7 +1176,7 @@ moves_loop: // When in check search starts from here
 
     // Check for an instant draw or if the maximum ply has been reached
     if (pos.is_draw() || ss->ply >= MAX_PLY)
-        return ss->ply >= MAX_PLY && !InCheck ? evaluate(pos)
+        return ss->ply >= MAX_PLY && !InCheck ? evaluate(pos, ei)
                                               : DrawValue[pos.side_to_move()];
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
@@ -1213,7 +1216,7 @@ moves_loop: // When in check search starts from here
         {
             // Never assume anything on values stored in TT
             if ((ss->staticEval = bestValue = tte->eval()) == VALUE_NONE)
-                ss->staticEval = bestValue = evaluate(pos);
+                ss->staticEval = bestValue = evaluate(pos, ei);
 
             // Can ttValue be used as a better position evaluation?
             if (ttValue != VALUE_NONE)
@@ -1222,7 +1225,7 @@ moves_loop: // When in check search starts from here
         }
         else
             ss->staticEval = bestValue =
-            (ss-1)->currentMove != MOVE_NULL ? evaluate(pos)
+            (ss-1)->currentMove != MOVE_NULL ? evaluate(pos, ei)
                                              : -(ss-1)->staticEval + 2 * Eval::Tempo;
 
         // Stand pat. Return immediately if static value is at least beta


### PR DESCRIPTION
The intention was accessing EvalInfo also in search for general purposes (e.g. to better calculate static eval in the null-move-search-condition in case of hanging pieces).
Surprisingly this seems also to be a small performance improvement.

x86-64-modern gcc 4.8.1 Win7-64 i7-3770 @ 3.4GHz
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    1927321   1987979   -60658    
    StDev   20600     27573     12066     

p-value: 1
speedup: 0,031