### PR TITLE
Dynamic contempt

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -905,7 +905,7 @@ namespace {
 
 } // namespace
 
-Score Eval::Contempt = SCORE_ZERO;
+std::atomic<Score> Eval::Contempt;
 
 /// evaluate() is the evaluator for the outer world. It returns a static evaluation
 /// of the position from the point of view of the side to move.

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -21,6 +21,7 @@
 #ifndef EVALUATE_H_INCLUDED
 #define EVALUATE_H_INCLUDED
 
+#include <atomic>
 #include <string>
 
 #include "types.h"
@@ -31,7 +32,7 @@ namespace Eval {
 
 const Value Tempo = Value(20); // Must be visible to search
 
-extern Score Contempt;
+extern std::atomic<Score> Contempt;
 
 std::string trace(const Position& pos);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -191,11 +191,6 @@ void MainThread::search() {
   Time.init(Limits, us, rootPos.game_ply());
   TT.new_search();
 
-  int contempt = Options["Contempt"] * PawnValueEg / 100; // From centipawns
-
-  Eval::Contempt = (us == WHITE ?  make_score(contempt, contempt / 2)
-                                : -make_score(contempt, contempt / 2));
-
   if (rootMoves.empty())
   {
       rootMoves.emplace_back(MOVE_NONE);
@@ -306,6 +301,10 @@ void Thread::search() {
 
   multiPV = std::min(multiPV, rootMoves.size());
 
+  int contempt = Options["Contempt"] * PawnValueEg / 100; // From centipawns
+  Eval::Contempt = (rootPos.side_to_move() == WHITE ?  make_score(contempt, contempt / 2)
+                                                    : -make_score(contempt, contempt / 2));
+
   // Iterative deepening loop until requested to stop or the target depth is reached
   while (   (rootDepth += ONE_PLY) < DEPTH_MAX
          && !Threads.stop
@@ -340,6 +339,17 @@ void Thread::search() {
               delta = Value(18);
               alpha = std::max(rootMoves[PVIdx].previousScore - delta,-VALUE_INFINITE);
               beta  = std::min(rootMoves[PVIdx].previousScore + delta, VALUE_INFINITE);
+
+              // Adjust contempt based on current situation
+
+              contempt  = Options["Contempt"] * PawnValueEg / 100;          // From centipawns
+              contempt += bestValue >  2 * PawnValueEg ?  PawnValueEg / 5:  // Dynamic contempt
+                          bestValue < -2 * PawnValueEg ? -PawnValueEg / 5:
+                          bestValue/10;
+
+              Eval::Contempt = (rootPos.side_to_move() == WHITE ?  make_score(contempt, contempt / 2)
+                                                                : -make_score(contempt, contempt / 2));
+
           }
 
           // Start with a small aspiration window and, in the case of a fail

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -59,7 +59,7 @@ void init(OptionsMap& o) {
   const int MaxHashMB = Is64Bit ? 131072 : 2048;
 
   o["Debug Log File"]        << Option("", on_logger);
-  o["Contempt"]              << Option(20, -100, 100);
+  o["Contempt"]              << Option(18, -100, 100);
   o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);


### PR DESCRIPTION
Adjust contempt based on current score.

[STC](http://tests.stockfishchess.org/tests/view/5a72e6020ebc590f2c86ea20)
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 110052 W: 24614 L: 23938 D: 61500

[LTC](http://tests.stockfishchess.org/tests/view/5a76c5b90ebc5902971a9830)
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 16470 W: 2896 L: 2705 D: 10869