### PR TITLE
Simplify magics generation

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -91,11 +91,6 @@ public:
   PRNG(uint64_t seed) : s(seed) { assert(seed); }
 
   template<typename T> T rand() { return T(rand64()); }
-
-  /// Special generator used to fast init magic numbers.
-  /// Output values only have 1/8th of their bits set on average.
-  template<typename T> T sparse_rand()
-  { return T(rand64() & rand64() & rand64()); }
 };
 
 


### PR DESCRIPTION
Also instrument code to measure speed (to be removed before merging).

Results on my i7:
(1) cold boot: 3ms (first run)
(2) next runs: 1.3ms (cache effect)

What we should measure, when we are comparing magic generation methods is (2).
The difference (1)-(2) is just an incompressible fixed cost (loading in cache).

After doing some experiments, I have come to the following conclusions:
* Magic Boosters are useless! Not only you need only 1 seed for all the magics
  (instead of 16 currently), but any seed will do, as long as it's not zero. So
  I just use seed=1, to make that point clear.
* sparse_rand is also useless! I don't know where this superstitious belief that
  sparsely populated bitboards work better as magics came from, but it has no
  base in reality.

If you don't believe me, feel free to use the instrumented code here to measure
your own tricks (eg. sparse_rand, different seeds).

No matter what I tried (using several seeds, using sparse or normal rand), the
meausre (2) was invariably the same at 1.3ms. This is certainly fast enough,
especially because the cost of generating magics is incurred only at program
startup.