### PR TITLE
Stat score initialization: children

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -507,7 +507,7 @@ namespace {
     Thread* thisThread = pos.this_thread();
     inCheck = pos.checkers();
     moveCount = captureCount = quietCount = ss->moveCount = 0;
-    ss->statScore = 0;
+    (ss+1)->statScore = 0;
     bestValue = -VALUE_INFINITE;
     maxValue = VALUE_INFINITE;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -514,9 +514,15 @@ namespace {
     Thread* thisThread = pos.this_thread();
     inCheck = pos.checkers();
     moveCount = captureCount = quietCount = ss->moveCount = 0;
-    (ss+1)->statScore = 0;
     bestValue = -VALUE_INFINITE;
     maxValue = VALUE_INFINITE;
+
+    // Initialize statScore to zero for the childs of the current position.
+    // So statScore is shared between sibling positions and only the first sibling
+    // starts with statScore = 0. Later siblings start with the last calculated
+    // statScore of the previous sibling. This influences in LMR the reduction rules
+    // which based on the statScore of parent position.
+    (ss+1)->statScore = 0;
 
     // Check for the available remaining time
     if (thisThread == Threads.main())


### PR DESCRIPTION
Let the parent node initialize stat score to zero once for all siblings.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 22683 W: 5202 L: 4946 D: 12535
http://tests.stockfishchess.org/tests/view/5a93315f0ebc590297cc894f

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 48548 W: 8346 L: 8035 D: 32167
http://tests.stockfishchess.org/tests/view/5a933ba90ebc590297cc8962

Bench: 5332277