### PR TITLE
Move initiative computations to pawn table

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -713,14 +713,13 @@ namespace {
   // evaluate_initiative() computes the initiative correction value for the
   // position, i.e., second order bonus/malus based on the known attacking/defending
   // status of the players.
-  Score evaluate_initiative(const Position& pos, int asymmetry, Value eg) {
+  Score evaluate_initiative(const Position& pos, int pawnInitiative, Value eg) {
 
     int kingDistance =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
                       - distance<Rank>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
-    int pawns = pos.count<PAWN>(WHITE) + pos.count<PAWN>(BLACK);
 
     // Compute the initiative bonus for the attacking side
-    int initiative = 8 * (asymmetry + kingDistance - 15) + 12 * pawns;
+    int initiative = 8 * kingDistance + pawnInitiative;
 
     // Now apply the bonus: note that we find the attacking side by extracting
     // the sign of the endgame value, and that we carefully cap the bonus so
@@ -852,7 +851,7 @@ Value Eval::evaluate(const Position& pos) {
               - evaluate_space<BLACK>(pos, ei);
 
   // Evaluate position potential for the winning side
-  score += evaluate_initiative(pos, ei.pi->pawn_asymmetry(), eg_value(score));
+  score += evaluate_initiative(pos, ei.pi->pawn_initiative(), eg_value(score));
 
   // Evaluate scale factor for the winning side
   ScaleFactor sf = evaluate_scale_factor(pos, ei, eg_value(score));

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -217,7 +217,7 @@ Entry* probe(const Position& pos) {
 
   e->key = key;
   e->score = evaluate<WHITE>(pos, e) - evaluate<BLACK>(pos, e);
-  e->asymmetry = popcount(e->semiopenFiles[WHITE] ^ e->semiopenFiles[BLACK]);
+  e->initiative = 12 * (pos.count<PAWN>(WHITE) + pos.count<PAWN>(BLACK)) + 8 * popcount(e->semiopenFiles[WHITE] ^ e->semiopenFiles[BLACK]) - 120;
   return e;
 }
 

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -38,7 +38,7 @@ struct Entry {
   Bitboard passed_pawns(Color c) const { return passedPawns[c]; }
   Bitboard pawn_attacks_span(Color c) const { return pawnAttacksSpan[c]; }
   int pawn_span(Color c) const { return pawnSpan[c]; }
-  int pawn_asymmetry() const { return asymmetry; }
+  int pawn_initiative() const { return initiative; }
 
   int semiopen_file(Color c, File f) const {
     return semiopenFiles[c] & (1 << f);
@@ -75,7 +75,7 @@ struct Entry {
   int semiopenFiles[COLOR_NB];
   int pawnSpan[COLOR_NB];
   int pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
-  int asymmetry;
+  int initiative;
 };
 
 typedef HashTable<Entry, 16384> Table;


### PR DESCRIPTION
Move initiative computations to pawn table, without creating a count variable. Follow-up of https://github.com/official-stockfish/Stockfish/pull/750. 

Patch reduces LOCs, so its reverting would not qualify as a simplification. Speed-up is small but measurable, see results from 50 runs.

Engine                                    | Nodes/second
stockfish_branch                | 2047541.0 +- 6970.24
stockfish_master                | 2038740.0 +- 6295.74

Differences                            | 9100.0 +- 883.0
Variance of the mean          | 124.88 ( 1.37 %)
Speed up                                | 0.45 %
