### PR TITLE
Bind each thread to its own CPU on Linux

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -32,6 +32,12 @@
 #include <sstream>
 #include <vector>
 
+#ifndef _WIN32
+extern "C" {
+#include <sched.h>
+}
+#endif
+
 #include "misc.h"
 #include "thread.h"
 
@@ -199,7 +205,12 @@ namespace WinProcGroup {
 
 #ifndef _WIN32
 
-void bindThisThread(size_t) {}
+void bindThisThread(size_t idx) {
+  cpu_set_t set;
+  CPU_ZERO(&set);
+  CPU_SET(idx, &set);
+  sched_setaffinity(0, sizeof(set), &set);
+}
 
 #else
 


### PR DESCRIPTION
Binding each thread to a specific CPU can prevent threads from bouncing
around from one CPU to another. This is especially damaging on NUMA
computers with many CPUs, as each jump to another CPU may essentially
cause cache thrashing.