### PR TITLE
Analysis Contempt combo box

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -194,8 +194,13 @@ void MainThread::search() {
 
   int contempt = Options["Contempt"] * PawnValueEg / 100; // From centipawns
 
-  Eval::Contempt = (us == WHITE ?  make_score(contempt, contempt / 2)
-                                : -make_score(contempt, contempt / 2));
+  // in analysis mode, let Analysis Contempt control the contempt value
+  contempt =  Limits.infinite || Options["UCI_AnalyseMode"]
+            ?   Options["Analysis Contempt"] == "White" ?  contempt
+              : Options["Analysis Contempt"] == "Black" ? -contempt : 0
+            : us == WHITE ? contempt : -contempt;
+
+  Eval::Contempt = make_score(contempt, contempt / 2);
 
   if (rootMoves.empty())
   {

--- a/src/uci.h
+++ b/src/uci.h
@@ -50,11 +50,13 @@ public:
   Option(bool v, OnChange = nullptr);
   Option(const char* v, OnChange = nullptr);
   Option(int v, int minv, int maxv, OnChange = nullptr);
+  Option(const char* v, const char *cur, OnChange = nullptr);
 
   Option& operator=(const std::string&);
   void operator<<(const Option&);
   operator int() const;
   operator std::string() const;
+  bool operator==(const char*);
 
 private:
   friend std::ostream& operator<<(std::ostream&, const OptionsMap&);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -60,6 +60,8 @@ void init(OptionsMap& o) {
 
   o["Debug Log File"]        << Option("", on_logger);
   o["Contempt"]              << Option(20, -100, 100);
+  o["Analysis Contempt"]     << Option("Off var Off var White var Black",
+                                       "Off");
   o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
@@ -71,6 +73,7 @@ void init(OptionsMap& o) {
   o["Slow Mover"]            << Option(89, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
+  o["UCI_AnalyseMode"]       << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);
   o["Syzygy50MoveRule"]      << Option(true);
@@ -117,6 +120,9 @@ Option::Option(OnChange f) : type("button"), min(0), max(0), on_change(f)
 Option::Option(int v, int minv, int maxv, OnChange f) : type("spin"), min(minv), max(maxv), on_change(f)
 { defaultValue = currentValue = std::to_string(v); }
 
+Option::Option(const char* v, const char* cur, OnChange f) : type("combo"), min(0), max(0), on_change(f)
+{ defaultValue = v; currentValue = cur; }
+
 Option::operator int() const {
   assert(type == "check" || type == "spin");
   return (type == "spin" ? stoi(currentValue) : currentValue == "true");
@@ -125,6 +131,11 @@ Option::operator int() const {
 Option::operator std::string() const {
   assert(type == "string");
   return currentValue;
+}
+
+bool Option::operator==(const char* s) {
+  assert(type == "combo");
+  return currentValue == s;
 }
 
 


### PR DESCRIPTION
This patch introduces an Analysis Contempt UCI combo box to control the behaviour of contempt during analysis. The possible values are Off, White, Black.

The engine is in analysis mode if UCI_AnalyseMode is set by the GUI or if the user has chosen infinite analysis mode ("go infinite"). (I'm not sure how many GUIs automatically set UCI_AnalyseMode in infinite analysis mode.)

The idea for the combo box is entirely @vdbergh 's.

No functional change outside analysis mode.