### PR TITLE
Introduce variadic relative_bitboard()

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -149,6 +149,16 @@ inline Bitboard file_bb(Square s) {
   return FileBB[file_of(s)];
 }
 
+/// make_bitboard<>() returns a bitboard from a variadic list of squares
+/// relative to the color specified by the template parameter.
+
+template<Color>
+constexpr Bitboard make_bitboard() { return 0; }
+
+template<Color C, typename ...Squares>
+constexpr Bitboard make_bitboard(Square s, Squares... squares) {
+  return (1ULL << relative_square(C, s)) | make_bitboard<C>(squares...);
+}
 
 /// shift() moves a bitboard one step along direction D. Mainly for pawns
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -237,10 +237,8 @@ template<Color Us>
 Value Entry::shelter_storm(const Position& pos, Square ksq) {
 
   const Color Them = (Us == WHITE ? BLACK : WHITE);
-  const Bitboard ShelterMask = (Us == WHITE ? 1ULL << SQ_A2 | 1ULL << SQ_B3 | 1ULL << SQ_C2 | 1ULL << SQ_F2 | 1ULL << SQ_G3 | 1ULL << SQ_H2
-                                            : 1ULL << SQ_A7 | 1ULL << SQ_B6 | 1ULL << SQ_C7 | 1ULL << SQ_F7 | 1ULL << SQ_G6 | 1ULL << SQ_H7);
-  const Bitboard StormMask   = (Us == WHITE ? 1ULL << SQ_A3 | 1ULL << SQ_C3 | 1ULL << SQ_F3 | 1ULL << SQ_H3
-                                            : 1ULL << SQ_A6 | 1ULL << SQ_C6 | 1ULL << SQ_F6 | 1ULL << SQ_H6);
+  const Bitboard ShelterMask = make_bitboard<Us>(SQ_A2, SQ_B3, SQ_C2, SQ_F2, SQ_G3, SQ_H2);
+  const Bitboard StormMask   = make_bitboard<Us>(SQ_A3, SQ_C3, SQ_F3, SQ_H3);
 
   enum { BlockedByKing, Unopposed, BlockedByPawn, Unblocked };
 


### PR DESCRIPTION
Adds a constexpr helper function to create a bitboard relative to the specified side based on a list of squares.

No functional change