### PR TITLE
Position::is_draw(): start searching from the 4th ply behind

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1079,14 +1079,20 @@ bool Position::is_draw() const {
   if (st->rule50 > 99 && (!checkers() || MoveList<LEGAL>(*this).size()))
       return true;
 
-  StateInfo* stp = st;
-  for (int i = 2, e = std::min(st->rule50, st->pliesFromNull); i <= e; i += 2)
-  {
+  int e = std::min(st->rule50, st->pliesFromNull);
+
+  if (e < 4)
+    return false;
+
+  StateInfo* stp = st->previous->previous;
+
+  do {
       stp = stp->previous->previous;
 
       if (stp->key == st->key)
           return true; // Draw at first repetition
-  }
+
+  } while ((e -= 2) >= 4);
 
   return false;
 }


### PR DESCRIPTION
A position can never repeat the one on the previous move. Thus we can start searching for a repetition from the 4th ply behind. In the case
`std::min(st->rule50, st->pliesFromNull) < 4`
we don't need to do any more calculations. This case happens very often - in more than a half of all calls of the function.

Speed tests (12 runs each, given time in milliseconds)

Linux 3.16 64-bit, AMD
test: mean 4899, st. dev. 31.5
base: mean 4951, st.dev. 19.8
speedup: 1.06%

Windows 7 64-bit, AMD
test: mean 5751, st.dev. 14.2
base: mean 5837, st.dev. 19.7
speedup: 1.49%

No functional change.