### PR TITLE
Logarithmic contempt

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -348,9 +348,10 @@ void Thread::search() {
 
               // Adjust contempt based on current bestValue
               ct =  Options["Contempt"] * PawnValueEg / 100 // From centipawns
-                  + (bestValue >  500 ?  50:                // Dynamic contempt
-                     bestValue < -500 ? -50:
-                     bestValue / 10);
+                  + (bestValue >  500 ?  70:                // Dynamic contempt
+                     bestValue < -500 ? -70:
+                     bestValue > 0    ? bestValue / 10 + int(std::round(3.22 * log(1 + abs(bestValue)))) :
+                                        bestValue / 10 - int(std::round(3.22 * log(1 + abs(bestValue)))));
 
               Eval::Contempt = (us == WHITE ?  make_score(ct, ct / 2)
                                             : -make_score(ct, ct / 2));

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -59,7 +59,7 @@ void init(OptionsMap& o) {
   const int MaxHashMB = Is64Bit ? 131072 : 2048;
 
   o["Debug Log File"]        << Option("", on_logger);
-  o["Contempt"]              << Option(18, -100, 100);
+  o["Contempt"]              << Option(10, -100, 100);
   o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);


### PR DESCRIPTION
This is a respin of https://github.com/official-stockfish/Stockfish/pull/1439 to keep things simple.

Add a logarithmic term in the contempt computation, increase the maximal contempt and lower contempt offset. 

This increases the dynamics of the contempt, giving a boost for balanced positions without skewing too much on unbalanced positions. This helps, since dynamic contempt is in general a good thing, for instance at LTC, but too high contempt rapidly contaminates play.

There has been extensive work on this patch with two major patches having been tested: this one with contempt of 10 (PR in the following) and version with a slightly higher contempt of 12 (HC in the following).

The original HC passed STC and LTC and was found to be even on master on different matches with SF7, SF8.

The PR passes a single LTC tests [0,4] against HC. Attempts to raise the contempt to 15, 18, 20 from 12 did not pass [-3, 1] tests. An attempt with contempt 22 is still running.

The PR raises the draw rate in self-play STC from 56% to 59%, higher than expected from Elo gain.

There have been several attempts to simplify the patch by removing the logarithm term, the most promising (and only not failing) being still running (but see this discussion there). Other attempts have included compensating the logarithm by a static contempt.

It must be mentioned that a version of the PR with contempt 0 did not pass STC [0,5].

**Further work**

- in the discussion from the original pull request it has been proposed to simplify the formula by using the atan function and no capping. My strong suggestion is to follow-up on this idea.
- no matter what, the parameters in the patch are most probably not optimal, in particular at LTC and could be very likely be improved on.

**References**

[HC, STC](http://tests.stockfishchess.org/tests/view/5a8db9340ebc590297cc85b6)

LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 159343 W: 34489 L: 33588 D: 91266

[HC, LTC](http://tests.stockfishchess.org/tests/view/5a9456a80ebc590297cc8a89)

LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 47491 W: 7825 L: 7517 D: 32149

[master vs SF7, STC](http://tests.stockfishchess.org/tests/view/5a954e540ebc590297cc8b9f): +165 Elo
[HC vs SF7, STC](http://tests.stockfishchess.org/tests/view/5a953f3c0ebc590297cc8b61): + 164 Elo

[master vs SF8, STC](http://tests.stockfishchess.org/tests/view/5a95c2ef0ebc590297cc8c5a): + 66 Elo
[HC vs SF8, STC](http://tests.stockfishchess.org/tests/view/5a95c2b50ebc590297cc8c56): + 68 Elo

[master vs SF8, LTC](http://tests.stockfishchess.org/tests/view/5a97f0810ebc590297cc8ded): +76 Elo
[HC vs SF8, LTC](http://tests.stockfishchess.org/tests/view/5a97f2320ebc590297cc8df5): + 75 Elo

[PR vs HC](http://tests.stockfishchess.org/tests/view/5a968d710ebc590297cc8ceb)

LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 48385 W: 7437 L: 7143 D: 33805

[PR, contempt 15 vs PR](http://tests.stockfishchess.org/tests/view/5a968d710ebc590297cc8ceb)
[PR, contempt 18 vs PR](http://tests.stockfishchess.org/tests/view/5a9622ef0ebc590297cc8ca8)
[PR, contempt 20 vs PR](http://tests.stockfishchess.org/tests/view/5a9623140ebc590297cc8caa)
[PR, contempt 22 vs PR](http://tests.stockfishchess.org/tests/view/5a96232b0ebc590297cc8cac)
[Linear + sign vs PR](http://tests.stockfishchess.org/tests/view/5a97fd5d0ebc590297cc8e09)

[master draw rate](http://tests.stockfishchess.org/tests/view/5a985c0e0ebc590297cc8e44)
[PR draw rate](http://tests.stockfishchess.org/tests/view/5a985c450ebc590297cc8e46)



