### PR TITLE
Hide some bitboards

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -26,22 +26,22 @@
 uint8_t PopCnt16[1 << 16];
 int SquareDistance[SQUARE_NB][SQUARE_NB];
 
+Bitboard  RookMasks  [SQUARE_NB];
+Bitboard  RookMagics [SQUARE_NB];
+Bitboard* RookAttacks[SQUARE_NB];
+unsigned  RookShifts [SQUARE_NB];
+
+Bitboard  BishopMasks  [SQUARE_NB];
+Bitboard  BishopMagics [SQUARE_NB];
+Bitboard* BishopAttacks[SQUARE_NB];
+unsigned  BishopShifts [SQUARE_NB];
+
 Bitboard SquareBB[SQUARE_NB];
 Bitboard StepAttacksBB[PIECE_NB][SQUARE_NB];
 Bitboard DistanceRingBB[SQUARE_NB][8];
 Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 
 namespace {
-
-  Bitboard  RookMasks  [SQUARE_NB];
-  Bitboard  RookMagics [SQUARE_NB];
-  Bitboard* RookAttacks[SQUARE_NB];
-  unsigned  RookShifts [SQUARE_NB];
-
-  Bitboard  BishopMasks  [SQUARE_NB];
-  Bitboard  BishopMagics [SQUARE_NB];
-  Bitboard* BishopAttacks[SQUARE_NB];
-  unsigned  BishopShifts [SQUARE_NB];
 
   Bitboard FileBB[FILE_NB];
   Bitboard RankBB[RANK_NB];
@@ -147,27 +147,6 @@ const std::string Bitboards::pretty(Bitboard b) {
 }
 
 
-/// magic_index() is a helper to look up the index using the 'magic bitboards' approach
-
-template<PieceType Pt>
-unsigned magic_index(Square s, Bitboard occupied) {
-
-  Bitboard* const Masks  = Pt == ROOK ? RookMasks  : BishopMasks;
-  Bitboard* const Magics = Pt == ROOK ? RookMagics : BishopMagics;
-  unsigned* const Shifts = Pt == ROOK ? RookShifts : BishopShifts;
-
-  if (HasPext)
-      return unsigned(pext(occupied, Masks[s]));
-
-  if (Is64Bit)
-      return unsigned(((occupied & Masks[s]) * Magics[s]) >> Shifts[s]);
-
-  unsigned lo = unsigned(occupied) & unsigned(Masks[s]);
-  unsigned hi = unsigned(occupied >> 32) & unsigned(Masks[s] >> 32);
-  return (lo * unsigned(Magics[s]) ^ hi * unsigned(Magics[s] >> 32)) >> Shifts[s];
-}
-
-
 /// Bitboards::init() initializes various bitboard tables. It is called at
 /// startup and relies on global objects to be already zero-initialized.
 
@@ -265,26 +244,6 @@ Bitboard pawn_attack_span(Color c, Square s) { return PawnAttackSpan[c][s]; }
 Bitboard passed_pawn_mask(Color c, Square s) { return PassedPawnMask[c][s]; }
 
 Bitboard line(Square s1, Square s2) { return LineBB[s1][s2]; }
-
-template<PieceType Pt>
-Bitboard attacks_bb(Square s, Bitboard occupied) {
-  return (Pt == ROOK ? RookAttacks : BishopAttacks)[s][magic_index<Pt>(s, occupied)];
-}
-
-template Bitboard attacks_bb<BISHOP>(Square s, Bitboard occupied);
-template Bitboard attacks_bb<ROOK>(Square s, Bitboard occupied);
-
-Bitboard attacks_bb(Piece pc, Square s, Bitboard occupied) {
-
-  switch (type_of(pc))
-  {
-  case BISHOP: return attacks_bb<BISHOP>(s, occupied);
-  case ROOK  : return attacks_bb<ROOK>(s, occupied);
-  case QUEEN : return attacks_bb<BISHOP>(s, occupied) | attacks_bb<ROOK>(s, occupied);
-  default    : return StepAttacksBB[pc][s];
-  }
-}
-
 
 namespace {
 

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -38,7 +38,6 @@ unsigned  BishopShifts [SQUARE_NB];
 
 Bitboard SquareBB[SQUARE_NB];
 Bitboard StepAttacksBB[PIECE_NB][SQUARE_NB];
-Bitboard LineBB[SQUARE_NB][SQUARE_NB];
 Bitboard DistanceRingBB[SQUARE_NB][8];
 Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 
@@ -52,6 +51,7 @@ namespace {
   Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
   Bitboard PassedPawnMask[COLOR_NB][SQUARE_NB];
   Bitboard PawnAttackSpan[COLOR_NB][SQUARE_NB];
+  Bitboard LineBB[SQUARE_NB][SQUARE_NB];
 
   // De Bruijn sequences. See chessprogramming.wikispaces.com/BitScan
   const uint64_t DeBruijn64 = 0x3F79D71B4CB0A89ULL;
@@ -242,6 +242,8 @@ Bitboard between_bb(Square s1, Square s2) { return BetweenBB[s1][s2]; }
 
 Bitboard pawn_attack_span(Color c, Square s) { return PawnAttackSpan[c][s]; }
 Bitboard passed_pawn_mask(Color c, Square s) { return PassedPawnMask[c][s]; }
+
+Bitboard line(Square s1, Square s2) { return LineBB[s1][s2]; }
 
 namespace {
 

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -37,20 +37,21 @@ Bitboard* BishopAttacks[SQUARE_NB];
 unsigned  BishopShifts [SQUARE_NB];
 
 Bitboard SquareBB[SQUARE_NB];
-Bitboard FileBB[FILE_NB];
-Bitboard RankBB[RANK_NB];
-Bitboard AdjacentFilesBB[FILE_NB];
-Bitboard InFrontBB[COLOR_NB][RANK_NB];
 Bitboard StepAttacksBB[PIECE_NB][SQUARE_NB];
-Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
 Bitboard LineBB[SQUARE_NB][SQUARE_NB];
 Bitboard DistanceRingBB[SQUARE_NB][8];
-Bitboard ForwardBB[COLOR_NB][SQUARE_NB];
-Bitboard PassedPawnMask[COLOR_NB][SQUARE_NB];
-Bitboard PawnAttackSpan[COLOR_NB][SQUARE_NB];
 Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 
 namespace {
+
+  Bitboard FileBB[FILE_NB];
+  Bitboard RankBB[RANK_NB];
+  Bitboard InFrontBB[COLOR_NB][RANK_NB];
+  Bitboard ForwardBB[COLOR_NB][SQUARE_NB];
+  Bitboard AdjacentFilesBB[FILE_NB];
+  Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
+  Bitboard PassedPawnMask[COLOR_NB][SQUARE_NB];
+  Bitboard PawnAttackSpan[COLOR_NB][SQUARE_NB];
 
   // De Bruijn sequences. See chessprogramming.wikispaces.com/BitScan
   const uint64_t DeBruijn64 = 0x3F79D71B4CB0A89ULL;
@@ -228,6 +229,19 @@ void Bitboards::init() {
   }
 }
 
+Bitboard rank_bb(Rank r)   { return RankBB[r]; }
+Bitboard rank_bb(Square s) { return RankBB[rank_of(s)]; }
+Bitboard file_bb(File f)   { return FileBB[f]; }
+Bitboard file_bb(Square s) { return FileBB[file_of(s)]; }
+
+Bitboard in_front_bb(Color c, Rank r)  { return InFrontBB[c][r]; }
+Bitboard forward_bb(Color c, Square s) { return ForwardBB[c][s]; }
+
+Bitboard adjacent_files_bb(File f) { return AdjacentFilesBB[f]; }
+Bitboard between_bb(Square s1, Square s2) { return BetweenBB[s1][s2]; }
+
+Bitboard pawn_attack_span(Color c, Square s) { return PawnAttackSpan[c][s]; }
+Bitboard passed_pawn_mask(Color c, Square s) { return PassedPawnMask[c][s]; }
 
 namespace {
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -138,7 +138,7 @@ Bitboard in_front_bb(Color c, Rank r);
 
 /// forward_bb() returns a bitboard representing all the squares along the line
 /// in front of the given one, from the point of view of the given color:
-///        ForwardBB[c][s] = in_front_bb(c, s) & file_bb(s)
+///        ForwardBB[c][s] = in_front_bb(c, rank_of(s)) & file_bb(s)
 
 Bitboard forward_bb(Color c, Square s);
 
@@ -146,7 +146,7 @@ Bitboard forward_bb(Color c, Square s);
 /// pawn_attack_span() returns a bitboard representing all the squares that can be
 /// attacked by a pawn of the given color when it moves along its file, starting
 /// from the given square:
-///       PawnAttackSpan[c][s] = in_front_bb(c, s) & adjacent_files_bb(s);
+///       PawnAttackSpan[c][s] = in_front_bb(c, rank_of(s)) & adjacent_files_bb(s);
 
 Bitboard pawn_attack_span(Color c, Square s);
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -63,7 +63,6 @@ extern int SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];
 extern Bitboard StepAttacksBB[PIECE_NB][SQUARE_NB];
-extern Bitboard LineBB[SQUARE_NB][SQUARE_NB];
 extern Bitboard DistanceRingBB[SQUARE_NB][8];
 extern Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 
@@ -158,12 +157,10 @@ Bitboard pawn_attack_span(Color c, Square s);
 Bitboard passed_pawn_mask(Color c, Square s);
 
 
-/// aligned() returns true if the squares s1, s2 and s3 are aligned either on a
-/// straight or on a diagonal line.
+/// line() returns the line that joins s1 and s2, if the squares can be joined by a
+/// vertical, horizontal or diagonal line. Otherwise the result is zero.
 
-inline bool aligned(Square s1, Square s2, Square s3) {
-  return LineBB[s1][s2] & s3;
-}
+Bitboard line(Square s1, Square s2);
 
 
 /// distance() functions return the distance between x and y, defined as the

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -161,54 +161,13 @@ template<> inline int distance<File>(Square x, Square y) { return distance(file_
 template<> inline int distance<Rank>(Square x, Square y) { return distance(rank_of(x), rank_of(y)); }
 
 
-/// attacks_bb() returns a bitboard representing all the squares attacked by a
-/// piece of type Pt (bishop or rook) placed on 's'. The helper magic_index()
-/// looks up the index using the 'magic bitboards' approach.
-template<PieceType Pt>
-inline unsigned magic_index(Square s, Bitboard occupied) {
-
-  extern Bitboard RookMasks[SQUARE_NB];
-  extern Bitboard RookMagics[SQUARE_NB];
-  extern unsigned RookShifts[SQUARE_NB];
-  extern Bitboard BishopMasks[SQUARE_NB];
-  extern Bitboard BishopMagics[SQUARE_NB];
-  extern unsigned BishopShifts[SQUARE_NB];
-
-  Bitboard* const Masks  = Pt == ROOK ? RookMasks  : BishopMasks;
-  Bitboard* const Magics = Pt == ROOK ? RookMagics : BishopMagics;
-  unsigned* const Shifts = Pt == ROOK ? RookShifts : BishopShifts;
-
-  if (HasPext)
-      return unsigned(pext(occupied, Masks[s]));
-
-  if (Is64Bit)
-      return unsigned(((occupied & Masks[s]) * Magics[s]) >> Shifts[s]);
-
-  unsigned lo = unsigned(occupied) & unsigned(Masks[s]);
-  unsigned hi = unsigned(occupied >> 32) & unsigned(Masks[s] >> 32);
-  return (lo * unsigned(Magics[s]) ^ hi * unsigned(Magics[s] >> 32)) >> Shifts[s];
-}
+/// attacks_bb() returns a bitboard representing all the squares attacked by a sliding
+/// piece of type Pt (bishop or rook) placed on 's'.
 
 template<PieceType Pt>
-inline Bitboard attacks_bb(Square s, Bitboard occupied) {
+Bitboard attacks_bb(Square s, Bitboard occupied);
 
-  extern Bitboard* RookAttacks[SQUARE_NB];
-  extern Bitboard* BishopAttacks[SQUARE_NB];
-
-  return (Pt == ROOK ? RookAttacks : BishopAttacks)[s][magic_index<Pt>(s, occupied)];
-}
-
-inline Bitboard attacks_bb(Piece pc, Square s, Bitboard occupied) {
-
-  switch (type_of(pc))
-  {
-  case BISHOP: return attacks_bb<BISHOP>(s, occupied);
-  case ROOK  : return attacks_bb<ROOK>(s, occupied);
-  case QUEEN : return attacks_bb<BISHOP>(s, occupied) | attacks_bb<ROOK>(s, occupied);
-  default    : return StepAttacksBB[pc][s];
-  }
-}
-
+Bitboard attacks_bb(Piece pc, Square s, Bitboard occupied);
 
 /// popcount() counts the number of non-zero bits in a bitboard
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -116,50 +116,37 @@ inline Bitboard shift(Bitboard b) {
 
 /// adjacent_files_bb() returns a bitboard representing all the squares on the
 /// adjacent files of the given one.
-
 Bitboard adjacent_files_bb(File f);
-
 
 /// between_bb() returns a bitboard representing all the squares between the two
 /// given ones. For instance, between_bb(SQ_C4, SQ_F7) returns a bitboard with
 /// the bits for square d5 and e6 set. If s1 and s2 are not on the same rank, file
 /// or diagonal, 0 is returned.
-
 Bitboard between_bb(Square s1, Square s2);
-
 
 /// in_front_bb() returns a bitboard representing all the squares on all the ranks
 /// in front of the given one, from the point of view of the given color. For
 /// instance, in_front_bb(BLACK, RANK_3) will return the squares on ranks 1 and 2.
-
 Bitboard in_front_bb(Color c, Rank r);
-
 
 /// forward_bb() returns a bitboard representing all the squares along the line
 /// in front of the given one, from the point of view of the given color:
 ///        ForwardBB[c][s] = in_front_bb(c, rank_of(s)) & file_bb(s)
-
 Bitboard forward_bb(Color c, Square s);
-
 
 /// pawn_attack_span() returns a bitboard representing all the squares that can be
 /// attacked by a pawn of the given color when it moves along its file, starting
 /// from the given square:
 ///       PawnAttackSpan[c][s] = in_front_bb(c, rank_of(s)) & adjacent_files_bb(s);
-
 Bitboard pawn_attack_span(Color c, Square s);
-
 
 /// passed_pawn_mask() returns a bitboard mask which can be used to test if a
 /// pawn of the given color and on the given square is a passed pawn:
 ///       PassedPawnMask[c][s] = pawn_attack_span(c, s) | forward_bb(c, s)
-
 Bitboard passed_pawn_mask(Color c, Square s);
-
 
 /// line() returns the line that joins s1 and s2, if the squares can be joined by a
 /// vertical, horizontal or diagonal line. Otherwise the result is zero.
-
 Bitboard line(Square s1, Square s2);
 
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -62,17 +62,9 @@ const Bitboard Rank8BB = Rank1BB << (8 * 7);
 extern int SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];
-extern Bitboard FileBB[FILE_NB];
-extern Bitboard RankBB[RANK_NB];
-extern Bitboard AdjacentFilesBB[FILE_NB];
-extern Bitboard InFrontBB[COLOR_NB][RANK_NB];
 extern Bitboard StepAttacksBB[PIECE_NB][SQUARE_NB];
-extern Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
 extern Bitboard LineBB[SQUARE_NB][SQUARE_NB];
 extern Bitboard DistanceRingBB[SQUARE_NB][8];
-extern Bitboard ForwardBB[COLOR_NB][SQUARE_NB];
-extern Bitboard PassedPawnMask[COLOR_NB][SQUARE_NB];
-extern Bitboard PawnAttackSpan[COLOR_NB][SQUARE_NB];
 extern Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 
 
@@ -107,22 +99,10 @@ inline bool more_than_one(Bitboard b) {
 /// rank_bb() and file_bb() return a bitboard representing all the squares on
 /// the given file or rank.
 
-inline Bitboard rank_bb(Rank r) {
-  return RankBB[r];
-}
-
-inline Bitboard rank_bb(Square s) {
-  return RankBB[rank_of(s)];
-}
-
-inline Bitboard file_bb(File f) {
-  return FileBB[f];
-}
-
-inline Bitboard file_bb(Square s) {
-  return FileBB[file_of(s)];
-}
-
+Bitboard rank_bb(Rank r);
+Bitboard rank_bb(Square s);
+Bitboard file_bb(File f);
+Bitboard file_bb(Square s);
 
 /// shift() moves a bitboard one step along direction D. Mainly for pawns
 
@@ -138,9 +118,7 @@ inline Bitboard shift(Bitboard b) {
 /// adjacent_files_bb() returns a bitboard representing all the squares on the
 /// adjacent files of the given one.
 
-inline Bitboard adjacent_files_bb(File f) {
-  return AdjacentFilesBB[f];
-}
+Bitboard adjacent_files_bb(File f);
 
 
 /// between_bb() returns a bitboard representing all the squares between the two
@@ -148,27 +126,21 @@ inline Bitboard adjacent_files_bb(File f) {
 /// the bits for square d5 and e6 set. If s1 and s2 are not on the same rank, file
 /// or diagonal, 0 is returned.
 
-inline Bitboard between_bb(Square s1, Square s2) {
-  return BetweenBB[s1][s2];
-}
+Bitboard between_bb(Square s1, Square s2);
 
 
 /// in_front_bb() returns a bitboard representing all the squares on all the ranks
 /// in front of the given one, from the point of view of the given color. For
 /// instance, in_front_bb(BLACK, RANK_3) will return the squares on ranks 1 and 2.
 
-inline Bitboard in_front_bb(Color c, Rank r) {
-  return InFrontBB[c][r];
-}
+Bitboard in_front_bb(Color c, Rank r);
 
 
 /// forward_bb() returns a bitboard representing all the squares along the line
 /// in front of the given one, from the point of view of the given color:
 ///        ForwardBB[c][s] = in_front_bb(c, s) & file_bb(s)
 
-inline Bitboard forward_bb(Color c, Square s) {
-  return ForwardBB[c][s];
-}
+Bitboard forward_bb(Color c, Square s);
 
 
 /// pawn_attack_span() returns a bitboard representing all the squares that can be
@@ -176,18 +148,14 @@ inline Bitboard forward_bb(Color c, Square s) {
 /// from the given square:
 ///       PawnAttackSpan[c][s] = in_front_bb(c, s) & adjacent_files_bb(s);
 
-inline Bitboard pawn_attack_span(Color c, Square s) {
-  return PawnAttackSpan[c][s];
-}
+Bitboard pawn_attack_span(Color c, Square s);
 
 
 /// passed_pawn_mask() returns a bitboard mask which can be used to test if a
 /// pawn of the given color and on the given square is a passed pawn:
 ///       PassedPawnMask[c][s] = pawn_attack_span(c, s) | forward_bb(c, s)
 
-inline Bitboard passed_pawn_mask(Color c, Square s) {
-  return PassedPawnMask[c][s];
-}
+Bitboard passed_pawn_mask(Color c, Square s);
 
 
 /// aligned() returns true if the squares s1, s2 and s3 are aligned either on a

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -161,13 +161,54 @@ template<> inline int distance<File>(Square x, Square y) { return distance(file_
 template<> inline int distance<Rank>(Square x, Square y) { return distance(rank_of(x), rank_of(y)); }
 
 
-/// attacks_bb() returns a bitboard representing all the squares attacked by a sliding
-/// piece of type Pt (bishop or rook) placed on 's'.
+/// attacks_bb() returns a bitboard representing all the squares attacked by a
+/// piece of type Pt (bishop or rook) placed on 's'. The helper magic_index()
+/// looks up the index using the 'magic bitboards' approach.
+template<PieceType Pt>
+inline unsigned magic_index(Square s, Bitboard occupied) {
+
+  extern Bitboard RookMasks[SQUARE_NB];
+  extern Bitboard RookMagics[SQUARE_NB];
+  extern unsigned RookShifts[SQUARE_NB];
+  extern Bitboard BishopMasks[SQUARE_NB];
+  extern Bitboard BishopMagics[SQUARE_NB];
+  extern unsigned BishopShifts[SQUARE_NB];
+
+  Bitboard* const Masks  = Pt == ROOK ? RookMasks  : BishopMasks;
+  Bitboard* const Magics = Pt == ROOK ? RookMagics : BishopMagics;
+  unsigned* const Shifts = Pt == ROOK ? RookShifts : BishopShifts;
+
+  if (HasPext)
+      return unsigned(pext(occupied, Masks[s]));
+
+  if (Is64Bit)
+      return unsigned(((occupied & Masks[s]) * Magics[s]) >> Shifts[s]);
+
+  unsigned lo = unsigned(occupied) & unsigned(Masks[s]);
+  unsigned hi = unsigned(occupied >> 32) & unsigned(Masks[s] >> 32);
+  return (lo * unsigned(Magics[s]) ^ hi * unsigned(Magics[s] >> 32)) >> Shifts[s];
+}
 
 template<PieceType Pt>
-Bitboard attacks_bb(Square s, Bitboard occupied);
+inline Bitboard attacks_bb(Square s, Bitboard occupied) {
 
-Bitboard attacks_bb(Piece pc, Square s, Bitboard occupied);
+  extern Bitboard* RookAttacks[SQUARE_NB];
+  extern Bitboard* BishopAttacks[SQUARE_NB];
+
+  return (Pt == ROOK ? RookAttacks : BishopAttacks)[s][magic_index<Pt>(s, occupied)];
+}
+
+inline Bitboard attacks_bb(Piece pc, Square s, Bitboard occupied) {
+
+  switch (type_of(pc))
+  {
+  case BISHOP: return attacks_bb<BISHOP>(s, occupied);
+  case ROOK  : return attacks_bb<ROOK>(s, occupied);
+  case QUEEN : return attacks_bb<BISHOP>(s, occupied) | attacks_bb<ROOK>(s, occupied);
+  default    : return StepAttacksBB[pc][s];
+  }
+}
+
 
 /// popcount() counts the number of non-zero bits in a bitboard
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -274,7 +274,7 @@ namespace {
                          : pos.attacks_from<Pt>(s);
 
         if (ei.pinnedPieces[Us] & s)
-            b &= LineBB[pos.square<KING>(Us)][s];
+            b &= line(pos.square<KING>(Us), s);
 
         ei.attackedBy2[Us] |= ei.attackedBy[Us][ALL_PIECES] & b;
         ei.attackedBy[Us][ALL_PIECES] |= ei.attackedBy[Us][Pt] |= b;

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -378,7 +378,7 @@ ExtMove* generate<EVASIONS>(const Position& pos, ExtMove* moveList) {
   while (sliders)
   {
       Square checksq = pop_lsb(&sliders);
-      sliderAttacks |= LineBB[checksq][ksq] ^ checksq;
+      sliderAttacks |= line(checksq, ksq) ^ checksq;
   }
 
   // Generate evasions for king, capture and non capture moves

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -547,7 +547,7 @@ bool Position::legal(Move m) const {
   // A non-king move is legal if and only if it is not pinned or it
   // is moving along the ray towards or away from the king.
   return   !(pinned_pieces(us) & from)
-        ||  aligned(from, to_sq(m), square<KING>(us));
+        ||  (line(from, to_sq(m)) & square<KING>(us));
 }
 
 
@@ -639,7 +639,7 @@ bool Position::gives_check(Move m) const {
 
   // Is there a discovered check?
   if (   (discovered_check_candidates() & from)
-      && !aligned(from, to, square<KING>(~sideToMove)))
+      && !(line(from, to) & square<KING>(~sideToMove)))
       return true;
 
   switch (type_of(m))


### PR DESCRIPTION
- prevents abuse: bitboards cannot be used directly in foreign code.
- reduces pollution of the global namespace.