### PR TITLE
Simplify history stats

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -167,7 +167,7 @@ void MovePicker::score<EVASIONS>() {
   for (auto& m : *this)
       if (pos.capture(m))
           m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
-                   - Value(type_of(pos.moved_piece(m))) + HistoryStats::Max;
+                   - Value(type_of(pos.moved_piece(m))) + (1 << 28);
       else
           m.value = history.get(c, m);
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -193,9 +193,9 @@ void Search::clear() {
 
   for (Thread* th : Threads)
   {
-      th->counterMoves.clear();
-      th->history.clear();
-      th->counterMoveHistory.clear();
+      th->counterMoves = {};
+      th->history = {};
+      for (auto& t : th->counterMoveHistory) t = {}; // Loop avoids large objects on stack
       th->resetCalls = true;
 
       CounterMoveStats& cm = th->counterMoveHistory[NO_PIECE][0];
@@ -1415,7 +1415,7 @@ moves_loop: // When in check search starts from here
     if (is_ok((ss-1)->currentMove))
     {
         Square prevSq = to_sq((ss-1)->currentMove);
-        thisThread->counterMoves.update(pos.piece_on(prevSq), prevSq, move);
+        thisThread->counterMoves[pos.piece_on(prevSq)][prevSq]=move;
     }
 
     // Decrease all the other played quiet moves

--- a/src/types.h
+++ b/src/types.h
@@ -246,6 +246,8 @@ enum Square {
   NORTH_WEST = NORTH + WEST
 };
 
+const int FROM_TO_NB = 4096;
+
 enum File : int {
   FILE_A, FILE_B, FILE_C, FILE_D, FILE_E, FILE_F, FILE_G, FILE_H, FILE_NB
 };
@@ -419,6 +421,10 @@ inline Square from_sq(Move m) {
 
 inline Square to_sq(Move m) {
   return Square(m & 0x3F);
+}
+
+inline int from_to_bits(Move m) {
+ return m & 0xFFF;
 }
 
 inline MoveType type_of(Move m) {


### PR DESCRIPTION
MoveStats is now an array of Moves, CounterMoveHistoryStats an array of CounterMoveStats, as nothing more was required.
CounterMoveStats and HistoryStats retain their own struct, given their different table sizes, and update rules.

Fixes a bug in Search::clear, where the filling of CounterMoveStats&, overwrote (currently presumably unused) memory because sizeof(cm) returns the size in bytes, whereas elements was needed.

Tested for no regression:
LLR: 2.97 (-2.94,2.94) [-3.00,1.00]
Total: 174175 W: 31503 L: 31643 D: 111029

No functional change.