### PR TITLE
remove pick_best

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -162,7 +162,7 @@ Move MovePicker::next_move(bool skipQuiets) {
       endBadCaptures = cur = moves;
       endMoves = generate<CAPTURES>(pos, cur);
       score<CAPTURES>();
-      partial_insertion_sort(cur, endMoves, limit);
+      partial_insertion_sort(cur, endMoves, -VALUE_NONE);
       ++stage;
       /* fallthrough */
 
@@ -244,7 +244,7 @@ Move MovePicker::next_move(bool skipQuiets) {
       cur = moves;
       endMoves = generate<EVASIONS>(pos, cur);
       score<EVASIONS>();
-      partial_insertion_sort(cur, endMoves, limit);
+      partial_insertion_sort(cur, endMoves, -VALUE_NONE);
       ++stage;
       /* fallthrough */
 
@@ -261,7 +261,7 @@ Move MovePicker::next_move(bool skipQuiets) {
       cur = moves;
       endMoves = generate<CAPTURES>(pos, cur);
       score<CAPTURES>();
-      partial_insertion_sort(cur, endMoves, limit);
+      partial_insertion_sort(cur, endMoves, -VALUE_NONE);
       ++stage;
       /* fallthrough */
 
@@ -279,7 +279,7 @@ Move MovePicker::next_move(bool skipQuiets) {
       cur = moves;
       endMoves = generate<CAPTURES>(pos, cur);
       score<CAPTURES>();
-      partial_insertion_sort(cur, endMoves, limit);
+      partial_insertion_sort(cur, endMoves, -VALUE_NONE);
       ++stage;
       /* fallthrough */
 
@@ -310,7 +310,6 @@ Move MovePicker::next_move(bool skipQuiets) {
       cur = moves;
       endMoves = generate<CAPTURES>(pos, cur);
       score<CAPTURES>();
-      partial_insertion_sort(cur, endMoves, limit);
       ++stage;
       /* fallthrough */
 


### PR DESCRIPTION
retrying with updated master.

repeatedly calling pick_best doesn't seem very efficient, however a comment says it's faster that way?

To me, it would seem much faster to insertion_sort the moves after generation . . . even for very few moves.

Here are my bench results:
  1    1795148    1830293   +35145
  2    1849046    1867416   +18370
  3    1847089    1860006   +12917
.
.
 17    1825829    1894868   +69039
 18    1794532    1845360   +50828
 19    1816326    1888621   +72295
 20    1848394    1871483   +23089

Result of  20 runs
==================
base (...kfish_master) =    1819869  +/- 14292
test (./stockfish    ) =    1859209  +/- 18078
diff                   =     +39341  +/- 10289

speedup        = +0.0216
P(speedup > 0) =  1.0000

CPU: 2 x Intel(R) Core(TM) i7-2640M CPU @ 2.80GHz
Hyperthreading: on 