### PR TITLE
remove pick_best

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -48,15 +48,6 @@ namespace {
         }
   }
 
-  // pick_best() finds the best move in the range (begin, end) and moves it to
-  // the front. It's faster than sorting all the moves in advance when there
-  // are few moves, e.g., the possible captures.
-  Move pick_best(ExtMove* begin, ExtMove* end) {
-
-    std::swap(*begin, *std::max_element(begin, end));
-    return *begin;
-  }
-
 } // namespace
 
 
@@ -158,6 +149,7 @@ void MovePicker::score() {
 Move MovePicker::next_move(bool skipQuiets) {
 
   Move move;
+  int limit = -4000 * depth / ONE_PLY;
 
   switch (stage) {
 
@@ -176,7 +168,7 @@ Move MovePicker::next_move(bool skipQuiets) {
   case GOOD_CAPTURES:
       while (cur < endMoves)
       {
-          move = pick_best(cur++, endMoves);
+          move = *cur++;
           if (move != ttMove)
           {
               if (pos.see_ge(move))
@@ -222,7 +214,7 @@ Move MovePicker::next_move(bool skipQuiets) {
       cur = endBadCaptures;
       endMoves = generate<QUIETS>(pos, cur);
       score<QUIETS>();
-      partial_insertion_sort(cur, endMoves, -4000 * depth / ONE_PLY);
+      partial_insertion_sort(cur, endMoves, limit);
       ++stage;
       /* fallthrough */
 
@@ -251,13 +243,14 @@ Move MovePicker::next_move(bool skipQuiets) {
       cur = moves;
       endMoves = generate<EVASIONS>(pos, cur);
       score<EVASIONS>();
+      partial_insertion_sort(cur, endMoves, limit);
       ++stage;
       /* fallthrough */
 
   case ALL_EVASIONS:
       while (cur < endMoves)
       {
-          move = pick_best(cur++, endMoves);
+          move = *cur++;
           if (move != ttMove)
               return move;
       }
@@ -267,13 +260,14 @@ Move MovePicker::next_move(bool skipQuiets) {
       cur = moves;
       endMoves = generate<CAPTURES>(pos, cur);
       score<CAPTURES>();
+      partial_insertion_sort(cur, endMoves, limit);
       ++stage;
       /* fallthrough */
 
   case PROBCUT_CAPTURES:
       while (cur < endMoves)
       {
-          move = pick_best(cur++, endMoves);
+          move = *cur++;
           if (   move != ttMove
               && pos.see_ge(move, threshold))
               return move;
@@ -284,13 +278,14 @@ Move MovePicker::next_move(bool skipQuiets) {
       cur = moves;
       endMoves = generate<CAPTURES>(pos, cur);
       score<CAPTURES>();
+      partial_insertion_sort(cur, endMoves, limit);
       ++stage;
       /* fallthrough */
 
   case QCAPTURES_1: case QCAPTURES_2:
       while (cur < endMoves)
       {
-          move = pick_best(cur++, endMoves);
+          move = *cur++;
           if (move != ttMove)
               return move;
       }
@@ -314,13 +309,14 @@ Move MovePicker::next_move(bool skipQuiets) {
       cur = moves;
       endMoves = generate<CAPTURES>(pos, cur);
       score<CAPTURES>();
+      partial_insertion_sort(cur, endMoves, limit);
       ++stage;
       /* fallthrough */
 
   case QRECAPTURES:
       while (cur < endMoves)
       {
-          move = pick_best(cur++, endMoves);
+          move = *cur++;
           if (to_sq(move) == recaptureSquare)
               return move;
       }


### PR DESCRIPTION
pick_best    ------   std::swap(*begin, *std::max_element(begin,end);

Repeatedly calling pick_best for ANY set of moves would always seem (to me) slower than insertion sorting them beforehand.  My bench seems to indicate the same (but, this code actually sorts a bit less because I'm using the limit for all of the move generations.

10    1829018    1848220   +19202
 11    1789012    1812825   +23813
 12    1828380    1847619   +19239
 13    1713470    1741135   +27665
 14    1803808    1841628   +37820
 15    1769061    1801898   +32837
 16    1739665    1784909   +45244
 17    1705653    1731580   +25927
 18    1841890    1847619    +5729
 19    1805675    1816304   +10629
 20    1825829    1847619   +21790

Result of  20 runs
==================
base (...kfish_master) =    1800448  +/- 17710
test (./stockfish    ) =    1822276  +/- 16489
diff                   =     +21827  +/- 6234

speedup        = +0.0121
P(speedup > 0) =  1.0000

CPU: 2 x Intel(R) Core(TM) i7-2640M CPU @ 2.80GHz
Hyperthreading: on 

I wouldn't think this would make a big difference, but it is test worthy?