### PR TITLE
Opp bishop simple

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -681,6 +681,8 @@ ScaleFactor Endgame<KBPKB>::operator()(const Position& pos) const {
           if (  (pos.attacks_from<BISHOP>(weakBishopSq) & path)
               && distance(weakBishopSq, pawnSq) >= 3)
               return SCALE_FACTOR_DRAW;
+
+	  return ScaleFactor(9);
       }
   }
   return SCALE_FACTOR_NONE;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -743,10 +743,12 @@ namespace {
         if (pos.opposite_bishops())
         {
             // Endgame with opposite-colored bishops and no other pieces (ignoring pawns)
-            // is almost a draw, in case of KBP vs KB, it is even more a draw.
+            // is almost a draw. KBP vs KB should not make it here because it
+	    // is assigned a ScaleFactor other than Normal or OnePawn in 
+	    // endgame.cpp.
             if (   pos.non_pawn_material(WHITE) == BishopValueMg
                 && pos.non_pawn_material(BLACK) == BishopValueMg)
-                sf = more_than_one(pos.pieces(PAWN)) ? ScaleFactor(31) : ScaleFactor(9);
+                sf = ScaleFactor(31);
 
             // Endgame with opposite-colored bishops, but also other pieces. Still
             // a bit drawish, but not as drawish as with only the two bishops.


### PR DESCRIPTION
I thought it made sense to keep all KBP vs. KB in endgame.cpp.  Additionally, this simplifies line 751 in evaluate.cpp.  I was unable to get FishBench to work but measured a speedup by running it several times. I'm quite new to this, so I apologize in advance if I've done something wrong. No functional change.

bench: 6335042