### PR TITLE
Knight threats on Queen

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -600,7 +600,7 @@ namespace {
     {
         b =  pos.attacks_from<KNIGHT>(pos.square<QUEEN>(Them)) 
            & attackedBy[Us][KNIGHT]
-           & ~pos.pieces(Us, PAWN, KING)
+           & ~pos.pieces(Us)
            & ~stronglyProtected;
 
         score += ThreatOnQueen * popcount(b);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -167,7 +167,7 @@ namespace {
   const Score CloseEnemies      = S(  7,  0);
   const Score Hanging           = S( 52, 30);
   const Score HinderPassedPawn  = S(  8,  1);
-  const Score KnightOnQueen     = S( 40,  0);
+  const Score KnightOnQueen     = S( 21, 11);
   const Score LongRangedBishop  = S( 22,  0);
   const Score MinorBehindPawn   = S( 16,  0);
   const Score PawnlessFlank     = S( 20, 80);
@@ -490,7 +490,7 @@ namespace {
     if (!(pos.pieces(PAWN) & kf))
         score -= PawnlessFlank;
 
-    // Find the squares that opponent attacks in our king flank, and the squares  
+    // Find the squares that opponent attacks in our king flank, and the squares
     // which are attacked twice in that flank but not defended by our pawns.
     b1 = attackedBy[Them][ALL_PIECES] & kf & Camp;
     b2 = b1 & attackedBy2[Them] & ~attackedBy[Us][PAWN];
@@ -599,7 +599,7 @@ namespace {
     // Bonus for knight threats on the next move towards enemy queen
     if (pos.count<QUEEN>(Them) == 1)
     {
-        b =  pos.attacks_from<KNIGHT>(pos.square<QUEEN>(Them)) 
+        b =  pos.attacks_from<KNIGHT>(pos.square<QUEEN>(Them))
            & attackedBy[Us][KNIGHT]
            & ~pos.pieces(Us, PAWN, KING)
            & ~stronglyProtected;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -167,6 +167,7 @@ namespace {
   const Score CloseEnemies      = S(  7,  0);
   const Score Hanging           = S( 52, 30);
   const Score HinderPassedPawn  = S(  8,  1);
+  const Score KnightOnQueen     = S( 21, 11);
   const Score LongRangedBishop  = S( 22,  0);
   const Score MinorBehindPawn   = S( 16,  0);
   const Score PawnlessFlank     = S( 20, 80);
@@ -600,10 +601,10 @@ namespace {
     {
         b =  pos.attacks_from<KNIGHT>(pos.square<QUEEN>(Them)) 
            & attackedBy[Us][KNIGHT]
-           & ~pos.pieces(Us)
+           & ~pos.pieces(Us, PAWN, KING)
            & ~stronglyProtected;
 
-        score += ThreatOnQueen * popcount(b);
+        score += KnightOnQueen * popcount(b);
     }
 
     if (T)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -167,7 +167,7 @@ namespace {
   const Score CloseEnemies      = S(  7,  0);
   const Score Hanging           = S( 52, 30);
   const Score HinderPassedPawn  = S(  8,  1);
-  const Score KnightOnQueen     = S( 21, 11);
+  const Score KnightOnQueen     = S( 40,  0);
   const Score LongRangedBishop  = S( 22,  0);
   const Score MinorBehindPawn   = S( 16,  0);
   const Score PawnlessFlank     = S( 20, 80);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -595,6 +595,17 @@ namespace {
 
     score += ThreatOnQueen * popcount(b & safeThreats);
 
+    // Bonus for knight threats on the next move towards enemy queen
+    if (pos.count<QUEEN>(Them) == 1)
+    {
+        b =  pos.attacks_from<KNIGHT>(pos.square<QUEEN>(Them)) 
+           & attackedBy[Us][KNIGHT]
+           & ~pos.pieces(Us, PAWN, KING)
+           & ~stronglyProtected;
+
+        score += ThreatOnQueen * popcount(b);
+    }
+
     if (T)
         Trace::add(THREAT, Us, score);
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -237,7 +237,7 @@ template<Color Us>
 Value Entry::shelter_storm(const Position& pos, Square ksq) {
 
   constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
-  constexpr Bitboard ShelterMask = 
+  constexpr Bitboard ShelterMask =
                 Us == WHITE ? make_bitboard(SQ_A2, SQ_B3, SQ_C2, SQ_F2, SQ_G3, SQ_H2)
                             : make_bitboard(SQ_A7, SQ_B6, SQ_C7, SQ_F7, SQ_G6, SQ_H7);
   constexpr Bitboard StormMask =


### PR DESCRIPTION
We give a S(21,11) bonus for knight threats on the next moves
against enemy queen. The threats are from squares which are
"not strongly protected" and which may be empty, contain enemy
pieces or even one of our piece at the moment (N,B,Q,R) -- hence
be two-steps threats in the later case because we will have to
move our piece and *then* attack the enemy queen with the knight.

STC: http://tests.stockfishchess.org/tests/view/5a9e442e0ebc590297cb6162
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 35129 W: 7346 L: 7052 D: 20731

LTC: http://tests.stockfishchess.org/tests/view/5a9e6e620ebc590297cb617f
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 42442 W: 6695 L: 6414 D: 29333

How to continue from there?

• Trying to refine the threat condition ("not strongly protected")
• Trying the two-steps idea for bishops or rooks threats against queen

Bench: 6051247