### PR TITLE
Simplify away the PawnSet[] imbalance array

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -53,11 +53,6 @@ namespace {
     { 101,  100, -37,   141,  268,    0 }  // Queen
   };
 
-  // PawnSet[pawn count] contains a bonus/malus indexed by number of pawns
-  const int PawnSet[] = {
-    24, -32, 107, -51, 117, -9, -126, -21, 31
-  };
-
   // QueenMinorsImbalance[opp_minor_count] is applied when only one side has a queen.
   // It contains a bonus/malus for the side with the queen.
   const int QueenMinorsImbalance[13] = {
@@ -100,7 +95,7 @@ namespace {
 
     const Color Them = (Us == WHITE ? BLACK : WHITE);
 
-    int bonus = PawnSet[pieceCount[Us][PAWN]];
+    int bonus = 0;
 
     // Second-degree polynomial material imbalance by Tord Romstad
     for (int pt1 = NO_PIECE_TYPE; pt1 <= QUEEN; ++pt1)

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -97,7 +97,7 @@ namespace {
 
     int bonus = 0;
 
-    // Second-degree polynomial material imbalance by Tord Romstad
+    // Second-degree polynomial material imbalance, by Tord Romstad
     for (int pt1 = NO_PIECE_TYPE; pt1 <= QUEEN; ++pt1)
     {
         if (!pieceCount[Us][pt1])


### PR DESCRIPTION
STC:
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 52977 W: 9550 L: 9484 D: 33943
http://tests.stockfishchess.org/tests/view/5a06b4780ebc590ccbb8a833

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 83717 W: 10599 L: 10559 D: 62559
http://tests.stockfishchess.org/tests/view/5a0aa36a0ebc590ccbb8aa99

Bench: 5340212