### PR TITLE
Pin-aware SEE: correct pinners calculation and fix bug with pinned pieces giving check

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -425,23 +425,27 @@ Phase Position::game_phase() const {
 /// slider if removing that piece from the board would result in a position where
 /// square 's' is attacked. For example, a king-attack blocking piece can be either
 /// a pinned or a discovered check piece, according if its color is the opposite
-/// or the same of the color of the slider. The pinners bitboard get filled with
-/// real and potential pinners.
+/// or the same of the color of the slider.
 
 Bitboard Position::slider_blockers(Bitboard sliders, Square s, Bitboard& pinners) const {
 
-  Bitboard b, p, result = 0;
+  Bitboard result = 0;
+  pinners = 0;
 
-  // Pinners are sliders that attack 's' when a pinned piece is removed
-  pinners = p = (  (PseudoAttacks[ROOK  ][s] & pieces(QUEEN, ROOK))
-                 | (PseudoAttacks[BISHOP][s] & pieces(QUEEN, BISHOP))) & sliders;
+  // Snipers are sliders that attack 's' when a piece is removed
+  Bitboard snipers = (  (PseudoAttacks[ROOK  ][s] & pieces(QUEEN, ROOK))
+                      | (PseudoAttacks[BISHOP][s] & pieces(QUEEN, BISHOP))) & sliders;
 
-  while (p)
+  while (snipers)
   {
-      b = between_bb(s, pop_lsb(&p)) & pieces();
-
-      if (!more_than_one(b))
-          result |= b;
+    Square sniperSquare = pop_lsb(&snipers);
+    Bitboard b = between_bb(s, sniperSquare) & pieces();
+    if (!more_than_one(b))
+    {
+        result |= b;
+        if (b & pieces(color_of(piece_on(s))))
+            pinners |= sniperSquare;
+    }
   }
   return result;
 }
@@ -1004,9 +1008,8 @@ Value Position::see(Move m) const {
   stmAttackers = attackers & pieces(stm);
   occupied ^= to; // For the case when captured piece is a pinner
 
-  // Don't allow pinned pieces to attack as long all pinners (this includes also
-  // potential ones) are on their original square. When a pinner moves to the
-  // exchange-square or get captured on it, we fall back to standard SEE behaviour.
+  // Don't allow pinned pieces to attack pieces except the king as long all pinners are on their original square.
+  // When a pinner moves to the exchange-square or get captured on it, we fall back to standard SEE behaviour.
   if (   (stmAttackers & pinned_pieces(stm))
       && (st->pinnersForKing[stm] & occupied) == st->pinnersForKing[stm])
       stmAttackers &= ~pinned_pieces(stm);
@@ -1032,7 +1035,8 @@ Value Position::see(Move m) const {
       captured = min_attacker<PAWN>(byTypeBB, to, stmAttackers, occupied, attackers);
       stm = ~stm;
       stmAttackers = attackers & pieces(stm);
-      if (   (stmAttackers & pinned_pieces(stm))
+      if ( captured != KING
+          && (stmAttackers & pinned_pieces(stm))
           && (st->pinnersForKing[stm] & occupied) == st->pinnersForKing[stm])
           stmAttackers &= ~pinned_pieces(stm);
 


### PR DESCRIPTION
This was a co-operation between Marco Costalba, Stéphane Nicolet and me.

Special thanks to Ronald de Man for reporting the bug with pinned pieces giving check,
discussed here: https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/S_4E_Xs5HaE

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 132118 W: 23578 L: 23645 D: 84895

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 36424 W: 4770 L: 4670 D: 26984

bench: 6272231