### PR TITLE
consistent quiet / capture usage

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -297,8 +297,8 @@ namespace {
 } // namespace
 
 
-/// generate<CAPTURES> generates all pseudo-legal captures and queen
-/// promotions. Returns a pointer to the end of the move list.
+/// generate<CAPTURES> generates all pseudo-legal captures (except capturing underpromotions)
+/// and queen promotions. Returns a pointer to the end of the move list.
 ///
 /// generate<QUIETS> generates all pseudo-legal non-captures and
 /// underpromotions. Returns a pointer to the end of the move list.

--- a/src/position.h
+++ b/src/position.h
@@ -121,7 +121,7 @@ public:
   bool legal(Move m) const;
   bool pseudo_legal(const Move m) const;
   bool capture(Move m) const;
-  bool capture_or_promotion(Move m) const;
+  bool capture_or_qpromotion(Move m) const;
   bool gives_check(Move m) const;
   bool advanced_pawn_push(Move m) const;
   Piece moved_piece(Move m) const;
@@ -359,9 +359,11 @@ inline bool Position::is_chess960() const {
   return chess960;
 }
 
-inline bool Position::capture_or_promotion(Move m) const {
+// the moves that generate<CAPTURES> will generate, which excludes capturing underpromotions.
+inline bool Position::capture_or_qpromotion(Move m) const {
   assert(is_ok(m));
-  return type_of(m) != NORMAL ? type_of(m) != CASTLING : !empty(to_sq(m));
+  return type_of(m) == NORMAL ? !empty(to_sq(m))
+                              : type_of(m) == ENPASSANT || promotion_type(m) == QUEEN;
 }
 
 inline bool Position::capture(Move m) const {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -570,7 +570,7 @@ namespace {
         {
             if (ttValue >= beta)
             {
-                if (!pos.capture_or_promotion(ttMove))
+                if (!pos.capture_or_qpromotion(ttMove))
                     update_stats(pos, ss, ttMove, nullptr, 0, stat_bonus(depth));
 
                 // Extra penalty for a quiet TT move in previous ply when it gets refuted
@@ -578,7 +578,7 @@ namespace {
                     update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth + ONE_PLY));
             }
             // Penalty for a quiet ttMove that fails low
-            else if (!pos.capture_or_promotion(ttMove))
+            else if (!pos.capture_or_qpromotion(ttMove))
             {
                 int penalty = -stat_bonus(depth);
                 thisThread->mainHistory.update(pos.side_to_move(), ttMove, penalty);
@@ -820,7 +820,7 @@ moves_loop: // When in check search starts from here
           (ss+1)->pv = nullptr;
 
       extension = DEPTH_ZERO;
-      captureOrPromotion = pos.capture_or_promotion(move);
+      captureOrPromotion = pos.capture_or_qpromotion(move);
       movedPiece = pos.moved_piece(move);
 
       givesCheck =  type_of(move) == NORMAL && !pos.discovered_check_candidates()
@@ -1092,7 +1092,7 @@ moves_loop: // When in check search starts from here
     else if (bestMove)
     {
         // Quiet best move: update move sorting heuristics
-        if (!pos.capture_or_promotion(bestMove))
+        if (!pos.capture_or_qpromotion(bestMove))
             update_stats(pos, ss, bestMove, quietsSearched, quietCount, stat_bonus(depth));
         else
             update_capture_stats(pos, bestMove, capturesSearched, captureCount, stat_bonus(depth));


### PR DESCRIPTION
`generate<CAPTURES>` will generate captures (except capturing underpromotions) and queen promotions, neither pos.capture nor pos.capture_or_promotion can thus be used to differentiate ```generate<QUIETS>``` from ```generate<CAPTURES>``` moves, leading to small inconsistences (AFAICT: a ttmove was not played in probcut as the first move if it was a queen promotion, but only later in the probcut phase, underpromotions were not scored as quiets). This patch replaces pos.capture_or_promotion by pos.capture_or_qpromotion that can be used to differentiate `generate<CAPTURES>` from `generate<QUIETS>` moves. Asserts are added to verify the consistency.

Edit: quotes added to show brackets. (SN)

passed STC:

http://tests.stockfishchess.org/tests/view/5a7777ad0ebc5902971a9888
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 20553 W: 4634 L: 4510 D: 11409

passed LTC:

http://tests.stockfishchess.org/tests/view/5a77f55c0ebc5902971a98ba
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 85016 W: 14585 L: 14569 D: 55862

compared to the tested patch a few comments have been added, and
```type_of(m) != CASTLING && (type_of(m) == ENPASSANT || promotion_type(m) == QUEEN)```
has been further simplified in
```type_of(m) == ENPASSANT || promotion_type(m) == QUEEN```
after realizing the castling check is redundant (and verifying no effect on bench).

Bench: 5084961