### PR TITLE
Return alpha+1 in qsearch when reaching MAX_PLY with check.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1191,9 +1191,10 @@ moves_loop: // When in check, search starts from here
     moveCount = 0;
 
     // Check for an immediate draw or maximum ply reached
-    if (   pos.is_draw(ss->ply)
-        || ss->ply >= MAX_PLY)
-        return (ss->ply >= MAX_PLY && !InCheck) ? evaluate(pos) : VALUE_DRAW;
+    if (pos.is_draw(ss->ply))
+         return VALUE_DRAW;
+    if (ss->ply >= MAX_PLY)
+         return InCheck ? alpha+1 : evaluate(pos);
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 


### PR DESCRIPTION
Bugfix: qsearch() was returning VALUE_DRAW if the search reached MAX_PLY with a check. This patch changes the return value to alpha+1.

To make this condition happen more often, this test fixed MAX_PLY at 20 and demonstrated that returning alpha+1 gave better results by passing [0,5] SPRT very easily:
STC: http://tests.stockfishchess.org/tests/view/5a9ce1330ebc590297cb605f
LLR: 3.02 (-2.94,2.94) [0.00,5.00]
Total: 6224 W: 1468 L: 1302 D: 3454

Tests with MAX_PLY at the normal value of 128 passed [-3,1] SPRT with more wins than losses:

STC: http://tests.stockfishchess.org/tests/view/5a9d7b270ebc590297cb60ee
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 23236 W: 5166 L: 5047 D: 13023

LTC: http://tests.stockfishchess.org/tests/view/5a9d96ff0ebc590297cb6109
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 43017 W: 7032 L: 6946 D: 29039