### PR TITLE
Only main thread check time

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -691,7 +691,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   assert(is_ok(m));
   assert(&newSt != st);
 
-  ++nodes;
+  thisThread->nodes.fetch_add(1, std::memory_order_relaxed);
   Key k = st->key ^ Zobrist::side;
 
   // Copy some fields of the old state to our new StateInfo object except the

--- a/src/position.h
+++ b/src/position.h
@@ -134,8 +134,6 @@ public:
   void undo_move(Move m);
   void do_null_move(StateInfo& newSt);
   void undo_null_move();
-  void increment_nodes();
-  void increment_tbHits();
 
   // Static Exchange Evaluation
   bool see_ge(Move m, Value value = VALUE_ZERO) const;
@@ -152,8 +150,6 @@ public:
   int game_ply() const;
   bool is_chess960() const;
   Thread* this_thread() const;
-  uint64_t nodes_searched() const;
-  uint64_t tb_hits() const;
   bool is_draw(int ply) const;
   int rule50_count() const;
   Score psq_score() const;
@@ -187,8 +183,6 @@ private:
   int castlingRightsMask[SQUARE_NB];
   Square castlingRookSquare[CASTLING_RIGHT_NB];
   Bitboard castlingPath[CASTLING_RIGHT_NB];
-  uint64_t nodes;
-  uint64_t tbHits;
   int gamePly;
   Color sideToMove;
   Thread* thisThread;
@@ -351,22 +345,6 @@ inline int Position::game_ply() const {
 
 inline int Position::rule50_count() const {
   return st->rule50;
-}
-
-inline uint64_t Position::nodes_searched() const {
-  return nodes;
-}
-
-inline void Position::increment_nodes() {
-  nodes++;
-}
-
-inline uint64_t Position::tb_hits() const {
-  return tbHits;
-}
-
-inline void Position::increment_tbHits() {
-  tbHits++;
 }
 
 inline bool Position::opposite_bishops() const {

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -34,9 +34,9 @@ ThreadPool Threads; // Global object
 
 Thread::Thread() {
 
-  resetCalls = exit = false;
-  maxPly = callsCnt = 0;
-  tbHits = 0;
+  exit = false;
+  maxPly = 0;
+  nodes = tbHits = 0;
   idx = Threads.size(); // Start from 0
 
   std::unique_lock<Mutex> lk(mutex);
@@ -163,7 +163,7 @@ uint64_t ThreadPool::nodes_searched() const {
 
   uint64_t nodes = 0;
   for (Thread* th : *this)
-      nodes += th->nodes;
+      nodes += th->nodes.load(std::memory_order_relaxed);
   return nodes;
 }
 
@@ -174,7 +174,7 @@ uint64_t ThreadPool::tb_hits() const {
 
   uint64_t hits = 0;
   for (Thread* th : *this)
-      hits += th->tbHits;
+      hits += th->tbHits.load(std::memory_order_relaxed);
   return hits;
 }
 
@@ -211,8 +211,8 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
   for (Thread* th : Threads)
   {
       th->maxPly = 0;
-      th->tbHits = 0;
       th->nodes = 0;
+      th->tbHits = 0;
       th->rootDepth = DEPTH_ZERO;
       th->rootMoves = rootMoves;
       th->rootPos.set(pos.fen(), pos.is_chess960(), &setupStates->back(), th);

--- a/src/thread.h
+++ b/src/thread.h
@@ -60,15 +60,13 @@ public:
   Material::Table materialTable;
   Endgames endgames;
   size_t idx, PVIdx;
-  int maxPly, callsCnt;
-  std::atomic<uint64_t> tbHits;
-  std::atomic<uint64_t> nodes;
+  int maxPly;
+  std::atomic<uint64_t> nodes, tbHits;
 
   Position rootPos;
   Search::RootMoves rootMoves;
   std::atomic<Depth> rootDepth;
   Depth completedDepth;
-  std::atomic_bool resetCalls;
   CounterMoveStat counterMoves;
   ButterflyHistory history;
   CounterMoveHistoryStat counterMoveHistory;
@@ -79,10 +77,12 @@ public:
 
 struct MainThread : public Thread {
   virtual void search();
+  void check_time();
 
   bool easyMovePlayed, failedLow;
   double bestMoveChanges;
   Value previousScore;
+  int callsCnt = 0;
 };
 
 


### PR DESCRIPTION
The main change of the patch is that now time check is done only by main thread. In the past, before lazy
SMP, we needed all the threads to check for available time because main thread could have been blocked on a split point, now this is no more the case and main thread can do the job alone, greatly simplifying the logic.

Verified for regression testing on STC with 7 threads:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 11895 W: 1741 L: 1608 D: 8546

No functional change.