### PR TITLE
Enable LTO for clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,21 +8,35 @@ matrix:
       compiler: gcc
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-6', 'g++-6-multilib', 'g++-multilib', 'valgrind', 'expect']
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+            - g++-7-multilib
+            - g++-multilib
+            - valgrind
+            - expect
       env:
-        - COMPILER=g++-6
+        - COMPILER=g++-7
         - COMP=gcc
 
     - os: linux
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['clang', 'g++-multilib', 'valgrind', 'expect']
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+            - llvm-5.0-dev
+            - g++-multilib
+            - valgrind
+            - expect
       env:
-        - COMPILER=clang++
+        - COMPILER=clang++-5.0
         - COMP=clang
+        - LDFLAGS=-fuse-ld=gold
 
     - os: osx
       compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,31 +8,18 @@ matrix:
       compiler: gcc
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-            - g++-7-multilib
-            - g++-multilib
-            - valgrind
-            - expect
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-6', 'g++-6-multilib', 'g++-multilib', 'valgrind', 'expect']
       env:
-        - COMPILER=g++-7
+        - COMPILER=g++-6
         - COMP=gcc
 
     - os: linux
       compiler: clang
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - clang-5.0
-            - llvm-5.0-dev
-            - g++-multilib
-            - valgrind
-            - expect
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
+          packages: ['clang-5.0', 'llvm-5.0-dev', 'g++-multilib', 'valgrind', 'expect']
       env:
         - COMPILER=clang++-5.0
         - COMP=clang

--- a/src/Makefile
+++ b/src/Makefile
@@ -302,8 +302,6 @@ ifeq ($(optimize),yes)
 
 	ifeq ($(comp),clang)
 		ifeq ($(KERNEL),Darwin)
-				CXXFLAGS += -flto
-				LDFLAGS += $(CXXFLAGS)
 			ifeq ($(arch),i386)
 				CXXFLAGS += -mdynamic-no-pic
 			endif
@@ -349,33 +347,20 @@ endif
 ### 3.8 Link Time Optimization, it works since gcc 4.5 but not on mingw under Windows.
 ### This is a mix of compile and link time options because the lto link phase
 ### needs access to the optimization flags.
-ifeq ($(comp),gcc)
-	ifeq ($(optimize),yes)
-	ifeq ($(debug),no)
+ifeq ($(optimize),yes)
+ifeq ($(debug), no)
+	ifeq ($(comp),$(filter $(comp),gcc clang))
 		CXXFLAGS += -flto
 		LDFLAGS += $(CXXFLAGS)
 	endif
-	endif
-endif
 
-ifeq ($(comp),clang)
-	ifeq ($(optimize),yes)
-	ifeq ($(debug),no)
-		CXXFLAGS += -flto
-		LDFLAGS += $(CXXFLAGS)
-	endif
-	endif
-endif
-
-ifeq ($(comp),mingw)
+	ifeq ($(comp),mingw)
 	ifeq ($(KERNEL),Linux)
-	ifeq ($(optimize),yes)
-	ifeq ($(debug),no)
 		CXXFLAGS += -flto
 		LDFLAGS += $(CXXFLAGS)
 	endif
 	endif
-	endif
+endif
 endif
 
 ### 3.9 Android 5 can only run position independent executables. Note that this

--- a/src/Makefile
+++ b/src/Makefile
@@ -358,6 +358,15 @@ ifeq ($(comp),gcc)
 	endif
 endif
 
+ifeq ($(comp),clang)
+	ifeq ($(optimize),yes)
+	ifeq ($(debug),no)
+		CXXFLAGS += -flto
+		LDFLAGS += $(CXXFLAGS)
+	endif
+	endif
+endif
+
 ifeq ($(comp),mingw)
 	ifeq ($(KERNEL),Linux)
 	ifeq ($(optimize),yes)


### PR DESCRIPTION
Enable link-time optimization when compiling with clang.

No functional change.