### PR TITLE
added position::show()

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -406,6 +406,33 @@ const string Position::fen() const {
   return ss.str();
 }
 
+/// Position::show() returns a board representation of the position. 
+const string Position::show() const {
+
+  std::ostringstream ss;
+  int cnt = 0;
+
+  ss << "+--------+" << std::endl;
+  for (Rank r = RANK_8; r >= RANK_1; --r)
+  {
+      ss << "|";
+      for (File f = FILE_A; f <= FILE_H; ++f)
+      {
+          char color = ( cnt & 1 ) ? '#' : ' ';
+          Square s = make_square(f, r);
+          if (empty(s))
+              ss << color;
+          else
+              ss << PieceToChar[piece_on(s)];
+          cnt++;
+      }
+      ss << "|" << std::endl;
+  }
+  ss << "+========+" << std::endl;
+
+  return ss.str();
+}
+
 
 /// Position::game_phase() calculates the game phase interpolating total non-pawn
 /// material between endgame and midgame limits.

--- a/src/position.h
+++ b/src/position.h
@@ -99,6 +99,7 @@ public:
   // FEN string input/output
   Position& set(const std::string& fenStr, bool isChess960, StateInfo* si, Thread* th);
   const std::string fen() const;
+  const std::string show() const;
 
   // Position representation
   Bitboard pieces() const;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -209,6 +209,7 @@ void UCI::loop(int argc, char* argv[]) {
 
           benchmark(pos, ss);
       }
+      else if (token == "show")       sync_cout << pos.show() << sync_endl;
       else
           sync_cout << "Unknown command: " << cmd << sync_endl;
 


### PR DESCRIPTION
Added show() method for Position class to show the board state in a more human readable format than the fen() method.