### PR TITLE
Miscelleneous optimization

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -210,7 +210,7 @@ namespace {
   // in KingDanger[]. Various little "meta-bonuses" measuring the strength
   // of the enemy attack are added up into an integer, which is used as an
   // index to KingDanger[].
-  Score KingDanger[512];
+  Score KingDanger[400];
 
   // KingAttackWeights[PieceType] contains king attack weights by piece type
   const int KingAttackWeights[PIECE_TYPE_NB] = { 0, 0, 7, 5, 4, 1 };

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -595,7 +595,7 @@ namespace {
     if (!rootNode)
     {
         // Step 2. Check for aborted search and immediate draw
-        if (Signals.stop.load(std::memory_order_relaxed) || pos.is_draw() || ss->ply >= MAX_PLY)
+        if (Signals.stop.load(std::memory_order_relaxed) ||  ss->ply >= MAX_PLY || pos.is_draw())
             return ss->ply >= MAX_PLY && !inCheck ? evaluate(pos)
                                                   : DrawValue[pos.side_to_move()];
 
@@ -725,8 +725,9 @@ namespace {
     // Step 6. Razoring (skipped when in check)
     if (   !PvNode
         &&  depth < 4 * ONE_PLY
-        &&  eval + razor_margin[depth / ONE_PLY] <= alpha
-        &&  ttMove == MOVE_NONE)
+        &&  ttMove == MOVE_NONE
+        &&  eval + razor_margin[depth / ONE_PLY] <= alpha)
+
     {
         if (   depth <= ONE_PLY
             && eval + razor_margin[3 * ONE_PLY] <= alpha)
@@ -741,8 +742,8 @@ namespace {
     // Step 7. Futility pruning: child node (skipped when in check)
     if (   !rootNode
         &&  depth < 7 * ONE_PLY
-        &&  eval - futility_margin(depth) >= beta
         &&  eval < VALUE_KNOWN_WIN  // Do not return unproven wins
+        &&  eval - futility_margin(depth) >= beta
         &&  pos.non_pawn_material(pos.side_to_move()))
         return eval - futility_margin(depth);
 
@@ -924,8 +925,8 @@ moves_loop: // When in check search starts from here
           && !captureOrPromotion
           && !inCheck
           && !givesCheck
-          && !pos.advanced_pawn_push(move)
-          &&  bestValue > VALUE_MATED_IN_MAX_PLY)
+          &&  bestValue > VALUE_MATED_IN_MAX_PLY
+          && !pos.advanced_pawn_push(move))
       {
           // Move count based pruning
           if (moveCountPruning)
@@ -1202,7 +1203,7 @@ moves_loop: // When in check search starts from here
     ss->ply = (ss-1)->ply + 1;
 
     // Check for an instant draw or if the maximum ply has been reached
-    if (pos.is_draw() || ss->ply >= MAX_PLY)
+    if (ss->ply >= MAX_PLY || pos.is_draw())
         return ss->ply >= MAX_PLY && !InCheck ? evaluate(pos)
                                               : DrawValue[pos.side_to_move()];
 
@@ -1222,8 +1223,8 @@ moves_loop: // When in check search starts from here
 
     if (  !PvNode
         && ttHit
-        && tte->depth() >= ttDepth
         && ttValue != VALUE_NONE // Only in case of TT access race
+        && tte->depth() >= ttDepth
         && (ttValue >= beta ? (tte->bound() &  BOUND_LOWER)
                             : (tte->bound() &  BOUND_UPPER)))
     {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -595,7 +595,7 @@ namespace {
     if (!rootNode)
     {
         // Step 2. Check for aborted search and immediate draw
-        if (Signals.stop.load(std::memory_order_relaxed) ||  ss->ply >= MAX_PLY || pos.is_draw())
+        if (Signals.stop.load(std::memory_order_relaxed) || ss->ply >= MAX_PLY || pos.is_draw())
             return ss->ply >= MAX_PLY && !inCheck ? evaluate(pos)
                                                   : DrawValue[pos.side_to_move()];
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -727,7 +727,6 @@ namespace {
         &&  depth < 4 * ONE_PLY
         &&  ttMove == MOVE_NONE
         &&  eval + razor_margin[depth / ONE_PLY] <= alpha)
-
     {
         if (   depth <= ONE_PLY
             && eval + razor_margin[3 * ONE_PLY] <= alpha)


### PR DESCRIPTION
Optimize If statements to use the simplest conditions first.
Also fix size of KingDanger array.
 
Gives a small speedup after 10 bench runs on my machine:
New master
=========
Nodes/second    : 1837579
Nodes/second    : 1842637
Nodes/second    : 1860995
Nodes/second    : 1861858
Nodes/second    : 1853266
Nodes/second    : 1842637
Nodes/second    : 1853694
Nodes/second    : 1881484
Nodes/second    : 1870094
Nodes/second    : 1864451

Mean value: 1856869.6

Current master
==========
Nodes/second    : 1837999
Nodes/second    : 1844753
Nodes/second    : 1831712
Nodes/second    : 1841792
Nodes/second    : 1840948
Nodes/second    : 1851984
Nodes/second    : 1861858
Nodes/second    : 1849000
Nodes/second    : 1851557
Nodes/second    : 1839683

Mean value: 1845128.6

Speedup: 0.64%

No functional change
