### PR TITLE
Fixes for ARM compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.depend
+stockfish
+*.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,10 @@
 ### ==========================================================================
 
 ### Establish the operating system name
-UNAME = $(shell uname)
+KERNEL = $(shell uname -s)
+ifeq ($(KERNEL),Linux)
+	OS = $(shell uname -o)
+endif
 
 ### Executable name
 EXE = stockfish
@@ -146,7 +149,7 @@ ifeq ($(COMP),gcc)
 	comp=gcc
 	CXX=g++
 	CXXFLAGS += -pedantic -Wextra -Wshadow -m$(bits)
-	ifneq ($(UNAME),Darwin)
+	ifneq ($(KERNEL),Darwin)
 	   LDFLAGS += -Wl,--no-as-needed
 	endif
 endif
@@ -154,7 +157,7 @@ endif
 ifeq ($(COMP),mingw)
 	comp=mingw
 
-	ifeq ($(UNAME),Linux)
+	ifeq ($(KERNEL),Linux)
 		ifeq ($(bits),64)
 			ifeq ($(shell which x86_64-w64-mingw32-c++-posix),)
 				CXX=x86_64-w64-mingw32-c++
@@ -187,7 +190,7 @@ ifeq ($(COMP),clang)
 	CXX=clang++
 	CXXFLAGS += -pedantic -Wextra -Wshadow -m$(bits)
 	LDFLAGS += -m$(bits)
-	ifeq ($(UNAME),Darwin)
+	ifeq ($(KERNEL),Darwin)
 		CXXFLAGS += -stdlib=libc++
 		DEPENDFLAGS += -stdlib=libc++
 	endif
@@ -205,7 +208,7 @@ else
 	profile_clean = gcc-profile-clean
 endif
 
-ifeq ($(UNAME),Darwin)
+ifeq ($(KERNEL),Darwin)
 	CXXFLAGS += -arch $(arch) -mmacosx-version-min=10.9
 	LDFLAGS += -arch $(arch) -mmacosx-version-min=10.9
 endif
@@ -223,9 +226,9 @@ endif
 ### On mingw use Windows threads, otherwise POSIX
 ifneq ($(comp),mingw)
 	# On Android Bionic's C library comes with its own pthread implementation bundled in
-	ifneq ($(arch),armv7)
+	ifneq ($(OS),Android)
 		# Haiku has pthreads in its libroot, so only link it in on other platforms
-		ifneq ($(UNAME),Haiku)
+		ifneq ($(KERNEL),Haiku)
 			LDFLAGS += -lpthread
 		endif
 	endif
@@ -245,7 +248,7 @@ ifeq ($(optimize),yes)
 
 	ifeq ($(comp),gcc)
 
-		ifeq ($(UNAME),Darwin)
+		ifeq ($(KERNEL),Darwin)
 			ifeq ($(arch),i386)
 				CXXFLAGS += -mdynamic-no-pic
 			endif
@@ -260,13 +263,13 @@ ifeq ($(optimize),yes)
 	endif
 
 	ifeq ($(comp),icc)
-		ifeq ($(UNAME),Darwin)
+		ifeq ($(KERNEL),Darwin)
 			CXXFLAGS += -mdynamic-no-pic
 		endif
 	endif
 
 	ifeq ($(comp),clang)
-		ifeq ($(UNAME),Darwin)
+		ifeq ($(KERNEL),Darwin)
 			ifeq ($(pext),no)
 				CXXFLAGS += -flto
 				LDFLAGS += $(CXXFLAGS)
@@ -326,7 +329,7 @@ ifeq ($(comp),gcc)
 endif
 
 ifeq ($(comp),mingw)
-	ifeq ($(UNAME),Linux)
+	ifeq ($(KERNEL),Linux)
 	ifeq ($(optimize),yes)
 	ifeq ($(debug),no)
 		CXXFLAGS += -flto
@@ -338,7 +341,7 @@ endif
 
 ### 3.9 Android 5 can only run position independent executables. Note that this
 ### breaks Android 4.0 and earlier.
-ifeq ($(arch),armv7)
+ifeq ($(OS), Android)
 	CXXFLAGS += -fPIE
 	LDFLAGS += -fPIE -pie
 endif
@@ -446,6 +449,8 @@ config-sanity:
 	@echo "optimize: '$(optimize)'"
 	@echo "arch: '$(arch)'"
 	@echo "bits: '$(bits)'"
+	@echo "kernel: '$(KERNEL)'"
+	@echo "os: '$(OS)'"
 	@echo "prefetch: '$(prefetch)'"
 	@echo "popcnt: '$(popcnt)'"
 	@echo "sse: '$(sse)'"

--- a/src/Makefile
+++ b/src/Makefile
@@ -276,7 +276,7 @@ ifeq ($(optimize),yes)
 			endif
 		endif
 
-		ifeq ($(arch),armv7)
+		ifeq ($(OS), Android)
 			CXXFLAGS += -fno-gcse -mthumb -march=armv7-a -mfloat-abi=softfp
 		endif
 	endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -148,7 +148,16 @@ endif
 ifeq ($(COMP),gcc)
 	comp=gcc
 	CXX=g++
-	CXXFLAGS += -pedantic -Wextra -Wshadow -m$(bits)
+	CXXFLAGS += -pedantic -Wextra -Wshadow
+
+	ifeq ($(ARCH),armv7)
+		ifeq ($(OS),Android)
+			CXXFLAGS += -m$(bits)
+		endif
+	else
+		CXXFLAGS += -m$(bits)
+	endif
+
 	ifneq ($(KERNEL),Darwin)
 	   LDFLAGS += -Wl,--no-as-needed
 	endif
@@ -188,8 +197,18 @@ endif
 ifeq ($(COMP),clang)
 	comp=clang
 	CXX=clang++
-	CXXFLAGS += -pedantic -Wextra -Wshadow -m$(bits)
-	LDFLAGS += -m$(bits)
+	CXXFLAGS += -pedantic -Wextra -Wshadow
+
+	ifeq ($(ARCH),armv7)
+		ifeq ($(OS),Android)
+			CXXFLAGS += -m$(bits)
+			LDFLAGS += -m$(bits)
+		endif
+	else
+		CXXFLAGS += -m$(bits)
+		LDFLAGS += -m$(bits)
+	endif
+
 	ifeq ($(KERNEL),Darwin)
 		CXXFLAGS += -stdlib=libc++
 		DEPENDFLAGS += -stdlib=libc++


### PR DESCRIPTION
Hi,

The target :
 - Odroid U3 (http://www.hardkernel.com/main/products/prdt_info.php?g_code=g138745696275)
 - Debian Jessie

As listed in https://github.com/official-stockfish/Stockfish/issues/550 and https://github.com/official-stockfish/Stockfish/issues/638 three modifications are needed for compilation to work :
 - `float-abi` flag for GCC
    If an FPU is present and supported by the installed os then passed value need to be `hard`.
   I didn't find any better solution than using `readelf` to check for the availibilty of `Tag_ABI_VFP_args` which sould indicate support for the FPU. The check is only done if the `arch` is arm and if `readelf` is not present on the system, there will be an error (`/bin/sh: 1: readelf: not found`) but it will not break and will continue with the default `softfp` value.
  Outputing the error is not really acceptable but I wanted some feedback on the check itself.

- `-lpthread` is needed on armv7 outside of Android
    I replaced `UNAME` with `KERNEL` and `OS` to allow to differentiate `Android`.

- `m32` flag
    My understanding is that outside of Android the flag is generating errors on armv7.

These modifications should introduce change only for non Android armv7 build.
