### PR TITLE
Bishop & Rook attacks: include x-rays through queens independently of the color.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -310,8 +310,8 @@ namespace {
     while ((s = *pl++) != SQ_NONE)
     {
         // Find attacked squares, including x-ray attacks for bishops and rooks
-        b = Pt == BISHOP ? attacks_bb<BISHOP>(s, pos.pieces() ^ pos.pieces(Us, QUEEN))
-          : Pt ==   ROOK ? attacks_bb<  ROOK>(s, pos.pieces() ^ pos.pieces(Us, ROOK, QUEEN))
+        b = Pt == BISHOP ? attacks_bb<BISHOP>(s, pos.pieces() ^ pos.pieces(QUEEN))
+          : Pt ==   ROOK ? attacks_bb<  ROOK>(s, pos.pieces() ^ pos.pieces(QUEEN) ^ pos.pieces(Us, ROOK))
                          : pos.attacks_from<Pt>(s);
 
         if (pos.pinned_pieces(Us) & s)


### PR DESCRIPTION
When calculating attacks from rooks/bishops current master includes x-rays through own queen. This patch includes also x-rays through opponent queen.

Credits go to Brian who inspired for this idea
https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/Z3APRYpQeMU

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 41549 W: 7544 L: 7244 D: 26761
Elo	2.05 [-0.29,4.19] (95%)
http://tests.stockfishchess.org/tests/view/5a3b5fe50ebc590ccbb8bf9a

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 110010 W: 14208 L: 13739 D: 82063
Elo	1.20 [-0.27,2.55] (95%)
http://tests.stockfishchess.org/tests/view/5a3b8e7c0ebc590ccbb8bfad

bench: 5544445