### PR TITLE
Rewrite selDepth logic

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -384,6 +384,9 @@ void Thread::search() {
       // MultiPV loop. We perform a full root search for each PV line
       for (PVIdx = 0; PVIdx < multiPV && !Signals.stop; ++PVIdx)
       {
+          // Reset UCI info selDepth for each depth and each PV line
+          selDepth = 0;
+
           // Reset aspiration window starting size
           if (rootDepth >= 5 * ONE_PLY)
           {
@@ -566,9 +569,8 @@ namespace {
     if (thisThread == Threads.main())
         static_cast<MainThread*>(thisThread)->check_time();
 
-    // Used to send selDepth info to GUI
-    if (PvNode && thisThread->maxPly < ss->ply)
-        thisThread->maxPly = ss->ply;
+    if (PvNode && thisThread->selDepth < ss->ply)
+        thisThread->selDepth = ss->ply;
 
     if (!rootNode)
     {
@@ -1526,7 +1528,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
 
       ss << "info"
          << " depth "    << d / ONE_PLY
-         << " seldepth " << pos.this_thread()->maxPly
+         << " seldepth " << pos.this_thread()->selDepth
          << " multipv "  << i + 1
          << " score "    << UCI::value(v);
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -35,7 +35,7 @@ ThreadPool Threads; // Global object
 Thread::Thread() {
 
   exit = false;
-  maxPly = 0;
+  selDepth = 0;
   nodes = tbHits = 0;
   idx = Threads.size(); // Start from 0
 
@@ -210,7 +210,6 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
 
   for (Thread* th : Threads)
   {
-      th->maxPly = 0;
       th->nodes = 0;
       th->tbHits = 0;
       th->rootDepth = DEPTH_ZERO;

--- a/src/thread.h
+++ b/src/thread.h
@@ -60,7 +60,7 @@ public:
   Material::Table materialTable;
   Endgames endgames;
   size_t idx, PVIdx;
-  int maxPly;
+  int selDepth;
   std::atomic<uint64_t> nodes, tbHits;
 
   Position rootPos;


### PR DESCRIPTION
Make selDepth associated at a given search depth
and Multi PV line. UCI protocol says:

"if the engine sends seldepth there must also
 a "depth" be present in the same string."

So seldepth should be reset for each search at a
given depth, i.e. for each ID iteration.

Moreover reset selDepth for each multi-PV line.

No functional change.