### PR TITLE
Remove cap from space score contribution.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -720,10 +720,9 @@ namespace {
 
     // ...count safe + (behind & safe) with a single popcount.
     int bonus = popcount((Us == WHITE ? safe << 32 : safe >> 32) | (behind & safe));
-    bonus = std::min(16, bonus);
     int weight = pos.count<ALL_PIECES>(Us) - 2 * ei.pe->open_files();
 
-    return make_score(bonus * weight * weight / 18, 0);
+    return make_score(bonus * weight * weight / 16, 0);
   }
 
 


### PR DESCRIPTION
Remove cap from space score contribution and increase bonus.

[STC](http://tests.stockfishchess.org/tests/view/58ebd94a0ebc59035df33876)
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 58462 W: 10615 L: 10558 D: 37289

[LTC](http://tests.stockfishchess.org/tests/view/58ec55e90ebc59035df33891)
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 65061 W: 8539 L: 8477 D: 48045

It is worth noting that an attempt to only increase the bonus passed STC but failed LTC, and an attempt to remove the cap without increasing the bonus is still running at STC, but will probably fail after more than 100k.

Bench: 6169347