### PR TITLE
Don't consider pawns in determining whether a rook is "trapped."

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -398,8 +398,7 @@ namespace {
             {
                 Square ksq = pos.square<KING>(Us);
 
-                if (   ((file_of(ksq) < FILE_E) == (file_of(s) < file_of(ksq)))
-                    && !pe->semiopen_side(Us, file_of(ksq), file_of(s) < file_of(ksq)))
+                if (   ((file_of(ksq) < FILE_E) == (file_of(s) < file_of(ksq))))
                     score -= (TrappedRook - make_score(mob * 22, 0)) * (1 + !pos.can_castle(Us));
             }
         }

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -45,10 +45,6 @@ struct Entry {
     return semiopenFiles[c] & (1 << f);
   }
 
-  int semiopen_side(Color c, File f, bool leftSide) const {
-    return semiopenFiles[c] & (leftSide ? (1 << f) - 1 : ~((1 << (f + 1)) - 1));
-  }
-
   int pawns_on_same_color_squares(Color c, Square s) const {
     return pawnsOnSquares[c][bool(DarkSquares & s)];
   }


### PR DESCRIPTION
As far as can tell, semiopenFiles are set if there is a pawn anywhere on the file.  The removed condition would be true even if the pawns were very advanced, which doesn't make sense if we're looking for a trapped rook.  Seems the engine fairs better with this removed.  My guess s that the condition that mobility is 3 or less does this well enough.

Begs the question whether this is a mobility issue alone. . . not sure.  Should I do LTC test?

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 13377 W: 3009 L: 2871 D: 7497

http://tests.stockfishchess.org/tests/view/5a855be40ebc590297cc8166

Bench: 5006365

