### PR TITLE
Clean-up skipEarlyPruning

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -38,15 +38,14 @@ namespace Search {
 
 struct Stack {
   Move* pv;
+  CounterMoveStats* counterMoves;
   int ply;
   Move currentMove;
   Move excludedMove;
   Move killers[2];
   Value staticEval;
   Value history;
-  bool skipEarlyPruning;
   int moveCount;
-  CounterMoveStats* counterMoves;
 };
 
 


### PR DESCRIPTION
make skipEarlyPruning a search argument instead of managing this by hand.

passed STC http://tests.stockfishchess.org/tests/view/584b171c0ebc5903140c59dc
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 96754 W: 17089 L: 17095 D: 62570

No functional change.