### PR TITLE
Simple lazy

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -812,6 +812,11 @@ Value Eval::evaluate(const Position& pos) {
   // Probe the pawn hash table
   ei.pi = Pawns::probe(pos);
   score += ei.pi->pawns_score();
+  
+  // Early exit if score is high
+  Value lazyValue = mg_value(score);
+  if (abs(lazyValue) > 1500)
+     return (pos.side_to_move() == WHITE ? lazyValue : -lazyValue);
 
   // Initialize attack and king safety bitboards
   ei.attackedBy[WHITE][ALL_PIECES] = ei.attackedBy[BLACK][ALL_PIECES] = 0;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -812,9 +812,9 @@ Value Eval::evaluate(const Position& pos) {
   // Probe the pawn hash table
   ei.pi = Pawns::probe(pos);
   score += ei.pi->pawns_score();
-  
+
   // Early exit if score is high
-  Value lazyValue = mg_value(score);
+  Value lazyValue = (mg_value(score) + eg_value(score)) / 2;
   if (abs(lazyValue) > 1500)
      return (pos.side_to_move() == WHITE ? lazyValue : -lazyValue);
 


### PR DESCRIPTION
Simplification of lazy threshold.

Passed STC
http://tests.stockfishchess.org/tests/view/587846c10ebc5915193f74ec
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 217236 W: 39041 L: 39254 D: 138941

Passed LTC
http://tests.stockfishchess.org/tests/view/587e157a0ebc5915193f76e7
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 52396 W: 6883 L: 6804 D: 38709

This submitted version (using if (abs(mg + eg) > 1500) )
seems more logical than the following other green simplification (using  if (abs(mg)>1500))
since it can happen than mg_value is > eg_value (about 20% of the time)
and the submitted version seems stronger at LTC

STC
http://tests.stockfishchess.org/tests/view/5879702d0ebc5915193f7585
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 39958 W: 7315 L: 7227 D: 25416

LTC
http://tests.stockfishchess.org/tests/view/5879af3e0ebc5915193f7592
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 204322 W: 26529 L: 26648 D: 151145
