### PR TITLE
Margin template

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -934,12 +934,10 @@ moves_loop: // When in check search starts from here
                   && !pos.see_ge(move, Value(-35 * lmrDepth * lmrDepth)))
                   continue;
           }
-          else if (depth < 7 * ONE_PLY && !extension)
-          {
-              Value v = -Value(400 - 100 * PvNode + 35 * depth / ONE_PLY * depth / ONE_PLY);
-              if (!pos.see_ge(move, v))
+          else if (    depth < 7 * ONE_PLY
+                   && !extension
+                   && !pos.see_ge(move, -PawnValueEg * (depth / ONE_PLY)))
                   continue;
-          }
       }
 
       // Speculative prefetch as early as possible

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -728,7 +728,7 @@ namespace {
     if (   !PvNode
         &&  depth < 4 * ONE_PLY
         &&  ttMove == MOVE_NONE
-        &&  eval + razor_margin[depth])
+        &&  eval + razor_margin[depth / ONE_PLY] <= alpha)
 //        &&  eval + margin<Razor>(depth) <= alpha)
     {
         if (depth <= ONE_PLY)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -62,10 +62,11 @@ namespace {
 
   // Different node types, used as a template parameter
   enum NodeType { NonPV, PV };
-  enum MarginType {Razor, Futility};
+  enum MarginType {Razor, Futility, Null, MarginsNB = 3};
 
   // Razoring and futility margin based on depth
-  const int Margins[2][2] = {{500, 30}, {0, 150}};
+  //                                 Razor      Futility  Null move
+  const int Margins[MarginsNB][2] = {{500, 30}, {0, 150}, {-210, 35}};
 
   template <MarginType mt> Value margin(Depth d){
     return Value((Margins[mt][0] + d * Margins[mt][1])/ONE_PLY);
@@ -744,7 +745,7 @@ namespace {
     // Step 8. Null move search with verification search (is omitted in PV nodes)
     if (   !PvNode
         &&  eval >= beta
-        && (ss->staticEval >= beta - 35 * (depth / ONE_PLY - 6) || depth >= 13 * ONE_PLY)
+        && (ss->staticEval >= beta - margin<Null>(depth) || depth >= 13 * ONE_PLY)
         &&  pos.non_pawn_material(pos.side_to_move()))
     {
         ss->currentMove = MOVE_NULL;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -65,6 +65,7 @@ namespace {
   enum MarginType {Razor, FutilityChild, FutilityParent, Null, MarginsNB = 4};
 
   // Razoring and futility margin based on depth
+  const int razor_margin[4] = { 483, 570, 603, 554 };
   const int Margins[MarginsNB][2] = {
       { 500,  30},  // Razor
       { 0,   150},  // Futility child
@@ -727,7 +728,8 @@ namespace {
     if (   !PvNode
         &&  depth < 4 * ONE_PLY
         &&  ttMove == MOVE_NONE
-        &&  eval + margin<Razor>(depth) <= alpha)
+        &&  eval + razor_margin[depth])
+//        &&  eval + margin<Razor>(depth) <= alpha)
     {
         if (depth <= ONE_PLY)
             return qsearch<NonPV, false>(pos, ss, alpha, beta, DEPTH_ZERO);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -734,7 +734,8 @@ namespace {
         if (depth <= ONE_PLY)
             return qsearch<NonPV, false>(pos, ss, alpha, beta, DEPTH_ZERO);
 
-        Value ralpha = alpha - margin<Razor>(depth);
+        Value ralpha = alpha - razor_margin[depth / ONE_PLY];
+//        Value ralpha = alpha - margin<Razor>(depth);
         Value v = qsearch<NonPV, false>(pos, ss, ralpha, ralpha+1, DEPTH_ZERO);
         if (v <= ralpha)
             return v;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -66,7 +66,7 @@ namespace {
 
   // Razoring and futility margin based on depth
   const int razor_margin[4] = { 483, 570, 603, 554 };
-  const int Margins[MarginsNB][3] = {
+  const int PruningMargins[MarginsNB][3] = {
       { 500,   30,    0},  // Razor
       { 0,    150,    0},  // Futility child
       { 256,  200,    0},  // Futility parent
@@ -76,7 +76,7 @@ namespace {
   };
 
   template <MarginType mt> Value margin(Depth d){
-    return Value((Margins[mt][0] + d * Margins[mt][1] + int(d) * d * Margins[mt][2])/ONE_PLY);
+    return Value((PruningMargins[mt][0] + d * PruningMargins[mt][1] + int(d) * d * PruningMargins[mt][2])/ONE_PLY);
   }
 
   // Futility and reductions lookup tables, initialized at startup

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -62,19 +62,21 @@ namespace {
 
   // Different node types, used as a template parameter
   enum NodeType { NonPV, PV };
-  enum MarginType {Razor, FutilityChild, FutilityParent, Null, MarginsNB = 4};
+  enum MarginType {Razor, FutilityChild, FutilityParent, Null, SeeRoot, SeeNonRoot, MarginsNB = 6};
 
   // Razoring and futility margin based on depth
   const int razor_margin[4] = { 483, 570, 603, 554 };
-  const int Margins[MarginsNB][2] = {
-      { 500,  30},  // Razor
-      { 0,   150},  // Futility child
-      { 256, 200},  // Futility parent
-      {-210,  35}   // Static null
+  const int Margins[MarginsNB][3] = {
+      { 500,   30,    0},  // Razor
+      { 0,    150,    0},  // Futility child
+      { 256,  200,    0},  // Futility parent
+      {-210,   35,    0},  // Static null
+      {   0, -248,    0},  // See at root
+      {   0,    0,  -35}   // See at non root
   };
 
   template <MarginType mt> Value margin(Depth d){
-    return Value((Margins[mt][0] + d * Margins[mt][1])/ONE_PLY);
+    return Value((Margins[mt][0] + d * Margins[mt][1] + int(d) * d * Margins[mt][2])/ONE_PLY);
   }
 
   // Futility and reductions lookup tables, initialized at startup
@@ -943,12 +945,12 @@ moves_loop: // When in check search starts from here
 
               // Prune moves with negative SEE
               if (   lmrDepth < 8 * ONE_PLY
-                  && !pos.see_ge(move, Value(-35 * (lmrDepth / ONE_PLY) * (lmrDepth / ONE_PLY))))
+                  && !pos.see_ge(move, margin<SeeNonRoot>(lmrDepth)))
                   continue;
           }
           else if (    depth < 7 * ONE_PLY
                    && !extension
-                   && !pos.see_ge(move, -PawnValueEg * (depth / ONE_PLY)))
+                   && !pos.see_ge(move, margin<SeeRoot>(depth)))
                   continue;
       }
 


### PR DESCRIPTION
This PR is to initiate a discussion and get feedback. It is not intended to be merged. I ask Marco if it is ok to keep it open for some time in order for the community to contribute.

I noticed that all our margins (apart of razor) can be written in the form margin = a + b * d + c * d^2, where d is the depth.

I reformulated the code making margin a template using an external table of the coefficients. This could not be done for razoring margins, which constitute an exception. I left the razor margins as they are now for inspection, but added a commented line showing how this would look like. If there is interest in the community, I will try to tune all values at once and see whether it is possible to make this patch pass.

Fot this, https://github.com/official-stockfish/Stockfish/pull/933 is needed.

As it is now, this is a nonfunctional change.

I see some advantages in this format:
+ all pruning mechanisms based on margins are documented in the enum which is used to address the table.
+ all values are kept in a clean table, which makes maybe easier to recognize patterns
+ the code in which margins are used becomes more uniform over the search function and (in my opinion) more readable
+ the division by ONE_PLY is moved in a single place instead of being kept in dozen of different places

I also see some disadvantages:
- we add approx 10 LOCs
- it is unclear to me whether this way of using templates is sensible or not 