### PR TITLE
Per thread TB::Hits counters

### DIFF
--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -6,6 +6,7 @@
 namespace Tablebases {
 
 extern int MaxCardinality;
+extern bool RootInTB;
 
 void init(const std::string& path);
 int probe_wdl(Position& pos, int *success);

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -158,12 +158,23 @@ void ThreadPool::read_uci_options() {
 
 /// ThreadPool::nodes_searched() returns the number of nodes searched
 
-int64_t ThreadPool::nodes_searched() {
+int64_t ThreadPool::nodes_searched() const {
 
   int64_t nodes = 0;
   for (Thread* th : *this)
       nodes += th->rootPos.nodes_searched();
   return nodes;
+}
+
+
+/// ThreadPool::tb_hits() returns the number of TB hits
+
+int64_t ThreadPool::tb_hits() const {
+
+    int64_t TBHits = 0;
+    for (Thread* th : *this)
+        TBHits += th->TBHits;
+    return TBHits;
 }
 
 
@@ -202,6 +213,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
       th->rootDepth = DEPTH_ZERO;
       th->rootMoves = rootMoves;
       th->rootPos.set(pos.fen(), pos.is_chess960(), &setupStates->back(), th);
+      th->TBHits = (Tablebases::RootInTB && th->idx == 0) ? rootMoves.size() : 0;
   }
 
   setupStates->back() = tmp; // Restore st->previous, cleared by Position::set()

--- a/src/thread.h
+++ b/src/thread.h
@@ -62,6 +62,7 @@ public:
   Endgames endgames;
   size_t idx, PVIdx;
   int maxPly, callsCnt;
+  uint64_t TBHits;
 
   Position rootPos;
   Search::RootMoves rootMoves;
@@ -98,7 +99,8 @@ struct ThreadPool : public std::vector<Thread*> {
   MainThread* main() { return static_cast<MainThread*>(at(0)); }
   void start_thinking(Position&, StateListPtr&, const Search::LimitsType&);
   void read_uci_options();
-  int64_t nodes_searched();
+  int64_t nodes_searched() const;
+  int64_t tb_hits() const;
 
 private:
   StateListPtr setupStates;


### PR DESCRIPTION
A single global TB::Hits++ creates a memory bottle neck on high core machines.  Similar to what cmh was doing here https://github.com/official-stockfish/Stockfish/pull/797
The slowdown has been measured to be 8% by salas...@gmail.com here
https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/ATJb681NTV8
This change also makes the counting correct because the current implementation is not well defined by the C++ standard.

@syzygy1 @mcostalba 
If either of you would like to implement this another way please just open your own pull request and I will promptly close this one.   I just want to make sure we can get this in before the TCEC final.  Thanks.