### PR TITLE
Multi-threaded search testing with valgrind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ script:
   #
   - export CXXFLAGS=-O1
   - if [ -x "$(command -v valgrind )" ]; then make clean && make -j2 ARCH=x86-64 debug=yes optimize=no build > /dev/null && ../tests/instrumented.sh --valgrind; fi
+  - if [ -x "$(command -v valgrind )" ]; then ../tests/instrumented.sh --valgrind-thread; fi
   #
   # Sanitizer
   #

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -75,9 +75,6 @@ namespace {
   int FutilityMoveCounts[2][16]; // [improving][depth]
   int Reductions[2][2][64][64];  // [pv][improving][depth][moveNumber]
 
-  // Threshold used for countermoves based pruning
-  const int CounterMovePruneThreshold = 0;
-
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {
     return Reductions[PvNode][i][std::min(d / ONE_PLY, 63)][std::min(mn, 63)] * ONE_PLY;
   }
@@ -219,16 +216,7 @@ void Search::clear() {
   TT.clear();
 
   for (Thread* th : Threads)
-  {
-      th->counterMoves.fill(MOVE_NONE);
-      th->mainHistory.fill(0);
-
-      for (auto& to : th->contHistory)
-          for (auto& h : to)
-              h.fill(0);
-
-      th->contHistory[NO_PIECE][0].fill(CounterMovePruneThreshold - 1);
-  }
+      th->clear();
 
   Threads.main()->callsCnt = 0;
   Threads.main()->previousScore = VALUE_INFINITE;

--- a/src/search.h
+++ b/src/search.h
@@ -31,6 +31,10 @@ class Position;
 
 namespace Search {
 
+/// Threshold used for countermoves based pruning
+const int CounterMovePruneThreshold = 0;
+
+
 /// Stack struct keeps track of the information we need to remember from nodes
 /// shallower and deeper in the tree during the search. Each search thread has
 /// its own array of Stack objects, indexed by the current ply.

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -35,6 +35,7 @@ ThreadPool Threads; // Global object
 Thread::Thread(size_t n) : idx(n), stdThread(&Thread::idle_loop, this) {
 
   wait_for_search_finished();
+  clear();
 }
 
 
@@ -50,6 +51,17 @@ Thread::~Thread() {
   stdThread.join();
 }
 
+void Thread::clear() {
+
+  counterMoves.fill(MOVE_NONE);
+  mainHistory.fill(0);
+
+  for (auto& to : contHistory)
+      for (auto& h : to)
+          h.fill(0);
+
+  contHistory[NO_PIECE][0].fill(Search::CounterMovePruneThreshold - 1);
+}
 
 /// Thread::start_searching() wakes up the thread that will start the search
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -52,6 +52,7 @@ public:
   explicit Thread(size_t);
   virtual ~Thread();
   virtual void search();
+  void clear();
   void idle_loop();
   void start_searching();
   void wait_for_search_finished();

--- a/tests/instrumented.sh
+++ b/tests/instrumented.sh
@@ -17,15 +17,22 @@ case $1 in
     postfix='1>/dev/null'
     threads="1"
   ;;
+  --valgrind-thread)
+    echo "valgrind-thread testing started"
+    prefix=''
+    exeprefix='valgrind --error-exitcode=42'
+    postfix='1>/dev/null'
+    threads="2"
+  ;;
   --sanitizer-undefined)
-    echo "sanitizer testing started"
+    echo "sanitizer-undefined testing started"
     prefix='!'
     exeprefix=''
     postfix='2>&1 | grep "runtime error:"'
     threads="1"
   ;;
   --sanitizer-thread)
-    echo "sanitizer testing started"
+    echo "sanitizer-thread testing started"
     prefix='!'
     exeprefix=''
     postfix='2>&1 | grep "WARNING: ThreadSanitizer:"'


### PR DESCRIPTION
Also check with valgrind the multi-threaded search.
    
On top of the fix for issue #1227 (PR #1235).
    
No functional change.
