### PR TITLE
Consolidate pick_best code

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -134,9 +134,8 @@ void MovePicker::score() {
       }
 }
 
-// pick_best() finds the best move in the range (begin, end) and moves it to
-// the front. It's faster than sorting all the moves in advance when there
-// are few moves, e.g., the possible captures.
+// pick_best() finds the next best (non ttMove) move and moves it to the front. 
+// It's faster than sorting all the moves in advance when we may cutoff. 
 Move MovePicker::pick_best()
 {
    while (cur < endMoves)
@@ -147,7 +146,6 @@ Move MovePicker::pick_best()
    }
    return MOVE_NONE;
 }
-
 
 /// next_move() is the most important method of the MovePicker class. It returns
 /// a new pseudo legal move every time it is called, until there are no more moves

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -136,7 +136,7 @@ void MovePicker::score() {
 
 // pick_best() finds the next best (non ttMove) move and moves it to the front. 
 // It's faster than sorting all the moves in advance when we may cutoff. 
-Move MovePicker::pick_best()
+inline Move MovePicker::pick_best()
 {
    while (cur < endMoves)
    {

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -131,7 +131,7 @@ public:
   Move next_move(bool skipQuiets = false);
 
 private:
-  Move pick_best();
+  inline Move pick_best();
   template<GenType> void score();
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -131,6 +131,7 @@ public:
   Move next_move(bool skipQuiets = false);
 
 private:
+  Move pick_best();
   template<GenType> void score();
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }


### PR DESCRIPTION
This is a non-functional simplification.  The code that manages pick_best has many similarities.  I've consolidated them into a single pick_best method that looks for the next move in the movesList and checks for ttMove.  Then we don't have to repeatedly be doing these things in the switch statement.  This removes about 15 lines of repeated code.  I assume no LTC is necessary since the bench is the same, but I'll just do whatever you want.  Also, making pick_best be an inline class method seems a bit faster (probably within noise).

Passed STC.
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 25053 W: 5584 L: 5469 D: 14000
http://tests.stockfishchess.org/tests/view/5a7bfa9a0ebc5902971a9aa8

Bench: 5023593