### PR TITLE
Do not probe TT for excluded move.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -610,6 +610,8 @@ namespace {
         ttMove = MOVE_NONE;
         ttValue = VALUE_NONE;
         ttHit = false;
+        tte = nullptr;
+        posKey = 0;
     }
     else
     {
@@ -652,7 +654,7 @@ namespace {
     }
 
     // Step 4a. Tablebase probe
-    if (!rootNode && TB::Cardinality)
+    if (!rootNode && TB::Cardinality && !excludedMove)
     {
         int piecesCount = pos.count<ALL_PIECES>();
 
@@ -1132,8 +1134,9 @@ moves_loop: // When in check search starts from here
              && !pos.captured_piece()
              && cm_ok)
         update_cm_stats(ss-1, pos.piece_on(prevSq), prevSq, stat_bonus(depth));
-	if(!excludedMove)
-    tte->save(posKey, value_to_tt(bestValue, ss->ply),
+
+    if(!excludedMove)
+            tte->save(posKey, value_to_tt(bestValue, ss->ply),
               bestValue >= beta ? BOUND_LOWER :
               PvNode && bestMove ? BOUND_EXACT : BOUND_UPPER,
               depth, bestMove, ss->staticEval, TT.generation());

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -602,26 +602,24 @@ namespace {
     (ss+2)->killers[0] = (ss+2)->killers[1] = MOVE_NONE;
     Square prevSq = to_sq((ss-1)->currentMove);
 
-    // Step 4. Transposition table lookup. We don't want the score of a partial
-    // search to overwrite a previous full search TT value, so we use a different
-    // position key in case of an excluded move.
-
-	excludedMove = ss->excludedMove;
-	if (excludedMove)
-	{
-		ttMove = MOVE_NONE;
-		ttValue = VALUE_NONE;
-		ttHit = false;
-	}
-	else
-	{
-
-    posKey = pos.key();
-    tte = TT.probe(posKey, ttHit);
-    ttValue = ttHit ? value_from_tt(tte->value(), ss->ply) : VALUE_NONE;
-    ttMove =  rootNode ? thisThread->rootMoves[thisThread->PVIdx].pv[0]
+    // Step 4. Transposition table lookup
+    
+    excludedMove = ss->excludedMove;
+    if (excludedMove) // Excluded moves are not saved so no need to lookup 
+    {
+        ttMove = MOVE_NONE;
+        ttValue = VALUE_NONE;
+        ttHit = false;
+    }
+    else
+    {
+        posKey = pos.key();
+        tte = TT.probe(posKey, ttHit);
+        ttValue = ttHit ? value_from_tt(tte->value(), ss->ply) : VALUE_NONE;
+        ttMove =  rootNode ? thisThread->rootMoves[thisThread->PVIdx].pv[0]
             : ttHit    ? tte->move() : MOVE_NONE;
-	}
+    }
+
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode
         && ttHit
@@ -708,9 +706,9 @@ namespace {
         eval = ss->staticEval =
         (ss-1)->currentMove != MOVE_NULL ? evaluate(pos)
                                          : -(ss-1)->staticEval + 2 * Eval::Tempo;
-		if(!excludedMove)
-        tte->save(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE,
-                  ss->staticEval, TT.generation());
+        if(!excludedMove)
+            tte->save(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE,
+            ss->staticEval, TT.generation());
     }
 
     if (skipEarlyPruning)


### PR DESCRIPTION
Simplification:
Do not probe TT for excluded move as we do not save them.

Regression check:

STC
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 67604 W: 12210 L: 12169 D: 43225

Non functional change