### PR TITLE
Bench 6459194

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -292,11 +292,6 @@ namespace {
             ei.kingAdjacentZoneAttacksCount[Us] += popcount(b & ei.attackedBy[Them][KING]);
         }
 
-        if (Pt == QUEEN)
-            b &= ~(  ei.attackedBy[Them][KNIGHT]
-                   | ei.attackedBy[Them][BISHOP]
-                   | ei.attackedBy[Them][ROOK]);
-
         int mob = popcount(b & ei.mobilityArea[Us]);
 
         mobility[Us] += MobilityBonus[Pt][mob];


### PR DESCRIPTION
Simplify by removing minor attack square in Queen's mobility area.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 85997 W: 15550 L: 15540 D: 54907

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 25333 W: 3370 L: 3256 D: 18707

Bench:  6459194