### PR TITLE
Swap mg and eg in internal representation of Score

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -264,22 +264,22 @@ enum Rank {
 enum Score : int { SCORE_ZERO };
 
 inline Score make_score(int mg, int eg) {
-  return Score((mg << 16) + eg);
+  return Score((eg << 16) + mg);
 }
 
 /// Extracting the signed lower and upper 16 bits is not so trivial because
 /// according to the standard a simple cast to short is implementation defined
 /// and so is a right shift of a signed integer.
-inline Value mg_value(Score s) {
-
-  union { uint16_t u; int16_t s; } mg = { uint16_t(unsigned(s + 0x8000) >> 16) };
-  return Value(mg.s);
-}
-
 inline Value eg_value(Score s) {
 
-  union { uint16_t u; int16_t s; } eg = { uint16_t(unsigned(s)) };
+  union { uint16_t u; int16_t s; } eg = { uint16_t(unsigned(s + 0x8000) >> 16) };
   return Value(eg.s);
+}
+
+inline Value mg_value(Score s) {
+
+  union { uint16_t u; int16_t s; } mg = { uint16_t(unsigned(s)) };
+  return Value(mg.s);
 }
 
 #define ENABLE_BASE_OPERATORS_ON(T)                             \


### PR DESCRIPTION
Instrumentation shows that in make_score(mg, eg) calls, the mg value is
zero in 25,9% of the calls while the eg value is zero in 36,8% of the
calls.

Swapping the fields of mg and eg in the internal representation
of Score allows the compiler to optimize away the shift in 
`(eg << 16) + mg` in more cases, thus resulting in a 0.3% speed-up
overall.

No functional change