### PR TITLE
Fix trace in case of space evaluation.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -877,8 +877,11 @@ Value Eval::evaluate(const Position& pos) {
       Trace::add(IMBALANCE, ei.me->imbalance());
       Trace::add(PAWN, ei.pi->pawns_score());
       Trace::add(MOBILITY, mobility[WHITE], mobility[BLACK]);
-      Trace::add(SPACE, evaluate_space<WHITE>(pos, ei)
-                      , evaluate_space<BLACK>(pos, ei));
+      if (pos.non_pawn_material(WHITE) + pos.non_pawn_material(BLACK) >= 12222)
+          Trace::add(SPACE, evaluate_space<WHITE>(pos, ei)
+                          , evaluate_space<BLACK>(pos, ei));
+      else
+          Trace::add(SPACE, SCORE_ZERO, SCORE_ZERO);
       Trace::add(TOTAL, score);
   }
 


### PR DESCRIPTION
We only compute space eval during the opening/early midgame.
Apply the same logic for DoTrace.

No functional change.