### PR TITLE
Remove king, minor and pawn vs king and minor endgames

### DIFF
--- a/src/endgame.h
+++ b/src/endgame.h
@@ -53,11 +53,8 @@ enum EndgameCode {
   KRPKB,   // KRP vs KB
   KRPPKRP, // KRPP vs KRP
   KPsK,    // K and pawns vs K
-  KBPKB,   // KBP vs KB
   KBPPKB,  // KBPP vs KB
-  KBPKN,   // KBP vs KN
   KNPK,    // KNP vs K
-  KNPKB,   // KNP vs KB
   KPKP     // KP vs KP
 };
 


### PR DESCRIPTION
Remove endgames of the type king, minor and pawn vs king and minor.

The removal of the single endgames did not show any Elo difference in:
1) superfast (0.5+0.01) conversion matches (2x10000) on random positions from generate branch
2) balanced endgames suite (2x1291) with reasonable thinking time (5+0.05)

The final patch was tested with STC on fishtest and locally with (4x1291) the endgames sutie on 5+0.05 and finished neutral in both cases.

Testing LTC has been avoided since fishtest is not sensitive for this kind of patches and it would be very expensive.

See also [forum thread](https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/lm_HRglsPq8).

[STC results:](http://tests.stockfishchess.org/tests/view/59ea3b090ebc590ccbb8972c)

LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 144407 W: 25381 L: 25466 D: 93560

Local testing results:

Report KBPKB
Conversion test
Score of KBPKB vs master: 2803 - 2817 - 14380  [0.500] 20000
Endgame test
Score of KBPKB vs master: 148 - 145 - 2289  [0.501] 2582

Report KBPKN
Conversion test
Score of KBPKN vs master: 4040 - 4036 - 11924  [0.500] 20000
Endgame test
Score of KBPKN vs master: 147 - 142 - 2293  [0.501] 2582

Report KNPKB
Conversion test
Score of KNPKB vs master: 2640 - 2547 - 14813  [0.502] 20000
Endgame test
Score of KNPKB vs master: 154 - 148 - 2280  [0.501] 2582

noMinorEndgames vs master on endgames suite
Score of new vs old: 623 - 623 - 9082  [0.500] 10328

Bench: 5247248