### PR TITLE
Simplification of checkmate detection in quiescence search.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1207,7 +1207,8 @@ moves_loop: // When in check search starts from here
     if (InCheck)
     {
         ss->staticEval = VALUE_NONE;
-        bestValue = futilityBase = -VALUE_INFINITE;
+        // Start from the worst case which is checkmate
+        bestValue = futilityBase = mated_in(ss->ply);  // Plies to mate from the root
     }
     else
     {
@@ -1335,11 +1336,6 @@ moves_loop: // When in check search starts from here
           }
        }
     }
-
-    // All legal moves have been searched. A special case: If we're in check
-    // and no legal moves were found, it is checkmate.
-    if (InCheck && bestValue == -VALUE_INFINITE)
-        return mated_in(ss->ply); // Plies to mate from the root
 
     tte->save(posKey, value_to_tt(bestValue, ss->ply),
               PvNode && bestValue > oldAlpha ? BOUND_EXACT : BOUND_UPPER,


### PR DESCRIPTION
Conceptually the same thing as before, with the exception that now checkmate positions get stored in the TT too. Tested for no regression:

[STC ](http://tests.stockfishchess.org/tests/view/590337e00ebc59035df34086)
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 19067 W: 3451 L: 3327 D: 12289

[LTC](http://tests.stockfishchess.org/tests/view/590357c60ebc59035df34093)
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 120659 W: 15383 L: 15390 D: 89886

bench: 5954618