### PR TITLE
Simple Protector

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,6 @@
 # Generated with 'git shortlog -sn | cut -c8-', which sorts by commits, manually ordered the first four authors, merged duplicates
 
-Tord Romstad
+Tord Romstad 
 Marco Costalba (mcostalba)
 Joona Kiiski (zamar)
 Gary Linscott (glinscott)

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,6 @@
 # Generated with 'git shortlog -sn | cut -c8-', which sorts by commits, manually ordered the first four authors, merged duplicates
 
-Tord Romstad 
+Tord Romstad
 Marco Costalba (mcostalba)
 Joona Kiiski (zamar)
 Gary Linscott (glinscott)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -174,10 +174,8 @@ namespace {
     S(-20,-12), S( 1, -8), S( 2, 10), S(  9, 10)
   };
 
-  // Protector[PieceType-2]contains the slope of penalty/bonus for going further away from our king,
-  // indexed by piece type.
-  
-  const Score Protector[] = {S(-3, -5), S(-4, -3),S(-3,  0),S(-1,  1) };
+  // KingProtector[PieceType-2] contains distance to king factors for each piece type
+  const Score KingProtector[] = {S(-3, -5), S(-4, -3), S(-3, 0), S(-1, 1) };
 
   // Assorted bonuses and penalties used by evaluation
   const Score MinorBehindPawn     = S( 16,  0);
@@ -295,8 +293,7 @@ namespace {
 
         mobility[Us] += MobilityBonus[Pt-2][mob];
 
-        // Bonus for this piece as a king protector
-        score += Protector[Pt-2] * distance(s, pos.square<KING>(Us));
+        score += KingProtector[Pt-2] * distance(s, pos.square<KING>(Us));
 
         if (Pt == BISHOP || Pt == KNIGHT)
         {

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -174,14 +174,10 @@ namespace {
     S(-20,-12), S( 1, -8), S( 2, 10), S(  9, 10)
   };
 
-  // Protector[PieceType-2][distance] contains a protecting bonus for our king,
-  // indexed by piece type and distance between the piece and the king.
-  const Score Protector[][8] = {
-    { S(0, 0), S( 7, 9), S( 7, 1), S( 1, 5), S(-10,-4), S( -1,-4), S( -7,-3), S(-16,-10) }, // Knight
-    { S(0, 0), S(11, 8), S(-7,-1), S(-1,-2), S( -1,-7), S(-11,-3), S( -9,-1), S(-16, -1) }, // Bishop
-    { S(0, 0), S(10, 0), S(-2, 2), S(-5, 4), S( -6, 2), S(-14,-3), S( -2,-9), S(-12, -7) }, // Rook
-    { S(0, 0), S( 3,-5), S( 2,-5), S(-4, 0), S( -9,-6), S( -4, 7), S(-13,-7), S(-10, -7) }  // Queen
-  };
+  // Protector[PieceType-2]contains the slope of penalty/bonus for going further away from our king,
+  // indexed by piece type.
+  
+  const Score Protector[] = {S(-3, -5), S(-4, -3),S(-3,  0),S(-1,  1) };
 
   // Assorted bonuses and penalties used by evaluation
   const Score MinorBehindPawn     = S( 16,  0);
@@ -300,7 +296,7 @@ namespace {
         mobility[Us] += MobilityBonus[Pt-2][mob];
 
         // Bonus for this piece as a king protector
-        score += Protector[Pt-2][distance(s, pos.square<KING>(Us))];
+        score += Protector[Pt-2] * distance(s, pos.square<KING>(Us));
 
         if (Pt == BISHOP || Pt == KNIGHT)
         {

--- a/src/types.h
+++ b/src/types.h
@@ -184,10 +184,10 @@ enum Value : int {
   VALUE_MATED_IN_MAX_PLY = -VALUE_MATE + 2 * MAX_PLY,
 
   PawnValueMg   = 188,   PawnValueEg   = 248,
-  KnightValueMg = 753,   KnightValueEg = 832,
-  BishopValueMg = 814,   BishopValueEg = 890,
-  RookValueMg   = 1285,  RookValueEg   = 1371,
-  QueenValueMg  = 2513,  QueenValueEg  = 2648,
+  KnightValueMg = 764,   KnightValueEg = 848,
+  BishopValueMg = 826,   BishopValueEg = 891,
+  RookValueMg   = 1282,  RookValueEg   = 1373,
+  QueenValueMg  = 2526,  QueenValueEg  = 2646,
 
   MidgameLimit  = 15258, EndgameLimit  = 3915
 };


### PR DESCRIPTION
Replacing the old Protector table with a simple linear formula which takes into account a different slope for each different piece type.

The idea of this simplification of Protector is originated by Alain (Rocky)

STC: LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 70382 W: 12859 L: 12823 D: 44700

LTC: LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 61554 W: 8098 L: 8031 D: 45425

Bench:6231822
