### PR TITLE
Simpler TrappedRook

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -348,9 +348,8 @@ namespace {
                 Square ksq = pos.square<KING>(Us);
 
                 if (   ((file_of(ksq) < FILE_E) == (file_of(s) < file_of(ksq)))
-                    && (rank_of(ksq) == rank_of(s) || relative_rank(Us, ksq) == RANK_1)
                     && !ei.pi->semiopen_side(Us, file_of(ksq), file_of(s) < file_of(ksq)))
-                    score -= (TrappedRook - make_score(mob * 22, 0)) * (1 + !pos.can_castle(Us));
+                    score -= (TrappedRook - make_score(mob * 22, 0)) * (1 + (relative_rank(Us, ksq) == RANK_1 && !pos.can_castle(Us)));
             }
         }
 


### PR DESCRIPTION
- TrappedRook penalty is given independent of rook rank with respect to king rank
- A double penalty is only given if the king is on the first rank and cannot castle

Tested as simplification since there is one condition less.

STC: http://tests.stockfishchess.org/tests/view/5832dcb60ebc5903140c4fff
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 11537 W: 2132 L: 1995 D: 7410

LTC: http://tests.stockfishchess.org/tests/view/583304940ebc5903140c500a
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 27420 W: 3573 L: 3461 D: 20386

bench: 5473446