### PR TITLE
Output PV if best move has changed.

### DIFF
--- a/src/thread.h
+++ b/src/thread.h
@@ -84,6 +84,8 @@ struct MainThread : public Thread {
   bool easyMovePlayed, failedLow;
   double bestMoveChanges;
   Value previousScore;
+
+  Move lastPvMoveDisplayed;
 };
 
 


### PR DESCRIPTION
If
- the best move changes due to a fail-low or fail-high,
- Stockfish does not finish the iteration, and
- the fail-low or fail-high occurred during the first 3 seconds,

then Stockfish plays a different move than what the last PV info output to the GUI shows. This seems undesirable.

This patch keeps track of the first move of the last full PV displayed.
If the final best move is not equal to this move, the PV will be printed out before outputting best move.

See https://github.com/official-stockfish/Stockfish/issues/834.