### PR TITLE
Value To and From tt

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1367,8 +1367,7 @@ moves_loop: // When in check search starts from here
 
     assert(v != VALUE_NONE);
 
-    return  v >= VALUE_MATE_IN_MAX_PLY  ? v + ply
-          : v <= VALUE_MATED_IN_MAX_PLY ? v - ply : v;
+    return v + ((v >= VALUE_MATE_IN_MAX_PLY) - (v <= VALUE_MATED_IN_MAX_PLY)) * ply;
   }
 
 
@@ -1378,9 +1377,8 @@ moves_loop: // When in check search starts from here
 
   Value value_from_tt(Value v, int ply) {
 
-    return  v == VALUE_NONE             ? VALUE_NONE
-          : v >= VALUE_MATE_IN_MAX_PLY  ? v - ply
-          : v <= VALUE_MATED_IN_MAX_PLY ? v + ply : v;
+    return  v + (v != VALUE_NONE) 
+          * ((v <= VALUE_MATED_IN_MAX_PLY) - (v >= VALUE_MATE_IN_MAX_PLY)) * ply;
   }
 
 


### PR DESCRIPTION
Rewrite value_to_tt() and value_from_tt() based on idea from line 743 in evaluate.cpp.
Less code and faster.  Could a few people please post their bench results?

No functional change.
bench: 6469989

```
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    517287    521422    -4135     
    StDev   153693    155358    2622      

p-value: 0.943
speedup: 0.008
```