### PR TITLE
Simplify BxN trade logic

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -179,12 +179,7 @@ Move MovePicker::next_move(bool skipQuiets) {
           move = pick_best(cur++, endMoves);
           if (move != ttMove)
           {
-              if (pos.see_ge(move))
-                  return move;
-
-              if (   type_of(pos.piece_on(to_sq(move))) == KNIGHT
-                  && type_of(pos.moved_piece(move)) == BISHOP
-                  && (cur-1)->value > 1090)
+              if (pos.see_ge(move, (cur-1)->value > 1090 ? KnightValueMg - BishopValueMg  : VALUE_ZERO))
                   return move;
 
               // Losing capture, move it to the beginning of the array


### PR DESCRIPTION
STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 14716 W: 2717 L: 2586 D: 9413
http://tests.stockfishchess.org/tests/view/5a0026940ebc590ccbb8a4a8

LTC: 
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 115424 W: 14540 L: 14540 D: 86344
http://tests.stockfishchess.org/tests/view/5a005c7c0ebc590ccbb8a4ef

Bench: 5019047