### PR TITLE
Prune dangerous moves at low depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -956,7 +956,21 @@ moves_loop: // When in check search starts from here
                   continue;
           }
       }
-
+      else if(
+	      
+	          depth < 3 * ONE_PLY
+              && !inCheck
+	      &&  bestValue > VALUE_MATED_IN_MAX_PLY
+	      && !rootNode
+	      && (  captureOrPromotion
+		  || givesCheck
+		  || pos.advanced_pawn_push(move)
+		  )
+	      && pos.see_sign(move) < VALUE_ZERO
+	  )
+	{
+	    continue;
+	}
       // Speculative prefetch as early as possible
       prefetch(TT.first_entry(pos.key_after(move)));
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -956,21 +956,13 @@ moves_loop: // When in check search starts from here
                   continue;
           }
       }
-      else if(
-	      
-	          depth < 3 * ONE_PLY
+      else if(    depth < 3 * ONE_PLY
               && !inCheck
-	      &&  bestValue > VALUE_MATED_IN_MAX_PLY
-	      && !rootNode
-	      && (  captureOrPromotion
-		  || givesCheck
-		  || pos.advanced_pawn_push(move)
-		  )
-	      && pos.see_sign(move) < VALUE_ZERO
-	  )
-	{
-	    continue;
-	}
+              &&  bestValue > VALUE_MATED_IN_MAX_PLY
+              && !rootNode
+              &&  pos.see_sign(move) < VALUE_ZERO)
+              continue;
+
       // Speculative prefetch as early as possible
       prefetch(TT.first_entry(pos.key_after(move)));
 


### PR DESCRIPTION
At very low depths prune captures, promotions and checks if see is negative.

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 6772 W: 1328 L: 1173 D: 4271

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 8917 W: 1270 L: 1122 D: 6525