### PR TITLE
Simplify next_move by always scoring evasions.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -271,8 +271,7 @@ Move MovePicker::next_move() {
   case EVASIONS_INIT:
       cur = moves;
       endMoves = generate<EVASIONS>(pos, cur);
-      if (endMoves - cur - (ttMove != MOVE_NONE) > 1)
-          score<EVASIONS>();
+      score<EVASIONS>();
       ++stage;
 
   case ALL_EVASIONS:


### PR DESCRIPTION
For a default bench, this fixes the last valgrind error (jump on uninitialised value).

passed STC : 

LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 187869 W: 33303 L: 33463 D: 121103

No functional change.