### PR TITLE
Increment nodes and TB hits non-atomically

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -682,7 +682,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   assert(is_ok(m));
   assert(&newSt != st);
 
-  thisThread->nodes.fetch_add(1, std::memory_order_relaxed);
+  thisThread->increment(&Thread::nodes);
   Key k = st->key ^ Zobrist::side;
 
   // Copy some fields of the old state to our new StateInfo object except the

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -603,7 +603,7 @@ namespace {
 
             if (err != TB::ProbeState::FAIL)
             {
-                thisThread->tbHits.fetch_add(1, std::memory_order_relaxed);
+                thisThread->increment(&Thread::tbHits);
 
                 int drawScore = TB::UseRule50 ? 1 : 0;
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -71,6 +71,12 @@ public:
   ButterflyHistory mainHistory;
   CapturePieceToHistory captureHistory;
   ContinuationHistory contHistory;
+
+  void increment(std::atomic<uint64_t> Thread::* member) {
+
+      // not ++, += or fetch_add, because we don't need to make the whole read-modify-write operation atomical
+      (this->*member).store((this->*member).load(std::memory_order_relaxed) + 1, std::memory_order_relaxed);
+  }
 };
 
 


### PR DESCRIPTION
In the current version during a search the per-thread counters `nodes` and `tbHits` are incremented in one read-modify-write operation. Such a restriction is unnecessary, because there are no concurrent writes with these operations (these fields are set to 0 only when threads are idle), and it causes a slowdown.

Here is a comparison between the assembly code generated by the two versions:

master:
```asm
00000000004d0a32:   mov     DWORD PTR [rsp+0xc8],edx
514                     { return __atomic_fetch_add(&_M_i, __i, __m); }
00000000004d0a39:   lock    add QWORD PTR [rax+0x108],0x1
 686                Key k = st->key ^ Zobrist::side;
00000000004d0a42:   mov     rcx,QWORD PTR [rcx+0x860]
```

The new version:
```asm
00000000004d0a34:   mov     DWORD PTR [rsp+0x34],r9d
00000000004d0a39:   mov     rax,QWORD PTR [rdx+0x108]
00000000004d0a40:   add     rax,0x1
374               	__atomic_store_n(&_M_i, __i, __m);
00000000004d0a44:   mov     QWORD PTR [rdx+0x108],rax
 686                Key k = st->key ^ Zobrist::side;
00000000004d0a4b:   mov     rcx,QWORD PTR [rcx+0x860]
```

I don't know why the compiler uses 3 instruction instead of simply `add QWORD PTR [rdx+0x108],0x1`, but this must still be faster than using the lock prefix.

Fishbench test with a similar version to the one in this PR:
Results for 200 tests for each version:

            Base      Test      Diff      
    Mean    1290360   1292849   -2489     
    StDev   40193     40859     6698      

p-value: 0.645
speedup: 0.002

No functional change.