### PR TITLE
Use moveCount history for reduction.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -908,7 +908,8 @@ moves_loop: // When in check search starts from here
               }
 
               // Reduced depth of the next LMR search
-              int lmrDepth = std::max(newDepth - reduction<PvNode>(improving, depth, moveCount), DEPTH_ZERO) / ONE_PLY;
+              int mch = std::max(1, moveCount - (ss-1)->moveCount / 16);
+              int lmrDepth = std::max(newDepth - reduction<PvNode>(improving, depth, mch), DEPTH_ZERO) / ONE_PLY;
 
               // Countermoves based pruning
               if (   lmrDepth < 3
@@ -959,7 +960,8 @@ moves_loop: // When in check search starts from here
           &&  moveCount > 1
           && (!captureOrPromotion || moveCountPruning))
       {
-          Depth r = reduction<PvNode>(improving, depth, moveCount);
+          int mch = std::max(1, moveCount - (ss-1)->moveCount / 16);
+          Depth r = reduction<PvNode>(improving, depth, mch);
 
           if (captureOrPromotion)
               r -= r ? ONE_PLY : DEPTH_ZERO;


### PR DESCRIPTION
passed STC:
http://tests.stockfishchess.org/tests/view/599f08cc0ebc5916ff64aace
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 9638 W: 1889 L: 1720 D: 6029
elo =    6.093 +-    4.238 LOS:   99.8%

passed LTC:
http://tests.stockfishchess.org/tests/view/599f1e5c0ebc5916ff64aadc
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 28308 W: 3742 L: 3533 D: 21033
elo =    2.565 +-    2.049 LOS:   99.3%

Bench: 5747429