### PR TITLE
Simplified select best thread

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -316,8 +316,7 @@ void MainThread::search() {
           Depth depthDiff = th->completedDepth - bestThread->completedDepth;
           Value scoreDiff = th->rootMoves[0].score - bestThread->rootMoves[0].score;
 
-          if (   (depthDiff > 0 && scoreDiff >= 0)
-              || (scoreDiff > 0 && depthDiff >= 0))
+          if (scoreDiff > 0 && depthDiff >= 0)
               bestThread = th;
       }
   }


### PR DESCRIPTION
Only select best thread if score is better and depth equal or larger.

STC (7 threads): http://tests.stockfishchess.org/tests/view/586a4d090ebc5903140c64b2
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 120297 W: 18652 L: 18682 D: 82963

LTC (7 threads): http://tests.stockfishchess.org/tests/view/586e31b30ebc5903140c663d
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 57187 W: 7035 L: 6959 D: 43193