### PR TITLE
Two search adjustments based on whether the score is improving

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -654,7 +654,7 @@ namespace {
     if (inCheck)
     {
         ss->staticEval = eval = VALUE_NONE;
-        improving = true;
+        improving = false;
         goto moves_loop;
     }
     else if (ttHit)
@@ -761,7 +761,7 @@ namespace {
     {
         assert(is_ok((ss-1)->currentMove));
 
-        Value rbeta = std::min(beta + 200, VALUE_INFINITE);
+        Value rbeta = std::min(beta + 216 - 48 * improving, VALUE_INFINITE);
         MovePicker mp(pos, ttMove, rbeta - ss->staticEval, &thisThread->captureHistory);
         int probCutCount = 0;
 


### PR DESCRIPTION
This patch has two parts:

1) The increased beta threshold for ProbCut is now adjusted based on whether the score is improving.

2) When in check, improving is always set to false.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 13480 W: 2840 L: 2648 D: 7992
http://tests.stockfishchess.org/tests/view/5aa693fe0ebc59029781004c

LTC:
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 25895 W: 4099 L: 3880 D: 17916
http://tests.stockfishchess.org/tests/view/5aa6ac940ebc59029781006e

In terms of opportunities for future work opened up by this patch, the ProbCut rBeta formula could be tuned.

This patch is co-authored by Joost VandeVondele (@vondele) and Bill Henry (@VoyagerOne).

Bench: 5328254