### PR TITLE
Don’t score and sort all captures in RECAPTURES stage.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -307,14 +307,13 @@ Move MovePicker::next_move(bool skipQuiets) {
   case QSEARCH_RECAPTURES:
       cur = moves;
       endMoves = generate<CAPTURES>(pos, cur);
-      score<CAPTURES>();
       ++stage;
       /* fallthrough */
 
   case QRECAPTURES:
       while (cur < endMoves)
       {
-          move = pick_best(cur++, endMoves);
+          move = *cur++;
           if (to_sq(move) == recaptureSquare)
               return move;
       }


### PR DESCRIPTION
For these recaptures, we’re are only considering those captures that
recapture the recapture square (small portion of all the captures).
Therefore, scoring all of the captures and pick_besting out of the whole group
is not necessary.

STC http://tests.stockfishchess.org/tests/view/5a717faa0ebc590f2c86e9a7
LTC http://tests.stockfishchess.org/tests/view/5a73ad330ebc5902971a96ba
Bench: 5023593