### PR TITLE
Improve readability of evaluation functions

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -73,10 +73,10 @@ namespace {
   // by the evaluation functions.
   class Evaluation {
 
+    const Position& pos;
     Material::Entry* me;
     Pawns::Entry* pe;
     Bitboard mobilityArea[COLOR_NB];
-    const Position& pos;
 
     // attackedBy[color][piece type] is a bitboard representing all squares
     // attacked by a given color and piece type (can be also ALL_PIECES).
@@ -134,14 +134,15 @@ namespace {
     Score evaluate_initiative(int asymmetry, Value eg);
     ScaleFactor evaluate_scale_factor(Value eg);
 
-    public:
+public:
 
-    template<bool DoTrace>
+    template<bool DoTrace = false>
        Value value();
 
     // Constructors
     Evaluation() = delete;
     Evaluation(const Position& p) : pos(p) {};
+    
   };
 
   #define V(v) Value(v)
@@ -905,7 +906,7 @@ namespace {
 
 Value Eval::evaluate(const Position& pos)
 {
-   return Evaluation(pos).value<false>();
+   return Evaluation(pos).value();
 }
 
 /// trace() is like evaluate(), but instead of returning a value, it returns

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -69,14 +69,14 @@ namespace {
 
   using namespace Trace;
 
-  // Struct Evaluation contains various information computed and collected
+  // Evaluation class contains various information computed and collected
   // by the evaluation functions.
-  struct Evaluation {
+  class Evaluation {
 
-    const Position& pos;
     Material::Entry* me;
     Pawns::Entry* pe;
     Bitboard mobilityArea[COLOR_NB];
+    const Position& pos;
 
     // attackedBy[color][piece type] is a bitboard representing all squares
     // attacked by a given color and piece type (can be also ALL_PIECES).
@@ -112,10 +112,6 @@ namespace {
     // to kingAdjacentZoneAttacksCount[WHITE].
     int kingAdjacentZoneAttacksCount[COLOR_NB];
 
-    // Constructors
-    Evaluation() = delete;
-    Evaluation(const Position& p) : pos(p) {};
-
     // Helpers
     template<Color Us> 
        void eval_init();
@@ -138,8 +134,14 @@ namespace {
     Score evaluate_initiative(int asymmetry, Value eg);
     ScaleFactor evaluate_scale_factor(Value eg);
 
+    public:
+
     template<bool DoTrace>
        Value value();
+
+    // Constructors
+    Evaluation() = delete;
+    Evaluation(const Position& p) : pos(p) {};
   };
 
   #define V(v) Value(v)
@@ -809,7 +811,8 @@ namespace {
     return sf;
   }
 
-  // value() returns the evaluation of the position for the side to move
+  // value() computes the various parts of the evaluation and returns
+  // the value of the position from the point of view of the side to move.
   template<bool DoTrace>
   Value Evaluation::value() {
 
@@ -897,8 +900,8 @@ namespace {
 } // namespace
 
 
-/// evaluate() is the main evaluation function. It returns a static evaluation
-/// of the position from the point of view of the side to move.
+/// evaluate() is the main evaluation function for the outer world. It returns 
+/// a static evaluation of the position from the point of view of the side to move.
 
 Value Eval::evaluate(const Position& pos)
 {

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -134,7 +134,7 @@ namespace {
     Score evaluate_initiative(int asymmetry, Value eg);
     ScaleFactor evaluate_scale_factor(Value eg);
 
-public:
+  public:
 
     template<bool DoTrace = false>
        Value value();
@@ -142,7 +142,6 @@ public:
     // Constructors
     Evaluation() = delete;
     Evaluation(const Position& p) : pos(p) {};
-    
   };
 
   #define V(v) Value(v)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -711,7 +711,7 @@ namespace {
   // squares one, two or three squares behind a friendly pawn are counted
   // twice. Finally, the space bonus is multiplied by a weight. The aim is to
   // improve play on game opening.
-  
+
   template<Tracing T>  template<Color Us>
   Score Evaluation<T>::evaluate_space() {
 
@@ -747,7 +747,7 @@ namespace {
   // evaluate_initiative() computes the initiative correction value for the
   // position, i.e., second order bonus/malus based on the known attacking/defending
   // status of the players.
-  
+
   template<Tracing T>
   Score Evaluation<T>::evaluate_initiative(Value eg) {
 
@@ -768,7 +768,7 @@ namespace {
 
 
   // evaluate_scale_factor() computes the scale factor for the winning side
-  
+
   template<Tracing T>
   ScaleFactor Evaluation<T>::evaluate_scale_factor(Value eg) {
 
@@ -803,10 +803,10 @@ namespace {
   }
 
 
-  // value() is the main function of the class. It computes the various parts of 
+  // value() is the main function of the class. It computes the various parts of
   // the evaluation and returns the value of the position from the point of view
   // of the side to move.
-  
+
   template<Tracing T>
   Value Evaluation<T>::value() {
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -113,10 +113,10 @@ namespace {
     int kingAdjacentZoneAttacksCount[COLOR_NB];
 
     // Helpers
-    template<Color Us> 
+    template<Color Us>
        void eval_init();
 
-    template<bool DoTrace, Color Us = WHITE, PieceType Pt = KNIGHT> 
+    template<bool DoTrace, Color Us = WHITE, PieceType Pt = KNIGHT>
        Score evaluate_pieces(Score* mobility);
 
     template<Color Us, bool DoTrace>
@@ -900,7 +900,7 @@ namespace {
 } // namespace
 
 
-/// evaluate() is the main evaluation function for the outer world. It returns 
+/// evaluate() is the main evaluation function for the outer world. It returns
 /// a static evaluation of the position from the point of view of the side to move.
 
 Value Eval::evaluate(const Position& pos)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -124,7 +124,7 @@ namespace {
     template<Color Us>               Score evaluate_space();
     template<Color Us, PieceType Pt> Score evaluate_pieces();
     ScaleFactor evaluate_scale_factor(Value eg);
-    Score       evaluate_initiative(int asymmetry, Value eg);
+    Score evaluate_initiative(Value eg);
 
   public:
 
@@ -281,7 +281,7 @@ namespace {
   // evaluate_pieces() assigns bonuses and penalties to the pieces of a given
   // color and type.
 
-  template<Tracing T> template<Color Us, PieceType Pt>
+  template<Tracing T>  template<Color Us, PieceType Pt>
   Score Evaluation<T>::evaluate_pieces() {
 
     const Color Them = (Us == WHITE ? BLACK : WHITE);
@@ -406,7 +406,7 @@ namespace {
     QueenSide, QueenSide, QueenSide, CenterFiles, CenterFiles, KingSide, KingSide, KingSide
   };
 
-  template<Tracing T> template<Color Us>
+  template<Tracing T>  template<Color Us>
   Score Evaluation<T>::evaluate_king() {
 
     const Color Them    = (Us == WHITE ? BLACK : WHITE);
@@ -524,7 +524,7 @@ namespace {
   // evaluate_threats() assigns bonuses according to the types of the attacking
   // and the attacked pieces.
 
-  template<Tracing T> template<Color Us>
+  template<Tracing T>  template<Color Us>
   Score Evaluation<T>::evaluate_threats() {
 
     const Color Them        = (Us == WHITE ? BLACK      : WHITE);
@@ -619,7 +619,7 @@ namespace {
   // evaluate_passer_pawns() evaluates the passed pawns and candidate passed
   // pawns of the given color.
 
-  template<Tracing T> template<Color Us>
+  template<Tracing T>  template<Color Us>
   Score Evaluation<T>::evaluate_passer_pawns() {
 
     const Color Them = (Us == WHITE ? BLACK : WHITE);
@@ -711,7 +711,7 @@ namespace {
   // twice. Finally, the space bonus is multiplied by a weight. The aim is to
   // improve play on game opening.
   
-  template<Tracing T> template<Color Us>
+  template<Tracing T>  template<Color Us>
   Score Evaluation<T>::evaluate_space() {
 
     const Color Them = (Us == WHITE ? BLACK : WHITE);
@@ -748,14 +748,14 @@ namespace {
   // status of the players.
   
   template<Tracing T>
-  Score Evaluation<T>::evaluate_initiative(int asymmetry, Value eg) {
+  Score Evaluation<T>::evaluate_initiative(Value eg) {
 
     int kingDistance =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
                       - distance<Rank>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
     bool bothFlanks = (pos.pieces(PAWN) & QueenSide) && (pos.pieces(PAWN) & KingSide);
 
     // Compute the initiative bonus for the attacking side
-    int initiative = 8 * (asymmetry + kingDistance - 17) + 12 * pos.count<PAWN>() + 16 * bothFlanks;
+    int initiative = 8 * (pe->pawn_asymmetry() + kingDistance - 17) + 12 * pos.count<PAWN>() + 16 * bothFlanks;
 
     // Now apply the bonus: note that we find the attacking side by extracting
     // the sign of the endgame value, and that we carefully cap the bonus so
@@ -857,7 +857,7 @@ namespace {
         score +=  evaluate_space<WHITE>()
                 - evaluate_space<BLACK>();
 
-    score += evaluate_initiative(pe->pawn_asymmetry(), eg_value(score));
+    score += evaluate_initiative(eg_value(score));
 
     // Interpolate between a middlegame and a (scaled by 'sf') endgame score
     ScaleFactor sf = evaluate_scale_factor(eg_value(score));

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,6 @@ const Value Tempo = Value(20); // Must be visible to search
 
 std::string trace(const Position& pos);
 
-template<bool DoTrace = false>
 Value evaluate(const Position& pos);
 }
 


### PR DESCRIPTION
This patch puts the evaluation helper functions inside EvalInfo struct, which simplifies a bit their signature and (most importantly, IMHO) makes their C++ code much cleaner and simpler to read (by removing the "ei." qualifiers all around in evaluate.cpp).

Also rename the EvalInfo struct into Evaluation class to get a natural invocation  v = Evaluation(p).value() to evaluation position p.

The downside is an increase of 20 lines in evaluate.cpp (for the prototypes of the helper functions). The upsides are better readability and a speed-up of 0.6% (by generating all the helpers for the NO_TRACE case together, which helps the instruction cache).