### PR TITLE
Lower and simplify the computed midgame passed pawn bonus

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -657,7 +657,7 @@ namespace {
                 mbonus += k * rr, ebonus += k * rr;
             }
             else if (pos.pieces(Us) & blockSq)
-                mbonus += rr + r * 2, ebonus += rr + r * 2;
+                mbonus += rr, ebonus += rr + r * 2;
         } // rr != 0
 
         score += make_score(mbonus, ebonus) + PassedFile[file_of(s)];


### PR DESCRIPTION
STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 18333 W: 3504 L: 3378 D: 11451

LTC:
LLR: 3.09 (-2.94,2.94) [-3.00,1.00]
Total: 33406 W: 4634 L: 4524 D: 24248