### PR TITLE
Fix undefined behavior (2).

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -115,7 +115,7 @@ const int MAX_PLY   = 128;
 /// any normal move destination square is always different from origin square
 /// while MOVE_NONE and MOVE_NULL have the same origin and destination square.
 
-enum Move {
+enum Move : int {
   MOVE_NONE,
   MOVE_NULL = 65
 };


### PR DESCRIPTION
use a typed enum to allow for the values actually stored.

passed SPRT at STC:

LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 246564 W: 43862 L: 44122 D: 158580

No functional change.