### PR TITLE
Minor edits in search.cpp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -75,11 +75,6 @@ namespace {
   int FutilityMoveCounts[2][16]; // [improving][depth]
   int Reductions[2][2][64][64];  // [pv][improving][depth][moveNumber]
 
-  int futility_move_counts(bool i, Depth d) {
-    assert(d / ONE_PLY < 16);
-    return FutilityMoveCounts[i][d / ONE_PLY];
-  }
-
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {
     return Reductions[PvNode][i][std::min(d / ONE_PLY, 63)][std::min(mn, 63)] * ONE_PLY;
   }
@@ -821,7 +816,7 @@ moves_loop: // When in check search starts from here
                   : pos.gives_check(move);
 
       moveCountPruning =   depth < 16 * ONE_PLY
-                        && moveCount >= futility_move_counts(improving, depth);
+                        && moveCount >= FutilityMoveCounts[improving][depth / ONE_PLY];
 
       // Step 12. Singular and Gives Check Extensions
 


### PR DESCRIPTION
Four very minor edits. Note that tte->save() uses posKey and not pos.key() in other places.

Originally I also added a futility_move_counts() function to make things more consistent with the futility_margin() and reduction() functions. But then razor_margin[] should probably also be turned into a function, etc. Maybe a good idea, maybe not. So I did not include it.

Non-functional.