### PR TITLE
Travis: fix bench fetch in case of PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
   # checking bench for various build types
   #
   # obtain reference from git log
-  - git log | grep "\b[Bb]ench[ :]\+[0-9]\{7\}" | head -n 1 | sed "s/[^0-9]*\([0-9][0-9]*\)/\1/g" > git_sig
+  - git log HEAD | grep "\b[Bb]ench[ :]\+[0-9]\{7\}" | head -n 1 | sed "s/[^0-9]*\([0-9][0-9]*\)/\1/g" > git_sig
   - export benchref=$(cat git_sig)
   - echo "Reference bench:" $benchref
   # verify against reference


### PR DESCRIPTION
When Travis tests a PR, a commit merge is created
but master is not updated.

Simulate a dummy bench here, for testing the fix.

bench: 9999999