### PR TITLE
Reorder evaluation initialization

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -782,19 +782,18 @@ Value Eval::evaluate(const Position& pos) {
   EvalInfo ei;
   Score score, mobility[COLOR_NB] = { SCORE_ZERO, SCORE_ZERO };
 
-  // Initialize score by reading the incrementally updated scores included in
-  // the position object (material + piece square tables). Score is computed
-  // internally from the white point of view.
-  score = pos.psq_score();
-
   // Probe the material hash table
   ei.me = Material::probe(pos);
-  score += ei.me->imbalance();
 
   // If we have a specialized evaluation function for the current material
   // configuration, call it and return.
   if (ei.me->specialized_eval_exists())
       return ei.me->evaluate(pos);
+
+  // Initialize score by reading the incrementally updated scores included in
+  // the position object (material + piece square tables) and the material imbalance.
+  // Score is computed internally from the white point of view.
+  score = pos.psq_score() + ei.me->imbalance();
 
   // Probe the pawn hash table
   ei.pi = Pawns::probe(pos);


### PR DESCRIPTION
In evaluate, we start by initializing the pos.psq_score and adding the material imbalance. After that, we check whether a specialized eval exists and if yes we return that value and discard whatever we have computed until now.

It sounds more logical to first probe material entry and return if we have a specialized eval, and only if it is not the case initialize eval with some values. There is no measurable speed-difference on my computer.

Non functional change.