### PR TITLE
Contempt 7

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -59,7 +59,7 @@ void init(OptionsMap& o) {
   const int MaxHashMB = Is64Bit ? 131072 : 2048;
 
   o["Debug Log File"]        << Option("", on_logger);
-  o["Contempt"]              << Option(0, -100, 100);
+  o["Contempt"]              << Option(7, -100, 100);
   o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);


### PR DESCRIPTION
STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 50665 W: 9813 L: 9745 D: 31107

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 13045 W: 1834 L: 1703 D: 9508

Contempt 4 tests were also good:
http://tests.stockfishchess.org/tests/view/5a512eea0ebc590ccbb8c723
http://tests.stockfishchess.org/tests/view/5a5205000ebc590ccbb8c762

Contempt 10 tests were also good:
http://tests.stockfishchess.org/tests/view/5a5227410ebc590ccbb8c76f
http://tests.stockfishchess.org/tests/view/5a550fac0ebc590296938a24

For safety reasons, it seems the best to use the medium value (7),
where tests anyway showed the greatest gain.

There is no an obvious Elo gain here, but it should be helpful against weaker engines.

Bench 5494441