### PR TITLE
Simplify updating of castling rights in Position::do_move()

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -780,11 +780,10 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   }
 
   // Update castling rights if needed
-  if (st->castlingRights && (castlingRightsMask[from] | castlingRightsMask[to]))
+  if (int removedCR = st->castlingRights & (castlingRightsMask[from] | castlingRightsMask[to]))
   {
-      int cr = castlingRightsMask[from] | castlingRightsMask[to];
-      k ^= Zobrist::castling[st->castlingRights & cr];
-      st->castlingRights &= ~cr;
+      k ^= Zobrist::castling[removedCR];
+      st->castlingRights &= ~removedCR;
   }
 
   // Move the piece. The tricky Chess960 castling is handled earlier


### PR DESCRIPTION
The patch removes duplicated parts of the condition expression.
Moreover, now the condition catches exactly all cases when the castling rights are changed. When you want to do something when castling rights are changed, you can simply add a statement info the block of the conditional statement.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 64878 W: 11438 L: 11391 D: 42049

No functional change.