### PR TITLE
Restore safety margin of 60ms

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -66,10 +66,7 @@ namespace {
     if (type == OptimumTime && ponder)
         time *= 1.25;
 
-    if (type == MaxTime)
-        time -= 10; // Keep always at least 10 millisecs on the clock
-
-    return std::max(0, time);
+    return time;
   }
 
 } // namespace

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -65,7 +65,7 @@ void init(OptionsMap& o) {
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);
   o["Skill Level"]           << Option(20, 0, 20);
-  o["Move Overhead"]         << Option(30, 0, 5000);
+  o["Move Overhead"]         << Option(60, 0, 5000);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);


### PR DESCRIPTION
What this patch does is:
* increase safety margin from 40ms to 60ms. It's worth noting that the previous
  code not only used 60ms incompressible safety margin, but also an additional
  buffer of 30ms for each "move to go".
* remove a whart, integrating the extra 10ms in Move Overhead value instead.
  Additionally, this ensures that optimumtime doesn't become bigger than maximum
  time after maximum time has been artificially discounted by 10ms. So it keeps
  the code more logical.

Tested at 3 different time controls:

Standard 10+0.1
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 58008 W: 10674 L: 10617 D: 36717

Sudden death 16+0
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 59664 W: 10945 L: 10891 D: 37828

Tournament 40/10
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 16371 W: 3092 L: 2963 D: 10316

bench 5608839