### PR TITLE
Contempt 20

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -59,7 +59,7 @@ void init(OptionsMap& o) {
   const int MaxHashMB = Is64Bit ? 131072 : 2048;
 
   o["Debug Log File"]        << Option("", on_logger);
-  o["Contempt"]              << Option(0, -100, 100);
+  o["Contempt"]              << Option(20, -100, 100);
   o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);


### PR DESCRIPTION
Set the default contempt value of Stockfish to 20 centipawns.

The so-called _contempt_ feature of Stockfish tries to prevent the
engine from simplifying the position too quickly when it feels that it 
is very slightly behind, instead keeping the tension a little bit longer.

Various tests in November 2017 have proved that our current imple-
mentation works well against SF7 (which is about 130 Elo weaker than
current master) and that the Elo gain is an increasing function of
contempt, going (against SF7) from +0 Elo when contempt is set at
zero centipawns, to +32 Elo when contempt is 40 centipawns.

See pull request 1325 for details:
https://github.com/official-stockfish/Stockfish/pull/1325

This November discussion left open the decision of which "default"
value for contempt we should use for Stockfish, taking into account
the various uses of Stockfish (opening preparation for humans, computer
online tournaments, analysis tool for web pages, human/computer play,
etc).

This pull request proposes to set the default contempt value of SF
to twenty centipawns, which turns out to be the highest value which
is not a regression against current master, as this seemed to be a
good compromise between risk and safety. A couple of SPRT[-3..1]
tests at long time control were done to bisect this value:

LTC:
Contempt 10: http://tests.stockfishchess.org/tests/view/5a5d42d20ebc5902977e2901 (PASSED)
Contempt 15: http://tests.stockfishchess.org/tests/view/5a5d41740ebc5902977e28fa (PASSED)
Contempt 20: http://tests.stockfishchess.org/tests/view/5a5d42060ebc5902977e28fc (PASSED)
Contempt 25: http://tests.stockfishchess.org/tests/view/5a5d433f0ebc5902977e2904 (FAILED)

Surprisingly, a test at "very long time control" hinted that using
contempt 20 would not only be non-regressive against contempt 0, but
may actually exhibit some small Elo gain (+2.4 Elo), giving a likelihood
of superiority of 90% after 8500 games:

VLTC:
ELO: 2.44 +-3.7 (95%) LOS: 90.2%
Total: 8546 W: 1104 L: 1044 D: 6398
http://tests.stockfishchess.org/tests/view/5a60b2820ebc590297b9b7e0

Finally, there were some concerns that a contempt value of 20 would
be worse than a value of 7, but a test with 20000 games at STC was
neutral:

STC:
ELO: 0.45 +-3.1 (95%) LOS: 61.2%
Total: 20000 W: 4222 L: 4196 D: 11582
http://tests.stockfishchess.org/tests/view/5a64d2fd0ebc590297903868

See the comments in pull request 1361 for the long, nice discussion
(180 entries :-)) leading to the decision to propose contempt 20 as
the default value:
https://github.com/official-stockfish/Stockfish/pull/1361

Whether Stockfish should strictly adhere to the Komodo and Houdini
semantics, adding the UCI commands to force the contempt to be White
in the so-called "analysis mode" is still under discussion, and may be or 
may not be the object of a future commit.

Bench: 5571216