### PR TITLE
skipEarlyPruning based simplification

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -413,7 +413,7 @@ void Thread::search() {
           // high/low anymore.
           while (true)
           {
-              bestValue = ::search<PV>(rootPos, ss, alpha, beta, rootDepth, false, false);
+              bestValue = ::search<PV>(rootPos, ss, alpha, beta, rootDepth, false, true);
 
               // Bring the best move to the front. It is critical that sorting
               // is done with a stable algorithm because all the values but the
@@ -746,8 +746,7 @@ namespace {
     }
 
     // Step 7. Futility pruning: child node (skipped when in check)
-    if (   !rootNode
-        &&  depth < 7 * ONE_PLY
+    if (    depth < 7 * ONE_PLY
         &&  eval - futility_margin(depth) >= beta
         &&  eval < VALUE_KNOWN_WIN  // Do not return unproven wins
         &&  pos.non_pawn_material(pos.side_to_move()))
@@ -843,11 +842,10 @@ moves_loop: // When in check search starts from here
             /* || ss->staticEval == VALUE_NONE Already implicit in the previous condition */
                ||(ss-2)->staticEval == VALUE_NONE;
 
-    singularExtensionNode =   !rootNode
+    singularExtensionNode =   !skipEarlyPruning
                            &&  depth >= 8 * ONE_PLY
                            &&  ttMove != MOVE_NONE
                            &&  ttValue != VALUE_NONE
-                           && !excludedMove // Recursive singular search is not allowed
                            && (tte->bound() & BOUND_LOWER)
                            &&  tte->depth() >= depth - 3 * ONE_PLY;
 


### PR DESCRIPTION
We can use the skipEarlyPruning flag to simplify the singularExtension logic.

Note that now we don't do singular extension after a null-move. This change the bench at longer time control. 

STC: 
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 15575 W: 2834 L: 2704 D: 10037

	
LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 63245 W: 8197 L: 8132 D: 46916

Bench:
6072262

