### PR TITLE
Introduce under_attack() helper

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -38,7 +38,6 @@ namespace {
     Square kfrom = pos.square<KING>(us);
     Square rfrom = pos.castling_rook_square(Cr);
     Square kto = relative_square(us, KingSide ? SQ_G1 : SQ_C1);
-    Bitboard enemies = pos.pieces(~us);
 
     assert(!pos.checkers());
 
@@ -46,7 +45,7 @@ namespace {
                               : KingSide    ? DELTA_W : DELTA_E;
 
     for (Square s = kto; s != kfrom; s += K)
-        if (pos.attackers_to(s) & enemies)
+        if (pos.under_attack(s, ~us))
             return moveList;
 
     // Because we generate only legal castling moves we need to verify that

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -495,7 +495,7 @@ bool Position::legal(Move m) const {
   // square is attacked by the opponent. Castling moves are checked
   // for legality during move generation.
   if (type_of(piece_on(from)) == KING)
-      return type_of(m) == CASTLING || !(attackers_to(to_sq(m)) & pieces(~us));
+      return type_of(m) == CASTLING || !(under_attack(to_sq(m), ~us));
 
   // A non-king move is legal if and only if it is not pinned or it
   // is moving along the ray towards or away from the king.
@@ -1116,7 +1116,7 @@ bool Position::pos_is_ok(int* failedStep) const {
       if (step == King)
           if (   std::count(board, board + SQUARE_NB, W_KING) != 1
               || std::count(board, board + SQUARE_NB, B_KING) != 1
-              || attackers_to(square<KING>(~sideToMove)) & pieces(sideToMove))
+              || under_attack(square<KING>(~sideToMove), sideToMove))
               return false;
 
       if (step == Bitboards)

--- a/src/position.h
+++ b/src/position.h
@@ -127,6 +127,7 @@ public:
   // Attacks to/from a given square
   Bitboard attackers_to(Square s) const;
   Bitboard attackers_to(Square s, Bitboard occupied) const;
+  bool under_attack(Square s, Color c) const;
   Bitboard attacks_from(Piece pc, Square s) const;
   template<PieceType> Bitboard attacks_from(Square s) const;
   template<PieceType> Bitboard attacks_from(Square s, Color c) const;
@@ -304,6 +305,14 @@ inline Bitboard Position::attacks_from(Piece pc, Square s) const {
 
 inline Bitboard Position::attackers_to(Square s) const {
   return attackers_to(s, byTypeBB[ALL_PIECES]);
+}
+
+inline bool Position::under_attack(Square s, Color c) const {
+   return    (attacks_from<PAWN>(s, ~c)                   & pieces(c, PAWN))
+          || (attacks_from<KNIGHT>(s)                     & pieces(c, KNIGHT))
+          || (attacks_bb<ROOK  >(s, byTypeBB[ALL_PIECES]) & pieces(c, ROOK,   QUEEN))
+          || (attacks_bb<BISHOP>(s, byTypeBB[ALL_PIECES]) & pieces(c, BISHOP, QUEEN))
+          || (attacks_from<KING>(s)                       & pieces(c, KING));
 }
 
 inline Bitboard Position::checkers() const {


### PR DESCRIPTION
Sometimes during move generation we don't need to know all the attackers of a king, but only the information whether the king has at least an attacker. For this case we introduce a new helper function under_attack(), similar to the old helper attackers_to(), but which only returns a boolean: this allows to use short-circuit boolean evaluations in under_attack(), giving a small speed-up overall.