### PR TITLE
Simplify threshold handling for probcut.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -111,11 +111,11 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th)
 
   stage = PROBCUT;
 
-  // In ProbCut we generate captures with SEE higher than the given threshold
+  // In ProbCut we generate captures with SEE higher than or equal to the given threshold
   ttMove =   ttm
           && pos.pseudo_legal(ttm)
           && pos.capture(ttm)
-          && pos.see_ge(ttm, threshold + 1)? ttm : MOVE_NONE;
+          && pos.see_ge(ttm, threshold)? ttm : MOVE_NONE;
 
   stage += (ttMove == MOVE_NONE);
 }
@@ -294,7 +294,7 @@ Move MovePicker::next_move() {
       {
           move = pick_best(cur++, endMoves);
           if (   move != ttMove
-              && pos.see_ge(move, threshold + 1))
+              && pos.see_ge(move, threshold))
               return move;
       }
       break;


### PR DESCRIPTION
just use greater equal as this is what see_ge does now.

passed STC
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 226506 W: 39755 L: 39978 D: 146773

passed LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 138483 W: 17450 L: 17479 D: 103554

Bench: 5212921