### PR TITLE
This solves premature using of all available time in x/y time controls

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -52,7 +52,7 @@ namespace {
         else
             ratio *= 1.5;
 
-        ratio = std::min(0.75, ratio);
+        if (movesToGo > 1) ratio = std::min(0.75, ratio);
         ratio *= 1 + inc / (myTime * 8.5);
     }
     // Otherwise we increase usage of remaining time as the game goes on

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -52,6 +52,7 @@ namespace {
         else
             ratio *= 1.5;
 
+        ratio = std::min(0.75, ratio);
         ratio *= 1 + inc / (myTime * 8.5);
     }
     // Otherwise we increase usage of remaining time as the game goes on

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -256,6 +256,8 @@ string UCI::value(Value v) {
 
   stringstream ss;
 
+  v = PawnValueEg; // to disable early adjudication for wins and draws with cutechess-cli 
+
   if (abs(v) < VALUE_MATE - MAX_PLY)
       ss << "cp " << v * 100 / PawnValueEg;
   else

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -256,8 +256,6 @@ string UCI::value(Value v) {
 
   stringstream ss;
 
-  v = PawnValueEg; // to disable early adjudication for wins and draws with cutechess-cli 
-
   if (abs(v) < VALUE_MATE - MAX_PLY)
       ss << "cp " << v * 100 / PawnValueEg;
   else


### PR DESCRIPTION
In x/y time controls there was a theoretical possibility to use all available time few moves before the clock will be updated with new time. This patch fixes that issue.

Tested at 60/15 time control:

LLR: 2.96 (-2.94,2.94) [-3.00,1.00] 
Total: 113963 W: 20008 L: 20042 D: 73913

The test was done without adjudication rules!

Bench 5234652