### PR TITLE
Make HistoryStats work the same as other stats

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -152,7 +152,7 @@ void MovePicker::score<QUIETS>() {
       m.value =  cmh[pos.moved_piece(m)][to_sq(m)]
                + fmh[pos.moved_piece(m)][to_sq(m)]
                + fm2[pos.moved_piece(m)][to_sq(m)]
-               + history.get(c, m);
+               + history[m][c];
 }
 
 template<>
@@ -166,7 +166,7 @@ void MovePicker::score<EVASIONS>() {
           m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
                    - Value(type_of(pos.moved_piece(m))) + HistoryStats::Max;
       else
-          m.value = history.get(c, m);
+          m.value = history[m][c];
 }
 
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -28,62 +28,47 @@
 #include "position.h"
 #include "types.h"
 
-
-/// HistoryStats records how often quiet moves have been successful or unsuccessful
-/// during the current search, and is used for reduction and move ordering decisions.
-struct HistoryStats {
-
-  static const Value Max = Value(1 << 28);
-
-  Value get(Color c, Move m) const { return table[c][from_sq(m)][to_sq(m)]; }
-  void clear() { std::memset(table, 0, sizeof(table)); }
-  void update(Color c, Move m, Value v) {
-
-    Square from = from_sq(m);
-    Square to = to_sq(m);
-
-    const int denom = 324;
-
-    assert(abs(int(v)) <= denom); // Needed for stability.
-
-    table[c][from][to] -= table[c][from][to] * abs(int(v)) / denom;
-    table[c][from][to] += int(v) * 32;
-  }
-
-private:
-  Value table[COLOR_NB][SQUARE_NB][SQUARE_NB];
-};
-
-
 /// A template struct, used to generate MoveStats and CounterMoveHistoryStats:
 /// MoveStats store the move that refute a previous one.
 /// CounterMoveHistoryStats is like HistoryStats, but with two consecutive moves.
+/// HistoryStats records how often quiet moves have been successful or unsuccessful
+/// during the current search, and is used for reduction and move ordering decisions.
 /// Entries are stored using only the moving piece and destination square, hence
 /// two moves with different origin but same destination and piece will be
 /// considered identical.
-template<typename T>
+template<typename T, int D1=PIECE_NB, int D2=SQUARE_NB>
 struct Stats {
+  static const Value Max = Value(1 << 28);
+
   const T* operator[](Piece pc) const { return table[pc]; }
   T* operator[](Piece pc) { return table[pc]; }
+  const T* operator[](Move m) const { return table[fromto_bits(m)]; }
   void clear() { std::memset(table, 0, sizeof(table)); }
   void update(Piece pc, Square to, Move m) { table[pc][to] = m; }
+  template<int Denom>
+  void update(int i, int j, Value v) {
+      assert(abs(int(v)) <= Denom); // Needed for stability.
+
+      table[i][j] -= table[i][j] * abs(int(v)) / Denom;
+      table[i][j] += int(v) * 32;
+  }
   void update(Piece pc, Square to, Value v) {
 
-    const int denom = 936;
+      update<936>(pc, to, v);
+  }
+  void update(Color c, Move m, Value v) {
 
-    assert(abs(int(v)) <= denom); // Needed for stability.
-
-    table[pc][to] -= table[pc][to] * abs(int(v)) / denom;
-    table[pc][to] += int(v) * 32;
+      update<324>(fromto_bits(m), c, v);
   }
 
 private:
-  T table[PIECE_NB][SQUARE_NB];
+  T table[D1][D2];
 };
 
 typedef Stats<Move> MoveStats;
 typedef Stats<Value> CounterMoveStats;
 typedef Stats<CounterMoveStats> CounterMoveHistoryStats;
+typedef Stats<Value, 1<<12, COLOR_NB> HistoryStats;
 
 
 /// MovePicker class is used to pick one pseudo legal move at a time from the

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -980,7 +980,7 @@ moves_loop: // When in check search starts from here
               ss->history =  cmh[moved_piece][to_sq(move)]
                            + fmh[moved_piece][to_sq(move)]
                            + fm2[moved_piece][to_sq(move)]
-                           + thisThread->history.get(~pos.side_to_move(), move)
+                           + thisThread->history[move][~pos.side_to_move()]
                            - 4000; // Correction factor
 
               // Decrease/increase reduction by comparing opponent's stat score

--- a/src/types.h
+++ b/src/types.h
@@ -422,6 +422,10 @@ inline Square to_sq(Move m) {
   return Square(m & 0x3F);
 }
 
+inline int fromto_bits(Move m) {
+    return int(m & 0xFFF);
+}
+
 inline MoveType type_of(Move m) {
   return MoveType(m & (3 << 14));
 }


### PR DESCRIPTION
This is a competing request to https://github.com/official-stockfish/Stockfish/pull/1049
Make HistoryStats work the same as other stats and reuse code.
A small side bonus is that fewer instructions are now required to access the HistoryStats table.
No functional change.
bench: 6197938