### PR TITLE
Remove ONE_PLY, use integer depths

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -161,7 +161,7 @@ void benchmark(const Position& current, istream& is) {
       cerr << "\nPosition: " << i + 1 << '/' << fens.size() << endl;
 
       if (limitType == "perft")
-          nodes += Search::perft(pos, limits.depth * ONE_PLY);
+          nodes += Search::perft(pos, limits.depth);
 
       else
       {

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -241,7 +241,7 @@ Move MovePicker::next_move() {
       cur = endBadCaptures;
       endMoves = generate<QUIETS>(pos, cur);
       score<QUIETS>();
-      if (depth < 3 * ONE_PLY)
+      if (depth < 3)
       {
           ExtMove* goodQuiet = std::partition(cur, endMoves, [](const ExtMove& m)
                                              { return m.value > VALUE_ZERO; });

--- a/src/tt.h
+++ b/src/tt.h
@@ -39,12 +39,10 @@ struct TTEntry {
   Move  move()  const { return (Move )move16; }
   Value value() const { return (Value)value16; }
   Value eval()  const { return (Value)eval16; }
-  Depth depth() const { return (Depth)(depth8 * int(ONE_PLY)); }
+  Depth depth() const { return (Depth)depth8; }
   Bound bound() const { return (Bound)(genBound8 & 0x3); }
 
   void save(Key k, Value v, Bound b, Depth d, Move m, Value ev, uint8_t g) {
-
-    assert(d / ONE_PLY * ONE_PLY == d);
 
     // Preserve any existing move for the same position
     if (m || (k >> 48) != key16)
@@ -52,7 +50,7 @@ struct TTEntry {
 
     // Don't overwrite more valuable entries
     if (  (k >> 48) != key16
-        || d / ONE_PLY > depth8 - 4
+        || d > depth8 - 4
      /* || g != (genBound8 & 0xFC) // Matching non-zero keys are already refreshed by probe() */
         || b == BOUND_EXACT)
     {
@@ -60,7 +58,7 @@ struct TTEntry {
         value16   = (int16_t)v;
         eval16    = (int16_t)ev;
         genBound8 = (uint8_t)(g | b);
-        depth8    = (int8_t)(d / ONE_PLY);
+        depth8    = (int8_t)d;
     }
   }
 

--- a/src/types.h
+++ b/src/types.h
@@ -209,20 +209,14 @@ const Piece Pieces[] = { W_PAWN, W_KNIGHT, W_BISHOP, W_ROOK, W_QUEEN, W_KING,
                          B_PAWN, B_KNIGHT, B_BISHOP, B_ROOK, B_QUEEN, B_KING };
 extern Value PieceValue[PHASE_NB][PIECE_NB];
 
-enum Depth : int {
+typedef int Depth;
 
-  ONE_PLY = 1,
-
-  DEPTH_ZERO          =  0 * ONE_PLY,
-  DEPTH_QS_CHECKS     =  0 * ONE_PLY,
-  DEPTH_QS_NO_CHECKS  = -1 * ONE_PLY,
-  DEPTH_QS_RECAPTURES = -5 * ONE_PLY,
-
-  DEPTH_NONE = -6 * ONE_PLY,
-  DEPTH_MAX  = MAX_PLY * ONE_PLY
-};
-
-static_assert(!(ONE_PLY & (ONE_PLY - 1)), "ONE_PLY is not a power of 2");
+const Depth DEPTH_ZERO          =  0;
+const Depth DEPTH_QS_CHECKS     =  0;
+const Depth DEPTH_QS_NO_CHECKS  = -1;
+const Depth DEPTH_QS_RECAPTURES = -5;
+const Depth DEPTH_NONE          = -6;
+const Depth DEPTH_MAX           = MAX_PLY;
 
 enum Square {
   SQ_A1, SQ_B1, SQ_C1, SQ_D1, SQ_E1, SQ_F1, SQ_G1, SQ_H1,
@@ -304,7 +298,6 @@ ENABLE_FULL_OPERATORS_ON(Value)
 ENABLE_FULL_OPERATORS_ON(PieceType)
 ENABLE_FULL_OPERATORS_ON(Piece)
 ENABLE_FULL_OPERATORS_ON(Color)
-ENABLE_FULL_OPERATORS_ON(Depth)
 ENABLE_FULL_OPERATORS_ON(Square)
 ENABLE_FULL_OPERATORS_ON(File)
 ENABLE_FULL_OPERATORS_ON(Rank)


### PR DESCRIPTION
The ability to use fractional depth has been there for ages, but nobody
has ever submitted a test on fishtest on the subject of fractional
depth in the last three years and ONE_PLY has been 1 since Sep 29, 2014.

Setting Depth to be an integer and retiring ONE_PLY would simplify the
code and improve readability.

No functional change.