### PR TITLE
Do not use GCC extension for anonymous unions (obsolete)

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -125,13 +125,44 @@ struct PairsData {
     int groupLen[TBPIECES+1];      // Number of pieces in a given group: KRKN -> (3, 1)
 };
 
-// Helper struct to avoid to manually define entry copy c'tor as we should
+// Helper struct to avoid manually defining entry copy constructor as we should
 // because default one is not compatible with std::atomic_bool.
 struct Atomic {
     Atomic() = default;
     Atomic(const Atomic& e) { ready = e.ready.load(); } // MSVC 2013 wants assignment within body
     std::atomic_bool ready;
 };
+
+// We define the four types for the variant parts of the WLDEntry and DTZEntry:
+// a WLD entry can store info for pieces (WLDEntryPiece) or pawns (WLDEntryPawn) 
+// a DTZ entry can store info for pieces (DZTEntryPiece) or pawns (DZTEntryPawn)
+
+typedef struct {
+    PairsData* precomp;
+} WLDEntryPiece;
+
+typedef struct {
+    uint8_t pawnCount[2];                     // [Lead color / other color]
+    struct { PairsData* precomp;} file[2][4]; // [wtm / btm][FILE_A..FILE_D]
+} WLDEntryPawn;
+
+typedef struct {
+    PairsData* precomp;
+    uint16_t map_idx[4];     // WDLWin, WDLLoss, WDLCursedWin, WDLCursedLoss
+    uint8_t* map;
+} DZTEntryPiece;
+
+typedef struct {
+    uint8_t pawnCount[2];
+    struct {
+                PairsData* precomp;
+                uint16_t map_idx[4];
+            } file[4];
+    uint8_t* map;
+} DZTEntryPawn;
+
+
+// Now the main types 
 
 struct WDLEntry : public Atomic {
     WDLEntry(const std::string& code);
@@ -145,16 +176,8 @@ struct WDLEntry : public Atomic {
     bool hasPawns;
     bool hasUniquePieces;
     union {
-        struct {
-            PairsData* precomp;
-        } pieceTable[2]; // [wtm / btm]
-
-        struct {
-            uint8_t pawnCount[2]; // [Lead color / other color]
-            struct {
-                PairsData* precomp;
-            } file[2][4]; // [wtm / btm][FILE_A..FILE_D]
-        } pawnTable;
+        WLDEntryPiece pieceTable[2]; // [wtm / btm]
+        WLDEntryPawn  pawnTable;
     };
 };
 
@@ -170,20 +193,8 @@ struct DTZEntry : public Atomic {
     bool hasPawns;
     bool hasUniquePieces;
     union {
-        struct {
-            PairsData* precomp;
-            uint16_t map_idx[4]; // WDLWin, WDLLoss, WDLCursedWin, WDLCursedLoss
-            uint8_t* map;
-        } pieceTable;
-
-        struct {
-            uint8_t pawnCount[2];
-            struct {
-                PairsData* precomp;
-                uint16_t map_idx[4];
-            } file[4];
-            uint8_t* map;
-        } pawnTable;
+        DZTEntryPiece pieceTable;
+        DZTEntryPawn  pawnTable;
     };
 };
 


### PR DESCRIPTION
Anonymous struct inside anonymous unions are a GCC extension. This
patch use typedefs to stick to the C+11 standard.

Avoids a string of warning on the Clang compiler.

Non functional change (same bench and same MD5 signature, so 
compiled code is exactly the same as in current master)