### PR TITLE
Fix issue #1058

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -34,18 +34,19 @@ namespace {
     QSEARCH_RECAPTURES, QRECAPTURES
   };
 
-  // Our insertion sort, which is guaranteed to be stable, as it should be
-  void insertion_sort(ExtMove* begin, ExtMove* end)
+  // an insertion sort, which sorts moves in descending order up to a given limit.
+  void partial_insertion_sort(ExtMove* begin, ExtMove* end, Value limit)
   {
-    ExtMove tmp, *p, *q;
-
-    for (p = begin + 1; p < end; ++p)
-    {
-        tmp = *p;
-        for (q = p; q != begin && *(q-1) < tmp; --q)
-            *q = *(q-1);
-        *q = tmp;
-    }
+      for (ExtMove *sortedEnd = begin + 1, *p = begin + 1; p < end; ++p)
+          if (p->value > limit)
+          {
+              ExtMove tmp = *p, *q;
+              *p = *sortedEnd;
+              for (q = sortedEnd; q != begin && *(q-1) < tmp; --q)
+                  *q = *(q-1);
+              *q = tmp;
+              ++sortedEnd;
+          }
   }
 
   // pick_best() finds the best move in the range (begin, end) and moves it to
@@ -238,13 +239,9 @@ Move MovePicker::next_move(bool skipQuiets) {
       cur = endBadCaptures;
       endMoves = generate<QUIETS>(pos, cur);
       score<QUIETS>();
-      if (depth < 3 * ONE_PLY)
-      {
-          ExtMove* goodQuiet = std::partition(cur, endMoves, [](const ExtMove& m)
-                                             { return m.value > VALUE_ZERO; });
-          insertion_sort(cur, goodQuiet);
-      } else
-          insertion_sort(cur, endMoves);
+
+      partial_insertion_sort(cur, endMoves,
+                             depth < 3 * ONE_PLY ? VALUE_ZERO : -VALUE_INFINITE);
       ++stage;
 
   case QUIET:

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -34,7 +34,9 @@ namespace {
     QSEARCH_RECAPTURES, QRECAPTURES
   };
 
-  // an insertion sort, which sorts moves in descending order up to a given limit.
+  // An insertion sort, which sorts moves in descending order up to and including a given limit.
+  // The order of moves smaller than the limit is left unspecified.
+  // To keep the implementation simple, *begin is always included in the list of sorted moves.
   void partial_insertion_sort(ExtMove* begin, ExtMove* end, Value limit)
   {
       for (ExtMove *sortedEnd = begin + 1, *p = begin + 1; p < end; ++p)

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -38,7 +38,7 @@ namespace {
   void partial_insertion_sort(ExtMove* begin, ExtMove* end, Value limit)
   {
       for (ExtMove *sortedEnd = begin + 1, *p = begin + 1; p < end; ++p)
-          if (p->value > limit)
+          if (p->value >= limit)
           {
               ExtMove tmp = *p, *q;
               *p = *sortedEnd;
@@ -241,7 +241,7 @@ Move MovePicker::next_move(bool skipQuiets) {
       score<QUIETS>();
 
       partial_insertion_sort(cur, endMoves,
-                             depth < 3 * ONE_PLY ? VALUE_ZERO : -VALUE_INFINITE);
+                             depth < 3 * ONE_PLY ? VALUE_ZERO : Value(INT_MIN));
       ++stage;
 
   case QUIET:


### PR DESCRIPTION
the order of elements returned by std::partition is implementation defined (since not stable) and could depend on the version of libstdc++ linked.
As std::stable_partition was tested to be too slow (http://tests.stockfishchess.org/tests/view/585cdfd00ebc5903140c6082).
Instead combine partition with our custom implementation of insert_sort, which fixes this issue.
Implementation based on a patch by mstembera (http://tests.stockfishchess.org/tests/view/58d4d3460ebc59035df3315c), which suggests some benefit by itself.
Note that, contrary to master, entries are only sorted up to -VALUE_INFINITE, even though they can be more negative.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 44997 W: 8145 L: 8065 D: 28787

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 18570 W: 2442 L: 2319 D: 13809

Bench: 5658907