### PR TITLE
History Stat Comparison

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -988,7 +988,7 @@ moves_loop: // When in check search starts from here
                          +    (fmh  ? (*fmh )[moved_piece][to_sq(move)] : VALUE_ZERO)
                          +    (fmh2 ? (*fmh2)[moved_piece][to_sq(move)] : VALUE_ZERO)
                          +    thisThread->fromTo.get(~pos.side_to_move(), move)
-                         -    10000;  // Correction Factor
+                         -    8000;  // Correction Factor
               ss->statTot=val;
 
               // Increase reduction for cut nodes

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -988,7 +988,7 @@ moves_loop: // When in check search starts from here
                          +    (fmh  ? (*fmh )[moved_piece][to_sq(move)] : VALUE_ZERO)
                          +    (fmh2 ? (*fmh2)[moved_piece][to_sq(move)] : VALUE_ZERO)
                          +    thisThread->fromTo.get(~pos.side_to_move(), move)
-                         -    8000;  // Correction Factor
+                         -    10000;  // Correction Factor
               ss->statTot=val;
 
               // Increase reduction for cut nodes

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -570,6 +570,7 @@ namespace {
     Thread* thisThread = pos.this_thread();
     inCheck = pos.checkers();
     moveCount = quietCount =  ss->moveCount = 0;
+    ss->statTot = VALUE_ZERO;
     bestValue = -VALUE_INFINITE;
     ss->ply = (ss-1)->ply + 1;
 
@@ -981,6 +982,15 @@ moves_loop: // When in check search starts from here
               r -= r ? ONE_PLY : DEPTH_ZERO;
           else
           {
+          
+              Value val = thisThread->history[moved_piece][to_sq(move)]
+                         +    (cmh  ? (*cmh )[moved_piece][to_sq(move)] : VALUE_ZERO)
+                         +    (fmh  ? (*fmh )[moved_piece][to_sq(move)] : VALUE_ZERO)
+                         +    (fmh2 ? (*fmh2)[moved_piece][to_sq(move)] : VALUE_ZERO)
+                         +    thisThread->fromTo.get(~pos.side_to_move(), move)
+                         -    8000;  // Correction Factor
+              ss->statTot=val;
+
               // Increase reduction for cut nodes
               if (cutNode)
                   r += 2 * ONE_PLY;
@@ -994,13 +1004,15 @@ moves_loop: // When in check search starts from here
                        && !pos.see_ge(make_move(to_sq(move), from_sq(move)),  VALUE_ZERO))
                   r -= 2 * ONE_PLY;
 
-              // Decrease/increase reduction for moves with a good/bad history
-              Value val = thisThread->history[moved_piece][to_sq(move)]
-                         +    (cmh  ? (*cmh )[moved_piece][to_sq(move)] : VALUE_ZERO)
-                         +    (fmh  ? (*fmh )[moved_piece][to_sq(move)] : VALUE_ZERO)
-                         +    (fmh2 ? (*fmh2)[moved_piece][to_sq(move)] : VALUE_ZERO)
-                         +    thisThread->fromTo.get(~pos.side_to_move(), move);
-              int rHist = (val - 8000) / 20000;
+              // Decrease/increase reduction by comparing opponent's stat score
+              Value priorStat = (ss - 1)->statTot;
+              if (val > VALUE_ZERO && priorStat < VALUE_ZERO)
+                  r -= ONE_PLY;
+              if (val < VALUE_ZERO && priorStat > VALUE_ZERO)
+                  r += ONE_PLY;
+              
+              // Decrease/increase reduction for moves with a good/bad history           
+              int rHist = val / 20000;
               r = std::max(DEPTH_ZERO, (r / ONE_PLY - rHist) * ONE_PLY);
           }
 

--- a/src/search.h
+++ b/src/search.h
@@ -43,6 +43,7 @@ struct Stack {
   Move excludedMove;
   Move killers[2];
   Value staticEval;
+  Value statTot;
   bool skipEarlyPruning;
   int moveCount;
   CounterMoveStats* counterMoves;


### PR DESCRIPTION
Adjust LMR by comparing history stats with opponent (prior ply).

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 27754 W: 5066 L: 4824 D: 17864

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 216596 W: 28157 L: 27343 D: 161096

Bench:  5437729