### PR TITLE
Outpost array simplification

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -134,19 +134,13 @@ namespace {
       S(118,174), S(119,177), S(123,191), S(128,199) }
   };
 
-  // Outpost[knight/bishop][supported by pawn] contains bonuses for knights and
-  // bishops outposts, bigger if outpost piece is supported by a pawn.
+  // Outpost[knight/bishop][supported by pawn] contains bonuses for minor pieces
+  // if they can reach an outpost square, bigger if that square is 
+  // supported by a pawn. 
+  // If the minor piece occupies an outpost square, score is doubled.
   const Score Outpost[][2] = {
-    { S(43,11), S(65,20) }, // Knights
-    { S(20, 3), S(29, 8) }  // Bishops
-  };
-
-  // ReachableOutpost[knight/bishop][supported by pawn] contains bonuses for
-  // knights and bishops which can reach an outpost square in one move, bigger
-  // if outpost square is supported by a pawn.
-  const Score ReachableOutpost[][2] = {
-    { S(21, 5), S(35, 8) }, // Knights
-    { S( 8, 0), S(14, 4) }  // Bishops
+    { S(22, 6), S(33, 9) }, // Knights
+    { S( 9, 2), S(14, 4) }  // Bishops
   };
 
   // RookOnFile[semiopen/open] contains bonuses for each rook when there is no
@@ -303,12 +297,12 @@ namespace {
             // Bonus for outpost squares
             bb = OutpostRanks & ~ei.pi->pawn_attacks_span(Them);
             if (bb & s)
-                score += Outpost[Pt == BISHOP][!!(ei.attackedBy[Us][PAWN] & s)];
+                score += Outpost[Pt == BISHOP][!!(ei.attackedBy[Us][PAWN] & s)] * 2;
             else
             {
                 bb &= b & ~pos.pieces(Us);
                 if (bb)
-                   score += ReachableOutpost[Pt == BISHOP][!!(ei.attackedBy[Us][PAWN] & bb)];
+                   score += Outpost[Pt == BISHOP][!!(ei.attackedBy[Us][PAWN] & bb)];
             }
 
             // Bonus when behind a pawn


### PR DESCRIPTION
The ReachableOutpost values were almost exactly half the Outpost values.

Passed STC
http://tests.stockfishchess.org/tests/view/588020510ebc5915193f781e
LLR: 3.86 (-2.94,2.94) [-3.00,1.00]
Total: 119238 W: 21462 L: 21460 D: 76316

Passed LTC
http://tests.stockfishchess.org/tests/view/5880ae090ebc5915193f7843
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 23540 W: 3097 L: 2980 D: 17463

Curiously, using a division by 2, with slightly different values, did not passed
http://tests.stockfishchess.org/tests/view/587fece00ebc5915193f780a
