### PR TITLE
StormDanger CleanUp

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -52,7 +52,8 @@ namespace {
     S(17, 16), S(33, 32), S(0, 0), S(0, 0)
   };
 
-  // Weakness of our pawn shelter in front of the king by [distance from edge][rank]
+  // Weakness of our pawn shelter in front of the king by [distance from edge][rank].
+  // RANK_1 = 0 is used for files where we have no pawns, or where our pawn is behind our king.
   const Value ShelterWeakness[][RANK_NB] = {
     { V(100), V(20), V(10), V(46), V(82), V( 86), V( 98) },
     { V(116), V( 4), V(28), V(87), V(94), V(108), V(104) },
@@ -60,25 +61,26 @@ namespace {
     { V( 75), V(12), V(43), V(59), V(90), V( 84), V(112) }
   };
 
-  // Danger of enemy pawns moving toward our king by [type][distance from edge][rank]
+  // Danger of enemy pawns moving toward our king by [type][distance from edge][rank].
+  // For the unopposed and unblocked cases, RANK_1 = 0 is used when opponent has no pawn
+  // on the given file, or his pawn his behind our king.
   const Value StormDanger[][4][RANK_NB] = {
-    { { V( 4),  V(  73), V( 132), V(46), V(31) },
+    { { V( 0),  V(-290), V(-274), V(57), V(41) },  //BlockedByKing
+      { V( 0),  V(  60), V( 144), V(39), V(13) },
+      { V( 0),  V(  65), V( 141), V(41), V(34) },
+      { V( 0),  V(  53), V( 127), V(56), V(14) } },
+    { { V( 4),  V(  73), V( 132), V(46), V(31) },  //Unopposed
       { V( 1),  V(  64), V( 143), V(26), V(13) },
       { V( 1),  V(  47), V( 110), V(44), V(24) },
       { V( 0),  V(  72), V( 127), V(50), V(31) } },
-    { { V(22),  V(  45), V( 104), V(62), V( 6) },
-      { V(31),  V(  30), V(  99), V(39), V(19) },
-      { V(23),  V(  29), V(  96), V(41), V(15) },
-      { V(21),  V(  23), V( 116), V(41), V(15) } },
-    { { V( 0),  V(   0), V(  79), V(23), V( 1) },
+    { { V( 0),  V(   0), V(  79), V(23), V( 1) },  //BlockedByPawn
       { V( 0),  V(   0), V( 148), V(27), V( 2) },
       { V( 0),  V(   0), V( 161), V(16), V( 1) },
       { V( 0),  V(   0), V( 171), V(22), V(15) } },
-    { { V( 0),  V(-290), V(-274), V(57), V(41) },
-      { V( 0),  V(  60), V( 144), V(39), V(13) },
-      { V( 0),  V(  65), V( 141), V(41), V(34) },
-      { V( 0),  V(  53), V( 127), V(56), V(14) } }
-
+    { { V(22),  V(  45), V( 104), V(62), V( 6) },  //Unblocked
+      { V(31),  V(  30), V(  99), V(39), V(19) },
+      { V(23),  V(  29), V(  96), V(41), V(15) },
+      { V(21),  V(  23), V( 116), V(41), V(15) } }
   };
 
   // Max bonus for king safety. Corresponds to start position with all the pawns
@@ -224,14 +226,14 @@ Entry* probe(const Position& pos) {
 
 
 /// Entry::shelter_storm() calculates shelter and storm penalties for the file
-/// the king is on, as well as the two adjacent files.
+/// the king is on, as well as the two closest files.
 
 template<Color Us>
 Value Entry::shelter_storm(const Position& pos, Square ksq) {
 
   const Color Them = (Us == WHITE ? BLACK : WHITE);
 
-  enum { NoFriendlyPawn, Unblocked, BlockedByPawn, BlockedByKing };
+  enum { BlockedByKing, Unopposed, BlockedByPawn, Unblocked };
 
   Bitboard b = pos.pieces(PAWN) & (in_front_bb(Us, rank_of(ksq)) | rank_bb(ksq));
   Bitboard ourPawns = b & pos.pieces(Us);
@@ -250,7 +252,7 @@ Value Entry::shelter_storm(const Position& pos, Square ksq) {
       safety -=  ShelterWeakness[std::min(f, FILE_H - f)][rkUs]
                + StormDanger
                  [f == file_of(ksq) && rkThem == relative_rank(Us, ksq) + 1 ? BlockedByKing  :
-                  rkUs   == RANK_1                                          ? NoFriendlyPawn :
+                  rkUs   == RANK_1                                          ? Unopposed :
                   rkThem == rkUs + 1                                        ? BlockedByPawn  : Unblocked]
                  [std::min(f, FILE_H - f)][rkThem];
   }


### PR DESCRIPTION
Order the enum and the array the same way they appear around line 250-255
Makes it much easier to follow.

Add comments in the array definition and critical rows.
Use same terminology as elsewhere in pawns.cpp

No functional change. bench: 5920493