### PR TITLE
Explicit Logic/Speedup

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -941,6 +941,7 @@ moves_loop: // When in check search starts from here
 
               // Futility pruning: parent node
               if (   lmrDepth < 7
+                  && !inCheck              
                   && ss->staticEval + 256 + 200 * lmrDepth <= alpha)
                   continue;
 
@@ -950,6 +951,7 @@ moves_loop: // When in check search starts from here
                   continue;
           }
           else if (   depth < 7 * ONE_PLY
+                   && !extension                   
                    && !pos.see_ge(move, Value(-35 * depth / ONE_PLY * depth / ONE_PLY)))
                   continue;
       }


### PR DESCRIPTION
Use explicit logic for pruning.
Also a speedup since we don't need to recalculate SEE for extensions...as it already determined to be positive.

Results for 12 tests for each version:

            Base      Test      Diff      
    Mean    2132395   2191002   -58607    
    StDev   128058    85917     134239    

p-value: 0.669
speedup: 0.027

Non functional change.