### PR TITLE
Calculate ProbCut depth inside loop

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -784,9 +784,7 @@ namespace {
         &&  abs(beta) < VALUE_MATE_IN_MAX_PLY)
     {
         Value rbeta = std::min(beta + 200, VALUE_INFINITE);
-        Depth rdepth = depth - 4 * ONE_PLY;
 
-        assert(rdepth >= ONE_PLY);
         assert(is_ok((ss-1)->currentMove));
 
         MovePicker mp(pos, ttMove, rbeta - ss->staticEval);
@@ -797,8 +795,9 @@ namespace {
                 ss->currentMove = move;
                 ss->history = &thisThread->counterMoveHistory[pos.moved_piece(move)][to_sq(move)];
 
+                assert(depth > 4 * ONE_PLY);
                 pos.do_move(move, st);
-                value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, rdepth, !cutNode, false);
+                value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, depth - 4 * ONE_PLY, !cutNode, false);
                 pos.undo_move(move);
                 if (value >= rbeta)
                     return value;


### PR DESCRIPTION
The loop over all ProbCut captures is executed much less than 1 time on average, so it "can't hurt" to put the depth calculation inside the loop rather than outside.

No functional change.

Results for 40 tests for each version:

            Base      Test      Diff
    Mean    2014338   2016121   -1783
    StDev   62655     63441     3860

p-value: 0.678
speedup: 0.001