### PR TITLE
Add JNI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+jni/src/main/cpp/*.h
+jni/build
+jni/target
+
+src/*.o
+src/stockfish
+src/syzygy/*.o

--- a/engine-interface.txt
+++ b/engine-interface.txt
@@ -1,0 +1,544 @@
+
+
+Description of the universal chess interface (UCI)    April  2006
+=================================================================
+
+* The specification is independent of the operating system. For Windows,
+  the engine is a normal exe file, either a console or "real" windows application.
+
+* all communication is done via standard input and output with text commands,
+
+* The engine should boot and wait for input from the GUI,
+  the engine should wait for the "isready" or "setoption" command to set up its internal parameters
+  as the boot process should be as quick as possible.
+
+* the engine must always be able to process input from stdin, even while thinking.
+
+* all command strings the engine receives will end with '\n',
+  also all commands the GUI receives should end with '\n',
+  Note: '\n' can be 0x0d or 0x0a0d or any combination depending on your OS.
+  If you use Engine and GUI in the same OS this should be no problem if you communicate in text mode,
+  but be aware of this when for example running a Linux engine in a Windows GUI.
+
+* arbitrary white space between tokens is allowed
+  Example: "debug on\n" and  "   debug     on  \n" and "\t  debug \t  \t\ton\t  \n"
+  all set the debug mode of the engine on.
+
+* The engine will always be in forced mode which means it should never start calculating
+  or pondering without receiving a "go" command first.
+
+* Before the engine is asked to search on a position, there will always be a position command
+  to tell the engine about the current position.
+
+* by default all the opening book handling is done by the GUI,
+  but there is an option for the engine to use its own book ("OwnBook" option, see below)
+
+* if the engine or the GUI receives an unknown command or token it should just ignore it and try to
+  parse the rest of the string in this line.
+  Examples: "joho debug on\n" should switch the debug mode on given that joho is not defined,
+            "debug joho on\n" will be undefined however.
+
+* if the engine receives a command which is not supposed to come, for example "stop" when the engine is
+  not calculating, it should also just ignore it.
+  
+
+Move format:
+------------
+
+The move format is in long algebraic notation.
+A nullmove from the Engine to the GUI should be sent as 0000.
+Examples:  e2e4, e7e5, e1g1 (white short castling), e7e8q (for promotion)
+
+
+
+GUI to engine:
+--------------
+
+These are all the command the engine gets from the interface.
+
+* uci
+	tell engine to use the uci (universal chess interface),
+	this will be sent once as a first command after program boot
+	to tell the engine to switch to uci mode.
+	After receiving the uci command the engine must identify itself with the "id" command
+	and send the "option" commands to tell the GUI which engine settings the engine supports if any.
+	After that the engine should send "uciok" to acknowledge the uci mode.
+	If no uciok is sent within a certain time period, the engine task will be killed by the GUI.
+
+* debug [ on | off ]
+	switch the debug mode of the engine on and off.
+	In debug mode the engine should send additional infos to the GUI, e.g. with the "info string" command,
+	to help debugging, e.g. the commands that the engine has received etc.
+	This mode should be switched off by default and this command can be sent
+	any time, also when the engine is thinking.
+
+* isready
+	this is used to synchronize the engine with the GUI. When the GUI has sent a command or
+	multiple commands that can take some time to complete,
+	this command can be used to wait for the engine to be ready again or
+	to ping the engine to find out if it is still alive.
+	E.g. this should be sent after setting the path to the tablebases as this can take some time.
+	This command is also required once before the engine is asked to do any search
+	to wait for the engine to finish initializing.
+	This command must always be answered with "readyok" and can be sent also when the engine is calculating
+	in which case the engine should also immediately answer with "readyok" without stopping the search.
+
+* setoption name <id> [value <x>]
+	this is sent to the engine when the user wants to change the internal parameters
+	of the engine. For the "button" type no value is needed.
+	One string will be sent for each parameter and this will only be sent when the engine is waiting.
+	The name and value of the option in <id> should not be case sensitive and can inlude spaces.
+	The substrings "value" and "name" should be avoided in <id> and <x> to allow unambiguous parsing,
+	for example do not use <name> = "draw value".
+	Here are some strings for the example below:
+	   "setoption name Nullmove value true\n"
+      "setoption name Selectivity value 3\n"
+	   "setoption name Style value Risky\n"
+	   "setoption name Clear Hash\n"
+	   "setoption name NalimovPath value c:\chess\tb\4;c:\chess\tb\5\n"
+
+* register
+	this is the command to try to register an engine or to tell the engine that registration
+	will be done later. This command should always be sent if the engine	has sent "registration error"
+	at program startup.
+	The following tokens are allowed:
+	* later
+	   the user doesn't want to register the engine now.
+	* name <x>
+	   the engine should be registered with the name <x>
+	* code <y>
+	   the engine should be registered with the code <y>
+	Example:
+	   "register later"
+	   "register name Stefan MK code 4359874324"
+
+* ucinewgame
+   this is sent to the engine when the next search (started with "position" and "go") will be from
+   a different game. This can be a new game the engine should play or a new game it should analyse but
+   also the next position from a testsuite with positions only.
+   If the GUI hasn't sent a "ucinewgame" before the first "position" command, the engine shouldn't
+   expect any further ucinewgame commands as the GUI is probably not supporting the ucinewgame command.
+   So the engine should not rely on this command even though all new GUIs should support it.
+   As the engine's reaction to "ucinewgame" can take some time the GUI should always send "isready"
+   after "ucinewgame" to wait for the engine to finish its operation.
+   
+* position [fen <fenstring> | startpos ]  moves <move1> .... <movei>
+	set up the position described in fenstring on the internal board and
+	play the moves on the internal chess board.
+	if the game was played  from the start position the string "startpos" will be sent
+	Note: no "new" command is needed. However, if this position is from a different game than
+	the last position sent to the engine, the GUI should have sent a "ucinewgame" inbetween.
+
+* go
+	start calculating on the current position set up with the "position" command.
+	There are a number of commands that can follow this command, all will be sent in the same string.
+	If one command is not sent its value should be interpreted as it would not influence the search.
+	* searchmoves <move1> .... <movei>
+		restrict search to this moves only
+		Example: After "position startpos" and "go infinite searchmoves e2e4 d2d4"
+		the engine should only search the two moves e2e4 and d2d4 in the initial position.
+	* ponder
+		start searching in pondering mode.
+		Do not exit the search in ponder mode, even if it's mate!
+		This means that the last move sent in in the position string is the ponder move.
+		The engine can do what it wants to do, but after a "ponderhit" command
+		it should execute the suggested move to ponder on. This means that the ponder move sent by
+		the GUI can be interpreted as a recommendation about which move to ponder. However, if the
+		engine decides to ponder on a different move, it should not display any mainlines as they are
+		likely to be misinterpreted by the GUI because the GUI expects the engine to ponder
+	   on the suggested move.
+	* wtime <x>
+		white has x msec left on the clock
+	* btime <x>
+		black has x msec left on the clock
+	* winc <x>
+		white increment per move in mseconds if x > 0
+	* binc <x>
+		black increment per move in mseconds if x > 0
+	* movestogo <x>
+      there are x moves to the next time control,
+		this will only be sent if x > 0,
+		if you don't get this and get the wtime and btime it's sudden death
+	* depth <x>
+		search x plies only.
+	* nodes <x>
+	   search x nodes only,
+	* mate <x>
+		search for a mate in x moves
+	* movetime <x>
+		search exactly x mseconds
+	* infinite
+		search until the "stop" command. Do not exit the search without being told so in this mode!
+    
+* stop
+	stop calculating as soon as possible,
+	don't forget the "bestmove" and possibly the "ponder" token when finishing the search
+
+* ponderhit
+	the user has played the expected move. This will be sent if the engine was told to ponder on the same move
+	the user has played. The engine should continue searching but switch from pondering to normal search.
+
+* quit
+	quit the program as soon as possible
+
+
+Engine to GUI:
+--------------
+
+* id
+	* name <x>
+		this must be sent after receiving the "uci" command to identify the engine,
+		e.g. "id name Shredder X.Y\n"
+	* author <x>
+		this must be sent after receiving the "uci" command to identify the engine,
+		e.g. "id author Stefan MK\n"
+
+* uciok
+	Must be sent after the id and optional options to tell the GUI that the engine
+	has sent all infos and is ready in uci mode.
+
+* readyok
+	This must be sent when the engine has received an "isready" command and has
+	processed all input and is ready to accept new commands now.
+	It is usually sent after a command that can take some time to be able to wait for the engine,
+	but it can be used anytime, even when the engine is searching,
+	and must always be answered with "isready".
+
+* bestmove <move1> [ ponder <move2> ]
+	the engine has stopped searching and found the move <move> best in this position.
+	the engine can send the move it likes to ponder on. The engine must not start pondering automatically.
+	this command must always be sent if the engine stops searching, also in pondering mode if there is a
+	"stop" command, so for every "go" command a "bestmove" command is needed!
+	Directly before that the engine should send a final "info" command with the final search information,
+	the the GUI has the complete statistics about the last search.
+
+* copyprotection
+	this is needed for copyprotected engines. After the uciok command the engine can tell the GUI,
+	that it will check the copy protection now. This is done by "copyprotection checking".
+	If the check is ok the engine should send "copyprotection ok", otherwise "copyprotection error".
+	If there is an error the engine should not function properly but should not quit alone.
+	If the engine reports "copyprotection error" the GUI should not use this engine
+	and display an error message instead!
+	The code in the engine can look like this
+      TellGUI("copyprotection checking\n");
+	   // ... check the copy protection here ...
+	   if(ok)
+	      TellGUI("copyprotection ok\n");
+      else
+         TellGUI("copyprotection error\n");
+         
+* registration
+	this is needed for engines that need a username and/or a code to function with all features.
+	Analog to the "copyprotection" command the engine can send "registration checking"
+	after the uciok command followed by either "registration ok" or "registration error".
+	Also after every attempt to register the engine it should answer with "registration checking"
+	and then either "registration ok" or "registration error".
+	In contrast to the "copyprotection" command, the GUI can use the engine after the engine has
+	reported an error, but should inform the user that the engine is not properly registered
+	and might not use all its features.
+	In addition the GUI should offer to open a dialog to
+	enable registration of the engine. To try to register an engine the GUI can send
+	the "register" command.
+	The GUI has to always answer with the "register" command	if the engine sends "registration error"
+	at engine startup (this can also be done with "register later")
+	and tell the user somehow that the engine is not registered.
+	This way the engine knows that the GUI can deal with the registration procedure and the user
+	will be informed that the engine is not properly registered.
+	      
+* info
+	the engine wants to send information to the GUI. This should be done whenever one of the info has changed.
+	The engine can send only selected infos or multiple infos with one info command,
+	e.g. "info currmove e2e4 currmovenumber 1" or
+	     "info depth 12 nodes 123456 nps 100000".
+	Also all infos belonging to the pv should be sent together
+	e.g. "info depth 2 score cp 214 time 1242 nodes 2124 nps 34928 pv e2e4 e7e5 g1f3"
+	I suggest to start sending "currmove", "currmovenumber", "currline" and "refutation" only after one second
+	to avoid too much traffic.
+	Additional info:
+	* depth <x>
+		search depth in plies
+	* seldepth <x>
+		selective search depth in plies,
+		if the engine sends seldepth there must also be a "depth" present in the same string.
+	* time <x>
+		the time searched in ms, this should be sent together with the pv.
+	* nodes <x>
+		x nodes searched, the engine should send this info regularly
+	* pv <move1> ... <movei>
+		the best line found
+	* multipv <num>
+		this for the multi pv mode.
+		for the best move/pv add "multipv 1" in the string when you send the pv.
+		in k-best mode always send all k variants in k strings together.
+	* score
+		* cp <x>
+			the score from the engine's point of view in centipawns.
+		* mate <y>
+			mate in y moves, not plies.
+			If the engine is getting mated use negative values for y.
+		* lowerbound
+	      the score is just a lower bound.
+		* upperbound
+		   the score is just an upper bound.
+	* currmove <move>
+		currently searching this move
+	* currmovenumber <x>
+		currently searching move number x, for the first move x should be 1 not 0.
+	* hashfull <x>
+		the hash is x permill full, the engine should send this info regularly
+	* nps <x>
+		x nodes per second searched, the engine should send this info regularly
+	* tbhits <x>
+		x positions where found in the endgame table bases
+	* sbhits <x>
+		x positions where found in the shredder endgame databases
+	* cpuload <x>
+		the cpu usage of the engine is x permill.
+	* string <str>
+		any string str which will be displayed be the engine,
+		if there is a string command the rest of the line will be interpreted as <str>.
+	* refutation <move1> <move2> ... <movei>
+	   move <move1> is refuted by the line <move2> ... <movei>, i can be any number >= 1.
+	   Example: after move d1h5 is searched, the engine can send
+	   "info refutation d1h5 g6h5"
+	   if g6h5 is the best answer after d1h5 or if g6h5 refutes the move d1h5.
+	   if there is no refutation for d1h5 found, the engine should just send
+	   "info refutation d1h5"
+		The engine should only send this if the option "UCI_ShowRefutations" is set to true.
+	* currline <cpunr> <move1> ... <movei>
+	   this is the current line the engine is calculating. <cpunr> is the number of the cpu if
+	   the engine is running on more than one cpu. <cpunr> = 1,2,3....
+	   if the engine is just using one cpu, <cpunr> can be omitted.
+	   If <cpunr> is greater than 1, always send all k lines in k strings together.
+		The engine should only send this if the option "UCI_ShowCurrLine" is set to true.
+	
+
+* option
+	This command tells the GUI which parameters can be changed in the engine.
+	This should be sent once at engine startup after the "uci" and the "id" commands
+	if any parameter can be changed in the engine.
+	The GUI should parse this and build a dialog for the user to change the settings.
+	Note that not every option needs to appear in this dialog as some options like
+	"Ponder", "UCI_AnalyseMode", etc. are better handled elsewhere or are set automatically.
+	If the user wants to change some settings, the GUI will send a "setoption" command to the engine.
+	Note that the GUI need not send the setoption command when starting the engine for every option if
+	it doesn't want to change the default value.
+	For all allowed combinations see the examples below,
+	as some combinations of this tokens don't make sense.
+	One string will be sent for each parameter.
+	* name <id>
+		The option has the name id.
+		Certain options have a fixed value for <id>, which means that the semantics of this option is fixed.
+		Usually those options should not be displayed in the normal engine options window of the GUI but
+		get a special treatment. "Pondering" for example should be set automatically when pondering is
+		enabled or disabled in the GUI options. The same for "UCI_AnalyseMode" which should also be set
+		automatically by the GUI. All those certain options have the prefix "UCI_" except for the
+		first 6 options below. If the GUI gets an unknown Option with the prefix "UCI_", it should just
+		ignore it and not display it in the engine's options dialog.
+		* <id> = Hash, type is spin
+			the value in MB for memory for hash tables can be changed,
+			this should be answered with the first "setoptions" command at program boot
+			if the engine has sent the appropriate "option name Hash" command,
+			which should be supported by all engines!
+			So the engine should use a very small hash first as default.
+		* <id> = NalimovPath, type string
+			this is the path on the hard disk to the Nalimov compressed format.
+			Multiple directories can be concatenated with ";"
+		* <id> = NalimovCache, type spin
+			this is the size in MB for the cache for the nalimov table bases
+			These last two options should also be present in the initial options exchange dialog
+			when the engine is booted if the engine supports it
+		* <id> = Ponder, type check
+			this means that the engine is able to ponder.
+			The GUI will send this whenever pondering is possible or not.
+			Note: The engine should not start pondering on its own if this is enabled, this option is only
+			needed because the engine might change its time management algorithm when pondering is allowed.
+		* <id> = OwnBook, type check
+			this means that the engine has its own book which is accessed by the engine itself.
+			if this is set, the engine takes care of the opening book and the GUI will never
+			execute a move out of its book for the engine. If this is set to false by the GUI,
+			the engine should not access its own book.
+		* <id> = MultiPV, type spin
+			the engine supports multi best line or k-best mode. the default value is 1
+		* <id> = UCI_ShowCurrLine, type check, should be false by default,
+			the engine can show the current line it is calculating. see "info currline" above.
+		* <id> = UCI_ShowRefutations, type check, should be false by default,
+			the engine can show a move and its refutation in a line. see "info refutations" above.
+		* <id> = UCI_LimitStrength, type check, should be false by default,
+			The engine is able to limit its strength to a specific Elo number,
+		   This should always be implemented together with "UCI_Elo".
+		* <id> = UCI_Elo, type spin
+			The engine can limit its strength in Elo within this interval.
+			If UCI_LimitStrength is set to false, this value should be ignored.
+			If UCI_LimitStrength is set to true, the engine should play with this specific strength.
+		   This should always be implemented together with "UCI_LimitStrength".
+		* <id> = UCI_AnalyseMode, type check
+		   The engine wants to behave differently when analysing or playing a game.
+		   For example when playing it can use some kind of learning.
+		   This is set to false if the engine is playing a game, otherwise it is true.
+		 * <id> = UCI_Opponent, type string
+		   With this command the GUI can send the name, title, elo and if the engine is playing a human
+		   or computer to the engine.
+		   The format of the string has to be [GM|IM|FM|WGM|WIM|none] [<elo>|none] [computer|human] <name>
+		   Examples:
+		   "setoption name UCI_Opponent value GM 2800 human Gary Kasparov"
+		   "setoption name UCI_Opponent value none none computer Shredder"
+		 * <id> = UCI_EngineAbout, type string
+		   With this command, the engine tells the GUI information about itself, for example a license text,
+		   usually it doesn't make sense that the GUI changes this text with the setoption command.
+		   Example:
+			"option name UCI_EngineAbout type string default Shredder by Stefan Meyer-Kahlen, see www.shredderchess.com"
+		* <id> = UCI_ShredderbasesPath, type string
+			this is either the path to the folder on the hard disk containing the Shredder endgame databases or
+			the path and filename of one Shredder endgame datbase.
+	   * <id> = UCI_SetPositionValue, type string
+	      the GUI can send this to the engine to tell the engine to use a certain value in centipawns from white's
+	      point of view if evaluating this specifix position. 
+	      The string can have the formats:
+	      <value> + <fen> | clear + <fen> | clearall
+	   		
+	* type <t>
+		The option has type t.
+		There are 5 different types of options the engine can send
+		* check
+			a checkbox that can either be true or false
+		* spin
+			a spin wheel that can be an integer in a certain range
+		* combo
+			a combo box that can have different predefined strings as a value
+		* button
+			a button that can be pressed to send a command to the engine
+		* string
+			a text field that has a string as a value,
+			an empty string has the value "<empty>"
+	* default <x>
+		the default value of this parameter is x
+	* min <x>
+		the minimum value of this parameter is x
+	* max <x>
+		the maximum value of this parameter is x
+	* var <x>
+		a predefined value of this parameter is x
+	Examples:
+    Here are 5 strings for each of the 5 possible types of options
+	   "option name Nullmove type check default true\n"
+      "option name Selectivity type spin default 2 min 0 max 4\n"
+	   "option name Style type combo default Normal var Solid var Normal var Risky\n"
+	   "option name NalimovPath type string default c:\\n"
+	   "option name Clear Hash type button\n"
+
+
+
+Examples:
+---------
+
+This is how the communication when the engine boots can look like:
+
+GUI     engine
+
+// tell the engine to switch to UCI mode
+uci
+
+// engine identify  
+      id name Shredder
+		id author Stefan MK
+
+// engine sends the options it can change
+// the engine can change the hash size from 1 to 128 MB
+		option name Hash type spin default 1 min 1 max 128
+
+// the engine supports Nalimov endgame tablebases
+		option name NalimovPath type string default <empty>
+		option name NalimovCache type spin default 1 min 1 max 32
+
+// the engine can switch off Nullmove and set the playing style
+	   option name Nullmove type check default true
+  		option name Style type combo default Normal var Solid var Normal var Risky
+
+// the engine has sent all parameters and is ready
+		uciok
+
+// Note: here the GUI can already send a "quit" command if it just wants to find out
+//       details about the engine, so the engine should not initialize its internal
+//       parameters before here.
+// now the GUI sets some values in the engine
+// set hash to 32 MB
+setoption name Hash value 32
+
+// init tbs
+setoption name NalimovCache value 1
+setoption name NalimovPath value d:\tb;c\tb
+
+// waiting for the engine to finish initializing
+// this command and the answer is required here!
+isready
+
+// engine has finished setting up the internal values
+		readyok
+
+// now we are ready to go
+
+// if the GUI is supporting it, tell the engine that is is
+// searching on a game that it hasn't searched on before
+ucinewgame
+
+// if the engine supports the "UCI_AnalyseMode" option and the next search is supposed to
+// be an analysis, the GUI should set "UCI_AnalyseMode" to true if it is currently
+// set to false with this engine
+setoption name UCI_AnalyseMode value true
+
+// tell the engine to search infinite from the start position after 1.e4 e5
+position startpos moves e2e4 e7e5
+go infinite
+
+// the engine starts sending infos about the search to the GUI
+// (only some examples are given)
+
+
+		info depth 1 seldepth 0
+		info score cp 13  depth 1 nodes 13 time 15 pv f1b5 
+		info depth 2 seldepth 2
+		info nps 15937
+		info score cp 14  depth 2 nodes 255 time 15 pv f1c4 f8c5 
+		info depth 2 seldepth 7 nodes 255
+		info depth 3 seldepth 7
+		info nps 26437
+		info score cp 20  depth 3 nodes 423 time 15 pv f1c4 g8f6 b1c3 
+		info nps 41562
+		....
+
+
+// here the user has seen enough and asks to stop the searching
+stop
+
+// the engine has finished searching and is sending the bestmove command
+// which is needed for every "go" command sent to tell the GUI
+// that the engine is ready again
+		bestmove g1f3 ponder d8f6
+
+
+
+Chess960
+========
+
+UCI could easily be extended to support Chess960 (also known as Fischer Random Chess).
+
+The engine has to tell the GUI that it is capable of playing Chess960 and the GUI has to tell
+the engine that is should play according to the Chess960 rules.
+This is done by the special engine option UCI_Chess960. If the engine knows about Chess960
+it should send the command 'option name UCI_Chess960 type check default false'
+to the GUI at program startup.
+Whenever a Chess960 game is played, the GUI should set this engine option to 'true'.
+
+Castling is different in Chess960 and the white king move when castling short is not always e1g1.
+A king move could both be the castling king move or just a normal king move.
+This is why castling moves are sent in the form king "takes" his own rook.
+Example: e1h1 for the white short castle move in the normal chess start position.
+
+In EPD and FEN position strings specifying the castle rights with w and q is not enough as
+there could be more than one rook on the right or left side of the king.
+This is why the castle rights are specified with the letter of the castle rook's line.
+Upper case letters for white's and lower case letters for black's castling rights.
+Example: The normal chess position would be:
+rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w AHah -
+

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.0)
+project(jstockfish)
+
+#-------------------------------------------------------------------------------
+# Build jstockfish.jar
+
+# http://www.cmake.org/cmake/help/v3.0/module/FindJava.html
+find_package(Java REQUIRED)
+if (Java_FOUND)
+    message (STATUS "Java_JAVAH_EXECUTABLE=${Java_JAVAH_EXECUTABLE}")
+endif()
+
+include(UseJava)
+set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.6" "-target" "1.6")
+file(GLOB JAVA_SOURCES "src/main/java/jstockfish/*.java")
+add_jar(javastockfish ${JAVA_SOURCES} OUTPUT_NAME jstockfish)
+
+#-------------------------------------------------------------------------------
+# Build libjstockfish.dylib/so/dll
+
+# http://www.cmake.org/cmake/help/v3.0/module/FindJNI.html
+find_package(JNI REQUIRED)
+if (JNI_FOUND)
+    message (STATUS "JNI_INCLUDE_DIRS=${JNI_INCLUDE_DIRS}")
+    message (STATUS "JNI_LIBRARIES=${JNI_LIBRARIES}")
+endif()
+
+# Generate JNI .h files
+execute_process(
+    COMMAND ${Java_JAVAH_EXECUTABLE} -verbose -jni
+        -cp ${CMAKE_CURRENT_LIST_DIR}/src/main/java
+        -d  ${CMAKE_CURRENT_LIST_DIR}/src/main/cpp
+        jstockfish.Uci
+
+    COMMAND ${Java_JAVAH_EXECUTABLE} -verbose -jni
+        -cp ${CMAKE_CURRENT_LIST_DIR}/src/main/java
+        -d  ${CMAKE_CURRENT_LIST_DIR}/src/main/cpp
+        jstockfish.Position
+)
+
+include_directories(${JNI_INCLUDE_DIRS} "../src" "src/main/cpp")
+
+# Exclude misc_sync_cout.cpp because we'll implement uci_out to
+# redirect Stockfish output to Java side
+file(GLOB JNI_SOURCES "../src/*.cpp" "../src/syzygy/tbprobe.cpp" "src/main/cpp/*.cpp")
+list(REMOVE_ITEM JNI_SOURCES "${CMAKE_CURRENT_LIST_DIR}/../src/misc_sync_cout.cpp")
+
+set(CMAKE_CXX_STANDARD 11)
+
+# See Stockfish's Makefile "make build ARCH=x86-64-modern"
+set(STOCKFISH_FLAGS "-Wall -Wcast-qual -fno-exceptions -fno-rtti -std=c++11 -pedantic -Wextra -Wshadow -m64 -DNDEBUG -O3 -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${STOCKFISH_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${STOCKFISH_FLAGS}")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${STOCKFISH_FLAGS}")
+
+add_library(jstockfish SHARED ${JNI_SOURCES} ${JNI_LIBRARIES})

--- a/jni/Readme.md
+++ b/jni/Readme.md
@@ -1,0 +1,125 @@
+## Features
+
+* [UCI commands](https://github.com/ngocdaothanh/JStockfish/blob/master/engine-interface.txt)
+* Additional commands convenient for checking if a move is legal, getting FEN
+  and state from a position (check mate, stale mate, draw by 50-move rule or
+  3-fold repetition rule)
+
+## Build
+
+You need [CMake](http://www.cmake.org/), JVM, and a C++ compiler to build:
+
+```
+./build.sh
+```
+
+`build` directory will be created, containing the compiled library.
+
+If you see error like this:
+
+```
+Could NOT find JNI
+```
+
+Then try exporting `JAVA_HOME` and try building again:
+
+```
+export JAVA_HOME=/usr/lib/jvm/java-8-oracle
+```
+
+## Try with SBT
+
+For details, please see [Javadoc](http://ngocdaothanh.github.io/JStockfish/).
+
+```
+sbt console -Djava.library.path=build
+```
+
+### Standard UCI commands
+
+```
+import jstockfish.Uci
+
+Uci.uci
+Uci.setoption("Threads", Runtime.getRuntime.availableProcessors.toString)
+Uci.setoption("UCI_Chess960", "true")
+
+Uci.ucinewgame()
+Uci.position("startpos moves d2d4")
+Uci.go("infinite")
+Uci.stop()
+Uci.ponderhit()
+```
+
+### Additional commands added by Stockfish
+
+```
+Uci.flip
+Uci.bench("512 4 16")
+Uci.d
+Uci.eval
+Uci.perft(16)
+```
+
+### Additional commands added by JStockfish
+
+```
+Uci.islegal("g8f6")
+Uci.fen
+Uci.state
+```
+
+State enum:
+
+```
+ALIVE,
+
+WHITE_MATE,       // White mates (white wins)
+BLACK_MATE,       // Black mates (black wins)
+
+// Automatic draw
+WHITE_STALEMATE,  // White is stalemated (white can't move)
+BLACK_STALEMATE,  // Black is stalemated (black can't move)
+DRAW_NO_MATE,     // Draw by insufficient material
+
+// Can draw, but players must claim
+CAN_DRAW_50,      // Can draw by 50-move rule
+CAN_DRAW_REP;     // Can draw by 3-fold repetition rule
+```
+
+The order is similar to that of
+[Cuckoo](https://code.google.com/p/cuckoochess/source/browse/trunk/CuckooChessEngine/src/chess/Game.java#134)
+chess engine.
+
+### Additional commands added by JStockfish, independent of the current game
+
+Stockfish can't process multiple games at a time. Calls to methods of class
+`Uci` should be synchronized. However, methods of class `Position` can be called
+any time, no need to synchronize:
+
+```
+import jstockfish.Position
+
+val chess960 = false
+Position.islegal(chess960, "startpos moves d2d4", "g8f6")
+Position.fen(chess960, "startpos moves d2d4")
+Position.state(chess960, "startpos moves d2d4")
+```
+
+### Get additional info together with bestmove
+
+Instead of sending `Uci.go` to get `bestmove`, then `Position.state` to get
+state of the position after the move is made, you can set option to tell `UCI.go`
+to also output `info state <state enum>` before outputing `bestmove`:
+
+```
+Uci.setoption("Info State", "true")
+```
+
+This way, you can get better performance.
+
+Similarly, to get `info fen <FEN>`:
+
+```
+Uci.setoption("Info FEN", "true")
+```

--- a/jni/build.sh
+++ b/jni/build.sh
@@ -1,0 +1,4 @@
+mkdir build
+cd build
+cmake ..
+make

--- a/jni/src/main/cpp/jstockfish.cpp
+++ b/jni/src/main/cpp/jstockfish.cpp
@@ -1,0 +1,344 @@
+// Basically, this file looks like uci.cpp file of Stockfish.
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "evaluate.h"
+#include "movegen.h"
+#include "position.h"
+#include "positionstate.h"
+#include "search.h"
+#include "thread.h"
+#include "timeman.h"
+#include "tt.h"
+#include "uci.h"
+#include "syzygy/tbprobe.h"
+
+#include "jstockfish_Uci.h"
+#include "jstockfish_Position.h"
+
+using namespace std;
+
+//------------------------------------------------------------------------------
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+jint JNI_OnLoad(JavaVM* vm, void* reserved);
+
+#ifdef __cplusplus
+}
+#endif
+
+//------------------------------------------------------------------------------
+
+static JavaVM* jvm = NULL;
+static jclass uciClass = NULL;
+static jmethodID onOutput = NULL;
+
+// Call jstockfish.Uci.onOutput
+void uci_out(string output) {
+  // Should another thread need to access the Java VM, it must first call
+  // AttachCurrentThread() to attach itself to the VM and obtain a JNI interface pointer
+  JNIEnv *env;
+  if (jvm->AttachCurrentThread((void **) &env, NULL) != 0) {
+    cout << "[JNI] Could not AttachCurrentThread" << endl;
+    return;
+  }
+
+  jstring js = env->NewStringUTF(output.c_str());
+  env->CallStaticVoidMethod(uciClass, onOutput, js);
+  jvm->DetachCurrentThread();
+}
+
+//------------------------------------------------------------------------------
+
+// In Stockfish's benchmark.cpp
+void benchmark(const Position& current, istream& is);
+
+// FEN string of the initial position, normal chess
+static const char* START_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+// A list to keep track of the position states along the setup moves (from the
+// start position to the position just before the search starts). Needed by
+// 'draw by repetition' detection.
+static StateListPtr gStates(new std::deque<StateInfo>(1));
+
+// The root position
+static Position gPos;
+
+//------------------------------------------------------------------------------
+
+bool initJvm(JavaVM *vm) {
+  jvm = vm;
+
+  JNIEnv *env;
+  int stat = jvm->GetEnv((void **) &env, JNI_VERSION_1_6);
+	if (stat != JNI_OK) {
+    cout << "[JNI] Could not GetEnv" << endl;
+    return false;
+  }
+
+  uciClass = env->FindClass("Ljstockfish/Uci;");
+	if (!uciClass) {
+    cout << "[JNI] Could not find class jstockfish.Uci" << endl;
+    return false;
+  }
+
+  onOutput = env->GetStaticMethodID(uciClass, "onOutput", "(Ljava/lang/String;)V");
+	if (!onOutput) {
+    cout << "[JNI] Could not get method jstockfish.Uci.onOutput" << endl;
+    return false;
+  }
+
+  return true;
+}
+
+bool read_position(
+  JNIEnv *env, jboolean chess960, jstring position,
+  StateListPtr& states, Position& pos
+) {
+  const char *chars = env->GetStringUTFChars(position, NULL);
+  istringstream is(chars);
+  env->ReleaseStringUTFChars(position, chars);
+
+  Move m;
+  string token, fen;
+
+  is >> token;
+
+  if (token == "startpos")
+  {
+    fen = START_FEN;
+    is >> token; // Consume "moves" token if any
+  }
+  else if (token == "fen")
+    while (is >> token && token != "moves")
+      fen += token + " ";
+  else
+    return false;
+
+  pos.set(fen, chess960, &states->back(), Threads.main());
+
+  // Parse move list (if any)
+  while (is >> token)
+  {
+    m = UCI::to_move(pos, token);
+    if (m == MOVE_NONE) return false;
+
+    states->push_back(StateInfo());
+    pos.do_move(m, states->back());
+  }
+
+  return true;
+}
+
+bool islegal(Position& pos, JNIEnv *env, jstring move) {
+  const char *chars = env->GetStringUTFChars(move, NULL);
+  string str = chars;
+  env->ReleaseStringUTFChars(move, chars);
+
+  Move m = UCI::to_move(pos, str);
+  return pos.pseudo_legal(m);
+}
+
+//------------------------------------------------------------------------------
+
+namespace PSQT {
+  void init();
+}
+
+jint JNI_OnLoad(JavaVM *vm, void*) {
+	if (!initJvm(vm)) return JNI_VERSION_1_6;
+
+  UCI::init(Options);
+  PSQT::init();
+  Bitboards::init();
+  Position::init();
+  Bitbases::init();
+  Search::init();
+  Pawns::init();
+  Threads.init();
+  Tablebases::init(Options["SyzygyPath"]);
+  TT.resize(Options["Hash"]);
+
+  gPos.set(START_FEN, Options["UCI_Chess960"], &gStates->back(), Threads.main());
+
+  return JNI_VERSION_1_6;
+}
+
+JNIEXPORT jstring JNICALL Java_jstockfish_Uci_uci(JNIEnv *env, jclass) {
+  stringstream uci;
+  uci << "id name " << engine_info(true)
+      << "\n"       << Options
+      << "\nuciok";
+
+  jstring ret = env->NewStringUTF(uci.str().c_str());
+  return ret;
+}
+
+JNIEXPORT jboolean JNICALL Java_jstockfish_Uci_setoption(JNIEnv *env, jclass, jstring name, jstring value) {
+  const char *chars_name = env->GetStringUTFChars(name, NULL);
+  string str_name = chars_name;
+  env->ReleaseStringUTFChars(name, chars_name);
+
+  const char *chars_value = env->GetStringUTFChars(value, NULL);
+  string str_value = chars_value;
+  env->ReleaseStringUTFChars(value, chars_value);
+
+  if (Options.count(str_name)) {
+      Options[str_name] = str_value;
+      return true;
+  } else {
+      return false;
+  }
+}
+
+JNIEXPORT void JNICALL Java_jstockfish_Uci_ucinewgame(JNIEnv *, jclass) {
+  Search::clear();
+  Tablebases::init(Options["SyzygyPath"]);
+  Time.availableNodes = 0;
+}
+
+JNIEXPORT jboolean JNICALL Java_jstockfish_Uci_position(JNIEnv *env, jclass, jstring position) {
+  gStates = StateListPtr(new std::deque<StateInfo>(1));
+  return read_position(
+    env, Options["UCI_Chess960"], position,
+    gStates, gPos
+  );
+}
+
+//------------------------------------------------------------------------------
+
+JNIEXPORT void JNICALL Java_jstockfish_Uci_go(JNIEnv *env, jclass, jstring options) {
+  const char *chars = env->GetStringUTFChars(options, NULL);
+  istringstream is(chars);
+  env->ReleaseStringUTFChars(options, chars);
+
+  Search::LimitsType limits;
+  string token;
+
+  while (is >> token)
+    if (token == "searchmoves")
+      while (is >> token)
+        limits.searchmoves.push_back(UCI::to_move(gPos, token));
+
+    else if (token == "wtime")     is >> limits.time[WHITE];
+    else if (token == "btime")     is >> limits.time[BLACK];
+    else if (token == "winc")      is >> limits.inc[WHITE];
+    else if (token == "binc")      is >> limits.inc[BLACK];
+    else if (token == "movestogo") is >> limits.movestogo;
+    else if (token == "depth")     is >> limits.depth;
+    else if (token == "nodes")     is >> limits.nodes;
+    else if (token == "movetime")  is >> limits.movetime;
+    else if (token == "mate")      is >> limits.mate;
+    else if (token == "infinite")  limits.infinite = true;
+    else if (token == "ponder")    limits.ponder = true;
+
+  Threads.start_thinking(gPos, gStates, limits);
+}
+
+JNIEXPORT void JNICALL Java_jstockfish_Uci_stop(JNIEnv *, jclass) {
+  Search::Signals.stop = true;
+  Threads.main()->start_searching(true); // Could be sleeping
+}
+
+JNIEXPORT void JNICALL Java_jstockfish_Uci_ponderhit(JNIEnv *, jclass) {
+  if (Search::Signals.stopOnPonderhit) {
+    Search::Signals.stop = true;
+    Threads.main()->start_searching(true); // Could be sleeping
+  } else {
+    Search::Limits.ponder = false; // Switch to normal search
+  }
+}
+
+//------------------------------------------------------------------------------
+
+JNIEXPORT void JNICALL Java_jstockfish_Uci_flip(JNIEnv *, jclass) {
+  gPos.flip();
+}
+
+JNIEXPORT void JNICALL Java_jstockfish_Uci_bench(JNIEnv *env, jclass, jstring options) {
+  const char *chars = env->GetStringUTFChars(options, NULL);
+  istringstream is(chars);
+  env->ReleaseStringUTFChars(options, chars);
+
+  benchmark(gPos, is);
+}
+
+JNIEXPORT jstring JNICALL Java_jstockfish_Uci_d(JNIEnv *env, jclass) {
+  stringstream ss;
+  ss << gPos;
+  jstring ret = env->NewStringUTF(ss.str().c_str());
+  return ret;
+}
+
+JNIEXPORT jstring JNICALL Java_jstockfish_Uci_eval(JNIEnv *env, jclass) {
+  stringstream ss;
+  ss << Eval::trace(gPos);
+  jstring ret = env->NewStringUTF(ss.str().c_str());
+  return ret;
+}
+
+JNIEXPORT void JNICALL Java_jstockfish_Uci_perft(JNIEnv *, jclass, jint depth) {
+  stringstream ss;
+  ss << Options["Hash"]    << " "
+     << Options["Threads"] << " " << depth << " current perft";
+  benchmark(gPos, ss);
+}
+
+//------------------------------------------------------------------------------
+
+JNIEXPORT jboolean JNICALL Java_jstockfish_Uci_islegal(
+  JNIEnv *env, jclass, jstring move
+) {
+  return islegal(gPos, env, move);
+}
+
+JNIEXPORT jstring JNICALL Java_jstockfish_Uci_fen(JNIEnv *env, jclass) {
+  string fen = gPos.fen();
+  jstring ret = env->NewStringUTF(fen.c_str());
+  return ret;
+}
+
+JNIEXPORT jint JNICALL Java_jstockfish_Uci_positionstate(JNIEnv *, jclass) {
+  return positionstate(gPos);
+}
+
+//------------------------------------------------------------------------------
+
+JNIEXPORT jboolean JNICALL Java_jstockfish_Position_islegal(
+  JNIEnv *env, jclass, jboolean chess960, jstring position, jstring move
+) {
+  StateListPtr states(new std::deque<StateInfo>(1));
+  Position pos;
+  return
+    read_position(env, chess960, position, states, pos) &&
+    islegal(pos, env, move);
+}
+
+JNIEXPORT jstring JNICALL Java_jstockfish_Position_fen(
+  JNIEnv *env, jclass, jboolean chess960, jstring position
+) {
+  StateListPtr states(new std::deque<StateInfo>(1));
+  Position pos;
+  read_position(env, chess960, position, states, pos);
+
+  // When read_position above returns false, the result is somewhere in the middle
+  string fen = pos.fen();
+  jstring ret = env->NewStringUTF(fen.c_str());
+  return ret;
+}
+
+JNIEXPORT jint JNICALL Java_jstockfish_Position_positionstate(
+  JNIEnv *env, jclass, jboolean chess960, jstring position
+) {
+  StateListPtr states(new std::deque<StateInfo>(1));
+  Position pos;
+  read_position(env, chess960, position, states, pos);
+
+  // When read_position above returns false, the result is somewhere in the middle
+  return positionstate(pos);
+}

--- a/jni/src/main/java/jstockfish/OutputListener.java
+++ b/jni/src/main/java/jstockfish/OutputListener.java
@@ -1,0 +1,5 @@
+package jstockfish;
+
+public interface OutputListener {
+    void onOutput(String output);
+}

--- a/jni/src/main/java/jstockfish/Position.java
+++ b/jni/src/main/java/jstockfish/Position.java
@@ -1,0 +1,22 @@
+package jstockfish;
+
+/**
+ * Additional commands added by JStockfish, independent of the current game,
+ * can be called any time.
+ */
+public class Position {
+    static {
+        System.loadLibrary("jstockfish");
+    }
+
+    public static native boolean islegal(boolean chess960, String position, String move);
+
+    public static native String fen(boolean chess960, String position);
+
+    private static native int positionstate(boolean chess960, String position);
+
+    public static State state(boolean chess960, String position) {
+        int ordinal = positionstate(chess960, position);
+        return State.values()[ordinal];
+    }
+}

