### PR TITLE
Reproducible searches after ucinewgame

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -212,6 +212,7 @@ void Search::clear() {
       th->counterMoves.clear();
       th->fromTo.clear();
       th->counterMoveHistory.clear();
+      th->resetCalls = true;
   }
 
   Threads.main()->previousScore = VALUE_INFINITE;


### PR DESCRIPTION
Fixes issue #859.
    
thisThread->callsCnt in search<>() was different (by 1) for the first and second game played.
    
No functional change.