### PR TITLE
Make valgrind testing part of travis ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-multilib']
+          packages: ['g++-multilib', 'valgrind']
       env:
         - COMPILER=g++
         - COMP=gcc
@@ -19,7 +19,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['clang', 'g++-multilib']
+          packages: ['clang', 'g++-multilib', 'valgrind']
       env:
         - COMPILER=clang++
         - COMP=clang
@@ -49,3 +49,5 @@ script:
   - echo "Checking for same bench numbers..."
   - diff bench1 bench2 > result
   - test ! -s result
+  # if valgrind is available check the build is without error, reduce depth to speedup testing, but not too shallow to catch more cases.
+  - if [ -x "$(command -v valgrind )" ] ; then make clean && make ARCH=x86-64 debug=yes build && valgrind --error-exitcode=42 ./stockfish bench 128 1 10 default depth 1>/dev/null ; fi


### PR DESCRIPTION
This pull request integrates valgrind testing into the travis script. 

The benefit of using valgrind is that certain undefined behaviour (such as out-of-bounds accesses, or the use of uninitialised memory), is automatically diagnosed. It does add < 1min to travis testing time (using somewhat reduced depth for the bench).

As soon as pull request #829 has been merged, Stockfish passes this additional test. I've verified that without the pull the error is correctly diagnosed (see https://travis-ci.org/vondele/Stockfish/builds)

I would suggest to enable travis testing also on pull requests as suggested earlier (https://groups.google.com/d/msg/fishcooking/THMSKTucOBw/p08DYjbkAgAJ)

For information on valgrind see http://www.valgrind.org/info/about.html
We have been using the tool for many years on a large software project.
