### PR TITLE
Threefold repetition detection

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -839,6 +839,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   // Set capture piece
   st->capturedPiece = captured;
 
+  // Draw at first repetition
   st->draw = true;
 
   // Update the key with the final value
@@ -962,6 +963,8 @@ void Position::do_null_move(StateInfo& newSt) {
 
   ++st->rule50;
   st->drawDepth = 0;
+
+  // Draw at first repetition
   st->draw = true;
 
   sideToMove = ~sideToMove;
@@ -1079,8 +1082,9 @@ bool Position::see_ge(Move m, Value v) const {
 }
 
 
-/// Position::calc_draw()
-///
+/// Position::calc_draw() calculates the value of st->draw - the boolean meaning
+/// the position occurred before in the game. This function is called for positions
+/// up to the root, so recursion into some of them becomes possible during search.
 
 void Position::calc_draw() {
 

--- a/src/position.h
+++ b/src/position.h
@@ -42,7 +42,7 @@ struct StateInfo {
   Value  nonPawnMaterial[COLOR_NB];
   int    castlingRights;
   int    rule50;
-  int    pliesFromNull;
+  int    drawDepth;
   Score  psq;
   Square epSquare;
 
@@ -50,6 +50,7 @@ struct StateInfo {
   Key        key;
   Bitboard   checkersBB;
   Piece      capturedPiece;
+  bool       draw;
   StateInfo* previous;
   Bitboard   blockersForKing[COLOR_NB];
   Bitboard   pinnersForKing[COLOR_NB];
@@ -150,6 +151,7 @@ public:
   bool is_chess960() const;
   Thread* this_thread() const;
   uint64_t nodes_searched() const;
+  void calc_draw();
   bool is_draw() const;
   int rule50_count() const;
   Score psq_score() const;

--- a/src/position.h
+++ b/src/position.h
@@ -42,7 +42,7 @@ struct StateInfo {
   Value  nonPawnMaterial[COLOR_NB];
   int    castlingRights;
   int    rule50;
-  int    drawDepth;
+  int    pliesFromNull;
   Score  psq;
   Square epSquare;
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1489,7 +1489,7 @@ int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
 static int has_repeated(StateInfo *st)
 {
     while (1) {
-        int i = 4, e = std::min(st->rule50, st->pliesFromNull);
+        int i = 4, e = st->drawDepth;
 
         if (e < i)
             return 0;

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1489,7 +1489,7 @@ int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
 static int has_repeated(StateInfo *st)
 {
     while (1) {
-        int i = 4, e = st->drawDepth;
+        int i = 4, e = std::min(st->rule50, st->pliesFromNull);
 
         if (e < i)
             return 0;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -77,6 +77,7 @@ namespace {
     {
         States->push_back(StateInfo());
         pos.do_move(m, States->back());
+        pos.calc_draw();
     }
   }
 


### PR DESCRIPTION
Implement a threefold repetition detection. Below are the examples of problems fixed by this change.

1. Loosing move in a drawn position.
position fen 8/k7/3p4/p2P1p2/P2P1P2/8/8/K7 w - - 0 1 moves a1a2 a7a8 a2a1
The old code suggested a loosing move "bestmove a8a7", the new code suggests "bestmove a8b7" leading to a draw.

2. Incorrect evaluation (happened in a real game in TCEC Season 9).
position fen 4rbkr/1q3pp1/b3pn2/7p/1pN5/1P1BBP1P/P1R2QP1/3R2K1 w - - 5 31 moves e3d4 h8h6 d4e3
The old code evaluated it as "cp 0", the new code evaluation is around "cp -50" which is adequate.

Brings 0.5-1 ELO gain. Passes [-3.00,1.00].

STC: http://tests.stockfishchess.org/tests/view/584ece040ebc5903140c5aea
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 47744 W: 8537 L: 8461 D: 30746

LTC: http://tests.stockfishchess.org/tests/view/584f134d0ebc5903140c5b37
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 36775 W: 4739 L: 4639 D: 27397