### PR TITLE
    Allow benches with more than 2G nodes.

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -117,7 +117,7 @@ void benchmark(const Position& current, istream& is) {
       limits.movetime = stoi(limit); // movetime is in millisecs
 
   else if (limitType == "nodes")
-      limits.nodes = stoi(limit);
+      limits.nodes = stoll(limit);
 
   else if (limitType == "mate")
       limits.mate = stoi(limit);


### PR DESCRIPTION
    ./stockfish bench 128 1 4000000000 default nodes

    crashes before, works after.

    No functional change.