### PR TITLE
Use int instead of Value for history related stats.

### DIFF
--- a/src/movegen.h
+++ b/src/movegen.h
@@ -38,7 +38,7 @@ enum GenType {
 
 struct ExtMove {
   Move move;
-  Value value;
+  int value;
 
   operator Move() const { return move; }
   void operator=(Move m) { move = m; }

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -37,7 +37,7 @@ namespace {
   // An insertion sort, which sorts moves in descending order up to and including a given limit.
   // The order of moves smaller than the limit is left unspecified.
   // To keep the implementation simple, *begin is always included in the list of sorted moves.
-  void partial_insertion_sort(ExtMove* begin, ExtMove* end, Value limit)
+  void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit)
   {
     for (ExtMove *sortedEnd = begin + 1, *p = begin + 1; p < end; ++p)
         if (p->value >= limit)
@@ -243,7 +243,7 @@ Move MovePicker::next_move(bool skipQuiets) {
       score<QUIETS>();
 
       partial_insertion_sort(cur, endMoves,
-                             depth < 3 * ONE_PLY ? VALUE_ZERO : Value(INT_MIN));
+                             depth < 3 * ONE_PLY ? 0 : INT_MIN);
       ++stage;
 
   case QUIET:

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -66,7 +66,7 @@ struct Stats {
   const T* operator[](Piece pc) const { return table[pc]; }
   T* operator[](Piece pc) { return table[pc]; }
   void clear() { std::memset(table, 0, sizeof(table)); }
-  void fill(const Value& v) { std::fill(&table[0][0], &table[PIECE_NB-1][SQUARE_NB-1]+1, v); };
+  void fill(const int& v) { std::fill(&table[0][0], &table[PIECE_NB-1][SQUARE_NB-1]+1, v); };
   void update(Piece pc, Square to, Move m) { table[pc][to] = m; }
   void update(Piece pc, Square to, int v) {
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -33,11 +33,11 @@
 /// during the current search, and is used for reduction and move ordering decisions.
 struct HistoryStats {
 
-  static const Value Max = Value(1 << 28);
+  static const int Max = 1 << 28;
 
-  Value get(Color c, Move m) const { return table[c][from_sq(m)][to_sq(m)]; }
+  int get(Color c, Move m) const { return table[c][from_sq(m)][to_sq(m)]; }
   void clear() { std::memset(table, 0, sizeof(table)); }
-  void update(Color c, Move m, Value v) {
+  void update(Color c, Move m, int v) {
 
     Square from = from_sq(m);
     Square to = to_sq(m);
@@ -51,7 +51,7 @@ struct HistoryStats {
   }
 
 private:
-  Value table[COLOR_NB][SQUARE_NB][SQUARE_NB];
+  int table[COLOR_NB][SQUARE_NB][SQUARE_NB];
 };
 
 
@@ -68,7 +68,7 @@ struct Stats {
   void clear() { std::memset(table, 0, sizeof(table)); }
   void fill(const Value& v) { std::fill(&table[0][0], &table[PIECE_NB-1][SQUARE_NB-1]+1, v); };
   void update(Piece pc, Square to, Move m) { table[pc][to] = m; }
-  void update(Piece pc, Square to, Value v) {
+  void update(Piece pc, Square to, int v) {
 
     const int denom = 936;
 
@@ -83,7 +83,7 @@ private:
 };
 
 typedef Stats<Move> MoveStats;
-typedef Stats<Value> CounterMoveStats;
+typedef Stats<int> CounterMoveStats;
 typedef Stats<CounterMoveStats> CounterMoveHistoryStats;
 
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -83,9 +83,9 @@ namespace {
   }
 
   // History and stats update bonus, based on depth
-  Value stat_bonus(Depth depth) {
+  int stat_bonus(Depth depth) {
     int d = depth / ONE_PLY ;
-    return d > 17 ? VALUE_ZERO : Value(d * d + 2 * d - 2);
+    return d > 17 ? 0 : d * d + 2 * d - 2;
   }
 
   // Skill structure is used to implement strength limit
@@ -151,8 +151,8 @@ namespace {
   Value value_to_tt(Value v, int ply);
   Value value_from_tt(Value v, int ply);
   void update_pv(Move* pv, Move move, Move* childPv);
-  void update_cm_stats(Stack* ss, Piece pc, Square s, Value bonus);
-  void update_stats(const Position& pos, Stack* ss, Move move, Move* quiets, int quietsCnt, Value bonus);
+  void update_cm_stats(Stack* ss, Piece pc, Square s, int bonus);
+  void update_stats(const Position& pos, Stack* ss, Move move, Move* quiets, int quietsCnt, int bonus);
   void check_time();
 
 } // namespace
@@ -554,7 +554,7 @@ namespace {
     Thread* thisThread = pos.this_thread();
     inCheck = pos.checkers();
     moveCount = quietCount =  ss->moveCount = 0;
-    ss->history = VALUE_ZERO;
+    ss->history = 0;
     bestValue = -VALUE_INFINITE;
     ss->ply = (ss-1)->ply + 1;
 
@@ -639,7 +639,7 @@ namespace {
             // Penalty for a quiet ttMove that fails low
             else if (!pos.capture_or_promotion(ttMove))
             {
-                Value penalty = -stat_bonus(depth);
+                int penalty = -stat_bonus(depth);
                 thisThread->history.update(pos.side_to_move(), ttMove, penalty);
                 update_cm_stats(ss, pos.moved_piece(ttMove), to_sq(ttMove), penalty);
             }
@@ -985,10 +985,10 @@ moves_loop: // When in check search starts from here
                            - 4000; // Correction factor
 
               // Decrease/increase reduction by comparing opponent's stat score
-              if (ss->history > VALUE_ZERO && (ss-1)->history < VALUE_ZERO)
+              if (ss->history > 0 && (ss-1)->history < 0)
                   r -= ONE_PLY;
 
-              else if (ss->history < VALUE_ZERO && (ss-1)->history > VALUE_ZERO)
+              else if (ss->history < 0 && (ss-1)->history > 0)
                   r += ONE_PLY;
 
               // Decrease/increase reduction for moves with a good/bad history
@@ -1382,7 +1382,7 @@ moves_loop: // When in check search starts from here
 
   // update_cm_stats() updates countermove and follow-up move history
 
-  void update_cm_stats(Stack* ss, Piece pc, Square s, Value bonus) {
+  void update_cm_stats(Stack* ss, Piece pc, Square s, int bonus) {
 
     for (int i : {1, 2, 4})
         if (is_ok((ss-i)->currentMove))
@@ -1393,7 +1393,7 @@ moves_loop: // When in check search starts from here
   // update_stats() updates move sorting heuristics when a new quiet best move is found
 
   void update_stats(const Position& pos, Stack* ss, Move move,
-                    Move* quiets, int quietsCnt, Value bonus) {
+                    Move* quiets, int quietsCnt, int bonus) {
 
     if (ss->killers[0] != move)
     {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -76,7 +76,7 @@ namespace {
   int Reductions[2][2][64][64];  // [pv][improving][depth][moveNumber]
 
   // Threshold used for countermoves based pruning.
-  const int CounterMovePruneThreshold = VALUE_ZERO;
+  const int CounterMovePruneThreshold = 0;
 
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {
     return Reductions[PvNode][i][std::min(d / ONE_PLY, 63)][std::min(mn, 63)] * ONE_PLY;
@@ -195,7 +195,7 @@ void Search::clear() {
       th->counterMoves.clear();
       th->history.clear();
       th->counterMoveHistory.clear();
-      th->counterMoveHistory[NO_PIECE][0].fill(Value(CounterMovePruneThreshold-1));
+      th->counterMoveHistory[NO_PIECE][0].fill(CounterMovePruneThreshold-1);
       th->resetCalls = true;
   }
 

--- a/src/search.h
+++ b/src/search.h
@@ -44,7 +44,7 @@ struct Stack {
   Move excludedMove;
   Move killers[2];
   Value staticEval;
-  Value history;
+  int history;
   int moveCount;
 };
 


### PR DESCRIPTION
    history related scores are not related to evaluation based scores.
    For example, can easily exceed the range -VALUE_INFINITE,VALUE_INFINITE.
    As such the current type is confusing, and a plain int is a better match.
    
    tested for no regression:
    
    STC:
    LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
    Total: 43693 W: 7909 L: 7827 D: 27957
    
    No functional change.
