### PR TITLE
Reproducible search.

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -48,7 +48,7 @@ inline TimePoint now() {
 template<class Entry, int Size>
 struct HashTable {
   Entry* operator[](Key key) { return &table[(uint32_t)key & (Size - 1)]; }
-
+  void clear() { std::fill(table.begin(), table.end(), Entry()); }
 private:
   std::vector<Entry> table = std::vector<Entry>(Size);
 };

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -213,6 +213,8 @@ void Search::clear() {
       th->fromTo.clear();
       th->counterMoveHistory.clear();
       th->resetCalls = true;
+      th->pawnsTable.clear();
+      th->materialTable.clear();
   }
 
   Threads.main()->previousScore = VALUE_INFINITE;


### PR DESCRIPTION
Clears the pawns and material hashtables after an ucinewgame command.

No functional change.