### PR TITLE
Good bishops on the main diagonals

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -42,6 +42,10 @@ const std::string pretty(Bitboard b);
 const Bitboard AllSquares = ~Bitboard(0);
 const Bitboard DarkSquares = 0xAA55AA55AA55AA55ULL;
 
+const Bitboard LongDiagonals = 0x8142241818244281ULL;
+const Bitboard Center        = 0x0000001818000000ULL;
+const Bitboard LargeCenter   = 0x00003C3C3C3C0000ULL;
+
 const Bitboard FileABB = 0x0101010101010101ULL;
 const Bitboard FileBBB = FileABB << 1;
 const Bitboard FileCBB = FileABB << 2;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -204,6 +204,7 @@ namespace {
   // Assorted bonuses and penalties used by evaluation
   const Score MinorBehindPawn     = S( 16,  0);
   const Score BishopPawns         = S(  8, 12);
+  const Score LongRangedBishop    = S( 22,  0);
   const Score RookOnPawn          = S(  8, 24);
   const Score TrappedRook         = S( 92,  0);
   const Score WeakQueen           = S( 50, 10);
@@ -338,9 +339,17 @@ namespace {
                 && (pos.pieces(PAWN) & (s + pawn_push(Us))))
                 score += MinorBehindPawn;
 
-            // Penalty for pawns on the same color square as the bishop
             if (Pt == BISHOP)
+            {
+                // Penalty for pawns on the same color square as the bishop
                 score -= BishopPawns * pe->pawns_on_same_color_squares(Us, s);
+
+                // Bonus for bishop on a long diagonal without pawns in the center
+                if (    (LongDiagonals & s)
+                    && !(attackedBy[Them][PAWN] & s)
+                    && !(Center & PseudoAttacks[BISHOP][s] & pos.pieces(PAWN)))
+                    score += LongRangedBishop;
+            }
 
             // An important Chess960 pattern: A cornered bishop blocked by a friendly
             // pawn diagonally in front of it is a very serious problem, especially


### PR DESCRIPTION
Bonus in midgame for bishops on long diagonals when the central squares are not occupied by pawns.

Author: ElbertoOne

Passed STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 10801 W: 1955 L: 1786 D: 7060
http://tests.stockfishchess.org/tests/view/59cf5c1d0ebc5916ff64b9da

and LTC:
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 83978 W: 10685 L: 10303 D: 62990
http://tests.stockfishchess.org/tests/view/59cf6f6c0ebc5916ff64b9e4

Bench: 5620312