### PR TITLE
Enable thread safety checking in travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,4 +72,5 @@ script:
   # sanitizer
   #
   # use g++-6 as a proxy for having sanitizers, might need revision as they become available for more recent versions of clang/gcc
-  - if [[ "$COMPILER" == "g++-6" ]]; then make clean && make ARCH=x86-64 sanitize=yes build > /dev/null && ../tests/instrumented.sh --sanitizer; fi
+  - if [[ "$COMPILER" == "g++-6" ]]; then make clean && make ARCH=x86-64 sanitize=undefined optimize=no debug=yes build > /dev/null && ../tests/instrumented.sh --sanitizer-undefined; fi
+  - if [[ "$COMPILER" == "g++-6" ]]; then make clean && make ARCH=x86-64 sanitize=thread optimize=no debug=yes build > /dev/null && ../tests/instrumented.sh --sanitizer-thread; fi

--- a/src/Makefile
+++ b/src/Makefile
@@ -264,8 +264,8 @@ endif
 
 ### 3.2.2 Debugging with undefined behavior sanitizers
 ifneq ($(sanitize),no)
-        CXXFLAGS += -g3 -fsanitize=$(sanitize)
-        LDFLAGS += -fsanitize=$(sanitize)
+        CXXFLAGS += -g3 -fsanitize=$(sanitize) -fuse-ld=gold
+        LDFLAGS += -fsanitize=$(sanitize) -fuse-ld=gold
 endif
 
 ### 3.3 Optimization

--- a/src/Makefile
+++ b/src/Makefile
@@ -50,7 +50,9 @@ OBJS = benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o \
 # ----------------------------------------------------------------------------
 #
 # debug = yes/no      --- -DNDEBUG         --- Enable/Disable debug mode
-# sanitize = yes/no   --- (-fsanitize )    --- enable undefined behavior checks
+# sanitize = undefined/thread/no (-fsanitize )
+#                     --- ( undefined )    --- enable undefined behavior checks
+#                     --- ( thread    )    --- enable threading error  checks
 # optimize = yes/no   --- (-O3/-fast etc.) --- Enable/Disable optimizations
 # arch = (name)       --- (-arch)          --- Target architecture
 # bits = 64/32        --- -DIS_64BIT       --- 64-/32-bit operating system
@@ -261,9 +263,9 @@ else
 endif
 
 ### 3.2.2 Debugging with undefined behavior sanitizers
-ifeq ($(sanitize),yes)
-        CXXFLAGS += -g3 -fsanitize=undefined
-        LDFLAGS += -fsanitize=undefined
+ifneq ($(sanitize),no)
+        CXXFLAGS += -g3 -fsanitize=$(sanitize)
+        LDFLAGS += -fsanitize=$(sanitize)
 endif
 
 ### 3.3 Optimization
@@ -496,7 +498,7 @@ config-sanity:
 	@echo "Testing config sanity. If this fails, try 'make help' ..."
 	@echo ""
 	@test "$(debug)" = "yes" || test "$(debug)" = "no"
-	@test "$(sanitize)" = "yes" || test "$(sanitize)" = "no"
+	@test "$(sanitize)" = "undefined" || test "$(sanitize)" = "thread" || test "$(sanitize)" = "no"
 	@test "$(optimize)" = "yes" || test "$(optimize)" = "no"
 	@test "$(arch)" = "any" || test "$(arch)" = "x86_64" || test "$(arch)" = "i386" || \
 	 test "$(arch)" = "ppc64" || test "$(arch)" = "ppc" || test "$(arch)" = "armv7"

--- a/tests/instrumented.sh
+++ b/tests/instrumented.sh
@@ -15,18 +15,50 @@ case $1 in
     prefix=''
     exeprefix='valgrind --error-exitcode=42'
     postfix='1>/dev/null'
+    threads="1"
   ;;
-  --sanitizer)
+  --sanitizer-undefined)
     echo "sanitizer testing started"
     prefix='!'
     exeprefix=''
     postfix='2>&1 | grep "runtime error:"'
+    threads="1"
+  ;;
+  --sanitizer-thread)
+    echo "sanitizer testing started"
+    prefix='!'
+    exeprefix=''
+    postfix='2>&1 | grep "WARNING: ThreadSanitizer:"'
+    threads="2"
+
+cat << EOF > tsan.supp
+race:TTEntry::move
+race:TTEntry::depth
+race:TTEntry::bound
+race:TTEntry::save
+race:TTEntry::value
+race:TTEntry::eval
+
+race:TranspositionTable::probe
+race:TranspositionTable::generation
+race:TranspositionTable::hashfull
+
+# four races to be fixed.
+# race:ThreadPool::nodes_searched
+# race:ThreadPool::tb_hits
+# race:check_time
+# race:Thread::search
+EOF
+
+    export TSAN_OPTIONS="suppressions=./tsan.supp"
+
   ;;
   *)
     echo "unknown testing started"
     prefix=''
     exeprefix=''
     postfix=''
+    threads="1"
   ;;
 esac
 
@@ -36,7 +68,7 @@ for args in "eval" \
             "go depth 10" \
             "go movetime 1000" \
             "go wtime 8000 btime 8000 winc 500 binc 500" \
-            "bench 128 1 10 default depth"
+            "bench 128 $threads 10 default depth"
 do
 
    echo "$prefix $exeprefix ./stockfish $args $postfix"
@@ -51,6 +83,8 @@ cat << EOF > game.exp
 
  send "uci\n"
  expect "uciok"
+
+ send "setoption name Threads value $threads\n"
 
  send "ucinewgame\n"
  send "position startpos\n"
@@ -76,11 +110,13 @@ EOF
 for exps in game.exp
 do
 
-  echo "$prefix expect game.exp $postfix"
-  eval "$prefix expect game.exp $postfix"
+  echo "$prefix expect $exps $postfix"
+  eval "$prefix expect $exps $postfix"
+
+  rm $exps
 
 done
 
-rm game.exp
+rm -f tsan.supp
 
 echo "instrumented testing OK"


### PR DESCRIPTION
extends the current travis continuous integration -fsanitize=undefined with -fsanitize=thread. This enables thread safety checking, including data race detection. Given that races are undefined behavior in C++, automatic testing can help reducing these bugs that are often difficult to find.

The current patch only enables the framework, but doesn't fix races found (as such travis-CI should flag this PR as failing). Fixing the races that trigger in search will be part of a followup patch. Races in the transposition table are automatically suppressed, as the code is written to deal with that.

No functional change.