### PR TITLE
Countermoves initialisation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) {
   Threads.init();
   Tablebases::init(Options["SyzygyPath"]);
   TT.resize(Options["Hash"]);
-
+  Search::clear();
   UCI::loop(argc, argv);
 
   Threads.exit();


### PR DESCRIPTION
Make sure the countermove tables are always initialized to SCORE_ZERO as they should.
Same bench.

Currently, at the engine start, if we call a setposition and start analyzing right away,
the tables exists but are not initialized, and therefore, in this scenario, some unnecessary pruning is done at step 13 in search.cpp

