### PR TITLE
Fix some warnings with clang static analyzer

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -713,8 +713,9 @@ T do_probe_table(const Position& pos, Entry* entry, WDLScore wdl, ProbeState* re
         assert(type_of(pc) == PAWN);
 
         leadPawns = b = pos.pieces(color_of(pc), PAWN);
-        while (b)
+        do
             squares[size++] = pop_lsb(&b) ^ flipSquares;
+        while (b);
 
         leadPawnsCnt = size;
 
@@ -737,11 +738,13 @@ T do_probe_table(const Position& pos, Entry* entry, WDLScore wdl, ProbeState* re
     // Now we are ready to get all the position pieces (but the lead pawns) and
     // directly map them to the correct color and square.
     b = pos.pieces() ^ leadPawns;
-    while (b) {
+    do {
         Square s = pop_lsb(&b);
         squares[size] = s ^ flipSquares;
         pieces[size++] = Piece(pos.piece_on(s) ^ flipColor);
-    }
+    } while (b);
+
+    assert(size >= 2);
 
     // Then we reorder the pieces to have the same sequence as the one stored
     // in precomp->pieces[i]: the sequence that ensures the best compression.
@@ -1517,6 +1520,8 @@ static int has_repeated(StateInfo *st)
 // no moves were filtered out.
 bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves, Value& score)
 {
+    assert(rootMoves.size());
+
     ProbeState result;
     int dtz = probe_dtz(pos, &result);
 
@@ -1562,7 +1567,7 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves, Value& 
 
     // Obtain 50-move counter for the root position.
     // In Stockfish there seems to be no clean way, so we do it like this:
-    int cnt50 = st.previous->rule50;
+    int cnt50 = st.previous ? st.previous->rule50 : 0;
 
     // Use 50-move counter to determine whether the root position is
     // won, lost or drawn.


### PR DESCRIPTION
Only one remains (also in tbprobe.cpp), but is bougus.

As a side note, tbprobe.cpp is almost clean, only the last 3
functions probe_wdl(), root_probe() and root_probe_wdl()
are still the original ones and are quite hacky.

Somewhere in the future we will reformat also the last 3
ones. The reason why has not been done before it is because
these functions are really wrong by design and should be
rewritten entirely, not only reformatted.

No functional change.