### PR TITLE
Use exceptions to terminate search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -85,6 +85,12 @@ namespace {
     return d > 17 ? 0 : d * d + 2 * d - 2;
   }
 
+  // break search and throw exception
+  void break_search() {
+    Threads.stop = true;
+    throw 42;
+  }
+
   // Skill structure is used to implement strength limit
   struct Skill {
     explicit Skill(int l) : level(l) {}
@@ -217,7 +223,6 @@ void Search::clear() {
   for (Thread* th : Threads)
       th->clear();
 
-  Threads.main()->callsCnt = 0;
   Threads.main()->previousScore = VALUE_INFINITE;
 }
 
@@ -324,16 +329,16 @@ void MainThread::search() {
 void Thread::search() {
 
   Stack stack[MAX_PLY+7], *ss = stack+4; // To reference from (ss-4) to (ss+2)
-  Value bestValue, alpha, beta, delta;
+  Value bestValue = -VALUE_INFINITE, alpha, beta, delta;
+  bool failLow, failHigh;
   Move easyMove = MOVE_NONE;
   MainThread* mainThread = (this == Threads.main() ? Threads.main() : nullptr);
+  Position searchPos;
+  std::memcpy(&searchPos, &rootPos, sizeof searchPos);
 
   std::memset(ss-4, 0, 7 * sizeof(Stack));
   for (int i = 4; i > 0; i--)
      (ss-i)->contHistory = &this->contHistory[NO_PIECE][0]; // Use as sentinel
-
-  bestValue = delta = alpha = -VALUE_INFINITE;
-  beta = VALUE_INFINITE;
 
   if (mainThread)
   {
@@ -353,12 +358,11 @@ void Thread::search() {
 
   multiPV = std::min(multiPV, rootMoves.size());
 
-  // Iterative deepening loop until requested to stop or the target depth is reached
-  while (   (rootDepth += ONE_PLY) < DEPTH_MAX
-         && !Threads.stop
-         && !(Limits.depth && mainThread && rootDepth / ONE_PLY > Limits.depth))
+  // Iterative deepening loop until the target depth is reached, or an exception thrown.
+  try {
+  while ((rootDepth += ONE_PLY) < (Limits.depth && mainThread ? (Limits.depth + 1) * ONE_PLY : DEPTH_MAX))
   {
-      // Distribute search depths across the threads
+      // skip plies depending on the thread idx.
       if (idx)
       {
           int i = (idx - 1) % 20;
@@ -366,35 +370,37 @@ void Thread::search() {
               continue;
       }
 
-      // Age out PV variability metric
-      if (mainThread)
-          mainThread->bestMoveChanges *= 0.505, mainThread->failedLow = false;
-
       // Save the last iteration's scores before first PV line is searched and
       // all the move scores except the (new) PV are set to -VALUE_INFINITE.
       for (RootMove& rm : rootMoves)
           rm.previousScore = rm.score;
 
       // MultiPV loop. We perform a full root search for each PV line
-      for (PVIdx = 0; PVIdx < multiPV && !Threads.stop; ++PVIdx)
+      for (PVIdx = 0; PVIdx < multiPV; ++PVIdx)
       {
           // Reset UCI info selDepth for each depth and each PV line
           selDepth = 0;
 
           // Reset aspiration window starting size
+          failLow = failHigh = true;
           if (rootDepth >= 5 * ONE_PLY)
           {
               delta = Value(18);
               alpha = std::max(rootMoves[PVIdx].previousScore - delta,-VALUE_INFINITE);
               beta  = std::min(rootMoves[PVIdx].previousScore + delta, VALUE_INFINITE);
+          } else {
+              alpha = -VALUE_INFINITE;
+              delta = beta = VALUE_INFINITE;
           }
 
           // Start with a small aspiration window and, in the case of a fail
           // high/low, re-search with a bigger window until we're not failing
           // high/low anymore.
-          while (true)
+          while (failLow || failHigh)
           {
               bestValue = ::search<PV>(rootPos, ss, alpha, beta, rootDepth, false, false);
+              failLow = bestValue <= alpha;
+              failHigh = bestValue >= beta;
 
               // Bring the best move to the front. It is critical that sorting
               // is done with a stable algorithm because all the values but the
@@ -402,25 +408,17 @@ void Thread::search() {
               // and we want to keep the same order for all the moves except the
               // new PV that goes to the front. Note that in case of MultiPV
               // search the already searched PV lines are preserved.
-              std::stable_sort(rootMoves.begin() + PVIdx, rootMoves.end());
+              std::stable_sort(rootMoves.begin() + ((failLow || failHigh) ? PVIdx : 0), rootMoves.end());
 
-              // If search has been stopped, we break immediately. Sorting and
-              // writing PV back to TT is safe because RootMoves is still
-              // valid, although it refers to the previous iteration.
-              if (Threads.stop)
-                  break;
-
-              // When failing high/low give some update (without cluttering
-              // the UI) before a re-search.
+              // Give an update (without cluttering the UI) before a re-search.
               if (   mainThread
-                  && multiPV == 1
-                  && (bestValue <= alpha || bestValue >= beta)
-                  && Time.elapsed() > 3000)
+                  && (   (multiPV == 1 && Time.elapsed() > 3000)
+                      || ( !(failLow || failHigh) && (PVIdx + 1 == multiPV || Time.elapsed() > 3000))))
                   sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
 
               // In case of failing low/high increase aspiration window and
               // re-search, otherwise exit the loop.
-              if (bestValue <= alpha)
+              if (failLow)
               {
                   beta = (alpha + beta) / 2;
                   alpha = std::max(bestValue - delta, -VALUE_INFINITE);
@@ -431,32 +429,22 @@ void Thread::search() {
                       Threads.stopOnPonderhit = false;
                   }
               }
-              else if (bestValue >= beta)
+              else if (failHigh)
                   beta = std::min(bestValue + delta, VALUE_INFINITE);
-              else
-                  break;
 
               delta += delta / 4 + 5;
 
               assert(alpha >= -VALUE_INFINITE && beta <= VALUE_INFINITE);
           }
-
-          // Sort the PV lines searched so far and update the GUI
-          std::stable_sort(rootMoves.begin(), rootMoves.begin() + PVIdx + 1);
-
-          if (    mainThread
-              && (Threads.stop || PVIdx + 1 == multiPV || Time.elapsed() > 3000))
-              sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
       }
 
-      if (!Threads.stop)
-          completedDepth = rootDepth;
+      completedDepth = rootDepth;
 
       // Have we found a "mate in x"?
       if (   Limits.mate
           && bestValue >= VALUE_MATE_IN_MAX_PLY
           && VALUE_MATE - bestValue <= 2 * Limits.mate)
-          Threads.stop = true;
+          break_search();
 
       if (!mainThread)
           continue;
@@ -468,53 +456,59 @@ void Thread::search() {
       // Do we have time for the next iteration? Can we stop searching now?
       if (Limits.use_time_management())
       {
-          if (!Threads.stop && !Threads.stopOnPonderhit)
-          {
-              // Stop the search if only one legal move is available, or if all
-              // of the available time has been used, or if we matched an easyMove
-              // from the previous search and just did a fast verification.
-              const int F[] = { mainThread->failedLow,
-                                bestValue - mainThread->previousScore };
+          // Stop the search if only one legal move is available, or if all
+          // of the available time has been used, or if we matched an easyMove
+          // from the previous search and just did a fast verification.
+          const int F[] = { mainThread->failedLow,
+                            bestValue - mainThread->previousScore };
 
-              int improvingFactor = std::max(229, std::min(715, 357 + 119 * F[0] - 6 * F[1]));
-              double unstablePvFactor = 1 + mainThread->bestMoveChanges;
+          int improvingFactor = std::max(229, std::min(715, 357 + 119 * F[0] - 6 * F[1]));
+          double unstablePvFactor = 1 + mainThread->bestMoveChanges;
 
-              bool doEasyMove =   rootMoves[0].pv[0] == easyMove
-                               && mainThread->bestMoveChanges < 0.03
-                               && Time.elapsed() > Time.optimum() * 5 / 44;
+          bool doEasyMove =   rootMoves[0].pv[0] == easyMove
+                           && mainThread->bestMoveChanges < 0.03
+                           && Time.elapsed() > Time.optimum() * 5 / 44;
 
-              if (   rootMoves.size() == 1
-                  || Time.elapsed() > Time.optimum() * unstablePvFactor * improvingFactor / 628
-                  || (mainThread->easyMovePlayed = doEasyMove, doEasyMove))
-              {
-                  // If we are allowed to ponder do not stop the search now but
-                  // keep pondering until the GUI sends "ponderhit" or "stop".
-                  if (Threads.ponder)
-                      Threads.stopOnPonderhit = true;
-                  else
-                      Threads.stop = true;
-              }
-          }
+          // Age out PV variability metric
+          mainThread->bestMoveChanges *= 0.505, mainThread->failedLow = false;
 
           if (rootMoves[0].pv.size() >= 3)
               EasyMove.update(rootPos, rootMoves[0].pv);
           else
               EasyMove.clear();
+
+          if (   rootMoves.size() == 1
+              || Time.elapsed() > Time.optimum() * unstablePvFactor * improvingFactor / 628
+              || (mainThread->easyMovePlayed = doEasyMove, doEasyMove))
+          {
+              // If we are allowed to ponder do not stop the search now but
+              // keep pondering until the GUI sends "ponderhit" or "stop".
+              if (Threads.ponder)
+                  Threads.stopOnPonderhit = true;
+              else
+                  break_search();
+          }
       }
   }
+  } catch (...) {
+     // restore the rootPos if the search was terminated by exception.
+     std::memcpy(&rootPos, &searchPos, sizeof rootPos);
+     std::stable_sort(rootMoves.begin(), rootMoves.end());
+     if (mainThread) {
+         if (completedDepth != rootDepth)
+             sync_cout << UCI::pv(rootPos, completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
 
-  if (!mainThread)
-      return;
+         // Clear any candidate easy move that wasn't stable for the last search
+         // iterations; the second condition prevents consecutive fast moves.
+         if (EasyMove.stableCnt < 6 || mainThread->easyMovePlayed)
+             EasyMove.clear();
 
-  // Clear any candidate easy move that wasn't stable for the last search
-  // iterations; the second condition prevents consecutive fast moves.
-  if (EasyMove.stableCnt < 6 || mainThread->easyMovePlayed)
-      EasyMove.clear();
-
-  // If skill level is enabled, swap best PV line with the sub-optimal one
-  if (skill.enabled())
-      std::swap(rootMoves[0], *std::find(rootMoves.begin(), rootMoves.end(),
+         // If skill level is enabled, swap best PV line with the sub-optimal one
+         if (skill.enabled())
+             std::swap(rootMoves[0], *std::find(rootMoves.begin(), rootMoves.end(),
                 skill.best ? skill.best : skill.pick_best(multiPV)));
+     }
+  }
 }
 
 
@@ -553,10 +547,6 @@ namespace {
     ss->statScore = 0;
     bestValue = -VALUE_INFINITE;
 
-    // Check for the available remaining time
-    if (thisThread == Threads.main())
-        static_cast<MainThread*>(thisThread)->check_time();
-
     // Used to send selDepth info to GUI (selDepth counts from 1, ply from 0)
     if (PvNode && thisThread->selDepth < ss->ply + 1)
         thisThread->selDepth = ss->ply + 1;
@@ -564,7 +554,7 @@ namespace {
     if (!rootNode)
     {
         // Step 2. Check for aborted search and immediate draw
-        if (Threads.stop.load(std::memory_order_relaxed) || pos.is_draw(ss->ply) || ss->ply >= MAX_PLY)
+        if (pos.is_draw(ss->ply) || ss->ply >= MAX_PLY)
             return ss->ply >= MAX_PLY && !inCheck ? evaluate(pos)
                                                   : DrawValue[pos.side_to_move()];
 
@@ -793,6 +783,9 @@ namespace {
     }
 
 moves_loop: // When in check search starts from here
+
+    // periodically check if the search needs to be terminated, throwing an exception if needed.
+    thisThread->check_time();
 
     const PieceToHistory* contHist[] = { (ss-1)->contHistory, (ss-2)->contHistory, nullptr, (ss-4)->contHistory };
     Move countermove = thisThread->counterMoves[pos.piece_on(prevSq)][prevSq];
@@ -1028,13 +1021,6 @@ moves_loop: // When in check search starts from here
 
       assert(value > -VALUE_INFINITE && value < VALUE_INFINITE);
 
-      // Step 18. Check for a new best move
-      // Finished searching the move. If a stop occurred, the return value of
-      // the search cannot be trusted, and we return immediately without
-      // updating best move, PV and TT.
-      if (Threads.stop.load(std::memory_order_relaxed))
-          return VALUE_ZERO;
-
       if (rootNode)
       {
           RootMove& rm = *std::find(thisThread->rootMoves.begin(),
@@ -1089,14 +1075,6 @@ moves_loop: // When in check search starts from here
       if (!captureOrPromotion && move != bestMove && quietCount < 64)
           quietsSearched[quietCount++] = move;
     }
-
-    // The following condition would detect a stop only after move loop has been
-    // completed. But in this case bestValue is valid because we have fully
-    // searched our subtree, and we can anyhow save the result in TT.
-    /*
-       if (Threads.stop)
-        return VALUE_DRAW;
-    */
 
     // Step 20. Check for mate and stalemate
     // All legal moves have been searched and if there are no legal moves, it
@@ -1462,20 +1440,19 @@ moves_loop: // When in check search starts from here
 
 } // namespace
 
-  // check_time() is used to print debug info and, more importantly, to detect
-  // when we are out of available time and thus stop the search.
+  // check_time() aborts the search throwing and exception when the stop signal is set.
+  // The main thread will signal with a stop when the available time or nodes are exceeded.
+  void Thread::check_time() {
 
-  void MainThread::check_time() {
+    if (Threads.stop.load(std::memory_order_relaxed))
+        break_search();
 
-    if (--callsCnt > 0)
+    if (nodes.load(std::memory_order_relaxed) < nodesTime || this != Threads.main())
         return;
 
-    // At low node count increase the checking rate to about 0.1% of nodes
-    // otherwise use a default value.
-    callsCnt = Limits.nodes ? std::min(4096, int(Limits.nodes / 1024)) : 4096;
+    nodesTime += Limits.nodes ? std::min(8192, int(Limits.nodes / 2048)) : 8192;
 
     static TimePoint lastInfoTime = now();
-
     int elapsed = Time.elapsed();
     TimePoint tick = Limits.startTime + elapsed;
 
@@ -1485,14 +1462,12 @@ moves_loop: // When in check search starts from here
         dbg_print();
     }
 
-    // An engine may not stop pondering until told so by the GUI
-    if (Threads.ponder)
-        return;
-
-    if (   (Limits.use_time_management() && elapsed > Time.maximum())
-        || (Limits.movetime && elapsed >= Limits.movetime)
-        || (Limits.nodes && Threads.nodes_searched() >= (uint64_t)Limits.nodes))
-            Threads.stop = true;
+    // If not pondering, check if nodes/time are exceeded and stop accorindingly.
+    if (!Threads.ponder.load(std::memory_order_relaxed)
+        && (   (Limits.use_time_management() && elapsed > Time.maximum())
+            || (Limits.movetime && elapsed >= Limits.movetime)
+            || (Limits.nodes && Threads.nodes_searched() >= (uint64_t)Limits.nodes)))
+        break_search();
   }
 
 
@@ -1513,7 +1488,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
   {
       bool updated = (i <= PVIdx && rootMoves[i].score != -VALUE_INFINITE);
 
-      if (depth == ONE_PLY && !updated)
+      if (depth <= ONE_PLY && !updated)
           continue;
 
       Depth d = updated ? depth : depth - ONE_PLY;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -182,7 +182,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
 
   for (Thread* th : Threads)
   {
-      th->nodes = th->tbHits = 0;
+      th->nodes = th->nodesTime = th->tbHits = 0;
       th->rootDepth = th->completedDepth = DEPTH_ZERO;
       th->rootMoves = rootMoves;
       th->rootPos.set(pos.fen(), pos.is_chess960(), &setupStates->back(), th);

--- a/src/thread.h
+++ b/src/thread.h
@@ -56,6 +56,7 @@ public:
   void idle_loop();
   void start_searching();
   void wait_for_search_finished();
+  void check_time();
 
   Pawns::Table pawnsTable;
   Material::Table materialTable;
@@ -63,6 +64,7 @@ public:
   size_t PVIdx;
   int selDepth;
   std::atomic<uint64_t> nodes, tbHits;
+  uint64_t nodesTime;
 
   Position rootPos;
   Search::RootMoves rootMoves;
@@ -80,12 +82,10 @@ struct MainThread : public Thread {
   using Thread::Thread;
 
   void search() override;
-  void check_time();
 
   bool easyMovePlayed, failedLow;
   double bestMoveChanges;
   Value previousScore;
-  int callsCnt;
 };
 
 


### PR DESCRIPTION
Fixes issue #1232

passed sprt @ 10+0.1 th 1
http://tests.stockfishchess.org/tests/view/59cc891f0ebc5916ff64b86f
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 52063 W: 9192 L: 9123 D: 33748
elo =    0.460 +-    1.768 LOS:   69.5%

pending sprt @ 5+0.05 th 5
http://tests.stockfishchess.org/tests/view/59cd23540ebc5916ff64b8ae
LLR: 1.12 (-2.94,2.94) [-4.00,0.00]
Total: 57088 W: 9152 L: 9272 D: 38664
elo =   -0.730 +-    1.617 LOS:   18.8%

The search loop (including ID loop, and aspiration) can now be quit throwing an exception via break_search(). This allows for removing quite some logic in search, and reorganizing Thread::search() to be more clear and concise.

The catch block must restore the rootPos, as well as sort the rootMoves, and possibly output the new PV.

The exception based approach to quit the search is essentially instantaneous, but practically, that is only a small advantage over the old implementation. The stop signal, as well as the clock is only checked in one place, namely check_time(), which is called only from the central search() function. While the stop signal is checked on every call, by all threads, time is checked (as in master) only by the main thread. Now, time checking is every ~8000 nodes, rather than counting the calls to search(). This yields potentially a more homogeneous sampling for the time, as also longer qsearches are taken into account.

unchanged bench:  5037819