### PR TITLE
move syzygy/tbprobe.* into main src dir

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ before_build:
   - echo project (Stockfish) >> CMakeLists.txt
   - echo add_executable(stockfish benchmark.cpp bitbase.cpp bitboard.cpp endgame.cpp evaluate.cpp >> CMakeLists.txt
   - echo main.cpp material.cpp misc.cpp movegen.cpp movepick.cpp pawns.cpp position.cpp psqt.cpp >> CMakeLists.txt
-  - echo search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp syzygy/tbprobe.cpp) >> CMakeLists.txt
+  - echo search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tbprobe.cpp) >> CMakeLists.txt
   - echo set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/src) >> CMakeLists.txt
 #   - echo target_compile_options(stockfish PUBLIC "/Ox") >> CMakeLists.txt
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -40,7 +40,7 @@ PGOBENCH = ./$(EXE) bench
 ### Object files
 OBJS = benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o \
 	material.o misc.o movegen.o movepick.o pawns.o position.o psqt.o \
-	search.o thread.o timeman.o tt.o uci.o ucioption.o syzygy/tbprobe.o
+	search.o thread.o timeman.o tt.o uci.o ucioption.o tbprobe.o
 
 ### ==========================================================================
 ### Section 2. High-level Configuration
@@ -452,16 +452,16 @@ install:
 
 #clean all
 clean: objclean profileclean
-	@rm -f .depend *~ core 
+	@rm -f .depend *~ core
 
 # clean binaries and objects
 objclean:
-	@rm -f $(EXE) $(EXE).exe *.o ./syzygy/*.o
+	@rm -f $(EXE) $(EXE).exe *.o
 
 # clean auxiliary profiling files
 profileclean:
 	@rm -rf profdir
-	@rm -f bench.txt *.gcda ./syzygy/*.gcda *.gcno ./syzygy/*.gcno
+	@rm -f bench.txt *.gcda *.gcno
 	@rm -f stockfish.profdata *.profraw
 
 default:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,7 @@
 #include "thread.h"
 #include "tt.h"
 #include "uci.h"
-#include "syzygy/tbprobe.h"
+#include "tbprobe.h"
 
 namespace PSQT {
   void init();

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -32,7 +32,7 @@
 #include "thread.h"
 #include "tt.h"
 #include "uci.h"
-#include "syzygy/tbprobe.h"
+#include "tbprobe.h"
 
 using std::string;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -35,7 +35,7 @@
 #include "thread.h"
 #include "tt.h"
 #include "uci.h"
-#include "syzygy/tbprobe.h"
+#include "tbprobe.h"
 
 namespace Search {
 

--- a/src/tbprobe.cpp
+++ b/src/tbprobe.cpp
@@ -28,12 +28,12 @@
 #include <sstream>
 #include <type_traits>
 
-#include "../bitboard.h"
-#include "../movegen.h"
-#include "../position.h"
-#include "../search.h"
-#include "../thread_win32.h"
-#include "../types.h"
+#include "bitboard.h"
+#include "movegen.h"
+#include "position.h"
+#include "search.h"
+#include "thread_win32.h"
+#include "types.h"
 
 #include "tbprobe.h"
 

--- a/src/tbprobe.h
+++ b/src/tbprobe.h
@@ -22,7 +22,7 @@
 
 #include <ostream>
 
-#include "../search.h"
+#include "search.h"
 
 namespace Tablebases {
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -25,7 +25,7 @@
 #include "search.h"
 #include "thread.h"
 #include "uci.h"
-#include "syzygy/tbprobe.h"
+#include "tbprobe.h"
 
 ThreadPool Threads; // Global object
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -29,7 +29,7 @@
 #include "thread.h"
 #include "timeman.h"
 #include "uci.h"
-#include "syzygy/tbprobe.h"
+#include "tbprobe.h"
 
 using namespace std;
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -27,7 +27,7 @@
 #include "thread.h"
 #include "tt.h"
 #include "uci.h"
-#include "syzygy/tbprobe.h"
+#include "tbprobe.h"
 
 using std::string;
 


### PR DESCRIPTION
after the rewrite of the syzygy code, it has become uniform in style and is not 'an independent library' anymore, for example by requiring six header files from the main src dir. Moving it in the main src dir allows for simplifying the Makefile, as well as the include paths around.

No functional change.