### PR TITLE
lcov integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ script:
   #
   # lcov
   #
-  - if [ -x "$(command -v lcov )" -a "$COMP" == "gcc" ]; then make clean && make ARCH=x86-64 profile-build lcov=yes optimize=no > /dev/null && printf "Coverage: Lines %s of %s (%s%%), Functions %s of %s (%s%%)\n" `grep headerCovTableEntry coveragedir/src/index.html | grep -o '[0-9\.][0-9\.]*' `; fi
+  - if [ -x "$(command -v lcov )" -a "$COMPILER" == "g++-6" ]; then make clean && make GCOVTOOL=gcov-6 ARCH=x86-64 profile-build lcov=yes optimize=no && grep headerCovTableEntry coveragedir/src/index.html | grep -o '[0-9\.][0-9\.]*' | xargs printf 'Coverage for lines %s of %s (%s%%), for Functions %s of %s (%s%%)\n'; fi
   # sanitizer
   #
   # use g++-6 as a proxy for having sanitizers, might need revision as they become available for more recent versions of clang/gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-6', 'g++-6-multilib', 'g++-multilib', 'valgrind', 'expect']
+          packages: ['g++-6', 'g++-6-multilib', 'g++-multilib', 'valgrind', 'expect', 'lcov']
       env:
         - COMPILER=g++-6
         - COMP=gcc
@@ -69,6 +69,9 @@ script:
   #
   - if [ -x "$(command -v valgrind )" ]; then make clean && make ARCH=x86-64 debug=yes optimize=no build > /dev/null && ../tests/instrumented.sh --valgrind; fi
   #
+  # lcov
+  #
+  - if [ -x "$(command -v lcov )" -a "$COMP" == "gcc" ]; then make clean && make ARCH=x86-64 profile-build lcov=yes optimize=no > /dev/null && printf "Coverage: Lines %s of %s (%s%%), Functions %s of %s (%s%%)\n" `grep headerCovTableEntry coveragedir/src/index.html | grep -o '[0-9\.][0-9\.]*' `; fi
   # sanitizer
   #
   # use g++-6 as a proxy for having sanitizers, might need revision as they become available for more recent versions of clang/gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,28 +52,28 @@ script:
   - export benchref=$(cat git_sig)
   - echo "Reference bench:" $benchref
   # verify against reference
-  - make clean && make ARCH=x86-64 build > /dev/null && ../tests/signature.sh $benchref
-  - make clean && make ARCH=x86-32 build > /dev/null && ../tests/signature.sh $benchref
-  - make clean && make ARCH=x86-64 optimize=no debug=yes build > /dev/null && ../tests/signature.sh $benchref
-  - make clean && make ARCH=x86-32 optimize=no debug=yes build > /dev/null && ../tests/signature.sh $benchref
+  - make clean && make -j2 ARCH=x86-64 build > /dev/null && ../tests/signature.sh $benchref
+  - make clean && make -j2 ARCH=x86-32 build > /dev/null && ../tests/signature.sh $benchref
+  - make clean && make -j2 ARCH=x86-64 optimize=no debug=yes build > /dev/null && ../tests/signature.sh $benchref
+  - make clean && make -j2 ARCH=x86-32 optimize=no debug=yes build > /dev/null && ../tests/signature.sh $benchref
   #
   # perft
   #
-  - make clean && make ARCH=x86-64 build > /dev/null && ../tests/perft.sh
+  - make clean && make -j2 ARCH=x86-64 build > /dev/null && ../tests/perft.sh
   #
   # reproducible search
   #
-  - make clean && make ARCH=x86-64 build > /dev/null && ../tests/reprosearch.sh
+  - make clean && make -j2 ARCH=x86-64 build > /dev/null && ../tests/reprosearch.sh
   #
   # valgrind
   #
-  - if [ -x "$(command -v valgrind )" ]; then make clean && make ARCH=x86-64 debug=yes optimize=no build > /dev/null && ../tests/instrumented.sh --valgrind; fi
+  - if [ -x "$(command -v valgrind )" ]; then make clean && make -j2 ARCH=x86-64 debug=yes optimize=no build > /dev/null && ../tests/instrumented.sh --valgrind; fi
   #
   # lcov
   #
