### PR TITLE
Sync variable names in decl vs def

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -127,9 +127,9 @@ public:
   bool opposite_bishops() const;
 
   // Doing and undoing moves
-  void do_move(Move m, StateInfo& st, bool givesCheck);
+  void do_move(Move m, StateInfo& newSt, bool givesCheck);
   void undo_move(Move m);
-  void do_null_move(StateInfo& st);
+  void do_null_move(StateInfo& newSt);
   void undo_null_move();
 
   // Static Exchange Evaluation

--- a/src/thread.h
+++ b/src/thread.h
@@ -55,7 +55,7 @@ public:
   void idle_loop();
   void start_searching(bool resume = false);
   void wait_for_search_finished();
-  void wait(std::atomic_bool& b);
+  void wait(std::atomic_bool& condition);
 
   Pawns::Table pawnsTable;
   Material::Table materialTable;

--- a/src/uci.h
+++ b/src/uci.h
@@ -49,7 +49,7 @@ public:
   Option(OnChange = nullptr);
   Option(bool v, OnChange = nullptr);
   Option(const char* v, OnChange = nullptr);
-  Option(int v, int min, int max, OnChange = nullptr);
+  Option(int v, int minv, int maxv, OnChange = nullptr);
 
   Option& operator=(const std::string&);
   void operator<<(const Option&);


### PR DESCRIPTION
Cosmetic change to have same function signatures in *.h and *.cpp