### PR TITLE
Fix involuntary conversions of ExtMove to Move

### DIFF
--- a/src/movegen.h
+++ b/src/movegen.h
@@ -42,6 +42,10 @@ struct ExtMove {
 
   operator Move() const { return move; }
   void operator=(Move m) { move = m; }
+
+  // Disable unwanted implicit conversions to
+  // Move creating an ambiguity for the compiler.
+  operator float() const;
 };
 
 inline bool operator<(const ExtMove& f, const ExtMove& s) {


### PR DESCRIPTION
The trick is to create an ambiguity for the
compiler in case an unwanted conversion to
Move is attempted like in:

    ExtMove m1{Move(17),4}, m2{Move(4),17};

    std::cout << (m1 < m2) << std::endl; // 1
    std::cout << (m1 > m2) << std::endl; // 1(!)

This fixes issue #1204

No functional change.