### PR TITLE
Retire lever

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -43,12 +43,6 @@ namespace {
   // Doubled pawn penalty
   const Score Doubled = S(18, 38);
 
-  // Lever bonus by rank
-  const Score Lever[RANK_NB] = {
-    S( 0,  0), S( 0,  0), S(0, 0), S(0, 0),
-    S(17, 16), S(33, 32), S(0, 0), S(0, 0)
-  };
-
   // Weakness of our pawn shelter in front of the king by [isKingFile][distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawns or our pawn is behind our king.
   const Value ShelterWeakness[][int(FILE_NB) / 2][RANK_NB] = {
@@ -184,9 +178,6 @@ namespace {
 
         if (doubled && !supported)
             score -= Doubled;
-
-        if (lever)
-            score += Lever[relative_rank(Us, s)];
     }
 
     return score;


### PR DESCRIPTION
Retire the lever bonus from pawns evaluation

STC: http://tests.stockfishchess.org/tests/view/5a6aef5c0ebc590d945d59c8
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 88290 W: 19549 L: 19560 D: 49181

LTC: http://tests.stockfishchess.org/tests/view/5a6b70140ebc590d945d59f7
LLR: 3.22 (-2.94,2.94) [-3.00,1.00]
Total: 104603 W: 18105 L: 18108 D: 68390