### PR TITLE
Pawn logic

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -166,9 +166,13 @@ namespace {
         else if (    stoppers == SquareBB[s + Up]
                  &&  relative_rank(Us, s) >= RANK_5
                  && (b = (shift<Up>(supported) & ~theirPawns)))
-            while(b)
-                if(!more_than_one(theirPawns & PawnAttacks[Us][pop_lsb(&b)]))
+            do
+                if (!more_than_one(theirPawns & PawnAttacks[Us][pop_lsb(&b)]))
+                {
                     e->passedPawns[Us] |= s;
+                    break;
+                }
+            while (b);
 
         // Score this pawn
         if (!neighbours)


### PR DESCRIPTION
1) The first entry to the while loop will always be true because of the if condition above.
2) Also once square s gets ORed in the first time it's redundant to keep oring it in again.
This takes care of both issues.  I realize the syntax is more verbose but IMO precise logic is preferred.  If maintainers disagree I will close.
No functional change.
bench: 6107863