### PR TITLE
ttCapture-LMR: Bench  5725676

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -956,12 +956,11 @@ moves_loop: // When in check search starts from here
       }
       
       if (moveCount == 1 && captureOrPromotion && ttMove)
-		   ttCapture = true;
+          ttCapture = true;
 
       // Update the current move (this must be done after singular extension search)
       ss->currentMove = move;
       ss->history = &thisThread->counterMoveHistory[moved_piece][to_sq(move)];
-
 
       // Step 14. Make the move
       pos.do_move(move, st, givesCheck);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -955,7 +955,7 @@ moves_loop: // When in check search starts from here
           continue;
       }
       
-      if (moveCount == 1 && captureOrPromotion && ttMove)
+      if (move == ttMove && captureOrPromotion)
           ttCapture = true;
 
       // Update the current move (this must be done after singular extension search)


### PR DESCRIPTION
Increase reduction if tt-move is a capture.
The idea is that chances are the tt-move is best and will be difficult to raise alpha when playing a quiet move.

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 7582 W: 1415 L: 1259 D: 4908


LTC:
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 59553 W: 7885 L: 7573 D: 44095

Bench:  5725676