### PR TITLE
Pick best2

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -54,14 +54,9 @@ namespace {
   // are few moves, e.g., the possible captures.
   Move pick_best(ExtMove* begin, ExtMove* end)
   {
-    ExtMove* ptrBest = begin;
-    ExtMove* iter = begin;
+    ExtMove* ptrBest = std::max_element( begin, end );
 
-    while(++iter != end)
-        if(ptrBest->value < iter->value)
-            ptrBest = iter;
-
-    Move best = ptrBest->move;
+    Move best = *ptrBest;
     *ptrBest = *begin;
     return best;
   }

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -48,13 +48,17 @@ namespace {
     }
   }
 
-  // pick_best() finds the best move in the range (begin, end) and moves it to
-  // the front. It's faster than sorting all the moves in advance when there
+  // pick_best() finds the best move in the range (begin, end) and returns it
+  // front move replaces best move on its position
+  // It's faster than sorting all the moves in advance when there
   // are few moves, e.g., the possible captures.
   Move pick_best(ExtMove* begin, ExtMove* end)
   {
-      std::swap(*begin, *std::max_element(begin, end));
-      return *begin;
+    ExtMove* ptrBest = std::max_element( begin, end );
+
+    Move best = *ptrBest;
+    *ptrBest = *begin;
+    return best;
   }
 
 } // namespace

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -54,9 +54,14 @@ namespace {
   // are few moves, e.g., the possible captures.
   Move pick_best(ExtMove* begin, ExtMove* end)
   {
-    ExtMove* ptrBest = std::max_element( begin, end );
+    ExtMove* ptrBest = begin;
+    ExtMove* iter = begin;
 
-    Move best = *ptrBest;
+    while(++iter != end)
+        if(ptrBest->value < iter->value)
+            ptrBest = iter;
+
+    Move best = ptrBest->move;
     *ptrBest = *begin;
     return best;
   }


### PR DESCRIPTION
Second attempt to speedup the MovePicker::pick_best(), now with better evidence of speedup.
Superfluous assignment in std::swap() is omitted

Points: 36207.5/72234
Elo gain: +0.87
Speedup : 1.45% assuming +60 Elo by 100% speedup

http://tests.stockfishchess.org/tests/view/57ff949c0ebc5910626b941c

LLR: -2.97 (-2.94,2.94) [0.00,5.00]
Total: 72234 W: 13085 L: 12904 D: 46245
