### PR TITLE
Natural TB

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1527,9 +1527,8 @@ moves_loop: // When in check search starts from here
             tbHit = true;
             wdl = TB::dtz_to_wdl(rm.dtz, rm.r50);
 
-            // Search at full depth only moves that preserve the score and if
-            // is a non-resetting move then should be among the shortests.
-            reduceDepth = !TB::is_shortest(rm);
+            // Search at reduced depth moves that don't preserve the score
+            reduceDepth = -wdl < TB::RootWDL;
         }
     }
     else

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1520,7 +1520,7 @@ moves_loop: // When in check search starts from here
         tbHit = true;
         RootMove& rm = *std::find(thisThread->rootMoves.begin(), thisThread->rootMoves.end(),
                                   (ss-1)->currentMove);
-        wdl = TB::dtz_to_wdl(rm.dtz, pos.rule50_count());
+        wdl = TB::dtz_to_wdl(rm.dtz, thisThread->rootPos.rule50_count());
 
         // Search at reduced depth moves that don't preserve the score
         reduceDepth = -wdl < TB::RootWDL;

--- a/src/search.h
+++ b/src/search.h
@@ -70,8 +70,7 @@ struct RootMove {
   Value score = -VALUE_INFINITE;
   Value previousScore = -VALUE_INFINITE;
   int selDepth = 0;
-  int dtz = 0;
-  int r50 = 0;
+  int dtz;
   std::vector<Move> pv;
 };
 

--- a/src/search.h
+++ b/src/search.h
@@ -70,7 +70,7 @@ struct RootMove {
   Value score = -VALUE_INFINITE;
   Value previousScore = -VALUE_INFINITE;
   int selDepth = 0;
-  int isDTZBest = false;
+  int dtz = 0;
   std::vector<Move> pv;
 };
 

--- a/src/search.h
+++ b/src/search.h
@@ -71,6 +71,7 @@ struct RootMove {
   Value previousScore = -VALUE_INFINITE;
   int selDepth = 0;
   int dtz = 0;
+  int r50 = 0;
   std::vector<Move> pv;
 };
 

--- a/src/search.h
+++ b/src/search.h
@@ -70,6 +70,7 @@ struct RootMove {
   Value score = -VALUE_INFINITE;
   Value previousScore = -VALUE_INFINITE;
   int selDepth = 0;
+  int isDTZBest = false;
   std::vector<Move> pv;
 };
 

--- a/src/search.h
+++ b/src/search.h
@@ -49,6 +49,7 @@ struct Stack {
   Value staticEval;
   int statScore;
   int moveCount;
+  int tbCardinality;
 };
 
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1515,9 +1515,10 @@ void Tablebases::dtz_score(Position& pos, Search::RootMoves& rootMoves) {
       || rootMoves.empty())
       return;
 
+  // Return value of probe_dtz() can be off by 1, so use search_dtz() for RootPosDTZ
   int dtz = Tablebases::probe_dtz(pos, &result);
   if (result != FAIL)
-      search_dtz(pos, &result, dtz_to_wdl(dtz, pos.rule50_count()), &rootMoves);
+      dtz = search_dtz(pos, &result, dtz_to_wdl(dtz, pos.rule50_count()), &rootMoves);
 
   if (result != FAIL)
       RootPosDTZ = dtz;

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -29,6 +29,7 @@
 #include <type_traits>
 
 #include "../bitboard.h"
+#include "../misc.h"
 #include "../movegen.h"
 #include "../position.h"
 #include "../search.h"
@@ -203,6 +204,9 @@ int MapPawns[SQUARE_NB];
 int MapB1H1H7[SQUARE_NB];
 int MapA1D1D4[SQUARE_NB];
 int MapKK[10][SQUARE_NB]; // [MapA1D1D4][SQUARE_NB]
+
+typedef std::pair<Key, std::pair<int, ProbeState>> CacheEntry;
+HashTable<CacheEntry, 32768> DTZCache;
 
 // Comparison function to sort leading pawns in ascending MapPawns[] order
 bool pawns_comp(Square i, Square j) { return MapPawns[i] < MapPawns[j]; }
