### PR TITLE
Fix some races and clarify the code

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -109,9 +109,9 @@ void benchmark(const Position& current, istream& is) {
   string fenFile   = (is >> token) ? token : "default";
   string limitType = (is >> token) ? token : "depth";
 
-  Options["Hash"]    = ttSize;
+  Search::clear(); // Wait for search finished
   Options["Threads"] = threads;
-  Search::clear();
+  Options["Hash"]    = ttSize;
 
   if (limitType == "time")
       limits.movetime = stoi(limit); // movetime is in millisecs

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,7 @@
 #include "position.h"
 #include "search.h"
 #include "thread.h"
+#include "tt.h"
 #include "uci.h"
 #include "syzygy/tbprobe.h"
 
@@ -42,7 +43,10 @@ int main(int argc, char* argv[]) {
   Bitbases::init();
   Search::init();
   Pawns::init();
+  Tablebases::init(Options["SyzygyPath"]);
+  TT.resize(Options["Hash"]);
   Threads.init();
+  Search::clear(); // After threads are up
 
   UCI::loop(argc, argv);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -183,10 +183,13 @@ void Search::init() {
 }
 
 
-/// Search::clear() resets search state to its initial value, to obtain reproducible results
+/// Search::clear() resets search state to its initial value
 
 void Search::clear() {
 
+  Threads.main()->wait_for_search_finished();
+
+  Time.availableNodes = 0;
   TT.clear();
 
   for (Thread* th : Threads)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -155,8 +155,9 @@ void UCI::loop(int argc, char* argv[]) {
 
   Position pos;
   string token, cmd;
+  Thread* uiThread = new Thread();
 
-  pos.set(StartFEN, false, &States->back(), Threads.main());
+  pos.set(StartFEN, false, &States->back(), uiThread);
 
   for (int i = 1; i < argc; ++i)
       cmd += std::string(argv[i]) + " ";
@@ -218,6 +219,7 @@ void UCI::loop(int argc, char* argv[]) {
   } while (token != "quit" && argc == 1); // Passed args have one-shot behaviour
 
   Threads.main()->wait_for_search_finished();
+  delete uiThread;
 }
 
 


### PR DESCRIPTION
Better split code that should be run at
startup from code run at ucinewgame. Also
fix several races when 'bench', 'perft' and
'ucinewgame' are sent just after 'bestomve'
from the engine threads are still running.

We accept a race on 'setoption' to allow the
GUI to change an option while engine is searching
withouth stalling the pipe. Note that changing an
option while searchingg is anyhow not mandated by
UCI protocol.

Also fixed a race on 'eval' using a specific thread to
setup UI position.

No functional change.