### PR TITLE
10 Stockfish skill levels

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -78,7 +78,7 @@ namespace {
   // Skill structure is used to implement strength limit
   struct Skill {
     Skill(int l) : level(l) {}
-    bool enabled() const { return level < 20; }
+    bool enabled() const { return level < 10; }
     bool time_to_pick(Depth depth) const { return depth / ONE_PLY == 1 + level; }
     Move best_move(size_t multiPV) { return best ? best : pick_best(multiPV); }
     Move pick_best(size_t multiPV);
@@ -1452,7 +1452,7 @@ moves_loop: // When in check search starts from here
     // RootMoves are already sorted by score in descending order
     Value topScore = rootMoves[0].score;
     int delta = std::min(topScore - rootMoves[multiPV - 1].score, PawnValueMg);
-    int weakness = 120 - 2 * level;
+    int weakness = 120 - 4 * level - 1;
     int maxScore = -VALUE_INFINITE;
 
     // Choose best move. For each move score we add two terms, both dependent on

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -79,7 +79,7 @@ namespace {
   struct Skill {
     Skill(int l) : level(l) {}
     bool enabled() const { return level < 10; }
-    bool time_to_pick(Depth depth) const { return depth / ONE_PLY == 1 + level; }
+    bool time_to_pick(Depth depth) const { return depth / ONE_PLY == 1 + level + level / 3; }
     Move best_move(size_t multiPV) { return best ? best : pick_best(multiPV); }
     Move pick_best(size_t multiPV);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1452,7 +1452,7 @@ moves_loop: // When in check search starts from here
     // RootMoves are already sorted by score in descending order
     Value topScore = rootMoves[0].score;
     int delta = std::min(topScore - rootMoves[multiPV - 1].score, PawnValueMg);
-    int weakness = 120 - 4 * level - 1;
+    int weakness = 120 - 4 * level + 3;
     int maxScore = -VALUE_INFINITE;
 
     // Choose best move. For each move score we add two terms, both dependent on

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -64,7 +64,7 @@ void init(OptionsMap& o) {
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);
-  o["Skill Level"]           << Option(20, 0, 20);
+  o["Skill Level"]           << Option(10, 0, 10);
   o["Move Overhead"]         << Option(30, 0, 5000);
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
   o["Slow Mover"]            << Option(89, 10, 1000);


### PR DESCRIPTION
Reduce playable skill levels from 20 to 10. 

The new reduced levels should have a more noticeable strength difference level to level, whilst maintaining a good low playing strength and a very challenging high playing strength.

This paves the way for changing the skill implementation in future by focusing on fewer more enjoyable playing levels.

No functional change.