### PR TITLE
Blocked pawn storm

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -266,7 +266,7 @@ Value Entry::shelter_storm(const Position& pos, Square ksq) {
           && (ourPawns   & make_square(File(f == FILE_H ? f - 1 : f + 1), relative_rank(Us, rkThem)))
           && (ourPawns   & make_square(File(f == FILE_H ? f - 2 : f + 2), relative_rank(Us, rkUs  )))
           && (theirPawns & make_square(File(f == FILE_H ? f - 2 : f + 2), relative_rank(Us, rkThem))))
-          safety += 200;
+          safety += 300;
   }
 
   return safety;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -260,6 +260,11 @@ Value Entry::shelter_storm(const Position& pos, Square ksq) {
                   rkUs   == RANK_1                                          ? Unopposed :
                   rkThem == rkUs + 1                                        ? BlockedByPawn  : Unblocked]
                  [d][rkThem];
+
+      // Less penalty for storming pawn at a6/h6 if surrounded by opponent pawns at a7/h7 and b6/g6
+      if (    d == 0 && rkThem == RANK_3 && rkThem == rkUs + 1
+          && (ourPawns & make_square(f == FILE_H ? FILE_G : FILE_B, relative_rank(Us, rkThem))))
+          safety += 100;
   }
 
   return safety;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -261,10 +261,12 @@ Value Entry::shelter_storm(const Position& pos, Square ksq) {
                   rkThem == rkUs + 1                                        ? BlockedByPawn  : Unblocked]
                  [d][rkThem];
 
-      // Less penalty for storming pawn at a6/h6 if surrounded by opponent pawns at a7/h7 and b6/g6
+      // Less penalty for storming pawns at a6/h6 and c6/f6 if surrounded by opponent pawns at a7/h7, b6/g6 and c7/f7
       if (    d == 0 && rkThem == RANK_3 && rkThem == rkUs + 1
-          && (ourPawns & make_square(f == FILE_H ? FILE_G : FILE_B, relative_rank(Us, rkThem))))
-          safety += 100;
+          && (ourPawns   & make_square(File(f == FILE_H ? f - 1 : f + 1), relative_rank(Us, rkThem)))
+          && (ourPawns   & make_square(File(f == FILE_H ? f - 2 : f + 2), relative_rank(Us, rkUs  )))
+          && (theirPawns & make_square(File(f == FILE_H ? f - 2 : f + 2), relative_rank(Us, rkThem))))
+          safety += 200;
   }
 
   return safety;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -237,14 +237,20 @@ template<Color Us>
 Value Entry::shelter_storm(const Position& pos, Square ksq) {
 
   const Color Them = (Us == WHITE ? BLACK : WHITE);
+  const Bitboard ShelterMask = (Us == WHITE ? 1ULL << SQ_A2 | 1ULL << SQ_B3 | 1ULL << SQ_C2 | 1ULL << SQ_F2 | 1ULL << SQ_G3 | 1ULL << SQ_H2
+                                            : 1ULL << SQ_A7 | 1ULL << SQ_B6 | 1ULL << SQ_C7 | 1ULL << SQ_F7 | 1ULL << SQ_G6 | 1ULL << SQ_H7);
+  const Bitboard StormMask   = (Us == WHITE ? 1ULL << SQ_A3 | 1ULL << SQ_C3 | 1ULL << SQ_F3 | 1ULL << SQ_H3
+                                            : 1ULL << SQ_A6 | 1ULL << SQ_C6 | 1ULL << SQ_F6 | 1ULL << SQ_H6);
 
   enum { BlockedByKing, Unopposed, BlockedByPawn, Unblocked };
 
-  Bitboard b = pos.pieces(PAWN) & (forward_ranks_bb(Us, ksq) | rank_bb(ksq));
+  File center = std::max(FILE_B, std::min(FILE_G, file_of(ksq)));
+  Bitboard b =   pos.pieces(PAWN)
+               & (forward_ranks_bb(Us, ksq) | rank_bb(ksq))
+               & (adjacent_files_bb(center) | file_bb(center));
   Bitboard ourPawns = b & pos.pieces(Us);
   Bitboard theirPawns = b & pos.pieces(Them);
   Value safety = MaxSafetyBonus;
-  File center = std::max(FILE_B, std::min(FILE_G, file_of(ksq)));
 
   for (File f = File(center - 1); f <= File(center + 1); ++f)
   {
@@ -261,14 +267,10 @@ Value Entry::shelter_storm(const Position& pos, Square ksq) {
                   rkUs   == RANK_1                                          ? Unopposed :
                   rkThem == rkUs + 1                                        ? BlockedByPawn  : Unblocked]
                  [d][rkThem];
-
-      // Less penalty for storming pawns at a6/h6 and c6/f6 if surrounded by opponent pawns at a7/h7, b6/g6 and c7/f7
-      if (    d == 0 && rkThem == RANK_3 && rkThem == rkUs + 1
-          && (ourPawns   & make_square(File(f == FILE_H ? f - 1 : f + 1), relative_rank(Us, rkThem)))
-          && (ourPawns   & make_square(File(f == FILE_H ? f - 2 : f + 2), relative_rank(Us, rkUs  )))
-          && (theirPawns & make_square(File(f == FILE_H ? f - 2 : f + 2), relative_rank(Us, rkThem))))
-          safety += 300;
   }
+
+  if (popcount((ourPawns & ShelterMask) | (theirPawns & StormMask)) == 5)
+      safety += Value(300);
 
   return safety;
 }


### PR DESCRIPTION
In pawn structures like white pawns f6,h6 against black pawns f7,g6,h7 the attack on the king is blocked by the own pawns. So decrease the penalty for king safety.

STC:
LLR: 2.94 (-2.94,2.94) [0.00,5.00]
Total: 16467 W: 3750 L: 3537 D: 9180
http://tests.stockfishchess.org/tests/view/5a92102d0ebc590297cc87d0

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 64242 W: 11130 L: 10745 D: 42367
http://tests.stockfishchess.org/tests/view/5a923dc80ebc590297cc8806

Bench: 5643527