### PR TITLE
Limit the king distance factor when evaluating passed pawns

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -489,7 +489,7 @@ namespace {
                      -   9 * mg_value(score) / 8
                      +  40;
 
-        // Transform the kingDanger units into a Score, and substract it from the evaluation
+        // Transform the kingDanger units into a Score, and subtract it from the evaluation
         if (kingDanger > 0)
         {
             int mobilityDanger = mg_value(mobility[Them] - mobility[Us]);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -97,6 +97,7 @@ namespace {
     template<Color Us> void initialize();
     template<Color Us> Score evaluate_king();
     template<Color Us> Score evaluate_threats();
+    int king_distance(Color c, Square s);
     template<Color Us> Score evaluate_passed_pawns();
     template<Color Us> Score evaluate_space();
     template<Color Us, PieceType Pt> Score evaluate_pieces();
@@ -625,6 +626,12 @@ namespace {
     return score;
   }
 
+  // helper used by evaluate_passed_pawns to cap the distance
+  template<Tracing T>
+  int Evaluation<T>::king_distance(Color c, Square s) {
+    return std::min(distance(pos.square<KING>(c), s), 5);
+  }
+
   // evaluate_passed_pawns() evaluates the passed pawns and candidate passed
   // pawns of the given color.
 
@@ -658,11 +665,11 @@ namespace {
             Square blockSq = s + Up;
 
             // Adjust bonus based on the king's proximity
-            ebonus += (pos.king_distance(Them, blockSq) * 5 - pos.king_distance(Us, blockSq) * 2) * rr;
+            ebonus += (king_distance(Them, blockSq) * 5 - king_distance(Us, blockSq) * 2) * rr;
 
             // If blockSq is not the queening square then consider also a second push
             if (r != RANK_7)
-                ebonus -= pos.king_distance(Us, blockSq + Up) * rr;
+                ebonus -= king_distance(Us, blockSq + Up) * rr;
 
             // If the pawn is free to advance, then increase the bonus
             if (pos.empty(blockSq))

--- a/src/position.h
+++ b/src/position.h
@@ -157,6 +157,7 @@ public:
   Score psq_score() const;
   Value non_pawn_material(Color c) const;
   Value non_pawn_material() const;
+  int king_distance(Color c, Square s) const;
 
   // Position consistency check, for debugging
   bool pos_is_ok() const;
@@ -253,6 +254,12 @@ template<PieceType Pt> inline Square Position::square(Color c) const {
 
 inline Square Position::ep_square() const {
   return st->epSquare;
+}
+
+// helper used by evaluation to get a distance between a king of color c and a blocking square s
+inline int Position::king_distance(Color c, Square s) const {
+  int d = distance(square<KING>(c), s);
+  return std::min(d, 5);
 }
 
 inline int Position::can_castle(CastlingRight cr) const {

--- a/src/position.h
+++ b/src/position.h
@@ -21,7 +21,6 @@
 #ifndef POSITION_H_INCLUDED
 #define POSITION_H_INCLUDED
 
-#include <algorithm>
 #include <cassert>
 #include <deque>
 #include <memory> // For std::unique_ptr
@@ -158,7 +157,6 @@ public:
   Score psq_score() const;
   Value non_pawn_material(Color c) const;
   Value non_pawn_material() const;
-  int king_distance(Color c, Square s) const;
 
   // Position consistency check, for debugging
   bool pos_is_ok() const;
@@ -255,11 +253,6 @@ template<PieceType Pt> inline Square Position::square(Color c) const {
 
 inline Square Position::ep_square() const {
   return st->epSquare;
-}
-
-// helper used by evaluation to get a distance between a king of color c and a blocking square s
-inline int Position::king_distance(Color c, Square s) const {
-  return std::min(distance(square<KING>(c), s), 5);
 }
 
 inline int Position::can_castle(CastlingRight cr) const {

--- a/src/position.h
+++ b/src/position.h
@@ -21,6 +21,7 @@
 #ifndef POSITION_H_INCLUDED
 #define POSITION_H_INCLUDED
 
+#include <algorithm>
 #include <cassert>
 #include <deque>
 #include <memory> // For std::unique_ptr
@@ -258,8 +259,7 @@ inline Square Position::ep_square() const {
 
 // helper used by evaluation to get a distance between a king of color c and a blocking square s
 inline int Position::king_distance(Color c, Square s) const {
-  int d = distance(square<KING>(c), s);
-  return std::min(d, 5);
+  return std::min(distance(square<KING>(c), s), 5);
 }
 
 inline int Position::can_castle(CastlingRight cr) const {


### PR DESCRIPTION
Limit the king distance factor when evaluating passed pawns
Passed STC
http://tests.stockfishchess.org/tests/view/5a6bf7290ebc590d945d5a3a
LLR: 3.31 (-2.94,2.94) [0.00,5.00]
Total: 23987 W: 5550 L: 5281 D: 13156

and LTC
http://tests.stockfishchess.org/tests/view/5a6c57710ebc590297c36af2
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 16926 W: 3014 L: 2820 D: 11092

bench: 5059457