### PR TITLE
Make Stockfish again compilable on older Windows versions

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -19,10 +19,12 @@
 */
 
 #ifdef _WIN32
+/*
 #if _WIN32_WINNT < 0x0601
 #undef  _WIN32_WINNT
 #define _WIN32_WINNT 0x0601 // Force to include newest API (Win 7 or later)
 #endif
+*/
 #include <windows.h> // For processor groups
 #endif
 
@@ -197,7 +199,17 @@ void prefetch(void* addr) {
 
 namespace WinProcGroup {
 
+//template<int factorial> 
+//struct _{ operator char() { return factorial + 256; } }; //always overflow
+//char(_<_WIN32_WINNT>());
+//static_assert(_WIN32_WINNT  >= 0x0601, " >= 0x0601");
+//#warning _WIN32_WINNT
+
 #ifndef _WIN32
+
+void bindThisThread(size_t) {}
+
+#elif _WIN32_WINNT < 0x0601
 
 void bindThisThread(size_t) {}
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -19,12 +19,6 @@
 */
 
 #ifdef _WIN32
-/*
-#if _WIN32_WINNT < 0x0601
-#undef  _WIN32_WINNT
-#define _WIN32_WINNT 0x0601 // Force to include newest API (Win 7 or later)
-#endif
-*/
 #include <windows.h> // For processor groups
 #endif
 
@@ -199,17 +193,13 @@ void prefetch(void* addr) {
 
 namespace WinProcGroup {
 
-//template<int factorial> 
-//struct _{ operator char() { return factorial + 256; } }; //always overflow
-//char(_<_WIN32_WINNT>());
-//static_assert(_WIN32_WINNT  >= 0x0601, " >= 0x0601");
-//#warning _WIN32_WINNT
-
 #ifndef _WIN32
 
 void bindThisThread(size_t) {}
 
 #elif _WIN32_WINNT < 0x0601
+
+// One older windows versions the newest API (Win 7 or later) is not supported.
 
 void bindThisThread(size_t) {}
 


### PR DESCRIPTION
The recently introduced process group stuff requires a API which is supported only for Windows 7 and later.
Now this new feature is skipped if the API is not available.