### PR TITLE
KDProtection

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -180,6 +180,17 @@ namespace {
     S(  9, 10), S( 2, 10), S( 1, -8), S(-20,-12),
     S(-20,-12), S( 1, -8), S( 2, 10), S(  9, 10)
   };
+  
+  // Protective bonuses, depending on the distance from the own King and 
+  // Attack bonuses, depending on the distance from opponent's King
+  const Score KnightProtection[8] = { S(10, 0),  S(7, 9),  S(7,  1),  S(1,  5), S(-10,-4), S(-1, -4), S(-7, -3),  S(-16,-10) };
+  const Score KnightAttack[8]     = { S(11, 4),  S(1,11),  S(-6, 1),  S(5,  8), S( 0,  3), S(-4, -1), S(-7, -6),  S(-13,  2) }; 
+  const Score BishopProtection[8] = { S(15, 7),  S(11,8),  S(-7,-1),  S(-1,-2), S(-1, -7), S(-11,-3), S(-9, -1),  S(-16, -1) };
+  const Score BishopAttack[8]     = { S(2, -6),  S(7, 0),  S(7, -2),  S(-1, 1), S(-1,  2), S(-5, -6), S(-6, -8),  S(-15, -9) };
+  const Score RookProtection[8]   = { S(9, 7),   S(10, 0), S(-2, 2),  S(-5, 4), S(-6,  2), S(-14,-3), S(-2, -9),  S(-12, -7)};
+  const Score RookAttack[8]       = { S(4, 5),   S(8, -3),  S(0, -4), S(-4, 1), S(-6,  1), S(-10,-5), S(-14,-15), S( -8, -2) };
+  const Score QueenProtection[8]  = { S(4,  2),  S(3,-5),  S(2,-5),   S(-4, 0), S(-9,-6),  S(-4, 7),  S(-13,-7),  S(-10, -7) };
+  const Score QueenAttack[8]      = { S(22, 5),  S(5, 6),  S(-5, 5),  S(0,-4), S(-8, -1),  S(-17,5),  S(-14,-7),  S(-17,  2) };
 
   // Assorted bonuses and penalties used by evaluation
   const Score MinorBehindPawn     = S(16,  0);
