### PR TITLE
Use consistent variable names for counterMoveStats

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -143,17 +143,17 @@ void MovePicker::score<QUIETS>() {
   const HistoryStats& history = pos.this_thread()->history;
   const FromToStats& fromTo = pos.this_thread()->fromTo;
 
-  const CounterMoveStats* cm = (ss-1)->counterMoves;
-  const CounterMoveStats* fm = (ss-2)->counterMoves;
-  const CounterMoveStats* f2 = (ss-4)->counterMoves;
+  const CounterMoveStats* cmh = (ss-1)->counterMoves;
+  const CounterMoveStats* fmh = (ss-2)->counterMoves;
+  const CounterMoveStats* fmh2 = (ss-4)->counterMoves;
 
   Color c = pos.side_to_move();
 
   for (auto& m : *this)
-      m.value =      history[pos.moved_piece(m)][to_sq(m)]
-               + (cm ? (*cm)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
-               + (fm ? (*fm)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
-               + (f2 ? (*f2)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
+      m.value =          history[pos.moved_piece(m)][to_sq(m)]
+               + (cmh  ?  (*cmh)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
+               + (fmh  ?  (*fmh)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
+               + (fmh2 ? (*fmh2)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
                + fromTo.get(c, m);
 }
 


### PR DESCRIPTION
unifies naming in movepick and search, by adopting the latter convention (cmh,fmh,fmh2).

No functional change.