### PR TITLE
mch only at quiet moves - Bench:  6351176

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -953,11 +953,6 @@ moves_loop: // When in check search starts from here
               r -= r ? ONE_PLY : DEPTH_ZERO;
           else
           {
-                    
-              // Decrease reduction if opponent's move count is high
-              if ((ss-1)->moveCount > 15)
-                  r -= ONE_PLY;
-          
               // Increase reduction if ttMove is a capture
               if (ttCapture)
                   r += ONE_PLY;
@@ -965,13 +960,21 @@ moves_loop: // When in check search starts from here
               // Increase reduction for cut nodes
               if (cutNode)
                   r += 2 * ONE_PLY;
+			  else
+			  {
 
-              // Decrease reduction for moves that escape a capture. Filter out
-              // castling moves, because they are coded as "king captures rook" and
-              // hence break make_move().
-              else if (    type_of(move) == NORMAL
-                       && !pos.see_ge(make_move(to_sq(move), from_sq(move))))
-                  r -= 2 * ONE_PLY;
+				  // Decrease reduction if opponent's move count is high
+				  if ((ss - 1)->moveCount > 15 && !cutNode)
+					  r -= ONE_PLY;
+
+				  // Decrease reduction for moves that escape a capture. Filter out
+				  // castling moves, because they are coded as "king captures rook" and
+				  // hence break make_move().
+				  if (type_of(move) == NORMAL
+					  && !pos.see_ge(make_move(to_sq(move), from_sq(move))))
+					  r -= 2 * ONE_PLY;
+
+			  }
 
               ss->statScore =  thisThread->mainHistory[~pos.side_to_move()][from_to(move)]
                              + (*contHist[0])[movedPiece][to_sq(move)]

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -953,6 +953,11 @@ moves_loop: // When in check search starts from here
               r -= r ? ONE_PLY : DEPTH_ZERO;
           else
           {
+
+              // Decrease reduction if opponent's move count is high
+              if ((ss-1)->moveCount > 15)
+                  r -= ONE_PLY;
+
               // Increase reduction if ttMove is a capture
               if (ttCapture)
                   r += ONE_PLY;
@@ -960,21 +965,13 @@ moves_loop: // When in check search starts from here
               // Increase reduction for cut nodes
               if (cutNode)
                   r += 2 * ONE_PLY;
-			  else
-			  {
 
-				  // Decrease reduction if opponent's move count is high
-				  if ((ss - 1)->moveCount > 15 && !cutNode)
-					  r -= ONE_PLY;
-
-				  // Decrease reduction for moves that escape a capture. Filter out
-				  // castling moves, because they are coded as "king captures rook" and
-				  // hence break make_move().
-				  if (type_of(move) == NORMAL
-					  && !pos.see_ge(make_move(to_sq(move), from_sq(move))))
-					  r -= 2 * ONE_PLY;
-
-			  }
+              // Decrease reduction for moves that escape a capture. Filter out
+              // castling moves, because they are coded as "king captures rook" and
+              // hence break make_move().
+              else if (    type_of(move) == NORMAL
+                       && !pos.see_ge(make_move(to_sq(move), from_sq(move))))
+                  r -= 2 * ONE_PLY;
 
               ss->statScore =  thisThread->mainHistory[~pos.side_to_move()][from_to(move)]
                              + (*contHist[0])[movedPiece][to_sq(move)]

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -947,13 +947,17 @@ moves_loop: // When in check search starts from here
           &&  moveCount > 1
           && (!captureOrPromotion || moveCountPruning))
       {
-          int mch = std::max(1, moveCount - (ss-1)->moveCount / 16);
-          Depth r = reduction<PvNode>(improving, depth, mch);
+          Depth r = reduction<PvNode>(improving, depth, moveCount);
 
           if (captureOrPromotion)
               r -= r ? ONE_PLY : DEPTH_ZERO;
           else
           {
+                    
+              // Decrease reduction if opponent's move count is high
+              if ((ss-1)->moveCount > 15)
+                  r -= ONE_PLY;
+          
               // Increase reduction if ttMove is a capture
               if (ttCapture)
                   r += ONE_PLY;


### PR DESCRIPTION
MoveCount History only at quiet moves and simply reduce reduction by one depth instead of increasing moveCount in formula

STC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 27511 W: 5171 L: 4919 D: 17421

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 92337 W: 12135 L: 11748 D: 68454

Bench:  6351176