### PR TITLE
statScore tweak v2 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -979,10 +979,10 @@ moves_loop: // When in check search starts from here
                              - 4000;
 
               // Decrease/increase reduction by comparing opponent's stat score
-              if (ss->statScore > 0 && (ss-1)->statScore < 0)
+              if (ss->statScore >= 0 && (ss-1)->statScore < 0)
                   r -= ONE_PLY;
 
-              else if (ss->statScore < 0 && (ss-1)->statScore > 0)
+              else if (ss->statScore < 0 && (ss-1)->statScore >= 0)
                   r += ONE_PLY;
 
               // Decrease/increase reduction for moves with a good/bad history

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1616,3 +1616,4 @@ void Tablebases::filter_root_moves(Position& pos, Search::RootMoves& rootMoves) 
                    : TB::Score < VALUE_DRAW ? -VALUE_MATE + MAX_PLY + 1
                                             :  VALUE_DRAW;
 }
+

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1616,5 +1616,3 @@ void Tablebases::filter_root_moves(Position& pos, Search::RootMoves& rootMoves) 
                    : TB::Score < VALUE_DRAW ? -VALUE_MATE + MAX_PLY + 1
                                             :  VALUE_DRAW;
 }
-
-

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1616,3 +1616,5 @@ void Tablebases::filter_root_moves(Position& pos, Search::RootMoves& rootMoves) 
                    : TB::Score < VALUE_DRAW ? -VALUE_MATE + MAX_PLY + 1
                                             :  VALUE_DRAW;
 }
+
+


### PR DESCRIPTION
statScore tweak v2 

Some change in the condition of accepting increase / decrease of reductions by comparing the opponent's stat score. The patch takes into account the use of increasing / decreasing the reductions, including for some certain cases if statScore = 0.


> if (ss-> statScore >= 0 && (ss-1) -> statScore < 0)

instead
> if (ss-> statScore > 0 && (ss-1) -> statScore < 0)

for  r -= ONE_PLY
 
and
> else if (ss-> statScore < 0 && (ss-1) -> statScore >= 0)

instead
> else if (ss-> statScore < 0 && (ss-1) -> statScore > 0)

for  r += ONE_PLY;


STC
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 57762 W: 10533 L: 10181 D: 37048

LTC
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 19973 W: 2662 L: 2480 D: 14831

Bench: 5037819