### PR TITLE
Moved gcc optimization flags into the optimization section.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -274,11 +274,11 @@ endif
 ### 3.3 Optimization
 ifeq ($(optimize),yes)
 
+# Optimization options for official stockfish should be
+# consistent, easy, future proof and simple.
 	CXXFLAGS += -O3
 
 	ifeq ($(comp),gcc)
-	  CXXFLAGS += -fno-peel-loops -fno-tracer
-
 		ifeq ($(KERNEL),Darwin)
 			ifeq ($(arch),i386)
 				CXXFLAGS += -mdynamic-no-pic

--- a/src/Makefile
+++ b/src/Makefile
@@ -277,6 +277,7 @@ ifeq ($(optimize),yes)
 	CXXFLAGS += -O3
 
 	ifeq ($(comp),gcc)
+	  CXXFLAGS += -fno-peel-loops -fno-tracer
 
 		ifeq ($(KERNEL),Darwin)
 			ifeq ($(arch),i386)
@@ -536,7 +537,7 @@ gcc-profile-make:
 
 gcc-profile-use:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-use -fno-peel-loops -fno-tracer' \
+	EXTRACXXFLAGS='-fprofile-use' \
 	EXTRALDFLAGS='-lgcov' \
 	all
 


### PR DESCRIPTION
Proposal to fix issue https://github.com/official-stockfish/Stockfish/issues/1164#issuecomment-313495059
f-profile-generate and -fprofile-use builds get the same build flags.
The logic of the make file, as i understand it, dictates that all optimization issues are handled in dedicated section 3.3. Within each section, there is further dispatching according to lower level issues. 

