### PR TITLE
Count all weak squares in the king ring with a single popcount

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -439,8 +439,8 @@ namespace {
         // the quality of the pawn shelter (current 'score' value).
         kingDanger =        kingAttackersCount[Them] * kingAttackersWeight[Them]
                     + 102 * kingAdjacentZoneAttacksCount[Them]
-                    + 201 * popcount(kingOnlyDefended)
-                    + 143 * (popcount(undefended) + !!pos.pinned_pieces(Us))
+                    + 191 * popcount(kingOnlyDefended | undefended)
+                    + 143 * !!pos.pinned_pieces(Us)
                     - 848 * !pos.count<QUEEN>(Them)
                     -   9 * mg_value(score) / 8
                     +  40;


### PR DESCRIPTION
Passed STC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 26966 W: 4993 L: 4745 D: 17228
http://tests.stockfishchess.org/tests/view/599e798a0ebc5916ff64aa8c

and LTC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 39570 W: 5104 L: 4857 D: 29609
http://tests.stockfishchess.org/tests/view/599ee5230ebc5916ff64aabe

Bench: 5590636