### PR TITLE
Don't pick_best if there's only one move.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -51,7 +51,8 @@ namespace {
   // are few moves, e.g., the possible captures.
   Move pick_best(ExtMove* begin, ExtMove* end) {
 
-    std::swap(*begin, *std::max_element(begin, end));
+    if (begin < (end-1))
+       std::swap(*begin, *std::max_element(begin, end));
     return *begin;
   }
 


### PR DESCRIPTION
This is a non-functional patch, which is a tiny bit faster than master with the same bench.  The README says to do a PR so other can verify speedup.

200 bench runs on my machine:
base: 1381839 +/- 7911
test: 1389857 +/- 7915
diff: +8018

It did not pass SPRT[0,4], but is clearly better than master (passed yellow up 250 games).  
http://tests.stockfishchess.org/tests/view/5aa973c80ebc5902978481f3