### PR TITLE
Connectivity Score S(3,1) is stronger than S(2,2)

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -19,6 +19,7 @@
 */
 
 #include <algorithm>
+#include <iostream>
 
 #include "bitboard.h"
 #include "misc.h"
@@ -207,6 +208,8 @@ void Bitboards::init() {
 
   for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
   {
+      std::cout << Bitboards::pretty(RookTable[s1]);
+
       PseudoAttacks[QUEEN][s1]  = PseudoAttacks[BISHOP][s1] = attacks_bb<BISHOP>(s1, 0);
       PseudoAttacks[QUEEN][s1] |= PseudoAttacks[  ROOK][s1] = attacks_bb<  ROOK>(s1, 0);
 

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -19,7 +19,6 @@
 */
 
 #include <algorithm>
-#include <iostream>
 
 #include "bitboard.h"
 #include "misc.h"
@@ -208,8 +207,6 @@ void Bitboards::init() {
 
   for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
   {
-      std::cout << Bitboards::pretty(RookTable[s1]);
-
       PseudoAttacks[QUEEN][s1]  = PseudoAttacks[BISHOP][s1] = attacks_bb<BISHOP>(s1, 0);
       PseudoAttacks[QUEEN][s1] |= PseudoAttacks[  ROOK][s1] = attacks_bb<  ROOK>(s1, 0);
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -165,7 +165,7 @@ namespace {
   // Assorted bonuses and penalties
   const Score BishopPawns       = S(  8, 12);
   const Score CloseEnemies      = S(  7,  0);
-  const Score Connectivity      = S(  1,  1);
+  const Score Connectivity      = S(  2,  1);
   const Score Hanging           = S( 52, 30);
   const Score HinderPassedPawn  = S(  8,  1);
   const Score KnightOnQueen     = S( 21, 11);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -165,7 +165,7 @@ namespace {
   // Assorted bonuses and penalties
   const Score BishopPawns       = S(  8, 12);
   const Score CloseEnemies      = S(  7,  0);
-  const Score Connectivity      = S(  2,  2);
+  const Score Connectivity      = S(  1,  1);
   const Score Hanging           = S( 52, 30);
   const Score HinderPassedPawn  = S(  8,  1);
   const Score KnightOnQueen     = S( 21, 11);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -165,7 +165,7 @@ namespace {
   // Assorted bonuses and penalties
   const Score BishopPawns       = S(  8, 12);
   const Score CloseEnemies      = S(  7,  0);
-  const Score Connectivity      = S(  3,  0);
+  const Score Connectivity      = S(  3,  1);
   const Score Hanging           = S( 52, 30);
   const Score HinderPassedPawn  = S(  8,  1);
   const Score KnightOnQueen     = S( 21, 11);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -165,7 +165,7 @@ namespace {
   // Assorted bonuses and penalties
   const Score BishopPawns       = S(  8, 12);
   const Score CloseEnemies      = S(  7,  0);
-  const Score Connectivity      = S(  2,  1);
+  const Score Connectivity      = S(  3,  0);
   const Score Hanging           = S( 52, 30);
   const Score HinderPassedPawn  = S(  8,  1);
   const Score KnightOnQueen     = S( 21, 11);


### PR DESCRIPTION
I believe my tests were conclusive enough to demonstrate that a connectivity score of S(3,1) is stronger than S(2,2).

STC
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 16175 W: 3386 L: 3165 D: 9624
http://tests.stockfishchess.org/tests/view/5aa48b150ebc59029780fef6

LTC
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 98685 W: 15209 L: 14765 D: 68711
http://tests.stockfishchess.org/tests/view/5aa496f50ebc59029780fefa

Bench 5601228
