### PR TITLE
Use predicted depth for history pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -914,16 +914,16 @@ moves_loop: // When in check search starts from here
           // Move count based pruning
           if (moveCountPruning)
               continue;
+              
+          predictedDepth = std::max(newDepth - reduction<PvNode>(improving, depth, moveCount), DEPTH_ZERO);
 
           // Countermoves based pruning
-          if (   depth <= 4 * ONE_PLY
+          if (   predictedDepth < 3 * ONE_PLY
               && move != ss->killers[0]
               && (!cmh  || (*cmh )[moved_piece][to_sq(move)] < VALUE_ZERO)
               && (!fmh  || (*fmh )[moved_piece][to_sq(move)] < VALUE_ZERO)
               && (!fmh2 || (*fmh2)[moved_piece][to_sq(move)] < VALUE_ZERO || (cmh && fmh)))
               continue;
-
-          predictedDepth = std::max(newDepth - reduction<PvNode>(improving, depth, moveCount), DEPTH_ZERO);
 
           // Futility pruning: parent node
           if (   predictedDepth < 7 * ONE_PLY


### PR DESCRIPTION
Use predicted depth for history pruning

STC:  (Yellow)
LLR: -2.96 (-2.94,2.94) [0.00,4.00]
Total: 69115 W: 12880 L: 12797 D: 43438

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 124163 W: 16923 L: 16442 D: 90798

Bench:  7351698

Note:  Note based off past experiments / patches... history pruning is quite TC sensitive.
I believe the reason for this TC dependency is that the CMH/FMH is a very large table that takes time to fill up with.  In addition having more time for will increase the accuracy of the stats' value.