### PR TITLE
Miscellenous optimization v2

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -210,7 +210,7 @@ namespace {
   // in KingDanger[]. Various little "meta-bonuses" measuring the strength
   // of the enemy attack are added up into an integer, which is used as an
   // index to KingDanger[].
-  Score KingDanger[512];
+  Score KingDanger[400];
 
   // KingAttackWeights[PieceType] contains king attack weights by piece type
   const int KingAttackWeights[PIECE_TYPE_NB] = { 0, 0, 7, 5, 4, 1 };

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -725,8 +725,8 @@ namespace {
     // Step 6. Razoring (skipped when in check)
     if (   !PvNode
         &&  depth < 4 * ONE_PLY
-        &&  eval + razor_margin[depth / ONE_PLY] <= alpha
-        &&  ttMove == MOVE_NONE)
+        &&  ttMove == MOVE_NONE
+        &&  eval + razor_margin[depth / ONE_PLY] <= alpha)
     {
         if (   depth <= ONE_PLY
             && eval + razor_margin[3 * ONE_PLY] <= alpha)
@@ -924,8 +924,9 @@ moves_loop: // When in check search starts from here
           && !captureOrPromotion
           && !inCheck
           && !givesCheck
-          && !pos.advanced_pawn_push(move)
-          &&  bestValue > VALUE_MATED_IN_MAX_PLY)
+          &&  bestValue > VALUE_MATED_IN_MAX_PLY
+          && !pos.advanced_pawn_push(move))
+
       {
           // Move count based pruning
           if (moveCountPruning)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -926,7 +926,6 @@ moves_loop: // When in check search starts from here
           && !givesCheck
           &&  bestValue > VALUE_MATED_IN_MAX_PLY
           && !pos.advanced_pawn_push(move))
-
       {
           // Move count based pruning
           if (moveCountPruning)


### PR DESCRIPTION
Optimize a few conditions to compute the simplest terms first.
Also fix size of KingDanger array to reduce memory footprint.
After 10 bench runs here are the mean values:
Test: 18650812
Base: 18533772
Speedup: 0.63%

No functional change