--- a/jni/src/main/java/jstockfish/State.java
+++ b/jni/src/main/java/jstockfish/State.java
@@ -1,0 +1,30 @@
+package jstockfish;
+
+/**
+ * States of a chess board position.
+ */
+public enum State {
+    // The order is NOT similar to that of Cuckoo chess engine:
+    // https://code.google.com/p/cuckoochess/source/browse/trunk/CuckooChessEngine/src/chess/Game.java#134
+
+    ALIVE,
+
+    WHITE_MATE,       // White mates (white wins)
+    BLACK_MATE,       // Black mates (black wins)
+
+    // Automatic draw
+    WHITE_STALEMATE,  // White is stalemated (white can't move)
+    BLACK_STALEMATE,  // Black is stalemated (black can't move)
+    DRAW_NO_MATE,     // Draw by insufficient material
+
+    // Can draw, but players must claim
+    CAN_DRAW_50,      // Can draw by 50-move rule
+    CAN_DRAW_REP;     // Can draw by 3-fold repetition rule
+
+    public boolean isAutomaticOver() {
+        return
+            this == WHITE_MATE || this == BLACK_MATE ||
+            this == WHITE_STALEMATE || this == BLACK_STALEMATE ||
+            this == DRAW_NO_MATE;
+    }
+}

