### PR TITLE
Obey skipQuiets strictly in MovePicker

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -221,8 +221,8 @@ Move MovePicker::next_move(bool skipQuiets) {
       /* fallthrough */
 
   case QUIET:
-      while (    cur < endMoves
-             && (!skipQuiets || cur->value >= VALUE_ZERO))
+      if (!skipQuiets)
+      while ( cur < endMoves )
       {
           move = *cur++;
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -222,16 +222,16 @@ Move MovePicker::next_move(bool skipQuiets) {
 
   case QUIET:
       if (!skipQuiets)
-      while ( cur < endMoves )
-      {
-          move = *cur++;
+         while ( cur < endMoves )
+         {
+             move = *cur++;
 
-          if (   move != ttMove
-              && move != killers[0]
-              && move != killers[1]
-              && move != countermove)
-              return move;
-      }
+             if (   move != ttMove
+                 && move != killers[0]
+                 && move != killers[1]
+                 && move != countermove)
+                 return move;
+         }
       ++stage;
       cur = moves; // Point to beginning of bad captures
       /* fallthrough */


### PR DESCRIPTION
Simplification:  The extra logic to continue returning quiet moves if their respective scores are above 0 (even after skipQuiets is set) is a bit complex but doesn't seem to add any strength.  This is a simplification, but a functional change with a different bench.  Is the format acceptable, or should i indent the "while?"

Passed STC:
http://tests.stockfishchess.org/tests/view/5a79f8d80ebc5902971a99db

Bench 4954595