### PR TITLE
divide movepick stages.

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -131,6 +131,11 @@ public:
   Move next_move(bool skipQuiets = false);
 
 private:
+  Move next_move_main();
+  Move next_move_evasion();
+  Move next_move_probcut();
+  Move next_move_qsearch();
+  Move (MovePicker::*fpNextMove)();
   template<GenType> void score();
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }
@@ -145,6 +150,7 @@ private:
   Square recaptureSquare;
   Value threshold;
   Depth depth;
+  bool skipQuiets;
   ExtMove moves[MAX_MOVES];
 };
 


### PR DESCRIPTION
This patch divides movepick into a few different stages: main, evasion, probcut, and qsearch and uses a function pointer to point to the appropriate next_move.

It is more code, but much of it is white space.  To me, this is more readable and understandable.  Figuring out the guts of this big switch and how these stages interplay is quite a challenge for newcomers.

I welcome any comments or suggestions.
