### PR TITLE
increase maximum number of threads.

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -59,7 +59,7 @@ void init(OptionsMap& o) {
 
   o["Debug Log File"]        << Option("", on_logger);
   o["Contempt"]              << Option(0, -100, 100);
-  o["Threads"]               << Option(1, 1, 128, on_threads);
+  o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(false);


### PR DESCRIPTION
a single Xeon Phi can present itself as a single numa node with up to 288 threads (4 threads per hardware core). Tested to work as expected with a Xeon Phi CPU 7230 up to 256 threads.

No functional change.