@@ -294,6 +305,14 @@ namespace {
         int mob = popcount(b & ei.mobilityArea[Us]);
 
         mobility[Us] += MobilityBonus[Pt][mob];
+        
+        // Knight King distance
+        if (Pt == KNIGHT)
+            score += KnightProtection[distance(s, pos.square<KING>(Us))];
+                       
+        if (Pt == KNIGHT)
+            score += KnightAttack[distance(s, pos.square<KING>(Them))];
+
 
         if (Pt == BISHOP || Pt == KNIGHT)
         {
@@ -316,6 +335,13 @@ namespace {
             // Penalty for pawns on the same color square as the bishop
             if (Pt == BISHOP)
                 score -= BishopPawns * ei.pe->pawns_on_same_color_squares(Us, s);
+                
+             // Bishop King distance
+            if (Pt == BISHOP)
+                score += BishopProtection[distance(s, pos.square<KING>(Us))];
+                       
+            if (Pt == BISHOP)
+                score += BishopAttack[distance(s, pos.square<KING>(Them))];
 
             // An important Chess960 pattern: A cornered bishop blocked by a friendly
             // pawn diagonally in front of it is a very serious problem, especially
@@ -337,6 +363,13 @@ namespace {
             // Bonus for aligning with enemy pawns on the same rank/file
             if (relative_rank(Us, s) >= RANK_5)
                 score += RookOnPawn * popcount(pos.pieces(Them, PAWN) & PseudoAttacks[ROOK][s]);
+                
+            // Rook King distance
+            if (Pt == ROOK)
+                score += RookProtection[distance(s, pos.square<KING>(Us))];
+                       
+            if (Pt == ROOK)
+                score += RookAttack[distance(s, pos.square<KING>(Them))];
 
             // Bonus when on an open or semi-open file
             if (ei.pe->semiopen_file(Us, file_of(s)))
@@ -355,6 +388,13 @@ namespace {
 
         if (Pt == QUEEN)
         {
+            // Queen King distance      
+               if (Pt == QUEEN)
+               score += QueenProtection[distance(s, pos.square<KING>(Us))];
+                 
+               if (Pt == QUEEN)
+               score += QueenAttack[distance(s, pos.square<KING>(Them))];
+        
             // Penalty if any relative pin or discovered attack against the queen
             Bitboard pinners;
             if (pos.slider_blockers(pos.pieces(Them, ROOK, BISHOP), s, pinners))

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -184,13 +184,13 @@ namespace {
   // Protective bonuses, depending on the distance from the own King and 
   // Attack bonuses, depending on the distance from opponent's King
   const Score KnightProtection[8] = { S(10, 0),  S(7, 9),  S(7,  1),  S(1,  5), S(-10,-4), S(-1, -4), S(-7, -3),  S(-16,-10) };
-  const Score KnightAttack[8]     = { S(11, 4),  S(1,11),  S(-6, 1),  S(5,  8), S( 0,  3), S(-4, -1), S(-7, -6),  S(-13,  2) }; 
+
   const Score BishopProtection[8] = { S(15, 7),  S(11,8),  S(-7,-1),  S(-1,-2), S(-1, -7), S(-11,-3), S(-9, -1),  S(-16, -1) };
-  const Score BishopAttack[8]     = { S(2, -6),  S(7, 0),  S(7, -2),  S(-1, 1), S(-1,  2), S(-5, -6), S(-6, -8),  S(-15, -9) };
+
   const Score RookProtection[8]   = { S(9, 7),   S(10, 0), S(-2, 2),  S(-5, 4), S(-6,  2), S(-14,-3), S(-2, -9),  S(-12, -7)};
-  const Score RookAttack[8]       = { S(4, 5),   S(8, -3),  S(0, -4), S(-4, 1), S(-6,  1), S(-10,-5), S(-14,-15), S( -8, -2) };
+
   const Score QueenProtection[8]  = { S(4,  2),  S(3,-5),  S(2,-5),   S(-4, 0), S(-9,-6),  S(-4, 7),  S(-13,-7),  S(-10, -7) };
-  const Score QueenAttack[8]      = { S(22, 5),  S(5, 6),  S(-5, 5),  S(0,-4), S(-8, -1),  S(-17,5),  S(-14,-7),  S(-17,  2) };
+
 
   // Assorted bonuses and penalties used by evaluation
   const Score MinorBehindPawn     = S(16,  0);
@@ -310,10 +310,6 @@ namespace {
         if (Pt == KNIGHT)
             score += KnightProtection[distance(s, pos.square<KING>(Us))];
                        
-        if (Pt == KNIGHT)
-            score += KnightAttack[distance(s, pos.square<KING>(Them))];
-
-
         if (Pt == BISHOP || Pt == KNIGHT)
         {
             // Bonus for outpost squares
@@ -340,9 +336,6 @@ namespace {
             if (Pt == BISHOP)
                 score += BishopProtection[distance(s, pos.square<KING>(Us))];
                        
-            if (Pt == BISHOP)
-                score += BishopAttack[distance(s, pos.square<KING>(Them))];
-
             // An important Chess960 pattern: A cornered bishop blocked by a friendly
             // pawn diagonally in front of it is a very serious problem, especially
             // when that pawn is also blocked.
@@ -368,9 +361,6 @@ namespace {
             if (Pt == ROOK)
                 score += RookProtection[distance(s, pos.square<KING>(Us))];
                        
-            if (Pt == ROOK)
-                score += RookAttack[distance(s, pos.square<KING>(Them))];
-
             // Bonus when on an open or semi-open file
             if (ei.pe->semiopen_file(Us, file_of(s)))
                 score += RookOnFile[!!ei.pe->semiopen_file(Them, file_of(s))];
@@ -392,9 +382,6 @@ namespace {
                if (Pt == QUEEN)
                score += QueenProtection[distance(s, pos.square<KING>(Us))];
                  
-               if (Pt == QUEEN)
-               score += QueenAttack[distance(s, pos.square<KING>(Them))];
-        
             // Penalty if any relative pin or discovered attack against the queen
             Bitboard pinners;
             if (pos.slider_blockers(pos.pieces(Them, ROOK, BISHOP), s, pinners))

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -181,15 +181,11 @@ namespace {
     S(-20,-12), S( 1, -8), S( 2, 10), S(  9, 10)
   };
   
-  // Protective bonuses, depending on the distance from the own King and 
-  // Attack bonuses, depending on the distance from opponent's King
-  const Score KnightProtection[8] = { S(10, 0),  S(7, 9),  S(7,  1),  S(1,  5), S(-10,-4), S(-1, -4), S(-7, -3),  S(-16,-10) };
-
-  const Score BishopProtection[8] = { S(15, 7),  S(11,8),  S(-7,-1),  S(-1,-2), S(-1, -7), S(-11,-3), S(-9, -1),  S(-16, -1) };
-
-  const Score RookProtection[8]   = { S(9, 7),   S(10, 0), S(-2, 2),  S(-5, 4), S(-6,  2), S(-14,-3), S(-2, -9),  S(-12, -7)};
-
-  const Score QueenProtection[8]  = { S(4,  2),  S(3,-5),  S(2,-5),   S(-4, 0), S(-9,-6),  S(-4, 7),  S(-13,-7),  S(-10, -7) };
+  // Protective bonuses, depending on the distance from the own King 
+  const Score KnightProtection[8] = { S(10, 0), S( 7, 9), S( 7, 1), S( 1, 5), S(-10,-4), S( -1,-4), S( -7,-3), S(-16,-10) };
+  const Score BishopProtection[8] = { S(15, 7), S(11, 8), S(-7,-1), S(-1,-2), S( -1,-7), S(-11,-3), S( -9,-1), S(-16, -1) };
+  const Score RookProtection[8]   = { S( 9, 7), S(10, 0), S(-2, 2), S(-5, 4), S( -6, 2), S(-14,-3), S( -2,-9), S(-12, -7) };
+  const Score QueenProtection[8]  = { S( 4, 2), S( 3,-5), S( 2,-5), S(-4, 0), S( -9,-6),  S(-4, 7), S(-13,-7), S(-10, -7) };
 
 
   // Assorted bonuses and penalties used by evaluation
@@ -379,8 +375,8 @@ namespace {
         if (Pt == QUEEN)
         {
             // Queen King distance      
-               if (Pt == QUEEN)
-               score += QueenProtection[distance(s, pos.square<KING>(Us))];
+            if (Pt == QUEEN)
+                score += QueenProtection[distance(s, pos.square<KING>(Us))];
                  
             // Penalty if any relative pin or discovered attack against the queen
             Bitboard pinners;


### PR DESCRIPTION
KDProtection (KingDistanceProtection)

Original distance idea by Snicolet for knight, for other pieces too
Patch add penalties and bonuses for pieces, depending on the distance from the own King

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 21192 W: 3919 L: 3704 D: 13569

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 26177 W: 3642 L: 3435 D: 19100