### PR TITLE
Obsolete

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -88,7 +88,7 @@ namespace {
 
     // kingRing[color] is the zone around the king which is considered
     // by the king safety evaluation. This consists of the squares directly
-    // adjacent to the king, and the three (or two, for a king on an edge file)
+    // adjacent to the king, and (only for a king on its first rank) the
     // squares two ranks in front of the king. For instance, if black's king
     // is on g8, kingRing[BLACK] is a bitboard containing the squares f8, h8,
     // f7, g7, h7, f6, g6 and h6.
@@ -242,7 +242,10 @@ namespace {
     // Init our king safety tables only if we are going to use them
     if (pos.non_pawn_material(Them) >= QueenValueMg)
     {
-        ei.kingRing[Us] = b | shift<Up>(b);
+        ei.kingRing[Us] = b;
+        if (relative_rank(Us, pos.square<KING>(Us)) == RANK_1)
+            ei.kingRing[Us] |= shift<Up>(b);
+
         ei.kingAttackersCount[Them] = popcount(b & ei.pe->pawn_attacks(Them));
         ei.kingAdjacentZoneAttacksCount[Them] = ei.kingAttackersWeight[Them] = 0;
     }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -475,7 +475,7 @@ namespace {
 
         // Transform the kingDanger units into a Score, and substract it from the evaluation
         if (kingDanger > 0)
-            score -= make_score(kingDanger * kingDanger / 4096, 0);
+            score -= make_score(kingDanger * kingDanger / 4096, kingDanger / 16);
     }
 
     // King tropism: firstly, find squares that opponent attacks in our king flank

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -475,7 +475,7 @@ namespace {
 
         // Transform the kingDanger units into a Score, and substract it from the evaluation
         if (kingDanger > 0)
-            score -= make_score(kingDanger * kingDanger / 4096, kingDanger / 8);
+            score -= make_score(kingDanger * kingDanger / 4096, kingDanger / 16);
     }
 
     // King tropism: firstly, find squares that opponent attacks in our king flank

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -475,7 +475,7 @@ namespace {
 
         // Transform the kingDanger units into a Score, and substract it from the evaluation
         if (kingDanger > 0)
-            score -= make_score(kingDanger * kingDanger / 4096, kingDanger / 16);
+            score -= make_score(kingDanger * kingDanger / 4096, kingDanger / 8);
     }
 
     // King tropism: firstly, find squares that opponent attacks in our king flank


### PR DESCRIPTION
When SF has an attack on the opponent king in one flank, the huge
midgame -> endgame gradient of the tapered eval prevents us to properly
evaluate neutral exchanges on the other flank as the current king
danger score is a pure midgame term, and this may affect SF's ability
to switch to defense in some positions. This patch adds a small
contribution of the king danger to the endgame score to limit this
effect.

Again suggested in the following forum thread:
https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/xrUCQ7b0ObE

Passed STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 12719 W: 2371 L: 2192 D: 8156

And LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 31293 W: 4194 L: 3974 D: 23125

Bench: 5961548