### PR TITLE
Fix MinGW PGO build on Windows

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -310,6 +310,10 @@ ifeq ($(optimize),yes)
 			endif
 		endif
 	endif
+
+	ifeq ($(comp),mingw)
+		CXXFLAGS += -fno-ipa-cp-clone
+	endif
 endif
 
 ### 3.4 Bits


### PR DESCRIPTION
As discussed in issue #1375 MinGW profile builds on Windows fail due to optimizing issues. This fix disables the offending -fipa-cp-clone optimization option for the `COMP=mingw` compiler target.

Please note that I'm not changing the `COMP=gcc` target mentioned in issue #1375 because that would negatively affect builds for other Operating Systems.

No functional change.