### PR TITLE
Long Diagonal fix

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -31,12 +31,10 @@
 
 namespace {
 
-  //const Bitboard LongDiagonals      = 0x8142241818244281ULL; // A1..H8 | H1..A8
-  const Bitboard Center             = (FileDBB | FileEBB) & (Rank4BB | Rank5BB);
-  //const Bitboard LargeCenter        = 0x00003C3C3C3C0000ULL;
-  const Bitboard QueenSide     = FileABB | FileBBB | FileCBB | FileDBB;
-  const Bitboard CenterFiles   = FileCBB | FileDBB | FileEBB | FileFBB;
-  const Bitboard KingSide      = FileEBB | FileFBB | FileGBB | FileHBB;
+  const Bitboard Center      = (FileDBB | FileEBB) & (Rank4BB | Rank5BB);
+  const Bitboard QueenSide   =  FileABB | FileBBB | FileCBB | FileDBB;
+  const Bitboard CenterFiles =  FileCBB | FileDBB | FileEBB | FileFBB;
+  const Bitboard KingSide    =  FileEBB | FileFBB | FileGBB | FileHBB;
 
   const Bitboard KingFlank[FILE_NB] = {
     QueenSide, QueenSide, QueenSide, CenterFiles, CenterFiles, KingSide, KingSide, KingSide
@@ -357,7 +355,7 @@ namespace {
 
                 // Bonus for bishop on a long diagonal if it can "see" both center squares
                 if (  !(attackedBy[Them][PAWN] & s)
-                    && (more_than_one(attacks_bb<BISHOP>(s, pos.pieces(PAWN)) & Center)))
+                    && (more_than_one((attacks_bb<BISHOP>(s, pos.pieces(PAWN)) | s) & Center)))
                     score += LongRangedBishop;
             }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -32,9 +32,9 @@
 namespace {
 
   const Bitboard Center      = (FileDBB | FileEBB) & (Rank4BB | Rank5BB);
-  const Bitboard QueenSide   =  FileABB | FileBBB | FileCBB | FileDBB;
-  const Bitboard CenterFiles =  FileCBB | FileDBB | FileEBB | FileFBB;
-  const Bitboard KingSide    =  FileEBB | FileFBB | FileGBB | FileHBB;
+  const Bitboard QueenSide   =  FileABB | FileBBB  |  FileCBB | FileDBB;
+  const Bitboard CenterFiles =  FileCBB | FileDBB  |  FileEBB | FileFBB;
+  const Bitboard KingSide    =  FileEBB | FileFBB  |  FileGBB | FileHBB;
 
   const Bitboard KingFlank[FILE_NB] = {
     QueenSide, QueenSide, QueenSide, CenterFiles, CenterFiles, KingSide, KingSide, KingSide
@@ -355,7 +355,7 @@ namespace {
 
                 // Bonus for bishop on a long diagonal if it can "see" both center squares
                 if (  !(attackedBy[Them][PAWN] & s)
-                    && (more_than_one((attacks_bb<BISHOP>(s, pos.pieces(PAWN)) | s) & Center)))
+                    && (more_than_one(Center & (attacks_bb<BISHOP>(s, pos.pieces(PAWN)) | s))))
                     score += LongRangedBishop;
             }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -31,8 +31,9 @@
 
 namespace {
 
-  const Bitboard LongDiagonals = 0x8142241818244281ULL; // A1..H8 | H1..A8
-  const Bitboard Center        = (FileDBB | FileEBB) & (Rank4BB | Rank5BB);
+  //const Bitboard LongDiagonals      = 0x8142241818244281ULL; // A1..H8 | H1..A8
+  const Bitboard Center             = (FileDBB | FileEBB) & (Rank4BB | Rank5BB);
+  //const Bitboard LargeCenter        = 0x00003C3C3C3C0000ULL;
   const Bitboard QueenSide     = FileABB | FileBBB | FileCBB | FileDBB;
   const Bitboard CenterFiles   = FileCBB | FileDBB | FileEBB | FileFBB;
   const Bitboard KingSide      = FileEBB | FileFBB | FileGBB | FileHBB;
@@ -354,10 +355,9 @@ namespace {
                 // Penalty for pawns on the same color square as the bishop
                 score -= BishopPawns * pe->pawns_on_same_color_squares(Us, s);
 
-                // Bonus for bishop on a long diagonal without pawns in the center
-                if (    (LongDiagonals & s)
-                    && !(attackedBy[Them][PAWN] & s)
-                    && !(Center & PseudoAttacks[BISHOP][s] & pos.pieces(PAWN)))
+                // Bonus for bishop on a long diagonal if it can "see" both center squares
+                if (  !(attackedBy[Them][PAWN] & s)
+                    && (more_than_one(attacks_bb<BISHOP>(s, pos.pieces(PAWN)) & Center)))
                     score += LongRangedBishop;
             }
 


### PR DESCRIPTION
Current master is giving bonus for White Bg2 or Bh1 behind a pawn on f3, or White Ba8 or b7 in front of a pawn on c6.
This patch does not give the LongDiagonal bonus in these cases.

STC
http://tests.stockfishchess.org/tests/view/59d391d10ebc5916ff64bbc3
LLR: 2.97 (-2.94,2.94) [-3.00,1.00]
Total: 31433 W: 5599 L: 5495 D: 20339

LTC
http://tests.stockfishchess.org/tests/view/59d4c67d0ebc5916ff64bc42
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 34432 W: 4394 L: 4291 D: 25747