### PR TITLE
History Pruning Simplification

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -935,7 +935,6 @@ moves_loop: // When in check search starts from here
 
           // Countermoves based pruning
           if (   predictedDepth < 3 * ONE_PLY
-              && move != ss->killers[0]
               && (!cmh  || (*cmh )[moved_piece][to_sq(move)] < VALUE_ZERO)
               && (!fmh  || (*fmh )[moved_piece][to_sq(move)] < VALUE_ZERO)
               && (!fmh2 || (*fmh2)[moved_piece][to_sq(move)] < VALUE_ZERO || (cmh && fmh)))


### PR DESCRIPTION
History Pruning Simplification
Removed condition. Now allows main killer to be history prune.

STC:
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 15852 W: 2910 L: 2781 D: 10161

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 56428 W: 7610 L: 7537 D: 41281

Bench:  8032058