### PR TITLE
Provide selective search depth info for each pv move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -836,7 +836,7 @@ moves_loop: // When in check search starts from here
       if (rootNode)
       {
           if (!std::count(thisThread->rootMoves.begin() + thisThread->PVIdx,
-                                  thisThread->rootMoves.end(), move))
+                          thisThread->rootMoves.end(), move))
               continue;
 
           thisThread->maxPly = 1;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -839,7 +839,7 @@ moves_loop: // When in check search starts from here
       // mode we also skip PV moves which have been already searched.
       if (rootNode && !std::count(thisThread->rootMoves.begin() + thisThread->PVIdx,
                                   thisThread->rootMoves.end(), move))
-              continue;
+          continue;
 
       ss->moveCount = ++moveCount;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -384,6 +384,9 @@ void Thread::search() {
       // MultiPV loop. We perform a full root search for each PV line
       for (PVIdx = 0; PVIdx < multiPV && !Signals.stop; ++PVIdx)
       {
+          // Reset UCI info selDepth for each depth and each PV line
+          selDepth = 0;
+
           // Reset aspiration window starting size
           if (rootDepth >= 5 * ONE_PLY)
           {
@@ -567,7 +570,8 @@ namespace {
         static_cast<MainThread*>(thisThread)->check_time();
 
     // Used to send selDepth info to GUI
-    thisThread->maxPly = std::max(ss->ply, thisThread->maxPly);
+    if (PvNode && thisThread->selDepth < ss->ply)
+        thisThread->selDepth = ss->ply;
 
     if (!rootNode)
     {
@@ -833,14 +837,9 @@ moves_loop: // When in check search starts from here
       // At root obey the "searchmoves" option and skip moves not listed in Root
       // Move List. As a consequence any illegal move is also skipped. In MultiPV
       // mode we also skip PV moves which have been already searched.
-      if (rootNode)
-      {
-          if (!std::count(thisThread->rootMoves.begin() + thisThread->PVIdx,
-                          thisThread->rootMoves.end(), move))
+      if (rootNode && !std::count(thisThread->rootMoves.begin() + thisThread->PVIdx,
+                                  thisThread->rootMoves.end(), move))
               continue;
-
-          thisThread->maxPly = 1;
-      }
 
       ss->moveCount = ++moveCount;
 
@@ -1048,7 +1047,7 @@ moves_loop: // When in check search starts from here
           if (moveCount == 1 || value > alpha)
           {
               rm.score = value;
-              rm.maxPly = thisThread->maxPly;
+              rm.selDepth = thisThread->selDepth;
               rm.pv.resize(1);
 
               assert((ss+1)->pv);
@@ -1531,7 +1530,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
 
       ss << "info"
          << " depth "    << d / ONE_PLY
-         << " seldepth " << rootMoves[i].maxPly
+         << " seldepth " << rootMoves[i].selDepth
          << " multipv "  << i + 1
          << " score "    << UCI::value(v);
 

--- a/src/search.h
+++ b/src/search.h
@@ -65,6 +65,7 @@ struct RootMove {
 
   Value score = -VALUE_INFINITE;
   Value previousScore = -VALUE_INFINITE;
+  int maxPly = 0;
   std::vector<Move> pv;
 };
 

--- a/src/search.h
+++ b/src/search.h
@@ -65,7 +65,7 @@ struct RootMove {
 
   Value score = -VALUE_INFINITE;
   Value previousScore = -VALUE_INFINITE;
-  int maxPly = 0;
+  int selDepth = 0;
   std::vector<Move> pv;
 };
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -35,7 +35,7 @@ ThreadPool Threads; // Global object
 Thread::Thread() {
 
   exit = false;
-  maxPly = 0;
+  selDepth = 0;
   nodes = tbHits = 0;
   idx = Threads.size(); // Start from 0
 
@@ -210,7 +210,6 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
 
   for (Thread* th : Threads)
   {
-      th->maxPly = 0;
       th->nodes = 0;
       th->tbHits = 0;
       th->rootDepth = DEPTH_ZERO;

--- a/src/thread.h
+++ b/src/thread.h
@@ -60,7 +60,7 @@ public:
   Material::Table materialTable;
   Endgames endgames;
   size_t idx, PVIdx;
-  int maxPly;
+  int selDepth;
   std::atomic<uint64_t> nodes, tbHits;
 
   Position rootPos;


### PR DESCRIPTION
Now we can show for each pv move how deep it has been searched.

No functional change.