### PR TITLE
Shallow search to verify probcut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -742,7 +742,16 @@ namespace {
                 assert(depth >= 5 * ONE_PLY);
 
                 pos.do_move(move, st);
-                value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, depth - 4 * ONE_PLY, !cutNode, false);
+                
+                // Perform a preliminary depth one search to verify that the move holds. We will only do
+                // this search if the depth is not five, thus avoiding two depth one searches in a row
+                if (depth != 5 * ONE_PLY)
+                    value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, ONE_PLY, !cutNode, true);
+                
+                // If the first search was skipped or was performed and held, perform the regular search
+                if (depth == 5 * ONE_PLY || value >= rbeta)
+                    value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, depth - 4 * ONE_PLY, !cutNode, false);
+
                 pos.undo_move(move);
                 if (value >= rbeta)
                     return value;


### PR DESCRIPTION
Perform a preliminary shallow search to verify a probcut before doing 
the normal "depth - 4 plies" search.

This is equivalent to the passed version, but the conditions are cleaned up and comments are added / fixed. I do not think re-testing is in order for the slight modifications...

Happy to see something from Ethereal work for Stockfish :)

STC:
LLR: 4.73 (-2.94,2.94) [0.00,5.00]
Total: 36281 W: 8221 L: 7830 D: 20230
http://tests.stockfishchess.org/tests/view/5a921cb90ebc590297cc87f6

LTC:
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 22907 W: 3954 L: 3738 D: 15215
http://tests.stockfishchess.org/tests/view/5a92672b0ebc590297cc8814

Bench: 5015811