### PR TITLE
Rename see_sign() to capture_see_sign()

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -243,7 +243,7 @@ void MovePicker::generate_next_stage() {
   }
 }
 
-int MovePicker::see_sign() const
+int MovePicker::capture_see_sign() const
 {
   return  stage == GOOD_CAPTURES ?  1
         : stage == BAD_CAPTURES  ? -1 : 0;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -104,7 +104,7 @@ public:
   MovePicker(const Position&, Move, Depth, Search::Stack*);
 
   Move next_move();
-  int see_sign() const;
+  int capture_see_sign() const;
 
 private:
   template<GenType> void score();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -958,8 +958,8 @@ moves_loop: // When in check search starts from here
               }
           }
           else if (   depth < 3 * ONE_PLY
-                   && (     mp.see_sign() < 0
-                       || (!mp.see_sign() && pos.see_sign(move) < VALUE_ZERO)))
+                   && (     mp.capture_see_sign() < 0
+                       || (!mp.capture_see_sign() && pos.see_sign(move) < VALUE_ZERO)))
               continue;
       }
 


### PR DESCRIPTION
This small renaming has a sensible impact: clarifies the
boundaries and the limits of the help that MovePicker
can give to the search and allows a natural coexsistence
of capture_see_sign() and pos.see_sign() in search, now
it is clear whay I want to call the latter if the first
one fails.

No functional change.