### PR TITLE
Retire depth-dependence in ProbCut move count pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -766,7 +766,7 @@ namespace {
         int probCutCount = 0;
 
         while (  (move = mp.next_move()) != MOVE_NONE
-               && probCutCount < depth / ONE_PLY - 3)
+               && probCutCount < 3)
             if (pos.legal(move))
             {
                 probCutCount++;


### PR DESCRIPTION
The move count limit in ProbCut is now unchanged with depth.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 33895 W: 6995 L: 6897 D: 20003
http://tests.stockfishchess.org/tests/view/5aa6eaba0ebc59029781009d

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 28959 W: 4441 L: 4333 D: 20185
http://tests.stockfishchess.org/tests/view/5aa73dfa0ebc5902978100be

Ideas for future work:
- Is a flat move count limit in ProbCut ideal? Depth dependence, or dependence on some other variable, could possibly be reintroduced.
- The move count limit (3) is untuned and a better value may exist.

Bench: 5817649