### PR TITLE
Simplify and improve portability of Score extraction.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -199,6 +199,7 @@ namespace {
   const Score ThreatByPawnPush    = S(38, 22);
   const Score Unstoppable         = S( 0, 20);
   const Score PawnlessFlank       = S(20, 80);
+  const Score HinderPassedPawn    = S( 7,  0);
 
   // Penalty for a bishop on a1/h1 (a8/h8 for black) which is trapped by
   // a friendly pawn on b2/g2 (b7/g7 for black). This can obviously only
@@ -601,7 +602,7 @@ namespace {
 
     const Color Them = (Us == WHITE ? BLACK : WHITE);
 
-    Bitboard b, squaresToQueen, defendedSquares, unsafeSquares;
+    Bitboard b, bb, squaresToQueen, defendedSquares, unsafeSquares;
     Score score = SCORE_ZERO;
 
     b = ei.pi->passed_pawns(Us);
@@ -612,6 +613,9 @@ namespace {
 
         assert(pos.pawn_passed(Us, s));
         assert(!(pos.pieces(PAWN) & forward_bb(Us, s)));
+
+        bb = forward_bb(Us, s) & (ei.attackedBy[Them][ALL_PIECES] | pos.pieces(Them));
+        score -= HinderPassedPawn * popcount(bb);
 
         int r = relative_rank(Us, s) - RANK_2;
         int rr = r * (r - 1);
@@ -638,7 +642,7 @@ namespace {
                 // in the pawn's path attacked or occupied by the enemy.
                 defendedSquares = unsafeSquares = squaresToQueen = forward_bb(Us, s);
 
-                Bitboard bb = forward_bb(Them, s) & pos.pieces(ROOK, QUEEN) & pos.attacks_from<ROOK>(s);
+                bb = forward_bb(Them, s) & pos.pieces(ROOK, QUEEN) & pos.attacks_from<ROOK>(s);
 
                 if (!(pos.pieces(Us) & bb))
                     defendedSquares &= ei.attackedBy[Us][ALL_PIECES];

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -32,7 +32,7 @@ namespace {
 
 /// Version number. If Version is left empty, then compile date in the format
 /// DD-MM-YY and show in engine_info.
-const string Version = "";
+const string Version = "8";
 
 /// Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 /// cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We


### PR DESCRIPTION
The current implementation uses a union to convert from uint16_t to int16_t. It is not clear that this is fully legal in C++. Although C99 and C11 allow it, C++11 only guarantees that the last member of a union written to is alive. (g++ gives the same guarantee as C99/C11 as a language extension.) See:
http://stackoverflow.com/questions/25664848/unions-and-type-punning
http://stackoverflow.com/questions/11373203/accessing-inactive-union-member-and-undefined-behavior
There is also the question whether the binary representations of int16_t and uint16_t necessarily correspond (hard to imagine they do not, but still).

Directly casting from uint16_t to int16_t has the problem that conversion to a signed integer type for values outside the range of the signed integer type is implementation-defined.

This patch removes the union-trick and takes care to convert from uint16_t to int16_t without relying on implementation-defined behavior:
- if uint16_t v < 0x8000, then int16_t(v) is fully defined.
- if uint16_t v >= 0x8000, then int16_t(v - 0x10000) is fully defined.

Note that C++ evaluates v - 0x10000 as (int)v - 0x10000 because the range of uint16_t fits within the range of int (integer promotion). So v - 0x10000 is a negative value of type signed int that lies in the range of int16_t.

I have verified that g++ fully optimizes eg_value() and mg_value() when defined as stand-alone functions. (It generates exactly the same code as the current implementation.) This patch does seem to affect overall code generation, though (but without effect on speed as far as I can tell).

The patch changes the underlying type of enum Score to uint32_t, since casting of an unsigned int to int again relies on implementation-defined behavior.

Please let me know if this patch is considered a useful simplification. Then I will run it through fishtest to verify that it is not a regression. (I guess a test is appropriate here... we're telling the compiler to do the same thing in a different way and we're relying on the compiler to recognise that it is really the same thing.)

A link to the discussion in https://github.com/official-stockfish/Stockfish/pull/211 may be useful.

Ah, this patch also updates the comments that now explain that eg goes in the upper and mg in the lower 16 bits of the Score enum.
