### PR TITLE
Ps recaptures

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -313,14 +313,13 @@ Move MovePicker::next_move(bool skipQuiets) {
   case QSEARCH_RECAPTURES:
       cur = moves;
       endMoves = generate<CAPTURES>(pos, cur);
-      score<CAPTURES>();
       ++stage;
       /* fallthrough */
 
   case QRECAPTURES:
       while (cur < endMoves)
       {
-          move = pick_best(cur++, endMoves);
+          move = *cur++;
           if (to_sq(move) == recaptureSquare)
               return move;
       }


### PR DESCRIPTION
sry I'm late on this.  Since we're only looking at captures that recapture the recapture square, it seems like we don't need to score or pick_best these moves.  Passed STC and LTC.

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 20231 W: 3533 L: 3411 D: 13287