### PR TITLE
SEE-Algorithm which is (more) aware of absolute pins

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -360,7 +360,8 @@ namespace {
         if (Pt == QUEEN)
         {
             // Penalty if any relative pin or discovered attack against the queen
-            if (pos.slider_blockers(pos.pieces(Them, ROOK, BISHOP), s))
+            Bitboard pinners;
+            if (pos.slider_blockers(pos.pieces(Them, ROOK, BISHOP), s, pinners))
                 score -= WeakQueen;
         }
     }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -291,8 +291,8 @@ void Position::set_castling_right(Color c, Square rfrom) {
 
 void Position::set_check_info(StateInfo* si) const {
 
-  si->blockersForKing[WHITE] = slider_blockers(pieces(BLACK), square<KING>(WHITE));
-  si->blockersForKing[BLACK] = slider_blockers(pieces(WHITE), square<KING>(BLACK));
+  si->blockersForKing[WHITE] = slider_blockers(pieces(BLACK), square<KING>(WHITE), si->pinnersForKing[WHITE]);
+  si->blockersForKing[BLACK] = slider_blockers(pieces(WHITE), square<KING>(BLACK), si->pinnersForKing[BLACK]);
 
   Square ksq = square<KING>(~sideToMove);
 
@@ -420,19 +420,19 @@ Phase Position::game_phase() const {
 /// if removing that piece from the board would result in a position where square 's'
 /// is attacked. For example, a king-attack blocking piece can be either a pinned or
 /// a discovered check piece, according if its color is the opposite or the same of
-/// the color of the slider.
+/// the color of the slider. The pinners bitboard get filled with real and potential pinners
 
-Bitboard Position::slider_blockers(Bitboard sliders, Square s) const {
+Bitboard Position::slider_blockers(Bitboard sliders, Square s, Bitboard& pinners) const {
 
-  Bitboard b, pinners, result = 0;
+  Bitboard b, p, result = 0;
 
   // Pinners are sliders that attack 's' when a pinned piece is removed
-  pinners = (  (PseudoAttacks[ROOK  ][s] & pieces(QUEEN, ROOK))
+  pinners = p = (  (PseudoAttacks[ROOK  ][s] & pieces(QUEEN, ROOK))
              | (PseudoAttacks[BISHOP][s] & pieces(QUEEN, BISHOP))) & sliders;
 
-  while (pinners)
+  while (p)
   {
-      b = between_bb(s, pop_lsb(&pinners)) & pieces();
+      b = between_bb(s, pop_lsb(&p)) & pieces();
 
       if (!more_than_one(b))
           result |= b;
@@ -999,6 +999,15 @@ Value Position::see(Move m) const {
   if (!stmAttackers)
       return swapList[0];
 
+  // Don't allow pinned pieces to attack as long all pinners (this includes also potential ones) are on their original square.
+  // As soon a pinner moves to the exchange-square or get captured on it, we fall back to standard SEE behaviour.
+  if (stmAttackers && (stmAttackers & st->blockersForKing[stm]) && ((st->pinnersForKing[stm] & (occupied ^ (occupied & to))) == st->pinnersForKing[stm]))
+  {
+      stmAttackers ^= (stmAttackers & st->blockersForKing[stm]); // pinned pieces can't attack so remove them from attackers
+      if (!stmAttackers)
+          return swapList[0];
+  }
+
   // The destination square is defended, which makes things rather more
   // difficult to compute. We proceed by building up a "swap list" containing
   // the material gain or loss at each stop in a sequence of captures to the
@@ -1017,6 +1026,8 @@ Value Position::see(Move m) const {
       captured = min_attacker<PAWN>(byTypeBB, to, stmAttackers, occupied, attackers);
       stm = ~stm;
       stmAttackers = attackers & pieces(stm);
+      if (stmAttackers && (stmAttackers & st->blockersForKing[stm]) && ((st->pinnersForKing[stm] & (occupied ^ (occupied & to))) == st->pinnersForKing[stm]))
+          stmAttackers ^= (stmAttackers & st->blockersForKing[stm]);
       ++slIndex;
 
   } while (stmAttackers && (captured != KING || (--slIndex, false))); // Stop before a king capture

--- a/src/position.h
+++ b/src/position.h
@@ -64,6 +64,7 @@ struct StateInfo {
   Piece      capturedPiece;
   StateInfo* previous;
   Bitboard   blockersForKing[COLOR_NB];
+  Bitboard   pinnersForKing[COLOR_NB]; // potential and real pinners for opponent king
   Bitboard   checkSquares[PIECE_TYPE_NB];
 };
 
@@ -121,7 +122,7 @@ public:
   Bitboard attacks_from(Piece pc, Square s) const;
   template<PieceType> Bitboard attacks_from(Square s) const;
   template<PieceType> Bitboard attacks_from(Square s, Color c) const;
-  Bitboard slider_blockers(Bitboard sliders, Square s) const;
+  Bitboard slider_blockers(Bitboard sliders, Square s, Bitboard& pinners) const;
 
   // Properties of moves
   bool legal(Move m) const;


### PR DESCRIPTION
Don't allow pinned pieces to attack the exchange-square as long all pinners (this includes also potential ones) are on their original square.
As soon a pinner moves to the exchange-square or get captured on it, we fall back to standard SEE behaviour. This correctly handles the majority of cases with absolute pins.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 23256 W: 4245 L: 4022 D: 14989

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 36372 W: 4905 L: 4667 D: 26800

bench: 6883133

If this will be accepted by the maintainers, I like to give credits to Alain Savard (Rocky) who encouraged me to not give up on this topic and to Marco who made this feasible by #768
