### PR TITLE
Sudden death bug fix

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -60,7 +60,7 @@ namespace {
         double k = 1 + 20 * moveNum / (500.0 + moveNum);
         double l = (type == OptimumTime ? 0.017 : 0.07);
         double sratio = k * l; // Ratio of myTime for sudden death case
-        if (moveNum > 60) sratio = std::min(0.05, sratio);
+        if (moveNum > 60) sratio = std::min(0.1, sratio);
         ratio = sratio + l * inc / myTime;
     }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -59,7 +59,8 @@ namespace {
     {
         double k = 1 + 20 * moveNum / (500.0 + moveNum);
         double l = (type == OptimumTime ? 0.017 : 0.07);
-        double sratio = std::min(0.1, l * k); // Ratio of myTime for sudden death case
+        double sratio = k * l; // Ratio of myTime for sudden death case
+        if (moveNum > 40) sratio = std::min(0.05, sratio);
         ratio = sratio + l * inc / myTime;
     }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -60,7 +60,7 @@ namespace {
         double k = 1 + 20 * moveNum / (500.0 + moveNum);
         double l = (type == OptimumTime ? 0.017 : 0.07);
         double sratio = k * l; // Ratio of myTime for sudden death case
-        if (moveNum > 40) sratio = std::min(0.05, sratio);
+        if (moveNum > 60) sratio = std::min(0.05, sratio);
         ratio = sratio + l * inc / myTime;
     }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -58,10 +58,12 @@ namespace {
     else
     {
         double k = 1 + 20 * moveNum / (500.0 + moveNum);
-        ratio = (type == OptimumTime ? 0.017 : 0.07) * (k + inc / myTime);
+        double l = (type == OptimumTime ? 0.017 : 0.07);
+        double sratio = std::min(0.1, l * k); // Ratio of myTime for sudden death case
+        ratio = sratio + l * inc / myTime;
     }
 
-    int time = int(std::min(0.1 + 0.9 * (myInc ? 1 : 0), ratio) * std::max(0, myTime - moveOverhead));
+    int time = int(std::min(1.0, ratio) * std::max(0, myTime - moveOverhead));
 
     if (type == OptimumTime && ponder)
         time = 5 * time / 4;

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -61,7 +61,7 @@ namespace {
         ratio = (type == OptimumTime ? 0.017 : 0.07) * (k + inc / myTime);
     }
 
-    int time = int(std::min(1.0, ratio) * std::max(0, myTime - moveOverhead));
+    int time = int(std::min(0.1 + 0.9 * (myInc ? 1 : 0), ratio) * std::max(0, myTime - moveOverhead));
 
     if (type == OptimumTime && ponder)
         time = 5 * time / 4;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -256,6 +256,8 @@ string UCI::value(Value v) {
 
   stringstream ss;
 
+  v = PawnValueEg; // to disable early adjudication for wins and draws with cutechess-cli 
+
   if (abs(v) < VALUE_MATE - MAX_PLY)
       ss << "cp " << v * 100 / PawnValueEg;
   else

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -256,8 +256,6 @@ string UCI::value(Value v) {
 
   stringstream ss;
 
-  v = PawnValueEg; // to disable early adjudication for wins and draws with cutechess-cli 
-
   if (abs(v) < VALUE_MATE - MAX_PLY)
       ss << "cp " << v * 100 / PawnValueEg;
   else


### PR DESCRIPTION
This patch simply caps time usage to 10% per move in sudden death games (after move 60). In current code the usage of available time constantly increases resulting in using all of remaining time at move 990.

Tested at sudden death TC (16+0):

LLR: 2.95 (-2.94,2.94) [-3.00,1.00] 
Total: 8636 W: 1646 L: 1504 D: 5486

and also at standard STC:

LLR: 2.95 (-2.94,2.94) [-3.00,1.00] 
Total: 65912 W: 11739 L: 11694 D: 42479

The tests were done without adjudication rules!

Bench 5234652








