### PR TITLE
Stats: raise the 'fancy' bar

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -127,7 +127,7 @@ void MovePicker::score() {
   for (auto& m : *this)
       if (Type == CAPTURES)
           m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
-                   + Value((*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))]);
+                   + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))];
 
       else if (Type == QUIETS)
           m.value =  (*mainHistory)[pos.side_to_move()][from_to(m)]

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -53,15 +53,18 @@ struct Stats : public std::array<Stats<T, W, D, Sizes...>, Size>
 template <typename T, int W, int D, int Size>
 struct Stats<T, W, D, Size> : public std::array<T, Size> {};
 
+/// Different tables use different W/D parameter, name them to ease readibility
+enum StatsParams { W2 = 2, W32 = 32, D324 = 324, D936 = 936, NOT_USED = 0 };
+
 /// ButterflyBoards are 2 tables (one for each color) indexed by the move's from
 /// and to squares, see chessprogramming.wikispaces.com/Butterfly+Boards
-typedef Stats<int16_t, 32, 324, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)> ButterflyBoards;
+typedef Stats<int16_t, W32, D324, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)> ButterflyBoards;
 
 /// PieceToBoards are addressed by a move's [piece][to] information
-typedef Stats<int16_t, 32, 936, PIECE_NB, SQUARE_NB> PieceToBoards;
+typedef Stats<int16_t, W32, D936, PIECE_NB, SQUARE_NB> PieceToBoards;
 
 /// CapturePieceToBoards are addressed by a move's [piece][to][captured piece type] information
-typedef Stats<int16_t, 2, 324, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB> CapturePieceToBoards;
+typedef Stats<int16_t, W2, D324, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB> CapturePieceToBoards;
 
 /// ButterflyHistory records how often quiet moves have been successful or
 /// unsuccessful during the current search, and is used for reduction and move
@@ -91,12 +94,12 @@ struct CapturePieceToHistory : public CapturePieceToBoards {
 
 /// CounterMoveHistory stores counter moves indexed by [piece][to] of the previous
 /// move, see chessprogramming.wikispaces.com/Countermove+Heuristic
-typedef Stats<Move, 32, 0, PIECE_NB, SQUARE_NB> CounterMoveHistory;
+typedef Stats<Move, W32, NOT_USED, PIECE_NB, SQUARE_NB> CounterMoveHistory;
 
 /// ContinuationHistory is the history of a given pair of moves, usually the
 /// current one given a previous one. History table is based on PieceToBoards
 /// instead of ButterflyBoards.
-typedef Stats<PieceToHistory, 32, 0, PIECE_NB, SQUARE_NB> ContinuationHistory;
+typedef Stats<PieceToHistory, W32, NOT_USED, PIECE_NB, SQUARE_NB> ContinuationHistory;
 
 
 /// MovePicker class is used to pick one pseudo legal move at a time from the

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -29,8 +29,8 @@
 #include "types.h"
 
 /// Stats is a generic N-dimensional array of T used to store various statistics
-template <typename T, int W, int Size, int... Sizes>
-struct Stats : public std::array<Stats<T, W, Sizes...>, Size>
+template <typename T, int W, int D, int Size, int... Sizes>
+struct Stats : public std::array<Stats<T, W, D, Sizes...>, Size>
 {
   T& front() { return (*this)[0].front(); }
 
@@ -39,7 +39,7 @@ struct Stats : public std::array<Stats<T, W, Sizes...>, Size>
     std::fill(p, p + sizeof(*this) / sizeof(*p), v);
   }
 
-  void update(T& entry, int bonus, const int D) {
+  void update(T& entry, int bonus) {
 
     assert(abs(bonus) <= D); // Ensure range is [-W * D, W * D]
     assert(abs(W * D) < (std::numeric_limits<T>::max)()); // Ensure we don't overflow
@@ -50,18 +50,18 @@ struct Stats : public std::array<Stats<T, W, Sizes...>, Size>
   }
 };
 
-template <typename T, int W, int Size>
-struct Stats<T, W, Size> : public std::array<T, Size> {};
+template <typename T, int W, int D, int Size>
+struct Stats<T, W, D, Size> : public std::array<T, Size> {};
 
 /// ButterflyBoards are 2 tables (one for each color) indexed by the move's from
 /// and to squares, see chessprogramming.wikispaces.com/Butterfly+Boards
-typedef Stats<int16_t, 32, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)> ButterflyBoards;
+typedef Stats<int16_t, 32, 324, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)> ButterflyBoards;
 
 /// PieceToBoards are addressed by a move's [piece][to] information
