### PR TITLE
Add a second check for correctly setting e.p. square.

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -176,8 +176,9 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
 
    4) En passant target square (in algebraic notation). If there's no en passant
       target square, this is "-". If a pawn has just made a 2-square move, this
-      is the position "behind" the pawn. This is recorded regardless of whether
-      there is a pawn in position to make an en passant capture.
+      is the position "behind" the pawn. This is recorded only if there is a pawn
+      in position to make an en passant capture, and if there really is a pawn
+      that might have advanced two squares.
 
    5) Halfmove clock. This is the number of halfmoves since the last pawn advance
       or capture. This is used to determine if a draw can be claimed under the
@@ -254,7 +255,8 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
   {
       st->epSquare = make_square(File(col - 'a'), Rank(row - '1'));
 
-      if (!(attackers_to(st->epSquare) & pieces(sideToMove, PAWN)))
+      if (   !(attackers_to(st->epSquare) & pieces(sideToMove, PAWN))
+          || !(pieces(~sideToMove, PAWN) & (st->epSquare + pawn_push(~sideToMove))))
           st->epSquare = SQ_NONE;
   }
   else


### PR DESCRIPTION
Currently, we only check if there is a pawn in place to make
the en-passant capture. Now also check that there is a pawn
that could just have advanced two squares.
Also update the corresponding comment.

This makes the parsing of FENs a bit more robust, and now correctly
handles positions like the one reported by Dann Corbit.
```
position fen rnbqkb1r/ppp3pp/3p1n2/3P4/8/2P5/PP3PPP/RNBQKB1R w KQkq e6
d

 +---+---+---+---+---+---+---+---+
 | r | n | b | q | k | b |   | r |
 +---+---+---+---+---+---+---+---+
 | p | p | p |   |   |   | p | p |
 +---+---+---+---+---+---+---+---+
 |   |   |   | p |   | n |   |   |
 +---+---+---+---+---+---+---+---+
 |   |   |   | P |   |   |   |   |
 +---+---+---+---+---+---+---+---+
 |   |   |   |   |   |   |   |   |
 +---+---+---+---+---+---+---+---+
 |   |   | P |   |   |   |   |   |
 +---+---+---+---+---+---+---+---+
 | P | P |   |   |   | P | P | P |
 +---+---+---+---+---+---+---+---+
 | R | N | B | Q | K | B |   | R |
 +---+---+---+---+---+---+---+---+

Fen: rnbqkb1r/ppp3pp/3p1n2/3P4/8/2P5/PP3PPP/RNBQKB1R w KQkq - 0 1
```
No functional change.