### PR TITLE
Move initiative computations and add a count variable to pawn table.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -713,14 +713,13 @@ namespace {
   // evaluate_initiative() computes the initiative correction value for the
   // position, i.e., second order bonus/malus based on the known attacking/defending
   // status of the players.
-  Score evaluate_initiative(const Position& pos, int asymmetry, Value eg) {
+  Score evaluate_initiative(const Position& pos, int pawnInitiative, Value eg) {
 
     int kingDistance =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
                       - distance<Rank>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
-    int pawns = pos.count<PAWN>(WHITE) + pos.count<PAWN>(BLACK);
 
     // Compute the initiative bonus for the attacking side
-    int initiative = 8 * (asymmetry + kingDistance - 15) + 12 * pawns;
+    int initiative = 8 * kingDistance + pawnInitiative;
 
     // Now apply the bonus: note that we find the attacking side by extracting
     // the sign of the endgame value, and that we carefully cap the bonus so
@@ -852,7 +851,7 @@ Value Eval::evaluate(const Position& pos) {
               - evaluate_space<BLACK>(pos, ei);
 
   // Evaluate position potential for the winning side
-  score += evaluate_initiative(pos, ei.pi->pawn_asymmetry(), eg_value(score));
+  score += evaluate_initiative(pos, ei.pi->pawn_initiative(), eg_value(score));
 
   // Evaluate scale factor for the winning side
   ScaleFactor sf = evaluate_scale_factor(pos, ei, eg_value(score));

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -103,12 +103,15 @@ namespace {
     Bitboard ourPawns   = pos.pieces(Us  , PAWN);
     Bitboard theirPawns = pos.pieces(Them, PAWN);
 
+    e->count[Us] = pos.count<PAWN>(Us);
+
     e->passedPawns[Us] = e->pawnAttacksSpan[Us] = 0;
     e->kingSquares[Us] = SQ_NONE;
     e->semiopenFiles[Us] = 0xFF;
     e->pawnAttacks[Us] = shift_bb<Right>(ourPawns) | shift_bb<Left>(ourPawns);
     e->pawnsOnSquares[Us][BLACK] = popcount(ourPawns & DarkSquares);
-    e->pawnsOnSquares[Us][WHITE] = pos.count<PAWN>(Us) - e->pawnsOnSquares[Us][BLACK];
+    e->pawnsOnSquares[Us][WHITE] = e->count[Us] - e->pawnsOnSquares[Us][BLACK];
+
 
     // Loop through all pawns of the current color and score each pawn
     while ((s = *pl++) != SQ_NONE)
@@ -217,7 +220,7 @@ Entry* probe(const Position& pos) {
 
   e->key = key;
   e->score = evaluate<WHITE>(pos, e) - evaluate<BLACK>(pos, e);
-  e->asymmetry = popcount(e->semiopenFiles[WHITE] ^ e->semiopenFiles[BLACK]);
+  e->initiative = 12 * (e->count[WHITE] + e->count[BLACK]) + 8 * popcount(e->semiopenFiles[WHITE] ^ e->semiopenFiles[BLACK]) - 120;
   return e;
 }
 

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -38,7 +38,7 @@ struct Entry {
   Bitboard passed_pawns(Color c) const { return passedPawns[c]; }
   Bitboard pawn_attacks_span(Color c) const { return pawnAttacksSpan[c]; }
   int pawn_span(Color c) const { return pawnSpan[c]; }
-  int pawn_asymmetry() const { return asymmetry; }
+  int pawn_initiative() const { return initiative; }
 
   int semiopen_file(Color c, File f) const {
     return semiopenFiles[c] & (1 << f);
@@ -75,7 +75,8 @@ struct Entry {
   int semiopenFiles[COLOR_NB];
   int pawnSpan[COLOR_NB];
   int pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
-  int asymmetry;
+  int initiative;
+  int count[COLOR_NB];
 };
 
 typedef HashTable<Entry, 16384> Table;


### PR DESCRIPTION
Move initiative computations and add a count variable to pawn table.

Saves two pos.count<PAWNS> calls and some arithmetic operations for every evaluate call. This also provides useful information in the pawn table which could be used elsewhere in evaluation or search.

It is a consistent speed-up for my non PGO-builds (50 samples):

python fishBench.py stockfish_branch stockfish_master 50

stockfish_branch                | 2046375.5 +- 7677.0
stockfish_master                | 2044332.0 +- 6494.62

Differences                           | 2040.0 +- 1175.0
Variance of the mean         | 166.17 ( 8.15 %)
Speed up                               | 0.1 %

No functional change.