### PR TITLE
rename shift variables.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -584,7 +584,7 @@ namespace {
     b &= ~attackedBy[Them][PAWN]
         & (attackedBy[Us][ALL_PIECES] | ~attackedBy[Them][ALL_PIECES]);
 
-    // Add a bonus for each new pawn threats from those squares
+    // Bonus for safe pawn threats on the next move
     b =  (shift<UpLeft>(b) | shift<UpRight>(b))
        &  pos.pieces(Them)
        & ~attackedBy[Us][PAWN];

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -585,7 +585,7 @@ namespace {
     b &= ~attackedBy[Them][PAWN]
         & (attackedBy[Us][ALL_PIECES] | ~attackedBy[Them][ALL_PIECES]);
 
-    // Bonus for safe pawn threats on the next move
+    // Add a bonus for each new pawn threats from those squares
     b =  (shift<UpLeft>(b) | shift<UpRight>(b))
        &  pos.pieces(Them)
        & ~attackedBy[Us][PAWN];

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -531,8 +531,8 @@ namespace {
 
     const Color     Them     = (Us == WHITE ? BLACK      : WHITE);
     const Direction Up       = (Us == WHITE ? NORTH      : SOUTH);
-    const Direction Left     = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
-    const Direction Right    = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
+    const Direction UpLeft   = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
+    const Direction UpRight  = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
     const Bitboard  TRank3BB = (Us == WHITE ? Rank3BB    : Rank6BB);
 
     Bitboard b, weak, defended, stronglyProtected, safeThreats;
@@ -546,7 +546,7 @@ namespace {
         b = pos.pieces(Us, PAWN) & ( ~attackedBy[Them][ALL_PIECES]
                                     | attackedBy[Us][ALL_PIECES]);
 
-        safeThreats = (shift<Right>(b) | shift<Left>(b)) & weak;
+        safeThreats = (shift<UpRight>(b) | shift<UpLeft>(b)) & weak;
 
         score += ThreatBySafePawn * popcount(safeThreats);
     }
@@ -606,7 +606,7 @@ namespace {
         & (attackedBy[Us][ALL_PIECES] | ~attackedBy[Them][ALL_PIECES]);
 
     // Add a bonus for each new pawn threats from those squares
-    b =  (shift<Left>(b) | shift<Right>(b))
+    b =  (shift<UpLeft>(b) | shift<UpRight>(b))
        &  pos.pieces(Them)
        & ~attackedBy[Us][PAWN];
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -530,7 +530,6 @@ namespace {
            & (~attackedBy[Them][ALL_PIECES] | attackedBy[Us][ALL_PIECES]);
 
         safeThreats = (shift<UpRight>(b) | shift<UpLeft>(b)) & weak;
-
         score += ThreatBySafePawn * popcount(safeThreats);
     }
 

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -99,8 +99,8 @@ namespace {
     const Bitboard  TRank7BB = (Us == WHITE ? Rank7BB    : Rank2BB);
     const Bitboard  TRank3BB = (Us == WHITE ? Rank3BB    : Rank6BB);
     const Direction Up       = (Us == WHITE ? NORTH      : SOUTH);
-    const Direction Right    = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
-    const Direction Left     = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
+    const Direction UpRight  = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
+    const Direction UpLeft   = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
 
     Bitboard emptySquares;
 
@@ -168,17 +168,17 @@ namespace {
         if (Type == EVASIONS)
             emptySquares &= target;
 
-        Bitboard b1 = shift<Right>(pawnsOn7) & enemies;
-        Bitboard b2 = shift<Left >(pawnsOn7) & enemies;
+        Bitboard b1 = shift<UpRight>(pawnsOn7) & enemies;
+        Bitboard b2 = shift<UpLeft >(pawnsOn7) & enemies;
         Bitboard b3 = shift<Up   >(pawnsOn7) & emptySquares;
 
         Square ksq = pos.square<KING>(Them);
 
         while (b1)
-            moveList = make_promotions<Type, Right>(moveList, pop_lsb(&b1), ksq);
+            moveList = make_promotions<Type, UpRight>(moveList, pop_lsb(&b1), ksq);
 
         while (b2)
-            moveList = make_promotions<Type, Left >(moveList, pop_lsb(&b2), ksq);
+            moveList = make_promotions<Type, UpLeft >(moveList, pop_lsb(&b2), ksq);
 
         while (b3)
             moveList = make_promotions<Type, Up   >(moveList, pop_lsb(&b3), ksq);
@@ -187,19 +187,19 @@ namespace {
     // Standard and en-passant captures
     if (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS)
     {
-        Bitboard b1 = shift<Right>(pawnsNotOn7) & enemies;
-        Bitboard b2 = shift<Left >(pawnsNotOn7) & enemies;
+        Bitboard b1 = shift<UpRight>(pawnsNotOn7) & enemies;
+        Bitboard b2 = shift<UpLeft >(pawnsNotOn7) & enemies;
 
         while (b1)
         {
             Square to = pop_lsb(&b1);
-            *moveList++ = make_move(to - Right, to);
+            *moveList++ = make_move(to - UpRight, to);
         }
 
         while (b2)
         {
             Square to = pop_lsb(&b2);
-            *moveList++ = make_move(to - Left, to);
+            *moveList++ = make_move(to - UpLeft, to);
         }
 
         if (pos.ep_square() != SQ_NONE)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -88,10 +88,10 @@ namespace {
   template<Color Us>
   Score evaluate(const Position& pos, Pawns::Entry* e) {
 
-    const Color     Them  = (Us == WHITE ? BLACK      : WHITE);
-    const Direction Up    = (Us == WHITE ? NORTH      : SOUTH);
-    const Direction Right = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
-    const Direction Left  = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
+    const Color     Them    = (Us == WHITE ? BLACK      : WHITE);
+    const Direction Up      = (Us == WHITE ? NORTH      : SOUTH);
+    const Direction UpRight = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
+    const Direction UpLeft  = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
 
     Bitboard b, neighbours, stoppers, doubled, supported, phalanx;
     Bitboard lever, leverPush;
@@ -106,7 +106,7 @@ namespace {
     e->passedPawns[Us] = e->pawnAttacksSpan[Us] = e->weakUnopposed[Us] = 0;
     e->semiopenFiles[Us] = 0xFF;
     e->kingSquares[Us]   = SQ_NONE;
-    e->pawnAttacks[Us]   = shift<Right>(ourPawns) | shift<Left>(ourPawns);
+    e->pawnAttacks[Us]   = shift<UpRight>(ourPawns) | shift<UpLeft>(ourPawns);
     e->pawnsOnSquares[Us][BLACK] = popcount(ourPawns & DarkSquares);
     e->pawnsOnSquares[Us][WHITE] = pos.count<PAWN>(Us) - e->pawnsOnSquares[Us][BLACK];
 


### PR DESCRIPTION
I know. . I'm a horrible person and this is not the way to contribute to an open source project, but where variable names are explicitly incorrect, I feel morally obligated to at least suggest an alternative.  There are many, but these two are especially egregious.

shift\<Left\> does NOT "shift left," it actually shifts either NORTH_WEST or SOUTH_EAST.
shift\<Right\> does NOT "shift right," it actually shifts either NORTH_EAST or SOUTH_WEST.