### PR TITLE
Rework the "unsupported" penalty into a "supported" bonus

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -32,10 +32,10 @@ namespace {
   #define S(mg, eg) make_score(mg, eg)
 
   // Isolated pawn penalty by opposed flag
-  const Score Isolated[] = { S(44-17, 38-8), S(30-17, 26-8) };
+  const Score Isolated[] = { S(27, 30), S(13, 18) };
 
   // Backward pawn penalty by opposed flag
-  const Score Backward[] = { S(57-17, 34-8), S(41-17, 20-8) };
+  const Score Backward[] = { S(40, 26), S(24, 12) };
 
   // Connected pawn bonus by opposed, phalanx, #support and rank
   Score Connected[2][2][3][RANK_NB];
@@ -171,8 +171,10 @@ namespace {
         // Score this pawn
         if (supported | phalanx)
             score += Connected[opposed][!!phalanx][popcount(supported)][relative_rank(Us, s)];
+
         else if (!neighbours)
             score -= Isolated[opposed];
+
         else if (backward)
             score -= Backward[opposed];
 
@@ -203,8 +205,9 @@ void init() {
           for (int support = 0; support <= 2; ++support)
               for (Rank r = RANK_2; r < RANK_8; ++r)
   {
-      int v = (Seed[r] + (phalanx ? (Seed[r + 1] - Seed[r]) / 2 : 0)) >> opposed;
-      v += 17 * support;
+      int v = 17 * support;
+      v += (Seed[r] + (phalanx ? (Seed[r + 1] - Seed[r]) / 2 : 0)) >> opposed;
+
       Connected[opposed][phalanx][support][r] = make_score(v, v * (r - 2) / 4);
   }
 }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -204,7 +204,7 @@ void init() {
               for (Rank r = RANK_2; r < RANK_8; ++r)
   {
       int v = (Seed[r] + (phalanx ? (Seed[r + 1] - Seed[r]) / 2 : 0)) >> opposed;
-      v += (support == 2 ? v / 2 : 17 * support);
+      v += 17 * support;
       Connected[opposed][phalanx][support][r] = make_score(v, v * (r - 2) / 4);
   }
 }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -32,16 +32,13 @@ namespace {
   #define S(mg, eg) make_score(mg, eg)
 
   // Isolated pawn penalty by opposed flag
-  const Score Isolated[] = { S(45, 40), S(30, 27) };
+  const Score Isolated[] = { S(44-17, 38-8), S(30-17, 26-8) };
 
   // Backward pawn penalty by opposed flag
-  const Score Backward[] = { S(56, 33), S(41, 19) };
+  const Score Backward[] = { S(57-17, 34-8), S(41-17, 20-8) };
 
-  // Unsupported pawn penalty for pawns which are neither isolated or backward
-  const Score Unsupported = S(17, 8);
-
-  // Connected pawn bonus by opposed, phalanx, twice supported and rank
-  Score Connected[2][2][2][RANK_NB];
+  // Connected pawn bonus by opposed, phalanx, #support and rank
+  Score Connected[2][2][3][RANK_NB];
 
   // Doubled pawn penalty
   const Score Doubled = S(18, 38);
@@ -99,7 +96,7 @@ namespace {
     const Square Left  = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
 
     Bitboard b, neighbours, stoppers, doubled, supported, phalanx;
-    Bitboard lever, leverPush, connected;
+    Bitboard lever, leverPush;
     Square s;
     bool opposed, backward;
     Score score = SCORE_ZERO;
@@ -134,7 +131,6 @@ namespace {
         neighbours = ourPawns   & adjacent_files_bb(f);
         phalanx    = neighbours & rank_bb(s);
         supported  = neighbours & rank_bb(s - Up);
-        connected  = supported | phalanx;
 
         // A pawn is backward when it is behind all pawns of the same color on the
         // adjacent files and cannot be safely advanced.
@@ -150,7 +146,7 @@ namespace {
             // stopper on adjacent file which controls the way to that rank.
             backward = (b | shift<Up>(b & adjacent_files_bb(f))) & stoppers;
 
-            assert(!backward || !(pawn_attack_span(Them, s + Up) & neighbours));
+            assert(!(backward && (forward_ranks_bb(Them, s + Up) & neighbours)));
         }
 
         // Passed pawns will be properly scored in evaluation because we need
@@ -173,17 +169,12 @@ namespace {
         }
 
         // Score this pawn
-        if (!neighbours)
+        if (supported | phalanx)
+            score += Connected[opposed][!!phalanx][popcount(supported)][relative_rank(Us, s)];
+        else if (!neighbours)
             score -= Isolated[opposed];
-
         else if (backward)
             score -= Backward[opposed];
-
-        else if (!supported)
-            score -= Unsupported;
-
-        if (connected)
-            score += Connected[opposed][!!phalanx][more_than_one(supported)][relative_rank(Us, s)];
 
         if (doubled && !supported)
             score -= Doubled;
@@ -209,12 +200,12 @@ void init() {
 
   for (int opposed = 0; opposed <= 1; ++opposed)
       for (int phalanx = 0; phalanx <= 1; ++phalanx)
-          for (int apex = 0; apex <= 1; ++apex)
+          for (int support = 0; support <= 2; ++support)
               for (Rank r = RANK_2; r < RANK_8; ++r)
   {
       int v = (Seed[r] + (phalanx ? (Seed[r + 1] - Seed[r]) / 2 : 0)) >> opposed;
-      v += (apex ? v / 2 : 0);
-      Connected[opposed][phalanx][apex][r] = make_score(v, v * (r-2) / 4);
+      v += (support == 2 ? v / 2 : 17 * support);
+      Connected[opposed][phalanx][support][r] = make_score(v, v * (r - 2) / 4);
   }
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -183,7 +183,7 @@ enum Value : int {
   VALUE_MATE_IN_MAX_PLY  =  VALUE_MATE - 2 * MAX_PLY,
   VALUE_MATED_IN_MAX_PLY = -VALUE_MATE + 2 * MAX_PLY,
 
-  PawnValueMg   = 188,   PawnValueEg   = 248,
+  PawnValueMg   = 171,   PawnValueEg   = 240,
   KnightValueMg = 764,   KnightValueEg = 848,
   BishopValueMg = 826,   BishopValueEg = 891,
   RookValueMg   = 1282,  RookValueEg   = 1373,


### PR DESCRIPTION
A pawn (according to all the searched positions of a bench run) is not supported 85% of the time,
(in current master it is either isolated, backward or "unsupported").

So it made sense to try moving the S(17, 8) "unsupported" penalty value into the base pawn value hoping for a more representative pawn value, and accordingly
a) adjust backward and isolated so that they stay more or less the same as master
b) increase the mg connected bonus in the supported case by S(17, 0) and let the Connected formula find a suitable eg value according to rank.

Tested as a simplification SPRT(-3, 1)

Passed STC
http://tests.stockfishchess.org/tests/view/5970dbd30ebc5916ff649dd6
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 19613 W: 3663 L: 3540 D: 12410

Passed LTC
http://tests.stockfishchess.org/tests/view/597137780ebc5916ff649de3
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 24721 W: 3306 L: 3191 D: 18224