### PR TITLE
Removing CM parameter from the Stats struct.

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -60,7 +60,7 @@ private:
 /// Entries are stored using only the moving piece and destination square, hence
 /// two moves with different origin but same destination and piece will be
 /// considered identical.
-template<typename T, bool CM = false>
+template<typename T>
 struct Stats {
   const T* operator[](Piece pc) const { return table[pc]; }
   T* operator[](Piece pc) { return table[pc]; }
@@ -71,7 +71,7 @@ struct Stats {
     if (abs(int(v)) >= 324)
         return;
 
-    table[pc][to] -= table[pc][to] * abs(int(v)) / (CM ? 936 : 324);
+    table[pc][to] -= table[pc][to] * abs(int(v)) / 936;
     table[pc][to] += int(v) * 32;
   }
 
@@ -80,7 +80,7 @@ private:
 };
 
 typedef Stats<Move> MoveStats;
-typedef Stats<Value, true> CounterMoveStats;
+typedef Stats<Value> CounterMoveStats;
 typedef Stats<CounterMoveStats> CounterMoveHistoryStats;
 
 


### PR DESCRIPTION
After the history simplifications, we are only using Value Stats for CounterMoveHistory table. Therefore the parameter CM is not necessary.

