### PR TITLE
Adjust SEE threshold using capture history.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -179,12 +179,8 @@ Move MovePicker::next_move(bool skipQuiets) {
           move = pick_best(cur++, endMoves);
           if (move != ttMove)
           {
-              if (pos.see_ge(move))
-                  return move;
-
-              if (   type_of(pos.piece_on(to_sq(move))) == KNIGHT
-                  && type_of(pos.moved_piece(move)) == BISHOP
-                  && (cur-1)->value > 1090)
+              int hist = (*captureHistory)[pos.moved_piece(move)][to_sq(move)][type_of(pos.piece_on(to_sq(move)))];
+              if (pos.see_ge(move, Value(-hist / 4)))
                   return move;
 
               // Losing capture, move it to the beginning of the array


### PR DESCRIPTION
This is inspired by, and an alternative for @pb00068 patch (#1300), in particular will also allow a BxN capture as good, if the history is good. It is slightly more general in that the threshold can be negative (e.g. bad history NxB captures will become bad).

Passed STC:
http://tests.stockfishchess.org/tests/view/5a0972dd0ebc590ccbb8a9fa
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 82288 W: 14729 L: 14712 D: 52847
Elo                         :  -0.3 [-2.0,1.3]

Passed LTC:
http://tests.stockfishchess.org/tests/view/5a0a891c0ebc590ccbb8aa6b
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 17637 W: 2339 L: 2214 D: 13084
Elo                         :  2.0 [-0.9,4.9]

Bench: 5259975