### PR TITLE
Let only the main thread do the sorting

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -115,7 +115,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th)
   ttMove =   ttm
           && pos.pseudo_legal(ttm)
           && pos.capture(ttm)
-          && pos.see_ge(ttm, threshold + 1)? ttm : MOVE_NONE;
+          && pos.see_ge(ttm, threshold + 1) ? ttm : MOVE_NONE;
 
   stage += (ttMove == MOVE_NONE);
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -454,11 +454,12 @@ void Thread::search() {
               assert(alpha >= -VALUE_INFINITE && beta <= VALUE_INFINITE);
           }
 
-          // Sort the PV lines searched so far and update the GUI
-          std::stable_sort(rootMoves.begin(), rootMoves.begin() + PVIdx + 1);
-
+          // Let helper threads immediately continue searching the next PV
           if (!mainThread)
               continue;
+
+          // Sort the PV lines searched so far and update the GUI
+          std::stable_sort(rootMoves.begin(), rootMoves.begin() + PVIdx + 1);
 
           if (Signals.stop || PVIdx + 1 == multiPV || Time.elapsed() > 3000)
               sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
@@ -467,6 +468,7 @@ void Thread::search() {
       if (!Signals.stop)
           completedDepth = rootDepth;
 
+      // Let helper threads immediately continue with the next iteration
       if (!mainThread)
           continue;
 


### PR DESCRIPTION
of the PVs before we output them.
Also add some comments to better document the SMP logic.

No functional change.