### PR TITLE
Remove cap from initiative contribution

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -737,7 +737,7 @@ namespace {
     // Compute the initiative bonus for the attacking side
     int initiative = 8 * (asymmetry + kingDistance - 17) + 12 * pos.count<PAWN>() + 16 * bothFlanks;
 
-    // Return the bonus for the attacking side
+    // Return the bonus or malus for the attacking side
     return make_score(0, ((eg > 0) - (eg < 0)) * initiative);
   }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -738,9 +738,8 @@ namespace {
     int initiative = 8 * (asymmetry + kingDistance - 17) + 12 * pos.count<PAWN>() + 16 * bothFlanks;
 
     // Now apply the bonus: note that we find the attacking side by extracting
-    // the sign of the endgame value, and that we carefully cap the bonus so
-    // that the endgame score will never change sign after the bonus.
-    int value = ((eg > 0) - (eg < 0)) * std::max(initiative, -abs(eg));
+    // the sign of the endgame value.
+    int value = ((eg > 0) - (eg < 0)) * initiative;
 
     return make_score(0, value);
   }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -737,11 +737,8 @@ namespace {
     // Compute the initiative bonus for the attacking side
     int initiative = 8 * (asymmetry + kingDistance - 17) + 12 * pos.count<PAWN>() + 16 * bothFlanks;
 
-    // Now apply the bonus: note that we find the attacking side by extracting
-    // the sign of the endgame value.
-    int value = ((eg > 0) - (eg < 0)) * initiative;
-
-    return make_score(0, value);
+    // Return the bonus for the attacking side
+    return make_score(0, ((eg > 0) - (eg < 0)) * initiative);
   }
 
 


### PR DESCRIPTION
Allow initiative contribution to change endgame evaluation sign.

[STC](http://tests.stockfishchess.org/tests/view/59316d540ebc59035df34f31)
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 22720 W: 4212 L: 4094 D: 14414

[LTC](http://tests.stockfishchess.org/tests/view/5931aeb30ebc59035df34f4b)
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 44447 W: 5802 L: 5712 D: 32933

Bench: 6140304