### PR TITLE
More accurate 'go nodes' searches at low count.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -575,7 +575,7 @@ namespace {
         thisThread->resetCalls = false;
         thisThread->callsCnt = 0;
     }
-    if (++thisThread->callsCnt > 4096)
+    if (++thisThread->callsCnt > Limits.callsCnt)
     {
         for (Thread* th : Threads)
             th->resetCalls = true;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -573,9 +573,9 @@ namespace {
     if (thisThread->resetCalls.load(std::memory_order_relaxed))
     {
         thisThread->resetCalls = false;
-        thisThread->callsCnt = 0;
+        thisThread->callsCnt = Limits.callsCnt;
     }
-    if (++thisThread->callsCnt > Limits.callsCnt)
+    if (--thisThread->callsCnt <= 0)
     {
         for (Thread* th : Threads)
             th->resetCalls = true;

--- a/src/search.h
+++ b/src/search.h
@@ -78,7 +78,7 @@ struct LimitsType {
 
   LimitsType() { // Init explicitly due to broken value-initialization of non POD in MSVC
     nodes = time[WHITE] = time[BLACK] = inc[WHITE] = inc[BLACK] =
-    npmsec = movestogo = depth = movetime = mate = infinite = ponder = 0;
+    npmsec = movestogo = depth = movetime = mate = infinite = ponder = callsCnt = 0;
   }
 
   bool use_time_management() const {
@@ -86,7 +86,7 @@ struct LimitsType {
   }
 
   std::vector<Move> searchmoves;
-  int time[COLOR_NB], inc[COLOR_NB], npmsec, movestogo, depth, movetime, mate, infinite, ponder;
+  int time[COLOR_NB], inc[COLOR_NB], npmsec, movestogo, depth, movetime, mate, infinite, ponder, callsCnt;
   int64_t nodes;
   TimePoint startTime;
 };

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -103,6 +103,9 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
       limits.npmsec = npmsec;
   }
 
+  // At low node count increase the checking rate to about 0.1% otherwise use a default value
+  limits.callsCnt = limits.nodes ? std::min((int64_t)4096, limits.nodes / 1000) : 4096;
+
   startTime = limits.startTime;
   optimumTime = maximumTime = std::max(limits.time[us], minThinkingTime);
 


### PR DESCRIPTION
Makes the actual number of nodes searched match closely the number of nodes requested, by increasing the frequency of checking the number of nodes searched at low node count. All other searches retain the default checking frequency of once per 4096 nodes, and are thus unaffected.

On master the number of nodes searched vs requested looks like:
```
 # requested       actual       %error
        1000         7379       637.90
        2000         7379       268.95
        4000         7379        84.47
        8000        14138        76.72
       16000        21185        32.41
       32000        36079        12.75
       64000        65371         2.14
      128000       131819         2.98
      256000       259799         1.48

This patch changes this into:

 # requested       actual       %error
        1000         1000         0.00
        2000         2001         0.05
        4000         4008         0.20
        8000         8002         0.03
       16000        16014         0.09
       32000        32035         0.11
       64000        64109         0.17
      128000       128097         0.08
      256000       256210         0.08
```
passed STC single threaded

LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 32410 W: 5644 L: 5542 D: 21224

with no noticeable slowdown on 32 threads

nodecount: 40139952 +- 218708 Nodes/second
master: 40091022 +- 118310 Nodes/second

No functional change.