### PR TITLE
Remove leverPush for passed pawns

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -94,7 +94,7 @@ namespace {
     const Direction Left  = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
 
     Bitboard b, neighbours, stoppers, doubled, supported, phalanx;
-    Bitboard lever, leverPush;
+    Bitboard lever;
     Square s;
     bool opposed, backward;
     Score score = SCORE_ZERO;
@@ -124,7 +124,6 @@ namespace {
         opposed    = theirPawns & forward_file_bb(Us, s);
         stoppers   = theirPawns & passed_pawn_mask(Us, s);
         lever      = theirPawns & PawnAttacks[Us][s];
-        leverPush  = theirPawns & PawnAttacks[Us][s + Up];
         doubled    = ourPawns   & (s - Up);
         neighbours = ourPawns   & adjacent_files_bb(f);
         phalanx    = neighbours & rank_bb(s);
@@ -151,10 +150,9 @@ namespace {
         // full attack info to evaluate them. Include also not passed pawns
         // which could become passed after one or two pawn pushes when are
         // not attacked more times than defended.
-        if (   !(stoppers ^ lever ^ leverPush)
+        if (   !(stoppers ^ lever)
             && !(ourPawns & forward_file_bb(Us, s))
-            && popcount(supported) >= popcount(lever)
-            && popcount(phalanx)   >= popcount(leverPush))
+            && popcount(supported) >= popcount(lever))
             e->passedPawns[Us] |= s;
 
         else if (   stoppers == SquareBB[s + Up]


### PR DESCRIPTION
leverPush does not seem to increase engine strength.  There are quite a number of other factors that determine whether stoppers 2 ranks up would keep a pawn from passing or not.  I'm not sure leverPush sufficiently addresses them.  STC Passed.  Should I run LTC?

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 56669 W: 12582 L: 12530 D: 31557
http://tests.stockfishchess.org/tests/view/5a8c9aa50ebc590297cc852e

Bench: 5637090