### PR TITLE
Don't consider defending queen as check blocker

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -459,8 +459,8 @@ namespace {
         safe  = ~pos.pieces(Them);
         safe &= ~attackedBy[Us][ALL_PIECES] | (weak & attackedBy2[Them]);
 
-        b1 = pos.attacks_from<  ROOK>(ksq);
-        b2 = pos.attacks_from<BISHOP>(ksq);
+        b1 = attacks_bb<ROOK  >(ksq, pos.pieces() ^ pos.pieces(Us, QUEEN));
+        b2 = attacks_bb<BISHOP>(ksq, pos.pieces() ^ pos.pieces(Us, QUEEN));
 
         // Enemy queen safe checks
         if ((b1 | b2) & attackedBy[Them][QUEEN] & safe & ~attackedBy[Us][QUEEN])


### PR DESCRIPTION
STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 22636 W: 4212 L: 3990 D: 14434
http://tests.stockfishchess.org/tests/view/5a2506140ebc590ccbb8b75a

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 63448 W: 8287 L: 7965 D: 47196
http://tests.stockfishchess.org/tests/view/5a253a610ebc590ccbb8b776

bench: 5767699

Side note: 
patch doesn't affect QueenCheck in line 467 as we have ~attackedBy[Us][QUEEN] in the condition.
So the change does mainly affect bishop/rook checks.
Not exclusively since bishop/rook attacks include also x-rays through own queen, so patch affects also some Queen-checks.