### PR TITLE
Use history stats also for captures and promotions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -982,37 +982,35 @@ moves_loop: // When in check search starts from here
       {
           Depth r = reduction<PvNode>(improving, depth, moveCount);
 
+          // Increase reduction for cut nodes
+          if (cutNode)
+              r += 2 * ONE_PLY;
+
+          // Decrease reduction for moves that escape a capture. Filter out
+          // castling moves, because they are coded as "king captures rook" and
+          // hence break make_move().
+          else if (   type_of(move) == NORMAL
+                      && !pos.see_ge(make_move(to_sq(move), from_sq(move)),  VALUE_ZERO))
+              r -= 2 * ONE_PLY;
+
+          ss->history =  (cmh  ? (*cmh )[moved_piece][to_sq(move)] : VALUE_ZERO)
+                  + (fmh  ? (*fmh )[moved_piece][to_sq(move)] : VALUE_ZERO)
+                  + (fmh2 ? (*fmh2)[moved_piece][to_sq(move)] : VALUE_ZERO)
+                  + thisThread->history.get(~pos.side_to_move(), move)
+                  - 4000; // Correction factor
+
+          // Decrease/increase reduction by comparing opponent's stat score
+          if (ss->history > VALUE_ZERO && (ss-1)->history < VALUE_ZERO)
+              r -= ONE_PLY;
+
+          else if (ss->history < VALUE_ZERO && (ss-1)->history > VALUE_ZERO)
+              r += ONE_PLY;
+
           if (captureOrPromotion)
-              r -= r ? ONE_PLY : DEPTH_ZERO;
-          else
-          {
-              // Increase reduction for cut nodes
-              if (cutNode)
-                  r += 2 * ONE_PLY;
+              r -= ONE_PLY;
 
-              // Decrease reduction for moves that escape a capture. Filter out
-              // castling moves, because they are coded as "king captures rook" and
-              // hence break make_move().
-              else if (   type_of(move) == NORMAL
-                       && !pos.see_ge(make_move(to_sq(move), from_sq(move)),  VALUE_ZERO))
-                  r -= 2 * ONE_PLY;
-
-              ss->history =  (cmh  ? (*cmh )[moved_piece][to_sq(move)] : VALUE_ZERO)
-                           + (fmh  ? (*fmh )[moved_piece][to_sq(move)] : VALUE_ZERO)
-                           + (fmh2 ? (*fmh2)[moved_piece][to_sq(move)] : VALUE_ZERO)
-                           + thisThread->history.get(~pos.side_to_move(), move)
-                           - 4000; // Correction factor
-
-              // Decrease/increase reduction by comparing opponent's stat score
-              if (ss->history > VALUE_ZERO && (ss-1)->history < VALUE_ZERO)
-                  r -= ONE_PLY;
-
-              else if (ss->history < VALUE_ZERO && (ss-1)->history > VALUE_ZERO)
-                  r += ONE_PLY;
-
-              // Decrease/increase reduction for moves with a good/bad history
-              r = std::max(DEPTH_ZERO, (r / ONE_PLY - ss->history / 20000) * ONE_PLY);
-          }
+          // Decrease/increase reduction for moves with a good/bad history
+          r = std::max(DEPTH_ZERO, (r / ONE_PLY - ss->history / 20000) * ONE_PLY);
 
           Depth d = std::max(newDepth - r, ONE_PLY);
 


### PR DESCRIPTION
Remove a nested `if` statement and take advantage of the fact that follow-up moves heuristics works also for captures and promotions.

Additional data are attached in the comments.

[STC](http://tests.stockfishchess.org/tests/view/58a1f9ea0ebc59099759f66b)
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 40451 W: 7235 L: 7147 D: 26069

[LTC](http://tests.stockfishchess.org/tests/view/58a2915f0ebc59099759f679)
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 59107 W: 7584 L: 7513 D: 44010

Bench: 5958091