### PR TITLE
Fix PGO build with GCC

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -523,7 +523,7 @@ clang-profile-use:
 
 gcc-profile-make:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-generate'\
+	EXTRACXXFLAGS='-fprofile-generate' \
 	EXTRALDFLAGS='-lgcov' \
 	all
 


### PR DESCRIPTION
Add missing space in the makefile that cause compilation failure.

Fixes #903.

No functional change.