### PR TITLE
Make staticEval independent of the search path

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -894,7 +894,7 @@ namespace {
         Trace::add(TOTAL, score);
     }
 
-    return (pos.side_to_move() == WHITE ? v : -v) + Eval::Tempo; // Side to move point of view
+    return pos.side_to_move() == WHITE ? v : -v; // Side to move point of view
   }
 
 } // namespace
@@ -906,7 +906,7 @@ Score Eval::Contempt = SCORE_ZERO;
 
 Value Eval::evaluate(const Position& pos)
 {
-   return Evaluation<>(pos).value();
+   return Evaluation<>(pos).value() + Eval::Tempo;
 }
 
 /// trace() is like evaluate(), but instead of returning a value, it returns
@@ -917,7 +917,7 @@ std::string Eval::trace(const Position& pos) {
 
   std::memset(scores, 0, sizeof(scores));
 
-  Value v = Evaluation<TRACE>(pos).value();
+  Value v = Evaluation<TRACE>(pos).value() + Eval::Tempo;
   v = pos.side_to_move() == WHITE ? v : -v; // White's point of view
 
   std::stringstream ss;


### PR DESCRIPTION
current master can yield different staticEvals depending on the path used to reach the position. The reason for this is that the evaluation after a null move is always computed subtracting 2 * Eval::Tempo, while this is not the case for lazy or specialized evals. This patch always adds tempo to evals, which doesn't affect playing strength:

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 59911 W: 7616 L: 7545 D: 44750

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 104947 W: 18897 L: 18919 D: 67131

Alternatively, one could just document that the 'null move evaluation trick' is not intended always yield the same result as evaluate(pos), and possibly rename staticEval to something more appropriate.

Fixes issue #1335

Bench: 5424450