### PR TITLE
Only spend about 10% of our time once in a RootInTB position.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -502,6 +502,7 @@ void Thread::search() {
                                && Time.elapsed() > Time.optimum() * 5 / 42;
 
               if (   rootMoves.size() == 1
+                  || (TB::RootInTB && Time.elapsed() > Time.optimum() / 10)
                   || Time.elapsed() > Time.optimum() * unstablePvFactor * improvingFactor / 628
                   || (mainThread->easyMovePlayed = doEasyMove))
               {


### PR DESCRIPTION
There is no need to spend much time once the root position
is a winning TB position. Filtered root moves guarantee we can't lose.

This should help against engines without TB support unable to see the loss,
and adjudication not kicking in. Happened now 3 or 4 times already at TCEC.

No functional change.