### PR TITLE
Stat score initialization: grandchildren

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -507,7 +507,7 @@ namespace {
     Thread* thisThread = pos.this_thread();
     inCheck = pos.checkers();
     moveCount = captureCount = quietCount = ss->moveCount = 0;
-    ss->statScore = 0;
+    (ss+1)->statScore = 0;
     bestValue = -VALUE_INFINITE;
     maxValue = VALUE_INFINITE;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -507,7 +507,7 @@ namespace {
     Thread* thisThread = pos.this_thread();
     inCheck = pos.checkers();
     moveCount = captureCount = quietCount = ss->moveCount = 0;
-    (ss+1)->statScore = 0;
+    (ss+2)->statScore = 0;
     bestValue = -VALUE_INFINITE;
     maxValue = VALUE_INFINITE;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -514,7 +514,6 @@ namespace {
     Thread* thisThread = pos.this_thread();
     inCheck = pos.checkers();
     moveCount = captureCount = quietCount = ss->moveCount = 0;
-    (ss+2)->statScore = 0;
     bestValue = -VALUE_INFINITE;
     maxValue = VALUE_INFINITE;
 
@@ -553,6 +552,13 @@ namespace {
     ss->contHistory = &thisThread->contHistory[NO_PIECE][0];
     (ss+2)->killers[0] = (ss+2)->killers[1] = MOVE_NONE;
     Square prevSq = to_sq((ss-1)->currentMove);
+
+    // Initialize statScore to zero for the grandchilds of the current position.
+    // So statScore is shared between all grandchilds and only the first grandchild
+    // starts with statScore = 0. Later grandchilds start with the last calculated
+    // statScore of the previous grandchild. This influences in LMR the reduction rules
+    // which based on the statScore of parent position.
+    (ss+2)->statScore = 0;
 
     // Step 4. Transposition table lookup. We don't want the score of a partial
     // search to overwrite a previous full search TT value, so we use a different


### PR DESCRIPTION
Let the parent node initialize stat score to zero once for all grandchilds.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 23676 W: 5417 L: 5157 D: 13102
http://tests.stockfishchess.org/tests/view/5a9423a90ebc590297cc8a46

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 35485 W: 6168 L: 5898 D: 23419
http://tests.stockfishchess.org/tests/view/5a9435550ebc590297cc8a54

Bench: 6047375