### PR TITLE
Let SF to be ONE_PLY value independent

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -652,7 +652,7 @@ namespace {
         int piecesCnt = pos.count<ALL_PIECES>(WHITE) + pos.count<ALL_PIECES>(BLACK);
 
         if (    piecesCnt <= TB::Cardinality
-            && (piecesCnt <  TB::Cardinality || depth / ONE_PLY >= TB::ProbeDepth)
+            && (piecesCnt <  TB::Cardinality || depth >= TB::ProbeDepth)
             &&  pos.rule50_count() == 0
             && !pos.can_castle(ANY_CASTLING))
         {

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -92,8 +92,8 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
       // nature we add 259 (256 is the modulus plus 3 to keep the lowest
       // two bound bits from affecting the result) to calculate the entry
       // age correctly even after generation8 overflows into the next cycle.
-      if (  replace->depth8 - ((259 + generation8 - replace->genBound8) & 0xFC) * 2 * ONE_PLY
-          >   tte[i].depth8 - ((259 + generation8 -   tte[i].genBound8) & 0xFC) * 2 * ONE_PLY)
+      if (  replace->depth8 - ((259 + generation8 - replace->genBound8) & 0xFC) * 2
+          >   tte[i].depth8 - ((259 + generation8 -   tte[i].genBound8) & 0xFC) * 2)
           replace = &tte[i];
 
   return found = false, replace;

--- a/src/tt.h
+++ b/src/tt.h
@@ -60,7 +60,7 @@ struct TTEntry {
         value16   = (int16_t)v;
         eval16    = (int16_t)ev;
         genBound8 = (uint8_t)(g | b);
-        depth8    = (int8_t)d / ONE_PLY;
+        depth8    = (int8_t)(d / ONE_PLY);
     }
   }
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -39,10 +39,13 @@ struct TTEntry {
   Move  move()  const { return (Move )move16; }
   Value value() const { return (Value)value16; }
   Value eval()  const { return (Value)eval16; }
-  Depth depth() const { return (Depth)depth8; }
+  Depth depth() const { return (Depth)(depth8 * ONE_PLY); }
   Bound bound() const { return (Bound)(genBound8 & 0x3); }
 
   void save(Key k, Value v, Bound b, Depth d, Move m, Value ev, uint8_t g) {
+
+    // Convert to integer
+    d /= ONE_PLY;
 
     // Preserve any existing move for the same position
     if (m || (k >> 48) != key16)

--- a/src/tt.h
+++ b/src/tt.h
@@ -44,8 +44,7 @@ struct TTEntry {
 
   void save(Key k, Value v, Bound b, Depth d, Move m, Value ev, uint8_t g) {
 
-    // Convert to integer
-    d /= ONE_PLY;
+    assert(d / ONE_PLY * ONE_PLY == d);
 
     // Preserve any existing move for the same position
     if (m || (k >> 48) != key16)
@@ -53,7 +52,7 @@ struct TTEntry {
 
     // Don't overwrite more valuable entries
     if (  (k >> 48) != key16
-        || d > depth8 - 4
+        || d / ONE_PLY > depth8 - 4
      /* || g != (genBound8 & 0xFC) // Matching non-zero keys are already refreshed by probe() */
         || b == BOUND_EXACT)
     {
@@ -61,7 +60,7 @@ struct TTEntry {
         value16   = (int16_t)v;
         eval16    = (int16_t)ev;
         genBound8 = (uint8_t)(g | b);
-        depth8    = (int8_t)d;
+        depth8    = (int8_t)d / ONE_PLY;
     }
   }
 

--- a/src/types.h
+++ b/src/types.h
@@ -218,6 +218,8 @@ enum Depth {
   DEPTH_MAX  = MAX_PLY * ONE_PLY
 };
 
+static_assert(!(ONE_PLY & (ONE_PLY - 1)), "ONE_PLY is not power of 2");
+
 enum Square {
   SQ_A1, SQ_B1, SQ_C1, SQ_D1, SQ_E1, SQ_F1, SQ_G1, SQ_H1,
   SQ_A2, SQ_B2, SQ_C2, SQ_D2, SQ_E2, SQ_F2, SQ_G2, SQ_H2,

--- a/src/types.h
+++ b/src/types.h
@@ -209,13 +209,13 @@ enum Depth {
 
   ONE_PLY = 1,
 
-  DEPTH_ZERO          =  0,
-  DEPTH_QS_CHECKS     =  0,
-  DEPTH_QS_NO_CHECKS  = -1,
-  DEPTH_QS_RECAPTURES = -5,
+  DEPTH_ZERO          =  0 * ONE_PLY,
+  DEPTH_QS_CHECKS     =  0 * ONE_PLY,
+  DEPTH_QS_NO_CHECKS  = -1 * ONE_PLY,
+  DEPTH_QS_RECAPTURES = -5 * ONE_PLY,
 
-  DEPTH_NONE = -6,
-  DEPTH_MAX  = MAX_PLY
+  DEPTH_NONE = -6 * ONE_PLY,
+  DEPTH_MAX  = MAX_PLY * ONE_PLY
 };
 
 enum Square {


### PR DESCRIPTION
This non-functional change patch series is a deep work to allow SF to be independent from the actual value of ONE_PLY (currently set to 1).

I have verified SF is now independent for ONE_PLY values 1, 2, 4, 8 above that there is still some change to be investigated (I think is some rounding error).

I will run a test to verify there is no regression and then I will open a PR because I think this work is important and gives consistency to the code. I think is also the base above which to rewrite the heterogeneous formulas involving depth to allow better interpolation and avoiding of rounding errors.

Diving in the low level detail of the code I found many issues, especially with relatively new code and I realized SF starts to suffer from continues add-on tweaks more or less bolted on existing code. It is time for some deep consistency improvement to allow future work to be based on solid grounds.

I will run some regression test as soon as fishtest (now is down) returns online.

