### PR TITLE
Smaller lookup tables

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -24,7 +24,7 @@
 #include "misc.h"
 
 uint8_t PopCnt16[1 << 16];
-int SquareDistance[SQUARE_NB][SQUARE_NB];
+int8_t  SquareDistance[SQUARE_NB][SQUARE_NB];
 
 Bitboard SquareBB[SQUARE_NB];
 Bitboard FileBB[FILE_NB];

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -59,7 +59,7 @@ const Bitboard Rank6BB = Rank1BB << (8 * 5);
 const Bitboard Rank7BB = Rank1BB << (8 * 6);
 const Bitboard Rank8BB = Rank1BB << (8 * 7);
 
-extern int SquareDistance[SQUARE_NB][SQUARE_NB];
+extern int8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];
 extern Bitboard FileBB[FILE_NB];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -73,13 +73,13 @@ namespace {
 
   // Futility and reductions lookup tables, initialized at startup
   int FutilityMoveCounts[2][16]; // [improving][depth]
-  int Reductions[2][2][64][64];  // [pv][improving][depth][moveNumber]
+  int8_t Reductions[2][2][64][64];  // [pv][improving][depth][moveNumber]
 
   // Threshold used for countermoves based pruning
   const int CounterMovePruneThreshold = 0;
 
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {
-    return Reductions[PvNode][i][std::min(d / ONE_PLY, 63)][std::min(mn, 63)] * ONE_PLY;
+    return (int)Reductions[PvNode][i][std::min(d / ONE_PLY, 63)][std::min(mn, 63)] * ONE_PLY;
   }
 
   // History and stats update bonus, based on depth


### PR DESCRIPTION
Reduce the size of two lookup tables to make them faster(by fitting into cache more easily).
No functional change.
bench: 5479946

http://tests.stockfishchess.org/tests/view/59977e7d0ebc5916ff64a846
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 94883 W: 17554 L: 17071 D: 60258

In the interest of full disclosure I also tested these together with one additional memory reduction which ended yellow
http://tests.stockfishchess.org/tests/view/5995f2900ebc5916ff64a7cd
LLR: -2.94 (-2.94,2.94) [0.00,4.00]
Total: 66130 W: 11871 L: 11803 D: 42456

