### PR TITLE
Scale factor tweak

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -794,7 +794,7 @@ namespace {
     // types of endgames, and use a lower scale for those.
     if (sf == SCALE_FACTOR_NORMAL || sf == SCALE_FACTOR_ONEPAWN)
     {
-        if (pos.opposite_bishops()) || (abs(eg) <= BishopValueEg
+        if ((pos.opposite_bishops()) || (abs(eg) <= BishopValueEg
                                         &&  pos.count<PAWN>(strongSide) <= 2
                                         && !pos.pawn_passed(~strongSide, pos.square<KING>(~strongSide)))
         {

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -796,7 +796,7 @@ namespace {
     {
         if ((pos.opposite_bishops()) || (abs(eg) <= BishopValueEg
                                         &&  pos.count<PAWN>(strongSide) <= 2
-                                        && !pos.pawn_passed(~strongSide, pos.square<KING>(~strongSide)))
+                                        && !pos.pawn_passed(~strongSide, pos.square<KING>(~strongSide))))
         {
             // Endgame with opposite-colored bishops and no other pieces (ignoring pawns)
             // is almost a draw, in case of KBP vs KB, it is even more a draw.

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -794,7 +794,9 @@ namespace {
     // types of endgames, and use a lower scale for those.
     if (sf == SCALE_FACTOR_NORMAL || sf == SCALE_FACTOR_ONEPAWN)
     {
-        if (pos.opposite_bishops())
+        if (pos.opposite_bishops()) || (abs(eg) <= BishopValueEg
+                                        &&  pos.count<PAWN>(strongSide) <= 2
+                                        && !pos.pawn_passed(~strongSide, pos.square<KING>(~strongSide)))
         {
             // Endgame with opposite-colored bishops and no other pieces (ignoring pawns)
             // is almost a draw, in case of KBP vs KB, it is even more a draw.
@@ -804,16 +806,12 @@ namespace {
 
             // Endgame with opposite-colored bishops, but also other pieces. Still
             // a bit drawish, but not as drawish as with only the two bishops.
+            // Endings where weaker side can place his king in front of the opponent's
+            // pawns are drawish.
             return ScaleFactor(46);
-        }
-        // Endings where weaker side can place his king in front of the opponent's
-        // pawns are drawish.
-        else if (    abs(eg) <= BishopValueEg
-                 &&  pos.count<PAWN>(strongSide) <= 2
-                 && !pos.pawn_passed(~strongSide, pos.square<KING>(~strongSide)))
-            return ScaleFactor(37 + 7 * pos.count<PAWN>(strongSide));
+         }
     }
-
+    
     return sf;
   }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -795,8 +795,8 @@ namespace {
     if (sf == SCALE_FACTOR_NORMAL || sf == SCALE_FACTOR_ONEPAWN)
     {
         if ((pos.opposite_bishops()) || (abs(eg) <= BishopValueEg
-                                        &&  pos.count<PAWN>(strongSide) <= 2
-                                        && !pos.pawn_passed(~strongSide, pos.square<KING>(~strongSide))))
+                                         && pos.count<PAWN>(strongSide) <= 2
+                                         && !pos.pawn_passed(~strongSide, pos.square<KING>(~strongSide))))
         {
             // Endgame with opposite-colored bishops and no other pieces (ignoring pawns)
             // is almost a draw, in case of KBP vs KB, it is even more a draw.


### PR DESCRIPTION
Scale Factor tweak (combining similar scale factor values in one with some simplification for acceptance conditions for using). Scale Factor value for endings where weaker side can place his king in front of the opponent's king replaced from (37 + 7 * pawn count strong side) to value (46), how resembling with scale factor value for multi-figure opposite-colored bishops endings.

STC: (not passed, at bounds [0.00,4.00])
LLR: -2.95 (-2.94,2.94) [0.00,4.00]
Total: 38110 W: 6740 L: 6768 D: 24602

LTC: (passed, at bounds [-3.00,1.00])
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 22994 W: 2906 L: 2788 D: 17300

Bench: 5210738