### PR TITLE
eliminate "goto moves_loop statement"

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -710,7 +710,7 @@ namespace {
     }
   }
 
-    if (!incheck && !skipEarlyPruning)
+    if (!inCheck && !skipEarlyPruning)
   {
 
     // Step 6. Razoring (skipped when in check)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -684,13 +684,11 @@ namespace {
     }
 
     // Step 5. Evaluate the position statically
-    if (inCheck)
-    {
-        ss->staticEval = eval = VALUE_NONE;
-        goto moves_loop;
-    }
+  if (!inCheck)
+  {
+       
 
-    else if (ttHit)
+    if (ttHit)
     {
         // Never assume anything on values stored in TT
         if ((ss->staticEval = eval = tte->eval()) == VALUE_NONE)
@@ -710,9 +708,10 @@ namespace {
         tte->save(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE,
                   ss->staticEval, TT.generation());
     }
+  }
 
-    if (skipEarlyPruning)
-        goto moves_loop;
+    if (!incheck && !skipEarlyPruning)
+  {
 
     // Step 6. Razoring (skipped when in check)
     if (   !PvNode
@@ -814,8 +813,8 @@ namespace {
         tte = TT.probe(posKey, ttHit);
         ttMove = ttHit ? tte->move() : MOVE_NONE;
     }
-
-moves_loop: // When in check search starts from here
+  }
+    if (inCheck)  ss->staticEval = eval = VALUE_NONE;// When in check search starts from here
 
     const CounterMoveStats* cmh  = (ss-1)->counterMoves;
     const CounterMoveStats* fmh  = (ss-2)->counterMoves;


### PR DESCRIPTION
Simplification : no functional change, slight speed pickup under clang and gcc for both build and pgo build, reduction in code, search and signature (bench)  remains the same.