### PR TITLE
Speed up Tweaks for Singular Extension.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -560,7 +560,7 @@ namespace {
     TTEntry* tte;
     Key posKey;
     Move ttMove, move, excludedMove, bestMove;
-    Depth extension, newDepth;
+    Depth newDepth;
     Value bestValue, value, ttValue, eval, nullValue;
     bool ttHit, inCheck, givesCheck, singularExtensionNode, improving;
     bool captureOrPromotion, doFullDepthSearch, moveCountPruning;
@@ -875,7 +875,7 @@ moves_loop: // When in check search starts from here
       if (PvNode)
           (ss+1)->pv = nullptr;
 
-      extension = DEPTH_ZERO;
+      newDepth = depth - ONE_PLY;
       captureOrPromotion = pos.capture_or_promotion(move);
       moved_piece = pos.moved_piece(move);
 
@@ -890,32 +890,7 @@ moves_loop: // When in check search starts from here
       if (    givesCheck
           && !moveCountPruning
           &&  pos.see_ge(move, VALUE_ZERO))
-          extension = ONE_PLY;
-
-      // Singular extension search. If all moves but one fail low on a search of
-      // (alpha-s, beta-s), and just one fails high on (alpha, beta), then that move
-      // is singular and should be extended. To verify this we do a reduced search
-      // on all the other moves but the ttMove and if the result is lower than
-      // ttValue minus a margin then we extend the ttMove.
-      if (    singularExtensionNode
-          &&  move == ttMove
-          && !extension
-          &&  pos.legal(move))
-      {
-          Value rBeta = std::max(ttValue - 2 * depth / ONE_PLY, -VALUE_MATE);
-          Depth d = (depth / (2 * ONE_PLY)) * ONE_PLY;
-          ss->excludedMove = move;
-          ss->skipEarlyPruning = true;
-          value = search<NonPV>(pos, ss, rBeta - 1, rBeta, d, cutNode);
-          ss->skipEarlyPruning = false;
-          ss->excludedMove = MOVE_NONE;
-
-          if (value < rBeta)
-              extension = ONE_PLY;
-      }
-
-      // Update the current move (this must be done after singular extension search)
-      newDepth = depth - ONE_PLY + extension;
+          newDepth += ONE_PLY;
 
       // Step 13. Pruning at shallow depth
       if (  !rootNode
@@ -956,6 +931,33 @@ moves_loop: // When in check search starts from here
 
       // Speculative prefetch as early as possible
       prefetch(TT.first_entry(pos.key_after(move)));
+
+      // Singular extension search. If all moves but one fail low on a search of
+      // (alpha-s, beta-s), and just one fails high on (alpha, beta), then that move
+      // is singular and should be extended. To verify this we do a reduced search
+      // on all the other moves but the ttMove and if the result is lower than
+      // ttValue minus a margin then we extend the ttMove.
+      if (    singularExtensionNode
+          &&  move == ttMove
+          &&  newDepth < depth
+          &&  pos.legal(move))
+      {
+          Value rBeta = std::max(ttValue - 2 * depth / ONE_PLY, -VALUE_MATE);
+          Depth d = (depth / (2 * ONE_PLY)) * ONE_PLY;
+          ss->excludedMove = move;
+          ss->skipEarlyPruning = true;
+          value = search<NonPV>(pos, ss, rBeta - 1, rBeta, d, cutNode);
+          ss->skipEarlyPruning = false;
+          ss->excludedMove = MOVE_NONE;
+          singularExtensionNode = false;
+
+          if (value < rBeta)
+              newDepth += ONE_PLY;
+
+          // Speculative prefetch as early as possible
+          prefetch(TT.first_entry(pos.key_after(move)));
+
+      }
 
       // Check for legality just before making the move
       if (!rootNode && !pos.legal(move))


### PR DESCRIPTION
This speed up consist of three parts:
a) Removing the variable extension, just update newDepth directly.
b) Reorder singular extension after prefetch.
c) Setting variable singularExtensionNode to false, after doing singular extension search.

### Results of 200 Bench 16 1 13
```
Variable     Master     Patch    Diff    Speedup
Mean        1183364   1209973   26609     2.24%
Max Speed   1194753   1221046   26293     2.20%
Median      1186159   1214551   28392     2.39%
Std           11579     14016

For both command line used for the build:
$  make build ARCH=x86-64-modern
```

I appreciate if others could repeat the test to confirm the speed up. 
