### PR TITLE
MCP in Probcut - Bench: 6361568

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -757,10 +757,11 @@ namespace {
 
         Value rbeta = std::min(beta + 200, VALUE_INFINITE);
         MovePicker mp(pos, ttMove, rbeta - ss->staticEval, &thisThread->captureHistory);
-
-        while ((move = mp.next_move()) != MOVE_NONE)
+        int mc = 0;
+        while ((move = mp.next_move()) != MOVE_NONE && mc < int(depth)-3)
             if (pos.legal(move))
             {
+                mc++;
                 ss->currentMove = move;
                 ss->contHistory = &thisThread->contHistory[pos.moved_piece(move)][to_sq(move)];
 


### PR DESCRIPTION
Do move-count pruning in probcut:

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 4928 W: 1163 L: 1007 D: 2758

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 20368 W: 3441 L: 3238 D: 13689

Bench: 6361568