### PR TITLE
Separate contempt for white and black

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -192,16 +192,16 @@ void MainThread::search() {
   Time.init(Limits, us, rootPos.game_ply());
   TT.new_search();
 
-  int contempt;
+  int contempt = 0;
 
-if (us == WHITE)
-{
-contempt = Options["Contempt for white"] * PawnValueEg / 100; // From centipawns
-}
-else
-{
-contempt = Options["Contempt for black"] * PawnValueEg / 100; // From centipawns
-}
+  if (us == WHITE)
+  {
+  contempt = Options["Contempt for white"] * PawnValueEg / 100; // From centipawns
+  }
+  else
+  {
+  contempt = Options["Contempt for black"] * PawnValueEg / 100; // From centipawns
+  }
 
 
   Eval::Contempt = (us == WHITE ?  make_score(contempt, contempt / 2)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -192,7 +192,17 @@ void MainThread::search() {
   Time.init(Limits, us, rootPos.game_ply());
   TT.new_search();
 
-  int contempt = Options["Contempt"] * PawnValueEg / 100; // From centipawns
+  int contempt;
+
+if (us == WHITE)
+{
+contempt = Options["Contempt for white"] * PawnValueEg / 100; // From centipawns
+}
+else
+{
+contempt = Options["Contempt for black"] * PawnValueEg / 100; // From centipawns
+}
+
 
   Eval::Contempt = (us == WHITE ?  make_score(contempt, contempt / 2)
                                 : -make_score(contempt, contempt / 2));

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -59,7 +59,8 @@ void init(OptionsMap& o) {
   const int MaxHashMB = Is64Bit ? 131072 : 2048;
 
   o["Debug Log File"]        << Option("", on_logger);
-  o["Contempt"]              << Option(20, -100, 100);
+  o["Contempt for white"]    << Option(20, -100, 100);
+  o["Contempt for black"]    << Option(20, -100, 100);
   o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);


### PR DESCRIPTION
The main idea of ​​this patch is to use different values ​​of contempt depending on what color we play.
For example, we can set contempt 30 for the game with white color and contempt 10 if we have black. When playing black we should not be as aggressive as if we were playing white.

No functional change