### PR TITLE
Early mate

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -547,7 +547,7 @@ namespace {
     Key posKey;
     Move ttMove, move, excludedMove, bestMove;
     Depth extension, newDepth;
-    Value bestValue, value, ttValue, eval;
+    Value bestValue, value, ttValue, eval, maxValue;
     bool ttHit, inCheck, givesCheck, singularExtensionNode, improving;
     bool captureOrPromotion, doFullDepthSearch, moveCountPruning, skipQuiets, ttCapture, pvExact;
     Piece movedPiece;
@@ -559,6 +559,7 @@ namespace {
     moveCount = quietCount = ss->moveCount = 0;
     ss->statScore = 0;
     bestValue = -VALUE_INFINITE;
+    maxValue = VALUE_INFINITE;
 
     // Check for the available remaining time
     if (thisThread == Threads.main())
@@ -647,7 +648,7 @@ namespace {
             && !pos.can_castle(ANY_CASTLING))
         {
             TB::ProbeState err;
-            TB::WDLScore v = Tablebases::probe_wdl(pos, &err);
+            TB::WDLScore wdl = Tablebases::probe_wdl(pos, &err);
 
             if (err != TB::ProbeState::FAIL)
             {
@@ -655,15 +656,30 @@ namespace {
 
                 int drawScore = TB::UseRule50 ? 1 : 0;
 
-                value =  v < -drawScore ? -VALUE_MATE + MAX_PLY + ss->ply + 1
-                       : v >  drawScore ?  VALUE_MATE - MAX_PLY - ss->ply - 1
-                                        :  VALUE_DRAW + 2 * v * drawScore;
+                value =  wdl < -drawScore ? -VALUE_MATE + MAX_PLY + ss->ply + 1
+                       : wdl >  drawScore ?  VALUE_MATE - MAX_PLY - ss->ply - 1
+                                          :  VALUE_DRAW + 2 * wdl * drawScore;
 
-                tte->save(posKey, value_to_tt(value, ss->ply), BOUND_EXACT,
-                          std::min(DEPTH_MAX - ONE_PLY, depth + 6 * ONE_PLY),
-                          MOVE_NONE, VALUE_NONE, TT.generation());
+                Bound b =  wdl < -drawScore ? BOUND_UPPER
+                         : wdl >  drawScore ? BOUND_LOWER : BOUND_EXACT;
 
-                return value;
+                if (    b == BOUND_EXACT
+                    || (b == BOUND_LOWER ? value >= beta : value <= alpha))
+                {
+                    tte->save(posKey, value_to_tt(value, ss->ply), b,
+                              std::min(DEPTH_MAX - ONE_PLY, depth + 6 * ONE_PLY),
+                              MOVE_NONE, VALUE_NONE, TT.generation());
+
+                    return value;
+                }
+
+                if (PvNode)
+                {
+                    if (b == BOUND_LOWER)
+                        bestValue = value, alpha = std::max(alpha, bestValue);
+                    else
+                        maxValue = value;
+                }
             }
         }
     }
@@ -1130,6 +1146,9 @@ moves_loop: // When in check search starts from here
              && !pos.captured_piece()
              && is_ok((ss-1)->currentMove))
         update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, stat_bonus(depth));
+
+    if (PvNode)
+        bestValue = std::min(bestValue, maxValue);
 
     if (!excludedMove)
         tte->save(posKey, value_to_tt(bestValue, ss->ply),
@@ -1648,4 +1667,9 @@ void Tablebases::filter_root_moves(Position& pos, Search::RootMoves& rootMoves) 
         TB::Score =  TB::Score > VALUE_DRAW ?  VALUE_MATE - MAX_PLY - 1
                    : TB::Score < VALUE_DRAW ? -VALUE_MATE + MAX_PLY + 1
                                             :  VALUE_DRAW;
+
+    // Since root_probe() and root_probe_wdl() dirty the root move scores,
+    // we reset them to -VALUE_INFINITE
+    for (RootMove& rm : rootMoves)
+        rm.score = -VALUE_INFINITE;
 }


