### PR TITLE
Add bonus for pieces that are "connected."

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -126,6 +126,9 @@ namespace {
     { S( 9, 2), S(15, 5) }  // Bishop
   };
 
+  // Connectedness
+  const Score Connected = S(2,2);
+
   // RookOnFile[semiopen/open] contains bonuses for each rook when there is
   // no (friendly) pawn on the rook file.
   const Score RookOnFile[] = { S(20, 7), S(45, 20) };
@@ -606,6 +609,12 @@ namespace {
 
         score += KnightOnQueen * popcount(b);
     }
+
+    // Connectedness
+    b = pos.pieces(Us) & attackedBy[Us][ALL_PIECES] 
+                       & ~attackedBy[Us][PAWN]
+                       & ~pos.pieces(Us, KING);
+    score += Connected * popcount(b);
 
     if (T)
         Trace::add(THREAT, Us, score);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -127,7 +127,7 @@ namespace {
   };
 
   // Connectedness
-  const Score Connected = S(2,2);
+  const Score Connected = S(3,3);
 
   // RookOnFile[semiopen/open] contains bonuses for each rook when there is
   // no (friendly) pawn on the rook file.
@@ -611,9 +611,7 @@ namespace {
     }
 
     // Connectedness for knights, bishops, rooks, and queens
-    b = (pos.pieces(Us) ^ pos.pieces(Us,PAWN) ^ pos.pieces(Us, KING))
-                       & attackedBy[Us][ALL_PIECES];
-
+    b = (pos.pieces(Us) ^ pos.pieces(Us,PAWN,KING)) & attackedBy[Us][ALL_PIECES];
     score += Connected * popcount(b);
 
     if (T)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -127,7 +127,7 @@ namespace {
   };
 
   // Connectedness
-  const Score Connected = S(2,2);
+  const Score Connected = S(3,3);
 
   // RookOnFile[semiopen/open] contains bonuses for each rook when there is
   // no (friendly) pawn on the rook file.

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -127,7 +127,7 @@ namespace {
   };
 
   // Connectedness
-  const Score Connected = S(3,3);
+  const Score Connected = S(2,2);
 
   // RookOnFile[semiopen/open] contains bonuses for each rook when there is
   // no (friendly) pawn on the rook file.

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -611,7 +611,7 @@ namespace {
     }
 
     // Connectedness
-    b = pos.pieces(Us) & attackedBy[Us][ALL_PIECES] 
+    b = pos.pieces(Us) & attackedBy[Us][ALL_PIECES]
                        & ~attackedBy[Us][PAWN]
                        & ~pos.pieces(Us, KING);
     score += Connected * popcount(b);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -127,7 +127,7 @@ namespace {
   };
 
   // Connectedness
-  const Score Connected = S(3,3);
+  const Score Connected = S(2,2);
 
   // RookOnFile[semiopen/open] contains bonuses for each rook when there is
   // no (friendly) pawn on the rook file.
@@ -610,10 +610,10 @@ namespace {
         score += KnightOnQueen * popcount(b);
     }
 
-    // Connectedness
-    b = pos.pieces(Us) & attackedBy[Us][ALL_PIECES]
-                       & ~attackedBy[Us][PAWN]
-                       & ~pos.pieces(Us, KING);
+    // Connectedness for knights, bishops, rooks, and queens
+    b = (pos.pieces(Us) ^ pos.pieces(Us,PAWN) ^ pos.pieces(Us, KING))
+                       & attackedBy[Us][ALL_PIECES];
+
     score += Connected * popcount(b);
 
     if (T)


### PR DESCRIPTION
Adding a small bonus for knights, bishops, rooks, and queens that are "connected" to each other (i.e., they are under attack by our own pieces) apparently is a good thing.  I assume it helps the pieces work together a bit better.

STC
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 12317 W: 2655 L: 2467 D: 7195
http://tests.stockfishchess.org/tests/view/5aa2d86b0ebc590297cb6474

LTC
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
http://tests.stockfishchess.org/tests/view/5aa2fc6f0ebc590297cb64a8

Honestly, this was kind of a shot in the dark.  Probably more testing is needed, but I submit the PR here for recommendations and advice on how to proceed.  Which is more relevant mg, or eg?  Can these be tuned before being added?  Adding pawn attacks seemed to help a lot, but shouldn't this be handled by the outpost code?

Bench 5843512
