### PR TITLE
Skip resolving failhigh

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -386,7 +386,7 @@ void Thread::search() {
                       Threads.stopOnPonderhit = false;
                   }
               }
-              else if (bestValue >= beta)
+              else if (bestValue >= beta && lastBestMove != rootMoves[0].pv[0])
                   beta = std::min(bestValue + delta, VALUE_INFINITE);
               else
                   break;
@@ -453,7 +453,7 @@ void Thread::search() {
               unstablePvFactor *=  std::pow(mainThread->previousTimeReduction, 0.51) / timeReduction;
 
               if (   rootMoves.size() == 1
-                  || Time.elapsed() > Time.optimum() * unstablePvFactor * improvingFactor / 628)
+                  || Time.elapsed() > Time.optimum() * unstablePvFactor * improvingFactor / 600)
               {
                   // If we are allowed to ponder do not stop the search now but
                   // keep pondering until the GUI sends "ponderhit" or "stop".


### PR DESCRIPTION
If the found move is the same as lastBestMove.

Based on earlier patches by @lp--

passed STC
http://tests.stockfishchess.org/tests/view/5a43d9630ebc590ccbb8c24c
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 4313 W: 893 L: 747 D: 2673

passed LTC
http://tests.stockfishchess.org/tests/view/5a43e7730ebc590ccbb8c265
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 4093 W: 571 L: 441 D: 3081

Bench: 3179264