### PR TITLE
Revert to old time management

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1497,7 +1497,7 @@ moves_loop: // When in check search starts from here
     if (Threads.ponder)
         return;
 
-    if (   (Limits.use_time_management() && elapsed > Time.maximum())
+    if (   (Limits.use_time_management() && elapsed > Time.maximum() - 10)
         || (Limits.movetime && elapsed >= Limits.movetime)
         || (Limits.nodes && Threads.nodes_searched() >= (uint64_t)Limits.nodes))
             Threads.stop = true;

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -19,6 +19,8 @@
 */
 
 #include <algorithm>
+#include <cfloat>
+#include <cmath>
 
 #include "search.h"
 #include "timeman.h"
@@ -30,46 +32,41 @@ namespace {
 
   enum TimeType { OptimumTime, MaxTime };
 
-  int remaining(int myTime, int myInc, int moveOverhead, int movesToGo,
-                int moveNum, bool ponder, TimeType type) {
+  const int MoveHorizon   = 50;   // Plan time management at most this many moves ahead
+  const double MaxRatio   = 7.09; // When in trouble, we can step over reserved time with this ratio
+  const double StealRatio = 0.35; // However we must not steal time from remaining moves over this ratio
 
-    if (myTime <= 0)
-        return 0;
 
-    double ratio; // Which ratio of myTime we are going to use
+  // move_importance() is a skew-logistic function based on naive statistical
+  // analysis of "how many games are still undecided after n half-moves". Game
+  // is considered "undecided" as long as neither side has >275cp advantage.
+  // Data was extracted from the CCRL game database with some simple filtering criteria.
 
-    // Usage of increment follows quadratic distribution with the maximum at move 25
-    double inc = myInc * std::max(55.0, 120 - 0.12 * (moveNum - 25) * (moveNum - 25));
+  double move_importance(int ply) {
 
-    // In moves-to-go we distribute time according to a quadratic function with
-    // the maximum around move 20 for 40 moves in y time case.
-    if (movesToGo)
-    {
-        ratio = (type == OptimumTime ? 1.0 : 6.0) / std::min(50, movesToGo);
+    const double XScale = 7.64;
+    const double XShift = 58.4;
+    const double Skew   = 0.183;
 
-        if (moveNum <= 40)
-            ratio *= 1.1 - 0.001 * (moveNum - 20) * (moveNum - 20);
-        else
-            ratio *= 1.5;
+    return pow((1 + exp((ply - XShift) / XScale)), -Skew) + DBL_MIN; // Ensure non-zero
+  }
 
-        if (movesToGo > 1)
-            ratio = std::min(0.75, ratio);
+  template<TimeType T>
+  int remaining(int myTime, int movesToGo, int ply, int slowMover) {
 
-        ratio *= 1 + inc / (myTime * 8.5);
-    }
-    // Otherwise we increase usage of remaining time as the game goes on
-    else
-    {
-        double k = 1 + 20 * moveNum / (500.0 + moveNum);
-        ratio = (type == OptimumTime ? 0.017 : 0.07) * (k + inc / myTime);
-    }
+    const double TMaxRatio   = (T == OptimumTime ? 1 : MaxRatio);
+    const double TStealRatio = (T == OptimumTime ? 0 : StealRatio);
 
-    int time = int(std::min(1.0, ratio) * std::max(0, myTime - moveOverhead));
+    double moveImportance = (move_importance(ply) * slowMover) / 100;
+    double otherMovesImportance = 0;
 
-    if (type == OptimumTime && ponder)
-        time = 5 * time / 4;
+    for (int i = 1; i < movesToGo; ++i)
+        otherMovesImportance += move_importance(ply + 2 * i);
 
-    return time;
+    double ratio1 = (TMaxRatio * moveImportance) / (TMaxRatio * moveImportance + otherMovesImportance);
+    double ratio2 = (moveImportance + TStealRatio * otherMovesImportance) / (moveImportance + otherMovesImportance);
+
+    return int(myTime * std::min(ratio1, ratio2)); // Intel C++ asks for an explicit cast
   }
 
 } // namespace
@@ -84,11 +81,12 @@ namespace {
 ///  inc >  0 && movestogo == 0 means: x basetime + z increment
 ///  inc >  0 && movestogo != 0 means: x moves in y minutes + z increment
 
-void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
-{
-  int moveOverhead = Options["Move Overhead"];
-  int npmsec       = Options["nodestime"];
-  bool ponder      = Options["Ponder"];
+void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
+
+  int minThinkingTime = Options["Minimum Thinking Time"];
+  int moveOverhead    = Options["Move Overhead"];
+  int slowMover       = Options["Slow Mover"];
+  int npmsec          = Options["nodestime"];
 
   // If we have to play in 'nodes as time' mode, then convert from time
   // to nodes, and use resulting values in time management formulas.
@@ -105,11 +103,30 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply)
       limits.npmsec = npmsec;
   }
 
-  int moveNum = (ply + 1) / 2;
-
   startTime = limits.startTime;
-  optimumTime = remaining(limits.time[us], limits.inc[us], moveOverhead,
-                          limits.movestogo, moveNum, ponder, OptimumTime);
-  maximumTime = remaining(limits.time[us], limits.inc[us], moveOverhead,
-                          limits.movestogo, moveNum, ponder, MaxTime);
+  optimumTime = maximumTime = std::max(limits.time[us], minThinkingTime);
+
+  const int MaxMTG = limits.movestogo ? std::min(limits.movestogo, MoveHorizon) : MoveHorizon;
+
+  // We calculate optimum time usage for different hypothetical "moves to go"-values
+  // and choose the minimum of calculated search time values. Usually the greatest
+  // hypMTG gives the minimum values.
+  for (int hypMTG = 1; hypMTG <= MaxMTG; ++hypMTG)
+  {
+      // Calculate thinking time for hypothetical "moves to go"-value
+      int hypMyTime =  limits.time[us]
+                     + limits.inc[us] * (hypMTG - 1)
+                     - moveOverhead * (2 + std::min(hypMTG, 40));
+
+      hypMyTime = std::max(hypMyTime, 0);
+
+      int t1 = minThinkingTime + remaining<OptimumTime>(hypMyTime, hypMTG, ply, slowMover);
+      int t2 = minThinkingTime + remaining<MaxTime    >(hypMyTime, hypMTG, ply, slowMover);
+
+      optimumTime = std::min(t1, optimumTime);
+      maximumTime = std::min(t2, maximumTime);
+  }
+
+  if (Options["Ponder"])
+      optimumTime += optimumTime / 4;
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -256,6 +256,9 @@ string UCI::value(Value v) {
 
   stringstream ss;
 
+  // Avoid draw and win adjudication in fishtest
+  v = PawnValueEg;
+
   if (abs(v) < VALUE_MATE - MAX_PLY)
       ss << "cp " << v * 100 / PawnValueEg;
   else

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -256,9 +256,6 @@ string UCI::value(Value v) {
 
   stringstream ss;
 
-  // Avoid draw and win adjudication in fishtest
-  v = PawnValueEg;
-
   if (abs(v) < VALUE_MATE - MAX_PLY)
       ss << "cp " << v * 100 / PawnValueEg;
   else

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -66,7 +66,9 @@ void init(OptionsMap& o) {
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);
   o["Skill Level"]           << Option(20, 0, 20);
-  o["Move Overhead"]         << Option(100, 0, 5000);
+  o["Move Overhead"]         << Option(30, 0, 5000);
+  o["Minimum Thinking Time"] << Option(20, 0, 5000);
+  o["Slow Mover"]            << Option(89, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);


### PR DESCRIPTION
As many users reported some problems with new time management,
and recent tests on longer time controls

http://tests.stockfishchess.org/tests/view/5a460e160ebc590ccbb8c35d
http://tests.stockfishchess.org/tests/view/5a462f4d0ebc590ccbb8c37a

are even little in favor of old time management, this revert seems as a logical step.

STC: 
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 14060 W: 2562 L: 2430 D: 9068

LTC:
LLR: 3.44 (-2.94,2.94) [-3.00,1.00]
Total: 31611 W: 3958 L: 3827 D: 23826