### PR TITLE
Avoid a race between uci thread and search threads.

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -185,8 +185,6 @@ uint64_t ThreadPool::tb_hits() const {
 void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
                                 const Search::LimitsType& limits) {
 
-  main()->wait_for_search_finished();
-
   stopOnPonderhit = stop = false;
   Search::Limits = limits;
   Search::RootMoves rootMoves;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -88,6 +88,8 @@ namespace {
 
   void setoption(istringstream& is) {
 
+    Threads.main()->wait_for_search_finished();
+
     string token, name, value;
 
     is >> token; // Consume "name" token
@@ -112,6 +114,8 @@ namespace {
   // the search.
 
   void go(Position& pos, istringstream& is) {
+
+    Threads.main()->wait_for_search_finished();
 
     Search::LimitsType limits;
     string token;
@@ -140,6 +144,8 @@ namespace {
 
   // On ucinewgame following steps are needed to reset the state
   void newgame() {
+
+    Threads.main()->wait_for_search_finished();
 
     TT.resize(Options["Hash"]);
     Search::clear();

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -88,8 +88,6 @@ namespace {
 
   void setoption(istringstream& is) {
 
-    Threads.main()->wait_for_search_finished();
-
     string token, name, value;
 
     is >> token; // Consume "name" token
@@ -114,8 +112,6 @@ namespace {
   // the search.
 
   void go(Position& pos, istringstream& is) {
-
-    Threads.main()->wait_for_search_finished();
 
     Search::LimitsType limits;
     string token;
@@ -144,8 +140,6 @@ namespace {
 
   // On ucinewgame following steps are needed to reset the state
   void newgame() {
-
-    Threads.main()->wait_for_search_finished();
 
     TT.resize(Options["Hash"]);
     Search::clear();
@@ -182,6 +176,13 @@ void UCI::loop(int argc, char* argv[]) {
 
       token.clear(); // getline() could return empty or blank line
       is >> skipws >> token;
+
+      // the folowing commands can not be executed unless the search is finished.
+      if (   token == "go"
+          || token == "bench"
+          || token == "setoption"
+          || token == "ucinewgame")
+          Threads.main()->wait_for_search_finished();
 
       // The GUI sends 'ponderhit' to tell us to ponder on the same move the
       // opponent has played. In case Threads.stopOnPonderhit is set we are

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -180,6 +180,8 @@ void UCI::loop(int argc, char* argv[]) {
       // the folowing commands can not be executed unless the search is finished.
       if (   token == "go"
           || token == "bench"
+          || token == "perft"
+          || token == "eval"
           || token == "setoption"
           || token == "ucinewgame")
           Threads.main()->wait_for_search_finished();


### PR DESCRIPTION
Fixes a race when ucinewgame is issued 'after' a search, as seen for a thread-sanitized binary issuing :

```
go depth 5
[wait for bestmove ..]
ucinewgame
```
leading to

```
WARNING: ThreadSanitizer: data race (pid=5148)
  Write of size 4 at 0x7fbf5dcf6af8 by main thread:
    #0 __gnu_cxx::__enable_if<!std::__is_scalar<Move>::__value, void>::__type std::__fill_a<Move*, Move>(Move*, Move*, Move const&) <null> (stockfish+0x000000462884)
    #1 void std::fill<Move*, Move>(Move*, Move*, Move const&) /usr/include/c++/5/bits/stl_algobase.h:747 (stockfish+0x0000004618cc)
    #2 StatBoards<16, 64, Move>::fill(Move const&) src/movepick.h:36 (stockfish+0x00000046084f)
    #3 Search::clear() src/search.cpp:194 (stockfish+0x000000451732)
    #4 newgame src/uci.cpp:145 (stockfish+0x0000004738a0)
    #5 UCI::loop(int, char**) src/uci.cpp:200 (stockfish+0x000000473d7d)
    #6 main src/main.cpp:47 (stockfish+0x000000433322)

  Previous write of size 4 at 0x7fbf5dcf6af8 by thread T1:
    #0 update_stats src/search.cpp:1417 (stockfish+0x000000453ecb)
    #1 search<(<unnamed>::NodeType)0u> src/search.cpp:1114 (stockfish+0x00000045c4c6)
    #2 search<(<unnamed>::NodeType)1u> src/search.cpp:997 (stockfish+0x000000457658)
    #3 search<(<unnamed>::NodeType)1u> src/search.cpp:1019 (stockfish+0x000000457a50)
    #4 search<(<unnamed>::NodeType)1u> src/search.cpp:1019 (stockfish+0x000000457a50)
    #5 Thread::search() src/search.cpp:402 (stockfish+0x000000452e28)
    #6 MainThread::search() src/search.cpp:264 (stockfish+0x000000451c32)
    #7 Thread::idle_loop() src/thread.cpp:114 (stockfish+0x000000468c90)

```

The solution adopted is to split the uci commands in those that can be issued during search (quit, stop, ponderhit, isready, uci) and those that should not run during search (ucinewgame, setoption, .. ).  Waiting for search to finish was previously done only for a 'go'.

This fixes the above race.

There are two side effects, one possibly negative, depending on how a gui deals with uci (or a user at the cli).
- crashes are avoided (e.g. resizing hash during search).
- as earlier commands can block on the search to be completed, 'stop' can be non-effective. This behavior is already present on master :

```
go depth 20
go depth 5
stop
```

will wait for depth 20 to be completed before stopping depth 5. This behavior now shows for other commands as well. As such some gui testing of this patch would be useful.

No functional change.