### PR TITLE
Remove code trick from Space evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -728,7 +728,7 @@ namespace {
 
     // ...count safe + (behind & safe)
     int weight = pos.count<ALL_PIECES>(Us) - 2 * pe->open_files();
-	return make_score((popcount(safe) + popcount(behind & safe)) * weight * weight / 16, 0);
+    return make_score((popcount(safe) + popcount(behind & safe)) * weight * weight / 16, 0);
   }
 
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -726,18 +726,9 @@ namespace {
     behind |= (Us == WHITE ? behind >>  8 : behind <<  8);
     behind |= (Us == WHITE ? behind >> 16 : behind << 16);
 
-    // Since SpaceMask[Us] is fully on our half of the board...
-    assert(unsigned(safe >> (Us == WHITE ? 32 : 0)) == 0);
-
-    // ...count safe + (behind & safe) with a single popcount.
-    int bonus = popcount((Us == WHITE ? safe << 32 : safe >> 32) | (behind & safe));
+    // ...count safe + (behind & safe)
     int weight = pos.count<ALL_PIECES>(Us) - 2 * pe->open_files();
-    Score score = make_score(bonus * weight * weight / 16, 0);
-
-    if (T)
-        Trace::add(SPACE, Us, score);
-
-    return score;
+	return make_score((popcount(safe) + popcount(behind & safe)) * weight * weight / 16, 0);
   }
 
 


### PR DESCRIPTION
Similar removal of code trick as in https://github.com/official-stockfish/Stockfish/commit/de642f16db0c443de2dc0ddf7b06c0a7d1c5b8b7

This would now allow to specify space masks which reach into enemy territory.

STC: http://tests.stockfishchess.org/tests/view/5a8433360ebc590297cc80c5
LLR: 3.38 (-2.94,2.94) [-3.00,1.00]
Total: 184630 W: 40581 L: 40758 D: 103291

LTC: http://tests.stockfishchess.org/tests/view/5a96a34a0ebc590297cc8cfd
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 231799 W: 37647 L: 37858 D: 156294