### PR TITLE
Let ss->ply count plies from root to current node.

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1071,11 +1071,10 @@ bool Position::is_draw(int ply) const {
   {
       stp = stp->previous->previous;
 
-      // At root position ply is 1, so return a draw score if a position
-      // repeats once earlier but strictly after the root, or repeats twice
-      // before or at the root.
+      // Return a draw score if a position repeats once earlier but strictly
+      // after the root, or repeats twice before or at the root.
       if (   stp->key == st->key
-          && ++cnt + (ply - 1 > i) == 2)
+          && ++cnt + (ply > i) == 2)
           return true;
   }
 


### PR DESCRIPTION
This patch lets ss->ply be equal to 0 at the root of the search.

Currently, the root has ss->ply == 1, which is less intuitive:
- Setting the rootNode bool has to check (ss-1)->ply == 0.
- All mate values are off by one: the code seems to assume that mated-in-0 is -VALUE_MATE, mate-1-in-ply is VALUE_MATE-1, mated-in-2-ply is -VALUE_MATE+2, etc. But the mate_in() and mated_in() functions are called with ss->ply, which is 1 at the root.
- The is_draw() function currently needs to explain why it has "ply - 1 > i" instead of simply "ply > i".
- The ss->ply >= MAX_PLY tests in search() and qsearch() already assume that ss->ply == 0 at the root, because if we start at ss->ply == 1, it would make more sense to go up to and including ss->ply == MAX_PLY, so to stop at ss->ply > MAX_PLY. See also the asserts testing for 0 <= ss->ply && ss->ply < MAX_PLY.

The reason for ss->ply == 1 at the root is the line "ss->ply = (ss-1)->ply + 1" at the start of search() and qsearch(). By replacing this with "(ss+1)->ply = ss->ply + 1" (moved to after the ss->ply >= MAX_PLY test) we keep ss->ply == 0 at the root. Note that search() already clears killers in (ss+2), so there is no danger in accessing ss+1.

Since this change effectively increases MAX_PLY by 1 (ss->ply now runs from 0 to MAX_PLY-1 instead of from 1 to MAX_PLY-1), I have increased Stack[MAX_PLY+7] to Stack[MAX_PLY+8]. I think +7 (and now +8) is more than needed, but one entry too many cannot hurt here.

I have NOT changed pv[MAX_PLY + 1] to pv[MAX_PLY + 2] in search() and qsearch(). It seems to me that MAX_PLY + 1 is exactly right:
- MAX_PLY entries for ss->ply running from 0 to MAX_PLY-1, and
- 1 entry for the final MOVE_NONE.
If there is any doubt here, then changing to pv[MAX_PLY + 2] may be better/safer.

I have verified that mate scores are reported correctly. (They were already reported correctly due to the extra ply being rounded down when converting to moves.)

The value of seldepth output to the user should probably not change, so I add 1 to it. (Humans count from 1, computers from 0.)

A small optimisation I did not include: instead of setting ss->ply in every invocation of search() and qsearch(), it could be set once for all plies at the start of Thread::search(). This saves a couple of instructions per node.

No functional change (unless the search searches a branch MAX_PLY deep), so bench does not change.

If this should be tested on fishtest (as simplification), just let me know.
