### PR TITLE
Using std

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -21,7 +21,6 @@
 #include <fstream>
 #include <iostream>
 #include <istream>
-#include <vector>
 
 #include "misc.h"
 #include "position.h"

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -30,7 +30,7 @@
 
 namespace {
 
-const std::vector<std::string> Defaults = {
+const vector<string> Defaults = {
   "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
   "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 10",
   "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 11",
@@ -95,16 +95,16 @@ const std::vector<std::string> Defaults = {
 
 void benchmark(const Position& current, std::istream& is) {
 
-  std::string token;
-  std::vector<std::string> fens;
+  string token;
+  vector<string> fens;
   Search::LimitsType limits;
 
   // Assign default values to missing arguments
-  std::string ttSize    = (is >> token) ? token : "16";
-  std::string threads   = (is >> token) ? token : "1";
-  std::string limit     = (is >> token) ? token : "13";
-  std::string fenFile   = (is >> token) ? token : "default";
-  std::string limitType = (is >> token) ? token : "depth";
+  string ttSize    = (is >> token) ? token : "16";
+  string threads   = (is >> token) ? token : "1";
+  string limit     = (is >> token) ? token : "13";
+  string fenFile   = (is >> token) ? token : "default";
+  string limitType = (is >> token) ? token : "depth";
 
   Options["Hash"]    = ttSize;
   Options["Threads"] = threads;
@@ -130,7 +130,7 @@ void benchmark(const Position& current, std::istream& is) {
 
   else
   {
-      std::string fen;
+      string fen;
       std::ifstream file(fenFile);
 
       if (!file.is_open())

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -28,11 +28,9 @@
 #include "thread.h"
 #include "uci.h"
 
-using namespace std;
-
 namespace {
 
-const vector<string> Defaults = {
+const std::vector<std::string> Defaults = {
   "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
   "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 10",
   "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 11",
@@ -95,18 +93,18 @@ const vector<string> Defaults = {
 /// format (defaults are the positions defined above) and the type of the
 /// limit value: depth (default), time in millisecs or number of nodes.
 
-void benchmark(const Position& current, istream& is) {
+void benchmark(const Position& current, std::istream& is) {
 
-  string token;
-  vector<string> fens;
+  std::string token;
+  std::vector<std::string> fens;
   Search::LimitsType limits;
 
   // Assign default values to missing arguments
-  string ttSize    = (is >> token) ? token : "16";
-  string threads   = (is >> token) ? token : "1";
-  string limit     = (is >> token) ? token : "13";
-  string fenFile   = (is >> token) ? token : "default";
-  string limitType = (is >> token) ? token : "depth";
+  std::string ttSize    = (is >> token) ? token : "16";
+  std::string threads   = (is >> token) ? token : "1";
+  std::string limit     = (is >> token) ? token : "13";
+  std::string fenFile   = (is >> token) ? token : "default";
+  std::string limitType = (is >> token) ? token : "depth";
 
   Options["Hash"]    = ttSize;
   Options["Threads"] = threads;
@@ -132,12 +130,12 @@ void benchmark(const Position& current, istream& is) {
 
   else
   {
-      string fen;
-      ifstream file(fenFile);
+      std::string fen;
+      std::ifstream file(fenFile);
 
       if (!file.is_open())
       {
-          cerr << "Unable to open file " << fenFile << endl;
+          std::cerr << "Unable to open file " << fenFile << std::endl;
           return;
       }
 
@@ -157,7 +155,7 @@ void benchmark(const Position& current, istream& is) {
       StateListPtr states(new std::deque<StateInfo>(1));
       pos.set(fens[i], Options["UCI_Chess960"], &states->back(), Threads.main());
 
-      cerr << "\nPosition: " << i + 1 << '/' << fens.size() << endl;
+      std::cerr << "\nPosition: " << i + 1 << '/' << fens.size() << std::endl;
 
       if (limitType == "perft")
           nodes += Search::perft(pos, limits.depth * ONE_PLY);
@@ -175,8 +173,8 @@ void benchmark(const Position& current, istream& is) {
 
   dbg_print(); // Just before exiting
 
-  cerr << "\n==========================="
-       << "\nTotal time (ms) : " << elapsed
-       << "\nNodes searched  : " << nodes
-       << "\nNodes/second    : " << 1000 * nodes / elapsed << endl;
+  std::cerr << "\n==========================="
+            << "\nTotal time (ms) : " << elapsed
+            << "\nNodes searched  : " << nodes
+            << "\nNodes/second    : " << 1000 * nodes / elapsed << std::endl;
 }

--- a/src/bitbase.cpp
+++ b/src/bitbase.cpp
@@ -18,9 +18,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <cassert>
-#include <vector>
-
 #include "bitboard.h"
 #include "types.h"
 

--- a/src/bitbase.cpp
+++ b/src/bitbase.cpp
@@ -55,10 +55,10 @@ namespace {
     KPKPosition() = default;
     explicit KPKPosition(unsigned idx);
     operator Result() const { return result; }
-    Result classify(const std::vector<KPKPosition>& db)
+    Result classify(const vector<KPKPosition>& db)
     { return us == WHITE ? classify<WHITE>(db) : classify<BLACK>(db); }
 
-    template<Color Us> Result classify(const std::vector<KPKPosition>& db);
+    template<Color Us> Result classify(const vector<KPKPosition>& db);
 
     Color us;
     Square ksq[COLOR_NB], psq;
@@ -79,7 +79,7 @@ bool Bitbases::probe(Square wksq, Square wpsq, Square bksq, Color us) {
 
 void Bitbases::init() {
 
-  std::vector<KPKPosition> db(MAX_INDEX);
+  vector<KPKPosition> db(MAX_INDEX);
   unsigned idx, repeat = 1;
 
   // Initialize db with known win / draw positions
@@ -135,7 +135,7 @@ namespace {
   }
 
   template<Color Us>
-  Result KPKPosition::classify(const std::vector<KPKPosition>& db) {
+  Result KPKPosition::classify(const vector<KPKPosition>& db) {
 
     // White to move: If one move leads to a position classified as WIN, the result
     // of the current position is WIN. If all moves lead to positions classified

--- a/src/bitbase.cpp
+++ b/src/bitbase.cpp
@@ -18,9 +18,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
 #include <cassert>
-#include <numeric>
 #include <vector>
 
 #include "bitboard.h"

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -18,8 +18,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
-
 #include "bitboard.h"
 #include "misc.h"
 

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -128,9 +128,9 @@ Square msb(Bitboard b) {
 /// Bitboards::pretty() returns an ASCII representation of a bitboard suitable
 /// to be printed to standard output. Useful for debugging.
 
-const std::string Bitboards::pretty(Bitboard b) {
+const string Bitboards::pretty(Bitboard b) {
 
-  std::string s = "+---+---+---+---+---+---+---+---+\n";
+  string s = "+---+---+---+---+---+---+---+---+\n";
 
   for (Rank r = RANK_8; r >= RANK_1; --r)
   {
@@ -185,7 +185,7 @@ void Bitboards::init() {
       for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2)
           if (s1 != s2)
           {
-              SquareDistance[s1][s2] = std::max(distance<File>(s1, s2), distance<Rank>(s1, s2));
+              SquareDistance[s1][s2] = max(distance<File>(s1, s2), distance<Rank>(s1, s2));
               DistanceRingBB[s1][SquareDistance[s1][s2] - 1] |= s2;
           }
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -21,8 +21,6 @@
 #ifndef BITBOARD_H_INCLUDED
 #define BITBOARD_H_INCLUDED
 
-#include <string>
-
 #include "types.h"
 
 namespace Bitbases {

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -33,7 +33,7 @@ bool probe(Square wksq, Square wpsq, Square bksq, Color us);
 namespace Bitboards {
 
 void init();
-const std::string pretty(Bitboard b);
+const string pretty(Bitboard b);
 
 }
 

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -18,10 +18,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
-#include <cassert>
-
-#include "bitboard.h"
 #include "endgame.h"
 #include "movegen.h"
 

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -105,7 +105,7 @@ Endgames::Endgames() {
 
 
 template<EndgameType E, typename T>
-void Endgames::add(const std::string& code) {
+void Endgames::add(const string& code) {
   StateInfo st;
   map<T>()[Position().set(code, WHITE, &st).material_key()] = std::unique_ptr<EndgameBase<T>>(new Endgame<E>(WHITE));
   map<T>()[Position().set(code, BLACK, &st).material_key()] = std::unique_ptr<EndgameBase<T>>(new Endgame<E>(BLACK));
@@ -139,7 +139,7 @@ Value Endgame<KXK>::operator()(const Position& pos) const {
       ||(pos.count<BISHOP>(strongSide) && pos.count<KNIGHT>(strongSide))
       ||(pos.count<BISHOP>(strongSide) > 1 && opposite_colors(pos.squares<BISHOP>(strongSide)[0],
                                                               pos.squares<BISHOP>(strongSide)[1])))
-      result = std::min(result + VALUE_KNOWN_WIN, VALUE_MATE_IN_MAX_PLY - 1);
+      result = min(result + VALUE_KNOWN_WIN, VALUE_MATE_IN_MAX_PLY - 1);
 
   return strongSide == pos.side_to_move() ? result : -result;
 }
@@ -573,7 +573,7 @@ ScaleFactor Endgame<KRPPKRP>::operator()(const Position& pos) const {
   if (pos.pawn_passed(strongSide, wpsq1) || pos.pawn_passed(strongSide, wpsq2))
       return SCALE_FACTOR_NONE;
 
-  Rank r = std::max(relative_rank(strongSide, wpsq1), relative_rank(strongSide, wpsq2));
+  Rank r = max(relative_rank(strongSide, wpsq1), relative_rank(strongSide, wpsq2));
 
   if (   distance<File>(bksq, wpsq1) <= 1
       && distance<File>(bksq, wpsq2) <= 1

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -21,8 +21,6 @@
 #include "endgame.h"
 #include "movegen.h"
 
-using std::string;
-
 namespace {
 
   // Table used to drive the king towards the edge of the board
@@ -107,7 +105,7 @@ Endgames::Endgames() {
 
 
 template<EndgameType E, typename T>
-void Endgames::add(const string& code) {
+void Endgames::add(const std::string& code) {
   StateInfo st;
   map<T>()[Position().set(code, WHITE, &st).material_key()] = std::unique_ptr<EndgameBase<T>>(new Endgame<E>(WHITE));
   map<T>()[Position().set(code, BLACK, &st).material_key()] = std::unique_ptr<EndgameBase<T>>(new Endgame<E>(BLACK));

--- a/src/endgame.h
+++ b/src/endgame.h
@@ -101,7 +101,7 @@ class Endgames {
   template<typename T> using Map = std::map<Key, std::unique_ptr<EndgameBase<T>>>;
 
   template<EndgameType E, typename T = eg_type<E>>
-  void add(const std::string& code);
+  void add(const string& code);
 
   template<typename T>
   Map<T>& map() {

--- a/src/endgame.h
+++ b/src/endgame.h
@@ -22,7 +22,6 @@
 #define ENDGAME_H_INCLUDED
 
 #include <map>
-#include <string>
 #include <type_traits>
 
 #include "position.h"

--- a/src/endgame.h
+++ b/src/endgame.h
@@ -22,10 +22,8 @@
 #define ENDGAME_H_INCLUDED
 
 #include <map>
-#include <memory>
 #include <string>
 #include <type_traits>
-#include <utility>
 
 #include "position.h"
 #include "types.h"

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -416,7 +416,7 @@ namespace {
         // number and types of the enemy's attacking pieces, the number of
         // attacked and undefended squares around our king and the quality of
         // the pawn shelter (current 'score' value).
-        kingDanger =  std::min(807, ei.kingAttackersCount[Them] * ei.kingAttackersWeight[Them])
+        kingDanger =  min(807, ei.kingAttackersCount[Them] * ei.kingAttackersWeight[Them])
                     + 101 * ei.kingAdjacentZoneAttacksCount[Them]
                     + 235 * popcount(undefended)
                     + 134 * (popcount(b) + !!ei.pinnedPieces[Us])
@@ -475,7 +475,7 @@ namespace {
 
         // Compute the king danger score and subtract it from the evaluation
         if (kingDanger > 0)
-            score -= make_score(std::min(kingDanger * kingDanger / 4096,  2 * int(BishopValueMg)), 0);
+            score -= make_score(min(kingDanger * kingDanger / 4096,  2 * int(BishopValueMg)), 0);
     }
 
     // King tropism: firstly, find squares that opponent attacks in our king flank
@@ -718,7 +718,7 @@ namespace {
 
     // ...count safe + (behind & safe) with a single popcount
     int bonus = popcount((Us == WHITE ? safe << 32 : safe >> 32) | (behind & safe));
-    bonus = std::min(16, bonus);
+    bonus = min(16, bonus);
     int weight = pos.count<ALL_PIECES>(Us) - 2 * ei.pi->open_files();
 
     return make_score(bonus * weight * weight / 18, 0);
@@ -740,7 +740,7 @@ namespace {
     // Now apply the bonus: note that we find the attacking side by extracting
     // the sign of the endgame value, and that we carefully cap the bonus so
     // that the endgame score will never be divided by more than two.
-    int value = ((eg > 0) - (eg < 0)) * std::max(initiative, -abs(eg / 2));
+    int value = ((eg > 0) - (eg < 0)) * max(initiative, -abs(eg / 2));
 
     return make_score(0, value);
   }
@@ -909,9 +909,9 @@ template Value Eval::evaluate<false>(const Position&);
 /// a string (suitable for outputting to stdout) that contains the detailed
 /// descriptions and values of each evaluation term. Useful for debugging.
 
-std::string Eval::trace(const Position& pos) {
+string Eval::trace(const Position& pos) {
 
-  std::memset(scores, 0, sizeof(scores));
+  memset(scores, 0, sizeof(scores));
 
   Value v = evaluate<true>(pos);
   v = pos.side_to_move() == WHITE ? v : -v; // White's point of view

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -18,9 +18,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
-#include <cassert>
-#include <cstring>   // For std::memset
 #include <iomanip>
 #include <sstream>
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -21,8 +21,6 @@
 #ifndef EVALUATE_H_INCLUDED
 #define EVALUATE_H_INCLUDED
 
-#include <string>
-
 #include "types.h"
 
 class Position;

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -29,7 +29,7 @@ namespace Eval {
 
 const Value Tempo = Value(20); // Must be visible to search
 
-std::string trace(const Position& pos);
+string trace(const Position& pos);
 
 template<bool DoTrace = false>
 Value evaluate(const Position& pos);

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -18,10 +18,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <algorithm> // For std::min
-#include <cassert>
-#include <cstring>   // For std::memset
-
 #include "material.h"
 #include "thread.h"
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -21,8 +21,6 @@
 #include "material.h"
 #include "thread.h"
 
-using namespace std;
-
 namespace {
 
   // Polynomial material imbalance parameters

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -120,7 +120,7 @@ Entry* probe(const Position& pos) {
   if (e->key == key)
       return e;
 
-  std::memset(e, 0, sizeof(Entry));
+  memset(e, 0, sizeof(Entry));
   e->key = key;
   e->factor[WHITE] = e->factor[BLACK] = (uint8_t)SCALE_FACTOR_NORMAL;
   e->gamePhase = pos.game_phase();

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -48,7 +48,7 @@ namespace {
 
 /// Version number. If Version is left empty, then compile date in the format
 /// DD-MM-YY and show in engine_info.
-const std::string Version = "";
+const string Version = "";
 
 /// Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 /// cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We
@@ -87,7 +87,7 @@ class Logger {
   Tie in, out;
 
 public:
-  static void start(const std::string& fname) {
+  static void start(const string& fname) {
 
     static Logger l;
 
@@ -113,10 +113,10 @@ public:
 /// the program was compiled) or "Stockfish <Version>", depending on whether
 /// Version is empty.
 
-const std::string engine_info(bool to_uci) {
+const string engine_info(bool to_uci) {
 
-  const std::string months("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec");
-  std::string month, day, year;
+  const string months("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec");
+  string month, day, year;
   std::stringstream ss, date(__DATE__); // From compiler, format is "Sep 21 2008"
 
   ss << "Stockfish " << Version << std::setfill('0');
@@ -173,7 +173,7 @@ std::ostream& operator<<(std::ostream& os, SyncCout sc) {
 
 
 /// Trampoline helper to avoid moving Logger to misc.h
-void start_logger(const std::string& fname) { Logger::start(fname); }
+void start_logger(const string& fname) { Logger::start(fname); }
 
 
 /// prefetch() preloads the given address in L1/L2 cache. This is a non-blocking
@@ -260,7 +260,7 @@ int get_group(size_t idx) {
 
   free(buffer);
 
-  std::vector<int> groups;
+  vector<int> groups;
 
   // Run as many threads as possible on the same node until core limit is
   // reached, then move on filling the next node.

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -44,13 +44,11 @@ typedef bool(*fun3_t)(HANDLE, CONST GROUP_AFFINITY*, PGROUP_AFFINITY);
 #include "misc.h"
 #include "thread.h"
 
-using namespace std;
-
 namespace {
 
 /// Version number. If Version is left empty, then compile date in the format
 /// DD-MM-YY and show in engine_info.
-const string Version = "";
+const std::string Version = "";
 
 /// Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 /// cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We
@@ -58,16 +56,16 @@ const string Version = "";
 /// usual I/O functionality, all without changing a single line of code!
 /// Idea from http://groups.google.com/group/comp.lang.c++/msg/1d941c0f26ea0d81
 
-struct Tie: public streambuf { // MSVC requires split streambuf for cin and cout
+struct Tie: public std::streambuf { // MSVC requires split streambuf for cin and cout
 
-  Tie(streambuf* b, streambuf* l) : buf(b), logBuf(l) {}
+  Tie(std::streambuf* b, std::streambuf* l) : buf(b), logBuf(l) {}
 
   int sync() { return logBuf->pubsync(), buf->pubsync(); }
   int overflow(int c) { return log(buf->sputc((char)c), "<< "); }
   int underflow() { return buf->sgetc(); }
   int uflow() { return log(buf->sbumpc(), ">> "); }
 
-  streambuf *buf, *logBuf;
+  std::streambuf *buf, *logBuf;
 
   int log(int c, const char* prefix) {
 
@@ -82,10 +80,10 @@ struct Tie: public streambuf { // MSVC requires split streambuf for cin and cout
 
 class Logger {
 
-  Logger() : in(cin.rdbuf(), file.rdbuf()), out(cout.rdbuf(), file.rdbuf()) {}
+  Logger() : in(std::cin.rdbuf(), file.rdbuf()), out(std::cout.rdbuf(), file.rdbuf()) {}
  ~Logger() { start(""); }
 
-  ofstream file;
+  std::ofstream file;
   Tie in, out;
 
 public:
@@ -95,14 +93,14 @@ public:
 
     if (!fname.empty() && !l.file.is_open())
     {
-        l.file.open(fname, ifstream::out);
-        cin.rdbuf(&l.in);
-        cout.rdbuf(&l.out);
+        l.file.open(fname, std::ifstream::out);
+        std::cin.rdbuf(&l.in);
+        std::cout.rdbuf(&l.out);
     }
     else if (fname.empty() && l.file.is_open())
     {
-        cout.rdbuf(l.out.buf);
-        cin.rdbuf(l.in.buf);
+        std::cout.rdbuf(l.out.buf);
+        std::cin.rdbuf(l.in.buf);
         l.file.close();
     }
   }
@@ -115,18 +113,18 @@ public:
 /// the program was compiled) or "Stockfish <Version>", depending on whether
 /// Version is empty.
 
-const string engine_info(bool to_uci) {
+const std::string engine_info(bool to_uci) {
 
-  const string months("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec");
-  string month, day, year;
-  stringstream ss, date(__DATE__); // From compiler, format is "Sep 21 2008"
+  const std::string months("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec");
+  std::string month, day, year;
+  std::stringstream ss, date(__DATE__); // From compiler, format is "Sep 21 2008"
 
-  ss << "Stockfish " << Version << setfill('0');
+  ss << "Stockfish " << Version << std::setfill('0');
 
   if (Version.empty())
   {
       date >> month >> day >> year;
-      ss << setw(2) << day << setw(2) << (1 + months.find(month) / 4) << year.substr(2);
+      ss << std::setw(2) << day << std::setw(2) << (1 + months.find(month) / 4) << year.substr(2);
   }
 
   ss << (Is64Bit ? " 64" : "")
@@ -148,12 +146,12 @@ void dbg_mean_of(int v) { ++means[0]; means[1] += v; }
 void dbg_print() {
 
   if (hits[0])
-      cerr << "Total " << hits[0] << " Hits " << hits[1]
-           << " hit rate (%) " << 100 * hits[1] / hits[0] << endl;
+      std::cerr << "Total " << hits[0] << " Hits " << hits[1]
+                << " hit rate (%) " << 100 * hits[1] / hits[0] << std::endl;
 
   if (means[0])
-      cerr << "Total " << means[0] << " Mean "
-           << (double)means[1] / means[0] << endl;
+      std::cerr << "Total " << means[0] << " Mean "
+                << (double)means[1] / means[0] << std::endl;
 }
 
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -40,7 +40,6 @@ typedef bool(*fun3_t)(HANDLE, CONST GROUP_AFFINITY*, PGROUP_AFFINITY);
 #include <iomanip>
 #include <iostream>
 #include <sstream>
-#include <vector>
 
 #include "misc.h"
 #include "thread.h"

--- a/src/misc.h
+++ b/src/misc.h
@@ -21,11 +21,8 @@
 #ifndef MISC_H_INCLUDED
 #define MISC_H_INCLUDED
 
-#include <cassert>
 #include <chrono>
 #include <ostream>
-#include <string>
-#include <vector>
 
 #include "types.h"
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -26,9 +26,9 @@
 
 #include "types.h"
 
-const std::string engine_info(bool to_uci = false);
+const string engine_info(bool to_uci = false);
 void prefetch(void* addr);
-void start_logger(const std::string& fname);
+void start_logger(const string& fname);
 
 void dbg_hit_on(bool b);
 void dbg_hit_on(bool c, bool b);
@@ -47,7 +47,7 @@ struct HashTable {
   Entry* operator[](Key key) { return &table[(uint32_t)key & (Size - 1)]; }
 
 private:
-  std::vector<Entry> table = std::vector<Entry>(Size);
+  vector<Entry> table = vector<Entry>(Size);
 };
 
 

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -18,8 +18,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <cassert>
-
 #include "movegen.h"
 #include "position.h"
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -18,8 +18,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <cassert>
-
 #include "movepick.h"
 #include "thread.h"
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -21,9 +21,6 @@
 #ifndef MOVEPICK_H_INCLUDED
 #define MOVEPICK_H_INCLUDED
 
-#include <algorithm> // For std::max
-#include <cstring>   // For std::memset
-
 #include "movegen.h"
 #include "position.h"
 #include "types.h"

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -33,7 +33,7 @@ struct HistoryStats {
   static const Value Max = Value(1 << 28);
 
   Value get(Color c, Move m) const { return table[c][from_sq(m)][to_sq(m)]; }
-  void clear() { std::memset(table, 0, sizeof(table)); }
+  void clear() { memset(table, 0, sizeof(table)); }
   void update(Color c, Move m, Value v) {
 
     if (abs(int(v)) >= 324)
@@ -61,7 +61,7 @@ template<typename T>
 struct Stats {
   const T* operator[](Piece pc) const { return table[pc]; }
   T* operator[](Piece pc) { return table[pc]; }
-  void clear() { std::memset(table, 0, sizeof(table)); }
+  void clear() { memset(table, 0, sizeof(table)); }
   void update(Piece pc, Square to, Move m) { table[pc][to] = m; }
   void update(Piece pc, Square to, Value v) {
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -23,7 +23,6 @@
 
 #include "bitboard.h"
 #include "pawns.h"
-#include "position.h"
 #include "thread.h"
 
 namespace {

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -234,7 +234,7 @@ Value Entry::shelter_storm(const Position& pos, Square ksq) {
   Bitboard ourPawns = b & pos.pieces(Us);
   Bitboard theirPawns = b & pos.pieces(Them);
   Value safety = MaxSafetyBonus;
-  File center = std::max(FILE_B, std::min(FILE_G, file_of(ksq)));
+  File center = max(FILE_B, min(FILE_G, file_of(ksq)));
 
   for (File f = center - File(1); f <= center + File(1); ++f)
   {
@@ -244,12 +244,12 @@ Value Entry::shelter_storm(const Position& pos, Square ksq) {
       b  = theirPawns & file_bb(f);
       Rank rkThem = b ? relative_rank(Us, frontmost_sq(Them, b)) : RANK_1;
 
-      safety -=  ShelterWeakness[std::min(f, FILE_H - f)][rkUs]
+      safety -=  ShelterWeakness[min(f, FILE_H - f)][rkUs]
                + StormDanger
                  [f == file_of(ksq) && rkThem == relative_rank(Us, ksq) + 1 ? BlockedByKing  :
                   rkUs   == RANK_1                                          ? Unopposed :
                   rkThem == rkUs + 1                                        ? BlockedByPawn  : Unblocked]
-                 [std::min(f, FILE_H - f)][rkThem];
+                 [min(f, FILE_H - f)][rkThem];
   }
 
   return safety;
@@ -274,10 +274,10 @@ Score Entry::do_king_safety(const Position& pos, Square ksq) {
 
   // If we can castle use the bonus after the castling if it is bigger
   if (pos.can_castle(MakeCastling<Us, KING_SIDE>::right))
-      bonus = std::max(bonus, shelter_storm<Us>(pos, relative_square(Us, SQ_G1)));
+      bonus = max(bonus, shelter_storm<Us>(pos, relative_square(Us, SQ_G1)));
 
   if (pos.can_castle(MakeCastling<Us, QUEEN_SIDE>::right))
-      bonus = std::max(bonus, shelter_storm<Us>(pos, relative_square(Us, SQ_C1)));
+      bonus = max(bonus, shelter_storm<Us>(pos, relative_square(Us, SQ_C1)));
 
   return make_score(bonus, -16 * minKingPawnDistance);
 }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -18,10 +18,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
-#include <cassert>
-
-#include "bitboard.h"
 #include "pawns.h"
 #include "thread.h"
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -18,10 +18,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
-#include <cassert>
 #include <cstddef> // For offsetof()
-#include <cstring> // For std::memset, std::memcmp
 #include <iomanip>
 #include <sstream>
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -25,7 +25,6 @@
 #include <iomanip>
 #include <sstream>
 
-#include "bitboard.h"
 #include "misc.h"
 #include "movegen.h"
 #include "position.h"

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -30,8 +30,6 @@
 #include "uci.h"
 #include "syzygy/tbprobe.h"
 
-using std::string;
-
 namespace PSQT {
   extern Score psq[PIECE_NB][SQUARE_NB];
 }
@@ -46,7 +44,7 @@ namespace Zobrist {
 
 namespace {
 
-const string PieceToChar(" PNBRQK  pnbrqk");
+const std::string PieceToChar(" PNBRQK  pnbrqk");
 
 // min_attacker() is a helper function used by see_ge() to locate the least
 // valuable attacker for the side to move, remove the attacker we just found
@@ -152,7 +150,7 @@ void Position::init() {
 /// This function is not very robust - make sure that input FENs are correct,
 /// this is assumed to be the responsibility of the GUI.
 
-Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Thread* th) {
+Position& Position::set(const std::string& fenStr, bool isChess960, StateInfo* si, Thread* th) {
 /*
    A FEN string defines a particular position using only the ASCII character set.
 
@@ -209,7 +207,7 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
       else if (token == '/')
           sq -= Square(16);
 
-      else if ((idx = PieceToChar.find(token)) != string::npos)
+      else if ((idx = PieceToChar.find(token)) != std::string::npos)
       {
           put_piece(Piece(idx), sq);
           ++sq;
@@ -377,18 +375,18 @@ void Position::set_state(StateInfo* si) const {
 /// get the material key out of an endgame code. Position is not playable,
 /// indeed is even not guaranteed to be legal.
 
-Position& Position::set(const string& code, Color c, StateInfo* si) {
+Position& Position::set(const std::string& code, Color c, StateInfo* si) {
 
   assert(code.length() > 0 && code.length() < 8);
   assert(code[0] == 'K');
 
-  string sides[] = { code.substr(code.find('K', 1)),      // Weak
-                     code.substr(0, code.find('K', 1)) }; // Strong
+  std::string sides[] = { code.substr(code.find('K', 1)),      // Weak
+                          code.substr(0, code.find('K', 1)) }; // Strong
 
   std::transform(sides[c].begin(), sides[c].end(), sides[c].begin(), tolower);
 
-  string fenStr =  sides[0] + char(8 - sides[0].length() + '0') + "/8/8/8/8/8/8/"
-                 + sides[1] + char(8 - sides[1].length() + '0') + " w - - 0 10";
+  std::string fenStr =  sides[0] + char(8 - sides[0].length() + '0') + "/8/8/8/8/8/8/"
+                      + sides[1] + char(8 - sides[1].length() + '0') + " w - - 0 10";
 
   return set(fenStr, false, si, nullptr);
 }
@@ -397,7 +395,7 @@ Position& Position::set(const string& code, Color c, StateInfo* si) {
 /// Position::fen() returns a FEN representation of the position. In case of
 /// Chess960 the Shredder-FEN notation is used. This is mainly a debugging function.
 
-const string Position::fen() const {
+const std::string Position::fen() const {
 
   int emptyCnt;
   std::ostringstream ss;
@@ -1109,7 +1107,7 @@ bool Position::is_draw(int ply) const {
 
 void Position::flip() {
 
-  string f, token;
+  std::string f, token;
   std::stringstream ss(fen());
 
   for (Rank r = RANK_8; r >= RANK_1; --r) // Piece placement

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -44,7 +44,7 @@ namespace Zobrist {
 
 namespace {
 
-const std::string PieceToChar(" PNBRQK  pnbrqk");
+const string PieceToChar(" PNBRQK  pnbrqk");
 
 // min_attacker() is a helper function used by see_ge() to locate the least
 // valuable attacker for the side to move, remove the attacker we just found
@@ -150,7 +150,7 @@ void Position::init() {
 /// This function is not very robust - make sure that input FENs are correct,
 /// this is assumed to be the responsibility of the GUI.
 
-Position& Position::set(const std::string& fenStr, bool isChess960, StateInfo* si, Thread* th) {
+Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Thread* th) {
 /*
    A FEN string defines a particular position using only the ASCII character set.
 
@@ -191,8 +191,8 @@ Position& Position::set(const std::string& fenStr, bool isChess960, StateInfo* s
   Square sq = SQ_A8;
   std::istringstream ss(fenStr);
 
-  std::memset(this, 0, sizeof(Position));
-  std::memset(si, 0, sizeof(StateInfo));
+  memset(this, 0, sizeof(Position));
+  memset(si, 0, sizeof(StateInfo));
   std::fill_n(&pieceList[0][0], sizeof(pieceList) / sizeof(Square), SQ_NONE);
   st = si;
 
@@ -207,7 +207,7 @@ Position& Position::set(const std::string& fenStr, bool isChess960, StateInfo* s
       else if (token == '/')
           sq -= Square(16);
 
-      else if ((idx = PieceToChar.find(token)) != std::string::npos)
+      else if ((idx = PieceToChar.find(token)) != string::npos)
       {
           put_piece(Piece(idx), sq);
           ++sq;
@@ -265,7 +265,7 @@ Position& Position::set(const std::string& fenStr, bool isChess960, StateInfo* s
 
   // Convert from fullmove starting from 1 to ply starting from 0,
   // handle also common incorrect FEN with fullmove = 0.
-  gamePly = std::max(2 * (gamePly - 1), 0) + (sideToMove == BLACK);
+  gamePly = max(2 * (gamePly - 1), 0) + (sideToMove == BLACK);
 
   chess960 = isChess960;
   thisThread = th;
@@ -294,11 +294,11 @@ void Position::set_castling_right(Color c, Square rfrom) {
   Square kto = relative_square(c, cs == KING_SIDE ? SQ_G1 : SQ_C1);
   Square rto = relative_square(c, cs == KING_SIDE ? SQ_F1 : SQ_D1);
 
-  for (Square s = std::min(rfrom, rto); s <= std::max(rfrom, rto); ++s)
+  for (Square s = min(rfrom, rto); s <= max(rfrom, rto); ++s)
       if (s != kfrom && s != rfrom)
           castlingPath[cr] |= s;
 
-  for (Square s = std::min(kfrom, kto); s <= std::max(kfrom, kto); ++s)
+  for (Square s = min(kfrom, kto); s <= max(kfrom, kto); ++s)
       if (s != kfrom && s != rfrom)
           castlingPath[cr] |= s;
 }
@@ -375,17 +375,17 @@ void Position::set_state(StateInfo* si) const {
 /// get the material key out of an endgame code. Position is not playable,
 /// indeed is even not guaranteed to be legal.
 
-Position& Position::set(const std::string& code, Color c, StateInfo* si) {
+Position& Position::set(const string& code, Color c, StateInfo* si) {
 
   assert(code.length() > 0 && code.length() < 8);
   assert(code[0] == 'K');
 
-  std::string sides[] = { code.substr(code.find('K', 1)),      // Weak
+  string sides[] = { code.substr(code.find('K', 1)),      // Weak
                           code.substr(0, code.find('K', 1)) }; // Strong
 
   std::transform(sides[c].begin(), sides[c].end(), sides[c].begin(), tolower);
 
-  std::string fenStr =  sides[0] + char(8 - sides[0].length() + '0') + "/8/8/8/8/8/8/"
+  string fenStr =  sides[0] + char(8 - sides[0].length() + '0') + "/8/8/8/8/8/8/"
                       + sides[1] + char(8 - sides[1].length() + '0') + " w - - 0 10";
 
   return set(fenStr, false, si, nullptr);
@@ -395,7 +395,7 @@ Position& Position::set(const std::string& code, Color c, StateInfo* si) {
 /// Position::fen() returns a FEN representation of the position. In case of
 /// Chess960 the Shredder-FEN notation is used. This is mainly a debugging function.
 
-const std::string Position::fen() const {
+const string Position::fen() const {
 
   int emptyCnt;
   std::ostringstream ss;
@@ -449,7 +449,7 @@ Phase Position::game_phase() const {
 
   Value npm = st->nonPawnMaterial[WHITE] + st->nonPawnMaterial[BLACK];
 
-  npm = std::max(EndgameLimit, std::min(npm, MidgameLimit));
+  npm = max(EndgameLimit, min(npm, MidgameLimit));
 
   return Phase(((npm - EndgameLimit) * PHASE_MIDGAME) / (MidgameLimit - EndgameLimit));
 }
@@ -688,7 +688,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   // Copy some fields of the old state to our new StateInfo object except the
   // ones which are going to be recalculated from scratch anyway and then switch
   // our state pointer to point to the new (ready to be updated) state.
-  std::memcpy(&newSt, st, offsetof(StateInfo, key));
+  memcpy(&newSt, st, offsetof(StateInfo, key));
   newSt.previous = st;
   st = &newSt;
 
@@ -939,7 +939,7 @@ void Position::do_null_move(StateInfo& newSt) {
   assert(!checkers());
   assert(&newSt != st);
 
-  std::memcpy(&newSt, st, sizeof(StateInfo));
+  memcpy(&newSt, st, sizeof(StateInfo));
   newSt.previous = st;
   st = &newSt;
 
@@ -1078,7 +1078,7 @@ bool Position::is_draw(int ply) const {
   if (st->rule50 > 99 && (!checkers() || MoveList<LEGAL>(*this).size()))
       return true;
 
-  int end = std::min(st->rule50, st->pliesFromNull);
+  int end = min(st->rule50, st->pliesFromNull);
 
   if (end < 4)
     return false;
@@ -1107,7 +1107,7 @@ bool Position::is_draw(int ply) const {
 
 void Position::flip() {
 
-  std::string f, token;
+  string f, token;
   std::stringstream ss(fen());
 
   for (Rank r = RANK_8; r >= RANK_1; --r) // Piece placement

--- a/src/position.h
+++ b/src/position.h
@@ -73,9 +73,9 @@ public:
   Position& operator=(const Position&) = delete;
 
   // FEN string input/output
-  Position& set(const std::string& fenStr, bool isChess960, StateInfo* si, Thread* th);
-  Position& set(const std::string& code, Color c, StateInfo* si);
-  const std::string fen() const;
+  Position& set(const string& fenStr, bool isChess960, StateInfo* si, Thread* th);
+  Position& set(const string& code, Color c, StateInfo* si);
+  const string fen() const;
 
   // Position representation
   Bitboard pieces() const;

--- a/src/position.h
+++ b/src/position.h
@@ -21,10 +21,8 @@
 #ifndef POSITION_H_INCLUDED
 #define POSITION_H_INCLUDED
 
-#include <cassert>
 #include <deque>
 #include <memory> // For std::unique_ptr
-#include <string>
 
 #include "bitboard.h"
 #include "types.h"

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -18,8 +18,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
-
 #include "types.h"
 
 Value PieceValue[PHASE_NB][PIECE_NB] = {

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -114,7 +114,7 @@ void init() {
 
       for (Square s = SQ_A1; s <= SQ_H8; ++s)
       {
-          File f = std::min(file_of(s), FILE_H - file_of(s));
+          File f = min(file_of(s), FILE_H - file_of(s));
           psq[ pc][ s] = v + Bonus[pc][rank_of(s)][f];
           psq[~pc][~s] = -psq[pc][s];
       }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -18,10 +18,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
-#include <cassert>
 #include <cmath>
-#include <cstring>   // For std::memset
 #include <iostream>
 #include <sstream>
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -26,9 +26,7 @@
 #include <sstream>
 
 #include "evaluate.h"
-#include "misc.h"
 #include "movegen.h"
-#include "movepick.h"
 #include "position.h"
 #include "search.h"
 #include "timeman.h"

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -49,7 +49,6 @@ namespace Tablebases {
 
 namespace TB = Tablebases;
 
-using std::string;
 using Eval::evaluate;
 using namespace Search;
 
@@ -1494,7 +1493,7 @@ moves_loop: // When in check search starts from here
 /// UCI::pv() formats PV information according to the UCI protocol. UCI requires
 /// that all (if any) unsearched PV lines are sent using a previous search score.
 
-string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
+std::string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
 
   std::stringstream ss;
   int elapsed = Time.elapsed() + 1;

--- a/src/search.h
+++ b/src/search.h
@@ -62,10 +62,10 @@ struct RootMove {
 
   Value score = -VALUE_INFINITE;
   Value previousScore = -VALUE_INFINITE;
-  std::vector<Move> pv;
+  vector<Move> pv;
 };
 
-typedef std::vector<RootMove> RootMoves;
+typedef vector<RootMove> RootMoves;
 
 
 /// LimitsType struct stores information sent by GUI about available time to
@@ -83,7 +83,7 @@ struct LimitsType {
     return !(mate | movetime | depth | nodes | infinite);
   }
 
-  std::vector<Move> searchmoves;
+  vector<Move> searchmoves;
   int time[COLOR_NB], inc[COLOR_NB], npmsec, movestogo, depth, movetime, mate, infinite, ponder;
   int64_t nodes;
   TimePoint startTime;

--- a/src/search.h
+++ b/src/search.h
@@ -22,7 +22,6 @@
 #define SEARCH_H_INCLUDED
 
 #include <atomic>
-#include <vector>
 
 #include "misc.h"
 #include "movepick.h"

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -20,7 +20,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
-#include <cstring>   // For std::memset
+#include <cstring>   // For memset
 #include <deque>
 #include <fstream>
 #include <iostream>
@@ -117,8 +117,8 @@ struct PairsData {
     SparseEntry* sparseIndex;      // Partial indices into blockLength[]
     size_t sparseIndexSize;        // Size of SparseIndex[] table
     uint8_t* data;                 // Start of Huffman compressed data
-    std::vector<uint64_t> base64;  // base64[l - min_sym_len] is the 64bit-padded lowest symbol of length l
-    std::vector<uint8_t> symlen;   // Number of values (-1) represented by a given Huffman symbol: 1..256
+    vector<uint64_t> base64;  // base64[l - min_sym_len] is the 64bit-padded lowest symbol of length l
+    vector<uint8_t> symlen;   // Number of values (-1) represented by a given Huffman symbol: 1..256
     Piece pieces[TBPIECES];        // Position pieces: the order of pieces defines the groups
     uint64_t groupIdx[TBPIECES+1]; // Start index used for the encoding of the group's pieces
     int groupLen[TBPIECES+1];      // Number of pieces in a given group: KRKN -> (3, 1)
@@ -168,7 +168,7 @@ struct TBEntry : public Atomic {
 
 // Now the main types: WDLEntry and DTZEntry
 struct WDLEntry : public TBEntry {
-    WDLEntry(const std::string& code);
+    WDLEntry(const string& code);
    ~WDLEntry();
     union {
         WLDEntryPiece pieceTable[2]; // [wtm / btm]
@@ -215,7 +215,7 @@ const Value WDL_to_value[] = {
     VALUE_MATE - MAX_PLY - 1
 };
 
-const std::string PieceToChar = " PNBRQK  pnbrqk";
+const string PieceToChar = " PNBRQK  pnbrqk";
 
 int Binomial[6][SQUARE_NB];    // [k][n] k elements from a set of n elements
 int LeadPawnIdx[5][SQUARE_NB]; // [leadPawnsCnt][SQUARE_NB]
@@ -240,7 +240,7 @@ template<typename T, int LE> T number(void* addr)
     T v;
 
     if ((uintptr_t)addr & (alignof(T) - 1)) // Unaligned pointer (very rare)
-        std::memcpy(&v, addr, sizeof(T));
+        memcpy(&v, addr, sizeof(T));
     else
         v = *((T*)addr);
 
@@ -288,19 +288,19 @@ public:
   }
 
   void clear() {
-      std::memset(hashTable, 0, sizeof(hashTable));
+      memset(hashTable, 0, sizeof(hashTable));
       wdlTable.clear();
       dtzTable.clear();
   }
   size_t size() const { return wdlTable.size(); }
-  void insert(const std::vector<PieceType>& pieces);
+  void insert(const vector<PieceType>& pieces);
 };
 
 HashTable EntryTable;
 
 class TBFile : public std::ifstream {
 
-    std::string fname;
+    string fname;
 
 public:
     // Look for and open the file among the Paths directories where the .rtbw
@@ -309,9 +309,9 @@ public:
     //
     // Example:
     // C:\tb\wdl345;C:\tb\wdl6;D:\tb\dtz345;D:\tb\dtz6
-    static std::string Paths;
+    static string Paths;
 
-    TBFile(const std::string& f) {
+    TBFile(const string& f) {
 
 #ifndef _WIN32
         const char SepChar = ':';
@@ -319,7 +319,7 @@ public:
         const char SepChar = ';';
 #endif
         std::stringstream ss(Paths);
-        std::string path;
+        string path;
 
         while (std::getline(ss, path, SepChar)) {
             fname = path + "/" + f;
@@ -397,9 +397,9 @@ public:
     }
 };
 
-std::string TBFile::Paths;
+string TBFile::Paths;
 
-WDLEntry::WDLEntry(const std::string& code) {
+WDLEntry::WDLEntry(const string& code) {
 
     StateInfo st;
     Position pos;
@@ -472,9 +472,9 @@ DTZEntry::~DTZEntry() {
         delete pieceTable.precomp;
 }
 
-void HashTable::insert(const std::vector<PieceType>& pieces) {
+void HashTable::insert(const vector<PieceType>& pieces) {
 
-    std::string code;
+    string code;
 
     for (PieceType pt : pieces)
         code += PieceToChar[pt];
@@ -486,7 +486,7 @@ void HashTable::insert(const std::vector<PieceType>& pieces) {
 
     file.close();
 
-    MaxCardinality = std::max((int)pieces.size(), MaxCardinality);
+    MaxCardinality = max((int)pieces.size(), MaxCardinality);
 
     wdlTable.push_back(WDLEntry(code));
     dtzTable.push_back(DTZEntry(wdlTable.back()));
@@ -953,7 +953,7 @@ void set_groups(T& e, PairsData* d, int order[], File f) {
 // In Recursive Pairing each symbol represents a pair of childern symbols. So
 // read d->btree[] symbols data and expand each one in his left and right child
 // symbol until reaching the leafs that represent the symbol value.
-uint8_t set_symlen(PairsData* d, Sym s, std::vector<bool>& visited) {
+uint8_t set_symlen(PairsData* d, Sym s, vector<bool>& visited) {
 
     visited[s] = true; // We can set it now because tree is acyclic
     Sym sr = d->btree[s].get<LR::Right>();
@@ -1028,7 +1028,7 @@ uint8_t* set_sizes(PairsData* d, uint8_t* data) {
     // reevaluating the frequencies of all of the symbol pairs with respect to
     // the extended alphabet, and then repeating the process.
     // See http://www.larsson.dogma.net/dcc99.pdf
-    std::vector<bool> visited(d->symlen.size());
+    vector<bool> visited(d->symlen.size());
 
     for (Sym sym = 0; sym < d->symlen.size(); ++sym)
         if (!visited[sym])
@@ -1141,10 +1141,10 @@ void* init(Entry& e, const Position& pos) {
         return e.baseAddress;
 
     // Pieces strings in decreasing order for each color, like ("KPP","KR")
-    std::string fname, w, b;
+    string fname, w, b;
     for (PieceType pt = KING; pt >= PAWN; --pt) {
-        w += std::string(popcount(pos.pieces(WHITE, pt)), PieceToChar[pt]);
-        b += std::string(popcount(pos.pieces(BLACK, pt)), PieceToChar[pt]);
+        w += string(popcount(pos.pieces(WHITE, pt)), PieceToChar[pt]);
+        b += string(popcount(pos.pieces(BLACK, pt)), PieceToChar[pt]);
     }
 
     const uint8_t TB_MAGIC[][4] = { { 0xD7, 0x66, 0x0C, 0xA5 },
@@ -1252,7 +1252,7 @@ WDLScore search(Position& pos, ProbeState* result) {
 
 } // namespace
 
-void Tablebases::init(const std::string& paths) {
+void Tablebases::init(const string& paths) {
 
     EntryTable.clear();
     MaxCardinality = 0;
@@ -1268,7 +1268,7 @@ void Tablebases::init(const std::string& paths) {
             MapB1H1H7[s] = code++;
 
     // MapA1D1D4[] encodes a square in the a1-d1-d4 triangle to 0..9
-    std::vector<Square> diagonal;
+    vector<Square> diagonal;
     code = 0;
     for (Square s = SQ_A1; s <= SQ_D4; ++s)
         if (off_A1H8(s) < 0 && file_of(s) <= FILE_D)
@@ -1284,7 +1284,7 @@ void Tablebases::init(const std::string& paths) {
     // MapKK[] encodes all the 461 possible legal positions of two kings where
     // the first is in the a1-d1-d4 triangle. If the first king is on the a1-d4
     // diagonal, the other one shall not to be above the a1-h8 diagonal.
-    std::vector<std::pair<int, Square>> bothOnDiagonal;
+    vector<std::pair<int, Square>> bothOnDiagonal;
     code = 0;
     for (int idx = 0; idx < 10; idx++)
         for (Square s1 = SQ_A1; s1 <= SQ_D4; ++s1)
@@ -1488,7 +1488,7 @@ int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
 static int has_repeated(StateInfo *st)
 {
     while (1) {
-        int i = 4, e = std::min(st->rule50, st->pliesFromNull);
+        int i = 4, e = min(st->rule50, st->pliesFromNull);
 
         if (e < i)
             return 0;

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -17,10 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
 #include <atomic>
-#include <cstdint>
-#include <cstring>   // For memset
 #include <deque>
 #include <fstream>
 #include <iostream>

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -31,7 +31,6 @@
 #include "../bitboard.h"
 #include "../movegen.h"
 #include "../position.h"
-#include "../search.h"
 #include "../thread_win32.h"
 #include "../types.h"
 

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -46,7 +46,7 @@ enum ProbeState {
 
 extern int MaxCardinality;
 
-void init(const std::string& paths);
+void init(const string& paths);
 WDLScore probe_wdl(Position& pos, ProbeState* result);
 int probe_dtz(Position& pos, ProbeState* result);
 bool root_probe(Position& pos, Search::RootMoves& rootMoves, Value& score);

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -22,7 +22,6 @@
 #include <cassert>
 
 #include "movegen.h"
-#include "search.h"
 #include "thread.h"
 #include "uci.h"
 #include "syzygy/tbprobe.h"

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -18,9 +18,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <algorithm> // For std::count
-#include <cassert>
-
 #include "movegen.h"
 #include "thread.h"
 #include "uci.h"

--- a/src/thread.h
+++ b/src/thread.h
@@ -22,7 +22,6 @@
 #define THREAD_H_INCLUDED
 
 #include <atomic>
-#include <bitset>
 #include <condition_variable>
 #include <mutex>
 #include <thread>

--- a/src/thread.h
+++ b/src/thread.h
@@ -88,7 +88,7 @@ struct MainThread : public Thread {
 /// parking and, most importantly, launching a thread. All the access to threads
 /// data is done through this class.
 
-struct ThreadPool : public std::vector<Thread*> {
+struct ThreadPool : public vector<Thread*> {
 
   void init(); // No constructor and destructor, threads rely on globals that should
   void exit(); // be initialized and valid during the whole thread lifetime.

--- a/src/thread.h
+++ b/src/thread.h
@@ -25,7 +25,6 @@
 #include <condition_variable>
 #include <mutex>
 #include <thread>
-#include <vector>
 
 #include "material.h"
 #include "movepick.h"

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -18,7 +18,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
 #include <cfloat>
 #include <cmath>
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -64,7 +64,7 @@ namespace {
     double ratio1 = (TMaxRatio * moveImportance) / (TMaxRatio * moveImportance + otherMovesImportance);
     double ratio2 = (moveImportance + TStealRatio * otherMovesImportance) / (moveImportance + otherMovesImportance);
 
-    return int(myTime * std::min(ratio1, ratio2)); // Intel C++ asks for an explicit cast
+    return int(myTime * min(ratio1, ratio2)); // Intel C++ asks for an explicit cast
   }
 
 } // namespace
@@ -102,9 +102,9 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
   }
 
   startTime = limits.startTime;
-  optimumTime = maximumTime = std::max(limits.time[us], minThinkingTime);
+  optimumTime = maximumTime = max(limits.time[us], minThinkingTime);
 
-  const int MaxMTG = limits.movestogo ? std::min(limits.movestogo, MoveHorizon) : MoveHorizon;
+  const int MaxMTG = limits.movestogo ? min(limits.movestogo, MoveHorizon) : MoveHorizon;
 
   // We calculate optimum time usage for different hypothetical "moves to go"-values
   // and choose the minimum of calculated search time values. Usually the greatest
@@ -114,15 +114,15 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
       // Calculate thinking time for hypothetical "moves to go"-value
       int hypMyTime =  limits.time[us]
                      + limits.inc[us] * (hypMTG - 1)
-                     - moveOverhead * (2 + std::min(hypMTG, 40));
+                     - moveOverhead * (2 + min(hypMTG, 40));
 
-      hypMyTime = std::max(hypMyTime, 0);
+      hypMyTime = max(hypMyTime, 0);
 
       int t1 = minThinkingTime + remaining<OptimumTime>(hypMyTime, hypMTG, ply, slowMover);
       int t2 = minThinkingTime + remaining<MaxTime    >(hypMyTime, hypMTG, ply, slowMover);
 
-      optimumTime = std::min(t1, optimumTime);
-      maximumTime = std::min(t2, maximumTime);
+      optimumTime = min(t1, optimumTime);
+      maximumTime = min(t2, maximumTime);
   }
 
   if (Options["Ponder"])

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -20,9 +20,7 @@
 
 #include <algorithm>
 #include <cfloat>
-#include <cmath>
 
-#include "search.h"
 #include "timeman.h"
 #include "uci.h"
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <cfloat>
+#include <cmath>
 
 #include "timeman.h"
 #include "uci.h"

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -18,7 +18,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <cstring>   // For std::memset
 #include <iostream>
 
 #include "bitboard.h"

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -59,7 +59,7 @@ void TranspositionTable::resize(size_t mbSize) {
 
 void TranspositionTable::clear() {
 
-  std::memset(table, 0, clusterCount * sizeof(Cluster));
+  memset(table, 0, clusterCount * sizeof(Cluster));
 }
 
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -21,7 +21,6 @@
 #ifndef TT_H_INCLUDED
 #define TT_H_INCLUDED
 
-#include "misc.h"
 #include "types.h"
 
 /// TTEntry struct is the 10 bytes transposition table entry, defined as below:

--- a/src/types.h
+++ b/src/types.h
@@ -43,6 +43,10 @@
 #include <climits>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>   // For std::memset
+#include <algorithm> // For std::max
+#include <vector>
+#include <string>
 
 #if defined(_MSC_VER)
 // Disable some silly and noisy warning from MSVC compiler

--- a/src/types.h
+++ b/src/types.h
@@ -43,10 +43,18 @@
 #include <climits>
 #include <cstdint>
 #include <cstdlib>
-#include <cstring>   // For std::memset
-#include <algorithm> // For std::max
-#include <vector>
-#include <string>
+
+#include <cstring>   // For memset, memcpy
+#include <algorithm> // For max, min
+#include <vector>    // For vector
+#include <string>    // For string
+
+using std::memset;
+using std::memcpy;
+using std::max;
+using std::min;
+using std::vector;
+using std::string;
 
 #if defined(_MSC_VER)
 // Disable some silly and noisy warning from MSVC compiler

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,9 +30,7 @@
 #include "uci.h"
 #include "syzygy/tbprobe.h"
 
-using namespace std;
-
-extern void benchmark(const Position& pos, istream& is);
+extern void benchmark(const Position& pos, std::istream& is);
 
 namespace {
 
@@ -50,10 +48,10 @@ namespace {
   // or the starting position ("startpos") and then makes the moves given in the
   // following move list ("moves").
 
-  void position(Position& pos, istringstream& is) {
+  void position(Position& pos, std::istringstream& is) {
 
     Move m;
-    string token, fen;
+    std::string token, fen;
 
     is >> token;
 
@@ -83,19 +81,19 @@ namespace {
   // setoption() is called when engine receives the "setoption" UCI command. The
   // function updates the UCI option ("name") to the given value ("value").
 
-  void setoption(istringstream& is) {
+  void setoption(std::istringstream& is) {
 
-    string token, name, value;
+    std::string token, name, value;
 
     is >> token; // Consume "name" token
 
     // Read option name (can contain spaces)
     while (is >> token && token != "value")
-        name += string(" ", name.empty() ? 0 : 1) + token;
+        name += std::string(" ", name.empty() ? 0 : 1) + token;
 
     // Read option value (can contain spaces)
     while (is >> token)
-        value += string(" ", value.empty() ? 0 : 1) + token;
+        value += std::string(" ", value.empty() ? 0 : 1) + token;
 
     if (Options.count(name))
         Options[name] = value;
@@ -108,10 +106,10 @@ namespace {
   // the thinking time and other parameters from the input string, then starts
   // the search.
 
-  void go(Position& pos, istringstream& is) {
+  void go(Position& pos, std::istringstream& is) {
 
     Search::LimitsType limits;
-    string token;
+    std::string token;
 
     limits.startTime = now(); // As early as possible!
 
@@ -147,7 +145,7 @@ namespace {
 void UCI::loop(int argc, char* argv[]) {
 
   Position pos;
-  string token, cmd;
+  std::string token, cmd;
 
   pos.set(StartFEN, false, &States->back(), Threads.main());
 
@@ -155,13 +153,13 @@ void UCI::loop(int argc, char* argv[]) {
       cmd += std::string(argv[i]) + " ";
 
   do {
-      if (argc == 1 && !getline(cin, cmd)) // Block here waiting for input or EOF
+      if (argc == 1 && !getline(std::cin, cmd)) // Block here waiting for input or EOF
           cmd = "quit";
 
-      istringstream is(cmd);
+      std::istringstream is(cmd);
 
       token.clear(); // getline() could return empty or blank line
-      is >> skipws >> token;
+      is >> std::skipws >> token;
 
       // The GUI sends 'ponderhit' to tell us to ponder on the same move the
       // opponent has played. In case Signals.stopOnPonderhit is set we are
@@ -202,7 +200,7 @@ void UCI::loop(int argc, char* argv[]) {
       else if (token == "perft")
       {
           int depth;
-          stringstream ss;
+          std::stringstream ss;
 
           is >> depth;
           ss << Options["Hash"]    << " "
@@ -226,9 +224,9 @@ void UCI::loop(int argc, char* argv[]) {
 /// mate <y>  Mate in y moves, not plies. If the engine is getting mated
 ///           use negative values for y.
 
-string UCI::value(Value v) {
+std::string UCI::value(Value v) {
 
-  stringstream ss;
+  std::stringstream ss;
 
   if (abs(v) < VALUE_MATE - MAX_PLY)
       ss << "cp " << v * 100 / PawnValueEg;
@@ -251,7 +249,7 @@ std::string UCI::square(Square s) {
 /// normal chess mode, and in e1h1 notation in chess960 mode. Internally all
 /// castling moves are always encoded as 'king captures rook'.
 
-string UCI::move(Move m, bool chess960) {
+std::string UCI::move(Move m, bool chess960) {
 
   Square from = from_sq(m);
   Square to = to_sq(m);
@@ -265,7 +263,7 @@ string UCI::move(Move m, bool chess960) {
   if (type_of(m) == CASTLING && !chess960)
       to = make_square(to > from ? FILE_G : FILE_C, rank_of(from));
 
-  string move = UCI::square(from) + UCI::square(to);
+  std::string move = UCI::square(from) + UCI::square(to);
 
   if (type_of(m) == PROMOTION)
       move += " pnbrqk"[promotion_type(m)];
@@ -277,7 +275,7 @@ string UCI::move(Move m, bool chess960) {
 /// UCI::to_move() converts a string representing a move in coordinate notation
 /// (g1f3, a7a8q) to the corresponding legal Move, if any.
 
-Move UCI::to_move(const Position& pos, string& str) {
+Move UCI::to_move(const Position& pos, std::string& str) {
 
   if (str.length() == 5) // Junior could send promotion piece in uppercase
       str[4] = char(tolower(str[4]));

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -20,7 +20,6 @@
 
 #include <iostream>
 #include <sstream>
-#include <string>
 
 #include "evaluate.h"
 #include "movegen.h"

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -51,7 +51,7 @@ namespace {
   void position(Position& pos, std::istringstream& is) {
 
     Move m;
-    std::string token, fen;
+    string token, fen;
 
     is >> token;
 
@@ -83,17 +83,17 @@ namespace {
 
   void setoption(std::istringstream& is) {
 
-    std::string token, name, value;
+    string token, name, value;
 
     is >> token; // Consume "name" token
 
     // Read option name (can contain spaces)
     while (is >> token && token != "value")
-        name += std::string(" ", name.empty() ? 0 : 1) + token;
+        name += string(" ", name.empty() ? 0 : 1) + token;
 
     // Read option value (can contain spaces)
     while (is >> token)
-        value += std::string(" ", value.empty() ? 0 : 1) + token;
+        value += string(" ", value.empty() ? 0 : 1) + token;
 
     if (Options.count(name))
         Options[name] = value;
@@ -109,7 +109,7 @@ namespace {
   void go(Position& pos, std::istringstream& is) {
 
     Search::LimitsType limits;
-    std::string token;
+    string token;
 
     limits.startTime = now(); // As early as possible!
 
@@ -145,12 +145,12 @@ namespace {
 void UCI::loop(int argc, char* argv[]) {
 
   Position pos;
-  std::string token, cmd;
+  string token, cmd;
 
   pos.set(StartFEN, false, &States->back(), Threads.main());
 
   for (int i = 1; i < argc; ++i)
-      cmd += std::string(argv[i]) + " ";
+      cmd += string(argv[i]) + " ";
 
   do {
       if (argc == 1 && !getline(std::cin, cmd)) // Block here waiting for input or EOF
@@ -224,7 +224,7 @@ void UCI::loop(int argc, char* argv[]) {
 /// mate <y>  Mate in y moves, not plies. If the engine is getting mated
 ///           use negative values for y.
 
-std::string UCI::value(Value v) {
+string UCI::value(Value v) {
 
   std::stringstream ss;
 
@@ -239,8 +239,8 @@ std::string UCI::value(Value v) {
 
 /// UCI::square() converts a Square to a string in algebraic notation (g1, a7, etc.)
 
-std::string UCI::square(Square s) {
-  return std::string{ char('a' + file_of(s)), char('1' + rank_of(s)) };
+string UCI::square(Square s) {
+  return string{ char('a' + file_of(s)), char('1' + rank_of(s)) };
 }
 
 
@@ -249,7 +249,7 @@ std::string UCI::square(Square s) {
 /// normal chess mode, and in e1h1 notation in chess960 mode. Internally all
 /// castling moves are always encoded as 'king captures rook'.
 
-std::string UCI::move(Move m, bool chess960) {
+string UCI::move(Move m, bool chess960) {
 
   Square from = from_sq(m);
   Square to = to_sq(m);
@@ -263,7 +263,7 @@ std::string UCI::move(Move m, bool chess960) {
   if (type_of(m) == CASTLING && !chess960)
       to = make_square(to > from ? FILE_G : FILE_C, rank_of(from));
 
-  std::string move = UCI::square(from) + UCI::square(to);
+  string move = UCI::square(from) + UCI::square(to);
 
   if (type_of(m) == PROMOTION)
       move += " pnbrqk"[promotion_type(m)];
@@ -275,7 +275,7 @@ std::string UCI::move(Move m, bool chess960) {
 /// UCI::to_move() converts a string representing a move in coordinate notation
 /// (g1f3, a7a8q) to the corresponding legal Move, if any.
 
-Move UCI::to_move(const Position& pos, std::string& str) {
+Move UCI::to_move(const Position& pos, string& str) {
 
   if (str.length() == 5) // Junior could send promotion piece in uppercase
       str[4] = char(tolower(str[4]));

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,6 @@
 #define UCI_H_INCLUDED
 
 #include <map>
-#include <string>
 
 #include "types.h"
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -33,11 +33,11 @@ class Option;
 
 /// Custom comparator because UCI options should be case insensitive
 struct CaseInsensitiveLess {
-  bool operator() (const std::string&, const std::string&) const;
+  bool operator() (const string&, const string&) const;
 };
 
 /// Our options container is actually a std::map
-typedef std::map<std::string, Option, CaseInsensitiveLess> OptionsMap;
+typedef std::map<string, Option, CaseInsensitiveLess> OptionsMap;
 
 /// Option class implements an option as defined by UCI protocol
 class Option {
@@ -50,15 +50,15 @@ public:
   Option(const char* v, OnChange = nullptr);
   Option(int v, int minv, int maxv, OnChange = nullptr);
 
-  Option& operator=(const std::string&);
+  Option& operator=(const string&);
   void operator<<(const Option&);
   operator int() const;
-  operator std::string() const;
+  operator string() const;
 
 private:
   friend std::ostream& operator<<(std::ostream&, const OptionsMap&);
 
-  std::string defaultValue, currentValue, type;
+  string defaultValue, currentValue, type;
   int min, max;
   size_t idx;
   OnChange on_change;
@@ -66,11 +66,11 @@ private:
 
 void init(OptionsMap&);
 void loop(int argc, char* argv[]);
-std::string value(Value v);
-std::string square(Square s);
-std::string move(Move m, bool chess960);
-std::string pv(const Position& pos, Depth depth, Value alpha, Value beta);
-Move to_move(const Position& pos, std::string& str);
+string value(Value v);
+string square(Square s);
+string move(Move m, bool chess960);
+string pv(const Position& pos, Depth depth, Value alpha, Value beta);
+Move to_move(const Position& pos, string& str);
 
 } // namespace UCI
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -40,7 +40,7 @@ void on_tb_path(const Option& o) { Tablebases::init(o); }
 
 
 /// Our case insensitive less() function as required by UCI protocol
-bool CaseInsensitiveLess::operator() (const std::string& s1, const std::string& s2) const {
+bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const {
 
   return std::lexicographical_compare(s1.begin(), s1.end(), s2.begin(), s2.end(),
          [](char c1, char c2) { return tolower(c1) < tolower(c2); });
@@ -117,7 +117,7 @@ Option::operator int() const {
   return (type == "spin" ? stoi(currentValue) : currentValue == "true");
 }
 
-Option::operator std::string() const {
+Option::operator string() const {
   assert(type == "string");
   return currentValue;
 }
@@ -138,7 +138,7 @@ void Option::operator<<(const Option& o) {
 /// the GUI to check for option's limits, but we could receive the new value from
 /// the user by console window, so let's check the bounds anyway.
 
-Option& Option::operator=(const std::string& v) {
+Option& Option::operator=(const string& v) {
 
   assert(!type.empty());
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -27,8 +27,6 @@
 #include "uci.h"
 #include "syzygy/tbprobe.h"
 
-using std::string;
-
 UCI::OptionsMap Options; // Global object
 
 namespace UCI {
@@ -42,7 +40,7 @@ void on_tb_path(const Option& o) { Tablebases::init(o); }
 
 
 /// Our case insensitive less() function as required by UCI protocol
-bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const {
+bool CaseInsensitiveLess::operator() (const std::string& s1, const std::string& s2) const {
 
   return std::lexicographical_compare(s1.begin(), s1.end(), s2.begin(), s2.end(),
          [](char c1, char c2) { return tolower(c1) < tolower(c2); });
@@ -140,7 +138,7 @@ void Option::operator<<(const Option& o) {
 /// the GUI to check for option's limits, but we could receive the new value from
 /// the user by console window, so let's check the bounds anyway.
 
-Option& Option::operator=(const string& v) {
+Option& Option::operator=(const std::string& v) {
 
   assert(!type.empty());
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -18,8 +18,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
-#include <cassert>
 #include <ostream>
 
 #include "misc.h"


### PR DESCRIPTION
This PR consists of two patches on top of the header cleanup. It brings consistency across the code base in using the std namespace. 'using namespace std' is now avoided everywhere (first commit 0fa98eb). The second part (223c059) brings exceptions, as done previously for std::string in some files. Now this is done consistently for std::string, std::vector, std::min, std::max, std::memcpy, std::memset, all related to the new headers moved to types.h.

No functional change