### PR TITLE
MovePicker: combine countermove with killers.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -19,6 +19,7 @@
 */
 
 #include <cassert>
+#include <iostream>
 
 #include "movepick.h"
 
@@ -67,8 +68,8 @@ namespace {
 /// MovePicker constructor for the main search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Move cm, Move* killers_p)
-           : pos(p), mainHistory(mh), captureHistory(cph), contHistory(ch), countermove(cm),
-             killers{killers_p[0], killers_p[1]}, depth(d){
+           : pos(p), mainHistory(mh), captureHistory(cph), contHistory(ch),
+             specials{killers_p[0], killers_p[1], cm}, depth(d){
 
   assert(d > DEPTH_ZERO);
 
@@ -174,31 +175,22 @@ Move MovePicker::next_move(bool skipQuiets) {
           }
       }
       ++stage;
+      if ((specials[2] == specials[0]) || (specials[2] == specials[1]))
+         specials[2] = MOVE_NONE;
       /* fallthrough */
 
   case KILLER0:
   case KILLER1:
+  case COUNTERMOVE:
       do
       {
-          move = killers[++stage - KILLER1];
+          move = specials[stage++ - KILLER0];
           if (    move != MOVE_NONE
               &&  move != ttMove
               &&  pos.pseudo_legal(move)
               && !pos.capture(move))
               return move;
-      } while (stage <= KILLER1);
-      /* fallthrough */
-
-  case COUNTERMOVE:
-      ++stage;
-      move = countermove;
-      if (    move != MOVE_NONE
-          &&  move != ttMove
-          &&  move != killers[0]
-          &&  move != killers[1]
-          &&  pos.pseudo_legal(move)
-          && !pos.capture(move))
-          return move;
+      } while (stage <= COUNTERMOVE);
       /* fallthrough */
 
   case QUIET_INIT:
@@ -215,9 +207,9 @@ Move MovePicker::next_move(bool skipQuiets) {
           {
               move = *cur++;
               if (   move != ttMove
-                  && move != killers[0]
-                  && move != killers[1]
-                  && move != countermove)
+                  && move != specials[0]
+                  && move != specials[1]
+                  && move != specials[2])
                   return move;
           }
       ++stage;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -179,7 +179,7 @@ Move MovePicker::next_move(bool skipQuiets) {
       /* fallthrough */
 
   case KILLER0: case KILLER1: case COUNTERMOVE:
-      do
+      while ( stage <= COUNTERMOVE)
       {
           move = specials[stage++ - KILLER0];
           if (    move != MOVE_NONE
@@ -187,7 +187,7 @@ Move MovePicker::next_move(bool skipQuiets) {
               &&  pos.pseudo_legal(move)
               && !pos.capture(move))
               return move;
-      } while (stage <= COUNTERMOVE);
+      }
       /* fallthrough */
 
   case QUIET_INIT:

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -149,9 +149,7 @@ Move MovePicker::next_move(bool skipQuiets) {
       ++stage;
       return ttMove;
 
-  case CAPTURES_INIT:
-  case PROBCUT_CAPTURES_INIT:
-  case QCAPTURES_INIT:
+  case CAPTURES_INIT: case PROBCUT_CAPTURES_INIT: case QCAPTURES_INIT:
       endBadCaptures = cur = moves;
       endMoves = generate<CAPTURES>(pos, cur);
       score<CAPTURES>();
@@ -180,9 +178,7 @@ Move MovePicker::next_move(bool skipQuiets) {
          specials[2] = MOVE_NONE;
       /* fallthrough */
 
-  case KILLER0:
-  case KILLER1:
-  case COUNTERMOVE:
+  case KILLER0: case KILLER1: case COUNTERMOVE:
       do
       {
           move = specials[stage++ - KILLER0];

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -19,7 +19,6 @@
 */
 
 #include <cassert>
-#include <iostream>
 
 #include "movepick.h"
 
@@ -175,6 +174,8 @@ Move MovePicker::next_move(bool skipQuiets) {
           }
       }
       ++stage;
+
+      //if the countermove is the same as a killer, skip it
       if ((specials[2] == specials[0]) || (specials[2] == specials[1]))
          specials[2] = MOVE_NONE;
       /* fallthrough */

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -128,7 +128,7 @@ private:
   const ButterflyHistory* mainHistory;
   const CapturePieceToHistory* captureHistory;
   const PieceToHistory** contHistory;
-  Move ttMove, countermove, killers[2];
+  Move ttMove, specials[3];
   ExtMove *cur, *endMoves, *endBadCaptures;
   int stage;
   Square recaptureSquare;


### PR DESCRIPTION
In the same way we use stages to progress through the killer moves, handle the countermove the same way and using the same code.  Removes 10+ lines of code.  This is faster than previous versions because I check the countermove only once by checking it before the stages.

STC: LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 71707 W: 14622 L: 14595 D: 42490
http://tests.stockfishchess.org/tests/view/5aa003cf0ebc590297cb6276

LTC: LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 22320 W: 3470 L: 3352 D: 15498
http://tests.stockfishchess.org/tests/view/5aa051020ebc590297cb62ba

Bench 5934644

