### PR TITLE
prefetch2

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -205,6 +205,12 @@ void prefetch(void* addr) {
 
 #endif
 
+void prefetch2(void* addr) {
+
+    prefetch(addr);
+    prefetch((uint8_t*)addr + 64);
+}
+
 namespace WinProcGroup {
 
 #ifndef _WIN32

--- a/src/misc.h
+++ b/src/misc.h
@@ -31,6 +31,7 @@
 
 const std::string engine_info(bool to_uci = false);
 void prefetch(void* addr);
+void prefetch2(void* addr);
 void start_logger(const std::string& fname);
 
 void dbg_hit_on(bool b);

--- a/src/misc.h
+++ b/src/misc.h
@@ -51,7 +51,7 @@ struct HashTable {
   Entry* operator[](Key key) { return &table[(uint32_t)key & (Size - 1)]; }
 
 private:
-  std::vector<Entry> table = std::vector<Entry>(Size);
+  alignas(64) std::vector<Entry> table = std::vector<Entry>(Size);
 };
 
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -51,8 +51,7 @@ struct HashTable {
   Entry* operator[](Key key) { return &table[(uint32_t)key & (Size - 1)]; }
 
 private:
-  uint8_t mem[Size * sizeof(Entry) + 63];
-  Entry* table = (Entry*)((uintptr_t(mem) + 63) & ~63);
+  alignas(128) std::vector<Entry> table = std::vector<Entry>(Size);
 };
 
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -51,7 +51,8 @@ struct HashTable {
   Entry* operator[](Key key) { return &table[(uint32_t)key & (Size - 1)]; }
 
 private:
-  alignas(128) std::vector<Entry> table = std::vector<Entry>(Size);
+  uint8_t mem[Size * sizeof(Entry) + 63];
+  Entry* table = (Entry*)((uintptr_t(mem) + 63) & ~63);
 };
 
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -51,7 +51,7 @@ struct HashTable {
   Entry* operator[](Key key) { return &table[(uint32_t)key & (Size - 1)]; }
 
 private:
-  alignas(64) std::vector<Entry> table = std::vector<Entry>(Size);
+  alignas(128) std::vector<Entry> table = std::vector<Entry>(Size);
 };
 
 

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -31,7 +31,7 @@ namespace Pawns {
 /// to the pawn hash table (performed by calling the probe function) returns a
 /// pointer to an Entry object.
 
-struct Entry {
+struct alignas(128) Entry {
 
   Score pawns_score() const { return score; }
   Bitboard pawn_attacks(Color c) const { return pawnAttacks[c]; }

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -31,7 +31,7 @@ namespace Pawns {
 /// to the pawn hash table (performed by calling the probe function) returns a
 /// pointer to an Entry object.
 
-struct alignas(128) Entry {
+struct Entry {
 
   Score pawns_score() const { return score; }
   Bitboard pawn_attacks(Color c) const { return pawnAttacks[c]; }
@@ -76,6 +76,7 @@ struct alignas(128) Entry {
   int pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
   int asymmetry;
   int openFiles;
+  char padding[8];
 };
 
 typedef HashTable<Entry, 16384> Table;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -827,7 +827,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
 
       // Update pawn hash key and prefetch access to pawnsTable
       st->pawnKey ^= Zobrist::psq[pc][from] ^ Zobrist::psq[pc][to];
-      prefetch(thisThread->pawnsTable[st->pawnKey]);
+      prefetch2(thisThread->pawnsTable[st->pawnKey]);
 
       // Reset rule 50 draw counter
       st->rule50 = 0;


### PR DESCRIPTION
Since sizeof(Pawns::Entry) is 120 bytes it spans a minimum of two 64 byte cache lines.
Fix the prefetch code accordingly.  Also a small speedup.
No functional change.
Same bench: 6269229

```
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    475753    479249    -3496     
    StDev   105266    107599    2632      

p-value: 0.908
speedup: 0.007
```

(Side Note:  An additional speedup should be possible by padding the size
to exactly 128 bytes and aligning the hash table to a cache line boundary.
However my attempts to align it have failed.)