### PR TITLE
OpenBSD friendly start.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -205,7 +205,9 @@ ifeq ($(COMP),clang)
 	CXX=clang++
 	CXXFLAGS += -pedantic -Wextra -Wshadow
 ifneq ($(KERNEL),Darwin)
+ifneq ($(KERNEL),OpenBSD)
 	LDFLAGS += -latomic
+endif
 endif
 
 	ifeq ($(ARCH),armv7)


### PR DESCRIPTION
Additional line in Makefile to bypass atomic LDFLAG on OpenBSD.