### PR TITLE
Tweak connected pawns seed[] array values

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -205,7 +205,7 @@ namespace Pawns {
 
 void init() {
 
-  static const int Seed[RANK_NB] = { 0, 8, 19, 13, 71, 94, 169, 324 };
+  static const int Seed[RANK_NB] = { 0, 13, 24, 18, 76, 100, 175, 330 };
 
   for (int opposed = 0; opposed <= 1; ++opposed)
       for (int phalanx = 0; phalanx <= 1; ++phalanx)


### PR DESCRIPTION
Raise a little bit the values in the connected pawns seed[] array.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 99033 W: 17939 L: 17448 D: 63646
http://tests.stockfishchess.org/tests/view/597355630ebc5916ff649e3e

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 48044 W: 6371 L: 6099 D: 35574
http://tests.stockfishchess.org/tests/view/597596610ebc5916ff649eba

Bench: 5896234