### PR TITLE
Cleanup Makfile for MacOS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -210,11 +210,6 @@ ifeq ($(COMP),clang)
 		CXXFLAGS += -m$(bits)
 		LDFLAGS += -m$(bits)
 	endif
-
-	ifeq ($(KERNEL),Darwin)
-		CXXFLAGS += -stdlib=libc++
-		DEPENDFLAGS += -stdlib=libc++
-	endif
 endif
 
 ifeq ($(comp),icc)
@@ -293,10 +288,8 @@ ifeq ($(optimize),yes)
 
 	ifeq ($(comp),clang)
 		ifeq ($(KERNEL),Darwin)
-			ifeq ($(pext),no)
 				CXXFLAGS += -flto
 				LDFLAGS += $(CXXFLAGS)
-			endif
 			ifeq ($(arch),i386)
 				CXXFLAGS += -mdynamic-no-pic
 			endif


### PR DESCRIPTION
1) Explicitly setting the default lib to the system-default is not
   needed on a Mac. See:
   http://libcxx.llvm.org/docs/UsingLibcxx.html

2) We do no longer need to exclude bmi2-builds from LTO. See:
   https://llvm.org/bugs/show_bug.cgi?id=19416

Changes tested and discussed on FishCooking:
   https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/acUQtKtEzMM