### PR TITLE
Add support for UCI_LimitStrength feature

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -63,6 +63,13 @@ namespace {
   // Different node types, used as a template parameter
   enum NodeType { NonPV, PV };
 
+  // ELO values corresponded to every of Skill Level values
+  const int elo[21] = {
+	  1250, 1380, 1515, 1635, 1750, 1830, 1900,
+	  1970, 2060, 2150, 2200, 2270, 2310, 2380,
+	  2450, 2500, 2580, 2660, 2720, 2780, 3350
+  };
+
   // Razoring and futility margin based on depth
   const int razor_margin[4] = { 483, 570, 603, 554 };
   Value futility_margin(Depth d) { return Value(150 * d); }
@@ -358,7 +365,21 @@ void Thread::search() {
   }
 
   size_t multiPV = Options["MultiPV"];
-  Skill skill(Options["Skill Level"]);
+  int SkillLevel = Options["Skill Level"];
+  
+  // Add support for the "UCI_LimitStrength" feature
+  if (Options["UCI_LimitStrength"]) {
+	  int UCIElo = Options["UCI_Elo"];
+
+	  for (idx = 0; idx < 20; ++idx)
+		  if (UCIElo < elo[idx + 1]) {
+			  SkillLevel = idx;
+
+			  break;
+		  }
+  }
+
+  Skill skill(SkillLevel);
 
   // When playing with strength handicap enable MultiPV search that we will
   // use behind the scenes to retrieve a set of possible moves.

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -70,6 +70,8 @@ void init(OptionsMap& o) {
   o["Slow Mover"]            << Option(89, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
+  o["UCI_LimitStrength"]     << Option(false);
+  o["UCI_Elo"]               << Option(1250, 1250, 2800);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);
   o["Syzygy50MoveRule"]      << Option(true);


### PR DESCRIPTION
Dear developers.

Here is my second attempt for adding this feature for comfortable using Stockfish engine with Shredder and Fritz GUI.

All Elo values was produced after 500 games with 4'+2'' time control for every level and rounded due to statistical errors for every level = 22 Elo.

Level 00: 1264
Level 01: 1384
Level 02: 1513
Level 03: 1633
Level 04: 1746
Level 05: 1830
Level 06: 1893
Level 07: 1966
Level 08: 2058
Level 09: 2150
Level 10: 2204
Level 11: 2265
Level 12: 2311
Level 13: 2381
Level 14: 2454
Level 15: 2504
Level 16: 2578
Level 17: 2655
Level 18: 2714
Level 19: 2775
Level 20: 3367

Sample for Level 11 & 12:

Level 11:
   # PLAYER                               : RATING  ERROR   POINTS  PLAYED    (%)
   1 Sungorus 1.4                      : 2310.0   ----    281.5     500   56.3%
   2 Stockfish 7 64 POPCNT       : 2265.4   21.6    218.5     500   43.7%

   White advantage = 22.10 +/- 10.71
   Draw rate (equal opponents) = 50.00 % +/- 0.00

Level 12:
   # PLAYER                               : RATING  ERROR   POINTS  PLAYED    (%)
   1 Stockfish 7 64 POPCNT       : 2311.4   21.7    251.0     500   50.2%
   2 Sungorus 1.4                      : 2310.0   ----    249.0     500   49.8%

White advantage = 59.45 +/- 10.75
Draw rate (equal opponents) = 50.00 % +/- 0.00
