### PR TITLE
Simplify away redundant SEE pruning condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1252,7 +1252,6 @@ moves_loop: // When in check search starts from here
 
       // Don't search moves with negative SEE values
       if (  (!InCheck || evasionPrunable)
-          &&  type_of(move) != PROMOTION
           &&  !pos.see_ge(move))
           continue;
 


### PR DESCRIPTION
SEE immediately returns true for promotions (since the threshold is zero in this case), so excluding them before checking SEE is redundant.

No functional change.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 56758 W: 10166 L: 10106 D: 36486
http://tests.stockfishchess.org/tests/view/5a645eaf0ebc590297903833