### PR TITLE
Fix comments in captures scoring

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -123,7 +123,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePiece
 
 /// score() assigns a numerical value to each move in a list, used for sorting.
 /// Captures are ordered by Most Valuable Victim (MVV), preferring captures
-/// near our home rank. Quiets are ordered using the histories.
+/// with a good history. Quiets are ordered using the histories.
 template<GenType Type>
 void MovePicker::score() {
 


### PR DESCRIPTION
Fix comments which were neglected in the capture scoring patch. No functional change.