### PR TITLE
QueenMinorsImblance

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -57,7 +57,11 @@ namespace {
   const int PawnSet[] = {
     24, -32, 107, -51, 117, -9, -126, -21, 31
   };
-
+  
+   const int QueenMinorsImblance[16] = { 
+     31, -8, -15, -25, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0  
+  };
+  
   // Endgame evaluation and scaling functions are accessed directly and not through
   // the function maps because they correspond to more than one material hash key.
   Endgame<KXK>    EvaluateKXK[] = { Endgame<KXK>(WHITE),    Endgame<KXK>(BLACK) };
@@ -95,6 +99,10 @@ namespace {
     const Color Them = (Us == WHITE ? BLACK : WHITE);
 
     int bonus = PawnSet[pieceCount[Us][PAWN]];
+    
+    if (pieceCount[Us][QUEEN] == 1 && pieceCount[Them][QUEEN] == 0)
+         
+    bonus += QueenMinorsImblance[pieceCount[Them][KNIGHT] + pieceCount[Them][BISHOP]];
 
     // Second-degree polynomial material imbalance by Tord Romstad
     for (int pt1 = NO_PIECE_TYPE; pt1 <= QUEEN; ++pt1)

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -55,7 +55,7 @@ namespace {
 
   // PawnSet[pawn count] contains a bonus/malus indexed by number of pawns
   const int PawnSet[] = {
-    24, -32, 107, -51, 117, -9, -126, -21, 31
+     24, -32, 107, -51, 117, -9, -126, -21, 31
   };
   
   // QueenMinorsImblance

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -101,8 +101,8 @@ namespace {
 
     int bonus = PawnSet[pieceCount[Us][PAWN]];
     
-    if   (pieceCount[Us][QUEEN] == 1 
-       && pieceCount[Them][QUEEN] == 0)
+    if  (pieceCount[Us][QUEEN] == 1 
+      && pieceCount[Them][QUEEN] == 0)
          
     bonus += QueenMinorsImblance[pieceCount[Them][KNIGHT] + pieceCount[Them][BISHOP]];
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -101,8 +101,8 @@ namespace {
 
     int bonus = PawnSet[pieceCount[Us][PAWN]];
     
-    if (pieceCount[Us][QUEEN] == 1 
-    && pieceCount[Them][QUEEN] == 0)
+    if   (pieceCount[Us][QUEEN] == 1 
+       && pieceCount[Them][QUEEN] == 0)
          
     bonus += QueenMinorsImblance[pieceCount[Them][KNIGHT] + pieceCount[Them][BISHOP]];
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -101,8 +101,7 @@ namespace {
 
     int bonus = PawnSet[pieceCount[Us][PAWN]];
     
-    if  (pieceCount[Us][QUEEN] == 1 
-      && pieceCount[Them][QUEEN] == 0)
+    if  (pieceCount[Us][QUEEN] == 1 && pieceCount[Them][QUEEN] == 0)
          
     bonus += QueenMinorsImblance[pieceCount[Them][KNIGHT] + pieceCount[Them][BISHOP]];
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -101,7 +101,8 @@ namespace {
 
     int bonus = PawnSet[pieceCount[Us][PAWN]];
     
-    if (pieceCount[Us][QUEEN] == 1 && pieceCount[Them][QUEEN] == 0)
+    if (pieceCount[Us][QUEEN] == 1 
+    && pieceCount[Them][QUEEN] == 0)
          
     bonus += QueenMinorsImblance[pieceCount[Them][KNIGHT] + pieceCount[Them][BISHOP]];
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -55,12 +55,12 @@ namespace {
 
   // PawnSet[pawn count] contains a bonus/malus indexed by number of pawns
   const int PawnSet[] = {
-     24, -32, 107, -51, 117, -9, -126, -21, 31
+      24, -32, 107, -51, 117, -9, -126, -21, 31
   };
   
   // QueenMinorsImblance
    const int QueenMinorsImblance[16] = { 
-     31, -8, -15, -25, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0  
+      31, -8, -15, -25, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0  
   };
   
   // Endgame evaluation and scaling functions are accessed directly and not through

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -58,6 +58,7 @@ namespace {
     24, -32, 107, -51, 117, -9, -126, -21, 31
   };
   
+  // QueenMinorsImblance
    const int QueenMinorsImblance[16] = { 
      31, -8, -15, -25, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0  
   };


### PR DESCRIPTION
QueenMinorsImblance* (Addition of correction values in case of Imbalance of queens, depending on the number of light pieces on the side without a queen). The values indirectly affect the dislocation Q vs BR,
Q vs RR, Q vs NBN and similar. (Basis idea Q vs light pieces by JoergOster).

*With update of the passed patch adding the possibility of rare cases of the number of light pieces
(by Snicolet), no functional change.

Passed patch:

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 29036 W: 5379 L: 5130 D: 18527

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 13680 W: 1836 L: 1674 D: 10170

Bench: 6258930