-  - if [ -x "$(command -v lcov )" -a "$COMPILER" == "g++-6" ]; then make clean && make GCOVTOOL=gcov-6 ARCH=x86-64 profile-build lcov=yes optimize=no && grep headerCovTableEntry coveragedir/src/index.html | grep -o '[0-9\.][0-9\.]*' | xargs printf 'Coverage for lines %s of %s (%s%%), for Functions %s of %s (%s%%)\n'; fi
+  - if [ -x "$(command -v lcov )" -a "$COMPILER" == "g++-6" ]; then make clean && make -j2 GCOVTOOL=gcov-6 ARCH=x86-64 profile-build lcov=yes optimize=no && grep headerCovTableEntry coveragedir/src/index.html | grep -o '[0-9\.][0-9\.]*' | xargs printf 'Coverage for lines %s of %s (%s%%), for Functions %s of %s (%s%%)\n'; fi
   # sanitizer
   #
   # use g++-6 as a proxy for having sanitizers, might need revision as they become available for more recent versions of clang/gcc
-  - if [[ "$COMPILER" == "g++-6" ]]; then make clean && make ARCH=x86-64 sanitize=undefined optimize=no debug=yes build > /dev/null && ../tests/instrumented.sh --sanitizer-undefined; fi
-  - if [[ "$COMPILER" == "g++-6" ]]; then make clean && make ARCH=x86-64 sanitize=thread optimize=no debug=yes build > /dev/null && ../tests/instrumented.sh --sanitizer-thread; fi
+  - if [[ "$COMPILER" == "g++-6" ]]; then make clean && make -j2 ARCH=x86-64 sanitize=undefined optimize=no debug=yes build > /dev/null && ../tests/instrumented.sh --sanitizer-undefined; fi
+  - if [[ "$COMPILER" == "g++-6" ]]; then make clean && make -j2 ARCH=x86-64 sanitize=thread optimize=no debug=yes build > /dev/null && ../tests/instrumented.sh --sanitizer-thread; fi

--- a/src/Makefile
+++ b/src/Makefile
@@ -240,6 +240,11 @@ ifeq ($(lcov),yes)
        lcov_generate = lcovgen
        gcc-profile-make-flags = -fprofile-generate -ftest-coverage
        PGOBENCH = ../tests/instrumented.sh
+ifdef GCOVTOOL
+      GCOV=$(GCOVTOOL)
+else
+      GCOV=gcov
+endif
 else
        lcov_generate = lcovclean
        gcc-profile-make-flags = -fprofile-generate
@@ -560,7 +565,7 @@ lcovclean:
 	@rm -rf coverage.info coveragedir
 
 lcovgen: lcovclean
-	@lcov --capture --directory . --no-external --output-file coverage.info > /dev/null
+	@lcov --capture --directory . --no-external --gcov-tool $(GCOV) --output-file coverage.info > /dev/null
 	@genhtml coverage.info --output-directory coveragedir > /dev/null
 	@echo "Generated coveragedir/index.html"
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 # Stockfish, a UCI chess playing engine derived from Glaurung 2.1
 # Copyright (C) 2004-2008 Tord Romstad (Glaurung author)
 # Copyright (C) 2008-2015 Marco Costalba, Joona Kiiski, Tord Romstad
-# Copyright (C) 2015-2016 Marco Costalba, Joona Kiiski, Gary Linscott, Tord Romstad
+# Copyright (C) 2015-2017 Marco Costalba, Joona Kiiski, Gary Linscott, Tord Romstad
 #
 # Stockfish is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -60,6 +60,9 @@ OBJS = benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o \
 # popcnt = yes/no     --- -DUSE_POPCNT     --- Use popcnt asm-instruction
 # sse = yes/no        --- -msse            --- Use Intel Streaming SIMD Extensions
 # pext = yes/no       --- -DUSE_PEXT       --- Use pext x86_64 asm-instruction
