### PR TITLE
Fix issue #502

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1500,7 +1500,8 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
   {
       bool updated = (i <= PVIdx && rootMoves[i].score != -VALUE_INFINITE);
 
-      if (depth == ONE_PLY && !updated)
+      if (   !updated
+          && (depth == ONE_PLY || rootMoves[i].previousScore == -VALUE_INFINITE))
           continue;
 
       Depth d = updated ? depth : depth - ONE_PLY;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1507,8 +1507,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
   {
       bool updated = (i <= PVIdx && rootMoves[i].score != -VALUE_INFINITE);
 
-      if (   !updated
-          && (depth == ONE_PLY || rootMoves[i].previousScore == -VALUE_INFINITE))
+      if (depth == ONE_PLY && !updated)
           continue;
 
       Depth d = updated ? depth : depth - ONE_PLY;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1498,7 +1498,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
 
   for (size_t i = 0; i < multiPV; ++i)
   {
-      bool updated = (i <= PVIdx);
+      bool updated = (i <= PVIdx && rootMoves[i].score != -VALUE_INFINITE);
 
       if (depth == ONE_PLY && !updated)
           continue;

--- a/src/search.h
+++ b/src/search.h
@@ -57,7 +57,8 @@ struct RootMove {
 
   explicit RootMove(Move m) : pv(1, m) {}
 
-  bool operator<(const RootMove& m) const { return m.score < score; } // Descending sort
+  bool operator<(const RootMove& m) const {
+    return m.score != score ? m.score < score : m.previousScore < previousScore; } // Descending sort
   bool operator==(const Move& m) const { return pv[0] == m; }
   bool extract_ponder_from_tt(Position& pos);
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -18,6 +18,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <cassert>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -228,6 +229,8 @@ void UCI::loop(int argc, char* argv[]) {
 ///           use negative values for y.
 
 string UCI::value(Value v) {
+
+  assert(-VALUE_INFINITE < v && v < VALUE_INFINITE);
 
   stringstream ss;
 


### PR DESCRIPTION
See description of this issue here: https://github.com/official-stockfish/Stockfish/issues/502

In general, this patch handles the cases where we don't have a valid score for each PV line in a multiPV search. This can happen if the search has been stopped in an unfortunate moment while still in the aspiration loop. The patch consists of two parts.

Part 1: The new PVIdx was already part of the k-best pv's in the last iteration, and we therefore have a valid pv and score to output from the last iteration. This is taken care of with:
```
      bool updated = (i <= PVIdx && rootMoves[i].score != -VALUE_INFINITE); 
```

Case 2: The new PVIdx was NOT part of the k-best pv's in the last iteration, and we have no valid pv and score to output. Not from the current nor from the previous iteration. To avoid this, we are now also considering the previous score when sorting, so that the PV lines with no actual but with a valid previous score are pushed up again, and the previous score can be displayed.
```
  bool operator<(const RootMove& m) const {
    return m.score != score ? m.score < score : m.previousScore < previousScore; } // Descending sort
```
I also added an assertion in UCI::value() to possibly catch similar issues earlier.

No functional change.