### PR TITLE
Fix a warning with MSVC

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -64,7 +64,7 @@ namespace {
     int time = int(std::min(1.0, ratio) * std::max(0, myTime - moveOverhead));
 
     if (type == OptimumTime && ponder)
-        time *= 1.25;
+        time = 5 * time / 4;
 
     return time;
   }


### PR DESCRIPTION
warning C4244: '*=': conversion from 'double' to 'int', possible loss of data

No functional change.