### PR TITLE
Make nodes until time checks dynamic.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1532,8 +1532,10 @@ void MainThread::check_time() {
   lastElapsed = elapsed;
   lastTimeCheckNodes = nodes;
 
-  // When using nodes, ensure checking rate is not lower than 0.1% of nodes
-  callsCnt = Limits.nodes ? std::min(targetCallsCnt, int(Limits.nodes / 1024))
+  // When using nodes, ensure checking rate is not lower than 0.1% of
+  // remaining nodes
+  int64_t remainingNodes = Limits.nodes - Threads.nodes_searched();
+  callsCnt = Limits.nodes ? std::min(targetCallsCnt, int(remainingNodes / 1024))
                           : targetCallsCnt;
 
   // We should not stop pondering until told so by the GUI

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1509,9 +1509,6 @@ void MainThread::check_time() {
   if (--callsCnt > 0)
       return;
 
-  // When using nodes, ensure checking rate is not lower than 0.1% of nodes
-  callsCnt = Limits.nodes ? std::min(4096, int(Limits.nodes / 1024)) : 4096;
-
   static TimePoint lastInfoTime = now();
 
   int elapsed = Time.elapsed();
@@ -1522,6 +1519,22 @@ void MainThread::check_time() {
       lastInfoTime = tick;
       dbg_print();
   }
+
+  // Determine a suitable node interval for time checking.
+  static int lastElapsed = 0;
+  int timeElapsed = elapsed - lastElapsed;
+  int nodesElapsed = nodes - lastTimeCheckNodes;
+  // Estimate current nodes per second
+  double mtNps = nodesElapsed * 1000.0 / (timeElapsed + 1);
+  // We aim at ~250 checks per second (close to 4096 nodes at 1Mnps),
+  // and suitable for ~30ms move overhead.
+  int targetCallsCnt = 1 + int(mtNps / 250.0);
+  lastElapsed = elapsed;
+  lastTimeCheckNodes = nodes;
+
+  // When using nodes, ensure checking rate is not lower than 0.1% of nodes
+  callsCnt = Limits.nodes ? std::min(targetCallsCnt, int(Limits.nodes / 1024))
+                          : targetCallsCnt;
 
   // We should not stop pondering until told so by the GUI
   if (Threads.ponder)

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -146,6 +146,7 @@ void ThreadPool::clear() {
       th->clear();
 
   main()->callsCnt = 0;
+  main()->lastTimeCheckNodes = 0;
   main()->previousScore = VALUE_INFINITE;
   main()->previousTimeReduction = 1.0;
 }

--- a/src/thread.h
+++ b/src/thread.h
@@ -87,6 +87,7 @@ struct MainThread : public Thread {
   double bestMoveChanges, previousTimeReduction;
   Value previousScore;
   int callsCnt;
+  uint64_t lastTimeCheckNodes;
 };
 
 


### PR DESCRIPTION
Because of the aggressive time management, and optimistic assumptions
about move overhead, it's still very easy to get Stockfish to forfeit
on time. A typical example I have observed is if we hit an endgame
and have Syzygy EGTB on a spinning drive. The latency from serving a
few thousand EGTB probes (~10ms each), of which there can currently
be up to 4000 outstanding before a time check, will easily overwhelm
the assumed Move Overhead of 30ms.

Keep track of the current NPS of the machine, and ensure a steady time
checking rate of 250Hz. This should lower the amount of time forfeits
from NPS drops like the above, and improve the responsiveness on
embedded platforms.

On very fast machines, the overhead of calling OS time functions might
be reduced as the interval will increase.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 57857 W: 11880 L: 11827 D: 34150
http://tests.stockfishchess.org/tests/view/5a9fe8700ebc590297cb6253

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 32908 W: 5071 L: 4969 D: 22868
http://tests.stockfishchess.org/tests/view/5aa0f0c80ebc590297cb632b