### PR TITLE
Candidate passed pawns

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -678,6 +678,9 @@ namespace {
         if (!pos.non_pawn_material(Them))
             ebonus += 20;
 
+        if (!pos.pawn_passed(Us, s + pawn_push(Us)))
+            mbonus /= 2, ebonus /= 2;
+
         score += make_score(mbonus, ebonus) + PassedFile[file_of(s)];
     }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -609,7 +609,8 @@ namespace {
   }
 
 
-  // evaluate_passed_pawns() evaluates the passed pawns of the given color
+  // evaluate_passed_pawns() evaluates the passed pawns and candidate passed pawns
+  // of the given color.
 
   template<Color Us, bool DoTrace>
   Score evaluate_passed_pawns(const Position& pos, const EvalInfo& ei) {
@@ -625,7 +626,6 @@ namespace {
     {
         Square s = pop_lsb(&b);
 
-        assert(pos.pawn_passed(Us, s));
         assert(!(pos.pieces(PAWN) & forward_bb(Us, s)));
 
         bb = forward_bb(Us, s) & (ei.attackedBy[Them][ALL_PIECES] | pos.pieces(Them));
@@ -686,6 +686,7 @@ namespace {
         if (!pos.non_pawn_material(Them))
             ebonus += 20;
 
+        // Scale down bonus for candidate passers which need more than one pawn push to become passed.
         if (!pos.pawn_passed(Us, s + pawn_push(Us)))
             mbonus /= 2, ebonus /= 2;
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -159,7 +159,7 @@ namespace {
 
         // Pawns which are able to become a passed pawn.
         else if (   !more_than_one(stoppers)
-                 && !opposed && supported && lever
+                 && supported && lever
                  && !(ourPawns & forward_bb(Us, s)))
             e->passedPawns[Us] |= s;
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -98,9 +98,9 @@ namespace {
     const Square Right = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
     const Square Left  = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
 
-    Bitboard b, neighbours, stoppers, doubled, supported, phalanx;
+    Bitboard b, neighbours, stoppers, doubled, supported, phalanx, lever;
     Square s;
-    bool opposed, lever, connected, backward;
+    bool opposed, connected, backward;
     Score score = SCORE_ZERO;
     const Square* pl = pos.squares<PAWN>(Us);
     const Bitboard* pawnAttacksBB = StepAttacksBB[make_piece(Us, PAWN)];
@@ -153,14 +153,11 @@ namespace {
         }
 
         // Passed pawns will be properly scored in evaluation because we need
-        // full attack info to evaluate them.
-        if (!stoppers && !(ourPawns & forward_bb(Us, s)))
-            e->passedPawns[Us] |= s;
-
-        // Pawns which are able to become a passed pawn.
-        else if (   !more_than_one(stoppers)
-                 && supported && lever
-                 && !(ourPawns & forward_bb(Us, s)))
+        // full attack info to evaluate them. Also pawns which could become passed
+        // after a pawn push and are not attacked more times than defended are considered.
+        if (   !(stoppers ^ lever)
+            && !(ourPawns & forward_bb(Us, s))
+            && popcount(supported) >= popcount(lever))
             e->passedPawns[Us] |= s;
 
         // Score this pawn

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -159,7 +159,7 @@ namespace {
         if (   !(stoppers ^ lever ^ leverPush)
             && !(ourPawns & forward_bb(Us, s))
             && popcount(supported) >= popcount(lever)
-            && popcount(phalanx) >= popcount(leverPush))
+            && popcount(phalanx)   >= popcount(leverPush))
             e->passedPawns[Us] |= s;
 
         // Score this pawn

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -157,6 +157,12 @@ namespace {
         if (!stoppers && !(ourPawns & forward_bb(Us, s)))
             e->passedPawns[Us] |= s;
 
+        // Pawns which are able to become a passed pawn.
+        else if (   !more_than_one(stoppers)
+                 && !opposed && supported && lever
+                 && !(ourPawns & forward_bb(Us, s)))
+            e->passedPawns[Us] |= s;
+
         // Score this pawn
         if (!neighbours)
             score -= Isolated[opposed];

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -98,9 +98,9 @@ namespace {
     const Square Right = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
     const Square Left  = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
 
-    Bitboard b, neighbours, stoppers, doubled, supported, phalanx, lever;
+    Bitboard b, neighbours, stoppers, doubled, supported, phalanx, lever, leverPush, connected;
     Square s;
-    bool opposed, connected, backward;
+    bool opposed, backward;
     Score score = SCORE_ZERO;
     const Square* pl = pos.squares<PAWN>(Us);
     const Bitboard* pawnAttacksBB = StepAttacksBB[make_piece(Us, PAWN)];
@@ -129,6 +129,7 @@ namespace {
         opposed    = theirPawns & forward_bb(Us, s);
         stoppers   = theirPawns & passed_pawn_mask(Us, s);
         lever      = theirPawns & pawnAttacksBB[s];
+        leverPush  = theirPawns & pawnAttacksBB[s + Up];
         doubled    = ourPawns   & (s + Up);
         neighbours = ourPawns   & adjacent_files_bb(f);
         phalanx    = neighbours & rank_bb(s);
@@ -154,10 +155,11 @@ namespace {
 
         // Passed pawns will be properly scored in evaluation because we need
         // full attack info to evaluate them. Also pawns which could become passed
-        // after a pawn push and are not attacked more times than defended are considered.
-        if (   !(stoppers ^ lever)
+        // after one or two pawn pushes and are not attacked more times than defended are considered.
+        if (   !(stoppers ^ lever ^ leverPush)
             && !(ourPawns & forward_bb(Us, s))
-            && popcount(supported) >= popcount(lever))
+            && popcount(supported) >= popcount(lever)
+            && popcount(phalanx) >= popcount(leverPush))
             e->passedPawns[Us] |= s;
 
         // Score this pawn


### PR DESCRIPTION
Detect safe candidate passers.

STC: http://tests.stockfishchess.org/tests/view/5882395c0ebc5915193f78b3
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 53569 W: 9925 L: 9570 D: 34074

LTC: http://tests.stockfishchess.org/tests/view/5882b4fb0ebc5915193f78e2
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 77576 W: 10387 L: 10014 D: 57175

Bench: 5325829