### PR TITLE
saturate depth in stat_bonus.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -81,8 +81,8 @@ namespace {
 
   // History and stats update bonus, based on depth
   Value stat_bonus(Depth depth) {
-    int d = depth / ONE_PLY ;
-    return d > 17 ? VALUE_ZERO : Value(d * d + 2 * d - 2);
+    int d = std::min(17, depth / ONE_PLY);
+    return Value(d * d + 2 * d - 2);
   }
 
   // Skill structure is used to implement strength limit


### PR DESCRIPTION
do not exclude higher depths for the updates, saturate instead.
Same bench, but functional at higher depth.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 39895 W: 7103 L: 7014 D: 25778

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 109101 W: 13955 L: 13948 D: 81198

Bench: 5919519