### PR TITLE
TB root ranking

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1654,7 +1654,7 @@ void Tablebases::rank_root_moves(Position& pos, Search::RootMoves& rootMoves) {
     {
         // Sort moves according to TB rank.
         std::sort(rootMoves.begin(), rootMoves.end(),
-                  [](RootMove &a, RootMove &b) { return a.TBRank > b.TBRank; } );
+                  [](const RootMove &a, const RootMove &b) { return a.TBRank > b.TBRank; } );
 
         // Only probe during search if DTZ is not available and we are winning.
         if (dtz_available || rootMoves[0].TBScore <= VALUE_DRAW)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -49,7 +49,6 @@ namespace Tablebases {
   bool RootInTB;
   bool UseRule50;
   Depth ProbeDepth;
-  Value Score;
 }
 
 namespace TB = Tablebases;
@@ -389,9 +388,20 @@ void Thread::search() {
       for (RootMove& rm : rootMoves)
           rm.previousScore = rm.score;
 
+      size_t PVFirst = 0;
+      PVLast = 0;
+
       // MultiPV loop. We perform a full root search for each PV line
       for (PVIdx = 0; PVIdx < multiPV && !Signals.stop; ++PVIdx)
       {
+          if (PVIdx == PVLast)
+          {
+              PVFirst = PVLast;
+              for (PVLast++; PVLast < rootMoves.size(); PVLast++)
+                  if (rootMoves[PVLast].TBRank != rootMoves[PVFirst].TBRank)
+                      break;
+          }
+
           // Reset aspiration window starting size
           if (rootDepth >= 5 * ONE_PLY)
           {
@@ -413,7 +423,7 @@ void Thread::search() {
               // and we want to keep the same order for all the moves except the
               // new PV that goes to the front. Note that in case of MultiPV
               // search the already searched PV lines are preserved.
-              std::stable_sort(rootMoves.begin() + PVIdx, rootMoves.end());
+              std::stable_sort(rootMoves.begin() + PVIdx, rootMoves.begin() + PVLast);
 
               // If search has been stopped, break immediately. Sorting and
               // writing PV back to TT is safe because RootMoves is still
@@ -456,7 +466,7 @@ void Thread::search() {
           }
 
           // Sort the PV lines searched so far and update the GUI
-          std::stable_sort(rootMoves.begin(), rootMoves.begin() + PVIdx + 1);
+          std::stable_sort(rootMoves.begin() + PVFirst, rootMoves.begin() + PVIdx + 1);
 
           if (!mainThread)
               continue;
@@ -857,9 +867,10 @@ moves_loop: // When in check search starts from here
 
       // At root obey the "searchmoves" option and skip moves not listed in Root
       // Move List. As a consequence any illegal move is also skipped. In MultiPV
-      // mode we also skip PV moves which have been already searched.
+      // mode we also skip PV moves which have been already searched and those
+      // of lower "TB rank" if we are in a TB root position.
       if (rootNode && !std::count(thisThread->rootMoves.begin() + thisThread->PVIdx,
-                                  thisThread->rootMoves.end(), move))
+                                  thisThread->rootMoves.begin() + thisThread->PVLast, move))
           continue;
 
       ss->moveCount = ++moveCount;
@@ -1549,7 +1560,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
       Value v = updated ? rootMoves[i].score : rootMoves[i].previousScore;
 
       bool tb = TB::RootInTB && abs(v) < VALUE_MATE - MAX_PLY;
-      v = tb ? TB::Score : v;
+      v = tb ? rootMoves[i].TBScore : v;
 
       if (ss.rdbuf()->in_avail()) // Not at first line
           ss << "\n";
@@ -1610,12 +1621,13 @@ bool RootMove::extract_ponder_from_tt(Position& pos) {
     return pv.size() > 1;
 }
 
-void Tablebases::filter_root_moves(Position& pos, Search::RootMoves& rootMoves) {
+void Tablebases::rank_root_moves(Position& pos, Search::RootMoves& rootMoves) {
 
     RootInTB = false;
     UseRule50 = Options["Syzygy50MoveRule"];
     ProbeDepth = Options["SyzygyProbeDepth"] * ONE_PLY;
     Cardinality = Options["SyzygyProbeLimit"];
+    bool dtz_available = true;
 
     // Skip TB probing when no TB found: !TBLargest -> !TB::Cardinality
     if (Cardinality > MaxCardinality)
@@ -1624,28 +1636,34 @@ void Tablebases::filter_root_moves(Position& pos, Search::RootMoves& rootMoves) 
         ProbeDepth = DEPTH_ZERO;
     }
 
-    if (Cardinality < popcount(pos.pieces()) || pos.can_castle(ANY_CASTLING))
-        return;
-
-    // If the current root position is in the tablebases, then RootMoves
-    // contains only moves that preserve the draw or the win.
-    RootInTB = root_probe(pos, rootMoves, TB::Score);
-
-    if (RootInTB)
-        Cardinality = 0; // Do not probe tablebases during the search
-
-    else // If DTZ tables are missing, use WDL tables as a fallback
+    if (Cardinality >= popcount(pos.pieces()) && !pos.can_castle(ANY_CASTLING))
     {
-        // Filter out moves that do not preserve the draw or the win.
-        RootInTB = root_probe_wdl(pos, rootMoves, TB::Score);
+        // If the current root position is in the tablebases, then RootMoves
+        // contains only moves that preserve the draw or the win.
+        RootInTB = root_probe(pos, rootMoves);
 
-        // Only probe during search if winning
-        if (RootInTB && TB::Score <= VALUE_DRAW)
-            Cardinality = 0;
+        if (!RootInTB)
+        {
+            // DTZ tables are missing, try ranking moves using WDL tables.
+            dtz_available = false;
+            RootInTB = root_probe_wdl(pos, rootMoves);
+        }
     }
 
-    if (RootInTB && !UseRule50)
-        TB::Score =  TB::Score > VALUE_DRAW ?  VALUE_MATE - MAX_PLY - 1
-                   : TB::Score < VALUE_DRAW ? -VALUE_MATE + MAX_PLY + 1
-                                            :  VALUE_DRAW;
+    if (RootInTB)
+    {
+        // Sort moves according to TB rank.
+        std::sort(rootMoves.begin(), rootMoves.end(),
+                  [](RootMove &a, RootMove &b) { return a.TBRank > b.TBRank; } );
+
+        // Only probe during search if DTZ is not available and we are winning.
+        if (dtz_available || rootMoves[0].TBScore <= VALUE_DRAW)
+            Cardinality = 0;
+    }
+    else
+    {
+        // Assign the same rank to all moves.
+        for (auto& m : rootMoves)
+            m.TBRank = 0;
+    }
 }

--- a/src/search.h
+++ b/src/search.h
@@ -63,6 +63,8 @@ struct RootMove {
 
   Value score = -VALUE_INFINITE;
   Value previousScore = -VALUE_INFINITE;
+  int TBRank;
+  Value TBScore;
   std::vector<Move> pv;
 };
 

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -10,9 +10,9 @@ extern int MaxCardinality;
 void init(const std::string& path);
 int probe_wdl(Position& pos, int *success);
 int probe_dtz(Position& pos, int *success);
-bool root_probe(Position& pos, Search::RootMoves& rootMoves, Value& score);
-bool root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, Value& score);
-void filter_root_moves(Position& pos, Search::RootMoves& rootMoves);
+bool root_probe(Position& pos, Search::RootMoves& rootMoves);
+bool root_probe_wdl(Position& pos, Search::RootMoves& rootMoves);
+void rank_root_moves(Position& pos, Search::RootMoves& rootMoves);
 
 }
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -197,7 +197,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
           rootMoves.push_back(Search::RootMove(m));
 
   if (!rootMoves.empty())
-      Tablebases::filter_root_moves(pos, rootMoves);
+      Tablebases::rank_root_moves(pos, rootMoves);
 
   // After ownership transfer 'states' becomes empty, so if we stop the search
   // and call 'go' again without setting a new position states.get() == NULL.

--- a/src/thread.h
+++ b/src/thread.h
@@ -60,7 +60,7 @@ public:
   Pawns::Table pawnsTable;
   Material::Table materialTable;
   Endgames endgames;
-  size_t idx, PVIdx;
+  size_t idx, PVIdx, PVLast;
   int maxPly, callsCnt;
   uint64_t tbHits;
 


### PR DESCRIPTION
This is a non-functional change unless MultiPV or "go searchmoves" is used.

If the root position is a TB position, to each root move a "rank" and a "score" are assigned. The rank determines the order in which the moves are searched in MultiPV mode. The score determines the score to be displayed in the GUI. Cursed wins are shown as at least 1 cp and as up to 49 cp if the position is close to a real win.

This patch fixes the interaction between MultiPV and TB root probing. Previously, MultiPV mode would show only what are now the "top-ranked" moves. This patch also fixes the interaction between TB root probing and the UCI go searchmoves command.

The MultiPV problem was complained about here: http://talkchess.com/forum/viewtopic.php?p=660778#660778
And recently in this (closed) issue: https://github.com/official-stockfish/Stockfish/issues/828

Originally I thought solving this issue would complicate the code too much, but it was easier than I thought. The key change is in the PVIdx-loop in Thread::search(), which now searches a range [PVFirst, PVlast) containing PVIdx of moves with equal TB rank. If the root position is not in the TBs, all TB ranks are 0 and nothing changes. If MultiPV == 1, nothing changes either.

Finally, this patch fixes the cluttering of rootMoves[i].score in root_probe() and root_probe_wdl(), which in current Stockfish survives into Thread::search(). That function was probably written to assume these values to be 0. (I don't know if this problem exists since the Lazy SMP rewrite or has been there for longer. It is not a fatal problem, but it is not right.)

One example:
Stockfish 221016 64 POPCNT by T. Romstad, M. Costalba, J. Kiiski, G. Linscott
setoption name SyzygyPath value <TB_PATH>
info string Found 510 tablebases.
setoption name MultiPV value 30
position fen 8/8/B7/8/4nn2/8/2R5/K3k3 b - - 0 1
go depth 1
info depth 1 seldepth 1 multipv 1 score cp -1 nodes 263 nps 87666 tbhits 17 time 3 pv e4g3
info depth 1 seldepth 1 multipv 2 score cp -33 nodes 263 nps 87666 tbhits 17 time 3 pv e4g5
info depth 1 seldepth 1 multipv 3 score cp -33 nodes 263 nps 87666 tbhits 17 time 3 pv e4d2
info depth 1 seldepth 1 multipv 4 score cp -12851 nodes 263 nps 87666 tbhits 17 time 3 pv e4f2
info depth 1 seldepth 1 multipv 5 score cp -12851 nodes 263 nps 87666 tbhits 17 time 3 pv e4f6
info depth 1 seldepth 1 multipv 6 score cp -12851 nodes 263 nps 87666 tbhits 17 time 3 pv e1d1
info depth 1 seldepth 1 multipv 7 score cp -12851 nodes 263 nps 87666 tbhits 17 time 3 pv e4d6
info depth 1 seldepth 1 multipv 8 score cp -12851 nodes 263 nps 87666 tbhits 17 time 3 pv f4d5
info depth 1 seldepth 1 multipv 9 score cp -12851 nodes 263 nps 87666 tbhits 17 time 3 pv f4g2 c2g2
info depth 1 seldepth 1 multipv 10 score cp -12851 nodes 263 nps 87666 tbhits 17 time 3 pv e4c3
info depth 1 seldepth 1 multipv 11 score cp -12851 nodes 263 nps 87666 tbhits 17 time 3 pv e4c5 c2c5
info depth 1 seldepth 1 multipv 12 score cp -12851 nodes 263 nps 87666 tbhits 17 time 3 pv f4e6
info depth 1 seldepth 1 multipv 13 score cp -12851 nodes 263 nps 87666 tbhits 17 time 3 pv f4g6
info depth 1 seldepth 1 multipv 14 score cp -12851 nodes 263 nps 87666 tbhits 17 time 3 pv f4d3 a6d3
info depth 1 seldepth 1 multipv 15 score cp -12851 nodes 263 nps 87666 tbhits 17 time 3 pv f4h5
info depth 1 seldepth 1 multipv 16 score cp -12851 nodes 263 nps 87666 tbhits 17 time 3 pv f4h3
info depth 1 seldepth 1 multipv 17 score cp -12851 nodes 263 nps 87666 tbhits 17 time 3 pv f4e2

Compare with: https://syzygy-tables.info/?fen=8/8/B7/8/4nn2/8/2R5/K3k3_b_-_-_0_1

Another example (5 pieces):
Stockfish 221016 64 POPCNT by T. Romstad, M. Costalba, J. Kiiski, G. Linscott
setoption name SyzygyPath value <TB_PATH>
info string Found 510 tablebases.
setoption name MultiPV value 30
position fen 2N5/8/8/5p2/1k3K2/6N1/8/8 w - - 0 1
go depth 1
info depth 1 seldepth 1 multipv 1 score cp 43 nodes 96 nps 3200 tbhits 15 time 30 pv g3e2
info depth 1 seldepth 1 multipv 2 score cp 41 nodes 96 nps 3200 tbhits 15 time 30 pv c8d6
info depth 1 seldepth 1 multipv 3 score cp 0 nodes 96 nps 3200 tbhits 15 time 30 pv c8e7
info depth 1 seldepth 1 multipv 4 score cp 0 nodes 96 nps 3200 tbhits 15 time 30 pv c8b6
info depth 1 seldepth 1 multipv 5 score cp 0 nodes 96 nps 3200 tbhits 15 time 30 pv f4e5
info depth 1 seldepth 1 multipv 6 score cp 0 nodes 96 nps 3200 tbhits 15 time 30 pv f4g5
info depth 1 seldepth 1 multipv 7 score cp 0 nodes 96 nps 3200 tbhits 15 time 30 pv c8a7
info depth 1 seldepth 1 multipv 8 score cp 0 nodes 96 nps 3200 tbhits 15 time 30 pv g3f1
info depth 1 seldepth 1 multipv 9 score cp 0 nodes 96 nps 3200 tbhits 15 time 30 pv g3h5
info depth 1 seldepth 1 multipv 10 score cp 0 nodes 96 nps 3200 tbhits 15 time 30 pv f4f3
info depth 1 seldepth 1 multipv 11 score cp 0 nodes 96 nps 3200 tbhits 15 time 30 pv f4e3
info depth 1 seldepth 1 multipv 12 score cp 0 nodes 96 nps 3200 tbhits 15 time 30 pv g3h1
info depth 1 seldepth 1 multipv 13 score cp 0 nodes 96 nps 3200 tbhits 15 time 30 pv g3e4 f5e4
info depth 1 seldepth 1 multipv 14 score cp 0 nodes 96 nps 3200 tbhits 15 time 30 pv g3f5
info depth 1 seldepth 1 multipv 15 score cp 0 nodes 96 nps 3200 tbhits 15 time 30 pv f4f5
bestmove g3e2

Compare with: https://syzygy-tables.info/?fen=2N5/8/8/5p2/1k3K2/6N1/8/8_w_-_-_0_1

This patch may first need to be tested and reviewed a bit more before it is integrated.
