### PR TITLE
Avoid warnings by the Clang compiler

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -319,7 +319,7 @@ inline Value& operator-=(Value& v, int i) { return v = v - i; }
 
 /// Only declared but not defined. We don't want to multiply two scores due to
 /// a very high risk of overflow. So user should explicitly convert to integer.
-Score operator*(Score s1, Score s2) = delete;
+Score operator*(Score, Score) = delete;
 
 /// Division of a Score must be handled separately for each term
 inline Score operator/(Score s, int i) {


### PR DESCRIPTION
Clang gave a couple of warnings for unused parameters after the recent commit "Use constexpr when makes sense".

No functional change.