### PR TITLE
Full PV search on the first move or after a NonPV fail high.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1017,9 +1017,8 @@ moves_loop: // When in check search starts from here
                                        : - search<NonPV>(pos, ss+1, -(alpha+1), -alpha, newDepth, !cutNode, false);
 
       // For PV nodes only, do a full PV search on the first move or after a fail
-      // high (in the latter case search only if value < beta), otherwise let the
-      // parent node fail low with value <= alpha and try another move.
-      if (PvNode && (moveCount == 1 || (value > alpha && (rootNode || value < beta))))
+      // high, otherwise let the parent node fail low with value <= alpha and try another move.
+      if (PvNode && (moveCount == 1 || value > alpha))
       {
           (ss+1)->pv = pv;
           (ss+1)->pv[0] = MOVE_NONE;


### PR DESCRIPTION
Simplification.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 25890 W: 4822 L: 4710 D: 16358

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 35986 W: 4576 L: 4475 D: 26935

Note: This patch failed yellow a previous run with limit [0,4]; I did not know about that previous patch before submitting the test. 

Previous run by VoyagerOne
LTC:
LLR: -2.95 (-2.94,2.94) [0.00,4.00]
Total: 110235 W: 14148 L: 14012 D: 82075

bench: 5039438