### PR TITLE
Skip early pruning when both sides only have pawns (bench 5067449)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -683,7 +683,6 @@ namespace {
         &&  eval >= beta
         &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225)
     {
-
         assert(eval - beta >= 0);
 
         // Null move dynamic reduction based on depth and value

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -654,7 +654,7 @@ namespace {
                   ss->staticEval, TT.generation());
     }
 
-    if (skipEarlyPruning || !pos.non_pawn_material(pos.side_to_move()))
+    if (skipEarlyPruning || !pos.non_pawn_material())
         goto moves_loop;
 
     // Step 6. Razoring (skipped when in check)


### PR DESCRIPTION
Skip early pruning when both sides only have pawns instead of the case when the side to move just has pawns.

Passed STC:
http://tests.stockfishchess.org/tests/view/5a28f7dd0ebc590ccbb8b96d
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 40129 W: 7270 L: 7182 D: 25677

and LTC:
http://tests.stockfishchess.org/tests/view/5a2939d00ebc590ccbb8b989
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 45819 W: 5910 L: 5822 D: 34087

Bench 5067449