### PR TITLE
Remove Stack/thread dependence in movepick

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -86,6 +86,30 @@ typedef StatBoards<PIECE_NB, SQUARE_NB, Move> CounterMoveStat;
 /// stores a full history (based on PieceTo boards instead of ButterflyBoards).
 typedef StatBoards<PIECE_NB, SQUARE_NB, PieceToHistory> CounterMoveHistoryStat;
 
+/// Collect StatBoards used together for scoring and pruning moves.
+class HistoryCollection {
+public:
+    HistoryCollection(const ButterflyHistory* history_p, const PieceToHistory* cmh_p,
+                     const PieceToHistory* fmh_p, const PieceToHistory* fm2_p) :
+                     history(history_p), cmh(cmh_p), fmh(fmh_p), fm2(fm2_p) {};
+
+    int score(Color c, Move m) const { return (*history)[c][from_to(m)]; }
+
+    int score(Color c, Piece pc, Move m) const {
+
+        return   (*cmh)[pc][to_sq(m)] + (*fmh)[pc][to_sq(m)]
+               + (*fm2)[pc][to_sq(m)] + (*history)[c][from_to(m)];
+    }
+
+    bool should_prune(Piece pc, Move m, int threshold) const {
+
+        return (*cmh)[pc][to_sq(m)] < threshold && (*fmh)[pc][to_sq(m)] < threshold;
+    }
+private:
+    const ButterflyHistory* history;
+    const PieceToHistory *cmh, *fmh, *fm2;
+};
+
 
 /// MovePicker class is used to pick one pseudo legal move at a time from the
 /// current position. The most important method is next_move(), which returns a
@@ -98,12 +122,9 @@ class MovePicker {
 public:
   MovePicker(const MovePicker&) = delete;
   MovePicker& operator=(const MovePicker&) = delete;
-
   MovePicker(const Position&, Move, Value);
-  MovePicker(const Position&, Move, Depth, const ButterflyHistory*, Square);
-  MovePicker(const Position&, Move, Depth, Move, Move kllrs[2], const ButterflyHistory*,
-             const PieceToHistory*, const PieceToHistory*, const PieceToHistory*);
-
+  MovePicker(const Position&, Move, Depth, const HistoryCollection*, Square);
+  MovePicker(const Position&, Move, Depth, const HistoryCollection*, Move, Move*);
   Move next_move(bool skipQuiets = false);
 
 private:
@@ -112,18 +133,13 @@ private:
   ExtMove* end() { return endMoves; }
 
   const Position& pos;
-  Depth depth;
-  const ButterflyHistory* history;
-  const PieceToHistory* cmh;
-  const PieceToHistory* fmh;
-  const PieceToHistory* fm2;
-  Move killers[2];
-  Move countermove;
-  Move ttMove;
+  Move ttMove, killers[2], countermove;
+  const HistoryCollection* hc;
+  ExtMove *cur, *endMoves, *endBadCaptures;
+  int stage;
   Square recaptureSquare;
   Value threshold;
-  int stage;
-  ExtMove *cur, *endMoves, *endBadCaptures;
+  Depth depth;
   ExtMove moves[MAX_MOVES];
 };
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -93,7 +93,6 @@ typedef StatBoards<PIECE_NB, SQUARE_NB, PieceToHistory> CounterMoveHistoryStat;
 /// when MOVE_NONE is returned. In order to improve the efficiency of the alpha
 /// beta algorithm, MovePicker attempts to return the moves which are most likely
 /// to get a cut-off first.
