### PR TITLE
Different keys for White and Black rooted searches

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -146,6 +146,7 @@ public:
   Key key_after(Move m) const;
   Key material_key() const;
   Key pawn_key() const;
+  void set_key_for_root_color(Color c);
 
   // Other properties of the position
   Color side_to_move() const;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -197,6 +197,9 @@ void MainThread::search() {
   Eval::Contempt = (us == WHITE ?  make_score(contempt, contempt / 2)
                                 : -make_score(contempt, contempt / 2));
 
+  if (contempt)
+      rootPos.set_key_for_root_color(us);
+
   if (rootMoves.empty())
   {
       rootMoves.emplace_back(MOVE_NONE);


### PR DESCRIPTION
The hash table stores different scores in the transposition table
in the current master when using non-null contempts. This patch
proposes to use different hash paths for the searches with root-
as-White and root-as-Black when contempt is not zero, which has
the following properties:

• In analysis, the hash table is coherent and stores two independent
  search trees, but will get filled at 100% with the search if the user
  decides to start a long think in one position, of course.

• In normal game play, the root positions of searches have always the
  same color and the engine will use the full hash naturally (same be-
  haviour as current master).

Bench is changed because some positions in the bench suite are with Black to move.

Bench: 5561299