### PR TITLE
Allow beta cut-off in PV nodes for non main threads

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -572,7 +572,7 @@ namespace {
             : ttHit    ? tte->move() : MOVE_NONE;
 
     // At non-PV nodes we check for an early TT cutoff
-    if ( (!PvNode || (ttValue != VALUE_NONE && thisThread != Threads.main() && ttValue >= beta + Value(thisThread->idx)))
+    if ( (!PvNode || (ttValue != VALUE_NONE && thisThread != Threads.main() && ttValue >= beta + 20/Value(thisThread->idx)))
         && ttHit
         && tte->depth() >= depth
         && ttValue != VALUE_NONE // Possible in case of TT access race

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -572,7 +572,7 @@ namespace {
             : ttHit    ? tte->move() : MOVE_NONE;
 
     // At non-PV nodes we check for an early TT cutoff
-    if ( (!PvNode || (ttValue != VALUE_NONE && thisThread != Threads.main() && ttValue >= beta + 20/Value(thisThread->idx)))
+    if ( (!PvNode || (ttValue != VALUE_NONE && thisThread != Threads.main() && ttValue > beta))
         && ttHit
         && tte->depth() >= depth
         && ttValue != VALUE_NONE // Possible in case of TT access race

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -572,7 +572,7 @@ namespace {
             : ttHit    ? tte->move() : MOVE_NONE;
 
     // At non-PV nodes we check for an early TT cutoff
-    if (  !PvNode
+    if ( (!PvNode || (ttValue != VALUE_NONE && thisThread != Threads.main() && ttValue >= beta + Value(thisThread->idx)))
         && ttHit
         && tte->depth() >= depth
         && ttValue != VALUE_NONE // Possible in case of TT access race

--- a/src/thread.h
+++ b/src/thread.h
@@ -44,6 +44,7 @@ class Thread {
 
   Mutex mutex;
   ConditionVariable cv;
+  size_t idx;
   bool exit = false, searching = true; // Set before starting std::thread
   std::thread stdThread;
 
@@ -60,7 +61,6 @@ public:
   Material::Table materialTable;
   Endgames endgames;
   size_t PVIdx;
-  size_t idx;
   int selDepth, nmp_ply, nmp_odd;
   std::atomic<uint64_t> nodes, tbHits;
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -44,7 +44,6 @@ class Thread {
 
   Mutex mutex;
   ConditionVariable cv;
-  size_t idx;
   bool exit = false, searching = true; // Set before starting std::thread
   std::thread stdThread;
 
@@ -61,6 +60,7 @@ public:
   Material::Table materialTable;
   Endgames endgames;
   size_t PVIdx;
+  size_t idx;
   int selDepth, nmp_ply, nmp_odd;
   std::atomic<uint64_t> nodes, tbHits;
 


### PR DESCRIPTION
This is a discussion thread more than a PR.

A version of this idea passed STC with 5 threads easily (ca. +6 Elo).

http://tests.stockfishchess.org/tests/view/5a958ac50ebc590297cc8c12

The problem with this patch is that it breaks PV as it is (or I assume so, more precisely). What do we want to do?
- test LTC, I would test 15+0.15 at 15 threads, which is quite expensive
- discuss a possible implementation of PV in this context before testing LTC
- dont work on this further since it cannot be committed because of some reasons

Feedback is needed!

