### PR TITLE
Revert "Allow for general transposition table sizes."

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -557,7 +557,7 @@ namespace {
     // search to overwrite a previous full search TT value, so we use a different
     // position key in case of an excluded move.
     excludedMove = ss->excludedMove;
-    posKey = pos.key() ^ Key(excludedMove << 16); // isn't a very good hash
+    posKey = pos.key() ^ Key(excludedMove);
     tte = TT.probe(posKey, ttHit);
     ttValue = ttHit ? value_from_tt(tte->value(), ss->ply) : VALUE_NONE;
     ttMove =  rootNode ? thisThread->rootMoves[thisThread->PVIdx].pv[0]

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -33,7 +33,7 @@ TranspositionTable TT; // Our global transposition table
 
 void TranspositionTable::resize(size_t mbSize) {
 
-  size_t newClusterCount = mbSize * 1024 * 1024 / sizeof(Cluster);
+  size_t newClusterCount = size_t(1) << msb((mbSize * 1024 * 1024) / sizeof(Cluster));
 
   if (newClusterCount == clusterCount)
       return;

--- a/src/tt.h
+++ b/src/tt.h
@@ -104,9 +104,9 @@ public:
   void resize(size_t mbSize);
   void clear();
 
-  // The 32 lowest order bits of the key are used to get the index of the cluster
+  // The lowest order bits of the key are used to get the index of the cluster
   TTEntry* first_entry(const Key key) const {
-    return &table[(uint32_t(key) * uint64_t(clusterCount)) >> 32].entry[0];
+    return &table[(size_t)key & (clusterCount - 1)].entry[0];
   }
 
 private:

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -55,8 +55,7 @@ bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const 
 
 void init(OptionsMap& o) {
 
-  // at most 2^32 clusters.
-  const int MaxHashMB = Is64Bit ? 131072 : 2048;
+  const int MaxHashMB = Is64Bit ? 1024 * 1024 : 2048;
 
   o["Debug Log File"]        << Option("", on_logger);
   o["Contempt"]              << Option(0, -100, 100);


### PR DESCRIPTION
Reverts official-stockfish/Stockfish#1341.

I would like to open a discussion about whether it was sensible to commit this patch.

1) It is definitely not a simplification and has been tested with [-3, 1] bounds.
2) It was tested only at STC although it is obviously a functional change, also given the considerable ingenuity which was needed to introduce the clustering in the hash table. For the patch, it took 128k to pass with an Elo result -0.48 [-2.07,0.97] (95%). It is most probably a modest Elo loss.
3) The very reason for which it has been done is to use all available memory, even if it is not a power of 2. Although this gives some Elo boost, as documented [here](http://tests.stockfishchess.org/tests/view/5a3805020ebc590ccbb8bec3) the results are humbling with a Elo 1.19 [-0.27,2.54] (95%). 

In the end, for users really interested in tournaments or analysis, it gives a Elo boost of well below 1 Elo against previous master, if the negative results of the simplification test would be considered. If the positive bias of SPRT passes is considered, the patch is most probably neutral or worse.

For this patch to be accepted the correct testing procedure would be to test for a Elo gain of the patch with hash set to almost a power of 2 versus the previous master with half the hash as normal, as usual at both STC and LTC. 