### PR TITLE
Run clang-tidy 'modernize'

### DIFF
--- a/src/endgame.h
+++ b/src/endgame.h
@@ -85,7 +85,7 @@ template<EndgameCode E, typename T = eg_type<E>>
 struct Endgame : public EndgameBase<T> {
 
   explicit Endgame(Color c) : EndgameBase<T>(c) {}
-  T operator()(const Position&) const;
+  T operator()(const Position&) const override;
 };
 
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -63,10 +63,10 @@ struct Tie: public streambuf { // MSVC requires split streambuf for cin and cout
 
   Tie(streambuf* b, streambuf* l) : buf(b), logBuf(l) {}
 
-  int sync() { return logBuf->pubsync(), buf->pubsync(); }
-  int overflow(int c) { return log(buf->sputc((char)c), "<< "); }
-  int underflow() { return buf->sgetc(); }
-  int uflow() { return log(buf->sbumpc(), ">> "); }
+  int sync() override { return logBuf->pubsync(), buf->pubsync(); }
+  int overflow(int c) override { return log(buf->sputc((char)c), "<< "); }
+  int underflow() override { return buf->sgetc(); }
+  int uflow() override { return log(buf->sbumpc(), ">> "); }
 
   streambuf *buf, *logBuf;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -253,7 +253,7 @@ void MainThread::search() {
 
   if (rootMoves.empty())
   {
-      rootMoves.push_back(RootMove(MOVE_NONE));
+      rootMoves.emplace_back(MOVE_NONE);
       sync_cout << "info depth 0 score "
                 << UCI::value(rootPos.checkers() ? -VALUE_MATE : VALUE_DRAW)
                 << sync_endl;

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -489,8 +489,8 @@ void HashTable::insert(const std::vector<PieceType>& pieces) {
 
     MaxCardinality = std::max((int)pieces.size(), MaxCardinality);
 
-    wdlTable.push_back(WDLEntry(code));
-    dtzTable.push_back(DTZEntry(wdlTable.back()));
+    wdlTable.emplace_back(code);
+    dtzTable.emplace_back(wdlTable.back());
 
     insert(wdlTable.back().key , &wdlTable.back(), &dtzTable.back());
     insert(wdlTable.back().key2, &wdlTable.back(), &dtzTable.back());

--- a/src/thread.h
+++ b/src/thread.h
@@ -78,7 +78,7 @@ struct MainThread : public Thread {
 
   using Thread::Thread;
 
-  virtual void search();
+  void search() override;
   void check_time();
 
   bool easyMovePlayed, failedLow;


### PR DESCRIPTION
Some warnings after a run of:

$ clang-tidy-3.8 -checks='modernize-*' *.cpp syzygy/*.cpp -header-filter=.* -- -std=c++11

I have not fixed all suggestions, for instance I still prefer
to declare the type instead of a spread use of 'auto'. I also
perfer good old 'typedef' to the new 'using' form.

I have not fixed some warnings in the last functions of
syzygy code because those are still the original functions
and need to be completely rewritten anyhow.

Thanks to erbsenzaehler for the original idea.

No functional change.