### PR TITLE
Remove TT refresh

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -78,12 +78,7 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 
   for (int i = 0; i < ClusterSize; ++i)
       if (!tte[i].key16 || tte[i].key16 == key16)
-      {
-          if ((tte[i].genBound8 & 0xFC) != generation8 && tte[i].key16)
-              tte[i].genBound8 = uint8_t(generation8 | tte[i].bound()); // Refresh
-
           return found = (bool)tte[i].key16, &tte[i];
-      }
 
   // Find an entry to be replaced according to the replacement strategy
   TTEntry* replace = tte;

--- a/src/tt.h
+++ b/src/tt.h
@@ -53,7 +53,6 @@ struct TTEntry {
     // Don't overwrite more valuable entries
     if (  (k >> 48) != key16
         || d / ONE_PLY > depth8 - 4
-     /* || g != (genBound8 & 0xFC) // Matching non-zero keys are already refreshed by probe() */
         || b == BOUND_EXACT)
     {
         key16     = (uint16_t)(k >> 48);


### PR DESCRIPTION
Remove TT entry refresh during probing.

STC:
http://tests.stockfishchess.org/tests/view/596cb4400ebc5916ff649c9b
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 18369 W: 3427 L: 3302 D: 11640

LTC:
http://tests.stockfishchess.org/tests/view/596cd5390ebc5916ff649ca7
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 71414 W: 9181 L: 9126 D: 53107

Bench: 6434800