### PR DESCRIPTION
Ronald de Man proposed a tablebase patch after a discussion on talkchess : 
http://talkchess.com/forum/viewtopic.php?p=739046#739046

Here is his comment :
"This modifies the in-search TB probing in a simple kludge-free way
to search further for a mate score after finding a TB win or TB loss.
If a mate score is found, it is returned. Otherwise, the TB win or
TB loss value is returned.

It also fixes a potential problem caused by root_probe() and root_probe_wdl()
dirtying the root-move scores. (A better solution of this problem was
included in the root-ranking patch.)"
Link to the patch : https://github.com/syzygy1/Stockfish/commit/7674d041a58798b19c81e98560dd8653730caf9d

The behavior of stockfish is really better : it finds mates and displays the PV ; here is a test position exemple :

FEN: 8/2P1P3/3k4/8/8/4K3/P2p1p2/8 b - - 0 1 

Stockfish_early_mate:
  1/1	00:00	          68	68k	+0.03	d2-d1Q e7-e8Q Kd6xc7 Ke3xf2
  2/2	00:00	         532	266k	+2.32	f2-f1Q c7-c8Q Qf1-e1+ Ke3-f4 Qe1xe7
  3/4	00:00	         894	179k	+4.82	f2-f1Q c7-c8N+ Kd6-c7 Ke3xd2
  4/6	00:00	          2k	150k	+6.87	f2-f1Q e7-e8N+ Kd6-d7 Ke3xd2
  5/8	00:00	          2k	167k	+10.13	f2-f1Q c7-c8Q Qf1-e1+ Ke3-f4 Qe1-e5+ Kf4-f3 d2-d1Q+ Kf3-g2 Qd1-d5+ Kg2-g1 Kd6xe7
  6/10	00:00	          3k	210k	+10.65	f2-f1Q c7-c8Q Qf1-e1+ Ke3-f4 Qe1-e5+ Kf4-f3 d2-d1Q+ Kf3-g2 Qd1-d5+ Kg2-f1 Qe5-a1+ Kf1-f2 Qa1xa2+ Kf2-g3 Kd6xe7
  7/12	00:00	          9k	425k	+132.75	f2-f1Q c7-c8Q Qf1-e1+ Ke3-f4 Qe1-e5+ Kf4-f3 d2-d1Q+ Kf3-g2 Qe5xe7 a2-a3
  8/11	00:00	         10k	428k	+132.75	f2-f1Q c7-c8Q Qf1-e1+ Ke3-f4 Qe1-e5+ Kf4-f3 d2-d1Q+ Kf3-g2 Kd6xe7 Qc8-c1
  9/12	00:00	         11k	440k	+132.75	f2-f1Q c7-c8Q Qf1-e1+ Ke3-f4 Qe1-e5+ Kf4-f3 d2-d1Q+ Kf3-g2 Kd6xe7 Kg2-h3
 10/18	00:00	         32k	796k	+132.76	f2-f1Q e7-e8N+ Kd6-d7 Ke3-d4 d2-d1Q+ Kd4-e5 Kd7xe8 c7-c8Q+
 11/22	00:00	         64k	1,091k	+132.76	f2-f1Q c7-c8N+ Kd6-d7 Ke3-e4 d2-d1Q e7-e8Q+ Kd7xe8 Ke4-e5 Qf1-f5+ Ke5xf5
 12/14	00:00	         68k	1,112k	+132.76	f2-f1Q c7-c8N+ Kd6-d7 Ke3-e4 d2-d1Q e7-e8Q+ Kd7xe8 Ke4-e5 Qf1-f5+ Ke5xf5
 13/19	00:00	         84k	1,185k	+132.76	f2-f1Q c7-c8N+ Kd6-d7 Ke3-e4 Qf1-e1+ Ke4-f4 Kd7xc8 Kf4-f5
 14/17	00:00	         97k	1,248k	+132.76	f2-f1Q c7-c8N+ Kd6-d7 Ke3-e4 Qf1-e1+ Ke4-f4 Kd7xc8 Kf4-f5 Qe1xe7 Kf5-f4
 15/24	00:00	        164k	1,669k	+132.77	f2-f1Q c7-c8N+ Kd6-d7 e7-e8Q+ Kd7xe8 Nc8-d6+ Ke8-d7 Nd6-f7 Qf1xf7 Ke3-e2 d2-d1Q+ Ke2xd1
 16/22	00:00	        169k	1,695k	+132.77	f2-f1Q c7-c8N+ Kd6-d7 e7-e8Q+ Kd7xe8 Nc8-d6+ Ke8-d7 Nd6-f7 Qf1xf7 Ke3-e2 d2-d1Q+ Ke2xd1
 17/19	00:00	        208k	1,875k	+132.77	f2-f1Q c7-c8N+ Kd6-d7 e7-e8Q+ Kd7xe8 Nc8-d6+ Ke8-d7 Nd6-c4 Qf1xc4 Ke3xd2
 18/21	00:00	        227k	1,942k	+132.77	f2-f1Q c7-c8N+ Kd6-d7 e7-e8Q+ Kd7xe8 Nc8-d6+ Ke8-d7 Ke3xd2
 19/17	00:00	        253k	1,992k	+132.77	f2-f1Q c7-c8N+ Kd6-d7 e7-e8Q+ Kd7xe8 Nc8-d6+ Ke8-d7 Ke3xd2
 20/17	00:00	        326k	2,159k	+132.77	f2-f1Q c7-c8N+ Kd6-d7 e7-e8Q+ Kd7xe8 Nc8-d6+ Ke8-d7 Ke3xd2
 21/19	00:00	        393k	2,269k	+132.77	f2-f1Q c7-c8N+ Kd6-d7 e7-e8Q+ Kd7xe8 Nc8-d6+ Ke8-d7 Ke3xd2
 22/16	00:00	        570k	2,535k	+132.77	f2-f1Q c7-c8N+ Kd6-d7 e7-e8Q+ Kd7xe8 Nc8-d6+ Ke8-d7 Ke3xd2
 23/17	00:00	        976k	2,903k	+132.77	f2-f1Q c7-c8N+ Kd6-d7 e7-e8Q+ Kd7xe8 Nc8-d6+ Ke8-d7 Ke3xd2
 24/20	00:00	      1,189k	3,033k	+132.77	f2-f1Q c7-c8N+ Kd6-d7 e7-e8Q+ Kd7xe8 Nc8-d6+ Ke8-d7 Ke3xd2
 25/23	00:00	      1,474k	3,137k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 26/7	00:00	      1,595k	3,152k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 27/7	00:00	      1,721k	3,051k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 28/7	00:00	      1,882k	3,096k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 29/7	00:00	      2,125k	3,144k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 30/7	00:00	      2,391k	3,213k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 31/7	00:00	      2,689k	3,275k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 32/7	00:00	      3,071k	3,364k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 33/7	00:01	      3,534k	3,441k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 34/7	00:01	      4,051k	3,522k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 35/7	00:01	      4,469k	3,558k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 36/7	00:01	      5,130k	3,628k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 37/7	00:01	      6,041k	3,706k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 38/7	00:01	      6,694k	3,742k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 39/7	00:02	      7,931k	3,806k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 40/7	00:02	      8,943k	3,827k	+132.77	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2
 41/45+	00:09	     42,116k	4,372k	+M58	f2-f1Q
 41/45+	00:11	     51,369k	4,425k	+M49	f2-f1Q
 41/52+	00:37	    177,940k	4,786k	+M16	f2-f1Q
 41/52	00:49	    233,757k	4,768k	+M15	f2-f1Q c7-c8N+ Kd6-c5 Ke3xd2 Qf1-f2+ Kd2-d3 Qf2-f5+ Kd3-e3 Qf5xc8 a2-a4 Qc8-e6+ Ke3-d3 Qe6-d7+ Kd3-e3 Qd7xe7+ Ke3-d3 Kc5-d5 a4-a5 Qe7-a3+ Kd3-d2 Kd5-e4 Kd2-c2 Ke4-d4 a5-a6 Qa3-a2+ Kc2-d1 Kd4-d3 a6-a7 Qa2-d2+
 42/30	01:01	    294,195k	4,822k	+M14	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2 Qd1-d7 Nc8-a7 Qd7xe7 Na7-c8 Qe7-e6 Kf2-f3 Qe6xc8 Kf3-e4 Qc8-e6+ Ke4-d3 Kc5-d5 a2-a3 Qe6-h3+ Kd3-d2 Kd5-d4 Kd2-c2 Qh3-c3+ Kc2-b1 Qc3-d2 Kb1-a1 Kd4-c3 a3-a4 Qd2-b2+
 43/44	01:10	    334,555k	4,779k	+M14	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2 Qd1-d7 Nc8-a7 Qd7xe7 Na7-c8 Qe7-e6 Nc8-a7 Qe6xa2+ Kf2-e3 Qa2xa7 Ke3-f4 Qa7-e7 Kf4-f3 Qe7-g5 Kf3-e2 Kc5-d4 Ke2-f3 Kd4-d3 Kf3-f2 Qg5-g4 Kf2-f1 Kd3-e3 Kf1-e1 Qg4-e2+
 44/28	01:16	    366,383k	4,787k	+M14	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2 Qd1-d7 Nc8-a7 Qd7xe7 Na7-c8 Qe7-e6 Nc8-a7 Qe6xa2+ Kf2-e3 Qa2xa7 Ke3-f4 Qa7-e7 Kf4-f3 Qe7-g5 Kf3-e2 Kc5-d4 Ke2-f3 Kd4-d3 Kf3-f2 Qg5-g4 Kf2-f1 Kd3-e3 Kf1-e1 Qg4-e2+
 45/28	01:21	    389,423k	4,782k	+M14	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2 Qd1-d7 Nc8-a7 Qd7xe7 Na7-c8 Qe7-e6 Nc8-a7 Qe6xa2+ Kf2-e3 Qa2xa7 Ke3-f4 Qa7-e7 Kf4-f3 Qe7-g5 Kf3-e2 Kc5-d4 Ke2-f3 Kd4-d3 Kf3-f2 Qg5-g4 Kf2-f1 Kd3-e3 Kf1-e1 Qg4-e2+
 46/28	01:27	    420,515k	4,781k	+M14	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2 Qd1-d7 Nc8-a7 Qd7xe7 Na7-c8 Qe7-e6 Nc8-a7 Qe6xa2+ Kf2-e3 Qa2xa7 Ke3-f4 Qa7-e7 Kf4-f3 Qe7-g5 Kf3-e2 Kc5-d4 Ke2-f3 Kd4-d3 Kf3-f2 Qg5-g4 Kf2-f1 Kd3-e3 Kf1-e1 Qg4-e2+
 47/28	01:35	    455,155k	4,760k	+M14	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2 Qd1-d7 Nc8-a7 Qd7xe7 Na7-c8 Qe7-e6 Nc8-a7 Qe6xa2+ Kf2-e3 Qa2xa7 Ke3-f4 Qa7-e7 Kf4-f3 Qe7-g5 Kf3-e2 Kc5-d4 Ke2-f3 Kd4-d3 Kf3-f2 Qg5-g4 Kf2-f1 Kd3-e3 Kf1-e1 Qg4-e2+
 48/28	01:46	    507,828k	4,786k	+M14	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2 Qd1-d7 Nc8-a7 Qd7xe7 Na7-c8 Qe7-e6 Nc8-a7 Qe6xa2+ Kf2-e3 Qa2xa7 Ke3-f4 Qa7-e7 Kf4-f3 Qe7-g5 Kf3-e2 Kc5-d4 Ke2-f3 Kd4-d3 Kf3-f2 Qg5-g4 Kf2-f1 Kd3-e3 Kf1-e1 Qg4-e2+
 49/34	02:00	    582,721k	4,833k	+M14	d2-d1Q c7-c8N+ Kd6-c5 Ke3xf2 Qd1-d7 Nc8-a7 Qd7xe7 Na7-c8 Qe7-e6 Nc8-a7 Qe6xa2+ Kf2-e3 Qa2xa7 Ke3-f4 Qa7-e7 Kf4-f3 Qe7-h4 Kf3-e3 Kc5-c4 Ke3-e2 Qh4-f4 Ke2-d1 Qf4-f2 Kd1-c1 Kc4-c3 Kc1-b1 Qf2-b2+



