### PR TITLE
Move Depth calculation in ProbCut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -784,9 +784,7 @@ namespace {
         &&  abs(beta) < VALUE_MATE_IN_MAX_PLY)
     {
         Value rbeta = std::min(beta + 200, VALUE_INFINITE);
-        Depth rdepth = depth - 4 * ONE_PLY;
 
-        assert(rdepth >= ONE_PLY);
         assert(is_ok((ss-1)->currentMove));
 
         MovePicker mp(pos, ttMove, rbeta - ss->staticEval);
@@ -797,8 +795,9 @@ namespace {
                 ss->currentMove = move;
                 ss->history = &thisThread->counterMoveHistory[pos.moved_piece(move)][to_sq(move)];
 
+                assert(depth > 4 * ONE_PLY);
                 pos.do_move(move, st);
-                value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, rdepth, !cutNode, false);
+                value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, depth - 4 * ONE_PLY, !cutNode, false);
                 pos.undo_move(move);
                 if (value >= rbeta)
                     return value;


### PR DESCRIPTION
Currently the code that calculates depth in ProbCut is calculated outside the loop where the depth is used. I think it is clearer to calculate depth at the point where it is used.

Compilers can decide whether to pull the common expression out of the loop. As the code stands now, it is better to calculate inside the loop, since the loop is executed on average less than one time, but if that should change then profile-based code generation will migrate the execution as needed.

The change passed an STC regression:

LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 59350 W: 10793 L: 10738 D: 37819

I verified that there was no change in performance on my machine, but of course YMMV:

Results for 40 tests for each version:

            Base      Test      Diff
    Mean    2014338   2016121   -1783
    StDev   62655     63441     3860

p-value: 0.678
speedup: 0.001

No functional change.