### PR TITLE
More accurate 'go nodes' searches at low count v2.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -573,9 +573,10 @@ namespace {
     if (thisThread->resetCalls.load(std::memory_order_relaxed))
     {
         thisThread->resetCalls = false;
-        thisThread->callsCnt = 0;
+        // At low node count increase the checking rate to about 0.1% otherwise use a default value
+        thisThread->callsCnt = Limits.nodes ? std::min((int64_t)4096, Limits.nodes / 1024) : 4096;
     }
-    if (++thisThread->callsCnt > 4096)
+    if (--thisThread->callsCnt <= 0)
     {
         for (Thread* th : Threads)
             th->resetCalls = true;


### PR DESCRIPTION
Makes the actual number of nodes searched match closely the number of nodes requested, by increasing the frequency of checking the number of nodes searched at low node count. All other searches retain the default checking frequency of once per 4096 nodes, and are thus unaffected.

Variant of PR #864 without introducing additional variables, but maybe slightly slower.

passed STC, so since it is simpler, I believe should be preferred over #864

LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 26643 W: 4766 L: 4655 D: 17222

No functional change.