### PR TITLE
Pawn endgames directly skip early pruning.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -656,7 +656,7 @@ namespace {
                   ss->staticEval, TT.generation());
     }
 
-    if (skipEarlyPruning)
+    if (skipEarlyPruning || !pos.non_pawn_material(pos.side_to_move()))
         goto moves_loop;
 
     // Step 6. Razoring (skipped when in check)
@@ -677,15 +677,13 @@ namespace {
     if (   !rootNode
         &&  depth < 7 * ONE_PLY
         &&  eval - futility_margin(depth) >= beta
-        &&  eval < VALUE_KNOWN_WIN  // Do not return unproven wins
-        &&  pos.non_pawn_material(pos.side_to_move()))
+        &&  eval < VALUE_KNOWN_WIN)  // Do not return unproven wins
         return eval;
 
     // Step 8. Null move search with verification search (is omitted in PV nodes)
     if (   !PvNode
         &&  eval >= beta
-        &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225
-        &&  pos.non_pawn_material(pos.side_to_move()))
+        &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225)
     {
 
         assert(eval - beta >= 0);


### PR DESCRIPTION
Instead of checking individual steps. Idea by @Stefano80.

passed STC
http://tests.stockfishchess.org/tests/view/5a23e5d20ebc590ccbb8b6d5
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 37445 W: 6866 L: 6773 D: 23806

passed LTC
http://tests.stockfishchess.org/tests/view/5a24260c0ebc590ccbb8b716
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 38780 W: 4946 L: 4848 D: 28986

Bench: 5466219