### PR TITLE
Lower razor depth to < 3 and adjust margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -67,7 +67,7 @@ namespace {
   const int SkipPhase[] = { 0, 1, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7 };
 
   // Razoring and futility margins
-  const int RazorMargin = 600;
+  const int RazorMargin = 590;
   Value futility_margin(Depth d) { return Value(150 * d / ONE_PLY); }
 
   // Futility and reductions lookup tables, initialized at startup
@@ -667,7 +667,7 @@ namespace {
 
     // Step 7. Razoring (skipped when in check)
     if (   !PvNode
-        &&  depth < 4 * ONE_PLY
+        &&  depth < 3 * ONE_PLY
         &&  eval + RazorMargin <= alpha)
     {
         if (depth <= ONE_PLY)


### PR DESCRIPTION
Various margins were tested: 600, 560, 585, 580, 590 and 595.

Only 590 (this patch) passed both STC and LTC.
Higher margins appear to be better for longer time controls.

STC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 24496 W: 5470 L: 5210 D: 13816
http://tests.stockfishchess.org/tests/view/5a8c6d040ebc590297cc8508

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 74540 W: 12888 L: 12491 D: 49161
http://tests.stockfishchess.org/tests/view/5a8d14c70ebc590297cc8566

Bench: 5475941