### PR TITLE
Simplify pos.gives_check(Move m) 

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -597,7 +597,7 @@ bool Position::gives_check(Move m) const {
       return true;
 
   // Is there a discovered check?
-  if (   (discovered_check_candidates() & from)
+  if (   (st->blockersForKing[~sideToMove] & from)
       && !aligned(from, to, square<KING>(~sideToMove)))
       return true;
 


### PR DESCRIPTION
Analog to [commit ](https://github.com/pb00068/Stockfish/commit/28240d375c837f2342163e84675bc9230124cd30) for #809  where we replaced pinned_pieces(stm) with st->blockersForKing[stm] to avoid a possible useless AND-bit-operation,
we can do the same for discovered_check_candidates() in position.cpp method gives_check().
On line 600 of current master we calculate
 
`discovered_check_candidates() & from`

which might be translated to

`st->blockersForKing(~sideToMove) & pieces(sideToMove) & from`

Since 'from' is a piece of sideToMove per definition, the bit-operation
with pieces(sideToMove) is useless and can be avoided by calling st->blockersForKing(~sideToMove) directly.

no functional change