### PR TITLE
Do not store thisThread in pos.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,17 @@ matrix:
         - COMP=clang
 
     - os: osx
+      osx_image: xcode8.3
       compiler: gcc
       env:
         - COMPILER=g++
         - COMP=gcc
 
     - os: osx
+      osx_image: xcode8.3
       compiler: clang
       env:
-        - COMPILER=clang++ V='Apple LLVM 6.0' # Apple LLVM version 6.0 (clang-600.0.54) (based on LLVM 3.5svn)
+        - COMPILER=clang++
         - COMP=clang
 
 branches:

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -156,7 +156,7 @@ void benchmark(const Position& current, istream& is) {
   for (size_t i = 0; i < fens.size(); ++i)
   {
       StateListPtr states(new std::deque<StateInfo>(1));
-      pos.set(fens[i], Options["UCI_Chess960"], &states->back(), Threads.main());
+      pos.set(fens[i], Options["UCI_Chess960"], &states->back());
 
       cerr << "\nPosition: " << i + 1 << '/' << fens.size() << endl;
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -126,7 +126,7 @@ namespace Material {
 Entry* probe(const Position& pos) {
 
   Key key = pos.material_key();
-  Entry* e = pos.this_thread()->materialTable[key];
+  Entry* e = thisThread->materialTable[key];
 
   if (e->key == key)
       return e;
@@ -139,7 +139,7 @@ Entry* probe(const Position& pos) {
   // Let's look if we have a specialized evaluation function for this particular
   // material configuration. Firstly we look for a fixed configuration one, then
   // for a generic one if the previous search failed.
-  if ((e->evaluationFunction = pos.this_thread()->endgames.probe<Value>(key)) != nullptr)
+  if ((e->evaluationFunction = thisThread->endgames.probe<Value>(key)) != nullptr)
       return e;
 
   for (Color c = WHITE; c <= BLACK; ++c)
@@ -153,7 +153,7 @@ Entry* probe(const Position& pos) {
   // configuration. Is there a suitable specialized scaling function?
   EndgameBase<ScaleFactor>* sf;
 
-  if ((sf = pos.this_thread()->endgames.probe<ScaleFactor>(key)) != nullptr)
+  if ((sf = thisThread->endgames.probe<ScaleFactor>(key)) != nullptr)
   {
       e->scalingFunction[sf->strong_side()] = sf; // Only strong color assigned
       return e;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -75,7 +75,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, Search::Stack* s)
   assert(d > DEPTH_ZERO);
 
   Square prevSq = to_sq((ss-1)->currentMove);
-  countermove = pos.this_thread()->counterMoves[pos.piece_on(prevSq)][prevSq];
+  countermove = thisThread->counterMoves[pos.piece_on(prevSq)][prevSq];
   killers[0] = ss->killers[0];
   killers[1] = ss->killers[1];
 
@@ -145,7 +145,7 @@ void MovePicker::score<CAPTURES>() {
 template<>
 void MovePicker::score<QUIETS>() {
 
-  const HistoryStats& history = pos.this_thread()->history;
+  const HistoryStats& history = thisThread->history;
 
   const CounterMoveStats& cmh = *(ss-1)->counterMoves;
   const CounterMoveStats& fmh = *(ss-2)->counterMoves;
@@ -163,7 +163,7 @@ void MovePicker::score<QUIETS>() {
 template<>
 void MovePicker::score<EVASIONS>() {
   // Try captures ordered by MVV/LVA, then non-captures ordered by stats heuristics
-  const HistoryStats& history = pos.this_thread()->history;
+  const HistoryStats& history = thisThread->history;
   Color c = pos.side_to_move();
 
   for (auto& m : *this)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -218,7 +218,7 @@ void init() {
 Entry* probe(const Position& pos) {
 
   Key key = pos.pawn_key();
-  Entry* e = pos.this_thread()->pawnsTable[key];
+  Entry* e = thisThread->pawnsTable[key];
 
   if (e->key == key)
       return e;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -110,7 +110,7 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
   {
       StateInfo st;
       Position p;
-      p.set(pos.fen(), pos.is_chess960(), &st, pos.this_thread());
+      p.set(pos.fen(), pos.is_chess960(), &st);
       Tablebases::ProbeState s1, s2;
       Tablebases::WDLScore wdl = Tablebases::probe_wdl(p, &s1);
       int dtz = Tablebases::probe_dtz(p, &s2);
@@ -156,7 +156,7 @@ void Position::init() {
 /// This function is not very robust - make sure that input FENs are correct,
 /// this is assumed to be the responsibility of the GUI.
 
-Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Thread* th) {
+Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si) {
 /*
    A FEN string defines a particular position using only the ASCII character set.
 
@@ -274,7 +274,6 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
   gamePly = std::max(2 * (gamePly - 1), 0) + (sideToMove == BLACK);
 
   chess960 = isChess960;
-  thisThread = th;
   set_state(st);
 
   assert(pos_is_ok());
@@ -394,7 +393,7 @@ Position& Position::set(const string& code, Color c, StateInfo* si) {
   string fenStr =  sides[0] + char(8 - sides[0].length() + '0') + "/8/8/8/8/8/8/"
                  + sides[1] + char(8 - sides[1].length() + '0') + " w - - 0 10";
 
-  return set(fenStr, false, si, nullptr);
+  return set(fenStr, false, si);
 }
 
 
@@ -1137,7 +1136,7 @@ void Position::flip() {
   std::getline(ss, token); // Half and full moves
   f += token;
 
-  set(f, is_chess960(), st, this_thread());
+  set(f, is_chess960(), st);
 
   assert(pos_is_ok());
 }

--- a/src/position.h
+++ b/src/position.h
@@ -75,7 +75,7 @@ public:
   Position& operator=(const Position&) = delete;
 
   // FEN string input/output
-  Position& set(const std::string& fenStr, bool isChess960, StateInfo* si, Thread* th);
+  Position& set(const std::string& fenStr, bool isChess960, StateInfo* si);
   Position& set(const std::string& code, Color c, StateInfo* si);
   const std::string fen() const;
 
@@ -149,7 +149,6 @@ public:
   Phase game_phase() const;
   int game_ply() const;
   bool is_chess960() const;
-  Thread* this_thread() const;
   uint64_t nodes_searched() const;
   bool is_draw(int ply) const;
   int rule50_count() const;
@@ -187,7 +186,6 @@ private:
   uint64_t nodes;
   int gamePly;
   Color sideToMove;
-  Thread* thisThread;
   StateInfo* st;
   bool chess960;
 };
@@ -376,10 +374,6 @@ inline bool Position::capture(Move m) const {
 
 inline Piece Position::captured_piece() const {
   return st->capturedPiece;
-}
-
-inline Thread* Position::this_thread() const {
-  return thisThread;
 }
 
 inline void Position::put_piece(Piece pc, Square s) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -554,7 +554,6 @@ namespace {
     int moveCount, quietCount;
 
     // Step 1. Initialize node
-    Thread* thisThread = pos.this_thread();
     inCheck = pos.checkers();
     moveCount = quietCount =  ss->moveCount = 0;
     ss->history = 0;
@@ -1408,7 +1407,6 @@ moves_loop: // When in check search starts from here
     }
 
     Color c = pos.side_to_move();
-    Thread* thisThread = pos.this_thread();
     thisThread->history.update(c, move, bonus);
     update_cm_stats(ss, pos.moved_piece(move), to_sq(move), bonus);
 
@@ -1497,8 +1495,8 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
 
   std::stringstream ss;
   int elapsed = Time.elapsed() + 1;
-  const RootMoves& rootMoves = pos.this_thread()->rootMoves;
-  size_t PVIdx = pos.this_thread()->PVIdx;
+  const RootMoves& rootMoves = thisThread->rootMoves;
+  size_t PVIdx = thisThread->PVIdx;
   size_t multiPV = std::min((size_t)Options["MultiPV"], rootMoves.size());
   uint64_t nodesSearched = Threads.nodes_searched();
   uint64_t tbHits = Threads.tb_hits() + (TB::RootInTB ? rootMoves.size() : 0);
@@ -1521,7 +1519,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
 
       ss << "info"
          << " depth "    << d / ONE_PLY
-         << " seldepth " << pos.this_thread()->maxPly
+         << " seldepth " << thisThread->maxPly
          << " multipv "  << i + 1
          << " score "    << UCI::value(v);
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -127,6 +127,9 @@ void Thread::idle_loop() {
 void ThreadPool::init() {
 
   push_back(new MainThread());
+  // The controlling thread executes perft/eval and in those cases
+  // needs a pointer to the MainThread data structure.
+  thisThread = back();
   read_uci_options();
 }
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -27,7 +27,9 @@
 #include "uci.h"
 #include "syzygy/tbprobe.h"
 
-ThreadPool Threads; // Global object
+// Global objects
+ThreadPool Threads;
+thread_local Thread* thisThread;
 
 /// Thread constructor launches the thread and then waits until it goes to sleep
 /// in idle_loop().
@@ -95,6 +97,7 @@ void Thread::start_searching(bool resume) {
 void Thread::idle_loop() {
 
   WinProcGroup::bindThisThread(idx);
+  thisThread = this;
 
   while (!exit)
   {
@@ -214,7 +217,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
       th->tbHits = 0;
       th->rootDepth = DEPTH_ZERO;
       th->rootMoves = rootMoves;
-      th->rootPos.set(pos.fen(), pos.is_chess960(), &setupStates->back(), th);
+      th->rootPos.set(pos.fen(), pos.is_chess960(), &setupStates->back());
   }
 
   setupStates->back() = tmp; // Restore st->previous, cleared by Position::set()

--- a/src/thread.h
+++ b/src/thread.h
@@ -74,7 +74,6 @@ public:
   CounterMoveHistoryStats counterMoveHistory;
 };
 
-
 /// MainThread is a derived class with a specific overload for the main thread
 
 struct MainThread : public Thread {
@@ -106,5 +105,6 @@ private:
 };
 
 extern ThreadPool Threads;
+extern thread_local Thread* thisThread;
 
 #endif // #ifndef THREAD_H_INCLUDED

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -71,7 +71,7 @@ namespace {
         return;
 
     States = StateListPtr(new std::deque<StateInfo>(1));
-    pos.set(fen, Options["UCI_Chess960"], &States->back(), Threads.main());
+    pos.set(fen, Options["UCI_Chess960"], &States->back());
 
     // Parse move list (if any)
     while (is >> token && (m = UCI::to_move(pos, token)) != MOVE_NONE)
@@ -151,7 +151,7 @@ void UCI::loop(int argc, char* argv[]) {
   Position pos;
   string token, cmd;
 
-  pos.set(StartFEN, false, &States->back(), Threads.main());
+  pos.set(StartFEN, false, &States->back());
 
   for (int i = 1; i < argc; ++i)
       cmd += std::string(argv[i]) + " ";


### PR DESCRIPTION
to describe the position, thread information is not needed. Remove it from Position and instead make it available as a thread_local variable, which simplifies both accessing this information, as well as constructing positions.

No functional change.