### PR TITLE
Logarithmic contempt.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -347,9 +347,10 @@ void Thread::search() {
 
               // Adjust contempt based on current bestValue
               ct =  Options["Contempt"] * PawnValueEg / 100 // From centipawns
-                  + (bestValue >  500 ?  50:                // Dynamic contempt
-                     bestValue < -500 ? -50:
-                     bestValue / 10);
+                  + (bestValue >  500 ?  70:                // Dynamic contempt
+                     bestValue < -500 ? -70:
+                     bestValue > 0    ? bestValue / 10 + int(std::round(3.22 * log(1 + abs(bestValue)))) :
+                                        bestValue / 10 - int(std::round(3.22 * log(1 + abs(bestValue)))));
 
               Eval::Contempt = (us == WHITE ?  make_score(ct, ct / 2)
                                             : -make_score(ct, ct / 2));

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -59,7 +59,7 @@ void init(OptionsMap& o) {
   const int MaxHashMB = Is64Bit ? 131072 : 2048;
 
   o["Debug Log File"]        << Option("", on_logger);
-  o["Contempt"]              << Option(18, -100, 100);
+  o["Contempt"]              << Option(12, -100, 100);
   o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);


### PR DESCRIPTION
Add a logarithmic term in the contempt computation, increases the maximal contempt and lower contempt offset. 

This increases the dynamics of the contempt, giving a boost for balanced positions without skewing too much on unbalanced positions. This helps, since dynamic contempt is in general a good thing for instance at LTC, but too high contempt rapidly contaminate play.

Possible further work: 
- tune the values accurately
- check whether it is possible to remove linear and offset term

[STC](http://tests.stockfishchess.org/tests/view/5a8db9340ebc590297cc85b6)

LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 159343 W: 34489 L: 33588 D: 91266

[LTC](http://tests.stockfishchess.org/tests/view/5a9456a80ebc590297cc8a89)

LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 47491 W: 7825 L: 7517 D: 32149