+# lcov = yes/no       --- ( coverage )     --- Use lcov to generate coverage info.
+#                                              Generates coveragedir/index.html .
+#                                              Requires currently a gcc build.
 #
 # Note that Makefile is space sensitive, so when adding new architectures
 # or modifying existing flags, you have to make sure there are no extra spaces
@@ -74,6 +77,7 @@ prefetch = no
 popcnt = no
 sse = no
 pext = no
+lcov = no
 
 ### 2.2 Architecture specific
 
@@ -230,6 +234,15 @@ else
 	profile_make = gcc-profile-make
 	profile_use = gcc-profile-use
 endif
+endif
+
+ifeq ($(lcov),yes)
+       lcov_generate = lcovgen
+       gcc-profile-make-flags = -fprofile-generate -ftest-coverage
+       PGOBENCH = ../tests/instrumented.sh
+else
+       lcov_generate = lcovclean
+       gcc-profile-make-flags = -fprofile-generate
 endif
 
 ifeq ($(KERNEL),Darwin)
@@ -441,6 +454,7 @@ profile-build: config-sanity objclean profileclean
 	$(PGOBENCH) > /dev/null
 	@echo ""
 	@echo "Step 3/4. Building optimized executable ..."
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(lcov_generate)
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) objclean
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_use)
 	@echo ""
@@ -456,7 +470,7 @@ install:
 	-strip $(BINDIR)/$(EXE)
 
 #clean all
-clean: objclean profileclean
+clean: objclean profileclean lcovclean
 	@rm -f .depend *~ core
 
 # clean binaries and objects
@@ -492,6 +506,7 @@ config-sanity:
 	@echo "popcnt: '$(popcnt)'"
 	@echo "sse: '$(sse)'"
 	@echo "pext: '$(pext)'"
+	@echo "lcov: '$(lcov)'"
 	@echo ""
 	@echo "Flags:"
 	@echo "CXX: $(CXX)"
@@ -510,6 +525,7 @@ config-sanity:
 	@test "$(popcnt)" = "yes" || test "$(popcnt)" = "no"
 	@test "$(sse)" = "yes" || test "$(sse)" = "no"
 	@test "$(pext)" = "yes" || test "$(pext)" = "no"
+	@test "$(lcov)" = "yes" || test "$(lcov)" = "no"
 	@test "$(comp)" = "gcc" || test "$(comp)" = "icc" || test "$(comp)" = "mingw" || test "$(comp)" = "clang"
 
 $(EXE): $(OBJS)
@@ -530,7 +546,7 @@ clang-profile-use:
 
 gcc-profile-make:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-generate' \
+	EXTRACXXFLAGS="$(gcc-profile-make-flags)" \
 	EXTRALDFLAGS='-lgcov' \
 	all
 
@@ -539,6 +555,14 @@ gcc-profile-use:
 	EXTRACXXFLAGS='-fprofile-use -fno-peel-loops -fno-tracer' \
 	EXTRALDFLAGS='-lgcov' \
 	all
+
+lcovclean:
+	@rm -rf coverage.info coveragedir
+
+lcovgen: lcovclean
+	@lcov --capture --directory . --no-external --output-file coverage.info > /dev/null
+	@genhtml coverage.info --output-directory coveragedir > /dev/null
+	@echo "Generated coveragedir/index.html"
 
 icc-profile-make:
 	@mkdir -p profdir

--- a/tests/instrumented.sh
+++ b/tests/instrumented.sh
@@ -21,14 +21,14 @@ case $1 in
     echo "sanitizer testing started"
     prefix='!'
     exeprefix=''
-    postfix='2>&1 | grep "runtime error:"'
+    postfix='2>&1 | grep -B40 -A40 "runtime error:"'
     threads="1"
   ;;
   --sanitizer-thread)
     echo "sanitizer testing started"
     prefix='!'
     exeprefix=''
-    postfix='2>&1 | grep "WARNING: ThreadSanitizer:"'
+    postfix='2>&1 | grep -B40 -A40 "WARNING: ThreadSanitizer:"'
     threads="2"
 
 cat << EOF > tsan.supp
@@ -42,12 +42,9 @@ race:TTEntry::eval
 race:TranspositionTable::probe
 race:TranspositionTable::hashfull
 
