### PR TITLE
Use evaluation trend to adjust futility margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -69,7 +69,7 @@ namespace {
   // Razor and futility margins
   const int RazorMargin1 = 590;
   const int RazorMargin2 = 604;
-  Value futility_margin(Depth d) { return Value(150 * d / ONE_PLY); }
+  Value futility_margin(Depth d, bool i) { return Value((175 - 50 * i) * d / ONE_PLY); }
 
   // Futility and reductions lookup tables, initialized at startup
   int FutilityMoveCounts[2][16]; // [improving][depth]
@@ -677,6 +677,10 @@ namespace {
         tte->save(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE,
                   ss->staticEval, TT.generation());
     }
+    
+    improving =   ss->staticEval >= (ss-2)->staticEval
+            /* || ss->staticEval == VALUE_NONE Already implicit in the previous condition */
+               ||(ss-2)->staticEval == VALUE_NONE;
 
     if (skipEarlyPruning || !pos.non_pawn_material(pos.side_to_move()))
         goto moves_loop;
@@ -702,7 +706,7 @@ namespace {
     // Step 8. Futility pruning: child node (skipped when in check)
     if (   !rootNode
         &&  depth < 7 * ONE_PLY
-        &&  eval - futility_margin(depth) >= beta
+        &&  eval - futility_margin(depth, improving) >= beta
         &&  eval < VALUE_KNOWN_WIN) // Do not return unproven wins
         return eval;
 


### PR DESCRIPTION
Adjust futility margin in the child node based on whether the static evaluation is improving.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 15271 W: 3157 L: 2958 D: 9156
http://tests.stockfishchess.org/tests/view/5a9f2f8c0ebc590297cb6216

LTC:
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 6617 W: 1053 L: 908 D: 4656
http://tests.stockfishchess.org/tests/view/5a9f98390ebc590297cb6241

Ideas for future work:
- Tune the new margins.
- Try to get this idea to work for futility pruning in parent nodes as well.

Bench: 5935718