### PR TITLE
Remove branching in key_after()

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -114,6 +114,8 @@ void Position::init() {
 
   PRNG rng(1070372);
 
+  std::memset(&Zobrist::psq, 0, (size_t)SQUARE_NB * sizeof(Key));
+
   for (Piece pc : Pieces)
       for (Square s = SQ_A1; s <= SQ_H8; ++s)
           Zobrist::psq[pc][s] = rng.rand<Key>();
@@ -946,12 +948,9 @@ Key Position::key_after(Move m) const {
   Square to = to_sq(m);
   Piece pc = piece_on(from);
   Piece captured = piece_on(to);
-  Key k = st->key ^ Zobrist::side;
 
-  if (captured)
-      k ^= Zobrist::psq[captured][to];
-
-  return k ^ Zobrist::psq[pc][to] ^ Zobrist::psq[pc][from];
+  return st->key ^ Zobrist::side          ^ Zobrist::psq[pc][to]
+                 ^ Zobrist::psq[pc][from] ^ Zobrist::psq[captured][to];
 }
 
 


### PR DESCRIPTION
I doubt how to classify this patch. It can be taken as simplification with [-3,1] test or as non-functional change speedup.

Results for 50 tests for each version:

            Base      Test      Diff      
    Mean    1333230   1338761   -5531     
    StDev   36961     37686     3108      

p-value: 0,962
speedup: 0,004 

