### PR TITLE
Stat revert

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -40,8 +40,8 @@ struct HistoryStats {
   void update(Color c, Move m, Value v) {
 
 
-	  if (abs(int(v)) >= 324)  // value must NOT excced the denominator in formula below
-		  return;
+    if (abs(int(v)) >= 324)  // value must NOT excced the denominator in formula below
+        return;
 
     Square from = from_sq(m);
     Square to = to_sq(m);
@@ -69,8 +69,8 @@ struct Stats {
   void update(Piece pc, Square to, Move m) { table[pc][to] = m; }
   void update(Piece pc, Square to, Value v) {
 
-	  if (abs(int(v)) >= 324)  // value must NOT excced the denominator in formula below
-		  return;
+    if (abs(int(v)) >= 324)  // value must NOT excced the denominator in formula below
+        return;
 
     table[pc][to] -= table[pc][to] * abs(int(v)) / 936;
     table[pc][to] += int(v) * 32;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -39,6 +39,10 @@ struct HistoryStats {
   void clear() { std::memset(table, 0, sizeof(table)); }
   void update(Color c, Move m, Value v) {
 
+
+	  if (abs(int(v)) >= 324)  // value must NOT excced the denominator in formula below
+		  return;
+
     Square from = from_sq(m);
     Square to = to_sq(m);
 
@@ -64,6 +68,9 @@ struct Stats {
   void clear() { std::memset(table, 0, sizeof(table)); }
   void update(Piece pc, Square to, Move m) { table[pc][to] = m; }
   void update(Piece pc, Square to, Value v) {
+
+	  if (abs(int(v)) >= 324)  // value must NOT excced the denominator in formula below
+		  return;
 
     table[pc][to] -= table[pc][to] * abs(int(v)) / 936;
     table[pc][to] += int(v) * 32;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -80,9 +80,9 @@ namespace {
   }
 
   // History and stats update bonus, based on depth
-  Value stat_bonus(Depth depth) {
-    int d = depth / ONE_PLY ;
-    return d > 17 ? VALUE_ZERO : Value(d * d + 2 * d - 2);
+  Value stat_bonus(Depth depth) { 
+	  int d = depth / ONE_PLY;
+	  return  Value(d * d + 2 * d - 2); 
   }
 
   // Skill structure is used to implement strength limit


### PR DESCRIPTION
The "simplified" version can easily lead to unintentional bug, if the value exceeds the denominator in the formula in movepick.h when tweaking the stat formula.  As it is now hidden.

Reverting will also make it easier to tweak the stat independently for history stats and cmh stats.

