### PR TITLE
Reduce memory footprint to help caches

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -24,7 +24,7 @@
 #include "misc.h"
 
 uint8_t PopCnt16[1 << 16];
-int SquareDistance[SQUARE_NB][SQUARE_NB];
+int8_t  SquareDistance[SQUARE_NB][SQUARE_NB];
 
 Bitboard SquareBB[SQUARE_NB];
 Bitboard FileBB[FILE_NB];

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -59,7 +59,7 @@ const Bitboard Rank6BB = Rank1BB << (8 * 5);
 const Bitboard Rank7BB = Rank1BB << (8 * 6);
 const Bitboard Rank8BB = Rank1BB << (8 * 7);
 
-extern int SquareDistance[SQUARE_NB][SQUARE_NB];
+extern int8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];
 extern Bitboard FileBB[FILE_NB];

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -65,17 +65,17 @@ struct Entry {
   Value shelter_storm(const Position& pos, Square ksq);
 
   Key key;
-  Score score;
   Bitboard passedPawns[COLOR_NB];
   Bitboard pawnAttacks[COLOR_NB];
   Bitboard pawnAttacksSpan[COLOR_NB];
+  Score score;
   Square kingSquares[COLOR_NB];
   Score kingSafety[COLOR_NB];
-  int castlingRights[COLOR_NB];
-  int semiopenFiles[COLOR_NB];
-  int pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
-  int asymmetry;
-  int openFiles;
+  int8_t castlingRights[COLOR_NB];
+  uint8_t semiopenFiles[COLOR_NB];
+  int8_t pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
+  int8_t asymmetry;
+  int8_t openFiles;
 };
 
 typedef HashTable<Entry, 16384> Table;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -73,13 +73,13 @@ namespace {
 
   // Futility and reductions lookup tables, initialized at startup
   int FutilityMoveCounts[2][16]; // [improving][depth]
-  int Reductions[2][2][64][64];  // [pv][improving][depth][moveNumber]
+  int8_t Reductions[2][2][64][64];  // [pv][improving][depth][moveNumber]
 
   // Threshold used for countermoves based pruning
   const int CounterMovePruneThreshold = 0;
 
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {
-    return Reductions[PvNode][i][std::min(d / ONE_PLY, 63)][std::min(mn, 63)] * ONE_PLY;
+    return (int)Reductions[PvNode][i][std::min(d / ONE_PLY, 63)][std::min(mn, 63)] * ONE_PLY;
   }
 
   // History and stats update bonus, based on depth


### PR DESCRIPTION
Shrinks the following data structures:
Bitboard SquareDistance from 16k to 4k
Pawns::Entry size from 120 bytes to 88 bytes
Pawns::HashTable from 1.9MB to 1.4MB
Search Reductions from 64k to 16k

Each has also been verified to produce a small speedup.
The total speedup is 2.5%.
No functional change.

bench: 5608839
```
Results for 20 tests for each version:

            Base      Test      Diff      
    Mean    1026879   1052306   -25427    
    StDev   36980     36231     2812      

p-value: 1
speedup: 0.025
```