### PR TITLE
Simplify finished search in ponder/infinite mode.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -277,11 +277,10 @@ void MainThread::search() {
   // the UCI protocol states that we shouldn't print the best move before the
   // GUI sends a "stop" or "ponderhit" command. We therefore simply wait here
   // until the GUI sends one of those commands (which also raises Threads.stop).
-  if (!Threads.stop && (Threads.ponder || Limits.infinite))
-  {
-      Threads.stopOnPonderhit = true;
-      wait(Threads.stop);
-  }
+  Threads.stopOnPonderhit = true;
+
+  while (!Threads.stop && (Threads.ponder || Limits.infinite))
+  {} // Busy wait
 
   // Stop the threads if not already stopped
   Threads.stop = true;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -68,24 +68,12 @@ void Thread::wait_for_search_finished() {
 }
 
 
-/// Thread::wait() waits on sleep condition until condition is true
-
-void Thread::wait(std::atomic_bool& condition) {
-
-  std::unique_lock<Mutex> lk(mutex);
-  sleepCondition.wait(lk, [&]{ return bool(condition); });
-}
-
-
 /// Thread::start_searching() wakes up the thread that will start the search
 
-void Thread::start_searching(bool resume) {
+void Thread::start_searching() {
 
   std::unique_lock<Mutex> lk(mutex);
-
-  if (!resume)
-      searching = true;
-
+  searching = true;
   sleepCondition.notify_one();
 }
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -52,7 +52,7 @@ public:
   virtual ~Thread();
   virtual void search();
   void idle_loop();
-  void start_searching(bool resume = false);
+  void start_searching();
   void wait_for_search_finished();
   void wait(std::atomic_bool& condition);
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -176,10 +176,7 @@ void UCI::loop(int argc, char* argv[]) {
       if (    token == "quit"
           ||  token == "stop"
           || (token == "ponderhit" && Threads.stopOnPonderhit))
-      {
           Threads.stop = true;
-          Threads.main()->start_searching(true); // Could be sleeping
-      }
       else if (token == "ponderhit")
           Threads.ponder = false; // Switch to normal search
 


### PR DESCRIPTION
In this rare case (e.g. go infinite on a stalemate), just spin till ponderhit/stop comes. Avoids corner-case bugs and simplifies code.

This is on top of PR #1185
    
No functional change.