### PR TITLE
Use one single block for both killer moves

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -207,8 +207,8 @@ Move MovePicker::next_move(bool skipQuiets) {
       }
 
   case KILLERS:
-	  while (stage < COUNTERMOVE)
-	  {
+      while (stage < COUNTERMOVE)
+      {
          ++stage;
          move = ss->killers[stage - KILLERS];
          if (    move != MOVE_NONE
@@ -216,7 +216,7 @@ Move MovePicker::next_move(bool skipQuiets) {
              &&  pos.pseudo_legal(move)
              && !pos.capture(move))
              return move;
-	  }
+      }
 
   case COUNTERMOVE:
       ++stage;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -209,7 +209,7 @@ Move MovePicker::next_move(bool skipQuiets) {
   case KILLERS:
 	  while (stage < COUNTERMOVE)
 	  {
-		 ++stage;
+         ++stage;
          move = ss->killers[stage - KILLERS];
          if (    move != MOVE_NONE
              &&  move != ttMove

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -206,22 +206,17 @@ Move MovePicker::next_move(bool skipQuiets) {
           }
       }
 
-      ++stage;
-      move = ss->killers[0];  // First killer move
-      if (    move != MOVE_NONE
-          &&  move != ttMove
-          &&  pos.pseudo_legal(move)
-          && !pos.capture(move))
-          return move;
-
   case KILLERS:
-      ++stage;
-      move = ss->killers[1]; // Second killer move
-      if (    move != MOVE_NONE
-          &&  move != ttMove
-          &&  pos.pseudo_legal(move)
-          && !pos.capture(move))
-          return move;
+	  while (stage < COUNTERMOVE)
+	  {
+		 ++stage;
+         move = ss->killers[stage - KILLERS];
+         if (    move != MOVE_NONE
+             &&  move != ttMove
+             &&  pos.pseudo_legal(move)
+             && !pos.capture(move))
+             return move;
+	  }
 
   case COUNTERMOVE:
       ++stage;


### PR DESCRIPTION
Surely not an enhancement in readability & robustness, but removes some duplicate code (DRY-principle).

Results for 20 tests for each version (pgo-builds):

            Base      Test      Diff      
    Mean    2193062   2196680   -3618     
    StDev   16479     11638     12702     

p-value: 0.612
speedup: 0.002

no functional change
bench: 5960754