### PR TITLE
Razor Simplification (6119788)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -423,7 +423,7 @@ void Thread::search() {
               // search the already searched PV lines are preserved.
               std::stable_sort(rootMoves.begin() + PVIdx, rootMoves.end());
 
-              // If search has been stopped, break immediately. Sorting and
+              // If search has been stopped, we break immediately. Sorting and
               // writing PV back to TT is safe because RootMoves is still
               // valid, although it refers to the previous iteration.
               if (Signals.stop)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -733,7 +733,6 @@ namespace {
     // Step 6. Razoring (skipped when in check)
     if (   !PvNode
         &&  depth < 4 * ONE_PLY
-        &&  ttMove == MOVE_NONE
         &&  eval + razor_margin[depth / ONE_PLY] <= alpha)
     {
         if (depth <= ONE_PLY)


### PR DESCRIPTION
Razor Simplification:  Remove code that restrict using tt-moves for razoring.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 67442 W: 12039 L: 11997 D: 43406

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 38541 W: 5044 L: 4947 D: 28550

Bench:  6119788