### PR TITLE
Space formula

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -705,7 +705,7 @@ namespace {
     int bonus = popcount((Us == WHITE ? safe << 32 : safe >> 32) | (behind & safe));
     int weight = pos.count<ALL_PIECES>(Us);
  
-    return make_score((bonus * weight * weight)  / (11 * 2), 0);
+    return make_score(bonus * weight * weight  / 22, 0);
   }
 
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -703,10 +703,9 @@ namespace {
 
     // ...count safe + (behind & safe) with a single popcount
     int bonus = popcount((Us == WHITE ? safe << 32 : safe >> 32) | (behind & safe));
-    int weight =  pos.count<KNIGHT>(Us) + pos.count<BISHOP>(Us)
-                + pos.count<KNIGHT>(Them) + pos.count<BISHOP>(Them);
-
-    return make_score(bonus * weight * weight * 2 / 11, 0);
+    int weight = pos.count<ALL_PIECES>(Us);
+ 
+    return make_score((bonus * weight * weight)  / (11 * 2), 0);
   }
 
 


### PR DESCRIPTION
Simplify the weight used in the space formula.

Instead of counting number of minors on board, count own pieces, and calibrate accordingly.

bench: 6663531
master: 6985912