### PR TITLE
Don't use the contempt setting in the analysis mode

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -192,10 +192,15 @@ void MainThread::search() {
   Time.init(Limits, us, rootPos.game_ply());
   TT.new_search();
 
-  int contempt = Options["Contempt"] * PawnValueEg / 100; // From centipawns
+  // Use the contempt setting only for playing, not for analysis
+  if (Limits.use_time_management()) {
+      int contempt = Options["Contempt"] * PawnValueEg / 100; // From centipawns
 
-  Eval::Contempt = (us == WHITE ?  make_score(contempt, contempt / 2)
-                                : -make_score(contempt, contempt / 2));
+      Eval::Contempt = (us == WHITE ?  make_score(contempt, contempt / 2)
+                                    : -make_score(contempt, contempt / 2));
+  }
+  else
+      Eval::Contempt = SCORE_ZERO;
 
   if (rootMoves.empty())
   {


### PR DESCRIPTION
The problem with using the current implementation of contempt for analysis is that the setting is applied from the point of view of the side to move. While in the analysis mode the side to move often switches. This leads to inconsistent analysis and incorrect functioning of the TT.

We should probably add a boolean option which makes possible to apply the contempt setting always from the white's perspective (Komodo and Houdini have White Contempt and Analysis Contempt respectively for this purpose). It probably needs discussion. But in any case disabling the contempt for analysis is a necessary step.

Bench: 5098576