### PR TITLE
TMM tweak: only calculate with 90% of our incremental time.

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -106,10 +106,10 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
   }
 
   int moveNum = (ply + 1) / 2;
+  int increment = limits.inc[us] * 90 / 100;
 
-  startTime = limits.startTime;
-  optimumTime = remaining(limits.time[us], limits.inc[us], moveOverhead,
+  optimumTime = remaining(limits.time[us], increment, moveOverhead,
                           limits.movestogo, moveNum, ponder, OptimumTime);
-  maximumTime = remaining(limits.time[us], limits.inc[us], moveOverhead,
+  maximumTime = remaining(limits.time[us], increment, moveOverhead,
                           limits.movestogo, moveNum, ponder, MaxTime);
 }

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -33,12 +33,11 @@ public:
   void init(Search::LimitsType& limits, Color us, int ply);
   int optimum() const { return optimumTime; }
   int maximum() const { return maximumTime; }
-  int elapsed() const { return int(Search::Limits.npmsec ? Threads.nodes_searched() : now() - startTime); }
+  int elapsed() const { return int(Search::Limits.npmsec ? Threads.nodes_searched() : now() - Search::Limits.startTime); }
 
   int64_t availableNodes; // When in 'nodes as time' mode
 
 private:
-  TimePoint startTime;
   int optimumTime;
   int maximumTime;
 };


### PR DESCRIPTION
Seems to be a gain with larger increment while still neutral at our standard STC.

TC: 1" + 2"
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 35856 W: 5287 L: 5040 D: 25529

STC
LLR: -2.96 (-2.94,2.94) [0.00,5.00]
Total: 26394 W: 4752 L: 4765 D: 16877

It is also a small simplification because there is no need to store startTime locally. Search::Limits.startTime never changes during its lifetime.

Bench: 5109559