### PR TITLE
Fix issue #1227

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -75,9 +75,6 @@ namespace {
   int FutilityMoveCounts[2][16]; // [improving][depth]
   int Reductions[2][2][64][64];  // [pv][improving][depth][moveNumber]
 
-  // Threshold used for countermoves based pruning
-  const int CounterMovePruneThreshold = 0;
-
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {
     return Reductions[PvNode][i][std::min(d / ONE_PLY, 63)][std::min(mn, 63)] * ONE_PLY;
   }
@@ -217,21 +214,7 @@ void Search::clear() {
 
   Time.availableNodes = 0;
   TT.clear();
-
-  for (Thread* th : Threads)
-  {
-      th->counterMoves.fill(MOVE_NONE);
-      th->mainHistory.fill(0);
-
-      for (auto& to : th->contHistory)
-          for (auto& h : to)
-              h.fill(0);
-
-      th->contHistory[NO_PIECE][0].fill(CounterMovePruneThreshold - 1);
-  }
-
-  Threads.main()->callsCnt = 0;
-  Threads.main()->previousScore = VALUE_INFINITE;
+  Threads.clear();
 }
 
 

--- a/src/search.h
+++ b/src/search.h
@@ -97,6 +97,9 @@ extern LimitsType Limits;
 void init();
 void clear();
 
+/// Threshold used for countermoves based pruning
+const int CounterMovePruneThreshold = 0;
+
 } // namespace Search
 
 #endif // #ifndef SEARCH_H_INCLUDED

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -127,6 +127,27 @@ void ThreadPool::set(size_t requested) {
 
   while (size() > requested)
       delete back(), pop_back();
+
+  if (requested>0)
+      clear();
+}
+
+void ThreadPool::clear() {
+
+  for (Thread* th : *this)
+  {
+      th->counterMoves.fill(MOVE_NONE);
+      th->mainHistory.fill(0);
+
+      for (auto& to : th->contHistory)
+          for (auto& h : to)
+              h.fill(0);
+
+      th->contHistory[NO_PIECE][0].fill(Search::CounterMovePruneThreshold - 1);
+  }
+
+  main()->callsCnt = 0;
+  main()->previousScore = VALUE_INFINITE;
 }
 
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -96,6 +96,7 @@ struct ThreadPool : public std::vector<Thread*> {
 
   void init(size_t); // No constructor and destructor, threads rely on globals that should
   void exit();       // be initialized and valid during the whole thread lifetime.
+  void clear();
   void start_thinking(Position&, StateListPtr&, const Search::LimitsType&, bool = false);
   void set(size_t);
 


### PR DESCRIPTION
after increasing the number of threads, the histories were not cleared, resulting in uninitialized memory usage.

This patch fixes this by splitting part of Search::clear() into a Threads::clear() function, which is now called also on thread resizing.
The simpler solution of just calling Search::clear() in Threads::set() would also clear the hash, which doesn't seem desirable.

No functional change.