### PR TITLE
Unopposed weak pawns and majors

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -162,8 +162,8 @@ namespace {
   // supported by a pawn. If the minor piece occupies an outpost square
   // then score is doubled.
   const Score Outpost[][2] = {
-    { S(22, 6), S(33, 9) }, // Knight
-    { S( 9, 2), S(14, 4) }  // Bishop
+    { S(22, 6), S(36,12) }, // Knight
+    { S( 9, 2), S(15, 5) }  // Bishop
   };
 
   // RookOnFile[semiopen/open] contains bonuses for each rook when there is no
@@ -214,6 +214,7 @@ namespace {
   const Score ThreatBySafePawn    = S(182,175);
   const Score ThreatByRank        = S( 16,  3);
   const Score Hanging             = S( 48, 27);
+  const Score MajorAndWeak        = S(  5, 25);
   const Score ThreatByPawnPush    = S( 38, 22);
   const Score HinderPassedPawn    = S(  7,  0);
   const Score TrappedBishopA1H1   = S( 50, 50);
@@ -592,6 +593,11 @@ namespace {
         if (b)
             score += ThreatByKing[more_than_one(b)];
     }
+
+    // Increase penalty for each opponent unopposed backward or isolated pawns
+    // when we have a rook or a queen on the board.
+    if (pos.pieces(Us, ROOK, QUEEN))
+        score += MajorAndWeak * pe->weak_unopposed(Them);
 
     // Find squares where our pawns can push on the next move
     b  = shift<Up>(pos.pieces(Us, PAWN)) & ~pos.pieces();

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -214,7 +214,7 @@ namespace {
   const Score ThreatBySafePawn    = S(182,175);
   const Score ThreatByRank        = S( 16,  3);
   const Score Hanging             = S( 48, 27);
-  const Score MajorAndWeak        = S(  5, 25);
+  const Score WeakUnopposedPawn   = S(  5, 25);
   const Score ThreatByPawnPush    = S( 38, 22);
   const Score HinderPassedPawn    = S(  7,  0);
   const Score TrappedBishopA1H1   = S( 50, 50);
@@ -594,10 +594,9 @@ namespace {
             score += ThreatByKing[more_than_one(b)];
     }
 
-    // Increase penalty for each opponent unopposed backward or isolated pawns
-    // when we have a rook or a queen on the board.
+    // Bonus for opponent unopposed weak pawns
     if (pos.pieces(Us, ROOK, QUEEN))
-        score += MajorAndWeak * pe->weak_unopposed(Them);
+        score += WeakUnopposedPawn * pe->weak_unopposed(Them);
 
     // Find squares where our pawns can push on the next move
     b  = shift<Up>(pos.pieces(Us, PAWN)) & ~pos.pieces();

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -31,11 +31,11 @@ namespace {
   #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
-  // Isolated pawn penalty by opposed flag
-  const Score Isolated[] = { S(27, 30), S(13, 18) };
+  // Isolated pawn penalty
+  const Score Isolated = S(13, 18);
 
-  // Backward pawn penalty by opposed flag
-  const Score Backward[] = { S(40, 26), S(24, 12) };
+  // Backward pawn penalty
+  const Score Backward = S(24, 12);
 
   // Connected pawn bonus by opposed, phalanx, #support and rank
   Score Connected[2][2][3][RANK_NB];
@@ -109,7 +109,7 @@ namespace {
     Bitboard ourPawns   = pos.pieces(  Us, PAWN);
     Bitboard theirPawns = pos.pieces(Them, PAWN);
 
-    e->passedPawns[Us]   = e->pawnAttacksSpan[Us] = 0;
+    e->weakUnopposed[Us] = e->passedPawns[Us] = e->pawnAttacksSpan[Us] = 0;
     e->semiopenFiles[Us] = 0xFF;
     e->kingSquares[Us]   = SQ_NONE;
     e->pawnAttacks[Us]   = shift<Right>(ourPawns) | shift<Left>(ourPawns);
@@ -177,10 +177,10 @@ namespace {
             score += Connected[opposed][!!phalanx][popcount(supported)][relative_rank(Us, s)];
 
         else if (!neighbours)
-            score -= Isolated[opposed];
+            score -= Isolated, e->weakUnopposed[Us] += !opposed;
 
         else if (backward)
-            score -= Backward[opposed];
+            score -= Backward, e->weakUnopposed[Us] += !opposed;
 
         if (doubled && !supported)
             score -= Doubled;

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -37,6 +37,7 @@ struct Entry {
   Bitboard pawn_attacks(Color c) const { return pawnAttacks[c]; }
   Bitboard passed_pawns(Color c) const { return passedPawns[c]; }
   Bitboard pawn_attacks_span(Color c) const { return pawnAttacksSpan[c]; }
+  int weak_unopposed(Color c) const { return weakUnopposed[c]; }
   int pawn_asymmetry() const { return asymmetry; }
   int open_files() const { return openFiles; }
 
@@ -71,6 +72,7 @@ struct Entry {
   Bitboard pawnAttacksSpan[COLOR_NB];
   Square kingSquares[COLOR_NB];
   Score kingSafety[COLOR_NB];
+  int weakUnopposed[COLOR_NB];
   int castlingRights[COLOR_NB];
   int semiopenFiles[COLOR_NB];
   int pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -111,7 +111,7 @@ void Thread::idle_loop() {
 
 
 /// ThreadPool::init() creates and launches the threads that will go
-/// immediately to sleep in idle_loop. We cannot use the c'tor because
+/// immediately to sleep in idle_loop. We cannot use the constructor because
 /// Threads is a static object and we need a fully initialized engine at
 /// this point due to allocation of Endgames in the Thread constructor.
 


### PR DESCRIPTION
Do not use the opposed flag for scoring backward and isolated pawns in pawns.cpp, instead give a S(5,25) bonus for each opponent unopposed weak pawns when we have a rook or a queen on the board.

STC run stopped after 113188 games:
LLR: 1.63 (-2.94,2.94) [0.00,5.00]
Total: 113188 W: 20804 L: 20251 D: 72133
http://tests.stockfishchess.org/tests/view/59b58e4d0ebc5916ff64b12e

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 66673 W: 8672 L: 8341 D: 49660
http://tests.stockfishchess.org/tests/view/59b902580ebc5916ff64b231

This is Alain Savard's idea, just with a different bonus. Original patch there:

• green STC, http://tests.stockfishchess.org/tests/view/597dcd2b0ebc5916ff64a09b
• yellow LTC, http://tests.stockfishchess.org/tests/view/597ea69e0ebc5916ff64a0e6