### PR TITLE
Always allow singular extension.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -845,8 +845,7 @@ moves_loop: // When in check search starts from here
     singularExtensionNode =   !rootNode
                            &&  depth >= 8 * ONE_PLY
                            &&  ttMove != MOVE_NONE
-                        /* &&  ttValue != VALUE_NONE // Already implicit in the next condition */
-                           &&  ttValue > VALUE_MATED_IN_MAX_PLY
+                           &&  ttValue != VALUE_NONE
                            && !excludedMove // Recursive singular search is not allowed
                            && (tte->bound() & BOUND_LOWER)
                            &&  tte->depth() >= depth - 3 * ONE_PLY;
@@ -904,7 +903,7 @@ moves_loop: // When in check search starts from here
           && !extension
           &&  pos.legal(move))
       {
-          Value rBeta = ttValue - 2 * depth / ONE_PLY;
+          Value rBeta = std::max(ttValue - 2 * depth / ONE_PLY, -VALUE_MATE);
           Depth d = (depth / (2 * ONE_PLY)) * ONE_PLY;
           ss->excludedMove = move;
           ss->skipEarlyPruning = true;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -845,7 +845,8 @@ moves_loop: // When in check search starts from here
     singularExtensionNode =   !rootNode
                            &&  depth >= 8 * ONE_PLY
                            &&  ttMove != MOVE_NONE
-                           &&  ttValue != VALUE_NONE
+                        /* &&  ttValue != VALUE_NONE // Already implicit in the next condition */
+                           &&  ttValue > VALUE_MATED_IN_MAX_PLY
                            && !excludedMove // Recursive singular search is not allowed
                            && (tte->bound() & BOUND_LOWER)
                            &&  tte->depth() >= depth - 3 * ONE_PLY;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -845,8 +845,7 @@ moves_loop: // When in check search starts from here
     singularExtensionNode =   !rootNode
                            &&  depth >= 8 * ONE_PLY
                            &&  ttMove != MOVE_NONE
-                       /*  &&  ttValue != VALUE_NONE Already implicit in the next condition */
-                           &&  abs(ttValue) < VALUE_KNOWN_WIN
+                           &&  ttValue != VALUE_NONE
                            && !excludedMove // Recursive singular search is not allowed
                            && (tte->bound() & BOUND_LOWER)
                            &&  tte->depth() >= depth - 3 * ONE_PLY;


### PR DESCRIPTION
It is also a bugfix of a bugfix.

Everything started with Eelco's patch https://github.com/official-stockfish/Stockfish/commit/55a3e0af8d0d1e169cc8b16541ffeb41e157b66e, after which the condition "abs(ttValue) < VALUE_KNOWN_WIN" had been removed from singular extension search, and condition "abs(beta) < VALUE_KNOWN_WIN" was added to the SingularExtensionNode definition.
This could lead to problems especially in positions where a mate is due.
For example, this position 5rk1/4K1pp/8/5PPP/8/8/8/1R6 w - - 12 1 triggered an assert.
This was fixed with this patch https://github.com/official-stockfish/Stockfish/commit/ffedfa33542a7de7d87fd545ea0a4b2fef8f8c6e but in a quite thoughtlessly way. Because then singular extensions were not allowed in way more positions than needed.

Dividing the triggered assert into 3 separate asserts reveals the real problem:
stockfish: search.cpp:552: Value {anonymous}::search(Position&, Search::Stack*, Value, Value, Depth, bool) [with {anonymous}::NodeType NT = (<unnamed>::NodeType)0u]: Assertion `-VALUE_INFINITE <= alpha' failed.

Because we subtract 2 * depth from ttValue during singular exclusion search
``` Value rBeta = ttValue - 2 * depth / ONE_PLY; ```
and call search() with rbeta-1, rbeta, we must take care that rbeta-1 is at least -VALUE_INFINITE.
``` Value rBeta = std::max(ttValue - 2 * depth / ONE_PLY, -VALUE_MATE); ``` does exactly that.

Now we can always use singular extensions which seems to be especially helpful in finding mates.

Passed STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 25655 W: 4578 L: 4465 D: 16612

and LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 66247 W: 8618 L: 8557 D: 49072

bench: 6335042