### PR TITLE
MSVC 2017 fixes

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -417,7 +417,8 @@ namespace {
     // Main king safety evaluation
     if (kingAttackersCount[Them] > 1 - pos.count<QUEEN>(Them))
     {
-        int kingDanger = unsafeChecks = 0;
+        int kingDanger = 0;
+        unsafeChecks = 0;
 
         // Attacked squares defended at most once by our queen or king
         weak =  attackedBy[Them][ALL_PIECES]

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -23,6 +23,11 @@
 #undef  _WIN32_WINNT
 #define _WIN32_WINNT 0x0601 // Force to include needed API prototypes
 #endif
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
 #include <windows.h>
 // The needed Windows API for processor groups could be missed from old Windows
 // versions, so instead of calling them directly (forcing the linker to resolve


### PR DESCRIPTION
This fixes:
A)
movepick.h(52): warning C4003: not enough actual parameters for macro 'max'
movepick.h(52): error C2760: syntax error: unexpected token 'void', expected 'expression'
see: https://stackoverflow.com/questions/6884093/warning-c4003-not-enough-actual-parameters-for-macro-max-visual-studio-2010
B)
evaluate.cpp(420): warning C4244: 'initializing': conversion from 'Bitboard' to 'int', possible loss of data

No functional change.
bench: 5741807