-# TODO fix races
-race:Search::clear
-
 EOF
 
-    export TSAN_OPTIONS="suppressions=./tsan.supp"
+    export TSAN_OPTIONS="halt_on_error=1 suppressions=./tsan.supp"
 
   ;;
   *)
@@ -84,7 +81,6 @@ cat << EOF > game.exp
 
  send "setoption name Threads value $threads\n"
 
- send "ucinewgame\n"
  send "position startpos\n"
  send "go nodes 1000\n"
  expect "bestmove"
@@ -93,19 +89,23 @@ cat << EOF > game.exp
  send "go nodes 1000\n"
  expect "bestmove"
 
- send "setoption name Clear Hash\n"
- send "position startpos moves e2e4 e7e6\n"
  send "d\n"
- send "go nodes 1000\n"
- expect "bestmove"
 
- send "ucinewgame\n"
  send "position startpos\n"
  send "setoption name Skill Level value 7\n"
  send "go wtime 8000 btime 8000 winc 500 binc 500\n"
  expect "bestmove"
 
- send "ucinewgame\n"
+ send "setoption name Skill Level value 20\n"
+
+ send "position startpos\n"
+ send "go wtime 8000 btime 8000 winc 500 binc 500 nodestime 200\n"
+ expect "bestmove"
+
+ send "position fen 8/8/8/7k/3BBK2/4P3/8/8 w - - 0 1\n"
+ send "go mate 7\n"
+ expect "bestmove"
+
  send "setoption name UCI_Chess960 value true\n"
  send "position startpos\n"
  send "go depth 10\n"

--- a/tests/instrumented.sh
+++ b/tests/instrumented.sh
@@ -42,6 +42,9 @@ race:TTEntry::eval
 race:TranspositionTable::probe
 race:TranspositionTable::hashfull
 
+# TODO fix races
+race:Search::clear
+
 EOF
 
     export TSAN_OPTIONS="suppressions=./tsan.supp"

--- a/tests/instrumented.sh
+++ b/tests/instrumented.sh
@@ -58,6 +58,7 @@ esac
 
 # simple command line testing
 for args in "eval" \
+            "perft 4" \
             "go nodes 1000" \
             "go depth 10" \
             "go movetime 1000" \
@@ -72,7 +73,7 @@ done
 
 # more general testing, following an uci protocol exchange
 cat << EOF > game.exp
- set timeout 10
+ set timeout 60
  spawn $exeprefix ./stockfish
 
  send "uci\n"
@@ -87,6 +88,24 @@ cat << EOF > game.exp
 
  send "position startpos moves e2e4 e7e6\n"
  send "go nodes 1000\n"
+ expect "bestmove"
+
+ send "setoption name Clear Hash\n"
+ send "position startpos moves e2e4 e7e6\n"
+ send "d\n"
+ send "go nodes 1000\n"
+ expect "bestmove"
+
+ send "ucinewgame\n"
+ send "position startpos\n"
+ send "setoption name Skill Level value 7\n"
+ send "go wtime 8000 btime 8000 winc 500 binc 500\n"
+ expect "bestmove"
+
+ send "ucinewgame\n"
+ send "setoption name UCI_Chess960 value true\n"
+ send "position startpos\n"
+ send "go depth 10\n"
  expect "bestmove"
 
  send "position fen 5rk1/1K4p1/8/8/3B4/8/8/8 b - - 0 1\n"


### PR DESCRIPTION

Optionally use lcov to generate an html overview of code coverage. Use as:

```
make ARCH=x86-64 profile-build lcov=yes optimize=no
firefox coveragedir/index.html
```

This requires lcov to be installed, as well as a build based on gcc.
```optimize=no``` results in more accurate profile line counts, but is not required.

Integration in travis-ci is light, will just add in the logs an additional line like:
```
Coverage: Lines 3130 of 3492 (89.6%), Functions 643 of 709 (90.7%)
```

As lcov based profiling is based on tests/instrumented.sh, it can be easily extended to cover broader use cases (e.g. chess960).

No functional change.