### PR TITLE
Combine killer moves

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -25,7 +25,7 @@
 namespace {
 
   enum Stages {
-    MAIN_SEARCH, CAPTURES_INIT, GOOD_CAPTURES, KILLERS, COUNTERMOVE, QUIET_INIT, QUIET, BAD_CAPTURES,
+    MAIN_SEARCH, CAPTURES_INIT, GOOD_CAPTURES, KILLER0, KILLER1, COUNTERMOVE, QUIET_INIT, QUIET, BAD_CAPTURES,
     EVASION, EVASIONS_INIT, ALL_EVASIONS,
     PROBCUT, PROBCUT_INIT, PROBCUT_CAPTURES,
     QSEARCH, QCAPTURES_INIT, QCAPTURES, QCHECKS, QSEARCH_RECAPTURES, QRECAPTURES
@@ -180,24 +180,20 @@ Move MovePicker::next_move(bool skipQuiets) {
               *endBadCaptures++ = move;
           }
       }
-
       ++stage;
-      move = killers[0];  // First killer move
-      if (    move != MOVE_NONE
-          &&  move != ttMove
-          &&  pos.pseudo_legal(move)
-          && !pos.capture(move))
-          return move;
       /* fallthrough */
 
-  case KILLERS:
-      ++stage;
-      move = killers[1]; // Second killer move
-      if (    move != MOVE_NONE
-          &&  move != ttMove
-          &&  pos.pseudo_legal(move)
-          && !pos.capture(move))
-          return move;
+  case KILLER0:
+  case KILLER1:
+      do
+      {
+          move = killers[++stage - KILLER1];
+          if (    move != MOVE_NONE
+              &&  move != ttMove
+              &&  pos.pseudo_legal(move)
+              && !pos.capture(move))
+              return move;
+      } while (stage <= KILLER1);
       /* fallthrough */
 
   case COUNTERMOVE:
@@ -225,7 +221,6 @@ Move MovePicker::next_move(bool skipQuiets) {
          while (cur < endMoves)
          {
              move = *cur++;
-
              if (   move != ttMove
                  && move != killers[0]
                  && move != killers[1]


### PR DESCRIPTION
moves the first killer move out of the capture stage, combine treatment of first and second killer move.

passed STC
http://tests.stockfishchess.org/tests/view/5a88617e0ebc590297cc8351
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 55777 W: 12367 L: 12313 D: 31097

similar to earlier #1075. I think it is more robust and readable, Why hand-unroll the loop over the killer array, and duplicate code ?

No functional change.