### PR TITLE
Implement complete MultiPV support in EGTB endings.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1554,7 +1554,12 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
       Depth d = updated ? depth : depth - ONE_PLY;
       Value v = updated ? rootMoves[i].score : rootMoves[i].previousScore;
 
-      bool tb = TB::RootInTB && abs(v) < VALUE_MATE - MAX_PLY;
+      // If the root position is a TB hit, this move conserves optimality,
+      // and we did not find a real mate, we replace the displayed
+      // evaluation of the move by the TB eval.
+      bool tb = TB::RootInTB
+                && ((abs(v) < VALUE_MATE - MAX_PLY) || (v == -VALUE_INFINITE))
+                && rootMoves[i].isTBOptimal;
       v = tb ? TB::Score : v;
 
       if (ss.rdbuf()->in_avail()) // Not at first line
@@ -1634,21 +1639,18 @@ void Tablebases::filter_root_moves(Position& pos, Search::RootMoves& rootMoves) 
     if (Cardinality < popcount(pos.pieces()) || pos.can_castle(ANY_CASTLING))
         return;
 
-    // Don't filter any moves if the user requested analysis on multiple
-    if (Options["MultiPV"] != 1)
-        return;
-
     // If the current root position is in the tablebases, then RootMoves
-    // contains only moves that preserve the draw or the win.
-    RootInTB = root_probe(pos, rootMoves, TB::Score);
+    // may be filtered to contain only moves that preserve the draw or the win.
+    RootInTB = root_filter(pos, rootMoves, TB::Score, Options["MultiPV"]);
 
     if (RootInTB)
         Cardinality = 0; // Do not probe tablebases during the search
 
     else // If DTZ tables are missing, use WDL tables as a fallback
     {
-        // Filter out moves that do not preserve the draw or the win.
-        RootInTB = root_probe_wdl(pos, rootMoves, TB::Score);
+        // Potentially filter out moves that do not preserve
+        // the draw or the win.
+        RootInTB = root_filter_wdl(pos, rootMoves, TB::Score, Options["MultiPV"]);
 
         // Only probe during search if winning
         if (RootInTB && TB::Score <= VALUE_DRAW)
@@ -1660,7 +1662,7 @@ void Tablebases::filter_root_moves(Position& pos, Search::RootMoves& rootMoves) 
                    : TB::Score < VALUE_DRAW ? -VALUE_MATE + MAX_PLY + 1
                                             :  VALUE_DRAW;
 
-    // Since root_probe() and root_probe_wdl() dirty the root move scores,
+    // Since root_filter() and root_filter_wdl() dirty the root move scores,
     // we reset them to -VALUE_INFINITE
     for (RootMove& rm : rootMoves)
         rm.score = -VALUE_INFINITE;

--- a/src/search.h
+++ b/src/search.h
@@ -62,13 +62,19 @@ struct RootMove {
   bool extract_ponder_from_tt(Position& pos);
   bool operator==(const Move& m) const { return pv[0] == m; }
   bool operator<(const RootMove& m) const { // Sort in descending order
-    return m.score != score ? m.score < score
-                            : m.previousScore < previousScore;
+    if (m.isTBOptimal != isTBOptimal) {
+      return m.isTBOptimal < isTBOptimal;
+    } else if (m.score != score) {
+      return m.score < score;
+    } else {
+      return m.previousScore < previousScore;
+    }
   }
 
   Value score = -VALUE_INFINITE;
   Value previousScore = -VALUE_INFINITE;
   int selDepth = 0;
+  bool isTBOptimal = false;
   std::vector<Move> pv;
 };
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1521,11 +1521,14 @@ static int has_repeated(StateInfo *st)
 
 // Use the DTZ tables to filter out moves that don't preserve the win or draw.
 // If the position is lost, but DTZ is fairly high, only keep moves that
-// maximise DTZ.
+// maximise DTZ. If we are requested to search both optimal and non-optimal
+// moves due to MultiPV, we will not filter but use the tags on the
+// optimal moves.
 //
 // A return value false indicates that not all probes were successful and that
 // no moves were filtered out.
-bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves, Value& score)
+bool Tablebases::root_filter(Position& pos, Search::RootMoves& rootMoves,
+                             Value& score, size_t retainCount)
 {
     assert(rootMoves.size());
 
@@ -1597,7 +1600,7 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves, Value& 
         score = -(Value)(((200 + dtz - cnt50) * int(PawnValueEg)) / 200);
 
     // Now be a bit smart about filtering out moves.
-    size_t j = 0;
+    Search::RootMoves filteredMoves;
 
     if (dtz > 0) { // winning (or 50-move rule draw)
         int best = 0xffff;
@@ -1616,11 +1619,12 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves, Value& 
         if (!has_repeated(st.previous) && best + cnt50 <= 99)
             max = 99 - cnt50;
 
-        for (size_t i = 0; i < rootMoves.size(); ++i) {
-            int v = rootMoves[i].score;
-
-            if (v > 0 && v <= max)
-                rootMoves[j++] = rootMoves[i];
+        for (auto& rootMove: rootMoves) {
+            int v = rootMove.score;
+            if (v > 0 && v <= max) {
+                rootMove.isTBOptimal = true;
+                filteredMoves.emplace_back(rootMove);
+            }
         }
     } else if (dtz < 0) { // losing (or 50-move rule draw)
         int best = 0;
@@ -1633,22 +1637,34 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves, Value& 
         }
 
         // Try all moves, unless we approach or have a 50-move rule draw.
-        if (-best * 2 + cnt50 < 100)
+        if (-best * 2 + cnt50 < 100) {
+            for (auto& rootMove: rootMoves) {
+                rootMove.isTBOptimal = true;
+            }
             return true;
+        }
 
-        for (size_t i = 0; i < rootMoves.size(); ++i) {
-            if (rootMoves[i].score == best)
-                rootMoves[j++] = rootMoves[i];
+        for (auto& rootMove: rootMoves) {
+            if (rootMove.score == best) {
+                rootMove.isTBOptimal = true;
+                filteredMoves.emplace_back(rootMove);
+            }
         }
     } else { // drawing
         // Try all moves that preserve the draw.
-        for (size_t i = 0; i < rootMoves.size(); ++i) {
-            if (rootMoves[i].score == 0)
-                rootMoves[j++] = rootMoves[i];
+        for (auto& rootMove: rootMoves) {
+            if (rootMove.score == 0) {
+                rootMove.isTBOptimal = true;
+                filteredMoves.emplace_back(rootMove);
+            }
         }
     }
 
-    rootMoves.resize(j, Search::RootMove(MOVE_NONE));
+    // If the filtered root move list is big enough to satisfy the minimum
+    // move count, then allow the filtering.
+    if (filteredMoves.size() >= retainCount) {
+        std::swap(rootMoves, filteredMoves);
+    }
 
     return true;
 }
@@ -1658,7 +1674,8 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves, Value& 
 //
 // A return value false indicates that not all probes were successful and that
 // no moves were filtered out.
-bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, Value& score)
+bool Tablebases::root_filter_wdl(Position& pos, Search::RootMoves& rootMoves,
+                                 Value& score, size_t retainCount)
 {
     ProbeState result;
 
@@ -1689,14 +1706,22 @@ bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, Val
             best = v;
     }
 
-    size_t j = 0;
-
-    for (size_t i = 0; i < rootMoves.size(); ++i) {
-        if (rootMoves[i].score == best)
-            rootMoves[j++] = rootMoves[i];
+    Search::RootMoves filteredMoves;
+    for (auto& rootMove : rootMoves) {
+        // "best" may be less than the root score if uci searchmoves is used
+        if (rootMove.score == score) {
+            rootMove.isTBOptimal = true;
+        }
+        if (rootMove.score == best) {
+            filteredMoves.emplace_back(rootMove);
+        }
     }
 
-    rootMoves.resize(j, Search::RootMove(MOVE_NONE));
+    // If the filtered root move list is big enough to satisfy the minimum
+    // move count, then allow the filtering.
+    if (filteredMoves.size() >= retainCount) {
+        std::swap(rootMoves, filteredMoves);
+    }
 
     return true;
 }

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -49,8 +49,10 @@ extern int MaxCardinality;
 void init(const std::string& paths);
 WDLScore probe_wdl(Position& pos, ProbeState* result);
 int probe_dtz(Position& pos, ProbeState* result);
-bool root_probe(Position& pos, Search::RootMoves& rootMoves, Value& score);
-bool root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, Value& score);
+bool root_filter(Position& pos, Search::RootMoves& rootMoves,
+                 Value& score, size_t retainCount);
+bool root_filter_wdl(Position& pos, Search::RootMoves& rootMoves,
+                     Value& score, size_t retainCount);
 void filter_root_moves(Position& pos, Search::RootMoves& rootMoves);
 
 inline std::ostream& operator<<(std::ostream& os, const WDLScore v) {


### PR DESCRIPTION
This continues #1276. Instead of disabling filtering when MultiPV is
requested in an EGTB position, we do a check whether filtering would
leave enough moves to comply with MultiPV. If it does, we revert to the
previous behavior and filter any non-optimal moves, avoiding useless
search effort.

If filtering would not leave enough moves, we disable it but mark all
TB-optimality preserving moves in the root move list. Root sorting is
then modified to always order TB-optimal moves ahead of all others, and
the MultiPV printout replaces the heuristic eval score by the score from
the EGTB.

There are some similarities to the approach in #1252 but I believe this
one is easier on the maintainers to review and take: the changes are
smaller and simpler, it's easier to verify there is no functional change
in normal mode, and it's a clear improvement in MultiPV mode.

It fixes the regression pointed out in #1276:
8/8/6k1/7q/3N4/8/1BK5/8 b - - 0 1

Stockfish will now always get the best move in this position, regardless
of whether MultiPV is enabled or not.