### PR TITLE
fixed depth bench with PGO.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,7 @@ PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds
-PGOBENCH = ./$(EXE) bench 16 1 1000 default time
+PGOBENCH = ./$(EXE) bench 16 1 13 default depth
 
 ### Object files
 OBJS = benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o \


### PR DESCRIPTION
As discussed on fishcooking, use fixed depth bench to make PGO builds more reproducible

No functional change