### PR TITLE
Update search.cpp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -505,7 +505,7 @@ void Thread::search() {
 
               bool doEasyMove =   rootMoves[0].pv[0] == easyMove
                                && mainThread->bestMoveChanges < 0.03
-                               && Time.elapsed() > Time.optimum() * 5 / 42;
+                               && Time.elapsed() > Time.optimum() * 5 / 44;
 
               if (   rootMoves.size() == 1
                   || Time.elapsed() > Time.optimum() * unstablePvFactor * improvingFactor / 628


### PR DESCRIPTION
tweak in search in bool doEasyMove
Time.elapsed() > Time.optimum() * 5 / 44 instaed Time.elapsed() > Time.optimum() * 5 / 42

This was yellow on STC:
LLR: -2.96 (-2.94,2.94) [0.00,4.00]
Total: 156856 W: 28317 L: 27942 D: 100597

Passed on LTC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 36909 W: 4926 L: 4682 D: 27301

No functional change