### PR TITLE
dbg_print only on MainThread.

### DIFF
--- a/tests/instrumented.sh
+++ b/tests/instrumented.sh
@@ -40,7 +40,6 @@ race:TTEntry::value
 race:TTEntry::eval
 
 race:TranspositionTable::probe
-race:TranspositionTable::generation
 race:TranspositionTable::hashfull
 
 EOF


### PR DESCRIPTION
in the review of pull #1130 it was suggested that dbg_print should only be called by MainThread, this patch implements this.

Furthermore, pull #1134 fixed another race, so that can be removed from the thread sanitizer suppressions as well.

No functional change.