### PR TITLE
Simplification in king danger scoring

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -477,7 +477,7 @@ namespace {
 
         // Transform the kingDanger units into a Score, and substract it from the evaluation
         if (kingDanger > 0)
-            score -= make_score(std::min(kingDanger * kingDanger / 4096,  2 * int(BishopValueMg)), 0);
+            score -= make_score(kingDanger * kingDanger / 4096, 0);
     }
 
     // King tropism: firstly, find squares that opponent attacks in our king flank


### PR DESCRIPTION
Remove minimum to contribution from king danger to score. 

[STC](http://tests.stockfishchess.org/tests/view/58e8d00e0ebc59035df33761)
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 24858 W: 4559 L: 4445 D: 15854

[LTC](http://tests.stockfishchess.org/tests/view/58e909cd0ebc59035df33783)
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 40789 W: 5338 L: 5244 D: 30207

Bench: 7027489