### PR TITLE
Don't uselessy share rootDepth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -360,9 +360,9 @@ void Thread::search() {
   multiPV = std::min(multiPV, rootMoves.size());
 
   // Iterative deepening loop until requested to stop or the target depth is reached
-  while (   (rootDepth = rootDepth + ONE_PLY) < DEPTH_MAX
+  while (   (rootDepth += ONE_PLY) < DEPTH_MAX
          && !Signals.stop
-         && (!Limits.depth || Threads.main()->rootDepth / ONE_PLY <= Limits.depth))
+         && !(Limits.depth && mainThread && rootDepth / ONE_PLY > Limits.depth))
   {
       // Distribute search depths across the threads
       if (idx)

--- a/src/thread.h
+++ b/src/thread.h
@@ -65,7 +65,7 @@ public:
 
   Position rootPos;
   Search::RootMoves rootMoves;
-  std::atomic<Depth> rootDepth;
+  Depth rootDepth;
   Depth completedDepth;
   CounterMoveStat counterMoves;
   ButterflyHistory history;


### PR DESCRIPTION
It is not needed becuase the only case is a real special
one (bench on depth with many threads) and can be easily
rewritten to avoid sharing rootDepth.

Verified with ThreadSanitizer.

No functional change.