### PR TITLE
Avoid constructing an empty tuple in qsearch (obsolete)

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -39,6 +39,7 @@ const std::string pretty(Bitboard b);
 
 }
 
+const Bitboard AllSquares = ~Bitboard(0);
 const Bitboard DarkSquares = 0xAA55AA55AA55AA55ULL;
 
 const Bitboard FileABB = 0x0101010101010101ULL;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -408,8 +408,8 @@ namespace {
 
     const Color Them    = (Us == WHITE ? BLACK : WHITE);
     const Square Up     = (Us == WHITE ? NORTH : SOUTH);
-    const Bitboard Camp = (Us == WHITE ? ~Bitboard(0) ^ Rank6BB ^ Rank7BB ^ Rank8BB
-                                       : ~Bitboard(0) ^ Rank1BB ^ Rank2BB ^ Rank3BB);
+    const Bitboard Camp = (Us == WHITE ? AllSquares ^ Rank6BB ^ Rank7BB ^ Rank8BB
+                                       : AllSquares ^ Rank1BB ^ Rank2BB ^ Rank3BB);
 
     const Square ksq = pos.square<KING>(Us);
     Bitboard kingOnlyDefended, undefended, b, b1, b2, safe, other;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -216,11 +216,7 @@ namespace {
   const Score Hanging             = S( 48, 27);
   const Score ThreatByPawnPush    = S( 38, 22);
   const Score HinderPassedPawn    = S(  7,  0);
-
-  // Penalty for a bishop on a1/h1 (a8/h8 for black) which is trapped by
-  // a friendly pawn on b2/g2 (b7/g7 for black). This can obviously only
-  // happen in Chess960 games.
-  const Score TrappedBishopA1H1 = S(50, 50);
+  const Score TrappedBishopA1H1   = S( 50, 50);
 
   #undef S
   #undef V
@@ -416,7 +412,7 @@ namespace {
                                        : ~Bitboard(0) ^ Rank1BB ^ Rank2BB ^ Rank3BB);
 
     const Square ksq = pos.square<KING>(Us);
-    Bitboard kingOnlyDefended, b, b1, b2, safe, other;
+    Bitboard kingOnlyDefended, undefended, b, b1, b2, safe, other;
     int kingDanger;
 
     // King shelter and enemy pawns storm
@@ -431,8 +427,10 @@ namespace {
                           & ~attackedBy2[Us];
 
         // ... and those which are not defended at all in the larger king ring
-        b =  attackedBy[Them][ALL_PIECES] & ~attackedBy[Us][ALL_PIECES]
-           & kingRing[Us] & ~pos.pieces(Them);
+        undefended =   attackedBy[Them][ALL_PIECES]
+                    & ~attackedBy[Us][ALL_PIECES]
+                    &  kingRing[Us]
+                    & ~pos.pieces(Them);
 
         // Initialize the 'kingDanger' variable, which will be transformed
         // later into a king danger score. The initial value is based on the
@@ -442,7 +440,7 @@ namespace {
         kingDanger =        kingAttackersCount[Them] * kingAttackersWeight[Them]
                     + 102 * kingAdjacentZoneAttacksCount[Them]
                     + 201 * popcount(kingOnlyDefended)
-                    + 143 * (popcount(b) + !!pos.pinned_pieces(Us))
+                    + 143 * (popcount(undefended) + !!pos.pinned_pieces(Us))
                     - 848 * !pos.count<QUEEN>(Them)
                     -   9 * mg_value(score) / 8
                     +  40;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -66,6 +66,7 @@ namespace {
 /// search captures, promotions, and some checks) and how important good move
 /// ordering is at the current node.
 
+/// MovePicker constructor for the main search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
                        const PieceToHistory** ch, Move cm, Move* killers_p)
            : pos(p), mainHistory(mh), contHistory(ch), countermove(cm),
@@ -78,9 +79,9 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
   stage += (ttMove == MOVE_NONE);
 }
 
-MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
-                       const PieceToHistory** ch, Square s)
-           : pos(p), mainHistory(mh), contHistory(ch) {
+/// MovePicker constructor for quiescence search 
+MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh, Square s)
+           : pos(p), mainHistory(mh) {
 
   assert(d <= DEPTH_ZERO);
 
@@ -104,14 +105,14 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
   stage += (ttMove == MOVE_NONE);
 }
 
+/// MovePicker constructor for Probcut: we generate captures with SEE
+/// higher than or equal to the given threshold
 MovePicker::MovePicker(const Position& p, Move ttm, Value th)
            : pos(p), threshold(th) {
 
   assert(!pos.checkers());
 
   stage = PROBCUT;
-
-  // In ProbCut we generate captures with SEE higher than or equal to the given threshold
   ttMove =   ttm
           && pos.pseudo_legal(ttm)
           && pos.capture(ttm)
@@ -123,6 +124,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th)
 /// score() assigns a numerical value to each move in a list, used for sorting.
 /// Captures are ordered by Most Valuable Victim (MVV), preferring captures
 /// near our home rank. Quiets are ordered using the histories.
+
 template<GenType T>
 void MovePicker::score() {
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -79,7 +79,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
   stage += (ttMove == MOVE_NONE);
 }
 
-/// MovePicker constructor for quiescence search 
+/// MovePicker constructor for quiescence search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh, Square s)
            : pos(p), mainHistory(mh) {
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -94,7 +94,7 @@ public:
   MovePicker(const MovePicker&) = delete;
   MovePicker& operator=(const MovePicker&) = delete;
   MovePicker(const Position&, Move, Value);
-  MovePicker(const Position&, Move, Depth, const ButterflyHistory*, const PieceToHistory**, Square);
+  MovePicker(const Position&, Move, Depth, const ButterflyHistory*, Square);
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*, const PieceToHistory**, Move, Move*);
   Move next_move(bool skipQuiets = false);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1246,8 +1246,7 @@ moves_loop: // When in check search starts from here
     // to search the moves. Because the depth is <= 0 here, only captures,
     // queen promotions and checks (only if depth >= DEPTH_QS_CHECKS) will
     // be generated.
-    const PieceToHistory* contHist[4] = {};
-    MovePicker mp(pos, ttMove, depth, &pos.this_thread()->mainHistory, contHist, to_sq((ss-1)->currentMove));
+    MovePicker mp(pos, ttMove, depth, &pos.this_thread()->mainHistory, to_sq((ss-1)->currentMove));
 
     // Loop through the moves until no moves remain or a beta cutoff occurs
     while ((move = mp.next_move()) != MOVE_NONE)


### PR DESCRIPTION
Avoid constructing, passing as a parameter and binding a useless empty tuple of pointers in the qsearch move picker constructor. Also add some comments in movepicker.cpp and do some cleaning in evaluate.cpp while there.

No functional change.