### PR TITLE
Decrease PIECE_TYPE_NB

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -195,7 +195,7 @@ enum Value : int {
 enum PieceType {
   NO_PIECE_TYPE, PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING,
   ALL_PIECES = 0,
-  PIECE_TYPE_NB = 8
+  PIECE_TYPE_NB = 7
 };
 
 enum Piece {


### PR DESCRIPTION
After commit 1093047e7d72, QUEEN_DIAGONAL is no longer used, so we can
safely decrease PIECE_TYPE_NB to 7.

No functional change.