-namespace Search { struct Stack; }
 
 class MovePicker {
 public:
@@ -101,8 +100,9 @@ public:
   MovePicker& operator=(const MovePicker&) = delete;
 
   MovePicker(const Position&, Move, Value);
-  MovePicker(const Position&, Move, Depth, Square);
-  MovePicker(const Position&, Move, Depth, Search::Stack*);
+  MovePicker(const Position&, Move, Depth, const ButterflyHistory*, Square);
+  MovePicker(const Position&, Move, Depth, Move, Move kllrs[2], const ButterflyHistory*,
+             const PieceToHistory*, const PieceToHistory*, const PieceToHistory*);
 
   Move next_move(bool skipQuiets = false);
 
@@ -112,10 +112,13 @@ private:
   ExtMove* end() { return endMoves; }
 
   const Position& pos;
-  const Search::Stack* ss;
+  Depth depth;
+  const ButterflyHistory* history;
+  const PieceToHistory* cmh;
+  const PieceToHistory* fmh;
+  const PieceToHistory* fm2;
   Move killers[2];
   Move countermove;
-  Depth depth;
   Move ttMove;
   Square recaptureSquare;
   Value threshold;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -807,8 +807,10 @@ moves_loop: // When in check search starts from here
     const PieceToHistory& cmh = *(ss-1)->history;
     const PieceToHistory& fmh = *(ss-2)->history;
     const PieceToHistory& fm2 = *(ss-4)->history;
+    const ButterflyHistory& history = thisThread->history;
+    Move countermove = thisThread->counterMoves[pos.piece_on(prevSq)][prevSq];
 
-    MovePicker mp(pos, ttMove, depth, ss);
+    MovePicker mp(pos, ttMove, depth, countermove, ss->killers, &history, &cmh, &fmh, &fm2);
     value = bestValue; // Workaround a bogus 'uninitialized' warning under gcc
     improving =   ss->staticEval >= (ss-2)->staticEval
             /* || ss->staticEval == VALUE_NONE Already implicit in the previous condition */
@@ -981,7 +983,7 @@ moves_loop: // When in check search starts from here
               ss->statScore =  cmh[moved_piece][to_sq(move)]
                              + fmh[moved_piece][to_sq(move)]
                              + fm2[moved_piece][to_sq(move)]
-                             + thisThread->history[~pos.side_to_move()][from_to(move)]
+                             + history[~pos.side_to_move()][from_to(move)]
                              - 4000; // Correction factor
 
               // Decrease/increase reduction by comparing opponent's stat score
@@ -1244,7 +1246,7 @@ moves_loop: // When in check search starts from here
     // to search the moves. Because the depth is <= 0 here, only captures,
     // queen promotions and checks (only if depth >= DEPTH_QS_CHECKS) will
     // be generated.
-    MovePicker mp(pos, ttMove, depth, to_sq((ss-1)->currentMove));
+    MovePicker mp(pos, ttMove, depth, &pos.this_thread()->history, to_sq((ss-1)->currentMove));
 
     // Loop through the moves until no moves remain or a beta cutoff occurs
     while ((move = mp.next_move()) != MOVE_NONE)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -804,13 +804,10 @@ namespace {
 
 moves_loop: // When in check search starts from here
 
-    const PieceToHistory& cmh = *(ss-1)->history;
-    const PieceToHistory& fmh = *(ss-2)->history;
-    const PieceToHistory& fm2 = *(ss-4)->history;
-    const ButterflyHistory& history = thisThread->history;
+    HistoryCollection hc(&thisThread->history, (ss-1)->history, (ss-2)->history, (ss-4)->history);
     Move countermove = thisThread->counterMoves[pos.piece_on(prevSq)][prevSq];
 
-    MovePicker mp(pos, ttMove, depth, countermove, ss->killers, &history, &cmh, &fmh, &fm2);
+    MovePicker mp(pos, ttMove, depth, &hc, countermove, ss->killers);
     value = bestValue; // Workaround a bogus 'uninitialized' warning under gcc
     improving =   ss->staticEval >= (ss-2)->staticEval
             /* || ss->staticEval == VALUE_NONE Already implicit in the previous condition */
@@ -912,8 +909,7 @@ moves_loop: // When in check search starts from here
 
               // Countermoves based pruning
               if (   lmrDepth < 3
-                  && (cmh[moved_piece][to_sq(move)] < CounterMovePruneThreshold)
-                  && (fmh[moved_piece][to_sq(move)] < CounterMovePruneThreshold))
+                  && hc.should_prune(moved_piece, move, CounterMovePruneThreshold))
                   continue;
 
               // Futility pruning: parent node
@@ -980,11 +976,7 @@ moves_loop: // When in check search starts from here
                        && !pos.see_ge(make_move(to_sq(move), from_sq(move))))
                   r -= 2 * ONE_PLY;
 
-              ss->statScore =  cmh[moved_piece][to_sq(move)]
-                             + fmh[moved_piece][to_sq(move)]
-                             + fm2[moved_piece][to_sq(move)]
-                             + history[~pos.side_to_move()][from_to(move)]
-                             - 4000; // Correction factor
+              ss->statScore = hc.score(~pos.side_to_move(), moved_piece, move) - 4000;
 
               // Decrease/increase reduction by comparing opponent's stat score
               if (ss->statScore > 0 && (ss-1)->statScore < 0)
@@ -1246,7 +1238,8 @@ moves_loop: // When in check search starts from here
     // to search the moves. Because the depth is <= 0 here, only captures,
     // queen promotions and checks (only if depth >= DEPTH_QS_CHECKS) will
     // be generated.
-    MovePicker mp(pos, ttMove, depth, &pos.this_thread()->history, to_sq((ss-1)->currentMove));
+    HistoryCollection hc(&pos.this_thread()->history, nullptr, nullptr, nullptr);
+    MovePicker mp(pos, ttMove, depth, &hc, to_sq((ss-1)->currentMove));
 
     // Loop through the moves until no moves remain or a beta cutoff occurs
     while ((move = mp.next_move()) != MOVE_NONE)


### PR DESCRIPTION
as a lower level routine, movepicker should not depend on the search stack or the thread class, removing a circular dependency. Instead of copying the search stack into the movepicker object, as well as accessing the thread class for one of the histories, pass the required fields explicitly to the constructor (removing the need for thread.h and implicitly search.h in movepick.cpp). The signature is thus longer, but more explicit:

```MovePicker mp(pos, ttMove, depth, countermove, ss->killers, &history, &cmh, &fmh, &fm2);```

passed STC [-3,1], suggesting a small elo impact:

LLR: 3.13 (-2.94,2.94) [-3.00,1.00]
Total: 381053 W: 68071 L: 68551 D: 244431
elo =   -0.438 +-    0.660 LOS:    9.7%

No functional change.