### PR TITLE
Two steps slider threats on queen

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -195,7 +195,6 @@ enum Value : int {
 enum PieceType {
   NO_PIECE_TYPE, PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING,
   ALL_PIECES = 0,
-  QUEEN_DIAGONAL = 7,
   PIECE_TYPE_NB = 8
 };
 


### PR DESCRIPTION
Allow a potential slider threat from  a square currently occupied by a harmless attacker,
just as the recent knight OnQueen idea. Also from not completely safe squares,

Use the mobilityArea instead of excluding all pawns for both SlidersOnQueen and KnightOnQueen

Compute the potential sliders threat on queen only if opponent has one queen

Run SPRT [0,4] since it is some kind of simplification but maybe not clearly one.

STC
http://tests.stockfishchess.org/tests/view/5aa1ddf10ebc590297cb63d8
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 22997 W: 4817 L: 4570 D: 13610

LTC 
http://tests.stockfishchess.org/tests/view/5aa1fe6b0ebc590297cb63e5
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 11926 W: 1891 L: 1705 D: 8330

bench: 5788691