### PR TITLE
Capture Stat Simplification- Bench:  5363761

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -580,8 +580,6 @@ namespace {
             {
                 if (!pos.capture_or_promotion(ttMove))
                     update_stats(pos, ss, ttMove, nullptr, 0, stat_bonus(depth));
-                else
-                    update_capture_stats(pos, ttMove, nullptr, 0, stat_bonus(depth));
 
                 // Extra penalty for a quiet TT move in previous ply when it gets refuted
                 if ((ss-1)->moveCount == 1 && !pos.captured_piece())


### PR DESCRIPTION
Don't update capture stats at TT-cutoffs

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 26431 W: 4810 L: 4698 D: 16923

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 91170 W: 11320 L: 11288 D: 68562

Bench:  5363761