@@ -1436,24 +1440,35 @@ WDLScore Tablebases::probe_wdl(Position& pos, ProbeState* result) {
 // then do not accept moves leading to dtz + 50-move-counter == 100.
 int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
 
+    Key key = pos.key();
+    CacheEntry* e = DTZCache[key];
+    auto& p = e->second;
+
+    if (e->first == key)
+        return *result = p.second, p.first;
+
+    e->first = key;
+
     *result = OK;
     WDLScore wdl = search<true>(pos, result);
+    p.second = *result;
 
     if (*result == FAIL || wdl == WDLDraw) // DTZ tables don't store draws
-        return 0;
+        return p.first = 0;
 
     // DTZ stores a 'don't care' value in this case, or even a plain wrong
     // one as in case the best move is a losing ep, so it cannot be probed.
     if (*result == ZEROING_BEST_MOVE)
-        return dtz_before_zeroing(wdl);
+        return p.first = dtz_before_zeroing(wdl);
 
     int dtz = probe_table<DTZEntry>(pos, result, wdl);
+    p.second = *result;
 
     if (*result == FAIL)
-        return 0;
+        return p.first = 0;
 
     if (*result != CHANGE_STM)
-        return (dtz + 100 * (wdl == WDLBlessedLoss || wdl == WDLCursedWin)) * sign_of(wdl);
+        return p.first = (dtz + 100 * (wdl == WDLBlessedLoss || wdl == WDLCursedWin)) * sign_of(wdl);
 
     // DTZ stores results for the other side, so we need to do a 1-ply search and
     // find the winning move that minimizes DTZ.
@@ -1472,11 +1487,11 @@ int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
         // winning position we could make a losing capture or going for a draw).
         dtz = zeroing ? -dtz_before_zeroing(search(pos, result))
                       : -probe_dtz(pos, result);
-
+        p.second = *result;
         pos.undo_move(move);
 
         if (*result == FAIL)
-            return 0;
+            return p.first = 0;
 
         // Convert result from 1-ply search. Zeroing moves are already accounted
         // by dtz_before_zeroing() that returns the DTZ of the previous move.
@@ -1491,212 +1506,5 @@ int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
     // Special handle a mate position, when there are no legal moves, in this
     // case return value is somewhat arbitrary, so stick to the original TB code
     // that returns -1 in this case.
-    return minDTZ == 0xFFFF ? -1 : minDTZ;
-}
-
-// Check whether there has been at least one repetition of positions
-// since the last capture or pawn move.
-static int has_repeated(StateInfo *st)
-{
-    while (1) {
-        int i = 4, e = std::min(st->rule50, st->pliesFromNull);
-
-        if (e < i)
-            return 0;
-
-        StateInfo *stp = st->previous->previous;
-
-        do {
-            stp = stp->previous->previous;
-
-            if (stp->key == st->key)
-                return 1;
-
-            i += 2;
-        } while (i <= e);
-
-        st = st->previous;
-    }
-}
-
-// Use the DTZ tables to filter out moves that don't preserve the win or draw.
-// If the position is lost, but DTZ is fairly high, only keep moves that
-// maximise DTZ.
-//
-// A return value false indicates that not all probes were successful and that
-// no moves were filtered out.
-bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves, Value& score)
-{
-    assert(rootMoves.size());
-
-    ProbeState result;
-    int dtz = probe_dtz(pos, &result);
-
-    if (result == FAIL)
-        return false;
-
-    StateInfo st;
-
-    // Probe each move
-    for (size_t i = 0; i < rootMoves.size(); ++i) {
-        Move move = rootMoves[i].pv[0];
-        pos.do_move(move, st);
-        int v = 0;
-
-        if (pos.checkers() && dtz > 0) {
-            ExtMove s[MAX_MOVES];
-
-            if (generate<LEGAL>(pos, s) == s)
-                v = 1;
-        }
-
-        if (!v) {
-            if (st.rule50 != 0) {
-                v = -probe_dtz(pos, &result);
-
-                if (v > 0)
-                    ++v;
-                else if (v < 0)
-                    --v;
-            } else {
-                v = -probe_wdl(pos, &result);
-                v = dtz_before_zeroing(WDLScore(v));
-            }
-        }
-
-        pos.undo_move(move);
-
-        if (result == FAIL)
-            return false;
-
-        rootMoves[i].score = (Value)v;
-    }
-
-    // Obtain 50-move counter for the root position.
-    // In Stockfish there seems to be no clean way, so we do it like this:
-    int cnt50 = st.previous ? st.previous->rule50 : 0;
-
-    // Use 50-move counter to determine whether the root position is
-    // won, lost or drawn.
-    WDLScore wdl = WDLDraw;
-
-    if (dtz > 0)
-        wdl = (dtz + cnt50 <= 100) ? WDLWin : WDLCursedWin;
-    else if (dtz < 0)
-        wdl = (-dtz + cnt50 <= 100) ? WDLLoss : WDLBlessedLoss;
-
-    // Determine the score to report to the user.
-    score = WDL_to_value[wdl + 2];
-
-    // If the position is winning or losing, but too few moves left, adjust the
-    // score to show how close it is to winning or losing.
-    // NOTE: int(PawnValueEg) is used as scaling factor in score_to_uci().
-    if (wdl == WDLCursedWin && dtz <= 100)
-        score = (Value)(((200 - dtz - cnt50) * int(PawnValueEg)) / 200);
-    else if (wdl == WDLBlessedLoss && dtz >= -100)
-        score = -(Value)(((200 + dtz - cnt50) * int(PawnValueEg)) / 200);
-
-    // Now be a bit smart about filtering out moves.
-    size_t j = 0;
-
-    if (dtz > 0) { // winning (or 50-move rule draw)
-        int best = 0xffff;
-
-        for (size_t i = 0; i < rootMoves.size(); ++i) {
-            int v = rootMoves[i].score;
-
-            if (v > 0 && v < best)
-                best = v;
-        }
-
-        int max = best;
-
-        // If the current phase has not seen repetitions, then try all moves
-        // that stay safely within the 50-move budget, if there are any.
-        if (!has_repeated(st.previous) && best + cnt50 <= 99)
-            max = 99 - cnt50;
-
-        for (size_t i = 0; i < rootMoves.size(); ++i) {
-            int v = rootMoves[i].score;
-
-            if (v > 0 && v <= max)
-                rootMoves[j++] = rootMoves[i];
-        }
-    } else if (dtz < 0) { // losing (or 50-move rule draw)
-        int best = 0;
-
-        for (size_t i = 0; i < rootMoves.size(); ++i) {
-            int v = rootMoves[i].score;
-
-            if (v < best)
-                best = v;
-        }
-
-        // Try all moves, unless we approach or have a 50-move rule draw.
-        if (-best * 2 + cnt50 < 100)
-            return true;
-
-        for (size_t i = 0; i < rootMoves.size(); ++i) {
-            if (rootMoves[i].score == best)
-                rootMoves[j++] = rootMoves[i];
-        }
-    } else { // drawing
-        // Try all moves that preserve the draw.
-        for (size_t i = 0; i < rootMoves.size(); ++i) {
-            if (rootMoves[i].score == 0)
-                rootMoves[j++] = rootMoves[i];
-        }
-    }
-
-    rootMoves.resize(j, Search::RootMove(MOVE_NONE));
-
-    return true;
-}
-
-// Use the WDL tables to filter out moves that don't preserve the win or draw.
-// This is a fallback for the case that some or all DTZ tables are missing.
-//
-// A return value false indicates that not all probes were successful and that
-// no moves were filtered out.
-bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, Value& score)
-{
-    ProbeState result;
-
-    WDLScore wdl = Tablebases::probe_wdl(pos, &result);
-
-    if (result == FAIL)
-        return false;
-
-    score = WDL_to_value[wdl + 2];
-
-    StateInfo st;
-
-    int best = WDLLoss;
-
-    // Probe each move
-    for (size_t i = 0; i < rootMoves.size(); ++i) {
-        Move move = rootMoves[i].pv[0];
-        pos.do_move(move, st);
-        WDLScore v = -Tablebases::probe_wdl(pos, &result);
-        pos.undo_move(move);
-
-        if (result == FAIL)
-            return false;
-
-        rootMoves[i].score = (Value)v;
-
-        if (v > best)
-            best = v;
-    }
-
-    size_t j = 0;
-
-    for (size_t i = 0; i < rootMoves.size(); ++i) {
-        if (rootMoves[i].score == best)
-            rootMoves[j++] = rootMoves[i];
-    }
-
-    rootMoves.resize(j, Search::RootMove(MOVE_NONE));
-
-    return true;
+    return p.first = (minDTZ == 0xFFFF ? -1 : minDTZ);
 }

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -29,7 +29,6 @@
 #include <type_traits>
 
 #include "../bitboard.h"
