### PR TITLE
Use intrinsics only for LSB/MSB

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -49,22 +49,10 @@ namespace {
   const uint64_t DeBruijn64 = 0x3F79D71B4CB0A89ULL;
   const uint32_t DeBruijn32 = 0x783A9B23;
 
-  int MSBTable[256];            // To implement software msb()
-  Square BSFTable[SQUARE_NB];   // To implement software bitscan
   Bitboard RookTable[0x19000];  // To store rook attacks
   Bitboard BishopTable[0x1480]; // To store bishop attacks
 
   void init_magics(Bitboard table[], Magic magics[], Direction directions[]);
-
-  // bsf_index() returns the index into BSFTable[] to look up the bitscan. Uses
-  // Matt Taylor's folding for 32 bit case, extended to 64 bit by Kim Walisch.
-
-  unsigned bsf_index(Bitboard b) {
-    b ^= b - 1;
-    return Is64Bit ? (b * DeBruijn64) >> 58
-                   : ((unsigned(b) ^ unsigned(b >> 32)) * DeBruijn32) >> 26;
-  }
-
 
   // popcount16() counts the non-zero bits using SWAR-Popcount algorithm
 
@@ -75,46 +63,6 @@ namespace {
     return (u * 0x0101U) >> 8;
   }
 }
-
-#ifdef NO_BSF
-
-/// Software fall-back of lsb() and msb() for CPU lacking hardware support
-
-Square lsb(Bitboard b) {
-  assert(b);
-  return BSFTable[bsf_index(b)];
-}
-
-Square msb(Bitboard b) {
-
-  assert(b);
-  unsigned b32;
-  int result = 0;
-
-  if (b > 0xFFFFFFFF)
-  {
-      b >>= 32;
-      result = 32;
-  }
-
-  b32 = unsigned(b);
-
-  if (b32 > 0xFFFF)
-  {
-      b32 >>= 16;
-      result += 16;
-  }
-
-  if (b32 > 0xFF)
-  {
-      b32 >>= 8;
-      result += 8;
-  }
-
-  return Square(result + MSBTable[b32]);
-}
-
-#endif // ifdef NO_BSF
 
 
 /// Bitboards::pretty() returns an ASCII representation of a bitboard suitable
@@ -145,13 +93,7 @@ void Bitboards::init() {
       PopCnt16[i] = (uint8_t) popcount16(i);
 
   for (Square s = SQ_A1; s <= SQ_H8; ++s)
-  {
       SquareBB[s] = 1ULL << s;
-      BSFTable[bsf_index(SquareBB[s])] = s;
-  }
-
-  for (Bitboard b = 2; b < 256; ++b)
-      MSBTable[b] = MSBTable[b - 1] + !more_than_one(b);
 
   for (File f = FILE_A; f <= FILE_H; ++f)
       FileBB[f] = f > FILE_A ? FileBB[f - 1] << 1 : FileABB;

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -323,10 +323,7 @@ inline Square msb(Bitboard b) {
 
 #else
 
-#define NO_BSF // Fallback on software implementation for other cases
-
-Square lsb(Bitboard b);
-Square msb(Bitboard b);
+#error "Compiler not supported."
 
 #endif
 


### PR DESCRIPTION
The NO_BSF does not cover any real-life use case today. The only compilers that
can compile SF today, with the current Makefile and no source code changes, are
GCC, Clang, MSVC, ICC. All of them support LSB/MSB intrinsics. It's the
compiler's job to figure out what to do of these intrinsice. If hardware LSB/MSB
are available on the target architecture, it will use those, otherwise it will
generate its own code.

No functional change.