### PR TITLE
Move CheckInfo under StateInfo

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -359,7 +359,7 @@ namespace {
         if (Pt == QUEEN)
         {
             // Penalty if any relative pin or discovered attack against the queen
-            if (pos.slider_blockers(pos.pieces(), pos.pieces(Them, ROOK, BISHOP), s))
+            if (pos.slider_blockers(pos.pieces(Them, ROOK, BISHOP), s))
                 score -= WeakQueen;
         }
     }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -231,7 +231,7 @@ namespace {
     const Color  Them = (Us == WHITE ? BLACK   : WHITE);
     const Square Down = (Us == WHITE ? DELTA_S : DELTA_N);
 
-    ei.pinnedPieces[Us] = pos.check_info().blockers[Us] & pos.pieces(Us);                                                                                              
+    ei.pinnedPieces[Us] = pos.pinned_pieces(Us);
     Bitboard b = ei.attackedBy[Them][KING];
     ei.attackedBy[Them][ALL_PIECES] |= b;
     ei.attackedBy[Us][ALL_PIECES] |= ei.attackedBy[Us][PAWN] = ei.pi->pawn_attacks(Us);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -231,7 +231,8 @@ namespace {
     const Color  Them = (Us == WHITE ? BLACK   : WHITE);
     const Square Down = (Us == WHITE ? DELTA_S : DELTA_N);
 
-    ei.pinnedPieces[Us] = pos.pinned_pieces(Us);
+    ei.pinnedPieces[Us] = Us == pos.side_to_move() ? pos.check_info().pinned
+                                                   : pos.pinned_pieces(Us);
     Bitboard b = ei.attackedBy[Them][KING];
     ei.attackedBy[Them][ALL_PIECES] |= b;
     ei.attackedBy[Us][ALL_PIECES] |= ei.attackedBy[Us][PAWN] = ei.pi->pawn_attacks(Us);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -231,8 +231,7 @@ namespace {
     const Color  Them = (Us == WHITE ? BLACK   : WHITE);
     const Square Down = (Us == WHITE ? DELTA_S : DELTA_N);
 
-    ei.pinnedPieces[Us] = Us == pos.side_to_move() ? pos.check_info().pinned
-                                                   : pos.pinned_pieces(Us);
+    ei.pinnedPieces[Us] = pos.check_info().blockers[Us] & pos.pieces(Us);                                                                                              
     Bitboard b = ei.attackedBy[Them][KING];
     ei.attackedBy[Them][ALL_PIECES] |= b;
     ei.attackedBy[Us][ALL_PIECES] |= ei.attackedBy[Us][PAWN] = ei.pi->pawn_attacks(Us);

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -133,9 +133,10 @@ namespace {
             // if the pawn is not on the same file as the enemy king, because we
             // don't generate captures. Note that a possible discovery check
             // promotion has been already generated amongst the captures.
-            if (pawnsNotOn7 & pos.check_info().dcCandidates)
+            Bitboard dcCandidates = pos.discovered_check_candidates();
+            if (pawnsNotOn7 & dcCandidates)
             {
-                Bitboard dc1 = shift_bb<Up>(pawnsNotOn7 & pos.check_info().dcCandidates) & emptySquares & ~file_bb(ksq);
+                Bitboard dc1 = shift_bb<Up>(pawnsNotOn7 & dcCandidates) & emptySquares & ~file_bb(ksq);
                 Bitboard dc2 = shift_bb<Up>(dc1 & TRank3BB) & emptySquares;
 
                 b1 |= dc1;
@@ -237,7 +238,7 @@ namespace {
                 && !(PseudoAttacks[Pt][from] & target & pos.check_info().checkSquares[Pt]))
                 continue;
 
-            if (pos.check_info().dcCandidates & from)
+            if (pos.discovered_check_candidates() & from)
                 continue;
         }
 
@@ -332,7 +333,7 @@ ExtMove* generate<QUIET_CHECKS>(const Position& pos, ExtMove* moveList) {
   assert(!pos.checkers());
 
   Color us = pos.side_to_move();
-  Bitboard dc = pos.check_info().dcCandidates;
+  Bitboard dc = pos.discovered_check_candidates();
 
   while (dc)
   {
@@ -399,7 +400,7 @@ ExtMove* generate<EVASIONS>(const Position& pos, ExtMove* moveList) {
 template<>
 ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
 
-  Bitboard pinned = pos.check_info().pinned;
+  Bitboard pinned = pos.pinned_pieces(pos.side_to_move());
   Square ksq = pos.square<KING>(pos.side_to_move());
   ExtMove* cur = moveList;
 

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -26,7 +26,7 @@
 namespace {
 
   template<CastlingRight Cr, bool Checks, bool Chess960>
-  ExtMove* generate_castling(const Position& pos, ExtMove* moveList, Color us, const CheckInfo* ci) {
+  ExtMove* generate_castling(const Position& pos, ExtMove* moveList, Color us) {
 
     static const bool KingSide = (Cr == WHITE_OO || Cr == BLACK_OO);
 
@@ -57,10 +57,8 @@ namespace {
 
     Move m = make<CASTLING>(kfrom, rfrom);
 
-    if (Checks && !pos.gives_check(m, *ci))
+    if (Checks && !pos.gives_check(m))
         return moveList;
-    else
-        (void)ci; // Silence a warning under MSVC
 
     *moveList++ = m;
     return moveList;
@@ -68,7 +66,7 @@ namespace {
 
 
   template<GenType Type, Square Delta>
-  ExtMove* make_promotions(ExtMove* moveList, Square to, const CheckInfo* ci) {
+  ExtMove* make_promotions(ExtMove* moveList, Square to, Square ksq) {
 
     if (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS)
         *moveList++ = make<PROMOTION>(to - Delta, to, QUEEN);
@@ -82,18 +80,15 @@ namespace {
 
     // Knight promotion is the only promotion that can give a direct check
     // that's not already included in the queen promotion.
-    if (Type == QUIET_CHECKS && (StepAttacksBB[W_KNIGHT][to] & ci->ksq))
+    if (Type == QUIET_CHECKS && (StepAttacksBB[W_KNIGHT][to] & ksq))
         *moveList++ = make<PROMOTION>(to - Delta, to, KNIGHT);
-    else
-        (void)ci; // Silence a warning under MSVC
 
     return moveList;
   }
 
 
   template<Color Us, GenType Type>
-  ExtMove* generate_pawn_moves(const Position& pos, ExtMove* moveList,
-                               Bitboard target, const CheckInfo* ci) {
+  ExtMove* generate_pawn_moves(const Position& pos, ExtMove* moveList, Bitboard target) {
 
     // Compute our parametrized parameters at compile time, named according to
     // the point of view of white side.
@@ -129,16 +124,18 @@ namespace {
 
         if (Type == QUIET_CHECKS)
         {
-            b1 &= pos.attacks_from<PAWN>(ci->ksq, Them);
-            b2 &= pos.attacks_from<PAWN>(ci->ksq, Them);
+            Square ksq = pos.square<KING>(Them);
+
+            b1 &= pos.attacks_from<PAWN>(ksq, Them);
+            b2 &= pos.attacks_from<PAWN>(ksq, Them);
 
             // Add pawn pushes which give discovered check. This is possible only
             // if the pawn is not on the same file as the enemy king, because we
             // don't generate captures. Note that a possible discovery check
             // promotion has been already generated amongst the captures.
-            if (pawnsNotOn7 & ci->dcCandidates)
+            if (pawnsNotOn7 & pos.check_info().dcCandidates)
             {
-                Bitboard dc1 = shift_bb<Up>(pawnsNotOn7 & ci->dcCandidates) & emptySquares & ~file_bb(ci->ksq);
+                Bitboard dc1 = shift_bb<Up>(pawnsNotOn7 & pos.check_info().dcCandidates) & emptySquares & ~file_bb(ksq);
                 Bitboard dc2 = shift_bb<Up>(dc1 & TRank3BB) & emptySquares;
 
                 b1 |= dc1;
@@ -172,14 +169,16 @@ namespace {
         Bitboard b2 = shift_bb<Left >(pawnsOn7) & enemies;
         Bitboard b3 = shift_bb<Up   >(pawnsOn7) & emptySquares;
 
+        Square ksq = pos.square<KING>(Them);
+
         while (b1)
-            moveList = make_promotions<Type, Right>(moveList, pop_lsb(&b1), ci);
+            moveList = make_promotions<Type, Right>(moveList, pop_lsb(&b1), ksq);
 
         while (b2)
-            moveList = make_promotions<Type, Left >(moveList, pop_lsb(&b2), ci);
+            moveList = make_promotions<Type, Left >(moveList, pop_lsb(&b2), ksq);
 
         while (b3)
-            moveList = make_promotions<Type, Up   >(moveList, pop_lsb(&b3), ci);
+            moveList = make_promotions<Type, Up   >(moveList, pop_lsb(&b3), ksq);
     }
 
     // Standard and en-passant captures
@@ -224,8 +223,7 @@ namespace {
 
 
   template<PieceType Pt, bool Checks>
-  ExtMove* generate_moves(const Position& pos, ExtMove* moveList, Color us,
-                          Bitboard target, const CheckInfo* ci) {
+  ExtMove* generate_moves(const Position& pos, ExtMove* moveList, Color us, Bitboard target) {
 
     assert(Pt != KING && Pt != PAWN);
 
@@ -236,17 +234,17 @@ namespace {
         if (Checks)
         {
             if (    (Pt == BISHOP || Pt == ROOK || Pt == QUEEN)
-                && !(PseudoAttacks[Pt][from] & target & ci->checkSquares[Pt]))
+                && !(PseudoAttacks[Pt][from] & target & pos.check_info().checkSquares[Pt]))
                 continue;
 
-            if (ci->dcCandidates & from)
+            if (pos.check_info().dcCandidates & from)
                 continue;
         }
 
         Bitboard b = pos.attacks_from<Pt>(from) & target;
 
         if (Checks)
-            b &= ci->checkSquares[Pt];
+            b &= pos.check_info().checkSquares[Pt];
 
         while (b)
             *moveList++ = make_move(from, pop_lsb(&b));
@@ -257,16 +255,15 @@ namespace {
 
 
   template<Color Us, GenType Type>
-  ExtMove* generate_all(const Position& pos, ExtMove* moveList, Bitboard target,
-                        const CheckInfo* ci = nullptr) {
+  ExtMove* generate_all(const Position& pos, ExtMove* moveList, Bitboard target) {
 
     const bool Checks = Type == QUIET_CHECKS;
 
-    moveList = generate_pawn_moves<Us, Type>(pos, moveList, target, ci);
-    moveList = generate_moves<KNIGHT, Checks>(pos, moveList, Us, target, ci);
-    moveList = generate_moves<BISHOP, Checks>(pos, moveList, Us, target, ci);
-    moveList = generate_moves<  ROOK, Checks>(pos, moveList, Us, target, ci);
-    moveList = generate_moves< QUEEN, Checks>(pos, moveList, Us, target, ci);
+    moveList = generate_pawn_moves<Us, Type>(pos, moveList, target);
+    moveList = generate_moves<KNIGHT, Checks>(pos, moveList, Us, target);
+    moveList = generate_moves<BISHOP, Checks>(pos, moveList, Us, target);
+    moveList = generate_moves<  ROOK, Checks>(pos, moveList, Us, target);
+    moveList = generate_moves< QUEEN, Checks>(pos, moveList, Us, target);
 
     if (Type != QUIET_CHECKS && Type != EVASIONS)
     {
@@ -280,13 +277,13 @@ namespace {
     {
         if (pos.is_chess960())
         {
-            moveList = generate_castling<MakeCastling<Us,  KING_SIDE>::right, Checks, true>(pos, moveList, Us, ci);
-            moveList = generate_castling<MakeCastling<Us, QUEEN_SIDE>::right, Checks, true>(pos, moveList, Us, ci);
+            moveList = generate_castling<MakeCastling<Us,  KING_SIDE>::right, Checks, true>(pos, moveList, Us);
+            moveList = generate_castling<MakeCastling<Us, QUEEN_SIDE>::right, Checks, true>(pos, moveList, Us);
         }
         else
         {
-            moveList = generate_castling<MakeCastling<Us,  KING_SIDE>::right, Checks, false>(pos, moveList, Us, ci);
-            moveList = generate_castling<MakeCastling<Us, QUEEN_SIDE>::right, Checks, false>(pos, moveList, Us, ci);
+            moveList = generate_castling<MakeCastling<Us,  KING_SIDE>::right, Checks, false>(pos, moveList, Us);
+            moveList = generate_castling<MakeCastling<Us, QUEEN_SIDE>::right, Checks, false>(pos, moveList, Us);
         }
     }
 
@@ -335,8 +332,7 @@ ExtMove* generate<QUIET_CHECKS>(const Position& pos, ExtMove* moveList) {
   assert(!pos.checkers());
 
   Color us = pos.side_to_move();
-  CheckInfo ci(pos);
-  Bitboard dc = ci.dcCandidates;
+  Bitboard dc = pos.check_info().dcCandidates;
 
   while (dc)
   {
@@ -349,14 +345,14 @@ ExtMove* generate<QUIET_CHECKS>(const Position& pos, ExtMove* moveList) {
      Bitboard b = pos.attacks_from(Piece(pt), from) & ~pos.pieces();
 
      if (pt == KING)
-         b &= ~PseudoAttacks[QUEEN][ci.ksq];
+         b &= ~PseudoAttacks[QUEEN][pos.square<KING>(~us)];
 
      while (b)
          *moveList++ = make_move(from, pop_lsb(&b));
   }
 
-  return us == WHITE ? generate_all<WHITE, QUIET_CHECKS>(pos, moveList, ~pos.pieces(), &ci)
-                     : generate_all<BLACK, QUIET_CHECKS>(pos, moveList, ~pos.pieces(), &ci);
+  return us == WHITE ? generate_all<WHITE, QUIET_CHECKS>(pos, moveList, ~pos.pieces())
+                     : generate_all<BLACK, QUIET_CHECKS>(pos, moveList, ~pos.pieces());
 }
 
 
@@ -403,7 +399,7 @@ ExtMove* generate<EVASIONS>(const Position& pos, ExtMove* moveList) {
 template<>
 ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
 
-  Bitboard pinned = pos.pinned_pieces(pos.side_to_move());
+  Bitboard pinned = pos.check_info().pinned;
   Square ksq = pos.square<KING>(pos.side_to_move());
   ExtMove* cur = moveList;
 
@@ -411,7 +407,7 @@ ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
                             : generate<NON_EVASIONS>(pos, moveList);
   while (cur != moveList)
       if (   (pinned || from_sq(*cur) == ksq || type_of(*cur) == ENPASSANT)
-          && !pos.legal(*cur, pinned))
+          && !pos.legal(*cur))
           *cur = (--moveList)->move;
       else
           ++cur;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -298,9 +298,6 @@ void Position::set_check_info(CheckInfo* ci) const {
 
   ci->blockers[WHITE] = slider_blockers(pieces(BLACK), square<KING>(WHITE));
   ci->blockers[BLACK] = slider_blockers(pieces(WHITE), square<KING>(BLACK));
-  
-  ci->pinned       = pieces(sideToMove) & ci->blockers[sideToMove];
-  ci->dcCandidates = pieces(sideToMove) & ci->blockers[~sideToMove];
 
   Square ksq = ci->ksq = square<KING>(~sideToMove);
 
@@ -468,7 +465,6 @@ Bitboard Position::attackers_to(Square s, Bitboard occupied) const {
 bool Position::legal(Move m) const {
 
   assert(is_ok(m));
-  assert(st->ci.pinned == pinned_pieces(sideToMove));
 
   Color us = sideToMove;
   Square from = from_sq(m);
@@ -503,7 +499,7 @@ bool Position::legal(Move m) const {
 
   // A non-king move is legal if and only if it is not pinned or it
   // is moving along the ray towards or away from the king.
-  return   !(st->ci.pinned & from)
+  return   !(pinned_pieces(us) & from)
         ||  aligned(from, to_sq(m), square<KING>(us));
 }
 
@@ -585,7 +581,6 @@ bool Position::pseudo_legal(const Move m) const {
 bool Position::gives_check(Move m) const {
 
   assert(is_ok(m));
-  assert(st->ci.dcCandidates == discovered_check_candidates());
   assert(color_of(moved_piece(m)) == sideToMove);
 
   Square from = from_sq(m);
@@ -596,7 +591,7 @@ bool Position::gives_check(Move m) const {
       return true;
 
   // Is there a discovered check?
-  if (   (st->ci.dcCandidates & from)
+  if (   (discovered_check_candidates() & from)
       && !aligned(from, to, st->ci.ksq))
       return true;
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -296,8 +296,11 @@ void Position::set_castling_right(Color c, Square rfrom) {
 
 void Position::set_check_info(CheckInfo* ci) const {
 
-  ci->pinned = pinned_pieces(sideToMove);
-  ci->dcCandidates = discovered_check_candidates();
+  ci->blockers[WHITE] = slider_blockers(pieces(), pieces(BLACK), square<KING>(WHITE));
+  ci->blockers[BLACK] = slider_blockers(pieces(), pieces(WHITE), square<KING>(BLACK));
+  
+  ci->pinned       = pieces(sideToMove) & ci->blockers[sideToMove];
+  ci->dcCandidates = pieces(sideToMove) & ci->blockers[~sideToMove];
 
   Square ksq = ci->ksq = square<KING>(~sideToMove);
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -296,8 +296,8 @@ void Position::set_castling_right(Color c, Square rfrom) {
 
 void Position::set_check_info(CheckInfo* ci) const {
 
-  ci->blockers[WHITE] = slider_blockers(pieces(BLACK), square<KING>(WHITE));
-  ci->blockers[BLACK] = slider_blockers(pieces(WHITE), square<KING>(BLACK));
+  ci->blockersForKing[WHITE] = slider_blockers(pieces(BLACK), square<KING>(WHITE));
+  ci->blockersForKing[BLACK] = slider_blockers(pieces(WHITE), square<KING>(BLACK));
 
   Square ksq = ci->ksq = square<KING>(~sideToMove);
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -81,25 +81,6 @@ PieceType min_attacker<KING>(const Bitboard*, Square, Bitboard, Bitboard&, Bitbo
 } // namespace
 
 
-/// CheckInfo constructor
-
-CheckInfo::CheckInfo(const Position& pos) {
-
-  Color them = ~pos.side_to_move();
-  ksq = pos.square<KING>(them);
-
-  pinned = pos.pinned_pieces(pos.side_to_move());
-  dcCandidates = pos.discovered_check_candidates();
-
-  checkSquares[PAWN]   = pos.attacks_from<PAWN>(ksq, them);
-  checkSquares[KNIGHT] = pos.attacks_from<KNIGHT>(ksq);
-  checkSquares[BISHOP] = pos.attacks_from<BISHOP>(ksq);
-  checkSquares[ROOK]   = pos.attacks_from<ROOK>(ksq);
-  checkSquares[QUEEN]  = checkSquares[BISHOP] | checkSquares[ROOK];
-  checkSquares[KING]   = 0;
-}
-
-
 /// operator<<(Position) returns an ASCII representation of the position
 
 std::ostream& operator<<(std::ostream& os, const Position& pos) {
@@ -311,6 +292,24 @@ void Position::set_castling_right(Color c, Square rfrom) {
 }
 
 
+/// Position::set_check_info() sets king attacks to detect if a move gives check
+
+void Position::set_check_info(CheckInfo* ci) const {
+
+  ci->pinned = pinned_pieces(sideToMove);
+  ci->dcCandidates = discovered_check_candidates();
+
+  Square ksq = ci->ksq = square<KING>(~sideToMove);
+
+  ci->checkSquares[PAWN]   = attacks_from<PAWN>(ksq, ~sideToMove);
+  ci->checkSquares[KNIGHT] = attacks_from<KNIGHT>(ksq);
+  ci->checkSquares[BISHOP] = attacks_from<BISHOP>(ksq);
+  ci->checkSquares[ROOK]   = attacks_from<ROOK>(ksq);
+  ci->checkSquares[QUEEN]  = ci->checkSquares[BISHOP] | ci->checkSquares[ROOK];
+  ci->checkSquares[KING]   = 0;
+}
+
+
 /// Position::set_state() computes the hash keys of the position, and other
 /// data that once computed is updated incrementally as moves are made.
 /// The function is only used when a new position is set up, and to verify
@@ -321,8 +320,9 @@ void Position::set_state(StateInfo* si) const {
   si->key = si->pawnKey = si->materialKey = 0;
   si->nonPawnMaterial[WHITE] = si->nonPawnMaterial[BLACK] = VALUE_ZERO;
   si->psq = SCORE_ZERO;
-
   si->checkersBB = attackers_to(square<KING>(sideToMove)) & pieces(~sideToMove);
+
+  set_check_info(&si->ci);
 
   for (Bitboard b = pieces(); b; )
   {
@@ -462,10 +462,10 @@ Bitboard Position::attackers_to(Square s, Bitboard occupied) const {
 
 /// Position::legal() tests whether a pseudo-legal move is legal
 
-bool Position::legal(Move m, Bitboard pinned) const {
+bool Position::legal(Move m) const {
 
   assert(is_ok(m));
-  assert(pinned == pinned_pieces(sideToMove));
+  assert(st->ci.pinned == pinned_pieces(sideToMove));
 
   Color us = sideToMove;
   Square from = from_sq(m);
@@ -500,7 +500,7 @@ bool Position::legal(Move m, Bitboard pinned) const {
 
   // A non-king move is legal if and only if it is not pinned or it
   // is moving along the ray towards or away from the king.
-  return   !(pinned & from)
+  return   !(st->ci.pinned & from)
         ||  aligned(from, to_sq(m), square<KING>(us));
 }
 
@@ -579,22 +579,22 @@ bool Position::pseudo_legal(const Move m) const {
 
 /// Position::gives_check() tests whether a pseudo-legal move gives a check
 
-bool Position::gives_check(Move m, const CheckInfo& ci) const {
+bool Position::gives_check(Move m) const {
 
   assert(is_ok(m));
-  assert(ci.dcCandidates == discovered_check_candidates());
+  assert(st->ci.dcCandidates == discovered_check_candidates());
   assert(color_of(moved_piece(m)) == sideToMove);
 
   Square from = from_sq(m);
   Square to = to_sq(m);
 
   // Is there a direct check?
-  if (ci.checkSquares[type_of(piece_on(from))] & to)
+  if (st->ci.checkSquares[type_of(piece_on(from))] & to)
       return true;
 
   // Is there a discovered check?
-  if (   (ci.dcCandidates & from)
-      && !aligned(from, to, ci.ksq))
+  if (   (st->ci.dcCandidates & from)
+      && !aligned(from, to, st->ci.ksq))
       return true;
 
   switch (type_of(m))
@@ -603,7 +603,7 @@ bool Position::gives_check(Move m, const CheckInfo& ci) const {
       return false;
 
   case PROMOTION:
-      return attacks_bb(Piece(promotion_type(m)), to, pieces() ^ from) & ci.ksq;
+      return attacks_bb(Piece(promotion_type(m)), to, pieces() ^ from) & st->ci.ksq;
 
   // En passant capture with check? We have already handled the case
   // of direct checks and ordinary discovered check, so the only case we
@@ -614,8 +614,8 @@ bool Position::gives_check(Move m, const CheckInfo& ci) const {
       Square capsq = make_square(file_of(to), rank_of(from));
       Bitboard b = (pieces() ^ from ^ capsq) | to;
 
-      return  (attacks_bb<  ROOK>(ci.ksq, b) & pieces(sideToMove, QUEEN, ROOK))
-            | (attacks_bb<BISHOP>(ci.ksq, b) & pieces(sideToMove, QUEEN, BISHOP));
+      return  (attacks_bb<  ROOK>(st->ci.ksq, b) & pieces(sideToMove, QUEEN, ROOK))
+            | (attacks_bb<BISHOP>(st->ci.ksq, b) & pieces(sideToMove, QUEEN, BISHOP));
   }
   case CASTLING:
   {
@@ -624,8 +624,8 @@ bool Position::gives_check(Move m, const CheckInfo& ci) const {
       Square kto = relative_square(sideToMove, rfrom > kfrom ? SQ_G1 : SQ_C1);
       Square rto = relative_square(sideToMove, rfrom > kfrom ? SQ_F1 : SQ_D1);
 
-      return   (PseudoAttacks[ROOK][rto] & ci.ksq)
-            && (attacks_bb<ROOK>(rto, (pieces() ^ kfrom ^ rfrom) | rto | kto) & ci.ksq);
+      return   (PseudoAttacks[ROOK][rto] & st->ci.ksq)
+            && (attacks_bb<ROOK>(rto, (pieces() ^ kfrom ^ rfrom) | rto | kto) & st->ci.ksq);
   }
   default:
       assert(false);
@@ -801,6 +801,9 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
 
   sideToMove = ~sideToMove;
 
+  // Update CheckInfo
+  set_check_info(&st->ci);
+
   assert(pos_is_ok());
 }
 
@@ -913,6 +916,8 @@ void Position::do_null_move(StateInfo& newSt) {
   st->pliesFromNull = 0;
 
   sideToMove = ~sideToMove;
+
+  set_check_info(&st->ci);
 
   assert(pos_is_ok());
 }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -296,8 +296,8 @@ void Position::set_castling_right(Color c, Square rfrom) {
 
 void Position::set_check_info(CheckInfo* ci) const {
 
-  ci->blockers[WHITE] = slider_blockers(pieces(), pieces(BLACK), square<KING>(WHITE));
-  ci->blockers[BLACK] = slider_blockers(pieces(), pieces(WHITE), square<KING>(BLACK));
+  ci->blockers[WHITE] = slider_blockers(pieces(BLACK), square<KING>(WHITE));
+  ci->blockers[BLACK] = slider_blockers(pieces(WHITE), square<KING>(BLACK));
   
   ci->pinned       = pieces(sideToMove) & ci->blockers[sideToMove];
   ci->dcCandidates = pieces(sideToMove) & ci->blockers[~sideToMove];
@@ -423,14 +423,14 @@ Phase Position::game_phase() const {
 }
 
 
-/// Position::slider_blockers() returns a bitboard of all the pieces in 'target' that
+/// Position::slider_blockers() returns a bitboard of all the pieces (both colors) that
 /// are blocking attacks on the square 's' from 'sliders'. A piece blocks a slider
 /// if removing that piece from the board would result in a position where square 's'
 /// is attacked. For example, a king-attack blocking piece can be either a pinned or
 /// a discovered check piece, according if its color is the opposite or the same of
 /// the color of the slider.
 
-Bitboard Position::slider_blockers(Bitboard target, Bitboard sliders, Square s) const {
+Bitboard Position::slider_blockers(Bitboard sliders, Square s) const {
 
   Bitboard b, pinners, result = 0;
 
@@ -443,7 +443,7 @@ Bitboard Position::slider_blockers(Bitboard target, Bitboard sliders, Square s) 
       b = between_bb(s, pop_lsb(&pinners)) & pieces();
 
       if (!more_than_one(b))
-          result |= b & target;
+          result |= b;
   }
   return result;
 }

--- a/src/position.h
+++ b/src/position.h
@@ -46,7 +46,7 @@ namespace PSQT {
 
 struct CheckInfo {
 
-  Bitboard blockers[COLOR_NB];
+  Bitboard blockersForKing[COLOR_NB];
   Bitboard checkSquares[PIECE_TYPE_NB];
   Square   ksq;
 };
@@ -311,11 +311,11 @@ inline Bitboard Position::checkers() const {
 }
 
 inline Bitboard Position::discovered_check_candidates() const {
-  return st->ci.blockers[~sideToMove] & pieces(sideToMove);
+  return st->ci.blockersForKing[~sideToMove] & pieces(sideToMove);
 }
 
 inline Bitboard Position::pinned_pieces(Color c) const {
-  return st->ci.blockers[c] & pieces(c);
+  return st->ci.blockersForKing[c] & pieces(c);
 }
 
 inline const CheckInfo& Position::check_info() const {

--- a/src/position.h
+++ b/src/position.h
@@ -46,6 +46,7 @@ namespace PSQT {
 
 struct CheckInfo {
 
+  Bitboard blockers[COLOR_NB];
   Bitboard dcCandidates;
   Bitboard pinned;
   Bitboard checkSquares[PIECE_TYPE_NB];

--- a/src/position.h
+++ b/src/position.h
@@ -132,7 +132,7 @@ public:
   Bitboard attacks_from(Piece pc, Square s) const;
   template<PieceType> Bitboard attacks_from(Square s) const;
   template<PieceType> Bitboard attacks_from(Square s, Color c) const;
-  Bitboard slider_blockers(Bitboard target, Bitboard sliders, Square s) const;
+  Bitboard slider_blockers(Bitboard sliders, Square s) const;
 
   // Properties of moves
   bool legal(Move m) const;
@@ -313,11 +313,11 @@ inline Bitboard Position::checkers() const {
 }
 
 inline Bitboard Position::discovered_check_candidates() const {
-  return slider_blockers(pieces(sideToMove), pieces(sideToMove), square<KING>(~sideToMove));
+  return slider_blockers(pieces(sideToMove), square<KING>(~sideToMove)) & pieces(sideToMove);
 }
 
 inline Bitboard Position::pinned_pieces(Color c) const {
-  return slider_blockers(pieces(c), pieces(~c), square<KING>(c));
+  return slider_blockers(pieces(~c), square<KING>(c)) & pieces(c);
 }
 
 inline const CheckInfo& Position::check_info() const {

--- a/src/position.h
+++ b/src/position.h
@@ -41,12 +41,10 @@ namespace PSQT {
   void init();
 }
 
-/// CheckInfo struct is initialized at constructor time and keeps info used to
-/// detect if a move gives check.
+
+/// CheckInfo struct keeps info used to detect if a move gives check
 
 struct CheckInfo {
-
-  explicit CheckInfo(const Position&);
 
   Bitboard dcCandidates;
   Bitboard pinned;
@@ -76,6 +74,7 @@ struct StateInfo {
   Bitboard   checkersBB;
   PieceType  capturedType;
   StateInfo* previous;
+  CheckInfo  ci;
 };
 
 // In a std::deque references to elements are unaffected upon resizing
@@ -124,6 +123,7 @@ public:
   Bitboard checkers() const;
   Bitboard discovered_check_candidates() const;
   Bitboard pinned_pieces(Color c) const;
+  const CheckInfo& check_info() const;
 
   // Attacks to/from a given square
   Bitboard attackers_to(Square s) const;
@@ -134,11 +134,11 @@ public:
   Bitboard slider_blockers(Bitboard target, Bitboard sliders, Square s) const;
 
   // Properties of moves
-  bool legal(Move m, Bitboard pinned) const;
+  bool legal(Move m) const;
   bool pseudo_legal(const Move m) const;
   bool capture(Move m) const;
   bool capture_or_promotion(Move m) const;
-  bool gives_check(Move m, const CheckInfo& ci) const;
+  bool gives_check(Move m) const;
   bool advanced_pawn_push(Move m) const;
   Piece moved_piece(Move m) const;
   PieceType captured_piece_type() const;
@@ -185,6 +185,7 @@ private:
   // Initialization helpers (used while setting up a position)
   void set_castling_right(Color c, Square rfrom);
   void set_state(StateInfo* si) const;
+  void set_check_info(CheckInfo* ci) const;
 
   // Other helpers
   void put_piece(Color c, PieceType pt, Square s);
@@ -316,6 +317,10 @@ inline Bitboard Position::discovered_check_candidates() const {
 
 inline Bitboard Position::pinned_pieces(Color c) const {
   return slider_blockers(pieces(c), pieces(~c), square<KING>(c));
+}
+
+inline const CheckInfo& Position::check_info() const {
+  return st->ci;
 }
 
 inline bool Position::pawn_passed(Color c, Square s) const {

--- a/src/position.h
+++ b/src/position.h
@@ -47,8 +47,6 @@ namespace PSQT {
 struct CheckInfo {
 
   Bitboard blockers[COLOR_NB];
-  Bitboard dcCandidates;
-  Bitboard pinned;
   Bitboard checkSquares[PIECE_TYPE_NB];
   Square   ksq;
 };
@@ -313,11 +311,11 @@ inline Bitboard Position::checkers() const {
 }
 
 inline Bitboard Position::discovered_check_candidates() const {
-  return slider_blockers(pieces(sideToMove), square<KING>(~sideToMove)) & pieces(sideToMove);
+  return st->ci.blockers[~sideToMove] & pieces(sideToMove);
 }
 
 inline Bitboard Position::pinned_pieces(Color c) const {
-  return slider_blockers(pieces(~c), square<KING>(c)) & pieces(c);
+  return st->ci.blockers[c] & pieces(c);
 }
 
 inline const CheckInfo& Position::check_info() const {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -801,13 +801,12 @@ namespace {
     }
 
     // Step 10. Internal iterative deepening (skipped when in check)
-    if (    depth >= (PvNode ? 5 * ONE_PLY : 8 * ONE_PLY)
+    if (    depth >= 6 * ONE_PLY
         && !ttMove
         && (PvNode || ss->staticEval + 256 >= beta))
     {
-        Depth d = depth - 2 * ONE_PLY - (PvNode ? DEPTH_ZERO : depth / 4);
         ss->skipEarlyPruning = true;
-        search<NT>(pos, ss, alpha, beta, d, cutNode);
+        search<NT>(pos, ss, alpha, beta, 3 * depth / 4 - 2 * ONE_PLY, cutNode);
         ss->skipEarlyPruning = false;
 
         tte = TT.probe(posKey, ttHit);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -862,7 +862,7 @@ moves_loop: // When in check search starts from here
       captureOrPromotion = pos.capture_or_promotion(move);
       moved_piece = pos.moved_piece(move);
 
-      givesCheck =  type_of(move) == NORMAL && !pos.check_info().dcCandidates
+      givesCheck =  type_of(move) == NORMAL && !pos.discovered_check_candidates()
                   ? pos.check_info().checkSquares[type_of(pos.piece_on(from_sq(move)))] & to_sq(move)
                   : pos.gives_check(move);
 
@@ -1255,7 +1255,7 @@ moves_loop: // When in check search starts from here
     {
       assert(is_ok(move));
 
-      givesCheck =  type_of(move) == NORMAL && !pos.check_info().dcCandidates
+      givesCheck =  type_of(move) == NORMAL && !pos.discovered_check_candidates()
                   ? pos.check_info().checkSquares[type_of(pos.piece_on(from_sq(move)))] & to_sq(move)
                   : pos.gives_check(move);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -113,8 +113,8 @@ namespace {
           std::copy(newPv.begin(), newPv.begin() + 3, pv);
 
           StateInfo st[2];
-          pos.do_move(newPv[0], st[0], pos.gives_check(newPv[0], CheckInfo(pos)));
-          pos.do_move(newPv[1], st[1], pos.gives_check(newPv[1], CheckInfo(pos)));
+          pos.do_move(newPv[0], st[0], pos.gives_check(newPv[0]));
+          pos.do_move(newPv[1], st[1], pos.gives_check(newPv[1]));
           expectedPosKey = pos.key();
           pos.undo_move(newPv[1]);
           pos.undo_move(newPv[0]);
@@ -227,7 +227,6 @@ uint64_t Search::perft(Position& pos, Depth depth) {
 
   StateInfo st;
   uint64_t cnt, nodes = 0;
-  CheckInfo ci(pos);
   const bool leaf = (depth == 2 * ONE_PLY);
 
   for (const auto& m : MoveList<LEGAL>(pos))
@@ -236,7 +235,7 @@ uint64_t Search::perft(Position& pos, Depth depth) {
           cnt = 1, nodes++;
       else
       {
-          pos.do_move(m, st, pos.gives_check(m, ci));
+          pos.do_move(m, st, pos.gives_check(m));
           cnt = leaf ? MoveList<LEGAL>(pos).size() : perft<false>(pos, depth - ONE_PLY);
           nodes += cnt;
           pos.undo_move(m);
@@ -785,14 +784,13 @@ namespace {
         assert((ss-1)->currentMove != MOVE_NULL);
 
         MovePicker mp(pos, ttMove, PieceValue[MG][pos.captured_piece_type()]);
-        CheckInfo ci(pos);
 
         while ((move = mp.next_move()) != MOVE_NONE)
-            if (pos.legal(move, ci.pinned))
+            if (pos.legal(move))
             {
                 ss->currentMove = move;
                 ss->counterMoves = &CounterMoveHistory[pos.moved_piece(move)][to_sq(move)];
-                pos.do_move(move, st, pos.gives_check(move, ci));
+                pos.do_move(move, st, pos.gives_check(move));
                 value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, rdepth, !cutNode);
                 pos.undo_move(move);
                 if (value >= rbeta)
@@ -820,7 +818,6 @@ moves_loop: // When in check search starts from here
     const CounterMoveStats* fmh2 = (ss-4)->counterMoves;
 
     MovePicker mp(pos, ttMove, depth, ss);
-    CheckInfo ci(pos);
     value = bestValue; // Workaround a bogus 'uninitialized' warning under gcc
     improving =   ss->staticEval >= (ss-2)->staticEval
             /* || ss->staticEval == VALUE_NONE Already implicit in the previous condition */
@@ -865,9 +862,9 @@ moves_loop: // When in check search starts from here
       captureOrPromotion = pos.capture_or_promotion(move);
       moved_piece = pos.moved_piece(move);
 
-      givesCheck =  type_of(move) == NORMAL && !ci.dcCandidates
-                  ? ci.checkSquares[type_of(pos.piece_on(from_sq(move)))] & to_sq(move)
-                  : pos.gives_check(move, ci);
+      givesCheck =  type_of(move) == NORMAL && !pos.check_info().dcCandidates
+                  ? pos.check_info().checkSquares[type_of(pos.piece_on(from_sq(move)))] & to_sq(move)
+                  : pos.gives_check(move);
 
       moveCountPruning =   depth < 16 * ONE_PLY
                         && moveCount >= FutilityMoveCounts[improving][depth];
@@ -886,7 +883,7 @@ moves_loop: // When in check search starts from here
       if (    singularExtensionNode
           &&  move == ttMove
           && !extension
-          &&  pos.legal(move, ci.pinned))
+          &&  pos.legal(move))
       {
           Value rBeta = ttValue - 2 * depth / ONE_PLY;
           ss->excludedMove = move;
@@ -945,7 +942,7 @@ moves_loop: // When in check search starts from here
       prefetch(TT.first_entry(pos.key_after(move)));
 
       // Check for legality just before making the move
-      if (!rootNode && !pos.legal(move, ci.pinned))
+      if (!rootNode && !pos.legal(move))
       {
           ss->moveCount = --moveCount;
           continue;
@@ -1252,16 +1249,15 @@ moves_loop: // When in check search starts from here
     // queen promotions and checks (only if depth >= DEPTH_QS_CHECKS) will
     // be generated.
     MovePicker mp(pos, ttMove, depth, to_sq((ss-1)->currentMove));
-    CheckInfo ci(pos);
 
     // Loop through the moves until no moves remain or a beta cutoff occurs
     while ((move = mp.next_move()) != MOVE_NONE)
     {
       assert(is_ok(move));
 
-      givesCheck =  type_of(move) == NORMAL && !ci.dcCandidates
-                  ? ci.checkSquares[type_of(pos.piece_on(from_sq(move)))] & to_sq(move)
-                  : pos.gives_check(move, ci);
+      givesCheck =  type_of(move) == NORMAL && !pos.check_info().dcCandidates
+                  ? pos.check_info().checkSquares[type_of(pos.piece_on(from_sq(move)))] & to_sq(move)
+                  : pos.gives_check(move);
 
       // Futility pruning
       if (   !InCheck
@@ -1301,7 +1297,7 @@ moves_loop: // When in check search starts from here
       prefetch(TT.first_entry(pos.key_after(move)));
 
       // Check for legality just before making the move
-      if (!pos.legal(move, ci.pinned))
+      if (!pos.legal(move))
           continue;
 
       ss->currentMove = move;
@@ -1594,7 +1590,7 @@ bool RootMove::extract_ponder_from_tt(Position& pos)
 
     assert(pv.size() == 1);
 
-    pos.do_move(pv[0], st, pos.gives_check(pv[0], CheckInfo(pos)));
+    pos.do_move(pv[0], st, pos.gives_check(pv[0]));
     TTEntry* tte = TT.probe(pos.key(), ttHit);
 
     if (ttHit)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -75,7 +75,7 @@ namespace {
     while (is >> token && (m = UCI::to_move(pos, token)) != MOVE_NONE)
     {
         States->push_back(StateInfo());
-        pos.do_move(m, States->back(), pos.gives_check(m, CheckInfo(pos)));
+        pos.do_move(m, States->back(), pos.gives_check(m));
     }
   }
 


### PR DESCRIPTION
This is based on the work done by Marco in pull request #716 , implementing on top of it the ideas in the discussion: caching the calls to slider_blockers() in the CheckInfo structure, and simplifying the slider_blockers() function by removing its first parameter.

Compared to master, bench is identical but the number of calls to slider_blockers() during bench goes down from 22461515 to 18853422, hopefully being a little bit faster overall.