### PR TITLE
Simplify magics generation

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -19,6 +19,7 @@
 */
 
 #include <algorithm>
+#include <iostream>
 
 #include "bitboard.h"
 #include "misc.h"
@@ -202,8 +203,15 @@ void Bitboards::init() {
   Square RookDeltas[] = { NORTH,  EAST,  SOUTH,  WEST };
   Square BishopDeltas[] = { NORTH_EAST, SOUTH_EAST, SOUTH_WEST, NORTH_WEST };
 
-  init_magics(RookTable, RookMagics, RookDeltas);
-  init_magics(BishopTable, BishopMagics, BishopDeltas);
+  const auto start = std::chrono::high_resolution_clock::now();
+
+  for (int tmp = 0; tmp < 1000; tmp++) {
+      init_magics(RookTable, RookMagics, RookDeltas);
+      init_magics(BishopTable, BishopMagics, BishopDeltas);
+  }
+
+  const int msec = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start).count();
+  std::cout << "time = " << msec << "ms" << std::endl;
 
   for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
   {
@@ -251,10 +259,7 @@ namespace {
 
   void init_magics(Bitboard table[], Magic magics[], Square deltas[]) {
 
-    // Optimal PRNG seeds to pick the correct magics in the shortest time
-    int seeds[][RANK_NB] = { { 8977, 44560, 54343, 38998,  5731, 95205, 104912, 17020 },
-                             {  728, 10316, 55013, 32803, 12281, 15100,  16645,   255 } };
-
+    PRNG rng(1);
     Bitboard occupancy[4096], reference[4096], edges, b;
     int epoch[4096] = {}, cnt = 0, size = 0;
 
@@ -293,14 +298,11 @@ namespace {
         if (HasPext)
             continue;
 
-        PRNG rng(seeds[Is64Bit][rank_of(s)]);
-
-        // Find a magic for square 's' picking up an (almost) random number
-        // until we find the one that passes the verification test.
+        // Find a magic for square 's', by trying random numbers until we find
+        // one that passes the verification test.
         for (int i = 0; i < size; )
         {
-            for (m.magic = 0; popcount((m.magic * m.mask) >> 56) < 6; )
-                m.magic = rng.sparse_rand<Bitboard>();
+            m.magic = rng.rand<Bitboard>();
 
             // A good magic must map every possible occupancy to an index that
             // looks up the correct sliding attack in the attacks[s] database.

--- a/src/misc.h
+++ b/src/misc.h
@@ -91,11 +91,6 @@ public:
   PRNG(uint64_t seed) : s(seed) { assert(seed); }
 
   template<typename T> T rand() { return T(rand64()); }
-
-  /// Special generator used to fast init magic numbers.
-  /// Output values only have 1/8th of their bits set on average.
-  template<typename T> T sparse_rand()
-  { return T(rand64() & rand64() & rand64()); }
 };
 
 


### PR DESCRIPTION
Also instrument code to measure speed. To be removed before merging, obviously.

Results on my i7:
(1) cold boot: 3ms (first run)
(2) next runs: 1.3ms (cache effect)

What we should measure, when we are comparing magic generation methods is (2).
The difference (1)-(2) is just an incompressible fixed cost (loading in cache).

After doing some experiments, I have realized that:
(a) Magic Boosters are useless!
(b) sparse_rand is useless!
(c) popcount((m.magic * m.mask) >> 56) >= 6 condition is... also useless!

I don't know where these superstitious beliefs (a), (b), (c) came from. But they
have no basis in reality, as can be seen by properly measuring.

If you don't believe it, feel free to use the instrumented code here to measure
your own tricks (eg. sparse_rand, different seeds).

No matter what I tried (using several seeds, using sparse or normal rand), the
measure (2) was invariably the same at 1.3ms, which is *more* than fast enough.

No functional change.