### PR TITLE
Fix makefile: 32 bit builds without optimization.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,8 @@ script:
   # verify against reference
   - make clean && make ARCH=x86-64 build > /dev/null && ../tests/signature.sh $benchref
   - make clean && make ARCH=x86-32 build > /dev/null && ../tests/signature.sh $benchref
+  - make clean && make ARCH=x86-64 optimize=no debug=yes build > /dev/null && ../tests/signature.sh $benchref
+  - make clean && make ARCH=x86-32 optimize=no debug=yes build > /dev/null && ../tests/signature.sh $benchref
   #
   # perft
   #

--- a/src/Makefile
+++ b/src/Makefile
@@ -155,9 +155,11 @@ ifeq ($(COMP),gcc)
 	ifeq ($(ARCH),armv7)
 		ifeq ($(OS),Android)
 			CXXFLAGS += -m$(bits)
+		        LDFLAGS += -m$(bits)
 		endif
 	else
 		CXXFLAGS += -m$(bits)
+		LDFLAGS += -m$(bits)
 	endif
 
 	ifneq ($(KERNEL),Darwin)


### PR DESCRIPTION
Fixes failing build for

make ARCH=x86-32 clean && make ARCH=x86-32 optimize=no build

by passing -m32 also to the link step.

Extend travis testing accordingly.

No functional change.