### PR TITLE
Join refutation stages in the movepicker.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -25,7 +25,7 @@
 namespace {
 
   enum Stages {
-    MAIN_TT, CAPTURE_INIT, GOOD_CAPTURE, KILLER0, KILLER1, COUNTERMOVE, QUIET_INIT, QUIET, BAD_CAPTURE,
+    MAIN_TT, CAPTURE_INIT, GOOD_CAPTURE, REFUTATION, QUIET_INIT, QUIET, BAD_CAPTURE,
     EVASION_TT, EVASION_INIT, EVASION,
     PROBCUT_TT, PROBCUT_INIT, PROBCUT,
     QSEARCH_TT, QCAPTURE_INIT, QCAPTURE, QCHECK_INIT, QCHECK
@@ -62,7 +62,7 @@ namespace {
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Move cm, Move* killers_p)
            : pos(p), mainHistory(mh), captureHistory(cph), contHistory(ch),
-             refutations{killers_p[0], killers_p[1], cm}, depth(d){
+             refutations{killers_p[0], 0, killers_p[1], 0, cm, 0}, depth(d){
 
   assert(d > DEPTH_ZERO);
 
@@ -129,7 +129,8 @@ void MovePicker::score() {
       }
 }
 
-/// MovePicker::select_move() returns the next move satisfying a predicate function
+/// MovePicker::select_move() returns the next move satisfying a predicate function.
+/// It never returns the TT move.
 template<PickType T, typename Pred>
 Move MovePicker::select_move(Pred filter) {
 
@@ -176,25 +177,21 @@ top:
                                                  true : (*endBadCaptures++ = move, false); }))
           return move;
 
+      // prepare refutations
+      cur = std::begin(refutations), endMoves = std::end(refutations);
       // If the countermove is the same as a killer, skip it
-      if (   refutations[0] == refutations[2]
-          || refutations[1] == refutations[2])
-          refutations[2] = MOVE_NONE;
+      if (   refutations[0].move == refutations[2].move
+          || refutations[1].move == refutations[2].move)
+          --endMoves;
       ++stage;
       /* fallthrough */
 
-  case KILLER0:
-  case KILLER1:
-  case COUNTERMOVE:
-      while (stage <= COUNTERMOVE)
-      {
-          move = refutations[ stage++ - KILLER0];
-          if (    move != MOVE_NONE
-              &&  move != ttMove
-              &&  pos.pseudo_legal(move)
-              && !pos.capture(move))
-              return move;
-      }
+  case REFUTATION:
+      if (select_move<NEXT>([&](){ return     move != MOVE_NONE
+                                          && !pos.capture(move)
+                                          &&  pos.pseudo_legal(move); }))
+          return move;
+      ++stage;
       /* fallthrough */
 
   case QUIET_INIT:

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -62,7 +62,7 @@ namespace {
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Move cm, Move* killers_p)
            : pos(p), mainHistory(mh), captureHistory(cph), contHistory(ch),
-             refutations{killers_p[0], 0, killers_p[1], 0, cm, 0}, depth(d){
+             refutations{{killers_p[0], 0}, {killers_p[1], 0}, {cm, 0}}, depth(d){
 
   assert(d > DEPTH_ZERO);
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -131,8 +131,8 @@ private:
   const ButterflyHistory* mainHistory;
   const CapturePieceToHistory* captureHistory;
   const PieceToHistory** contHistory;
-  Move ttMove, refutations[3];
-  ExtMove *cur, *endMoves, *endBadCaptures;
+  Move ttMove;
+  ExtMove refutations[3], *cur, *endMoves, *endBadCaptures;
   int stage;
   Move move;
   Square recaptureSquare;


### PR DESCRIPTION
unifies a bit further, treating the skipping of TT move now always via select_move (as discussed in #1454).
Improves over #1497 by avoiding an unneeded copy.

Passed STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 16608 W: 3461 L: 3331 D: 9816
http://tests.stockfishchess.org/tests/view/5ab0aaf00ebc59029fb6f6c3

No functional change.