### PR TITLE
Reorder members of Material::Entry

### DIFF
--- a/src/material.h
+++ b/src/material.h
@@ -56,11 +56,11 @@ struct Entry {
   }
 
   Key key;
-  int16_t value;
-  uint8_t factor[COLOR_NB];
   EndgameBase<Value>* evaluationFunction;
   EndgameBase<ScaleFactor>* scalingFunction[COLOR_NB]; // Could be one for each
                                                        // side (e.g. KPKP, KBPsKs)
+  int16_t value;
+  uint8_t factor[COLOR_NB];
   Phase gamePhase;
 };
 


### PR DESCRIPTION
Reorder members of Material::Entry eliminating alignment padding
and reducing size from 48 to 40 bytes. This makes the material
HashTable smaller and more cache friendly.

NO functional change.
bench: 6976310