### PR TITLE
Simplify software fallback msb

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -86,10 +86,15 @@ Square lsb(Bitboard b) {
 
 Square msb(Bitboard b) {
 
-   //msb of b = mantissa of a double representing b
-   union {double x; uint32_t y[2];};
-   x = b;
-   return Square((y[1] >> 20) - 1023);
+  //turn off all bits but the MSB, then return LSB
+  b |= (b >> 1);
+  b |= (b >> 2);
+  b |= (b >> 4);
+  b |= (b >> 8);
+  b |= (b >> 16);
+  b |= (b >> 32);
+
+  return lsb(b & ~(b >> 1));
 }
 
 #endif // ifdef NO_BSF

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -293,6 +293,7 @@ inline int popcount(Bitboard b) {
 
 /// lsb() and msb() return the least/most significant bit in a non-zero bitboard
 
+/*
 #if defined(__GNUC__)
 
 inline Square lsb(Bitboard b) {
@@ -322,13 +323,14 @@ inline Square msb(Bitboard b) {
 }
 
 #else
+*/
 
 #define NO_BSF // Fallback on software implementation for other cases
 
 Square lsb(Bitboard b);
 Square msb(Bitboard b);
 
-#endif
+//#endif
 
 
 /// pop_lsb() finds and clears the least significant bit in a non-zero bitboard

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -293,7 +293,6 @@ inline int popcount(Bitboard b) {
 
 /// lsb() and msb() return the least/most significant bit in a non-zero bitboard
 
-/*
 #if defined(__GNUC__)
 
 inline Square lsb(Bitboard b) {
@@ -323,14 +322,13 @@ inline Square msb(Bitboard b) {
 }
 
 #else
-*/
 
 #define NO_BSF // Fallback on software implementation for other cases
 
 Square lsb(Bitboard b);
 Square msb(Bitboard b);
 
-//#endif
+#endif
 
 
 /// pop_lsb() finds and clears the least significant bit in a non-zero bitboard


### PR DESCRIPTION
This is a more simple version of software msb for systems that don't use gcc and don't have hardware msb support.  It's also a little faster than master (software msb).

base = 1354074 +/- 15668
test  = 1356769  +/- 15970
diff           +2694 +/- 1018

Passed STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 15124 W: 3397 L: 3262 D: 8465

http://tests.stockfishchess.org/tests/view/5a960c3d0ebc590297cc8c9b

Is LTC necessary?

Bench 5475941

