### PR TITLE
Introduce an Analysis Contempt setting to control application of the Contempt setting during analysis

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -192,11 +192,6 @@ void MainThread::search() {
   Time.init(Limits, us, rootPos.game_ply());
   TT.new_search();
 
-  int contempt = Options["Contempt"] * PawnValueEg / 100; // From centipawns
-
-  Eval::Contempt = (us == WHITE ?  make_score(contempt, contempt / 2)
-                                : -make_score(contempt, contempt / 2));
-
   if (rootMoves.empty())
   {
       rootMoves.emplace_back(MOVE_NONE);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -60,6 +60,7 @@ void init(OptionsMap& o) {
 
   o["Debug Log File"]        << Option("", on_logger);
   o["Contempt"]              << Option(20, -100, 100);
+  o["Analysis Contempt"]     << Option(false);
   o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
@@ -70,6 +71,7 @@ void init(OptionsMap& o) {
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
   o["Slow Mover"]            << Option(89, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
+  o["UCI_AnalyseMode"]       << Option(false);
   o["UCI_Chess960"]          << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);


### PR DESCRIPTION
The problem with the current implementation of contempt for analysis is that the setting is applied from the point of view of the side to move. While in the analysis mode the side to move often switches. This leads to inconsistent analysis and incorrect functioning of the TT. Moreover, since the default value of Contempt isn't zero, users who are unaware of this setting and of the fact its default value is not zero may perform analysis with undesirable conditions.

This patch solves these problems by introducing a new Analysis Contempt setting of the check type. It turns on and off contempt during analysis, in which case the Contempt setting is always applied for the white side.

The Contempt and Analysis Contempt options work together as follows:

- Playing mode: Analysis Contempt has no effect and Contempt applies for the side to move
- Analysis mode, Analysis Contempt is false: Contempt has no effect and the behaviour is as if it was set to 0
- Analysis mode, Analysis Contempt is true: Contempt applies for the white side

Whether the engine is in the playing or analysis mode, is identified using the UCI_AnalyseMode setting.

In the patch I also moved reading of engine options to the thread working with user input. This better prevents a potential race condition.

Unfortunately, not all chess interfaces use the UCI_AnalyseMode properly. Therefore, in my opinion, this problem may be solved in either of the two ways with future pull requests:

- Set the default value of the Contempt setting back to 0;
- Change the condition identifying the analysis mode from `Options["UCI_AnalyseMode"]` to something like `Options["UCI_AnalyseMode"] || limits.infinite`.

Which way to choose probably needs further discussion.

Bench: 5059457 (unchanged)