### PR TITLE
Pawns count imbalance table

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -55,7 +55,7 @@ namespace {
 
   // PawnsSet[count] contains a bonus/malus indexed by number of pawns
   const int PawnsSet[9] = { 
-     -128, -16, 16, 32, 48, 16, -8, -32, -64
+     24, -32, 107, -51, 117, -9, -126, -21, 31
   };
 
   // Endgame evaluation and scaling functions are accessed directly and not through

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -55,7 +55,7 @@ namespace {
 
   // PawnsSet[count] contains a bonus/malus indexed by number of pawns
   const int PawnsSet[9] = { 
-     0, -12, -8, -4,  0,  5, 12, 14, 16
+     0, 5, -1, 3, 21, -5, -11, 1, 9
   };
 
   // Endgame evaluation and scaling functions are accessed directly and not through

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -35,7 +35,7 @@ namespace {
     //            OUR PIECES
     // pair pawn knight bishop rook queen
     {1667                               }, // Bishop pair
-    {  40,    2                         }, // Pawn
+    {  40,    0                         }, // Pawn
     {  32,  255,  -3                    }, // Knight      OUR PIECES
     {   0,  104,   4,    0              }, // Bishop
     { -26,   -2,  47,   105,  -149      }, // Rook
@@ -51,6 +51,11 @@ namespace {
     {  59,   65,  42,     0             }, // Bishop
     {  46,   39,  24,   -24,    0       }, // Rook
     { 101,  100, -37,   141,  268,    0 }  // Queen
+  };
+
+  // PawnsSet[count] contains a bonus/malus indexed by number of pawns
+  const int PawnsSet[9] = { 
+     0, -12, -8, -4,  0,  5, 12, 14, 16
   };
 
   // Endgame evaluation and scaling functions are accessed directly and not through
@@ -89,7 +94,7 @@ namespace {
 
     const Color Them = (Us == WHITE ? BLACK : WHITE);
 
-    int bonus = 0;
+    int bonus = PawnsSet[pieceCount[Us][PAWN]];
 
     // Second-degree polynomial material imbalance by Tord Romstad
     for (int pt1 = NO_PIECE_TYPE; pt1 <= QUEEN; ++pt1)

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -55,7 +55,7 @@ namespace {
 
   // PawnsSet[count] contains a bonus/malus indexed by number of pawns
   const int PawnsSet[9] = { 
-     0, 5, -1, 3, 21, -5, -11, 1, 9
+     -128, -16, 16, 32, 48, 16, -8, -32, -64
   };
 
   // Endgame evaluation and scaling functions are accessed directly and not through


### PR DESCRIPTION
Instead of having a continuous increasing bonus for our number of pawns when calculating imbalance, use a separate lookup array with tuned values.
Idea by GuardianRM.

STC
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 16155 W: 2980 L: 2787 D: 10388

LTC
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 100478 W: 13055 L: 12615 D: 74808

Bench: 6128779