### PR TITLE
Ps killers

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -186,14 +186,18 @@ Move MovePicker::next_move(bool skipQuiets) {
               *endBadCaptures++ = move;
           }
       }
-      if ((special[2] == special[0]) || 
-          (special[2] == special[1])) special[2] = MOVE_NONE;
       ++stage;
       /* fallthrough */
 
   case SPECIAL: //killers and countermoves
       while (specialIndex < 3)
       {
+         //break if countermove is same as a killer move
+         if (specialIndex == 2)
+         {
+            if (special[2] == special[0]) break;
+            else if (special[2] == special[1]) break;
+         }
          move = special[specialIndex++];
          if (    move != MOVE_NONE
              &&  move != ttMove

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -187,17 +187,15 @@ Move MovePicker::next_move(bool skipQuiets) {
           }
       }
       ++stage;
+
+      //if the countermove is same as a killer, ignore it
+      if ((special[2] == special[0]) ||
+          (special[2] == special[1])) special[2] = MOVE_NONE;
       /* fallthrough */
 
   case SPECIAL: //killers and countermoves
       while (specialIndex < 3)
       {
-         //break if countermove is same as a killer move
-         if (specialIndex == 2)
-         {
-            if ((special[2] == special[0]) ||
-                (special[2] == special[1])) break;
-         }
          move = special[specialIndex++];
          if (    move != MOVE_NONE
              &&  move != ttMove

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -70,7 +70,7 @@ namespace {
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Move cm, Move* killers_p)
            : pos(p), mainHistory(mh), captureHistory(cph), contHistory(ch), countermove(cm),
-             killers{killers_p[0], killers_p[1]}, depth(d){
+             killers{killers_p[0], killers_p[1]}, killersIndex(0), depth(d){
 
   assert(d > DEPTH_ZERO);
 
@@ -186,24 +186,20 @@ Move MovePicker::next_move(bool skipQuiets) {
               *endBadCaptures++ = move;
           }
       }
-
       ++stage;
-      move = killers[0];  // First killer move
-      if (    move != MOVE_NONE
-          &&  move != ttMove
-          &&  pos.pseudo_legal(move)
-          && !pos.capture(move))
-          return move;
       /* fallthrough */
 
   case KILLERS:
+      while (killersIndex < 2)
+      {
+         move = killers[killersIndex++];
+         if (    move != MOVE_NONE
+             &&  move != ttMove
+             &&  pos.pseudo_legal(move)
+             && !pos.capture(move))
+             return move;
+      }
       ++stage;
-      move = killers[1]; // Second killer move
-      if (    move != MOVE_NONE
-          &&  move != ttMove
-          &&  pos.pseudo_legal(move)
-          && !pos.capture(move))
-          return move;
       /* fallthrough */
 
   case COUNTERMOVE:

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -195,8 +195,8 @@ Move MovePicker::next_move(bool skipQuiets) {
          //break if countermove is same as a killer move
          if (specialIndex == 2)
          {
-            if (special[2] == special[0]) break;
-            else if (special[2] == special[1]) break;
+            if ((special[2] == special[0]) ||
+                (special[2] == special[1])) break;
          }
          move = special[specialIndex++];
          if (    move != MOVE_NONE

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -190,7 +190,7 @@ Move MovePicker::next_move(bool skipQuiets) {
       /* fallthrough */
 
   case KILLERS:
-      while (killersIndex < 2)
+      while (killersIndex < NUM_KILLERS)
       {
          move = killers[killersIndex++];
          if (    move != MOVE_NONE

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -113,8 +113,6 @@ typedef StatBoards<PIECE_NB, SQUARE_NB, Move> CounterMoveHistory;
 /// instead of ButterflyBoards.
 typedef StatBoards<PIECE_NB, SQUARE_NB, PieceToHistory> ContinuationHistory;
 
-const int NUM_KILLERS = 2;
-
 /// MovePicker class is used to pick one pseudo legal move at a time from the
 /// current position. The most important method is next_move(), which returns a
 /// new pseudo legal move each time it is called, until there are no moves left,
@@ -140,10 +138,10 @@ private:
   const ButterflyHistory* mainHistory;
   const CapturePieceToHistory* captureHistory;
   const PieceToHistory** contHistory;
-  Move ttMove, countermove, killers[NUM_KILLERS];
-  ExtMove *cur, *endMoves, *endBadCaptures;
+  Move ttMove, countermove, special[3];
+  ExtMove *cur, *endMoves, *endBadCaptures; //, special[3];
   int stage;
-  int killersIndex;
+  int specialIndex;
   Square recaptureSquare;
   Value threshold;
   Depth depth;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -138,8 +138,8 @@ private:
   const ButterflyHistory* mainHistory;
   const CapturePieceToHistory* captureHistory;
   const PieceToHistory** contHistory;
-  Move ttMove, countermove, special[3];
-  ExtMove *cur, *endMoves, *endBadCaptures; //, special[3];
+  Move ttMove, special[3];
+  ExtMove *cur, *endMoves, *endBadCaptures;
   int stage;
   int specialIndex;
   Square recaptureSquare;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -142,6 +142,7 @@ private:
   Move ttMove, countermove, killers[2];
   ExtMove *cur, *endMoves, *endBadCaptures;
   int stage;
+  int killersIndex;
   Square recaptureSquare;
   Value threshold;
   Depth depth;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -113,6 +113,7 @@ typedef StatBoards<PIECE_NB, SQUARE_NB, Move> CounterMoveHistory;
 /// instead of ButterflyBoards.
 typedef StatBoards<PIECE_NB, SQUARE_NB, PieceToHistory> ContinuationHistory;
 
+const int NUM_KILLERS = 2;
 
 /// MovePicker class is used to pick one pseudo legal move at a time from the
 /// current position. The most important method is next_move(), which returns a
@@ -139,7 +140,7 @@ private:
   const ButterflyHistory* mainHistory;
   const CapturePieceToHistory* captureHistory;
   const PieceToHistory** contHistory;
-  Move ttMove, countermove, killers[2];
+  Move ttMove, countermove, killers[NUM_KILLERS];
   ExtMove *cur, *endMoves, *endBadCaptures;
   int stage;
   int killersIndex;

--- a/src/search.h
+++ b/src/search.h
@@ -26,6 +26,7 @@
 #include "misc.h"
 #include "movepick.h"
 #include "types.h"
+#include "movepick.h"
 
 class Position;
 
@@ -45,7 +46,7 @@ struct Stack {
   int ply;
   Move currentMove;
   Move excludedMove;
-  Move killers[2];
+  Move killers[NUM_KILLERS];
   Value staticEval;
   int statScore;
   int moveCount;

--- a/src/search.h
+++ b/src/search.h
@@ -26,7 +26,6 @@
 #include "misc.h"
 #include "movepick.h"
 #include "types.h"
-#include "movepick.h"
 
 class Position;
 

--- a/src/search.h
+++ b/src/search.h
@@ -46,7 +46,7 @@ struct Stack {
   int ply;
   Move currentMove;
   Move excludedMove;
-  Move killers[NUM_KILLERS];
+  Move killers[2];
   Value staticEval;
   int statScore;
   int moveCount;


### PR DESCRIPTION
Killers and countermoves are handled the same way.   This patch combines them into a "SPECIAL" stage and uses the same code to handle them all (code reuse).

same bench.  Removes about 10 lines of code. Passed -3,1 SPRT at 
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 42802 W: 9615 L: 9535 D: 23652