### PR TITLE
Clean partial_insertion_sort()

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -36,18 +36,16 @@ namespace {
 
   // partial_insertion_sort() sorts moves in descending order up to and including
   // a given limit. The order of moves smaller than the limit is left unspecified.
-  // To keep the implementation simple, *begin is always included in the sorted moves.
   void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
 
-    for (ExtMove *sortedEnd = begin + 1, *p = begin + 1; p < end; ++p)
+    for (ExtMove *sortedEnd = begin, *p = begin + 1; p < end; ++p)
         if (p->value >= limit)
         {
             ExtMove tmp = *p, *q;
-            *p = *sortedEnd;
-            for (q = sortedEnd; q != begin && *(q-1) < tmp; --q)
-                *q = *(q-1);
+            *p = *++sortedEnd;
+            for (q = sortedEnd; q != begin && *(q - 1) < tmp; --q)
+                *q = *(q - 1);
             *q = tmp;
-            ++sortedEnd;
         }
   }
 


### PR DESCRIPTION
Avoid *begin always being included in the sorted list regardless of its value.
This was a minor criticism by @zamar in the original pull request
https://github.com/official-stockfish/Stockfish/pull/1065
necessitating a comment explanation.
No functional change.
bench: 5934421