### PR TITLE
Use array instead of vector for tables

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -50,7 +50,7 @@ struct HashTable {
   Entry* operator[](Key key) { return &table[(uint32_t)key & (Size - 1)]; }
 
 private:
-  std::vector<Entry> table = std::vector<Entry>(Size);
+  Entry table[Size] = {0};
 };
 
 


### PR DESCRIPTION
Use an array instead of a vector for the pawn and material tables. Fishbench shows a negligible (0.1% - 0.2%) speedup, but I'm primarily submitting this as a simplification (table is only ever used as though it were a raw array, so it seems only logical for it to actually be one).