### PR TITLE
Don't score as an immediate draw 2-fold repetitions of the root position (fixes #948)

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1100,10 +1100,10 @@ bool Position::is_draw(int ply) const {
       stp = stp->previous->previous;
 
       // At root position ply is 1, so return a draw score if a position
-      // repeats once earlier but after or at the root, or repeats twice
-      // strictly before the root.
+      // repeats once earlier but strictly after the root, or repeats twice
+      // before or at the root.
       if (   stp->key == st->key
-          && ++cnt + (ply - i > 0) == 2)
+          && ++cnt + (ply - 1 > i) == 2)
           return true;
   }
 


### PR DESCRIPTION
In the current version a search stops when the current position is the same as any position earlier in the search stack, including the root position but excluding positions before the root. The new version makes an exception for repeating the root position.

This gives correct scores for moves in the MultiPV > 1 mode.

Fixes #948 (see it for the detailed description of the bug).

Idea by @saproj (see the original PR - #925)

LTC: http://tests.stockfishchess.org/tests/view/587910bc0ebc5915193f754b
ELO: 0.38 +-1.7 (95%) LOS: 66.8%
Total: 40000 W: 5166 L: 5122 D: 29712

STC: http://tests.stockfishchess.org/tests/view/5922e6230ebc59035df34a50
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 94622 W: 17059 L: 17064 D: 60499

LTC: http://tests.stockfishchess.org/tests/view/59273a000ebc59035df34c03
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 61259 W: 7965 L: 7897 D: 45397

Bench: 6599721