### PR TITLE
Fix issue #1268

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -513,7 +513,7 @@ void Thread::search() {
       EasyMove.clear();
 
   // If skill level is enabled, swap best PV line with the sub-optimal one
-  if (skill.enabled())
+  if (skill.enabled() && skill.best_move(multiPV) != MOVE_NONE)
       std::swap(rootMoves[0], *std::find(rootMoves.begin(),
                 rootMoves.end(), skill.best_move(multiPV)));
 }


### PR DESCRIPTION
if the search is quit before skill.pick_best is called, skill.best_move might be MOVE_NONE.
Do not find-and-swap rootmoves in that case, avoiding segfaults

No functional change.