### PR TITLE
 Probcut Qsearch - Bench: 6076641

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -778,15 +778,11 @@ namespace {
 
                 pos.do_move(move, st);
 
-                // Perform a preliminary search at depth 1 to verify that the move holds.
-                // We will only do this search if the depth is not 5, thus avoiding two
-                // searches at depth 1 in a row.
-                if (depth != 5 * ONE_PLY)
-                    value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, ONE_PLY, !cutNode, true);
+                // Perform a preliminary Q-Search to verify that the move holds
+				value = -qsearch<NonPV, false>(pos, ss + 1, -rbeta, -rbeta + 1);
 
-                // If the first search was skipped or was performed and held, perform
-                // the regular search.
-                if (depth == 5 * ONE_PLY || value >= rbeta)
+                // If the first search was held, perform the regular search
+                if (value >= rbeta)
                     value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, depth - 4 * ONE_PLY, !cutNode, false);
 
                 pos.undo_move(move);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -778,10 +778,10 @@ namespace {
 
                 pos.do_move(move, st);
 
-                // Perform a preliminary Q-Search to verify that the move holds
-				value = -qsearch<NonPV, false>(pos, ss + 1, -rbeta, -rbeta + 1);
+                // Perform a preliminary qsearch to verify that the move holds
+                value = -qsearch<NonPV, false>(pos, ss+1, -rbeta, -rbeta + 1);
 
-                // If the first search was held, perform the regular search
+                // If the qsearch was held, perform the regular search
                 if (value >= rbeta)
                     value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, depth - 4 * ONE_PLY, !cutNode, false);
 


### PR DESCRIPTION
Simplify preliminary search by performing a qsearch.  
We don't need any special logic to omit this search.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 5312 W: 1183 L: 1031 D: 3098

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 11113 W: 1727 L: 1592 D: 7794

Bench: 6076641