### PR TITLE
Use xor for queen attacks

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -260,7 +260,7 @@ inline Bitboard attacks_bb(PieceType pt, Square s, Bitboard occupied) {
   {
   case BISHOP: return attacks_bb<BISHOP>(s, occupied);
   case ROOK  : return attacks_bb<ROOK>(s, occupied);
-  case QUEEN : return attacks_bb<BISHOP>(s, occupied) | attacks_bb<ROOK>(s, occupied);
+  case QUEEN : return attacks_bb<BISHOP>(s, occupied) ^ attacks_bb<ROOK>(s, occupied);
   default    : return PseudoAttacks[pt][s];
   }
 }


### PR DESCRIPTION
Not sure if it's worth it or if my testing method is even accurate enough, but here you go anyway:

100 runs on x86-64-modern pgo build:

```
base =    2179673 +/- 19036
test =    2182763 +/- 19626
diff =       3089 +/- 4838
speedup = 0.001418
```

No functional change.