### PR TITLE
Output PV if last iteration does not complete.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -461,11 +461,7 @@ void Thread::search() {
           if (!mainThread)
               continue;
 
-          if (Signals.stop)
-              sync_cout << "info nodes " << Threads.nodes_searched()
-                        << " time " << Time.elapsed() << sync_endl;
-
-          else if (PVIdx + 1 == multiPV || Time.elapsed() > 3000)
+          if (Signals.stop || PVIdx + 1 == multiPV || Time.elapsed() > 3000)
               sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
       }
 


### PR DESCRIPTION
Instead of outputting "info nodes ... time ..." when the last iteration is interrupted, simply call UCI::pv() to output the PV.

I thought about calling UCI::pv() with bounds -VALUE_INFINITE, VALUE_INFINITE to avoid "lowerbound" or "upperbound" appearing in it, but I'm not sure that would be any better.

This patch fixes rare inconsistencies between the first move of the last PV output and the bestmove played. It also makes sure that all the latest statistics are sent to the GUI (not only nodes and time but also nps, tbhits, hashfull). And it is much simpler than the previous attempt ;-)