### PR TITLE
Probcut qsearch - Bench:  5404567

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -782,7 +782,7 @@ namespace {
                 value = pos.checkers() ? -qsearch<NonPV, true>(pos, ss+1, -rbeta, -rbeta+1)
                     : -qsearch<NonPV, false>(pos, ss+1, -rbeta, -rbeta+1);
 
-                // If the qsearch was held, perform the regular search
+                // If the qsearch was held perform the regular search
                 if (value >= rbeta)
                     value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, depth - 4 * ONE_PLY, !cutNode, false);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -778,15 +778,12 @@ namespace {
 
                 pos.do_move(move, st);
 
-                // Perform a preliminary search at depth 1 to verify that the move holds.
-                // We will only do this search if the depth is not 5, thus avoiding two
-                // searches at depth 1 in a row.
-                if (depth != 5 * ONE_PLY)
-                    value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, ONE_PLY, !cutNode, true);
+                // Perform a preliminary qsearch to verify that the move holds
+                value = pos.checkers() ? -qsearch<NonPV, true>(pos, ss+1, -rbeta, -rbeta+1)
+                    : -qsearch<NonPV, false>(pos, ss+1, -rbeta, -rbeta+1);
 
-                // If the first search was skipped or was performed and held, perform
-                // the regular search.
-                if (depth == 5 * ONE_PLY || value >= rbeta)
+                // If the qsearch was held, perform the regular search
+                if (value >= rbeta)
                     value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, depth - 4 * ONE_PLY, !cutNode, false);
 
                 pos.undo_move(move);


### PR DESCRIPTION
Perform qsearch for the preliminary search in probcut

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 31090 W: 6386 L: 6283 D: 18421

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 104056 W: 15990 L: 15531 D: 72535

 Bench:  5404567