### PR TITLE
Simplify mch - bench: 5417521

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -908,8 +908,7 @@ moves_loop: // When in check search starts from here
               }
 
               // Reduced depth of the next LMR search
-              int mch = std::max(1, moveCount - (ss-1)->moveCount / 16);
-              int lmrDepth = std::max(newDepth - reduction<PvNode>(improving, depth, mch), DEPTH_ZERO) / ONE_PLY;
+              int lmrDepth = std::max(newDepth - reduction<PvNode>(improving, depth, moveCount), DEPTH_ZERO) / ONE_PLY;
 
               // Countermoves based pruning
               if (   lmrDepth < 3


### PR DESCRIPTION
Adjust moveCount history only at LMR

STC:
LLR: 3.32 (-2.94,2.94) [-3.00,1.00]
Total: 17584 W: 3277 L: 3131 D: 11176

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 26412 W: 3447 L: 3334 D: 19631

Bench:  5417521