### PR TITLE
Prefetch2

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -205,6 +205,12 @@ void prefetch(void* addr) {
 
 #endif
 
+void prefetch2(void* addr) {
+
+    prefetch(addr);
+    prefetch((uint8_t*)addr + 64);
+}
+
 namespace WinProcGroup {
 
 #ifndef _WIN32

--- a/src/misc.h
+++ b/src/misc.h
@@ -31,6 +31,7 @@
 
 const std::string engine_info(bool to_uci = false);
 void prefetch(void* addr);
+void prefetch2(void* addr);
 void start_logger(const std::string& fname);
 
 void dbg_hit_on(bool b);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -827,7 +827,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
 
       // Update pawn hash key and prefetch access to pawnsTable
       st->pawnKey ^= Zobrist::psq[pc][from] ^ Zobrist::psq[pc][to];
-      prefetch(thisThread->pawnsTable[st->pawnKey]);
+      prefetch2(thisThread->pawnsTable[st->pawnKey]);
 
       // Reset rule 50 draw counter
       st->rule50 = 0;


### PR DESCRIPTION
Fix ineffective/broken pawn entry prefetch as explained here https://github.com/official-stockfish/Stockfish/pull/1022

Unfortunately also fixing the alignment as here https://github.com/official-stockfish/Stockfish/pull/1022/commits/e118e89c0e552584b9e1ea6f68b08d2abbf0db78
breaks Travis CL for bogus alignment issues.  Not breaking Travis CL requires additional code here  https://github.com/official-stockfish/Stockfish/pull/1022/commits/16dd284845f801def3d15e1096b6c484d0017e08 
Given that I can't measure an additional speedup (although @snicolet can but no numbers were posted by him) I leave the fix as simple as possible for now.

Additional relevant comments are in the original pull request here https://github.com/official-stockfish/Stockfish/pull/1022

No functional change.
bench: 5803228