### PR TITLE
Check for overflow in Score * int multiplication (obsolete)

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -285,19 +285,19 @@ inline Value mg_value(Score s) {
 #define ENABLE_BASE_OPERATORS_ON(T)                             \
 inline T operator+(T d1, T d2) { return T(int(d1) + int(d2)); } \
 inline T operator-(T d1, T d2) { return T(int(d1) - int(d2)); } \
-inline T operator*(int i, T d) { return T(i * int(d)); }        \
-inline T operator*(T d, int i) { return T(int(d) * i); }        \
 inline T operator-(T d) { return T(-int(d)); }                  \
 inline T& operator+=(T& d1, T d2) { return d1 = d1 + d2; }      \
 inline T& operator-=(T& d1, T d2) { return d1 = d1 - d2; }      \
-inline T& operator*=(T& d, int i) { return d = T(int(d) * i); }
 
 #define ENABLE_FULL_OPERATORS_ON(T)                             \
 ENABLE_BASE_OPERATORS_ON(T)                                     \
+inline T operator*(int i, T d) { return T(i * int(d)); }        \
+inline T operator*(T d, int i) { return T(int(d) * i); }        \
 inline T& operator++(T& d) { return d = T(int(d) + 1); }        \
 inline T& operator--(T& d) { return d = T(int(d) - 1); }        \
 inline T operator/(T d, int i) { return T(int(d) / i); }        \
 inline int operator/(T d1, T d2) { return int(d1) / int(d2); }  \
+inline T& operator*=(T& d, int i) { return d = T(int(d) * i); } \
 inline T& operator/=(T& d, int i) { return d = T(int(d) / i); }
 
 ENABLE_FULL_OPERATORS_ON(Value)
@@ -327,6 +327,17 @@ inline Score operator*(Score s1, Score s2);
 /// Division of a Score must be handled separately for each term
 inline Score operator/(Score s, int i) {
   return make_score(mg_value(s) / i, eg_value(s) / i);
+}
+
+/// Multiplication of a Score by an integer. We check for overflow in debug mode.
+inline Score operator*(Score s, int i) {
+  Score result = Score(int(s) * i);
+
+  assert( eg_value(result) == (i * eg_value(s)));
+  assert( mg_value(result) == (i * mg_value(s)));
+  assert( (i == 0) || (result / i) == s );
+
+  return result;
 }
 
 inline Color operator~(Color c) {


### PR DESCRIPTION
Add asserts to check for overflow in Score * int multiplication.

There is no overflow in current master, but it would be easy to
create one as the scale of the current evals do not leave much
spare bits. For instance, adding the following unused variables
in master at the end of evaluate() (line 882 of evaluate.cpp)
overflows:

Score s1 = score * 4;  // no overflow
Score s2 = score * 5;  // overflow

Assertion failed: (eg_value(result) == (i * eg_value(s))),
                  function operator*, file ./types.h, line 336.

Same md5 checksum as current master for non debug compiles.

No functional change