### PR TITLE
Remove OldAlpha- Bench: 5967663

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1162,13 +1162,12 @@ moves_loop: // When in check search starts from here
     TTEntry* tte;
     Key posKey;
     Move ttMove, move, bestMove;
-    Value bestValue, value, ttValue, futilityValue, futilityBase, oldAlpha;
+    Value bestValue, value, ttValue, futilityValue, futilityBase;
     bool ttHit, givesCheck, evasionPrunable;
     Depth ttDepth;
 
     if (PvNode)
     {
-        oldAlpha = alpha; // To flag BOUND_EXACT when eval above alpha and no available moves
         (ss+1)->pv = pv;
         ss->pv[0] = MOVE_NONE;
     }
@@ -1341,7 +1340,7 @@ moves_loop: // When in check search starts from here
         return mated_in(ss->ply); // Plies to mate from the root
 
     tte->save(posKey, value_to_tt(bestValue, ss->ply),
-              PvNode && bestValue > oldAlpha ? BOUND_EXACT : BOUND_UPPER,
+              PvNode && bestMove ? BOUND_EXACT : BOUND_UPPER,
               ttDepth, bestMove, ss->staticEval, TT.generation());
 
     assert(bestValue > -VALUE_INFINITE && bestValue < VALUE_INFINITE);


### PR DESCRIPTION
Simplification:  Remove Old Alpha.
It may not be wise to save leaf positions in TT without trying a move.

Since the position may be drawn or zugzwang. 

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 49481 W: 8995 L: 8923 D: 31563

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 74246 W: 9703 L: 9652 D: 54891

Bench: 5967663