### PR TITLE
Use one single block for all killer moves (inclusive countermove)

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -112,7 +112,7 @@ private:
 
   const Position& pos;
   const Search::Stack* ss;
-  Move countermove;
+  Move killers[3];
   Depth depth;
   Move ttMove;
   Square recaptureSquare;


### PR DESCRIPTION
An alternative version to #1075 which includes also countermove

Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    2218766   2224014   -5248     
    StDev   12727     11883     8757      

p-value: 0.726
speedup: 0.002

no functional change
bench: 5960754

N.B.: Of course the benefit of this 2 pull request is  can be put in question, I have no problem with closing them, if asked.