### PR TITLE
pick_best() speedup without full std::swap

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -48,13 +48,24 @@ namespace {
     }
   }
 
-  // pick_best() finds the best move in the range (begin, end) and moves it to
-  // the front. It's faster than sorting all the moves in advance when there
+  // pick_best() finds the best move in the range (begin, end) and returns it
+  // front move replaces best move on its position
+  // It's faster than sorting all the moves in advance when there
   // are few moves, e.g., the possible captures.
   Move pick_best(ExtMove* begin, ExtMove* end)
   {
-      std::swap(*begin, *std::max_element(begin, end));
-      return *begin;
+      assert(begin < end);
+
+      ExtMove *ptr = begin;
+      ExtMove *iter = begin;
+
+      while (++iter < end)
+          if (*ptr < *iter)
+              ptr = iter;
+
+      ExtMove res = *ptr;
+      *ptr = *begin;
+      return res;
   }
 
 } // namespace


### PR DESCRIPTION
pick_best() refactored
changes: 
opening begin == end condition from std::max_element omitted, is replaced by assert precondition
best move is returned only from pick_best(), no more stored in front slot, was never read from this position

Average speedup 0.4 - 0.5% 

Tested on Ubuntu 16.04, Clang 4.0, Win7 Pro GCC 6.2.0

FishBench:
Results for 500 tests for each version:

                   Base           Test        Diff      
    Mean    1311066   1315976   -4910     
    StDev        49793     50213     3421      

p-value: 0,924
speedup: 0,004

