### PR TITLE
Appveyor: do a Debug and Release build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,10 +13,11 @@ os: Visual Studio 2015
 platform:
   - x86
   - x64
-  - Any CPU
 
 # build Configuration, i.e. Debug, Release, etc.
-configuration: Debug
+configuration:
+  - Debug
+  - Release
 
 matrix:
   # The build fail immediately once one of the job fails
@@ -50,13 +51,16 @@ before_build:
       $b = git log HEAD | sls "\b[Bb]ench[ :]+[0-9]{7}" | select -first 1
       $bench = $b -match '\D+(\d+)' | % { $matches[1] }
       Write-Host "Reference bench:" $bench
+      $g = "Visual Studio 14 2015"
+      If (${env:PLATFORM} -eq 'x64') { $g = $g + ' Win64' }
+      cmake -G "${g}" .
+      Write-Host "Generated files for: " $g
 
 build_script:
-  - cmake -G "Visual Studio 14 2015 Win64" .
-  - cmake --build .
+  - cmake --build . --config %CONFIGURATION% -- /verbosity:minimal
 
 before_test:
-  - cd src/Debug
+  - cd src/%CONFIGURATION%
   - ps: |
       # Verify bench number
       ./stockfish bench 2> out.txt 1> null


### PR DESCRIPTION
And set x86 and x64 platforms for real.

Currently this is broken and the same binary is compiled for all platforms.

This is becuase we use a custom build step. OTH the default
build step seems not compatible with cmake generated *sln file.

No functional change.