### PR TITLE
use int16_t for histories

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -28,7 +28,7 @@
 #include "types.h"
 
 /// StatBoards is a generic 2-dimensional array used to store various statistics
-template<int Size1, int Size2, typename T = int>
+template<int Size1, int Size2, typename T = int16_t>
 struct StatBoards : public std::array<std::array<T, Size2>, Size1> {
 
   void fill(const T& v) {
@@ -52,7 +52,7 @@ struct ButterflyHistory : public ButterflyBoards {
   void update(Color c, Move m, int v) {
 
     const int D = 324;
-    int& entry = (*this)[c][from_to(m)];
+    auto& entry = (*this)[c][from_to(m)];
 
     assert(abs(v) <= D); // Consistency check for below formula
 
@@ -68,7 +68,7 @@ struct PieceToHistory : public PieceToBoards {
   void update(Piece pc, Square to, int v) {
 
     const int D = 936;
-    int& entry = (*this)[pc][to];
+    auto& entry = (*this)[pc][to];
 
     assert(abs(v) <= D); // Consistency check for below formula
 


### PR DESCRIPTION
saves over 2Mb of memory, as in particular CounterMoveHistoryStats is a large object. Improved cache utilization yields a small speedup (0.7% locally).

The patch is non-functional as int16_t is sufficiently large to capture all values that can be reached with the current update scheme.
The accessible range of values is [-32 * D, 32 * D] as a closer analysis of the update formula reveals.

Two functionally equivalent, but less clean, versions of this patch have been tested for no-regression:

http://tests.stockfishchess.org/tests/view/591353890ebc59035df344e4
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 54476 W: 9949 L: 9886 D: 34641

http://tests.stockfishchess.org/tests/view/59140f6b0ebc59035df3451a
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 27019 W: 4905 L: 4794 D: 17320

No functional change.