### PR TITLE
simplify logic for history based pruning

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -66,6 +66,7 @@ struct Stats {
   const T* operator[](Piece pc) const { return table[pc]; }
   T* operator[](Piece pc) { return table[pc]; }
   void clear() { std::memset(table, 0, sizeof(table)); }
+  void minusOne() { std::memset(table, -1 , sizeof(table)); }
   void update(Piece pc, Square to, Move m) { table[pc][to] = m; }
   void update(Piece pc, Square to, Value v) {
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -66,7 +66,7 @@ struct Stats {
   const T* operator[](Piece pc) const { return table[pc]; }
   T* operator[](Piece pc) { return table[pc]; }
   void clear() { std::memset(table, 0, sizeof(table)); }
-  void minusOne() { std::memset(table, -1 , sizeof(table)); }
+  void fill(const Value& v) { std::fill(&table[0][0], &table[PIECE_NB-1][SQUARE_NB-1]+1, v); };
   void update(Piece pc, Square to, Move m) { table[pc][to] = m; }
   void update(Piece pc, Square to, Value v) {
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -192,6 +192,7 @@ void Search::clear() {
       th->counterMoves.clear();
       th->history.clear();
       th->counterMoveHistory.clear();
+      th->counterMoveHistory[NO_PIECE][0].minusOne();
       th->resetCalls = true;
   }
 
@@ -812,9 +813,6 @@ moves_loop: // When in check search starts from here
     const CounterMoveStats& cmh = *(ss-1)->counterMoves;
     const CounterMoveStats& fmh = *(ss-2)->counterMoves;
     const CounterMoveStats& fm2 = *(ss-4)->counterMoves;
-    const bool cm_ok = is_ok((ss-1)->currentMove);
-    const bool fm_ok = is_ok((ss-2)->currentMove);
-    const bool f2_ok = is_ok((ss-4)->currentMove);
 
     MovePicker mp(pos, ttMove, depth, ss);
     value = bestValue; // Workaround a bogus 'uninitialized' warning under gcc
@@ -916,9 +914,8 @@ moves_loop: // When in check search starts from here
 
               // Countermoves based pruning
               if (   lmrDepth < 3
-                  && ((cmh[moved_piece][to_sq(move)] < VALUE_ZERO) || !cm_ok)
-                  && ((fmh[moved_piece][to_sq(move)] < VALUE_ZERO) || !fm_ok)
-                  && ((fm2[moved_piece][to_sq(move)] < VALUE_ZERO) || !f2_ok || (cm_ok && fm_ok)))
+                  && (cmh[moved_piece][to_sq(move)] < VALUE_ZERO)
+                  && (fmh[moved_piece][to_sq(move)] < VALUE_ZERO))
                   continue;
 
               // Futility pruning: parent node
@@ -1123,7 +1120,7 @@ moves_loop: // When in check search starts from here
     // Bonus for prior countermove that caused the fail low
     else if (    depth >= 3 * ONE_PLY
              && !pos.captured_piece()
-             && cm_ok)
+             && is_ok((ss-1)->currentMove))
         update_cm_stats(ss-1, pos.piece_on(prevSq), prevSq, stat_bonus(depth));
 
     if(!excludedMove)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -75,6 +75,8 @@ namespace {
   int FutilityMoveCounts[2][16]; // [improving][depth]
   int Reductions[2][2][64][64];  // [pv][improving][depth][moveNumber]
 
+  const int cmThreshold = VALUE_ZERO;
+
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {
     return Reductions[PvNode][i][std::min(d / ONE_PLY, 63)][std::min(mn, 63)] * ONE_PLY;
   }
@@ -192,7 +194,7 @@ void Search::clear() {
       th->counterMoves.clear();
       th->history.clear();
       th->counterMoveHistory.clear();
-      th->counterMoveHistory[NO_PIECE][0].minusOne();
+      th->counterMoveHistory[NO_PIECE][0].fill(Value(cmThreshold-1));
       th->resetCalls = true;
   }
 
@@ -914,8 +916,8 @@ moves_loop: // When in check search starts from here
 
               // Countermoves based pruning
               if (   lmrDepth < 3
-                  && (cmh[moved_piece][to_sq(move)] < VALUE_ZERO)
-                  && (fmh[moved_piece][to_sq(move)] < VALUE_ZERO))
+                  && (cmh[moved_piece][to_sq(move)] < cmThreshold)
+                  && (fmh[moved_piece][to_sq(move)] < cmThreshold))
                   continue;
 
               // Futility pruning: parent node

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -75,6 +75,7 @@ namespace {
   int FutilityMoveCounts[2][16]; // [improving][depth]
   int Reductions[2][2][64][64];  // [pv][improving][depth][moveNumber]
 
+  // Threshold used for countermoves based pruning.
   const int cmThreshold = VALUE_ZERO;
 
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {


### PR DESCRIPTION
Use -1 one as a sentinel value, which allows for simplifying the logic for pruning later.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 34255 W: 6292 L: 6194 D: 21769

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 89914 W: 11769 L: 11739 D: 66406

Bench: 5767899