### PR TITLE
PV-Exact Reduction- bench:  5742466

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -543,7 +543,7 @@ namespace {
     Depth extension, newDepth;
     Value bestValue, value, ttValue, eval;
     bool ttHit, inCheck, givesCheck, singularExtensionNode, improving;
-    bool captureOrPromotion, doFullDepthSearch, moveCountPruning, skipQuiets, ttCapture;
+    bool captureOrPromotion, doFullDepthSearch, moveCountPruning, skipQuiets, ttCapture, pvExact;
     Piece movedPiece;
     int moveCount, quietCount;
 
@@ -813,6 +813,7 @@ moves_loop: // When in check search starts from here
                            &&  tte->depth() >= depth - 3 * ONE_PLY;
     skipQuiets = false;
     ttCapture = false;
+    pvExact = PvNode && ttHit && tte->bound() == BOUND_EXACT;
 
     // Step 11. Loop through moves
     // Loop through all pseudo-legal moves until no moves remain or a beta cutoff occurs
@@ -960,6 +961,10 @@ moves_loop: // When in check search starts from here
               // Increase reduction if ttMove is a capture
               if (ttCapture)
                   r += ONE_PLY;
+
+              // Decrease reduction for exact nodes
+              if (pvExact)
+                  r -= ONE_PLY;
 
               // Increase reduction for cut nodes
               if (cutNode)


### PR DESCRIPTION
Reduce reduction for exact nodes.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 59004 W: 10621 L: 10249 D: 38134

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 25801 W: 3306 L: 3108 D: 19387

Bench:  5742466