### PR TITLE
Time is not a global

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -189,7 +189,7 @@ void Search::clear() {
 
   Threads.main()->wait_for_search_finished();
 
-  Time.availableNodes = 0;
+  Threads.main()->time.availableNodes = 0;
   TT.clear();
 
   for (Thread* th : Threads)
@@ -244,7 +244,7 @@ template uint64_t Search::perft<true>(Position&, Depth);
 void MainThread::search() {
 
   Color us = rootPos.side_to_move();
-  Time.init(Limits, us, rootPos.game_ply());
+  time.init(Limits, us, rootPos.game_ply());
   TT.new_search();
 
   int contempt = Options["Contempt"] * PawnValueEg / 100; // From centipawns
@@ -270,7 +270,7 @@ void MainThread::search() {
   // When playing in 'nodes as time' mode, subtract the searched nodes from
   // the available ones before exiting.
   if (Limits.npmsec)
-      Time.availableNodes += Limits.inc[us] - Threads.nodes_searched();
+      time.availableNodes += Limits.inc[us] - Threads.nodes_searched();
 
   // When we reach the maximum depth, we can arrive here without a raise of
   // Threads.stop. However, if we are pondering or in an infinite search,
@@ -313,7 +313,8 @@ void MainThread::search() {
 
   // Send new PV when needed
   if (bestThread != this)
-      sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
+      sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth,
+                           -VALUE_INFINITE, VALUE_INFINITE, time.elapsed()) << sync_endl;
 
   sync_cout << "bestmove " << UCI::move(bestThread->rootMoves[0].pv[0], rootPos.is_chess960());
 
@@ -422,8 +423,8 @@ void Thread::search() {
               if (   mainThread
                   && multiPV == 1
                   && (bestValue <= alpha || bestValue >= beta)
-                  && Time.elapsed() > 3000)
-                  sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
+                  && mainThread->time.elapsed() > 3000)
+                  sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta, mainThread->time.elapsed()) << sync_endl;
 
               // In case of failing low/high increase aspiration window and
               // re-search, otherwise exit the loop.
@@ -454,8 +455,8 @@ void Thread::search() {
           if (!mainThread)
               continue;
 
-          if (Threads.stop || PVIdx + 1 == multiPV || Time.elapsed() > 3000)
-              sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
+          if (Threads.stop || PVIdx + 1 == multiPV || mainThread->time.elapsed() > 3000)
+              sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta, mainThread->time.elapsed()) << sync_endl;
       }
 
       if (!Threads.stop)
@@ -490,10 +491,10 @@ void Thread::search() {
 
               bool doEasyMove =   rootMoves[0].pv[0] == easyMove
                                && mainThread->bestMoveChanges < 0.03
-                               && Time.elapsed() > Time.optimum() * 5 / 44;
+                               && mainThread->time.elapsed() > mainThread->time.optimum() * 5 / 44;
 
               if (   rootMoves.size() == 1
-                  || Time.elapsed() > Time.optimum() * unstablePvFactor * improvingFactor / 628
+                  || mainThread->time.elapsed() > mainThread->time.optimum() * unstablePvFactor * improvingFactor / 628
                   || (mainThread->easyMovePlayed = doEasyMove, doEasyMove))
               {
                   // If we are allowed to ponder do not stop the search now but
@@ -840,7 +841,7 @@ moves_loop: // When in check search starts from here
 
       ss->moveCount = ++moveCount;
 
-      if (rootNode && thisThread == Threads.main() && Time.elapsed() > 3000)
+      if (rootNode && thisThread == Threads.main() && Threads.main()->time.elapsed() > 3000)
           sync_cout << "info depth " << depth / ONE_PLY
                     << " currmove " << UCI::move(move, pos.is_chess960())
                     << " currmovenumber " << moveCount + thisThread->PVIdx << sync_endl;
@@ -1478,7 +1479,7 @@ moves_loop: // When in check search starts from here
 
     static TimePoint lastInfoTime = now();
 
-    int elapsed = Time.elapsed();
+    int elapsed = time.elapsed();
     TimePoint tick = Limits.startTime + elapsed;
 
     if (tick - lastInfoTime >= 1000)
@@ -1491,7 +1492,7 @@ moves_loop: // When in check search starts from here
     if (Threads.ponder)
         return;
 
-    if (   (Limits.use_time_management() && elapsed > Time.maximum() - 10)
+    if (   (Limits.use_time_management() && elapsed > time.maximum() - 10)
         || (Limits.movetime && elapsed >= Limits.movetime)
         || (Limits.nodes && Threads.nodes_searched() >= (uint64_t)Limits.nodes))
             Threads.stop = true;
@@ -1501,10 +1502,9 @@ moves_loop: // When in check search starts from here
 /// UCI::pv() formats PV information according to the UCI protocol. UCI requires
 /// that all (if any) unsearched PV lines are sent using a previous search score.
 
-string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
+string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta, int elapsed) {
 
   std::stringstream ss;
-  int elapsed = Time.elapsed() + 1;
   const RootMoves& rootMoves = pos.this_thread()->rootMoves;
   size_t PVIdx = pos.this_thread()->PVIdx;
   size_t multiPV = std::min((size_t)Options["MultiPV"], rootMoves.size());
@@ -1537,7 +1537,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
           ss << (v >= beta ? " lowerbound" : v <= alpha ? " upperbound" : "");
 
       ss << " nodes "    << nodesSearched
-         << " nps "      << nodesSearched * 1000 / elapsed;
+         << " nps "      << nodesSearched * 1000 / std::max(1, elapsed);
 
       if (elapsed > 1000) // Earlier makes little sense
           ss << " hashfull " << TT.hashfull();

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -137,6 +137,9 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
                                 const Search::LimitsType& limits, bool ponderMode) {
 
   main()->wait_for_search_finished();
+  main()->time.elapsed=[](){
+      return int(Search::Limits.npmsec ? Threads.nodes_searched() : now() - Search::Limits.startTime);
+  };
 
   stopOnPonderhit = stop = false;
   ponder = ponderMode;

--- a/src/thread.h
+++ b/src/thread.h
@@ -33,6 +33,7 @@
 #include "position.h"
 #include "search.h"
 #include "thread_win32.h"
+#include "timeman.h"
 
 
 /// Thread class keeps together all the thread-related stuff. We use
@@ -85,6 +86,7 @@ struct MainThread : public Thread {
   double bestMoveChanges;
   Value previousScore;
   int callsCnt;
+  TimeManagement time;
 };
 
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -26,8 +26,6 @@
 #include "timeman.h"
 #include "uci.h"
 
-TimeManagement Time; // Our global time management object
-
 namespace {
 
   enum TimeType { OptimumTime, MaxTime };
@@ -100,7 +98,6 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
       limits.npmsec = npmsec;
   }
 
-  startTime = limits.startTime;
   optimumTime = remaining(limits.time[us], limits.inc[us], moveOverhead, limits.movestogo, ply, OptimumTime);
   maximumTime = remaining(limits.time[us], limits.inc[us], moveOverhead, limits.movestogo, ply, MaxTime);
 

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -21,9 +21,10 @@
 #ifndef TIMEMAN_H_INCLUDED
 #define TIMEMAN_H_INCLUDED
 
+#include <functional>
+
 #include "misc.h"
 #include "search.h"
-#include "thread.h"
 
 /// The TimeManagement class computes the optimal time to think depending on
 /// the maximum available time, the game move number and other parameters.
@@ -33,16 +34,13 @@ public:
   void init(Search::LimitsType& limits, Color us, int ply);
   int optimum() const { return optimumTime; }
   int maximum() const { return maximumTime; }
-  int elapsed() const { return int(Search::Limits.npmsec ? Threads.nodes_searched() : now() - startTime); }
+  std::function<int()> elapsed;
 
   int64_t availableNodes; // When in 'nodes as time' mode
 
 private:
-  TimePoint startTime;
   int optimumTime;
   int maximumTime;
 };
-
-extern TimeManagement Time;
 
 #endif // #ifndef TIMEMAN_H_INCLUDED

--- a/src/uci.h
+++ b/src/uci.h
@@ -70,7 +70,7 @@ void loop(int argc, char* argv[]);
 std::string value(Value v);
 std::string square(Square s);
 std::string move(Move m, bool chess960);
-std::string pv(const Position& pos, Depth depth, Value alpha, Value beta);
+std::string pv(const Position& pos, Depth depth, Value alpha, Value beta, int elapsed);
 Move to_move(const Position& pos, std::string& str);
 
 } // namespace UCI


### PR DESCRIPTION
only mainThread needs Time, keep it there.
Removes dependency of timeman on thread.
Removes duplicated startTime.

No functional change.