### PR TITLE
Fix PGO build for clang

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -219,12 +219,6 @@ else
 ifeq ($(comp),clang)
 	profile_make = clang-profile-make
 	profile_use = clang-profile-use
-        ifeq ($(shell which llvm-profdata),)
-          # if llvm-profdata doesn't exist in the path find it in the directory where clang resides
-          PROFDATA = $(shell /bin/bash -c 'echo $$(dirname $$(readlink -f $$(which clang)))/llvm-profdata')
-        else
-          PROFDATA = llvm-profdata
-        endif
 else
 	profile_make = gcc-profile-make
 	profile_use = gcc-profile-use
@@ -521,7 +515,7 @@ clang-profile-make:
 	all
 
 clang-profile-use:
-	$(PROFDATA) merge -output=stockfish.profdata *.profraw
+	llvm-profdata merge -output=stockfish.profdata *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
 	EXTRACXXFLAGS='-fprofile-instr-use=stockfish.profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \

--- a/src/Makefile
+++ b/src/Makefile
@@ -425,7 +425,8 @@ help:
 
 
 .PHONY: help build profile-build strip install clean objclean profileclean help \
-        config-sanity icc-profile-use icc-profile-make gcc-profile-use gcc-profile-make
+        config-sanity icc-profile-use icc-profile-make gcc-profile-use gcc-profile-make \
+        clang-profile-use clang-profile-make
 
 build: config-sanity
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) all

--- a/src/Makefile
+++ b/src/Makefile
@@ -221,8 +221,19 @@ ifeq ($(comp),icc)
 	profile_make = icc-profile-make
 	profile_use = icc-profile-use
 else
+ifeq ($(comp),clang)
+	profile_make = clang-profile-make
+	profile_use = clang-profile-use
+        ifeq ($(shell which llvm-profdata),)
+          # if llvm-profdata doesn't exist in the path find it in the directory where clang resides
+          PROFDATA = $(shell /bin/bash -c 'echo $$(dirname $$(readlink -f $$(which clang)))/llvm-profdata')
+        else
+          PROFDATA = llvm-profdata
+        endif
+else
 	profile_make = gcc-profile-make
 	profile_use = gcc-profile-use
+endif
 endif
 
 ifeq ($(KERNEL),Darwin)
@@ -461,6 +472,7 @@ objclean:
 profileclean:
 	@rm -rf profdir
 	@rm -f bench.txt *.gcda ./syzygy/*.gcda *.gcno ./syzygy/*.gcno
+	@rm -f stockfish.profdata *.profraw
 
 default:
 	help
@@ -507,6 +519,20 @@ config-sanity:
 
 $(EXE): $(OBJS)
 	$(CXX) -o $@ $(OBJS) $(LDFLAGS)
+
+clang-profile-make:
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+	EXTRACXXFLAGS='-fprofile-instr-generate ' \
+	EXTRALDFLAGS=' -fprofile-instr-generate' \
+	all
+
+clang-profile-use:
+	$(PROFDATA) merge -output=stockfish.profdata *.profraw
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+	EXTRACXXFLAGS='-fprofile-instr-use=stockfish.profdata' \
+	EXTRALDFLAGS='-fprofile-use ' \
+	all
+
 
 gcc-profile-make:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \


### PR DESCRIPTION
fixes issue #167.

Refines an earlier #891 pull request by @MichaelB7 by working around a missing symlink for llvm-profdata on ubuntu and cleaning up intermediate files.

Further testing on OSX and ubuntu (install llvm and clang packages) welcome.

No functional change.