### PR TITLE
fix syzygy undef.

### DIFF
--- a/src/syzygy/tbcore.cpp
+++ b/src/syzygy/tbcore.cpp
@@ -1232,7 +1232,8 @@ static ubyte decompress_pairs(struct PairsData *d, uint64 idx)
 
   uint32 mainidx = static_cast<uint32>(idx >> d->idxbits);
   int litidx = (idx & ((1ULL << d->idxbits) - 1)) - (1ULL << (d->idxbits - 1));
-  uint32 block = *(uint32 *)(d->indextable + 6 * mainidx);
+  uint32 block;
+  memcpy(&block, d->indextable + 6 * mainidx, sizeof(uint32));
   if (!LittleEndian)
     block = BSWAP32(block);
 


### PR DESCRIPTION
This fixes a sanitizer runtime error: load of misaligned address for type 'uint32', which requires 4 byte alignment. The use of memcpy is the canonical way to do such a load, on x86-64 the generated (optimized) gcc code remains identical.

With this fix bench runs fine under -fsanitize=undefined, if syzygy bases are loaded.

No functional change.
