### PR TITLE
Remove excluded move from TT position key formula.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -614,11 +614,11 @@ namespace {
     // search to overwrite a previous full search TT value, so we use a different
     // position key in case of an excluded move.
     excludedMove = ss->excludedMove;
-    posKey = pos.key() ^ Key(excludedMove);
+    posKey = pos.key();
     tte = TT.probe(posKey, ttHit);
-    ttValue = ttHit ? value_from_tt(tte->value(), ss->ply) : VALUE_NONE;
+    ttValue = ttHit && !excludedMove ? value_from_tt(tte->value(), ss->ply) : VALUE_NONE;
     ttMove =  rootNode ? thisThread->rootMoves[thisThread->PVIdx].pv[0]
-            : ttHit    ? tte->move() : MOVE_NONE;
+                       : ttHit && !excludedMove ? tte->move() : MOVE_NONE;
 
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode


### PR DESCRIPTION
The point here is that we avoid computing the staticeval and saving an entry in the TT table.
We can use the staticeval for the position without the excludedMove (Removing excluded move from posKey formula)

This is safe to do, because positions with excluded move are not saved to the TT table after the full node  evaluation.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 27206 W: 4923 L: 4813 D: 17470

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 22048 W: 2913 L: 2794 D: 16341



bench: 5773225