### PR TITLE
Remove !inCheck condition in futility pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -941,7 +941,6 @@ moves_loop: // When in check search starts from here
 
               // Futility pruning: parent node
               if (   lmrDepth < 7
-                  && !inCheck
                   && ss->staticEval + 256 + 200 * lmrDepth <= alpha)
                   continue;
 


### PR DESCRIPTION
Removing the condition amounts to a non-functional change because if we are in check for ss->staticEval no eval is calculated (see line 703-708) and instead VALUE_NONE is used. But VALUE_NONE is greater than VALUE_INFINITE so last condition is never triggered if in check.

Local speed comparison gives a neutral result:
Results for 25 tests for each version:

            Base      Test      Diff      
    Mean    2044535   2045987   -1452     
    StDev   6015      6148      2333      

p-value: 0.733
speedup: 0.001

Bench 6687377