### PR TITLE
Per-thread TB hit counters.

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -149,6 +149,8 @@ public:
   Thread* this_thread() const;
   uint64_t nodes_searched() const;
   void set_nodes_searched(uint64_t n);
+  uint64_t tb_hits() const;
+  void count_tb_hit();
   bool is_draw() const;
   int rule50_count() const;
   Score psq_score() const;
@@ -182,6 +184,7 @@ private:
   Square castlingRookSquare[CASTLING_RIGHT_NB];
   Bitboard castlingPath[CASTLING_RIGHT_NB];
   uint64_t nodes;
+  uint64_t tbHits;
   int gamePly;
   Color sideToMove;
   Thread* thisThread;
@@ -343,6 +346,14 @@ inline uint64_t Position::nodes_searched() const {
 
 inline void Position::set_nodes_searched(uint64_t n) {
   nodes = n;
+}
+
+inline uint64_t Position::tb_hits() const {
+  return tbHits;
+}
+
+inline void Position::count_tb_hit() {
+  tbHits++;
 }
 
 inline bool Position::opposite_bishops() const {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -46,7 +46,6 @@ namespace Search {
 namespace Tablebases {
 
   int Cardinality;
-  uint64_t Hits;
   bool RootInTB;
   bool UseRule50;
   Depth ProbeDepth;
@@ -672,7 +671,7 @@ namespace {
 
             if (found)
             {
-                TB::Hits++;
+                pos.count_tb_hit();
 
                 int drawScore = TB::UseRule50 ? 1 : 0;
 
@@ -1537,6 +1536,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
   size_t PVIdx = pos.this_thread()->PVIdx;
   size_t multiPV = std::min((size_t)Options["MultiPV"], rootMoves.size());
   uint64_t nodes_searched = Threads.nodes_searched();
+  uint64_t tb_hits = Threads.tb_hits() + (TB::RootInTB ? rootMoves.size() : 0);
 
   for (size_t i = 0; i < multiPV; ++i)
   {
@@ -1569,7 +1569,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
       if (elapsed > 1000) // Earlier makes little sense
           ss << " hashfull " << TT.hashfull();
 
-      ss << " tbhits "   << TB::Hits
+      ss << " tbhits "   << tb_hits
          << " time "     << elapsed
          << " pv";
 
@@ -1612,7 +1612,6 @@ bool RootMove::extract_ponder_from_tt(Position& pos) {
 
 void Tablebases::filter_root_moves(Position& pos, Search::RootMoves& rootMoves) {
 
-    Hits = 0;
     RootInTB = false;
     UseRule50 = Options["Syzygy50MoveRule"];
     ProbeDepth = Options["SyzygyProbeDepth"] * ONE_PLY;
@@ -1645,13 +1644,8 @@ void Tablebases::filter_root_moves(Position& pos, Search::RootMoves& rootMoves) 
             Cardinality = 0;
     }
 
-    if (RootInTB)
-    {
-        Hits = rootMoves.size();
-
-        if (!UseRule50)
-            TB::Score =  TB::Score > VALUE_DRAW ?  VALUE_MATE - MAX_PLY - 1
-                       : TB::Score < VALUE_DRAW ? -VALUE_MATE + MAX_PLY + 1
-                                                :  VALUE_DRAW;
-    }
+    if (RootInTB && !UseRule50)
+        TB::Score =  TB::Score > VALUE_DRAW ?  VALUE_MATE - MAX_PLY - 1
+                   : TB::Score < VALUE_DRAW ? -VALUE_MATE + MAX_PLY + 1
+                                            :  VALUE_DRAW;
 }

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -167,6 +167,17 @@ int64_t ThreadPool::nodes_searched() {
 }
 
 
+/// ThreadPool::tb_hits() returns the number of TB hits.
+
+int64_t ThreadPool::tb_hits() {
+
+  int64_t hits = 0;
+  for (Thread* th : *this)
+      hits += th->rootPos.tb_hits();
+  return hits;
+}
+
+
 /// ThreadPool::start_thinking() wakes up the main thread sleeping in idle_loop()
 /// and starts a new search, then returns immediately.
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -99,6 +99,7 @@ struct ThreadPool : public std::vector<Thread*> {
   void start_thinking(Position&, StateListPtr&, const Search::LimitsType&);
   void read_uci_options();
   int64_t nodes_searched();
+  int64_t tb_hits();
 
 private:
   StateListPtr setupStates;


### PR DESCRIPTION
See https://groups.google.com/forum/?hl=en#!topic/fishcooking/ATJb681NTV8 for a discussion.

I don't think it adds measurable Elo even on big machines and it does add code, but it is better and cleaner depending on perhaps personal taste. So I'll leave it to the maintainers.

ThreadPool::tb_hits() returns int64_t instead of uint64_t only because ThreadPool::nodes_searched() does the same. It seems more consistent to change both to returning uint64_t.

Btw, it seems that set_nodes_searched() is no longer used and can be removed from the Position class.