-typedef Stats<int16_t, 32, PIECE_NB, SQUARE_NB> PieceToBoards;
+typedef Stats<int16_t, 32, 936, PIECE_NB, SQUARE_NB> PieceToBoards;
 
 /// CapturePieceToBoards are addressed by a move's [piece][to][captured piece type] information
-typedef Stats<int16_t, 2, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB> CapturePieceToBoards;
+typedef Stats<int16_t, 2, 324, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB> CapturePieceToBoards;
 
 /// ButterflyHistory records how often quiet moves have been successful or
 /// unsuccessful during the current search, and is used for reduction and move
@@ -69,7 +69,7 @@ typedef Stats<int16_t, 2, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB> CapturePieceToBoar
 struct ButterflyHistory : public ButterflyBoards {
 
   void update(Color c, Move m, int bonus) {
-    ButterflyBoards::update((*this)[c][from_to(m)], bonus, 324);
+    ButterflyBoards::update((*this)[c][from_to(m)], bonus);
   }
 };
 
@@ -77,7 +77,7 @@ struct ButterflyHistory : public ButterflyBoards {
 struct PieceToHistory : public PieceToBoards {
 
   void update(Piece pc, Square to, int bonus) {
-    PieceToBoards::update((*this)[pc][to], bonus, 936);
+    PieceToBoards::update((*this)[pc][to], bonus);
   }
 };
 
@@ -85,18 +85,18 @@ struct PieceToHistory : public PieceToBoards {
 struct CapturePieceToHistory : public CapturePieceToBoards {
 
   void update(Piece pc, Square to, PieceType captured, int bonus) {
-    CapturePieceToBoards::update((*this)[pc][to][captured], bonus, 324);
+    CapturePieceToBoards::update((*this)[pc][to][captured], bonus);
   }
 };
 
 /// CounterMoveHistory stores counter moves indexed by [piece][to] of the previous
 /// move, see chessprogramming.wikispaces.com/Countermove+Heuristic
-typedef Stats<Move, 32, PIECE_NB, SQUARE_NB> CounterMoveHistory;
+typedef Stats<Move, 32, 0, PIECE_NB, SQUARE_NB> CounterMoveHistory;
 
 /// ContinuationHistory is the history of a given pair of moves, usually the
 /// current one given a previous one. History table is based on PieceToBoards
 /// instead of ButterflyBoards.
-typedef Stats<PieceToHistory, 32, PIECE_NB, SQUARE_NB> ContinuationHistory;
+typedef Stats<PieceToHistory, 32, 0, PIECE_NB, SQUARE_NB> ContinuationHistory;
 
 
 /// MovePicker class is used to pick one pseudo legal move at a time from the

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -28,36 +28,18 @@
 #include "position.h"
 #include "types.h"
 
-/// StatBoards is a generic 2-dimensional array used to store various statistics
-template<int Size1, int Size2, typename T = int16_t>
-struct StatBoards : public std::array<std::array<T, Size2>, Size1> {
+/// Stats is a generic N-dimensional array of T used to store various statistics
+template <typename T, int W, int Size, int... Sizes>
+struct Stats : public std::array<Stats<T, W, Sizes...>, Size>
+{
+  T& front() { return (*this)[0].front(); }
 
   void fill(const T& v) {
-    T* p = &(*this)[0][0];
+    T* p = &front();
     std::fill(p, p + sizeof(*this) / sizeof(*p), v);
   }
 
   void update(T& entry, int bonus, const int D) {
-
-    assert(abs(bonus) <= D); // Ensure range is [-32 * D, 32 * D]
-    assert(abs(32 * D) < (std::numeric_limits<T>::max)()); // Ensure we don't overflow
-
-    entry += bonus * 32 - entry * abs(bonus) / D;
-
-    assert(abs(entry) <= 32 * D);
-  }
-};
-
-/// StatCubes is a generic 3-dimensional array used to store various statistics
-template<int Size1, int Size2, int Size3, typename T = int16_t>
-struct StatCubes : public std::array<std::array<std::array<T, Size3>, Size2>, Size1> {
-
-  void fill(const T& v) {
-    T* p = &(*this)[0][0][0];
-    std::fill(p, p + sizeof(*this) / sizeof(*p), v);
-  }
-
-  void update(T& entry, int bonus, const int D, const int W) {
 
     assert(abs(bonus) <= D); // Ensure range is [-W * D, W * D]
     assert(abs(W * D) < (std::numeric_limits<T>::max)()); // Ensure we don't overflow
@@ -68,15 +50,18 @@ struct StatCubes : public std::array<std::array<std::array<T, Size3>, Size2>, Si
   }
 };
 
+template <typename T, int W, int Size>
+struct Stats<T, W, Size> : public std::array<T, Size> {};
+
 /// ButterflyBoards are 2 tables (one for each color) indexed by the move's from
 /// and to squares, see chessprogramming.wikispaces.com/Butterfly+Boards
-typedef StatBoards<COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)> ButterflyBoards;
+typedef Stats<int16_t, 32, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)> ButterflyBoards;
 
 /// PieceToBoards are addressed by a move's [piece][to] information
-typedef StatBoards<PIECE_NB, SQUARE_NB> PieceToBoards;
+typedef Stats<int16_t, 32, PIECE_NB, SQUARE_NB> PieceToBoards;
 
 /// CapturePieceToBoards are addressed by a move's [piece][to][captured piece type] information
-typedef StatCubes<PIECE_NB, SQUARE_NB, PIECE_TYPE_NB> CapturePieceToBoards;
+typedef Stats<int16_t, 2, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB> CapturePieceToBoards;
 
 /// ButterflyHistory records how often quiet moves have been successful or
 /// unsuccessful during the current search, and is used for reduction and move
@@ -84,7 +69,7 @@ typedef StatCubes<PIECE_NB, SQUARE_NB, PIECE_TYPE_NB> CapturePieceToBoards;
 struct ButterflyHistory : public ButterflyBoards {
 
   void update(Color c, Move m, int bonus) {
-    StatBoards::update((*this)[c][from_to(m)], bonus, 324);
+    ButterflyBoards::update((*this)[c][from_to(m)], bonus, 324);
   }
 };
 
@@ -92,7 +77,7 @@ struct ButterflyHistory : public ButterflyBoards {
 struct PieceToHistory : public PieceToBoards {
 
   void update(Piece pc, Square to, int bonus) {
-    StatBoards::update((*this)[pc][to], bonus, 936);
+    PieceToBoards::update((*this)[pc][to], bonus, 936);
   }
 };
 
@@ -100,18 +85,18 @@ struct PieceToHistory : public PieceToBoards {
 struct CapturePieceToHistory : public CapturePieceToBoards {
 
   void update(Piece pc, Square to, PieceType captured, int bonus) {
-    StatCubes::update((*this)[pc][to][captured], bonus, 324, 2);
+    CapturePieceToBoards::update((*this)[pc][to][captured], bonus, 324);
   }
 };
 
 /// CounterMoveHistory stores counter moves indexed by [piece][to] of the previous
 /// move, see chessprogramming.wikispaces.com/Countermove+Heuristic
-typedef StatBoards<PIECE_NB, SQUARE_NB, Move> CounterMoveHistory;
+typedef Stats<Move, 32, PIECE_NB, SQUARE_NB> CounterMoveHistory;
 
 /// ContinuationHistory is the history of a given pair of moves, usually the
 /// current one given a previous one. History table is based on PieceToBoards
 /// instead of ButterflyBoards.
-typedef StatBoards<PIECE_NB, SQUARE_NB, PieceToHistory> ContinuationHistory;
+typedef Stats<PieceToHistory, 32, PIECE_NB, SQUARE_NB> ContinuationHistory;
 
 
 /// MovePicker class is used to pick one pseudo legal move at a time from the

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -288,7 +288,7 @@ void Thread::search() {
 
   std::memset(ss-4, 0, 7 * sizeof(Stack));
   for (int i = 4; i > 0; i--)
-     (ss-i)->contHistory = &this->contHistory[NO_PIECE][0]; // Use as sentinel
+     (ss-i)->contHistory = this->contHistory[NO_PIECE][0].get(); // Use as sentinel
 
   bestValue = delta = alpha = -VALUE_INFINITE;
   beta = VALUE_INFINITE;
@@ -550,7 +550,7 @@ namespace {
 
     (ss+1)->ply = ss->ply + 1;
     ss->currentMove = (ss+1)->excludedMove = bestMove = MOVE_NONE;
-    ss->contHistory = &thisThread->contHistory[NO_PIECE][0];
+    ss->contHistory = thisThread->contHistory[NO_PIECE][0].get();
     (ss+2)->killers[0] = (ss+2)->killers[1] = MOVE_NONE;
     Square prevSq = to_sq((ss-1)->currentMove);
 
@@ -588,7 +588,7 @@ namespace {
             else if (!pos.capture_or_promotion(ttMove))
             {
                 int penalty = -stat_bonus(depth);
-                thisThread->mainHistory.update(pos.side_to_move(), ttMove, penalty);
+                thisThread->mainHistory[pos.side_to_move()][from_to(ttMove)] << penalty;
                 update_continuation_histories(ss, pos.moved_piece(ttMove), to_sq(ttMove), penalty);
             }
         }
@@ -697,7 +697,7 @@ namespace {
         Depth R = ((823 + 67 * depth / ONE_PLY) / 256 + std::min((eval - beta) / PawnValueMg, 3)) * ONE_PLY;
 
         ss->currentMove = MOVE_NULL;
-        ss->contHistory = &thisThread->contHistory[NO_PIECE][0];
+        ss->contHistory = thisThread->contHistory[NO_PIECE][0].get();
 
         pos.do_null_move(st);
         Value nullValue = depth-R < ONE_PLY ? -qsearch<NonPV, false>(pos, ss+1, -beta, -beta+1)
@@ -744,7 +744,7 @@ namespace {
             if (pos.legal(move))
             {
                 ss->currentMove = move;
-                ss->contHistory = &thisThread->contHistory[pos.moved_piece(move)][to_sq(move)];
+                ss->contHistory = thisThread->contHistory[pos.moved_piece(move)][to_sq(move)].get();
 
                 assert(depth >= 5 * ONE_PLY);
 
@@ -919,7 +919,7 @@ moves_loop: // When in check, search starts from here
 
       // Update the current move (this must be done after singular extension search)
       ss->currentMove = move;
-      ss->contHistory = &thisThread->contHistory[movedPiece][to_sq(move)];
+      ss->contHistory = thisThread->contHistory[movedPiece][to_sq(move)].get();
 
       // Step 15. Make the move
       pos.do_move(move, st, givesCheck);
@@ -1383,7 +1383,7 @@ moves_loop: // When in check, search starts from here
 
     for (int i : {1, 2, 4})
         if (is_ok((ss-i)->currentMove))
-            (ss-i)->contHistory->update(pc, to, bonus);
+            (*(ss-i)->contHistory)[pc][to] << bonus;
   }
 
 
@@ -1395,14 +1395,14 @@ moves_loop: // When in check, search starts from here
       CapturePieceToHistory& captureHistory =  pos.this_thread()->captureHistory;
       Piece moved_piece = pos.moved_piece(move);
       PieceType captured = type_of(pos.piece_on(to_sq(move)));
-      captureHistory.update(moved_piece, to_sq(move), captured, bonus);
+      captureHistory[moved_piece][to_sq(move)][captured] << bonus;
 
       // Decrease all the other played capture moves
       for (int i = 0; i < captureCnt; ++i)
       {
           moved_piece = pos.moved_piece(captures[i]);
           captured = type_of(pos.piece_on(to_sq(captures[i])));
-          captureHistory.update(moved_piece, to_sq(captures[i]), captured, -bonus);
+          captureHistory[moved_piece][to_sq(captures[i])][captured] << -bonus;
       }
   }
 
@@ -1420,7 +1420,7 @@ moves_loop: // When in check, search starts from here
 
     Color us = pos.side_to_move();
     Thread* thisThread = pos.this_thread();
-    thisThread->mainHistory.update(us, move, bonus);
+    thisThread->mainHistory[us][from_to(move)] << bonus;
     update_continuation_histories(ss, pos.moved_piece(move), to_sq(move), bonus);
 
     if (is_ok((ss-1)->currentMove))
@@ -1432,7 +1432,7 @@ moves_loop: // When in check, search starts from here
     // Decrease all the other played quiet moves
     for (int i = 0; i < quietsCnt; ++i)
     {
-        thisThread->mainHistory.update(us, quiets[i], -bonus);
+        thisThread->mainHistory[us][from_to(quiets[i])] << -bonus;
         update_continuation_histories(ss, pos.moved_piece(quiets[i]), to_sq(quiets[i]), -bonus);
     }
   }

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -62,9 +62,9 @@ void Thread::clear() {
 
   for (auto& to : contHistory)
       for (auto& h : to)
-          h.fill(0);
+          h.get()->fill(0);
 
-  contHistory[NO_PIECE][0].fill(Search::CounterMovePruneThreshold - 1);
+  contHistory[NO_PIECE][0].get()->fill(Search::CounterMovePruneThreshold - 1);
 }
 
 /// Thread::start_searching() wakes up the thread that will start the search


### PR DESCRIPTION
Reformat Stats to call update() directly on
the entry itself without passing the entry
index in Stats update() function.

This has several advantages:

1. Get rid of intermediate XXXXBoards helpers

2. Use Stats as a multidim array at calling site

Patch removes more lines than what adds and streamlines the Stats soup in movepick.h

Tested for no slowdown at STC:
LLR: 2.95 (-2.94,2.94) [-4.00,0.00]
Total: 26354 W: 5837 L: 5777 D: 14740
http://tests.stockfishchess.org/tests/view/5a950ec20ebc590297cc8b4c

No functional change.