### PR TITLE
Ronald's root ranking revisited

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -821,23 +821,12 @@ moves_loop: // When in check search starts from here
       if (move == excludedMove)
           continue;
 
-      if (rootNode) {
-          
-          RootMoves rm = thisThread->rootMoves;
-          auto it = std::find(rm.begin() + thisThread->PVIdx, rm.end(), move);
-          
-          // If the move was not found in the root move list then it was
-          // either illegal, already appeared in an earlier multiPV line
-          // or was absent from the UCI "searchmoves" command.
-          if (it == rm.end())
-              continue;
-
-          // When we have TB information at the root we only use search to
-          // differentiate between moves of the same rank. In the case of no
-          // TB information all ranks are identical and we search all moves.
-          if (it->TBRank != rm[thisThread->PVIdx].TBRank)
-              continue;
-      }
+      // At root obey the "searchmoves" option and skip moves not listed in Root
+      // Move List. As a consequence any illegal move is also skipped. In MultiPV
+      // mode we also skip PV moves which have been already searched.
+      if (rootNode && !std::count(thisThread->rootMoves.begin() + thisThread->PVIdx,
+                                  thisThread->rootMoves.end(), move))
+          continue;
 
       ss->moveCount = ++moveCount;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -812,6 +812,15 @@ moves_loop: // When in check search starts from here
     skipQuiets = false;
     ttCapture = false;
 
+    int bestTBRank, thisTBRank;
+
+    if (rootNode) {
+        bestTBRank = -1000;
+        RootMoves rm = thisThread->rootMoves;
+        for (auto it = rm.begin() + thisThread->PVIdx; it != rm.end(); it++)
+            bestTBRank = std::max(bestTBRank, it->TBRank);
+    }
+
     // Step 11. Loop through moves
     // Loop through all pseudo-legal moves until no moves remain or a beta cutoff occurs
     while ((move = mp.next_move(skipQuiets)) != MOVE_NONE)
@@ -821,12 +830,19 @@ moves_loop: // When in check search starts from here
       if (move == excludedMove)
           continue;
 
-      // At root obey the "searchmoves" option and skip moves not listed in Root
-      // Move List. As a consequence any illegal move is also skipped. In MultiPV
-      // mode we also skip PV moves which have been already searched.
-      if (rootNode && !std::count(thisThread->rootMoves.begin() + thisThread->PVIdx,
-                                  thisThread->rootMoves.end(), move))
-          continue;
+      if (rootNode) {
+          
+          RootMoves rm = thisThread->rootMoves;
+          auto it = std::find(rm.begin() + thisThread->PVIdx, rm.end(), move);
+          
+          // If the move was not found in the root move list then it was
+          // either illegal, already appeared in an earlier multiPV line
+          // or was absent from the UCI "searchmoves" command.
+          if (it == rm.end())
+              continue;
+
+          thisTBRank = it->TBRank;
+      }
 
       ss->moveCount = ++moveCount;
 
@@ -1059,7 +1075,11 @@ moves_loop: // When in check search starts from here
               rm.score = -VALUE_INFINITE;
       }
 
