### PR TITLE
Adjust initiative in pure pawn endgames

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -765,6 +765,7 @@ namespace {
                     +  8 * pe->pawn_asymmetry()
                     + 12 * pos.count<PAWN>()
                     + 16 * pawnsOnBothFlanks
+                    + 48 * !pos.non_pawn_material()
                     -136 ;
 
     // Now apply the bonus: note that we find the attacking side by extracting


### PR DESCRIPTION
King and pawn endgames are typically decisive, and a small advantage is often sufficient to win. Therefore we now take this into account when computing the initiative adjustment.

This idea came from a series of patches by Gian-Carlo Pascutto.

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 48770 W: 10203 L: 9845 D: 28722
http://tests.stockfishchess.org/tests/view/5aa58cce0ebc59029780ff8d

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 22252 W: 3572 L: 3366 D: 15314
http://tests.stockfishchess.org/tests/view/5aa5b27c0ebc59029780ffad

Ideas for future development:

- There have been a number of changes to the initiative calculation lately. Perhaps the coefficients could be tuned again.

- It may be possible to add special knowledge for other endgames in the initiative calculation.

Bench: 5750110