### PR TITLE
Simplify trapped rook eval

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -216,7 +216,6 @@ namespace {
   const Score BishopPawns           = S(  8, 12);
   const Score LongRangedBishop      = S( 22,  0);
   const Score RookOnPawn            = S(  8, 24);
-  const Score TrappedRook           = S( 92,  0);
   const Score WeakQueen             = S( 50, 10);
   const Score CloseEnemies          = S(  7,  0);
   const Score PawnlessFlank         = S( 20, 80);
@@ -297,6 +296,7 @@ namespace {
     const Bitboard OutpostRanks = (Us == WHITE ? Rank4BB | Rank5BB | Rank6BB
                                                : Rank5BB | Rank4BB | Rank3BB);
     const Square* pl = pos.squares<Pt>(Us);
+    const Square ksq = pos.square<KING>(Us);
 
     Bitboard b, bb;
     Square s;
@@ -315,7 +315,7 @@ namespace {
                          : pos.attacks_from<Pt>(s);
 
         if (pos.pinned_pieces(Us) & s)
-            b &= LineBB[pos.square<KING>(Us)][s];
+            b &= LineBB[ksq][s];
 
         attackedBy2[Us] |= attackedBy[Us][ALL_PIECES] & b;
         attackedBy[Us][ALL_PIECES] |= attackedBy[Us][Pt] |= b;
@@ -335,7 +335,7 @@ namespace {
         mobility[Us] += MobilityBonus[Pt - 2][mob];
 
         // Bonus for this piece as a king protector
-        score += KingProtector[Pt - 2] * distance(s, pos.square<KING>(Us));
+        score += KingProtector[Pt - 2] * distance(s, ksq);
 
         if (Pt == BISHOP || Pt == KNIGHT)
         {
@@ -391,14 +391,8 @@ namespace {
                 score += RookOnFile[bool(pe->semiopen_file(Them, file_of(s)))];
 
             // Penalty when trapped by the king, even more if the king cannot castle
-            else if (mob <= 3)
-            {
-                Square ksq = pos.square<KING>(Us);
-
-                if (   ((file_of(ksq) < FILE_E) == (file_of(s) < file_of(ksq)))
-                    && !pe->semiopen_side(Us, file_of(ksq), file_of(s) < file_of(ksq)))
-                    score -= (TrappedRook - make_score(mob * 22, 0)) * (1 + !pos.can_castle(Us));
-            }
+            else if (mob <= 3 && !pe->semiopen_side(Us, file_of(ksq), file_of(s) < file_of(ksq)))
+                score -= make_score((4 - mob) * 25, 0) * (1 + !pos.can_castle(Us) && ((file_of(ksq) < FILE_E) == (file_of(s) < file_of(ksq))));
         }
 
         if (Pt == QUEEN)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -216,6 +216,7 @@ namespace {
   const Score BishopPawns           = S(  8, 12);
   const Score LongRangedBishop      = S( 22,  0);
   const Score RookOnPawn            = S(  8, 24);
+  const Score TrappedRook           = S( 23,  0);
   const Score WeakQueen             = S( 50, 10);
   const Score CloseEnemies          = S(  7,  0);
   const Score PawnlessFlank         = S( 20, 80);
@@ -393,7 +394,7 @@ namespace {
             // Penalty when trapped by the king, even more if the king cannot castle
             else if (mob < 4 && ((file_of(ksq) < FILE_E) == (file_of(s) < file_of(ksq)))
                 && !pe->semiopen_side(Us, file_of(ksq), file_of(s) < file_of(ksq)))
-                    score -= make_score((4 - mob) * 23, 0) * (1 + !pos.can_castle(Us));
+                    score -= TrappedRook * (4 - mob) * (1 + !pos.can_castle(Us));
         }
 
         if (Pt == QUEEN)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -391,8 +391,9 @@ namespace {
                 score += RookOnFile[bool(pe->semiopen_file(Them, file_of(s)))];
 
             // Penalty when trapped by the king, even more if the king cannot castle
-            else if (mob <= 3 && !pe->semiopen_side(Us, file_of(ksq), file_of(s) < file_of(ksq)))
-                score -= make_score((4 - mob) * 25, 0) * (1 + !pos.can_castle(Us) && ((file_of(ksq) < FILE_E) == (file_of(s) < file_of(ksq))));
+            else if (mob < 4 && ((file_of(ksq) < FILE_E) == (file_of(s) < file_of(ksq)))
+                && !pe->semiopen_side(Us, file_of(ksq), file_of(s) < file_of(ksq)))
+                    score -= make_score((4 - mob) * 23, 0) * (1 + !pos.can_castle(Us));
         }
 
         if (Pt == QUEEN)


### PR DESCRIPTION
Small simplification of the TrappedRook eval.

This code is more compact and relies only on one tuned parameter (instead of 2 for the old implementation).

STC : http://tests.stockfishchess.org/tests/view/5a3d54260ebc590ccbb8c036
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 38159 W: 6943 L: 6851 D: 24365

LTC : http://tests.stockfishchess.org/tests/view/5a3d941a0ebc590ccbb8c041
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 278734 W: 35130 L: 35337 D: 208267

Bench: 5413698