### PR TITLE
Bugfix

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -766,6 +766,7 @@ namespace {
         search<NT>(pos, ss, alpha, beta, d, cutNode, true);
 
         tte = TT.probe(posKey, ttHit);
+        ttValue = ttHit ? value_from_tt(tte->value(), ss->ply) : VALUE_NONE;
         ttMove = ttHit ? tte->move() : MOVE_NONE;
     }
 
@@ -1172,8 +1173,8 @@ moves_loop: // When in check, search starts from here
     // Transposition table lookup
     posKey = pos.key();
     tte = TT.probe(posKey, ttHit);
-    ttMove = ttHit ? tte->move() : MOVE_NONE;
     ttValue = ttHit ? value_from_tt(tte->value(), ss->ply) : VALUE_NONE;
+    ttMove = ttHit ? tte->move() : MOVE_NONE;
 
     if (  !PvNode
         && ttHit


### PR DESCRIPTION
STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 76981 W: 17060 L: 17048 D: 42873
http://tests.stockfishchess.org/tests/view/5a7738b70ebc5902971a9868

No LTC because the test was just for slowdown.

When iid is invoked, the prior value of ttValue is not guaranteed to be VALUE_NONE. As such, it is currently possible to enter a state in which ttValue has a specific value which is inconsistent with tte->bound() and tte->depth(). Currently, ttValue is only used within the search in a context that prevents this situation from making a difference (and so this change is non-functional), but this is not guaranteed to remain the case in the future.

No functional change.