### PR TITLE
Fix undefined behaviour (1).

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -379,10 +379,9 @@ const string Position::fen() const {
               ss << PieceToChar[piece_on(make_square(f, r))];
       }
 
-      if (r > RANK_1)
-          ss << '/';
-      else
-          break; // decrementing RANK_1 would be undefined behavior
+      if (r == RANK_1) break; 
+
+      ss << '/';
   }
 
   ss << (sideToMove == WHITE ? " w " : " b ");

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -381,6 +381,8 @@ const string Position::fen() const {
 
       if (r > RANK_1)
           ss << '/';
+      else
+          break; // decrementing RANK_1 would be undefined behavior
   }
 
   ss << (sideToMove == WHITE ? " w " : " b ");


### PR DESCRIPTION
avoids decrementing a variable beyond its defined range.

failed SPRT testing at STC, but as discussed, is likely noise, as game play is not influenced:

LLR: -2.95 (-2.94,2.94) [-3.00,1.00]
Total: 43548 W: 7555 L: 7783 D: 28210

No functional change.