### PR TITLE
Copy killers in the movepicker.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -76,6 +76,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, Search::Stack* s)
 
   Square prevSq = to_sq((ss-1)->currentMove);
   countermove = pos.this_thread()->counterMoves[pos.piece_on(prevSq)][prevSq];
+  killers[0] = ss->killers[0];
+  killers[1] = ss->killers[1];
 
   stage = pos.checkers() ? EVASION : MAIN_SEARCH;
   ttMove = ttm && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE;
@@ -210,7 +212,7 @@ Move MovePicker::next_move(bool skipQuiets) {
       }
 
       ++stage;
-      move = ss->killers[0];  // First killer move
+      move = killers[0];  // First killer move
       if (    move != MOVE_NONE
           &&  move != ttMove
           &&  pos.pseudo_legal(move)
@@ -219,7 +221,7 @@ Move MovePicker::next_move(bool skipQuiets) {
 
   case KILLERS:
       ++stage;
-      move = ss->killers[1]; // Second killer move
+      move = killers[1]; // Second killer move
       if (    move != MOVE_NONE
           &&  move != ttMove
           &&  pos.pseudo_legal(move)
@@ -231,8 +233,8 @@ Move MovePicker::next_move(bool skipQuiets) {
       move = countermove;
       if (    move != MOVE_NONE
           &&  move != ttMove
-          &&  move != ss->killers[0]
-          &&  move != ss->killers[1]
+          &&  move != killers[0]
+          &&  move != killers[1]
           &&  pos.pseudo_legal(move)
           && !pos.capture(move))
           return move;
@@ -251,8 +253,8 @@ Move MovePicker::next_move(bool skipQuiets) {
           move = *cur++;
 
           if (   move != ttMove
-              && move != ss->killers[0]
-              && move != ss->killers[1]
+              && move != killers[0]
+              && move != killers[1]
               && move != countermove)
               return move;
       }

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -111,6 +111,7 @@ private:
 
   const Position& pos;
   const Search::Stack* ss;
+  Move killers[2];
   Move countermove;
   Depth depth;
   Move ttMove;


### PR DESCRIPTION
ss->killers can change while the movepicker is active. As a result, the logic to exclude killers while going through the quiets is flawed, excluding moves 'at random'. The reason ss->killers changes is related to the singular extension search in the moves loop that calls search<> recursively with ss instead of ss+1, effectively using the same stack entry for caller and callee. By making a copy of the killers, the movepicker does the right thing nevertheless.

Tested as a bug fix.

STC:
http://tests.stockfishchess.org/tests/view/58ff130f0ebc59035df33f37
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 70845 W: 12752 L: 12716 D: 45377

LTC:
http://tests.stockfishchess.org/tests/view/58ff48000ebc59035df33f3d
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 28368 W: 3730 L: 3619 D: 21019

Bench: 6465887