--- a/jni/src/main/java/jstockfish/Uci.java
+++ b/jni/src/main/java/jstockfish/Uci.java
@@ -1,0 +1,85 @@
+package jstockfish;
+
+/**
+ * This class contains commands that mimic UCI commands.
+ *
+ * <p>{@code go}, {@code ponderhit}, {@code bench}, and {@code perft} are async. Use
+ * {@code setOutputListener} to capture the results. Others are sync, they return
+ * results immediately.
+ *
+ * <p>Stockfish can't process multiple games at a time. User of this class should
+ * handle synchronization.
+ */
+public class Uci {
+    static {
+        System.loadLibrary("jstockfish");
+    }
+
+    // By default, just dump to console
+    private static OutputListener listener = new OutputListener() {
+        @Override
+        public void onOutput(String output) {
+            System.out.println(output);
+        }
+    };
+
+    /** Only one listener is supported. */
+    public static void setOutputListener(OutputListener listener) {
+        Uci.listener = listener;
+    }
+
+    /** Called by native code. This method will in turn call the listener. */
+    private static void onOutput(String output) {
+        if (listener != null) listener.onOutput(output);
+    }
+
+    // Standard UCI commands ---------------------------------------------------
+    // - debug: unavailable because Stockfish always outputs "info"
+    // - isready: unavailable this lib is always ready
+
+    /** Returns UCI id and options. */
+    public static native String uci();
+
+    /** Returns false if the option name is incorrect. */
+    public static native boolean setoption(String name, String value);
+
+    public static native void ucinewgame();
+
+    /** Returns false if the position is invalid. */
+    public static native boolean position(String position);
+
+    /** The result will be output asynchronously. */
+    public static native void go(String options);
+
+    /** Stops when {@code go("infinite")} is called. */
+    public static native void stop();
+
+    public static native void ponderhit();
+
+    // Additional commands added by Stockfish ----------------------------------
+
+    public static native void flip();
+
+    /** The result will be output asynchronously. */
+    public static native void bench(String options);
+
+    /** The result will be output asynchronously. */
+    public static native void perft(int depth);
+
+    public static native String d();
+
+    public static native String eval();
+
+    // Additional commands added by JStockfish ---------------------------------
+
+    public static native boolean islegal(String move);
+
+    public static native String fen();
+
+    private static native int positionstate();
+
+    public static State state() {
+        int ordinal = positionstate();
+        return State.values()[ordinal];
+    }
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,7 +39,7 @@ PGOBENCH = ./$(EXE) bench
 
 ### Object files
 OBJS = benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o \
-	material.o misc.o movegen.o movepick.o pawns.o position.o psqt.o \
+	material.o misc.o misc_sync_cout.o movegen.o movepick.o pawns.o position.o positionstate.o psqt.o \
 	search.o thread.o timeman.o tt.o uci.o ucioption.o syzygy/tbprobe.o
 
 ### ==========================================================================
@@ -450,7 +450,7 @@ install:
 
 #clean all
 clean: objclean profileclean
-	@rm -f .depend *~ core 
+	@rm -f .depend *~ core
 
 # clean binaries and objects
 objclean:

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -40,6 +40,7 @@ const std::string pretty(Bitboard b);
 }
 
 const Bitboard DarkSquares = 0xAA55AA55AA55AA55ULL;
