### PR TITLE
Rename FromTo -> History

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -140,7 +140,7 @@ void MovePicker::score<CAPTURES>() {
 template<>
 void MovePicker::score<QUIETS>() {
 
-  const FromToStats& fromTo = pos.this_thread()->fromTo;
+  const HistoryStats& history = pos.this_thread()->history;
 
   const CounterMoveStats* cmh = (ss-1)->counterMoves;
   const CounterMoveStats* fmh = (ss-2)->counterMoves;
@@ -152,21 +152,21 @@ void MovePicker::score<QUIETS>() {
       m.value =  (cmh  ?  (*cmh)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
                + (fmh  ?  (*fmh)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
                + (fmh2 ? (*fmh2)[pos.moved_piece(m)][to_sq(m)] : VALUE_ZERO)
-               + fromTo.get(c, m);
+               + history.get(c, m);
 }
 
 template<>
 void MovePicker::score<EVASIONS>() {
   // Try captures ordered by MVV/LVA, then non-captures ordered by stats heuristics
-  const FromToStats& fromTo = pos.this_thread()->fromTo;
+  const HistoryStats& history = pos.this_thread()->history;
   Color c = pos.side_to_move();
 
   for (auto& m : *this)
       if (pos.capture(m))
           m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
-                   - Value(type_of(pos.moved_piece(m))) + FromToStats::Max;
+                   - Value(type_of(pos.moved_piece(m))) + HistoryStats::Max;
       else
-          m.value = fromTo.get(c, m);
+          m.value = history.get(c, m);
 }
 
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -212,7 +212,7 @@ void Search::clear() {
   for (Thread* th : Threads)
   {
       th->counterMoves.clear();
-      th->fromTo.clear();
+      th->history.clear();
       th->counterMoveHistory.clear();
       th->resetCalls = true;
   }
@@ -985,7 +985,7 @@ moves_loop: // When in check search starts from here
               ss->history =  (cmh  ? (*cmh )[moved_piece][to_sq(move)] : VALUE_ZERO)
                            + (fmh  ? (*fmh )[moved_piece][to_sq(move)] : VALUE_ZERO)
                            + (fmh2 ? (*fmh2)[moved_piece][to_sq(move)] : VALUE_ZERO)
-                           + thisThread->fromTo.get(~pos.side_to_move(), move)
+                           + thisThread->history.get(~pos.side_to_move(), move)
                            - 8000; // Correction factor
 
               // Decrease/increase reduction by comparing opponent's stat score
@@ -1415,7 +1415,7 @@ moves_loop: // When in check search starts from here
 
     Color c = pos.side_to_move();
     Thread* thisThread = pos.this_thread();
-    thisThread->fromTo.update(c, move, bonus);
+    thisThread->history.update(c, move, bonus);
     update_cm_stats(ss, pos.moved_piece(move), to_sq(move), bonus);
 
     if ((ss-1)->counterMoves)
@@ -1427,7 +1427,7 @@ moves_loop: // When in check search starts from here
     // Decrease all the other played quiet moves
     for (int i = 0; i < quietsCnt; ++i)
     {
-        thisThread->fromTo.update(c, quiets[i], -bonus);
+        thisThread->history.update(c, quiets[i], -bonus);
         update_cm_stats(ss, pos.moved_piece(quiets[i]), to_sq(quiets[i]), -bonus);
     }
   }

--- a/src/thread.h
+++ b/src/thread.h
@@ -70,7 +70,7 @@ public:
   Depth completedDepth;
   std::atomic_bool resetCalls;
   MoveStats counterMoves;
-  FromToStats fromTo;
+  HistoryStats history;
   CounterMoveHistoryStats counterMoveHistory;
 };
 


### PR DESCRIPTION
Previously, we had duplicated History:
- one with (piece,to) called History
- one with (from,to) called FromTo

Now that we have only one, rename it to History, which is the generally accepted
name in the chess programming litterature for this technique.

Also correct some comments that had not been updated since the introduction of CMH.

No functional change.