### PR TITLE
Avoid constructing an empty tuple in qsearch

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -39,6 +39,7 @@ const std::string pretty(Bitboard b);
 
 }
 
+const Bitboard AllSquares = ~Bitboard(0);
 const Bitboard DarkSquares = 0xAA55AA55AA55AA55ULL;
 
 const Bitboard FileABB = 0x0101010101010101ULL;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -66,6 +66,7 @@ namespace {
 /// search captures, promotions, and some checks) and how important good move
 /// ordering is at the current node.
 
+/// MovePicker constructor for the main search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
                        const PieceToHistory** ch, Move cm, Move* killers_p)
            : pos(p), mainHistory(mh), contHistory(ch), countermove(cm),
@@ -78,9 +79,9 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
   stage += (ttMove == MOVE_NONE);
 }
 
-MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
-                       const PieceToHistory** ch, Square s)
-           : pos(p), mainHistory(mh), contHistory(ch) {
+/// MovePicker constructor for quiescence search
+MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh, Square s)
+           : pos(p), mainHistory(mh) {
 
   assert(d <= DEPTH_ZERO);
 
@@ -104,14 +105,14 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
   stage += (ttMove == MOVE_NONE);
 }
 
+/// MovePicker constructor for ProbCut: we generate captures with SEE
+/// higher than or equal to the given threshold
 MovePicker::MovePicker(const Position& p, Move ttm, Value th)
            : pos(p), threshold(th) {
 
   assert(!pos.checkers());
 
   stage = PROBCUT;
-
-  // In ProbCut we generate captures with SEE higher than or equal to the given threshold
   ttMove =   ttm
           && pos.pseudo_legal(ttm)
           && pos.capture(ttm)
@@ -123,22 +124,29 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th)
 /// score() assigns a numerical value to each move in a list, used for sorting.
 /// Captures are ordered by Most Valuable Victim (MVV), preferring captures
 /// near our home rank. Quiets are ordered using the histories.
-template<GenType T>
+
+template<GenType Type>
 void MovePicker::score() {
 
+  static_assert(Type == CAPTURES || Type == QUIETS || Type == EVASIONS, "Wrong type");
+
   for (auto& m : *this)
-      if (T == CAPTURES || (T == EVASIONS && pos.capture(m)))
-          m.value =   PieceValue[MG][pos.piece_on(to_sq(m))]
-                   - (T == EVASIONS ? Value(type_of(pos.moved_piece(m)))
-                                    : Value(200 * relative_rank(pos.side_to_move(), to_sq(m))));
-      else if (T == QUIETS)
+      if (Type == CAPTURES)
+          m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
+                   - Value(200 * relative_rank(pos.side_to_move(), to_sq(m)));
+
+      else if (Type == QUIETS)
           m.value =  (*mainHistory)[pos.side_to_move()][from_to(m)]
                    + (*contHistory[0])[pos.moved_piece(m)][to_sq(m)]
                    + (*contHistory[1])[pos.moved_piece(m)][to_sq(m)]
                    + (*contHistory[3])[pos.moved_piece(m)][to_sq(m)];
 
-      else // Quiet evasions
-          m.value = (*mainHistory)[pos.side_to_move()][from_to(m)] - (1 << 28);
+      else // (Type == EVASIONS)
+          if (pos.capture(m))
+              m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
+                       - Value(type_of(pos.moved_piece(m)));
+          else
+              m.value = (*mainHistory)[pos.side_to_move()][from_to(m)] - (1 << 28);
 }
 
 /// next_move() is the most important method of the MovePicker class. It returns

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -94,7 +94,7 @@ public:
   MovePicker(const MovePicker&) = delete;
   MovePicker& operator=(const MovePicker&) = delete;
   MovePicker(const Position&, Move, Value);
-  MovePicker(const Position&, Move, Depth, const ButterflyHistory*, const PieceToHistory**, Square);
+  MovePicker(const Position&, Move, Depth, const ButterflyHistory*, Square);
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*, const PieceToHistory**, Move, Move*);
   Move next_move(bool skipQuiets = false);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1246,8 +1246,7 @@ moves_loop: // When in check search starts from here
     // to search the moves. Because the depth is <= 0 here, only captures,
     // queen promotions and checks (only if depth >= DEPTH_QS_CHECKS) will
     // be generated.
-    const PieceToHistory* contHist[4] = {};
-    MovePicker mp(pos, ttMove, depth, &pos.this_thread()->mainHistory, contHist, to_sq((ss-1)->currentMove));
+    MovePicker mp(pos, ttMove, depth, &pos.this_thread()->mainHistory, to_sq((ss-1)->currentMove));
 
     // Loop through the moves until no moves remain or a beta cutoff occurs
     while ((move = mp.next_move()) != MOVE_NONE)


### PR DESCRIPTION
Avoid constructing, passing as a parameter and binding a useless empty tuple of pointers in the qsearch move picker constructor.

Also reformat the scoring function in movepicker.cpp and do some cleaning in evaluate.cpp while there.

No functional change.