### PR TITLE
Use intrinsics only for LSB/MSB

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -323,10 +323,7 @@ inline Square msb(Bitboard b) {
 
 #else
 
-#define NO_BSF // Fallback on software implementation for other cases
-
-Square lsb(Bitboard b);
-Square msb(Bitboard b);
+#error "Compiler not supported."
 
 #endif
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -305,7 +305,9 @@ inline Square msb(Bitboard b) {
   return Square(63 ^ __builtin_clzll(b));
 }
 
-#elif defined(_WIN64) && defined(_MSC_VER)
+#elif defined(_MSC_VER)
+
+#ifdef _WIN64  // use 64-bit intrinsics
 
 inline Square lsb(Bitboard b) {
   assert(b);
@@ -320,6 +322,36 @@ inline Square msb(Bitboard b) {
   _BitScanReverse64(&idx, b);
   return (Square) idx;
 }
+
+#else  // use 32-bit intrinsics
+
+inline Square lsb(Bitboard b) {
+  assert(b);
+  unsigned long idx;
+
+  if (b & 0xffffffff) {
+      _BitScanForward(&idx, int32_t(b));
+      return Square(idx);
+  } else {
+      _BitScanForward(&idx, int32_t(b >> 32));
+      return Square(idx + 32);
+  }
+}
+
+inline Square msb(Bitboard b) {
+  assert(b);
+  unsigned long idx;
+
+  if (b >> 32) {
+      _BitScanReverse(&idx, int32_t(b >> 32));
+      return Square(idx + 32);
+  } else {
+      _BitScanReverse(&idx, int32_t(b));
+      return Square(idx);
+  }
+}
+
+#endif
 
 #else
 


### PR DESCRIPTION
The NO_BSF does not cover any real-life use case today. The only compilers that
can compile SF today, with the current Makefile and no source code changes, are
GCC, Clang, MSVC, ICC. All of them support LSB/MSB intrinsics. It's the
compiler's job to figure out what to do of these intrinsice. If hardware LSB/MSB
are available on the target architecture, it will use those, otherwise it will
generate its own code.

No functional change.