### PR TITLE
Writing const position on stream

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -118,6 +118,10 @@ std::ostream& operator<<(std::ostream& os, Position& pos) {
   return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const Position& pos) {
+  return os << const_cast<Position&>(pos);
+}
+
 
 /// Position::init() initializes at startup the various arrays used to compute
 /// hash keys.

--- a/src/position.h
+++ b/src/position.h
@@ -191,6 +191,7 @@ private:
 };
 
 extern std::ostream& operator<<(std::ostream& os, Position& pos);
+extern std::ostream& operator<<(std::ostream& os, const Position& pos);
 
 inline Color Position::side_to_move() const {
   return sideToMove;


### PR DESCRIPTION
Restore ability to write a position on a standard stream, even if the
position is const.

See discussion in the fishcooking forum: 
https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/Jn4TWs-4_pw

No functional change.