### PR TITLE
Don't clear EasyMove in ::search()

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1074,13 +1074,6 @@ moves_loop: // When in check search starts from here
 
           if (value > alpha)
           {
-              // If there is an easy move for this position, clear it if unstable
-              if (    PvNode
-                  &&  thisThread == Threads.main()
-                  &&  EasyMove.get(pos.key())
-                  && (move != EasyMove.get(pos.key()) || moveCount > 1))
-                  EasyMove.clear();
-
               bestMove = move;
 
               if (PvNode && !rootNode) // Update pv even in fail-high case


### PR DESCRIPTION
EasyMove is cleared after every iteration of the search if the 3rd move in the PV of the main thread changes from the previous iteration. Therefore, clearing EasyMove during a search iteration may be excessive. The tests show that this is indeed unnecessary.
In the new version the EasyMove variable is used only in the Thread::search function.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 47719 W: 8438 L: 8362 D: 30919

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 122841 W: 15448 L: 15457 D: 91936

Bench: 5255881 (unchanged)