### PR TITLE
Fix bug

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -65,6 +65,7 @@ struct Stats {
   const T* operator[](Piece pc) const { return table[pc]; }
   T* operator[](Piece pc) { return table[pc]; }
   void clear() { std::memset(table, 0, sizeof(table)); }
+  void fill(int v) { std::fill(&table[0][0], &table[PIECE_NB - 1][SQUARE_NB - 1] + 1, v); }
   void update(Piece pc, Square to, Move m) { table[pc][to] = m; }
   void update(Piece pc, Square to, int v) {
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -65,7 +65,6 @@ struct Stats {
   const T* operator[](Piece pc) const { return table[pc]; }
   T* operator[](Piece pc) { return table[pc]; }
   void clear() { std::memset(table, 0, sizeof(table)); }
-  void fill(int v) { std::fill(&table[0][0], &table[PIECE_NB - 1][SQUARE_NB - 1] + 1, v); }
   void update(Piece pc, Square to, Move m) { table[pc][to] = m; }
   void update(Piece pc, Square to, int v) {
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -197,7 +197,10 @@ void Search::clear() {
       th->history.clear();
       th->counterMoveHistory.clear();
       th->resetCalls = true;
-      th->counterMoveHistory[NO_PIECE][0].fill(CounterMovePruneThreshold - 1);
+
+      CounterMoveStats& cm = th->counterMoveHistory[NO_PIECE][0];
+      auto* t = &cm[NO_PIECE][0];
+      std::fill(t, t + sizeof(cm)/sizeof(*t), CounterMovePruneThreshold - 1);
   }
 
   Threads.main()->previousScore = VALUE_INFINITE;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -197,9 +197,7 @@ void Search::clear() {
       th->history.clear();
       th->counterMoveHistory.clear();
       th->resetCalls = true;
-      CounterMoveStats& cm = th->counterMoveHistory[NO_PIECE][0];
-      int* t = &cm[NO_PIECE][0];
-      std::fill(t, t + sizeof(cm), CounterMovePruneThreshold - 1);
+      th->counterMoveHistory[NO_PIECE][0].fill(CounterMovePruneThreshold - 1);
   }
 
   Threads.main()->previousScore = VALUE_INFINITE;


### PR DESCRIPTION
Fixes a bug in Search::clear, where the filling of CounterMoveStats&, overwrote (currently presumably unused) memory because sizeof(cm) returns the size in bytes, whereas elements was needed.

No functional change.