### PR TITLE
travis-ci: Enable undefined behavior checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-multilib', 'valgrind']
+          packages: ['g++-6', 'g++-6-multilib', 'g++-multilib', 'valgrind']
       env:
-        - COMPILER=g++
+        - COMPILER=g++-6
         - COMP=gcc
 
     - os: linux
@@ -51,3 +51,5 @@ script:
   - test ! -s result
   # if valgrind is available check the build is without error, reduce depth to speedup testing, but not too shallow to catch more cases.
   - if [ -x "$(command -v valgrind )" ] ; then make clean && make ARCH=x86-64 debug=yes build && valgrind --error-exitcode=42 ./stockfish bench 128 1 10 default depth 1>/dev/null ; fi
+  # use g++-6 as a proxy for having sanitizers ... might need revision as they become available for more recent versions of clang/gcc than trusty provides
+  - if [[ "$COMPILER" == "g++-6" ]]; then make clean && make ARCH=x86-64 sanitize=yes build && ! ./stockfish bench 2>&1 | grep "runtime error:" ; fi

--- a/src/Makefile
+++ b/src/Makefile
@@ -50,6 +50,7 @@ OBJS = benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o \
 # ----------------------------------------------------------------------------
 #
 # debug = yes/no      --- -DNDEBUG         --- Enable/Disable debug mode
+# sanitize = yes/no   --- (-fsanitize )    --- enable undefined behavior checks
 # optimize = yes/no   --- (-O3/-fast etc.) --- Enable/Disable optimizations
 # arch = (name)       --- (-arch)          --- Target architecture
 # bits = 64/32        --- -DIS_64BIT       --- 64-/32-bit operating system
@@ -65,6 +66,7 @@ OBJS = benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o \
 ### 2.1. General and architecture defaults
 optimize = yes
 debug = no
+sanitize = no
 bits = 32
 prefetch = no
 popcnt = no
@@ -253,11 +255,16 @@ ifneq ($(comp),mingw)
 	endif
 endif
 
-### 3.2 Debugging
+### 3.2.1 Debugging
 ifeq ($(debug),no)
 	CXXFLAGS += -DNDEBUG
 else
 	CXXFLAGS += -g
+endif
+
+### 3.2.2 Debugging with undefined behavior sanitizers
+ifeq ($(sanitize),yes)
+	CXXFLAGS += -g3 -fsanitize=undefined
 endif
 
 ### 3.3 Optimization


### PR DESCRIPTION
Enables undefined behaviour checking using the gcc sanitizers with a makefile option, and enables this under travis-ci. 

This will cause the travis-ci check to fail with current master, till the various undefined behaviour fixes are in (#837 #838 #839).

No functional change.