### PR TITLE
simplify doubled pawn evaluation

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -99,7 +99,7 @@ namespace {
     const Direction Right = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
     const Direction Left  = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
 
-    Bitboard b, neighbours, stoppers, doubled, supported, phalanx;
+    Bitboard b, neighbours, stoppers, supported, phalanx;
     Bitboard lever, leverPush;
     Square s;
     bool opposed, backward;
@@ -116,6 +116,9 @@ namespace {
     e->pawnsOnSquares[Us][BLACK] = popcount(ourPawns & DarkSquares);
     e->pawnsOnSquares[Us][WHITE] = pos.count<PAWN>(Us) - e->pawnsOnSquares[Us][BLACK];
 
+	// doubled pawns
+	score -= Doubled * popcount(ourPawns & shift<Up>(ourPawns) & ~e->pawnAttacks[Us]);
+	
     // Loop through all pawns of the current color and score each pawn
     while ((s = *pl++) != SQ_NONE)
     {
@@ -131,7 +134,6 @@ namespace {
         stoppers   = theirPawns & passed_pawn_mask(Us, s);
         lever      = theirPawns & PawnAttacks[Us][s];
         leverPush  = theirPawns & PawnAttacks[Us][s + Up];
-        doubled    = ourPawns   & (s - Up);
         neighbours = ourPawns   & adjacent_files_bb(f);
         phalanx    = neighbours & rank_bb(s);
         supported  = neighbours & rank_bb(s - Up);
@@ -181,9 +183,6 @@ namespace {
 
         else if (backward)
             score -= Backward, e->weakUnopposed[Us] += !opposed;
-
-        if (doubled && !supported)
-            score -= Doubled;
 
         if (lever)
             score += Lever[relative_rank(Us, s)];


### PR DESCRIPTION
Moves the evaluation from within the loop into a single line.

STC: http://tests.stockfishchess.org/tests/view/5a623c3d0ebc590297b9b86b
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 106298 W: 19103 L: 19127 D: 68068

LTC: http://tests.stockfishchess.org/tests/view/5a632c7d0ebc590297b9b892
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 57983 W: 7288 L: 7214 D: 43481