-      if (value > bestValue)
+      // At the root node only increase bestValue for mates or moves
+      // that have the best possible TBRank.
+      if (value > bestValue && (   !rootNode
+                                || abs(value) >= VALUE_MATE_IN_MAX_PLY
+                                || thisTBRank == bestTBRank))
       {
           bestValue = value;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -45,6 +45,7 @@ namespace Search {
 namespace Tablebases {
 
   int Cardinality;
+  bool RootInTB;
   bool UseRule50;
   Depth ProbeDepth;
 }
@@ -177,6 +178,21 @@ namespace {
 
 } // namespace
 
+
+bool RootMove::operator<(const RootMove& m) const {
+
+  bool heuristic_only =      abs(score) < VALUE_MATE_IN_MAX_PLY
+                        && abs(m.score) < VALUE_MATE_IN_MAX_PLY;
+  
+  return heuristic_only && m.TBRank != TBRank ? m.TBRank < TBRank :
+                           m.score  != score  ? m.score < score
+                                              : m.previousScore < previousScore;
+}
+
+bool tb_compare(const RootMove& a, const RootMove& b) {
+
+    return b.TBRank < a.TBRank;
+}
 
 /// Search::init() is called during startup to initialize various lookup tables
 
@@ -393,6 +409,12 @@ void Thread::search() {
           // high/low anymore.
           while (true)
           {
+              // If we have TB information then we avoid the scenario where
+              // all moves of highest TBRank fail low by using a simple stable
+              // sort to bring them to the front.
+              if (TB::RootInTB)
+                  std::stable_sort(rootMoves.begin() + PVIdx, rootMoves.end(), tb_compare);
+
               bestValue = ::search<PV>(rootPos, ss, alpha, beta, rootDepth, false, false);
 
               // Bring the best move to the front. It is critical that sorting
@@ -812,15 +834,6 @@ moves_loop: // When in check search starts from here
     skipQuiets = false;
     ttCapture = false;
 
-    int bestTBRank, thisTBRank;
-
-    if (rootNode) {
-        bestTBRank = -1000;
-        RootMoves rm = thisThread->rootMoves;
-        for (auto it = rm.begin() + thisThread->PVIdx; it != rm.end(); it++)
-            bestTBRank = std::max(bestTBRank, it->TBRank);
-    }
-
     // Step 11. Loop through moves
     // Loop through all pseudo-legal moves until no moves remain or a beta cutoff occurs
     while ((move = mp.next_move(skipQuiets)) != MOVE_NONE)
@@ -830,19 +843,12 @@ moves_loop: // When in check search starts from here
       if (move == excludedMove)
           continue;
 
-      if (rootNode) {
-          
-          RootMoves rm = thisThread->rootMoves;
-          auto it = std::find(rm.begin() + thisThread->PVIdx, rm.end(), move);
-          
-          // If the move was not found in the root move list then it was
-          // either illegal, already appeared in an earlier multiPV line
-          // or was absent from the UCI "searchmoves" command.
-          if (it == rm.end())
-              continue;
-
-          thisTBRank = it->TBRank;
-      }
+      // At root obey the "searchmoves" option and skip moves not listed in Root
+      // Move List. As a consequence any illegal move is also skipped. In MultiPV
+      // mode we also skip PV moves which have been already searched.
+      if (rootNode && !std::count(thisThread->rootMoves.begin() + thisThread->PVIdx,
+                                  thisThread->rootMoves.end(), move))
+          continue;
 
       ss->moveCount = ++moveCount;
 
@@ -1075,11 +1081,7 @@ moves_loop: // When in check search starts from here
               rm.score = -VALUE_INFINITE;
       }
 
-      // At the root node only increase bestValue for mates or moves
-      // that have the best possible TBRank.
-      if (value > bestValue && (   !rootNode
-                                || abs(value) >= VALUE_MATE_IN_MAX_PLY
-                                || thisTBRank == bestTBRank))
+      if (value > bestValue)
       {
           bestValue = value;
 
@@ -1596,6 +1598,7 @@ bool RootMove::extract_ponder_from_tt(Position& pos) {
 
 void Tablebases::rank_root_moves(Position& pos, Search::RootMoves& rootMoves) {
 
+    RootInTB = false;
     UseRule50 = Options["Syzygy50MoveRule"];
     ProbeDepth = Options["SyzygyProbeDepth"] * ONE_PLY;
     Cardinality = Options["SyzygyProbeLimit"];
@@ -1612,6 +1615,8 @@ void Tablebases::rank_root_moves(Position& pos, Search::RootMoves& rootMoves) {
         // Rank root moves using DTZ information if possible, else WDL
         if (root_probe(pos, rootMoves) || root_probe_wdl(pos, rootMoves))
         {
+            RootInTB = true;
+
             // Sort moves according to TB rank.
             std::sort(rootMoves.begin(), rootMoves.end());
 

--- a/src/search.h
+++ b/src/search.h
@@ -62,12 +62,15 @@ struct RootMove {
   bool extract_ponder_from_tt(Position& pos);
   bool operator==(const Move& m) const { return pv[0] == m; }
   bool operator<(const RootMove& m) const { // Sort in descending order
-    return m.score != score ? m.score < score
-                            : m.previousScore < previousScore;
+    return m.TBRank != TBRank ? m.TBRank < TBRank :
+           m.score  != score  ? m.score < score
+                              : m.previousScore < previousScore;
   }
 
   Value score = -VALUE_INFINITE;
   Value previousScore = -VALUE_INFINITE;
+  int TBRank;
+  Value TBScore;
   int selDepth = 0;
   std::vector<Move> pv;
 };

--- a/src/search.h
+++ b/src/search.h
@@ -67,10 +67,9 @@ struct RootMove {
                               : m.previousScore < previousScore;
   }
 
+  int TBRank = 0;
   Value score = -VALUE_INFINITE;
   Value previousScore = -VALUE_INFINITE;
-  int TBRank;
-  Value TBScore;
   int selDepth = 0;
   std::vector<Move> pv;
 };

--- a/src/search.h
+++ b/src/search.h
@@ -61,16 +61,7 @@ struct RootMove {
   explicit RootMove(Move m) : pv(1, m) {}
   bool extract_ponder_from_tt(Position& pos);
   bool operator==(const Move& m) const { return pv[0] == m; }
-  bool operator<(const RootMove& m) const { // Sort in descending order
-
-    bool no_mate =    abs(score)   < VALUE_MATE_IN_MAX_PLY
-                   && abs(m.score) < VALUE_MATE_IN_MAX_PLY;
-
-    return no_mate && m.TBRank != TBRank ? m.TBRank < TBRank :
-                      m.score  != score  ? m.score < score
-                                         : m.previousScore < previousScore;
-  }
-
+  bool operator<(const RootMove& m) const;
   int TBRank = 0;
   Value score = -VALUE_INFINITE;
   Value previousScore = -VALUE_INFINITE;

--- a/src/search.h
+++ b/src/search.h
@@ -62,9 +62,13 @@ struct RootMove {
   bool extract_ponder_from_tt(Position& pos);
   bool operator==(const Move& m) const { return pv[0] == m; }
   bool operator<(const RootMove& m) const { // Sort in descending order
-    return m.TBRank != TBRank ? m.TBRank < TBRank :
-           m.score  != score  ? m.score < score
-                              : m.previousScore < previousScore;
+
+    bool no_mate =    abs(score)   < VALUE_MATE_IN_MAX_PLY
+                   && abs(m.score) < VALUE_MATE_IN_MAX_PLY;
+
+    return no_mate && m.TBRank != TBRank ? m.TBRank < TBRank :
+                      m.score  != score  ? m.score < score
+                                         : m.previousScore < previousScore;
   }
 
   int TBRank = 0;

--- a/src/search.h
+++ b/src/search.h
@@ -61,7 +61,16 @@ struct RootMove {
   explicit RootMove(Move m) : pv(1, m) {}
   bool extract_ponder_from_tt(Position& pos);
   bool operator==(const Move& m) const { return pv[0] == m; }
-  bool operator<(const RootMove& m) const;
+  bool operator<(const RootMove& m) const { // Sort in descending order
+
+    bool no_mate =    abs(score)   < VALUE_MATE_IN_MAX_PLY
+                   && abs(m.score) < VALUE_MATE_IN_MAX_PLY;
+
+    return no_mate && m.TBRank != TBRank ? m.TBRank < TBRank :
+                      m.score  != score  ? m.score < score
+                                         : m.previousScore < previousScore;
+  }
+
   int TBRank = 0;
   Value score = -VALUE_INFINITE;
   Value previousScore = -VALUE_INFINITE;

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1498,25 +1498,25 @@ int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
 // since the last capture or pawn move.
 static int has_repeated(StateInfo *st)
 {
-    while (1) {
-        int i = 4, e = std::min(st->rule50, st->pliesFromNull);
-
-        if (e < i)
-            return 0;
-
+    // The outer loop steps back by 1 ply per iteration. The inner
+    // loop steps back by 2 ply per iteration starting from 4 ply back
+    // since positions that repeat must be 4, 6, 8, ... ply apart.
+    for (int e = st->rule50; e >= 4; e--)
+    {
         StateInfo *stp = st->previous->previous;
 
-        do {
+        for (int i = 4; i <= e; i += 2)
+        {
             stp = stp->previous->previous;
 
             if (stp->key == st->key)
                 return 1;
-
-            i += 2;
-        } while (i <= e);
+        }
 
         st = st->previous;
     }
+
+    return 0;
 }
 
 // Use the DTZ tables to rank root moves.

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -32,7 +32,6 @@
 #include "../movegen.h"
 #include "../position.h"
 #include "../search.h"
-#include "../uci.h"
 #include "../thread_win32.h"
 #include "../types.h"
 
@@ -1542,8 +1541,6 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
       pos.undo_move(rootMoves[0].pv[0]);
   }
 
-  int bound = Options["Syzygy50MoveRule"] ? 900 : 1;
-
   // Probe and rank each move.
   for (auto& m : rootMoves)
   {
@@ -1578,15 +1575,6 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
              : v < 0 ? (-v * 2 + cnt50 < 100 ? -1000 : -1000 + (-v + cnt50))
              : 0;
       m.TBRank = r;
-
-      // Determine the score to be displayed for this move. Assign at least
-      // 1 cp to cursed wins and let it grow to 49 cp as the positions gets
-      // closer to a real win.
-      m.TBScore =  r >= bound ? VALUE_MATE - MAX_PLY - 1
-                 : r >  0     ? Value((std::max( 3, r - 800) * int(PawnValueEg)) / 200)
-                 : r == 0     ? VALUE_DRAW
-                 : r > -bound ? Value((std::min(-3, r + 800) * int(PawnValueEg)) / 200)
-                 :             -VALUE_MATE + MAX_PLY + 1;
   }
 
   return true;
@@ -1604,8 +1592,6 @@ bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves) {
   int v;
   StateInfo st;
 
-  bool rule50 = Options["Syzygy50MoveRule"];
-
   // Probe and rank each move.
   for (auto& m : rootMoves)
   {
@@ -1617,9 +1603,6 @@ bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves) {
           return false;
 
       m.TBRank = wdl_to_rank[v + 2];
-      if (!rule50)
-          v = v > 0 ? 2 : v < 0 ? -2 : 0;
-      m.TBScore = WDL_to_value[v + 2];
   }
 
   return true;

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -32,6 +32,7 @@
 #include "../movegen.h"
 #include "../position.h"
 #include "../search.h"
+#include "../uci.h"
 #include "../thread_win32.h"
 #include "../types.h"
 
@@ -1519,184 +1520,107 @@ static int has_repeated(StateInfo *st)
     }
 }
 
-// Use the DTZ tables to filter out moves that don't preserve the win or draw.
-// If the position is lost, but DTZ is fairly high, only keep moves that
-// maximise DTZ.
+// Use the DTZ tables to rank root moves.
 //
-// A return value false indicates that not all probes were successful and that
-// no moves were filtered out.
-bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves, Value& score)
-{
-    assert(rootMoves.size());
+// A return value false indicates that not all probes were successful.
+bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
 
-    ProbeState result;
-    int dtz = probe_dtz(pos, &result);
+  ProbeState success;
+  int v;
+  StateInfo st;
 
-    if (result == FAIL)
-        return false;
+  // Obtain 50-move counter for the root position.
+  int cnt50 = pos.rule50_count();
 
-    StateInfo st;
+  // Check whether a position was repeated since the last zeroing move.
+  // Unfortunately this requires a bit of a hack.
+  bool rep = false;
+  if (rootMoves.size() > 0)
+  {
+      pos.do_move(rootMoves[0].pv[0], st);
+      rep = has_repeated(st.previous);
+      pos.undo_move(rootMoves[0].pv[0]);
+  }
 
-    // Probe each move
-    for (size_t i = 0; i < rootMoves.size(); ++i) {
-        Move move = rootMoves[i].pv[0];
-        pos.do_move(move, st);
-        int v = 0;
+  int bound = Options["Syzygy50MoveRule"] ? 900 : 1;
 
-        if (pos.checkers() && dtz > 0) {
-            ExtMove s[MAX_MOVES];
+  // Probe and rank each move.
+  for (auto& m : rootMoves)
+  {
+      pos.do_move(m.pv[0], st);
+      // Calculate dtz for the current move counting from the root position.
+      if (pos.rule50_count() == 0)
+      {
+          // In case of a zeroing move, dtz is one of -101/-1/0/1/101.
+          v = dtz_before_zeroing(-Tablebases::probe_wdl(pos, &success));
+      }
+      else
+      {
+          // Otherwise, take dtz for the new position and correct by 1 ply.
+          v = -Tablebases::probe_dtz(pos, &success);
+          v =  v > 0 ? v + 1
+             : v < 0 ? v - 1
+             : v;
+      }
+      // Make sure that a mating move gets value 1.
+      if (   pos.checkers()
+          && v == 2
+          && MoveList<LEGAL>(pos).size() == 0)
+          v = 1;
+      pos.undo_move(m.pv[0]);
 
-            if (generate<LEGAL>(pos, s) == s)
-                v = 1;
-        }
+      if (!success)
+          return false;
 
-        if (!v) {
-            if (st.rule50 != 0) {
-                v = -probe_dtz(pos, &result);
+      // Better moves are ranked higher. Certains wins are ranked equally.
+      // Losing moves are ranked equally unless a 50-move draw is in sight.
+      int r =  v > 0 ? (v + cnt50 <= 99 && !rep ? 1000 : 1000 - (v + cnt50))
+             : v < 0 ? (-v * 2 + cnt50 < 100 ? -1000 : -1000 + (-v + cnt50))
+             : 0;
+      m.TBRank = r;
 
-                if (v > 0)
-                    ++v;
-                else if (v < 0)
-                    --v;
-            } else {
-                v = -probe_wdl(pos, &result);
-                v = dtz_before_zeroing(WDLScore(v));
-            }
-        }
+      // Determine the score to be displayed for this move. Assign at least
+      // 1 cp to cursed wins and let it grow to 49 cp as the positions gets
+      // closer to a real win.
+      m.TBScore =  r >= bound ? VALUE_MATE - MAX_PLY - 1
+                 : r >  0     ? Value((std::max( 3, r - 800) * int(PawnValueEg)) / 200)
+                 : r == 0     ? VALUE_DRAW
+                 : r > -bound ? Value((std::min(-3, r + 800) * int(PawnValueEg)) / 200)
+                 :             -VALUE_MATE + MAX_PLY + 1;
+  }
 
-        pos.undo_move(move);
-
-        if (result == FAIL)
-            return false;
-
-        rootMoves[i].score = (Value)v;
-    }
-
-    // Obtain 50-move counter for the root position.
-    // In Stockfish there seems to be no clean way, so we do it like this:
-    int cnt50 = st.previous ? st.previous->rule50 : 0;
-
-    // Use 50-move counter to determine whether the root position is
-    // won, lost or drawn.
-    WDLScore wdl = WDLDraw;
-
-    if (dtz > 0)
-        wdl = (dtz + cnt50 <= 100) ? WDLWin : WDLCursedWin;
-    else if (dtz < 0)
-        wdl = (-dtz + cnt50 <= 100) ? WDLLoss : WDLBlessedLoss;
-
-    // Determine the score to report to the user.
-    score = WDL_to_value[wdl + 2];
-
-    // If the position is winning or losing, but too few moves left, adjust the
-    // score to show how close it is to winning or losing.
-    // NOTE: int(PawnValueEg) is used as scaling factor in score_to_uci().
-    if (wdl == WDLCursedWin && dtz <= 100)
-        score = (Value)(((200 - dtz - cnt50) * int(PawnValueEg)) / 200);
-    else if (wdl == WDLBlessedLoss && dtz >= -100)
-        score = -(Value)(((200 + dtz - cnt50) * int(PawnValueEg)) / 200);
-
-    // Now be a bit smart about filtering out moves.
-    size_t j = 0;
-
-    if (dtz > 0) { // winning (or 50-move rule draw)
-        int best = 0xffff;
-
-        for (size_t i = 0; i < rootMoves.size(); ++i) {
-            int v = rootMoves[i].score;
-
-            if (v > 0 && v < best)
-                best = v;
-        }
-
-        int max = best;
-
-        // If the current phase has not seen repetitions, then try all moves
-        // that stay safely within the 50-move budget, if there are any.
-        if (!has_repeated(st.previous) && best + cnt50 <= 99)
-            max = 99 - cnt50;
-
-        for (size_t i = 0; i < rootMoves.size(); ++i) {
-            int v = rootMoves[i].score;
-
-            if (v > 0 && v <= max)
-                rootMoves[j++] = rootMoves[i];
-        }
-    } else if (dtz < 0) { // losing (or 50-move rule draw)
-        int best = 0;
-
-        for (size_t i = 0; i < rootMoves.size(); ++i) {
-            int v = rootMoves[i].score;
-
-            if (v < best)
-                best = v;
-        }
-
-        // Try all moves, unless we approach or have a 50-move rule draw.
-        if (-best * 2 + cnt50 < 100)
-            return true;
-
-        for (size_t i = 0; i < rootMoves.size(); ++i) {
-            if (rootMoves[i].score == best)
-                rootMoves[j++] = rootMoves[i];
-        }
-    } else { // drawing
-        // Try all moves that preserve the draw.
-        for (size_t i = 0; i < rootMoves.size(); ++i) {
-            if (rootMoves[i].score == 0)
-                rootMoves[j++] = rootMoves[i];
-        }
-    }
-
-    rootMoves.resize(j, Search::RootMove(MOVE_NONE));
-
-    return true;
+  return true;
 }
 
-// Use the WDL tables to filter out moves that don't preserve the win or draw.
+// Use the WDL tables to rank root moves.
 // This is a fallback for the case that some or all DTZ tables are missing.
 //
-// A return value false indicates that not all probes were successful and that
-// no moves were filtered out.
-bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, Value& score)
-{
-    ProbeState result;
+// A return value false indicates that not all probes were successful.
+bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves) {
 
-    WDLScore wdl = Tablebases::probe_wdl(pos, &result);
+  static const int wdl_to_rank[] = { -1000, -899, 0, 899, 1000 };
 
-    if (result == FAIL)
-        return false;
+  ProbeState success;
+  int v;
+  StateInfo st;
 
-    score = WDL_to_value[wdl + 2];
+  bool rule50 = Options["Syzygy50MoveRule"];
 
-    StateInfo st;
+  // Probe and rank each move.
+  for (auto& m : rootMoves)
+  {
+      pos.do_move(m.pv[0], st);
+      v = -Tablebases::probe_wdl(pos, &success);
+      pos.undo_move(m.pv[0]);
 
-    int best = WDLLoss;
+      if (!success)
+          return false;
 
-    // Probe each move
-    for (size_t i = 0; i < rootMoves.size(); ++i) {
-        Move move = rootMoves[i].pv[0];
-        pos.do_move(move, st);
-        WDLScore v = -Tablebases::probe_wdl(pos, &result);
-        pos.undo_move(move);
+      m.TBRank = wdl_to_rank[v + 2];
+      if (!rule50)
+          v = v > 0 ? 2 : v < 0 ? -2 : 0;
+      m.TBScore = WDL_to_value[v + 2];
+  }
 
-        if (result == FAIL)
-            return false;
-
-        rootMoves[i].score = (Value)v;
-
-        if (v > best)
-            best = v;
-    }
-
-    size_t j = 0;
-
-    for (size_t i = 0; i < rootMoves.size(); ++i) {
-        if (rootMoves[i].score == best)
-            rootMoves[j++] = rootMoves[i];
-    }
-
-    rootMoves.resize(j, Search::RootMove(MOVE_NONE));
-
-    return true;
+  return true;
 }

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -49,9 +49,9 @@ extern int MaxCardinality;
 void init(const std::string& paths);
 WDLScore probe_wdl(Position& pos, ProbeState* result);
 int probe_dtz(Position& pos, ProbeState* result);
-bool root_probe(Position& pos, Search::RootMoves& rootMoves, Value& score);
-bool root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, Value& score);
-void filter_root_moves(Position& pos, Search::RootMoves& rootMoves);
+bool root_probe(Position& pos, Search::RootMoves& rootMoves);
+bool root_probe_wdl(Position& pos, Search::RootMoves& rootMoves);
+void rank_root_moves(Position& pos, Search::RootMoves& rootMoves);
 
 inline std::ostream& operator<<(std::ostream& os, const WDLScore v) {
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -164,7 +164,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
           rootMoves.emplace_back(m);
 
   if (!rootMoves.empty())
-      Tablebases::filter_root_moves(pos, rootMoves);
+      Tablebases::rank_root_moves(pos, rootMoves);
 
   // After ownership transfer 'states' becomes empty, so if we stop the search
   // and call 'go' again without setting a new position states.get() == NULL.

--- a/src/thread.h
+++ b/src/thread.h
@@ -62,6 +62,7 @@ public:
   Endgames endgames;
   size_t PVIdx;
   int selDepth;
+  int bestTBRank;
   std::atomic<uint64_t> nodes, tbHits;
 
   Position rootPos;


### PR DESCRIPTION
This a pull request for discussing the root ranking code of @syzygy1 from #840 

Code in this PR is largely taken from there but with some tweaks to make it compile 11 months later.

The only real change by me is to do with how the TB ranking information is fed into the search. I think it is nicer because changes to the search are minimal and it is very obvious that the search remains the same if no TB information is present.

The idea behind the patch can be summed up as:

1. TB code produces a ranking of all root moves.
2. Always keep the root move list sorted by TBRank followed by Score followed by PreviousScore.
3. Use the search only to differentiate between root moves that have the same TBRank.

Like the original root ranking code it should always be able to convert endings perfectly and doesn't always insist on DTZ optimal play. Most of the time it will rank by expected game result and only rank by DTZ in certain tricky situations. It should be MultiPV compatible and I think it is nicer than the post-processing way of doing things in the Natural TB branch.

I've done very little testing with this code. It is intended to be a non-functional change unless the root position is in the TBs. Also I have removed any of the code that changes the output score based on TB information just to keep things as simple as possible. Personally I like the sound of the Texel approach where scores for known draws are mapped into a small range around zero, cursed wins go into a higher range above and definite wins are given a large bonus, but I digress...