### PR TITLE
Unify scoring

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -127,18 +127,15 @@ template<GenType T>
 void MovePicker::score() {
 
   for (auto& m : *this)
-      if (T == CAPTURES || (T == EVASIONS && pos.capture(m)))
-          m.value =   PieceValue[MG][pos.piece_on(to_sq(m))]
-                   - (T == EVASIONS ? Value(type_of(pos.moved_piece(m)))
-                                    : Value(200 * relative_rank(pos.side_to_move(), to_sq(m))));
-      else if (T == QUIETS)
+      if (T != QUIETS && (T == CAPTURES || pos.capture(m)))
+          m.value =  (1 << 28) + PieceValue[MG][pos.piece_on(to_sq(m))]
+                   - Value(type_of(pos.moved_piece(m)))
+                   - Value(200 * relative_rank(pos.side_to_move(), to_sq(m)));
+      else
           m.value =  (*mainHistory)[pos.side_to_move()][from_to(m)]
                    + (*contHistory[0])[pos.moved_piece(m)][to_sq(m)]
                    + (*contHistory[1])[pos.moved_piece(m)][to_sq(m)]
                    + (*contHistory[3])[pos.moved_piece(m)][to_sq(m)];
-
-      else // Quiet evasions
-          m.value = (*mainHistory)[pos.side_to_move()][from_to(m)] - (1 << 28);
 }
 
 /// next_move() is the most important method of the MovePicker class. It returns

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1242,7 +1242,8 @@ moves_loop: // When in check search starts from here
     // to search the moves. Because the depth is <= 0 here, only captures,
     // queen promotions and checks (only if depth >= DEPTH_QS_CHECKS) will
     // be generated.
-    const PieceToHistory* contHist[4] = {};
+    const PieceToHistory* contHist[4] = { (ss-1)->contHistory, (ss-2)->contHistory, nullptr, (ss-4)->contHistory };
+    ss->contHistory = &pos.this_thread()->contHistory[NO_PIECE][0]; // Use as sentinel
     MovePicker mp(pos, ttMove, depth, &pos.this_thread()->mainHistory, contHist, to_sq((ss-1)->currentMove));
 
     // Loop through the moves until no moves remain or a beta cutoff occurs


### PR DESCRIPTION
Use the same quiets / capture scoring for evasions, less complicated flow in score() (1 branch instead of 3).
Same construction of contHist in search and qsearch.

tested version prior to PR #1199

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 27377 W: 4957 L: 4847 D: 17573
elo =    1.396 +-    2.459 LOS:   86.7%

LTC:
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 34641 W: 4521 L: 4419 D: 25701
elo =    1.023 +-    1.856 LOS:   86.0%

bench: 5163585