### PR TITLE
Revert prefetch earlier in qsearch()

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1256,9 +1256,6 @@ moves_loop: // When in check search starts from here
     {
       assert(is_ok(move));
 
-      // Speculative prefetch as early as possible
-      prefetch(TT.first_entry(pos.key_after(move)));
-
       givesCheck =  type_of(move) == NORMAL && !pos.discovered_check_candidates()
                   ? pos.check_squares(type_of(pos.piece_on(from_sq(move)))) & to_sq(move)
                   : pos.gives_check(move);
@@ -1299,6 +1296,9 @@ moves_loop: // When in check search starts from here
           &&  type_of(move) != PROMOTION
           &&  !pos.see_ge(move))
           continue;
+
+      // Speculative prefetch as early as possible
+      prefetch(TT.first_entry(pos.key_after(move)));
 
       // Check for legality just before making the move
       if (!pos.legal(move))


### PR DESCRIPTION
reverting prefetch earlier in qsearch (non functional) change was tested in Fishtest as parameter patch and FAILED at STC:
LLR: -2.96 (-2.94,2.94) [0.00,4.00]
Total: 71365 W: 13006 L: 12919 D: 45440
Reason for pull request is: This patch really hurts perfomance on multi-node-AMD-Opteron computer:
I measured a >10% (!) slowdown in speed between commit reordering magic data and latest stockfish master.
I looked again in more detail to the prefetch earlier in qsearch() commit:
Engine 1: Better naming in endgame code 27ba611a3da37423a3502e49beeebe11c9a11d8e 
Engine 2: Prefetch earlier in qsearch() b73016bb41d4c2fad3126b2e0018d71a36e78331 

Result for 64 Thread Opteron Windows GCC 7.1 profile 64bit modern profile-build:
Windows Server 2012 R2 (Version 6.3, Build 0, 64-bit Edition)
AMD Opteron(tm) Processor 6386 SE              
Command Line: bench 256 64 24  default depth
Tests per Build: 20
                Engine# (NPS)                     Speedup     Sp     Conf. 95%    S.S.
1  (32 197 119,3  ) ---> 2  (28 783 183,4  ) ---> 11,861%  1 532 364,1    Yes       No

My normal working PC 8 Thread AMD FX, Windows GCC 7.1 64bit modern profile-build
Windows 10 (Version 10.0, Build 0, 64-bit Edition)
AMD FX(tm)-9590 Eight-Core Processor           
Command Line: bench 256 8 24 default depth
Tests per Build: 20
                Engine# (NPS)                     Speedup     Sp     Conf. 95%    S.S.
2  (11.997.368,6  ) ---> 1  (11.976.652,6  ) --->  0,173%  176.202,1    No        No 

Summary: 
1) 0 Elo in STC on Fishtest.
2) same speed on AMD with 8 threads
3) terrible performance on 8 Node AMD machine with 64 threads.

So for me it seems to be safe to apply this pull request.
