### PR TITLE
remove evasionPrunable variable, reorder condition evaluation

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1188,7 +1188,7 @@ moves_loop: // When in check search starts from here
     Key posKey;
     Move ttMove, move, bestMove;
     Value bestValue, value, ttValue, futilityValue, futilityBase, oldAlpha;
-    bool ttHit, givesCheck, evasionPrunable;
+    bool ttHit, givesCheck;
     Depth ttDepth;
 
     if (PvNode)
@@ -1310,12 +1310,8 @@ moves_loop: // When in check search starts from here
       }
 
       // Detect non-capture evasions that are candidates to be pruned
-      evasionPrunable =    InCheck
-                       &&  bestValue > VALUE_MATED_IN_MAX_PLY
-                       && !pos.capture(move);
-
       // Don't search moves with negative SEE values
-      if (  (!InCheck || evasionPrunable)
+      if (  (!InCheck || (!pos.capture(move) && bestValue > VALUE_MATED_IN_MAX_PLY ))
           &&  type_of(move) != PROMOTION
           &&  pos.see_sign(move) < VALUE_ZERO)
           continue;


### PR DESCRIPTION
I doubt how to classify this patch. Should I run simplification [-3,1] test on Fishtest even if there is no functional change?

Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    1342830   1348716   -5886     
    StDev   17509     17425     1849      

p-value: 0,999
speedup: 0,004