### PR TITLE
Remove cap in kingDanger initialization

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -423,7 +423,7 @@ namespace {
         // number and types of the enemy's attacking pieces, the number of
         // attacked and undefended squares around our king and the quality of
         // the pawn shelter (current 'score' value).
-        kingDanger =  std::min(820, ei.kingAttackersCount[Them] * ei.kingAttackersWeight[Them])
+        kingDanger =        ei.kingAttackersCount[Them] * ei.kingAttackersWeight[Them]
                     + 103 * ei.kingAdjacentZoneAttacksCount[Them]
                     + 190 * popcount(undefended)
                     + 142 * (popcount(b) + !!pos.pinned_pieces(Us))


### PR DESCRIPTION
A natural follow-up to this idea of Stefano Cardanobile
https://github.com/official-stockfish/Stockfish/commit/b258b4fee789680566bff973cd6f45dc5d24b365

Passed STC
http://tests.stockfishchess.org/tests/view/58fd53be0ebc59035df33eb5
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 52048 W: 9397 L: 9329 D: 33322

Passed LTC
http://tests.stockfishchess.org/tests/view/58ff9e0a0ebc59035df33f5c
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 35382 W: 4650 L: 4549 D: 26183