### PR TITLE
Changed spelling back to "Bishops" in eval output

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -895,7 +895,7 @@ std::string Eval::trace(const Position& pos) {
      << "      Imbalance | " << Term(IMBALANCE)
      << "          Pawns | " << Term(PAWN)
      << "        Knights | " << Term(KNIGHT)
-     << "         Bishop | " << Term(BISHOP)
+     << "        Bishops | " << Term(BISHOP)
      << "          Rooks | " << Term(ROOK)
      << "         Queens | " << Term(QUEEN)
      << "       Mobility | " << Term(MOBILITY)


### PR DESCRIPTION
I know it's pretty insignificant, but I noticed that the spelling of the word "Bishops" in the eval command <a href=https://github.com/official-stockfish/Stockfish/commit/c0a80afe89e5d48acb3cbca7cf1fc0adb9f2f468#diff-e88e03386a215910d76a232ae9603922L872>got changed</a>.

No functional change.