### PR TITLE
ttExact - Bench:  4744425

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -508,7 +508,7 @@ namespace {
     Depth extension, newDepth;
     Value bestValue, value, ttValue, eval;
     bool ttHit, inCheck, givesCheck, singularExtensionNode, improving;
-    bool captureOrPromotion, doFullDepthSearch, moveCountPruning, skipQuiets, ttCapture, pvExact;
+    bool captureOrPromotion, doFullDepthSearch, moveCountPruning, skipQuiets, ttCapture, ttExact;
     Piece movedPiece;
     int moveCount, captureCount, quietCount;
 
@@ -775,7 +775,7 @@ moves_loop: // When in check search starts from here
                            &&  tte->depth() >= depth - 3 * ONE_PLY;
     skipQuiets = false;
     ttCapture = false;
-    pvExact = PvNode && ttHit && tte->bound() == BOUND_EXACT;
+    ttExact = ttHit && tte->bound() == BOUND_EXACT;
 
     // Step 11. Loop through moves
     // Loop through all pseudo-legal moves until no moves remain or a beta cutoff occurs
@@ -921,7 +921,7 @@ moves_loop: // When in check search starts from here
                   r -= ONE_PLY;
 
               // Decrease reduction for exact PV nodes
-              if (pvExact)
+              if (ttExact)
                   r -= ONE_PLY;
 
               // Increase reduction if ttMove is a capture

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -920,7 +920,7 @@ moves_loop: // When in check search starts from here
               if ((ss-1)->moveCount > 15)
                   r -= ONE_PLY;
 
-              // Decrease reduction for exact PV nodes
+              // Decrease reduction for exact TT nodes
               if (ttExact)
                   r -= ONE_PLY;
 


### PR DESCRIPTION
Simplification (possible slight Elo gain) reduce LMR if TT bounds are exact


STC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 110053 W: 20233 L: 19700 D: 70120

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 75161 W: 9548 L: 9497 D: 56116