### PR TITLE
Enhanced verify search for better zugzwang detecting

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -681,7 +681,8 @@ namespace {
     // Step 8. Null move search with verification search (is omitted in PV nodes)
     if (   !PvNode
         &&  eval >= beta
-        &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225)
+        &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225
+		&& (ss->ply >= thisThread->nmp_ply || ss->ply % 2 == thisThread->pair))
     {
 
         assert(eval - beta >= 0);
@@ -707,8 +708,17 @@ namespace {
                 return nullValue;
 
             // Do verification search at high depths
+            R += ONE_PLY;
+            // disable null move pruning for side to move for the first part of the remaining search tree
+            int nmp_ply = thisThread->nmp_ply;
+            int pair = thisThread->pair;
+            thisThread->nmp_ply = ss->ply + 3 * (depth-R) / 4;
+            thisThread->pair = (ss->ply % 2) == 0;
+
             Value v = depth-R < ONE_PLY ? qsearch<NonPV, false>(pos, ss, beta-1, beta)
                                         :  search<NonPV>(pos, ss, beta-1, beta, depth-R, false, true);
+            thisThread->pair = pair;
+            thisThread->nmp_ply = nmp_ply;
 
             if (v >= beta)
                 return nullValue;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -187,6 +187,8 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
       th->rootDepth = th->completedDepth = DEPTH_ZERO;
       th->rootMoves = rootMoves;
       th->rootPos.set(pos.fen(), pos.is_chess960(), &setupStates->back(), th);
+      th->nmp_ply = 0;
+      th->pair = -1;
   }
 
   setupStates->back() = tmp;

--- a/src/thread.h
+++ b/src/thread.h
@@ -61,7 +61,7 @@ public:
   Material::Table materialTable;
   Endgames endgames;
   size_t PVIdx;
-  int selDepth;
+  int selDepth, nmp_ply, pair;
   std::atomic<uint64_t> nodes, tbHits;
 
   Position rootPos;


### PR DESCRIPTION
**Preface:** 
A recent [test](http://tests.stockfishchess.org/tests/view/5a2a2f4b0ebc590ccbb8b9ec) and an older [one](http://tests.stockfishchess.org/tests/view/52f1614d0ebc5901df50f8ae) both suggest that verification search brings nothing in terms of Elo's and if we stick to standard rules it could be simplified away. 
However it looks like the community was afraid of SF being prone to zugzwang, so verification search was introduced as kind of remedy against this weakness.

**Current verification search implementation is weak.**
Anyhow we continue to see loosing SF due to zugzwang from time to time since the current verification search implementation IMO is weak. Why is it weak?

It suppresses null-move-pruning in current ply but nothing is done to avoid its recursive reuse in deeper plies for the interested side to move, so this simply allows SF to move the problem behind it's search-horizon when the zugzwang motif implies a larger sequence of forced 'worsening' moves.

This patch encounters this by disabling null-move-pruning for the side to move for first part of
the remaining search tree sistematically. This helps to better recognize zugzwang as shown in following EPD suite [Zugzwang-Allgeuer.zip](https://github.com/official-stockfish/Stockfish/files/1558563/Zugzwang-Allgeuer.zip) which is an extended suite of the one reported at [chessprogramming ](https://chessprogramming.wikispaces.com/Test-Positions)wiki.

Benchmarks made with pgo-builds, 1 thread, 512 MB hash, max. 40 seconds per position:
```
Master with disabled verification scored  23 out of 37 in 9:45
Current master scored                     26 out of 37 in 8:13
patch               scored:               32 out of 37 in 5:47
```
The 6 critical positions the patch is able to resolve within 40 secs (and the master not) are the following ones:
```
8/8/8/1B6/6p1/8/3K1Ppp/3N2kr w - - bm f4; found by patch in 6 secs
8/3p1p2/5Ppp/K2R2bk/4pPrr/6Pp/4B2P/3N4 w - - bm Nc3; found by patch in 35 secs
8/8/p5p1/p2N3p/k2P3P/5P2/KP1qB3/8 w - - bm f4; found by patch in 3 secs
8/p5pq/8/p2N3p/k2P3P/8/KP3PB1/8 w - - bm Be4; found by patch in 3 secs
1k3b1q/pP2p1p1/P1K1P1Pp/7P/2B5/8/8/8 w - - bm Kd5 Bb5; found by patch in 14 secs (Bb5)
1q2k3/1Pp1Pp1K/2P2B2/8/8/8/8/8 w - - bm Kg8; found by patch in 31 secs
```

For further details about the patch and choosen test bounds please see commit notes and discussion at this [commit ](https://github.com/pb00068/Stockfish/commit/6401a80ab91df5c54390ac357409fef2e51ff5bb).

Tested with no-regression bounds
STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 18220 W: 3379 L: 3253 D: 11588
http://tests.stockfishchess.org/tests/view/5a2fa6460ebc590ccbb8bc2f

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 41899 W: 5359 L: 5265 D: 31275
http://tests.stockfishchess.org/tests/view/5a2fcf440ebc590ccbb8bc47



bench: 5776193