-#include "../misc.h"
 #include "../movegen.h"
 #include "../position.h"
 #include "../search.h"
@@ -204,9 +203,6 @@ int MapPawns[SQUARE_NB];
 int MapB1H1H7[SQUARE_NB];
 int MapA1D1D4[SQUARE_NB];
 int MapKK[10][SQUARE_NB]; // [MapA1D1D4][SQUARE_NB]
-
-typedef std::pair<Key, std::pair<int, ProbeState>> CacheEntry;
-HashTable<CacheEntry, 32768> DTZCache;
 
 // Comparison function to sort leading pawns in ascending MapPawns[] order
 bool pawns_comp(Square i, Square j) { return MapPawns[i] < MapPawns[j]; }
@@ -1440,35 +1436,24 @@ WDLScore Tablebases::probe_wdl(Position& pos, ProbeState* result) {
 // then do not accept moves leading to dtz + 50-move-counter == 100.
 int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
 
-    Key key = pos.key();
-    CacheEntry* e = DTZCache[key];
-    auto& p = e->second;
-
-    if (e->first == key)
-        return *result = p.second, p.first;
-
-    e->first = key;
-
     *result = OK;
     WDLScore wdl = search<true>(pos, result);
-    p.second = *result;
 
     if (*result == FAIL || wdl == WDLDraw) // DTZ tables don't store draws
-        return p.first = 0;
+        return 0;
 
     // DTZ stores a 'don't care' value in this case, or even a plain wrong
     // one as in case the best move is a losing ep, so it cannot be probed.
     if (*result == ZEROING_BEST_MOVE)
-        return p.first = dtz_before_zeroing(wdl);
+        return dtz_before_zeroing(wdl);
 
     int dtz = probe_table<DTZEntry>(pos, result, wdl);
-    p.second = *result;
 
     if (*result == FAIL)
-        return p.first = 0;
+        return 0;
 
     if (*result != CHANGE_STM)
-        return p.first = (dtz + 100 * (wdl == WDLBlessedLoss || wdl == WDLCursedWin)) * sign_of(wdl);
+        return (dtz + 100 * (wdl == WDLBlessedLoss || wdl == WDLCursedWin)) * sign_of(wdl);
 
     // DTZ stores results for the other side, so we need to do a 1-ply search and
     // find the winning move that minimizes DTZ.
@@ -1487,11 +1472,11 @@ int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
         // winning position we could make a losing capture or going for a draw).
         dtz = zeroing ? -dtz_before_zeroing(search(pos, result))
                       : -probe_dtz(pos, result);
-        p.second = *result;
+
         pos.undo_move(move);
 
         if (*result == FAIL)
-            return p.first = 0;
+            return 0;
 
         // Convert result from 1-ply search. Zeroing moves are already accounted
         // by dtz_before_zeroing() that returns the DTZ of the previous move.
@@ -1506,5 +1491,31 @@ int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
     // Special handle a mate position, when there are no legal moves, in this
     // case return value is somewhat arbitrary, so stick to the original TB code
     // that returns -1 in this case.
-    return p.first = (minDTZ == 0xFFFF ? -1 : minDTZ);
+    return minDTZ == 0xFFFF ? -1 : minDTZ;
 }
