### PR TITLE
Compile without exceptions

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -141,7 +141,7 @@ endif
 
 ### 3.1 Selecting compiler (default = gcc)
 
-CXXFLAGS += -Wall -Wcast-qual -std=c++11 $(EXTRACXXFLAGS)
+CXXFLAGS += -Wall -Wcast-qual -fno-exceptions -std=c++11 $(EXTRACXXFLAGS)
 DEPENDFLAGS += -std=c++11
 LDFLAGS += $(EXTRALDFLAGS)
 


### PR DESCRIPTION
Add the -fno-exceptions flag to the Makefile to avoid the unecessary exceptions support in the executable (we do not use any exception in Stockfish at the moment).

This change gives a 9.2% reduction in size for the executable binary.

Before: executable size = 376 956 bytes
After: executable size = 347 652 bytes

No functional change.