### PR TITLE
Exploit Extmove for passing capture-SEE-values to search

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -185,9 +185,9 @@ void MovePicker::score<EVASIONS>() {
 /// left. It picks the move with the biggest value from a list of generated moves
 /// taking care not to return the ttMove if it has already been searched.
 
-Move MovePicker::next_move() {
+ExtMove MovePicker::next_move() {
 
-  Move move;
+  ExtMove move;
 
   switch (stage) {
 
@@ -208,7 +208,7 @@ Move MovePicker::next_move() {
           move = pick_best(cur++, endMoves);
           if (move != ttMove)
           {
-              if (pos.see_sign(move) >= VALUE_ZERO)
+              if ((move.value = pos.see_sign(move)) >= VALUE_ZERO)
                   return move;
 
               // Losing capture, move it to the beginning of the array
@@ -350,5 +350,6 @@ remaining:
       assert(false);
   }
 
-  return MOVE_NONE;
+  ttMove.move = MOVE_NONE;
+  return ttMove;
 }

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -103,7 +103,7 @@ public:
   MovePicker(const Position&, Move, Depth, Square);
   MovePicker(const Position&, Move, Depth, Search::Stack*);
 
-  Move next_move();
+  ExtMove next_move();
 
 private:
   template<GenType> void score();
@@ -114,7 +114,7 @@ private:
   const Search::Stack* ss;
   Move countermove;
   Depth depth;
-  Move ttMove;
+  ExtMove ttMove;
   Square recaptureSquare;
   Value threshold;
   int stage;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -559,7 +559,8 @@ namespace {
     StateInfo st;
     TTEntry* tte;
     Key posKey;
-    Move ttMove, move, excludedMove, bestMove;
+    Move ttMove, excludedMove, bestMove;
+    ExtMove move;
     Depth extension, newDepth;
     Value bestValue, value, ttValue, eval, nullValue;
     bool ttHit, inCheck, givesCheck, singularExtensionNode, improving;
@@ -952,9 +953,16 @@ moves_loop: // When in check search starts from here
                   && pos.see_sign(move) < Value(-35 * lmrDepth * lmrDepth))
                   continue;
           }
-          else if (   depth < 7 * ONE_PLY
-                   && pos.see_sign(move) < Value(-35 * depth / ONE_PLY * depth / ONE_PLY))
-                  continue;
+          else if (   depth < 7 * ONE_PLY)
+          {
+            if (pos.capture(move) && type_of(move) != PROMOTION)
+            {
+               if (move.value < Value(-35 * depth / ONE_PLY * depth / ONE_PLY))
+                   continue;
+            }
+            else if (pos.see_sign(move) < Value(-35 * depth / ONE_PLY * depth / ONE_PLY))
+               continue;
+          }
       }
 
       // Speculative prefetch as early as possible


### PR DESCRIPTION
On profile builds I measure a speed-up of 1,4%
gcc 4.8.1 Win7-64 i7-3770 @ 3.4GHz x86-64-modern
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    2052317   2081929   -29612    
    StDev   20296     16897     11059     

p-value: 0,996
speedup: 0,014

Unfortunately I'm not sure if the implementation is fully sound and if on all OS we have the same bench (I only have a win-system where the bench corresponds, bench: 5341477)
No functional change.

I'm asking other users to make some measurements too and to verify the bench.
(Apologies for the case it should deliver other bench-numbers under linux)