### PR TITLE
Small simplication of see_ge()

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1004,13 +1004,9 @@ bool Position::see_ge(Move m, Value threshold) const {
   Bitboard occupied, stmAttackers;
 
   balance = PieceValue[MG][piece_on(to)];
-  occupied = 0;
 
   if (balance < threshold)
       return false;
-
-  if (nextVictim == KING)
-      return true;
 
   balance -= PieceValue[MG][nextVictim];
 
@@ -1018,7 +1014,7 @@ bool Position::see_ge(Move m, Value threshold) const {
       return true;
 
   bool relativeStm = true; // True if the opponent is to move
-  occupied ^= pieces() ^ from ^ to;
+  occupied = pieces() ^ from ^ to;
 
   // Find all attackers to the destination square, with the moving piece removed,
   // but possibly an X-ray attacker added behind it.

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -23,8 +23,8 @@
 #include "types.h"
 
 Value PieceValue[PHASE_NB][PIECE_NB] = {
-  { VALUE_ZERO, PawnValueMg, KnightValueMg, BishopValueMg, RookValueMg, QueenValueMg },
-  { VALUE_ZERO, PawnValueEg, KnightValueEg, BishopValueEg, RookValueEg, QueenValueEg }
+  { VALUE_ZERO, PawnValueMg, KnightValueMg, BishopValueMg, RookValueMg, QueenValueMg, VALUE_ZERO },
+  { VALUE_ZERO, PawnValueEg, KnightValueEg, BishopValueEg, RookValueEg, QueenValueEg, VALUE_ZERO }
 };
 
 namespace PSQT {


### PR DESCRIPTION
Two simplifications:
- Remove the initialisation to 0 of occupied, which is now unnecessary.
- Remove the initial check for nextVictim == KING. If nextVictim == KING, then PieceValue[MG][nextVictim] will be 0, so that balance >= threshold is true. So see_ge() returns true anyway. To make this a bit more explicit, I have added corresponding initialisers to the PieceValue[][] array in psqt.c. (Interestingly, PSQT::init() already loops from W_PAWN to W_KING, so including the VALUE_ZERO values for W_KING seems to make sense for that reason alone.)

I don't think the later test in see_ge() for nextVictim == KING can be removed so easily, but I did not investigate thoroughly.

Running this on fishtest seem unnecessary, but let me know.

No functional change.