### PR TITLE
avoid a race between uci and search threads (II)

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -151,6 +151,7 @@ void benchmark(const Position& current, istream& is) {
 
   uint64_t nodes = 0;
   TimePoint elapsed = now();
+  Threads.ponder = false;
   Position pos;
 
   for (size_t i = 0; i < fens.size(); ++i)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -274,7 +274,7 @@ void MainThread::search() {
   // the UCI protocol states that we shouldn't print the best move before the
   // GUI sends a "stop" or "ponderhit" command. We therefore simply wait here
   // until the GUI sends one of those commands (which also raises Threads.stop).
-  if (!Threads.stop && (Limits.ponder || Limits.infinite))
+  if (!Threads.stop && (Threads.ponder || Limits.infinite))
   {
       Threads.stopOnPonderhit = true;
       wait(Threads.stop);
@@ -496,7 +496,7 @@ void Thread::search() {
               {
                   // If we are allowed to ponder do not stop the search now but
                   // keep pondering until the GUI sends "ponderhit" or "stop".
-                  if (Limits.ponder)
+                  if (Threads.ponder)
                       Threads.stopOnPonderhit = true;
                   else
                       Threads.stop = true;
@@ -1485,7 +1485,7 @@ moves_loop: // When in check search starts from here
     }
 
     // An engine may not stop pondering until told so by the GUI
-    if (Limits.ponder)
+    if (Threads.ponder)
         return;
 
     if (   (Limits.use_time_management() && elapsed > Time.maximum() - 10)

--- a/src/search.h
+++ b/src/search.h
@@ -72,14 +72,13 @@ typedef std::vector<RootMove> RootMoves;
 
 
 /// LimitsType struct stores information sent by GUI about available time to
-/// search the current move, maximum depth/time, if we are in analysis mode or
-/// if we have to ponder while it's our opponent's turn to move.
+/// search the current move, maximum depth/time, or if we are in analysis mode.
 
 struct LimitsType {
 
   LimitsType() { // Init explicitly due to broken value-initialization of non POD in MSVC
     nodes = time[WHITE] = time[BLACK] = inc[WHITE] = inc[BLACK] =
-    npmsec = movestogo = depth = movetime = mate = infinite = ponder = 0;
+    npmsec = movestogo = depth = movetime = mate = infinite = 0;
   }
 
   bool use_time_management() const {
@@ -87,7 +86,7 @@ struct LimitsType {
   }
 
   std::vector<Move> searchmoves;
-  int time[COLOR_NB], inc[COLOR_NB], npmsec, movestogo, depth, movetime, mate, infinite, ponder;
+  int time[COLOR_NB], inc[COLOR_NB], npmsec, movestogo, depth, movetime, mate, infinite;
   int64_t nodes;
   TimePoint startTime;
 };

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -188,6 +188,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
   main()->wait_for_search_finished();
 
   stopOnPonderhit = stop = false;
+  ponder = limits.ponder;
   Search::Limits = limits;
   Search::RootMoves rootMoves;
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -188,7 +188,6 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
   main()->wait_for_search_finished();
 
   stopOnPonderhit = stop = false;
-  ponder = limits.ponder;
   Search::Limits = limits;
   Search::RootMoves rootMoves;
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -101,7 +101,7 @@ struct ThreadPool : public std::vector<Thread*> {
   uint64_t nodes_searched() const;
   uint64_t tb_hits() const;
 
-  std::atomic_bool stop, stopOnPonderhit;
+  std::atomic_bool stop, ponder, stopOnPonderhit;
 
 private:
   StateListPtr setupStates;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -117,6 +117,7 @@ namespace {
     string token;
 
     limits.startTime = now(); // As early as possible!
+    Threads.ponder = false;
 
     while (is >> token)
         if (token == "searchmoves")
@@ -133,7 +134,7 @@ namespace {
         else if (token == "movetime")  is >> limits.movetime;
         else if (token == "mate")      is >> limits.mate;
         else if (token == "infinite")  limits.infinite = 1;
-        else if (token == "ponder")    limits.ponder = 1;
+        else if (token == "ponder")    Threads.ponder = true;
 
     Threads.start_thinking(pos, States, limits);
   }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -190,7 +190,7 @@ void UCI::loop(int argc, char* argv[]) {
           Threads.main()->start_searching(true); // Could be sleeping
       }
       else if (token == "ponderhit")
-          Search::Limits.ponder = 0; // Switch to normal search
+          Threads.ponder = false; // Switch to normal search
 
       else if (token == "uci")
           sync_cout << "id name " << engine_info(true)


### PR DESCRIPTION
limits.ponder was used as a signal between uci and search threads, but is not an atomic variable,
leading to the following race as flagged by a sanitized binary.

Expect input:
```
 spawn  ./stockfish
 send "uci\n"
 expect "uciok"
 send "setoption name Ponder value true\n"
 send "go wtime 4000 btime 4000\n"
 expect "bestmove"
 send "position startpos e2e4 d7d5\n"
 send "go wtime 4000 btime 4000 ponder\n"
 sleep 0.01
 send "ponderhit\n"
 expect "bestmove"
 send "quit\n"
 expect eof
```

Race:
```
WARNING: ThreadSanitizer: data race (pid=7191)
  Read of size 4 at 0x0000005c2260 by thread T1:
    #0 MainThread::check_time() src/search.cpp:1488 (stockfish+0x000000454471)
    #1 search<(<unnamed>::NodeType)0u> src/search.cpp:566 (stockfish+0x0000004594e0)
    #2 search<(<unnamed>::NodeType)0u> src/search.cpp:997 (stockfish+0x00000045bfb6)
    #3 search<(<unnamed>::NodeType)0u> src/search.cpp:1006 (stockfish+0x00000045c1a3)
    #4 search<(<unnamed>::NodeType)1u> src/search.cpp:997 (stockfish+0x000000457658)
    #5 Thread::search() src/search.cpp:402 (stockfish+0x000000452e28)
    #6 MainThread::search() src/search.cpp:264 (stockfish+0x000000451c32)
    #7 Thread::idle_loop() src/thread.cpp:114 (stockfish+0x000000468c90)

  Previous write of size 4 at 0x0000005c2260 by main thread:
    #0 UCI::loop(int, char**) src/uci.cpp:193 (stockfish+0x000000473c9b)
    #1 main src/main.cpp:47 (stockfish+0x000000433322)

  Location is global 'Search::Limits' of size 88 at 0x0000005c2220 (stockfish+0x0000005c2260)
```

The fix is to add an atomic bool to the threads structure to signal the ponder status, letting Search::Limits to reflect just what was passed to 'go'.

No functional change.