### PR TITLE
Contempt from whites point of view

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -252,8 +252,8 @@ void MainThread::search() {
   TT.new_search();
 
   int contempt = Options["Contempt"] * PawnValueEg / 100; // From centipawns
-  DrawValue[WHITE] = VALUE_DRAW - Value(contempt);
-  DrawValue[BLACK] = VALUE_DRAW + Value(contempt);
+  DrawValue[Search::Limits.infinite ? WHITE :  us] = VALUE_DRAW - Value(contempt);
+  DrawValue[Search::Limits.infinite ? BLACK : ~us] = VALUE_DRAW + Value(contempt);
 
   if (rootMoves.empty())
   {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -252,8 +252,8 @@ void MainThread::search() {
   TT.new_search();
 
   int contempt = Options["Contempt"] * PawnValueEg / 100; // From centipawns
-  DrawValue[ us] = VALUE_DRAW - Value(contempt);
-  DrawValue[~us] = VALUE_DRAW + Value(contempt);
+  DrawValue[WHITE] = VALUE_DRAW - Value(contempt);
+  DrawValue[BLACK] = VALUE_DRAW + Value(contempt);
 
   if (rootMoves.empty())
   {


### PR DESCRIPTION
Previously contempt was set always from the viewpoint of the first mover. This makes this option unusable, in settings where stockfish calculates moves for black and for white. (Reported from [Ronald de Man](http://www.talkchess.com/forum/viewtopic.php?topic_view=threads&p=729280&t=64990) 