### PR TITLE
fix wasted copies

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -38,15 +38,19 @@ namespace {
   // a given limit. The order of moves smaller than the limit is left unspecified.
   void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
 
-    for (ExtMove *sortedEnd = begin, *p = begin + 1; p < end; ++p)
+     for (ExtMove *sortedEnd = begin, *p = begin + 1; p < end; ++p)
+     {
         if (p->value >= limit)
         {
+            if (((p-1) == sortedEnd) && (sortedEnd->value >= p->value)) 
+                {sortedEnd++; continue;}
             ExtMove tmp = *p, *q;
             *p = *++sortedEnd;
             for (q = sortedEnd; q != begin && *(q - 1) < tmp; --q)
                 *q = *(q - 1);
             *q = tmp;
         }
+     }
   }
 
   // pick_best() finds the best move in the range (begin, end) and moves it to

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -19,6 +19,7 @@
 */
 
 #include <cassert>
+#include <iostream>
 
 #include "movepick.h"
 #include "thread.h"
@@ -38,16 +39,17 @@ namespace {
   // a given limit. The order of moves smaller than the limit is left unspecified.
   void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
 
-     for (ExtMove *sortedEnd = begin, *p = begin + 1; p < end; ++p)
-     {
-        if (p->value >= limit)
-        {
-            if (((p-1) == sortedEnd) && (sortedEnd->value >= p->value)) 
-                {sortedEnd++; continue;}
-            ExtMove tmp = *p, *q;
-            *p = *++sortedEnd;
-            for (q = sortedEnd; q != begin && *(q - 1) < tmp; --q)
-                *q = *(q - 1);
+     for (ExtMove *sortedEnd = begin, *p = begin + 1; p < end; ++p) {
+        if (p->value >= limit) {
+            ++sortedEnd;
+            ExtMove tmp = *p;
+            ExtMove* q;
+            for (q=p; q>sortedEnd-1;--q) {
+                *q = *(q-1);
+            }
+            for (q=sortedEnd; (q > begin) && (q->value < tmp.value);--q) {
+                *q = *(q-1);
+            }
             *q = tmp;
         }
      }
@@ -249,7 +251,7 @@ Move MovePicker::next_move(bool skipQuiets) {
       cur = endBadCaptures;
       endMoves = generate<QUIETS>(pos, cur);
       score<QUIETS>();
-      partial_insertion_sort(cur, endMoves, -4000 * depth / ONE_PLY);
+      partial_insertion_sort(cur, endMoves, -2048 * depth / ONE_PLY);
       ++stage;
       /* fallthrough */
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -40,14 +40,13 @@ namespace {
   void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
 
      for (ExtMove *sortedEnd = begin, *p = begin + 1; p < end; ++p) {
-        if (p->value >= limit) {
-            ++sortedEnd;
-            ExtMove tmp = *p;
-            ExtMove* q;
-            for (q=p; q>sortedEnd-1;--q) {
-                *q = *(q-1);
-            }
-            for (q=sortedEnd; (q > begin) && (q->value < tmp.value);--q) {
+        if (p->value >= limit) 
+        {
+            if (((p-1) == sortedEnd) && (sortedEnd->value >= p->value))
+               {++sortedEnd; continue;}
+            ExtMove tmp = *p, *q;
+            *p = *++sortedEnd;
+            for (q=sortedEnd; q!= begin && (q-1)->value < tmp.value;--q) {
                 *q = *(q-1);
             }
             *q = tmp;
@@ -251,7 +250,7 @@ Move MovePicker::next_move(bool skipQuiets) {
       cur = endBadCaptures;
       endMoves = generate<QUIETS>(pos, cur);
       score<QUIETS>();
-      partial_insertion_sort(cur, endMoves, -2048 * depth / ONE_PLY);
+      partial_insertion_sort(cur, endMoves, -4000 * depth / ONE_PLY);
       ++stage;
       /* fallthrough */
 


### PR DESCRIPTION
As suggested by vondele, I've identified situations where moves are being copied unnecessarily.  This patch fixes the wasted copies.  There should be no functional change. same bench numbers, etc.

My pybench numbers are:
base = 1551873 +/- 52520
test = 1564765 +/- 53476
diff =  +12892  +/- 1318

speedup = +.008
P(speedup > 0) = 1.000

CPU 2xIntel(R) i7-2640M @ 2.8GHz

I'm not sure, but it looks like almost a 1% speedup.  I can clean up the patch a bit, but how should I proceed?