+
+
+// DTZ probe each root move and store the score
+void Tablebases::dtz_score(Position& pos, Search::RootMoves& rootMoves) {
+
+  StateInfo st;
+  ProbeState err;
+  RootPosDTZ = DTZ_NONE;
+
+  if (   pos.count<ALL_PIECES>() > MaxCardinality
+      || pos.can_castle(ANY_CASTLING)
+      || rootMoves.empty())
+      return;
+
+  int dtz = Tablebases::probe_dtz(pos, &err);
+  RootPosDTZ = err != ProbeState::FAIL ? dtz : DTZ_NONE;
+
+  for (Search::RootMove& rm : rootMoves)
+  {
+      pos.do_move(rm.pv[0], st);
+      dtz = Tablebases::probe_dtz(pos, &err);
+      rm.dtz = err != ProbeState::FAIL ? dtz : DTZ_NONE;
+      pos.undo_move(rm.pv[0]);
+  }
+}
+

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -49,9 +49,6 @@ extern int MaxCardinality;
 void init(const std::string& paths);
 WDLScore probe_wdl(Position& pos, ProbeState* result);
 int probe_dtz(Position& pos, ProbeState* result);
-bool root_probe(Position& pos, Search::RootMoves& rootMoves, Value& score);
-bool root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, Value& score);
-void filter_root_moves(Position& pos, Search::RootMoves& rootMoves);
 
 inline std::ostream& operator<<(std::ostream& os, const WDLScore v) {
 

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -48,12 +48,15 @@ enum ProbeState {
 
 extern int MaxCardinality;
 extern int RootPosDTZ;
+extern WDLScore RootWDL;
+extern bool CanProbeDTZ;
 
 void init(const std::string& paths);
 WDLScore probe_wdl(Position& pos, ProbeState* result);
 int probe_dtz(Position& pos, ProbeState* result);
 void dtz_score(Position& pos, Search::RootMoves& rootMoves);
 bool is_shortest(const Search::RootMove& rm);
+WDLScore dtz_to_wdl(int dtz, int r50);
 
 inline std::ostream& operator<<(std::ostream& os, const WDLScore v) {
 

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -26,6 +26,8 @@
 
 namespace Tablebases {
 
+const int DTZ_NONE = 999;
+
 enum WDLScore {
     WDLLoss        = -2, // Loss
     WDLBlessedLoss = -1, // Loss, but draw under 50-move rule
@@ -45,10 +47,25 @@ enum ProbeState {
 };
 
 extern int MaxCardinality;
+extern int RootPosDTZ;
 
 void init(const std::string& paths);
 WDLScore probe_wdl(Position& pos, ProbeState* result);
 int probe_dtz(Position& pos, ProbeState* result);
+void dtz_score(Position& pos, Search::RootMoves& rootMoves);
+
+inline bool is_optimal(int dtz) {
+
+  assert(RootPosDTZ != DTZ_NONE);
+
+  if (dtz == DTZ_NONE)
+      return false;
+
+  return   (RootPosDTZ >  1 && dtz < 0 && -dtz < RootPosDTZ)
+        || (RootPosDTZ < -1 && dtz > 0 && -dtz > RootPosDTZ)
+        || (RootPosDTZ == 0 && dtz == 0)
+        || (abs(RootPosDTZ) == 1 && RootPosDTZ * dtz < 0);
+}
 
 inline std::ostream& operator<<(std::ostream& os, const WDLScore v) {
 

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -55,7 +55,6 @@ void init(const std::string& paths);
 WDLScore probe_wdl(Position& pos, ProbeState* result);
 int probe_dtz(Position& pos, ProbeState* result);
 void dtz_score(Position& pos, Search::RootMoves& rootMoves);
-bool is_shortest(const Search::RootMove& rm);
 WDLScore dtz_to_wdl(int dtz, int r50);
 
 inline std::ostream& operator<<(std::ostream& os, const WDLScore v) {

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -53,19 +53,7 @@ void init(const std::string& paths);
 WDLScore probe_wdl(Position& pos, ProbeState* result);
 int probe_dtz(Position& pos, ProbeState* result);
 void dtz_score(Position& pos, Search::RootMoves& rootMoves);
-
-inline bool is_optimal(int dtz) {
-
-  assert(RootPosDTZ != DTZ_NONE);
-
-  if (dtz == DTZ_NONE)
-      return false;
-
-  return   (RootPosDTZ >  1 && dtz < 0 && -dtz < RootPosDTZ)
-        || (RootPosDTZ < -1 && dtz > 0 && -dtz > RootPosDTZ)
-        || (RootPosDTZ == 0 && dtz == 0)
-        || (abs(RootPosDTZ) == 1 && RootPosDTZ * dtz < 0);
-}
+bool is_shortest(const Search::RootMove& rm);
 
 inline std::ostream& operator<<(std::ostream& os, const WDLScore v) {
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -163,9 +163,6 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
           || std::count(limits.searchmoves.begin(), limits.searchmoves.end(), m))
           rootMoves.emplace_back(m);
 
-  if (!rootMoves.empty())
-      Tablebases::filter_root_moves(pos, rootMoves);
-
   // After ownership transfer 'states' becomes empty, so if we stop the search
   // and call 'go' again without setting a new position states.get() == NULL.
   assert(states.get() || setupStates.get());

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -163,6 +163,8 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
           || std::count(limits.searchmoves.begin(), limits.searchmoves.end(), m))
           rootMoves.emplace_back(m);
 
+  Tablebases::dtz_score(pos, rootMoves);
+
   // After ownership transfer 'states' becomes empty, so if we stop the search
   // and call 'go' again without setting a new position states.get() == NULL.
   assert(states.get() || setupStates.get());

--- a/src/types.h
+++ b/src/types.h
@@ -180,8 +180,8 @@ enum Value : int {
   VALUE_INFINITE  = 32001,
   VALUE_NONE      = 32002,
 
-  VALUE_MATE_IN_MAX_PLY  =  VALUE_MATE - 2 * MAX_PLY,
-  VALUE_MATED_IN_MAX_PLY = -VALUE_MATE + 2 * MAX_PLY,
+  VALUE_MATE_IN_MAX_PLY  =  VALUE_MATE - MAX_PLY,
+  VALUE_MATED_IN_MAX_PLY = -VALUE_MATE + MAX_PLY,
 
   PawnValueMg   = 171,   PawnValueEg   = 240,
   KnightValueMg = 764,   KnightValueEg = 848,

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -142,8 +142,8 @@ namespace {
 
   void bench(Position& pos, istream& args, StateListPtr& states) {
 
-    string token;
-    uint64_t num, nodes = 0, cnt = 1;
+    string token, tbh;
+    uint64_t num, nodes = 0, tbHits = 0, cnt = 1;
 
     vector<string> list = setup_bench(pos, args);
     num = count_if(list.begin(), list.end(), [](string s) { return s.find("go ") == 0; });
@@ -160,7 +160,8 @@ namespace {
             cerr << "\nPosition: " << cnt++ << '/' << num << endl;
             go(pos, is, states);
             Threads.main()->wait_for_search_finished();
-            nodes += Threads.nodes_searched();
+            nodes  += Threads.nodes_searched();
+            tbHits += Threads.tb_hits();
         }
         else if (token == "setoption")  setoption(is);
         else if (token == "position")   position(pos, is, states);
@@ -174,7 +175,8 @@ namespace {
     cerr << "\n==========================="
          << "\nTotal time (ms) : " << elapsed
          << "\nNodes searched  : " << nodes
-         << "\nNodes/second    : " << 1000 * nodes / elapsed << endl;
+         << "\nNodes/second    : " << 1000 * nodes / elapsed
+         << "\nTB hits         : " << tbHits << endl;
   }
 
 } // namespace


### PR DESCRIPTION
Rewrite TB probing code to ovecome the main traditional TB artifacts:

1. Don't hide forever mate line in a winning position

2. Don't stick to odd sacrifices to simplify in a TB position

This version mostly fixes the above 2 issues. In particular
it keeps searching even in a winning position so that sooner
or later a mate is found and reported to user. Moreover, although
in rare cases odd sacrifice moves could still be selected for a
temporary and transitory time, keeping searching the engine always
moves off form them.

In both cases these phenomenons are greatly reduced compared to
current version.

DTZ tables are used only when strictly needed: to differentiate, when
the root position is in TB, between a cursed win/blessed loss and an
actual win/loss. This applies only if rule50 is used and also in this
case the returned value is used to set as a draw a cursed/blessed result,
it is NOT used to alter search result.

The approach of this work is that a search result is never altered: TB
is used to detect a draw (clear or hidden behind a 50 moves rule) and
to steer the search toward winning path.

Not altering search result is the main reason why behaviour is different
from current version.

Efficeny is preserved in 2 ways:

- Always returning a draw score as soon as detected
- Always returning from a deep tree WDL win/loss score

Same bench as master, because bench does not use TB.