### PR TITLE
Travis CI: Make all warnings into errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,11 @@ script:
   - echo "Reference bench:" $benchref
   #
   # Verify bench number against various builds
-  - make clean && make -j2 ARCH=x86-64 optimize=no debug=yes build > /dev/null && ../tests/signature.sh $benchref
-  - make clean && make -j2 ARCH=x86-32 optimize=no debug=yes build > /dev/null && ../tests/signature.sh $benchref
-  - make clean && make -j2 ARCH=x86-32 build > /dev/null && ../tests/signature.sh $benchref
-  - make clean && make -j2 ARCH=x86-64 build > /dev/null && ../tests/signature.sh $benchref
+  - export CXXFLAGS=-Werror
+  - make clean && make -j2 ARCH=x86-64 optimize=no debug=yes build && ../tests/signature.sh $benchref
+  - make clean && make -j2 ARCH=x86-32 optimize=no debug=yes build && ../tests/signature.sh $benchref
+  - make clean && make -j2 ARCH=x86-32 build && ../tests/signature.sh $benchref
+  - make clean && make -j2 ARCH=x86-64 build && ../tests/signature.sh $benchref
   #
   # Check perft and reproducible search
   - ../tests/perft.sh


### PR DESCRIPTION
Compile with -Werror flag. To make debugging easier
also show compile ourput.

This flag is enabled only in Travis CI, not in the shipped
Makefile because we can't test on every possible platform.