### PR TITLE
Perform a preliminary depth one search before trying regular ProbCut searches

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -742,10 +742,17 @@ namespace {
                 assert(depth >= 5 * ONE_PLY);
 
                 pos.do_move(move, st);
-                value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, depth - 4 * ONE_PLY, !cutNode, false);
+                
+                // Perform a preliminary depth one search to verify that the move holds
+                value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, ONE_PLY, !cutNode, true);
+                
+                // If the preliminary search held, perform the regular reduced search
+                if (value >= rbeta)
+                    value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, depth - 4 * ONE_PLY, !cutNode, false);
+                
                 pos.undo_move(move);
                 if (value >= rbeta)
-                    return value;
+                    return rbeta;
             }
     }
 


### PR DESCRIPTION
There is still a second version of this running at LTC, although it seems to be struggling. 
Opening this now because I suspect some may not like the new return value.

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 9841 W: 2251 L: 2071 D: 5519
http://tests.stockfishchess.org/tests/view/5a9219f10ebc590297cc87e4

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 23202 W: 4044 L: 3826 D: 15332
http://tests.stockfishchess.org/tests/view/5a9228770ebc590297cc87fa

Bench: 5654164