### PR TITLE
Fix undefined behaviour (3).

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -263,7 +263,8 @@ enum Rank {
 enum Score : int { SCORE_ZERO };
 
 inline Score make_score(int mg, int eg) {
-  return Score((eg << 16) + mg);
+  // Left-shifting a negative signed int would be undefined behavior.
+  return Score((int)((unsigned int)eg << 16) + mg);
 }
 
 /// Extracting the signed lower and upper 16 bits is not so trivial because


### PR DESCRIPTION
Avoid shifting negative signed ints.

Verified that identical  code is generated.

Passed SPRT at STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 51430 W: 9035 L: 8965 D: 33430

No functional change.