### PR TITLE
Skip quiet clean - Bench: 5900851

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -175,7 +175,7 @@ void MovePicker::score<EVASIONS>() {
 /// left. It picks the move with the biggest value from a list of generated moves
 /// taking care not to return the ttMove if it has already been searched.
 
-Move MovePicker::next_move() {
+Move MovePicker::next_move(bool skipQuiets) {
 
   Move move;
 
@@ -250,7 +250,12 @@ Move MovePicker::next_move() {
   case QUIET:
       while (cur < endMoves)
       {
-          move = *cur++;
+          
+		  if (skipQuiets && cur->value < VALUE_ZERO)
+			  break;
+
+		  move = *cur++;
+
           if (   move != ttMove
               && move != ss->killers[0]
               && move != ss->killers[1]

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -253,8 +253,8 @@ Move MovePicker::next_move(bool skipQuiets) {
           
           if (skipQuiets && cur->value < VALUE_ZERO)
               break;
-
-		  move = *cur++;
+	  
+	  move = *cur++;
 
           if (   move != ttMove
               && move != ss->killers[0]

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -251,8 +251,8 @@ Move MovePicker::next_move(bool skipQuiets) {
       while (cur < endMoves)
       {
           
-		  if (skipQuiets && cur->value < VALUE_ZERO)
-			  break;
+          if (skipQuiets && cur->value < VALUE_ZERO)
+              break;
 
 		  move = *cur++;
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -101,7 +101,7 @@ public:
   MovePicker(const Position&, Move, Depth, Square);
   MovePicker(const Position&, Move, Depth, Search::Stack*);
 
-  Move next_move();
+  Move next_move(bool skipQuiets = false);
 
 private:
   template<GenType> void score();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -172,7 +172,7 @@ void Search::init() {
       for (int d = 1; d < 64; ++d)
           for (int mc = 1; mc < 64; ++mc)
           {
-              double r = log(d) * log(mc) / 2;
+              double r = log(d) * log(mc) / 1.95;
 
               Reductions[NonPV][imp][d][mc] = int(std::round(r));
               Reductions[PV][imp][d][mc] = std::max(Reductions[NonPV][imp][d][mc] - 1, 0);
@@ -545,7 +545,7 @@ namespace {
     Depth extension, newDepth;
     Value bestValue, value, ttValue, eval;
     bool ttHit, inCheck, givesCheck, singularExtensionNode, improving;
-    bool captureOrPromotion, doFullDepthSearch, moveCountPruning;
+    bool captureOrPromotion, doFullDepthSearch, moveCountPruning, skipQuiets;
     Piece moved_piece;
     int moveCount, quietCount;
 
@@ -828,10 +828,11 @@ moves_loop: // When in check search starts from here
                            && !excludedMove // Recursive singular search is not allowed
                            && (tte->bound() & BOUND_LOWER)
                            &&  tte->depth() >= depth - 3 * ONE_PLY;
+    skipQuiets = false;
 
     // Step 11. Loop through moves
     // Loop through all pseudo-legal moves until no moves remain or a beta cutoff occurs
-    while ((move = mp.next_move()) != MOVE_NONE)
+    while ((move = mp.next_move(skipQuiets)) != MOVE_NONE)
     {
       assert(is_ok(move));
 
@@ -904,6 +905,7 @@ moves_loop: // When in check search starts from here
               && !givesCheck
               && (!pos.advanced_pawn_push(move) || pos.non_pawn_material(WHITE) + pos.non_pawn_material(BLACK) >= 5000))
           {
+			  skipQuiets = moveCountPruning;
               // Move count based pruning
               if (moveCountPruning)
                   continue;


### PR DESCRIPTION
If we can moveCountPrune and next quiet move has negative stats, then go directly to the next move stage (Bad_Captures). Reduction formula is tweaked to compensate for the decrease in move count that is used in LMR.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 6847 W: 1276 L: 1123 D: 4448

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 48687 W: 6503 L: 6226 D: 35958

Bench: 5900851