### PR TITLE
Simplify the way we keep StateInfo structures for preceding moves.

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -145,11 +145,12 @@ void benchmark(const Position& current, istream& is) {
   uint64_t nodes = 0;
   TimePoint elapsed = now();
   Position pos;
+  StateList states;
 
   for (size_t i = 0; i < fens.size(); ++i)
   {
-      StateListPtr states(new std::deque<StateInfo>(1));
-      pos.set(fens[i], Options["UCI_Chess960"], &states->back(), Threads.main());
+      states.resize(1);
+      pos.set(fens[i], Options["UCI_Chess960"], &states.back(), Threads.main());
 
       cerr << "\nPosition: " << i + 1 << '/' << fens.size() << endl;
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -144,8 +144,8 @@ void benchmark(const Position& current, istream& is) {
 
   uint64_t nodes = 0;
   TimePoint elapsed = now();
-  Position pos;
   StateList states;
+  Position pos;
 
   for (size_t i = 0; i < fens.size(); ++i)
   {

--- a/src/position.h
+++ b/src/position.h
@@ -24,7 +24,6 @@
 #include <cassert>
 #include <cstddef>  // For offsetof()
 #include <deque>
-#include <memory>   // For std::unique_ptr
 #include <string>
 #include <vector>
 
@@ -79,7 +78,7 @@ struct StateInfo {
 };
 
 // In a std::deque references to elements are unaffected upon resizing
-typedef std::unique_ptr<std::deque<StateInfo>> StateListPtr;
+typedef std::deque<StateInfo> StateList;
 
 
 /// Position class stores information regarding the board representation as

--- a/src/thread.h
+++ b/src/thread.h
@@ -95,12 +95,9 @@ struct ThreadPool : public std::vector<Thread*> {
   void exit(); // be initialized and valid during the whole thread lifetime.
 
   MainThread* main() { return static_cast<MainThread*>(at(0)); }
-  void start_thinking(Position&, StateListPtr&, const Search::LimitsType&);
+  void start_thinking(Position&, StateList&, const Search::LimitsType&);
   void read_uci_options();
   int64_t nodes_searched();
-
-private:
-  StateListPtr setupStates;
 };
 
 extern ThreadPool Threads;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -42,7 +42,7 @@ namespace {
   // A list to keep track of the position states along the setup moves (from the
   // start position to the position just before the search starts). Needed by
   // 'draw by repetition' detection.
-  StateListPtr States(new std::deque<StateInfo>(1));
+  StateList States(1);
 
 
   // position() is called when engine receives the "position" UCI command.
@@ -68,14 +68,14 @@ namespace {
     else
         return;
 
-    States = StateListPtr(new std::deque<StateInfo>(1));
-    pos.set(fen, Options["UCI_Chess960"], &States->back(), Threads.main());
+    States.resize(1);
+    pos.set(fen, Options["UCI_Chess960"], &States.back(), Threads.main());
 
     // Parse move list (if any)
     while (is >> token && (m = UCI::to_move(pos, token)) != MOVE_NONE)
     {
-        States->push_back(StateInfo());
-        pos.do_move(m, States->back(), pos.gives_check(m, CheckInfo(pos)));
+        States.push_back(StateInfo());
+        pos.do_move(m, States.back(), pos.gives_check(m, CheckInfo(pos)));
     }
   }
 
@@ -149,7 +149,7 @@ void UCI::loop(int argc, char* argv[]) {
   Position pos;
   string token, cmd;
 
-  pos.set(StartFEN, false, &States->back(), Threads.main());
+  pos.set(StartFEN, false, &States.back(), Threads.main());
 
   for (int i = 1; i < argc; ++i)
       cmd += std::string(argv[i]) + " ";


### PR DESCRIPTION
Using unique_ptr<deque<>> and transferring ownership serves no purpose.
Get rid of dynamically-allocating deque<StateInfo> and reallocating it
on every new position. It makes code simpler. Using resize(1) instead of
reallocating the container will spare execution time.

This change does not break consecutive 'go' commands.