### PR TITLE
Count passed pawns in asymmetry measure

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -164,6 +164,9 @@ namespace {
                     e->passedPawns[Us] |= s;
         }
 
+        if (e->passedPawns[Us] & s)
+            e->asymmetry++;
+
         // Score this pawn
         if (supported | phalanx)
             score += Connected[opposed][bool(phalanx)][popcount(supported)][relative_rank(Us, s)];
@@ -220,10 +223,11 @@ Entry* probe(const Position& pos) {
       return e;
 
   e->key = key;
+  e->asymmetry = 0;
   e->scores[WHITE] = evaluate<WHITE>(pos, e);
   e->scores[BLACK] = evaluate<BLACK>(pos, e);
-  e->asymmetry = popcount(e->semiopenFiles[WHITE] ^ e->semiopenFiles[BLACK]);
-  e->openFiles = popcount(e->semiopenFiles[WHITE] & e->semiopenFiles[BLACK]);
+  e->asymmetry += popcount(e->semiopenFiles[WHITE] ^ e->semiopenFiles[BLACK]);
+  e->openFiles  = popcount(e->semiopenFiles[WHITE] & e->semiopenFiles[BLACK]);
 
   return e;
 }


### PR DESCRIPTION
The previous asymmetry measure of the pawn structure only used to 
consider the number of pawns on semi-opened files in the postions. 
With this patch we also increase the measure by the number of passed 
pawns for both players. 

STC: 
LLR: 2.96 (-2.94,2.94) [0.00,5.00] 
Total: 13146 W: 3038 L: 2840 D: 7268 
http://tests.stockfishchess.org/tests/view/5a91dd0c0ebc590297cc877e 

LTC: 
LLR: 2.96 (-2.94,2.94) [0.00,5.00] 
Total: 27776 W: 4771 L: 4536 D: 18469 
http://tests.stockfishchess.org/tests/view/5a91fdd50ebc590297cc879b 

How to continue from there: Stockfish will now evaluate more positions 
with passed pawns, so tuning the passed pawns values may bring Elo. 
The patch also has consequences on the initiative term. 

Bench: 5302866 