### PR TITLE
Capture order

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -179,12 +179,7 @@ Move MovePicker::next_move(bool skipQuiets) {
           move = pick_best(cur++, endMoves);
           if (move != ttMove)
           {
-              if (pos.see_ge(move))
-                  return move;
-
-              if (   type_of(pos.piece_on(to_sq(move))) == KNIGHT
-                  && type_of(pos.moved_piece(move)) == BISHOP
-                  && (cur-1)->value > 1090)
+              if (pos.see_ge(move, Value(-55 * (cur-1)->value / 1024)))
                   return move;
 
               // Losing capture, move it to the beginning of the array


### PR DESCRIPTION
This is a simplification of the bad capture detection in move sorting. The credits goes to vondele.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 24191 W: 4414 L: 4299 D: 15478

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 57191 W: 7200 L: 7125 D: 42866

Bench: 5336313