FEN: 8/2P1P3/3k4/8/8/4K3/P2p1p2/8 b - - 0 1 

Stockfish_base:
  1/1	00:00	          68	68k	+0.03	d2-d1Q e7-e8Q Kd6xc7 Ke3xf2
  2/2	00:00	         532	266k	+2.32	f2-f1Q c7-c8Q Qf1-e1+ Ke3-f4 Qe1xe7
  3/4	00:00	         894	224k	+4.82	f2-f1Q c7-c8N+ Kd6-c7 Ke3xd2
  4/6	00:00	          2k	230k	+6.87	f2-f1Q e7-e8N+ Kd6-d7 Ke3xd2
  5/8	00:00	          2k	256k	+10.13	f2-f1Q c7-c8Q Qf1-e1+ Ke3-f4 Qe1-e5+ Kf4-f3 d2-d1Q+ Kf3-g2 Qd1-d5+ Kg2-g1 Kd6xe7
  6/10	00:00	          3k	311k	+10.65	f2-f1Q c7-c8Q Qf1-e1+ Ke3-f4 Qe1-e5+ Kf4-f3 d2-d1Q+ Kf3-g2 Qd1-d5+ Kg2-f1 Qe5-a1+ Kf1-f2 Qa1xa2+ Kf2-g3 Kd6xe7
  7/12	00:00	          9k	662k	+132.75	f2-f1Q c7-c8Q Qf1-e1+ Ke3-f4 Qe1-e5+ Kf4-f3 d2-d1Q+ Kf3-g2 Qe5xe7
  8/10	00:00	         10k	649k	+132.75	f2-f1Q c7-c8Q Qf1-e1+ Ke3-f4 Qe1-e5+ Kf4-f3 d2-d1Q+ Kf3-g2 Qe5xe7
  9/10	00:00	         10k	647k	+132.75	f2-f1Q c7-c8Q Qf1-e1+ Ke3-f4 Qe1-e5+ Kf4-f3 d2-d1Q+ Kf3-g2 Qe5xe7
 10/10	00:00	         18k	936k	+132.76	f2-f1Q e7-e8N+ Kd6-d7 Ke3-e4 d2-d1Q c7-c8Q+ Kd7xc8
 11/8	00:00	         21k	872k	+132.76	f2-f1Q e7-e8N+ Kd6-d7 Ke3-e4 d2-d1Q c7-c8Q+ Kd7xc8
 12/8	00:00	         25k	926k	+132.76	f2-f1Q e7-e8N+ Kd6-d7 Ke3-e4 d2-d1Q c7-c8Q+ Kd7xc8
 13/16	00:00	         31k	977k	+132.77	f2-f1Q e7-e8N+ Kd6-d7 Ke3-e4 Qf1-f4+ Ke4xf4
 14/7	00:00	         44k	1,196k	+132.77	f2-f1Q e7-e8N+ Kd6-d7 Ke3-e4 Qf1-f4+ Ke4xf4
 15/7	00:00	         52k	1,294k	+132.77	f2-f1Q e7-e8N+ Kd6-d7 Ke3-e4 Qf1-f4+ Ke4xf4
 16/7	00:00	         62k	1,386k	+132.77	f2-f1Q e7-e8N+ Kd6-d7 Ke3-e4 Qf1-f4+ Ke4xf4
 17/7	00:00	         75k	1,474k	+132.77	f2-f1Q e7-e8N+ Kd6-d7 Ke3-e4 Qf1-f4+ Ke4xf4
 18/7	00:00	         91k	1,598k	+132.77	f2-f1Q e7-e8N+ Kd6-d7 Ke3-e4 Qf1-f4+ Ke4xf4
 19/7	00:00	        108k	1,667k	+132.77	f2-f1Q e7-e8N+ Kd6-d7 Ke3-e4 Qf1-f4+ Ke4xf4
 20/7	00:00	        159k	1,678k	+132.77	f2-f1Q e7-e8N+ Kd6-d7 Ke3-e4 Qf1-f4+ Ke4xf4
 21/7	00:00	        209k	1,657k	+132.77	f2-f1Q e7-e8N+ Kd6-d7 Ke3-e4 Qf1-f4+ Ke4xf4
 22/7	00:00	        269k	1,701k	+132.77	f2-f1Q e7-e8N+ Kd6-d7 Ke3-e4 Qf1-f4+ Ke4xf4
 23/7	00:00	        375k	1,691k	+132.77	f2-f1Q e7-e8N+ Kd6-d7 Ke3-e4 Qf1-f4+ Ke4xf4
 24/18	00:00	        713k	1,987k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 25/6	00:00	        792k	1,918k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 26/6	00:00	        928k	1,941k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 27/6	00:00	      1,068k	1,986k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 28/6	00:00	      1,249k	2,044k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 29/6	00:00	      1,451k	1,971k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 30/6	00:00	      1,641k	2,046k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 31/6	00:00	      1,936k	2,082k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 32/6	00:01	      2,223k	2,141k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 33/6	00:01	      2,693k	2,200k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 34/6	00:01	      3,206k	1,813k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 35/6	00:02	      3,734k	1,815k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 36/6	00:02	      4,325k	1,839k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 37/6	00:02	      5,227k	1,932k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 38/6	00:03	      6,017k	1,966k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 39/6	00:03	      6,595k	2,023k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 40/6	00:03	      7,452k	2,001k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 41/6	00:04	     10,193k	2,184k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 42/6	00:05	     11,293k	2,190k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 43/6	00:05	     13,024k	2,183k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 44/6	00:06	     14,652k	2,179k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 45/6	00:08	     19,082k	2,325k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 46/6	00:08	     20,349k	2,363k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 47/6	00:11	     28,209k	2,506k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 48/6	00:12	     31,867k	2,576k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 49/6	00:14	     39,309k	2,666k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 50/6	00:15	     42,028k	2,678k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 51/6	00:17	     45,905k	2,701k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 52/6	00:19	     54,801k	2,762k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 53/6	00:23	     66,695k	2,848k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 54/6	00:25	     73,438k	2,867k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 55/6	00:27	     79,392k	2,895k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 56/6	00:34	    101,336k	2,946k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8
 57/6	00:38	    114,697k	2,992k	+132.77	d2-d1Q e7-e8Q Qd1-e1+ Ke3-d4 Qe1xe8

Results at STC :
Score of sf_early_mate vs sf_base: 1917 - 1913 - 6170 [0.500] 10000 

ELO: 0.14 +- 99%: 8.97 95%: 6.81 
LOS: 52.58% 
Wins: 1917 Losses: 1913 Draws: 6170 Total: 10000

Testing in the framework is impossible with the tablebases : is this result sufficient ? Or should I do other tests ?