### PR TITLE
Slow Mover revert

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -30,7 +30,7 @@ namespace {
 
   enum TimeType { OptimumTime, MaxTime };
 
-  int remaining(int myTime, int myInc, int moveOverhead, int slowMover, int movesToGo,
+  int remaining(int myTime, int myInc, int moveOverhead, int movesToGo,
                 int moveNum, bool ponder, TimeType type) {
 
     if (myTime <= 0)
@@ -57,7 +57,7 @@ namespace {
     // Otherwise we increase usage of remaining time as the game goes on
     else
     {
-        double k = 1 + slowMover * moveNum / (500.0 + moveNum);
+        double k = 1 + 20 * moveNum / (500.0 + moveNum);
         ratio = (type == OptimumTime ? 0.017 : 0.07) * (k + inc / myTime);
     }
 
@@ -84,7 +84,6 @@ namespace {
 void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
 {
   int moveOverhead = Options["Move Overhead"];
-  int slowMover    = Options["Slow Mover"];
   int npmsec       = Options["nodestime"];
   bool ponder      = Options["Ponder"];
 
@@ -106,8 +105,8 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
   int moveNum = (ply + 1) / 2;
 
   startTime = limits.startTime;
-  optimumTime = remaining(limits.time[us], limits.inc[us], moveOverhead, slowMover
+  optimumTime = remaining(limits.time[us], limits.inc[us], moveOverhead,
                           limits.movestogo, moveNum, ponder, OptimumTime);
-  maximumTime = remaining(limits.time[us], limits.inc[us], moveOverhead, slowMover
+  maximumTime = remaining(limits.time[us], limits.inc[us], moveOverhead,
                           limits.movestogo, moveNum, ponder, MaxTime);
 }

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -57,7 +57,7 @@ namespace {
     // Otherwise we increase usage of remaining time as the game goes on
     else
     {
-        double k = 1 + 20 * moveNum / (500.0 + moveNum);
+        double k = 1 + 0.04 * std::min(50, moveNum);
         ratio = (type == OptimumTime ? 0.017 : 0.07) * (k + inc / myTime);
     }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -106,8 +106,8 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
   int moveNum = (ply + 1) / 2;
 
   startTime = limits.startTime;
-  optimumTime = remaining(limits.time[us], limits.inc[us], moveOverhead, slowMover,
+  optimumTime = remaining(limits.time[us], limits.inc[us], moveOverhead, slowMover
                           limits.movestogo, moveNum, ponder, OptimumTime);
-  maximumTime = remaining(limits.time[us], limits.inc[us], moveOverhead, slowMover,
+  maximumTime = remaining(limits.time[us], limits.inc[us], moveOverhead, slowMover
                           limits.movestogo, moveNum, ponder, MaxTime);
 }

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -106,8 +106,8 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
   int moveNum = (ply + 1) / 2;
 
   startTime = limits.startTime;
-  optimumTime = remaining(limits.time[us], limits.inc[us], moveOverhead, slowMover
+  optimumTime = remaining(limits.time[us], limits.inc[us], moveOverhead, slowMover,
                           limits.movestogo, moveNum, ponder, OptimumTime);
-  maximumTime = remaining(limits.time[us], limits.inc[us], moveOverhead, slowMover
+  maximumTime = remaining(limits.time[us], limits.inc[us], moveOverhead, slowMover,
                           limits.movestogo, moveNum, ponder, MaxTime);
 }

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -30,7 +30,7 @@ namespace {
 
   enum TimeType { OptimumTime, MaxTime };
 
-  int remaining(int myTime, int myInc, int moveOverhead, int movesToGo,
+  int remaining(int myTime, int myInc, int moveOverhead, int slowMover, int movesToGo,
                 int moveNum, bool ponder, TimeType type) {
 
     if (myTime <= 0)
@@ -57,7 +57,7 @@ namespace {
     // Otherwise we increase usage of remaining time as the game goes on
     else
     {
-        double k = 1 + 20 * moveNum / (500.0 + moveNum);
+        double k = 1 + slowMover * moveNum / (500.0 + moveNum);
         ratio = (type == OptimumTime ? 0.017 : 0.07) * (k + inc / myTime);
     }
 
@@ -84,6 +84,7 @@ namespace {
 void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
 {
   int moveOverhead = Options["Move Overhead"];
+  int slowMover    = Options["Slow Mover"];
   int npmsec       = Options["nodestime"];
   bool ponder      = Options["Ponder"];
 
@@ -105,8 +106,8 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
   int moveNum = (ply + 1) / 2;
 
   startTime = limits.startTime;
-  optimumTime = remaining(limits.time[us], limits.inc[us], moveOverhead,
+  optimumTime = remaining(limits.time[us], limits.inc[us], moveOverhead, slowMover
                           limits.movestogo, moveNum, ponder, OptimumTime);
-  maximumTime = remaining(limits.time[us], limits.inc[us], moveOverhead,
+  maximumTime = remaining(limits.time[us], limits.inc[us], moveOverhead, slowMover
                           limits.movestogo, moveNum, ponder, MaxTime);
 }

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -66,7 +66,6 @@ void init(OptionsMap& o) {
   o["MultiPV"]               << Option(1, 1, 500);
   o["Skill Level"]           << Option(20, 0, 20);
   o["Move Overhead"]         << Option(100, 0, 5000);
-  o["Slow Mover"]            << Option(20, 0, 30);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -66,6 +66,7 @@ void init(OptionsMap& o) {
   o["MultiPV"]               << Option(1, 1, 500);
   o["Skill Level"]           << Option(20, 0, 20);
   o["Move Overhead"]         << Option(100, 0, 5000);
+  o["Slow Mover"]            << Option(20, 0, 30);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);


### PR DESCRIPTION
People playing online chess games reported huge number of time losses in sudden death case.
It seems that games on longer time controls and without adjudications have higher average number of moves resulting in frequent occurence of time losses.

Reducing Slow Mover value below default (20) will result in moving more quickly both in sudden death case and when playing on increment, thus significantly reducing the possibility of losing on time. Elo loss is not expected on longer time controls with recommended parameters as below:

Move Overhead: 500 - 1000
Slow Mover: 10 - 15

This is a non-functional change, it only intoduces one UCI parameter.

Bench 5322108