+const Bitboard LightSquares = 0x55AA55AA55AA55AAULL;
 
 const Bitboard FileABB = 0x0101010101010101ULL;
 const Bitboard FileBBB = FileABB << 1;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -161,6 +161,7 @@ void dbg_print() {
 /// Used to serialize access to std::cout to avoid multiple threads writing at
 /// the same time.
 
+std::stringstream sync_ss;
 std::ostream& operator<<(std::ostream& os, SyncCout sc) {
 
   static Mutex m;
@@ -168,8 +169,17 @@ std::ostream& operator<<(std::ostream& os, SyncCout sc) {
   if (sc == IO_LOCK)
       m.lock();
 
-  if (sc == IO_UNLOCK)
+  if (sc == IO_UNLOCK) {
+      string out = sync_ss.str();
+
+      // Reset sync_ss
+      sync_ss.str("");
+      sync_ss.clear();
+
+      // Unlock before calling uci_out because m may not be reentrant
       m.unlock();
+      uci_out(out);
+  }
 
   return os;
 }

--- a/src/misc.h
+++ b/src/misc.h
@@ -24,6 +24,7 @@
 #include <cassert>
 #include <chrono>
 #include <ostream>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -57,8 +58,14 @@ private:
 enum SyncCout { IO_LOCK, IO_UNLOCK };
 std::ostream& operator<<(std::ostream&, SyncCout);
 
-#define sync_cout std::cout << IO_LOCK
-#define sync_endl std::endl << IO_UNLOCK
+// Modified by JStockfish
+extern std::stringstream sync_ss;
+#define sync_cout sync_ss << IO_LOCK
+#define sync_endl IO_UNLOCK
+
+// The default implementation is in misc_sync_cout.cpp.
+// Programs can easily replace this implementation with their own.
+void uci_out(std::string out);
 
 
 /// xorshift64star Pseudo-Random Number Generator

--- a/src/misc_sync_cout.cpp
+++ b/src/misc_sync_cout.cpp
@@ -1,0 +1,5 @@
+#include <iostream>
+
+void uci_out(std::string output) {
+  std::cout << output << std::endl;
+}

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1080,10 +1080,16 @@ bool Position::see_ge(Move m, Value v) const {
 /// or by repetition. It does not detect stalemates.
 
 bool Position::is_draw(int ply) const {
+  return
+    is_draw_rule50() ||
+    is_draw_repetition(ply);  // ply = 2: Draw at first repetition
+}
 
-  if (st->rule50 > 99 && (!checkers() || MoveList<LEGAL>(*this).size()))
-      return true;
+bool Position::is_draw_rule50() const {
+  return st->rule50 > 99 && (!checkers() || MoveList<LEGAL>(*this).size());
+}
 
+bool Position::is_draw_repetition(int ply) const {
   int end = std::min(st->rule50, st->pliesFromNull);
 
   if (end < 4)

--- a/src/position.h
+++ b/src/position.h
@@ -151,6 +151,8 @@ public:
   Thread* this_thread() const;
   uint64_t nodes_searched() const;
   bool is_draw(int ply) const;
+  bool is_draw_rule50() const;
+  bool is_draw_repetition(int ply) const;
   int rule50_count() const;
   Score psq_score() const;
   Value non_pawn_material(Color c) const;

--- a/src/positionstate.cpp
+++ b/src/positionstate.cpp
@@ -1,0 +1,52 @@
+#include "positionstate.h"
+#include "bitboard.h"
+#include "movegen.h"
+
+// https://code.google.com/p/cuckoochess/source/browse/trunk/CuckooChessEngine/src/chess/Game.java#527
+bool is_draw_insufficient_material(Position& pos) {
+  if (pos.pieces(QUEEN) != 0) return false;
+  if (pos.pieces(ROOK)  != 0) return false;
+  if (pos.pieces(PAWN)  != 0) return false;
+
+  Bitboard wb = pos.pieces(WHITE, BISHOP);
+  Bitboard bb = pos.pieces(BLACK, BISHOP);
+
+  int nwb = popcount(wb);
+  int nbb = popcount(bb);
+  int nwn = popcount(pos.pieces(WHITE, KNIGHT));
+  int nbn = popcount(pos.pieces(BLACK, KNIGHT));
+
+  // King + bishop/knight vs king is draw
+  if (nwb + nwn + nbb + nbn <= 1) return true;
+
+  if (nwn + nbn == 0) {
+    // Only bishops. If they are all on the same color, the position is a draw.
+    Bitboard bMask = wb | bb;
+    if (((bMask & DarkSquares) == 0) || ((bMask & LightSquares) == 0)) return true;
+  }
+
+  return false;
+}
+
+int positionstate(Position& pos) {
+  Bitboard checkers = pos.checkers();
+  int noLegalMove = MoveList<LEGAL>(pos).size() == 0;
+
+  if (noLegalMove) {
+    if (checkers) {
+      return (pos.side_to_move() == BLACK)? WHITE_MATE : BLACK_MATE;
+    } else {
+      return (pos.side_to_move() == BLACK)? BLACK_STALEMATE : WHITE_STALEMATE;
+    }
+  }
+
+  if (is_draw_insufficient_material(pos)) return DRAW_NO_MATE;
+
+  // Don't use Posistion::is_draw_rule50 to avoid checking noLegalMove again,
+  // see the implementation of is_draw_rule50
+  if (pos.rule50_count() > 99 && !checkers) return CAN_DRAW_50;
+
+  if (pos.is_draw_repetition(3)) return CAN_DRAW_REP;
+
+  return ALIVE;
+}

--- a/src/positionstate.h
+++ b/src/positionstate.h
@@ -1,0 +1,20 @@
+#ifndef POSITION_STATE_H_INCLUDED
+#define POSITION_STATE_H_INCLUDED
+
+#include "position.h"
+
+// Added by JStockfish, see its Java counterpart
+enum State {
+  ALIVE,
+  WHITE_MATE,       // White mates (white wins)
+  BLACK_MATE,       // Black mates (black wins)
+  WHITE_STALEMATE,  // White is stalemated (white can't move)
+  BLACK_STALEMATE,  // Black is stalemated (black can't move)
+  DRAW_NO_MATE,     // Draw by insufficient material
+  CAN_DRAW_50,      // Can draw by 50-move rule
+  CAN_DRAW_REP      // Can draw by 3-fold repetition rule
+};
+
+int positionstate(Position& pos);
+
+#endif

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -74,6 +74,10 @@ void init(OptionsMap& o) {
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(6, 0, 6);
+
+  // Additional options added by JStockfish
+  o["Info State"]            << Option(false);
+  o["Info FEN"]              << Option(false);
 }
 
 


### PR DESCRIPTION
This pull request is for adding JNI binding, so that it's possible to embed Stockfish as a library in JVM-based processes (Java, Scala, Clojure, Kotlin etc.), instead of having to run Stockfish in a separate process.

Core changes:
* Change misc.h to modify `sync_cout` and `sync_endl` so that we the JNI binding can efficiently catch the output of Stockfish.
* Add directory "jni". The JNI binding can be built with CMake.