### PR TITLE
TrappedRook simplification

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -348,7 +348,6 @@ namespace {
                 Square ksq = pos.square<KING>(Us);
 
                 if (   ((file_of(ksq) < FILE_E) == (file_of(s) < file_of(ksq)))
-                    && (rank_of(ksq) == rank_of(s) || relative_rank(Us, ksq) == RANK_1)
                     && !ei.pi->semiopen_side(Us, file_of(ksq), file_of(s) < file_of(ksq)))
                     score -= (TrappedRook - make_score(mob * 22, 0)) * (1 + !pos.can_castle(Us));
             }


### PR DESCRIPTION
Just remove rank checks for rook and king for TrappedRook evaluation.

STC: http://tests.stockfishchess.org/tests/view/5833fdfc0ebc5903140c5050
LLR: 3.03 (-2.94,2.94) [-3.00,1.00]
Total: 34474 W: 6088 L: 5986 D: 22400

LTC: http://tests.stockfishchess.org/tests/view/58392f3f0ebc5903140c5276
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 48358 W: 6221 L: 6136 D: 36001