### PR TITLE
Replace explicit sum by game phase.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -846,7 +846,7 @@ Value Eval::evaluate(const Position& pos) {
           - evaluate_passer_pawns<BLACK, DoTrace>(pos, ei);
 
   // Evaluate space for both sides, only during opening
-  if (pos.non_pawn_material(WHITE) + pos.non_pawn_material(BLACK) >= 12222)
+  if (ei.me->game_phase() >= 94)
       score +=  evaluate_space<WHITE>(pos, ei)
               - evaluate_space<BLACK>(pos, ei);
 
@@ -869,7 +869,7 @@ Value Eval::evaluate(const Position& pos) {
       Trace::add(IMBALANCE, ei.me->imbalance());
       Trace::add(PAWN, ei.pe->pawns_score());
       Trace::add(MOBILITY, mobility[WHITE], mobility[BLACK]);
-      if (pos.non_pawn_material(WHITE) + pos.non_pawn_material(BLACK) >= 12222)
+      if (ei.me->game_phase() >= 94)
           Trace::add(SPACE, evaluate_space<WHITE>(pos, ei)
                           , evaluate_space<BLACK>(pos, ei));
       Trace::add(TOTAL, score);


### PR DESCRIPTION
Clarify the code by using the prescribed interface in the material entry for assessing the game phase, instead of explicitly calculating it.

Passed non-slowdown test, see http://tests.stockfishchess.org/tests/view/588deaaf0ebc5915193f7d3a

LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 201967 W: 36014 L: 36199 D: 129754

Thanks to @joergoster to pointing out that change must be incorporated in trace, too.

Non functional change.

Bench : 5885815