### PR TITLE
subtract contempt from reported eval. bench 5023629

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1543,6 +1543,10 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
 
       bool tb = TB::RootInTB && abs(v) < VALUE_MATE - MAX_PLY;
       v = tb ? TB::Score : v;
+      Value reduce = pos.side_to_move()==WHITE
+                     ? eg_value(Eval::Contempt) : -eg_value(Eval::Contempt);
+      Value vdisp = tb ? TB::Score
+                       : (v == VALUE_DRAW) ? VALUE_DRAW : v - reduce;
 
       if (ss.rdbuf()->in_avail()) // Not at first line
           ss << "\n";
@@ -1551,7 +1555,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
          << " depth "    << d / ONE_PLY
          << " seldepth " << rootMoves[i].selDepth
          << " multipv "  << i + 1
-         << " score "    << UCI::value(v);
+         << " score "    << UCI::value(vdisp);
 
       if (!tb && i == PVIdx)
           ss << (v >= beta ? " lowerbound" : v <= alpha ? " upperbound" : "");


### PR DESCRIPTION
No functional change.

Using default Contempt of 20 has caused stockfish to display evals inflated by the contempt value. When these are displayed from black and white consecutively, the eval appears to bounce. For example an eval of +30 might be displayed as +50 for white and +10 for black, then back to +50, and so on.
This PR attempts to remove most of this swing to make the evals seen by users more consistent.

Some example evals at start of game (evals all from white point-of-view, note that the opening played changes when contempt changed from 0 to 20 so the evals reported are not only adjusted for contempt):

SF9 with Contempt 0:
```
info depth 15 seldepth 21 multipv 1 score cp 22 ...
bestmove d2d4 ponder d7d5
info depth 15 seldepth 23 multipv 1 score cp 29 ...
bestmove e7e6 ponder d2d4
info depth 14 seldepth 20 multipv 1 score cp 25 ...
bestmove g1f3 ponder b8c6
info depth 15 seldepth 24 multipv 1 score cp 36 ...
bestmove g8f6 ponder f3e5
info depth 15 seldepth 21 multipv 1 score cp 32 ...
bestmove f3e5 ponder d7d6
info depth 15 seldepth 24 multipv 1 score cp 70 ...
bestmove d7d6 ponder e5f3
```
Eval changes are 7, 2, 11, 4, 38

SF9 with Contempt 20:
```
info depth 15 seldepth 22 multipv 1 score cp 71 ...
bestmove e2e4 ponder e7e5
info depth 15 seldepth 22 multipv 1 score cp 20 ...
bestmove e7e5 ponder g1f3
info depth 14 seldepth 22 multipv 1 score cp 46 ...
bestmove g1f3 ponder g8f6
info depth 16 seldepth 22 multipv 1 score cp 28 ...
bestmove b8c6 ponder f1b5
info depth 16 seldepth 24 multipv 1 score cp 51 ...
bestmove f1b5 ponder a7a6
info depth 14 seldepth 21 multipv 1 score cp 29 ...
bestmove g8f6 ponder e1g1
```
Eval changes are much larger now; 49, 26, 18, 23, 22

Updated code to reduce swings:
```
info depth 15 seldepth 22 multipv 1 score cp 61 ...
bestmove e2e4 ponder e7e5
info depth 15 seldepth 22 multipv 1 score cp -30 ...
bestmove e7e5 ponder g1f3
info depth 14 seldepth 22 multipv 1 score cp 36 ...
bestmove g1f3 ponder g8f6
info depth 16 seldepth 22 multipv 1 score cp -38 ...
bestmove b8c6 ponder f1b5
info depth 16 seldepth 24 multipv 1 score cp 41 ...
bestmove f1b5 ponder a7a6
info depth 14 seldepth 21 multipv 1 score cp -39 ...
bestmove g8f6 ponder e1g1
```
Eval swings are now; 31, 5, 2, 3, 2.

There is an edge case where if the "real" eval is adjusted to zero by the contempt, this code will treat it as a draw value and not undo the contempt change, but I do not think that is a big problem. In general, this change should make the evals reported to users more intuitive.