### PR TITLE
Makefile ARM bugfix

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -152,16 +152,6 @@ ifeq ($(COMP),gcc)
 	CXX=g++
 	CXXFLAGS += -pedantic -Wextra -Wshadow
 
-	ifeq ($(ARCH),armv7)
-		ifeq ($(OS),Android)
-			CXXFLAGS += -m$(bits)
-			LDFLAGS += -m$(bits)
-		endif
-	else
-		CXXFLAGS += -m$(bits)
-		LDFLAGS += -m$(bits)
-	endif
-
 	ifneq ($(KERNEL),Darwin)
 	   LDFLAGS += -Wl,--no-as-needed
 	endif


### PR DESCRIPTION
The gcc -m32 or -m64 option is x86 specific (see https://gcc.gnu.org/onlinedocs/gcc-6.3.0/gcc/x86-Options.html) ; using it leads to compilation error on ARM processor.

No functional change