### PR TITLE
Fix issue #1101

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,6 @@
 #include "position.h"
 #include "search.h"
 #include "thread.h"
-#include "tt.h"
 #include "uci.h"
 #include "syzygy/tbprobe.h"
 
@@ -44,8 +43,6 @@ int main(int argc, char* argv[]) {
   Search::init();
   Pawns::init();
   Threads.init();
-  Tablebases::init(Options["SyzygyPath"]);
-  TT.resize(Options["Hash"]);
 
   UCI::loop(argc, argv);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -185,7 +185,7 @@ void Search::init() {
 }
 
 
-/// Search::clear() resets search state to zero, to obtain reproducible results
+/// Search::clear() resets search state to its initial value, to obtain reproducible results
 
 void Search::clear() {
 


### PR DESCRIPTION
execute an implied ucinewgame upon entering the UCI::loop, to make sure that searches starting with and without an (optional) ucinewgame command yield the same search. This is needed now that seach::clear() initializes tables to non-zero default values.

No functional change.