### PR TITLE
Remove popcount trick from space evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -726,12 +726,9 @@ namespace {
     behind |= (Us == WHITE ? behind >>  8 : behind <<  8);
     behind |= (Us == WHITE ? behind >> 16 : behind << 16);
 
-    // Since SpaceMask[Us] is fully on our half of the board...
-    assert(unsigned(safe >> (Us == WHITE ? 32 : 0)) == 0);
-
-    // ...count safe + (behind & safe) with a single popcount.
-    int bonus = popcount((Us == WHITE ? safe << 32 : safe >> 32) | (behind & safe));
+    int bonus = popcount(safe) + popcount(behind & safe);
     int weight = pos.count<ALL_PIECES>(Us) - 2 * pe->open_files();
+
     Score score = make_score(bonus * weight * weight / 16, 0);
 
     if (T)


### PR DESCRIPTION
Similar removal of code trick as in de642f1

This would now allow to specify space masks which reach into enemy territory.

STC: http://tests.stockfishchess.org/tests/view/5a8433360ebc590297cc80c5
 LLR: 3.38 (-2.94,2.94) [-3.00,1.00]
 Total: 184630 W: 40581 L: 40758 D: 103291

LTC: http://tests.stockfishchess.org/tests/view/5a96a34a0ebc590297cc8cfd
 LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
 Total: 231799 W: 37647 L: 37858 D: 156294

Reopened due to request by Stephane