### PR TITLE
Sudden death bug fix

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -60,7 +60,7 @@ namespace {
     // Otherwise we increase usage of remaining time as the game goes on
     else
     {
-        double k = 1 + 20 * moveNum / (500.0 + moveNum);
+        double k = std::min(0.2, 1 + 0.04 * moveNum);
         ratio = (type == OptimumTime ? 0.017 : 0.07) * (k + inc / myTime);
     }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -60,7 +60,7 @@ namespace {
     // Otherwise we increase usage of remaining time as the game goes on
     else
     {
-        double k = 3600 / (1200.0 + (moveNum - 50) * (moveNum - 50));
+        double k = std::min(3.0, 1 + 0.04 * moveNum);
         ratio = (type == OptimumTime ? 0.017 : 0.07) * (k + inc / myTime);
     }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -60,7 +60,7 @@ namespace {
     // Otherwise we increase usage of remaining time as the game goes on
     else
     {
-        double k = std::min(3.0, 1 + 0.04 * moveNum);
+        double k = 3600 / (1200.0 + (moveNum - 50) * (moveNum - 50));
         ratio = (type == OptimumTime ? 0.017 : 0.07) * (k + inc / myTime);
     }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -60,7 +60,7 @@ namespace {
     // Otherwise we increase usage of remaining time as the game goes on
     else
     {
-        double k = std::min(0.2, 1 + 0.04 * moveNum);
+        double k = std::min(3.0, 1 + 0.04 * moveNum);
         ratio = (type == OptimumTime ? 0.017 : 0.07) * (k + inc / myTime);
     }
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -256,6 +256,8 @@ string UCI::value(Value v) {
 
   stringstream ss;
 
+  v = PawnValueEg; // to disable early adjudication for wins and draws with cutechess-cli
+
   if (abs(v) < VALUE_MATE - MAX_PLY)
       ss << "cp " << v * 100 / PawnValueEg;
   else

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -256,8 +256,6 @@ string UCI::value(Value v) {
 
   stringstream ss;
 
-  v = PawnValueEg; // to disable early adjudication for wins and draws with cutechess-cli
-
   if (abs(v) < VALUE_MATE - MAX_PLY)
       ss << "cp " << v * 100 / PawnValueEg;
   else


### PR DESCRIPTION
This patch is doing two things:

1) It gives Stockfish an opportunity to survive longer in sudden death case. Maximum time per move is now 21%, compared to 100% in the current code.

2) It lowers a stress on Move Overhead in games with increment. An optimum time per move do not go above 98.6% even if we have only increment on the clock. In the current code this is 100% from move 83.

The patch is also a small simplification.

The patch passed easily STC tests (without adjudication rules):

16+0:
LLR: 3.30 (-2.94,2.94) [-3.00,1.00]
Total: 22876 W: 4278 L: 4142 D: 14456

10+0.1:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 18561 W: 3402 L: 3277 D: 11882