### PR TITLE
initialize previousScore in constructor.

### DIFF
--- a/src/thread.h
+++ b/src/thread.h
@@ -79,6 +79,7 @@ public:
 /// MainThread is a derived class with a specific overload for the main thread
 
 struct MainThread : public Thread {
+  MainThread() { previousScore = VALUE_INFINITE; }
   virtual void search();
 
   bool easyMovePlayed, failedLow;


### PR DESCRIPTION
It can be used uninitialized in time management. Uses the same value as set by Search::clear().
Fixes all valgrind errors on './stockfish go wtime 8000 btime 8000 winc 500 binc 500'

No functional change.