### PR TITLE
Overload make_bitboard() for file and rank arguments

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -89,13 +89,13 @@ void Bitboards::init() {
       PopCnt16[i] = (uint8_t) popcount16(i);
 
   for (Square s = SQ_A1; s <= SQ_H8; ++s)
-      SquareBB[s] = 1ULL << s;
+      SquareBB[s] = make_bitboard(s);
 
   for (File f = FILE_A; f <= FILE_H; ++f)
-      FileBB[f] = f > FILE_A ? FileBB[f - 1] << 1 : FileABB;
+      FileBB[f] = f > FILE_A ? FileBB[f - 1] << 1 : make_bitboard(FILE_A);
 
   for (Rank r = RANK_1; r <= RANK_8; ++r)
-      RankBB[r] = r > RANK_1 ? RankBB[r - 1] << 8 : Rank1BB;
+      RankBB[r] = r > RANK_1 ? RankBB[r - 1] << 8 : make_bitboard(RANK_1);
 
   for (File f = FILE_A; f <= FILE_H; ++f)
       AdjacentFilesBB[f] = (f > FILE_A ? FileBB[f - 1] : 0) | (f < FILE_H ? FileBB[f + 1] : 0);
@@ -199,7 +199,8 @@ namespace {
     for (Square s = SQ_A1; s <= SQ_H8; ++s)
     {
         // Board edges are not considered in the relevant occupancies
-        edges = ((Rank1BB | Rank8BB) & ~rank_bb(s)) | ((FileABB | FileHBB) & ~file_bb(s));
+        edges =   (make_bitboard(RANK_1, RANK_8) & ~rank_bb(s))
+                | (make_bitboard(FILE_A, FILE_H) & ~file_bb(s));
 
         // Given a square 's', the mask is the bitboard of sliding attacks from
         // 's' computed on an empty board. The index must be big enough to contain

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -39,26 +39,7 @@ const std::string pretty(Bitboard b);
 
 }
 
-constexpr Bitboard AllSquares = ~Bitboard(0);
 constexpr Bitboard DarkSquares = 0xAA55AA55AA55AA55ULL;
-
-constexpr Bitboard FileABB = 0x0101010101010101ULL;
-constexpr Bitboard FileBBB = FileABB << 1;
-constexpr Bitboard FileCBB = FileABB << 2;
-constexpr Bitboard FileDBB = FileABB << 3;
-constexpr Bitboard FileEBB = FileABB << 4;
-constexpr Bitboard FileFBB = FileABB << 5;
-constexpr Bitboard FileGBB = FileABB << 6;
-constexpr Bitboard FileHBB = FileABB << 7;
-
-constexpr Bitboard Rank1BB = 0xFF;
-constexpr Bitboard Rank2BB = Rank1BB << (8 * 1);
-constexpr Bitboard Rank3BB = Rank1BB << (8 * 2);
-constexpr Bitboard Rank4BB = Rank1BB << (8 * 3);
-constexpr Bitboard Rank5BB = Rank1BB << (8 * 4);
-constexpr Bitboard Rank6BB = Rank1BB << (8 * 5);
-constexpr Bitboard Rank7BB = Rank1BB << (8 * 6);
-constexpr Bitboard Rank8BB = Rank1BB << (8 * 7);
 
 extern int SquareDistance[SQUARE_NB][SQUARE_NB];
 
@@ -150,23 +131,36 @@ inline Bitboard file_bb(Square s) {
 }
 
 
-/// make_bitboard() returns a bitboard from a list of squares
+/// make_bitboard() returns a bitboard compile-time constructed from a list of
+/// squares, files and/or ranks
 
 constexpr Bitboard make_bitboard() { return 0; }
 
-template<typename ...Squares>
-constexpr Bitboard make_bitboard(Square s, Squares... squares) {
-  return (1ULL << s) | make_bitboard(squares...);
+template<typename ...Descriptors>
+constexpr Bitboard make_bitboard(Square s, Descriptors... descriptors) {
+  return (1ULL << s) | make_bitboard(descriptors...);
 }
 
+template<typename ...Descriptors>
+constexpr Bitboard make_bitboard(File f, Descriptors... descriptors) {
+  return (0x0101010101010101ULL << f) | make_bitboard(descriptors...);
+}
+
+template<typename ...Descriptors>
+constexpr Bitboard make_bitboard(Rank r, Descriptors... descriptors) {
+  return (0xFFULL << (r * 8)) | make_bitboard(descriptors...);
+}
 
 /// shift() moves a bitboard one step along direction D (mainly for pawns)
 
 template<Direction D>
 constexpr Bitboard shift(Bitboard b) {
-  return  D == NORTH      ?  b             << 8 : D == SOUTH      ?  b             >> 8
-        : D == NORTH_EAST ? (b & ~FileHBB) << 9 : D == SOUTH_EAST ? (b & ~FileHBB) >> 7
-        : D == NORTH_WEST ? (b & ~FileABB) << 7 : D == SOUTH_WEST ? (b & ~FileABB) >> 9
+  return  D == NORTH      ?  b                           << 8
+        : D == SOUTH      ?  b                           >> 8
+        : D == NORTH_EAST ? (b & ~make_bitboard(FILE_H)) << 9
+        : D == SOUTH_EAST ? (b & ~make_bitboard(FILE_H)) >> 7
+        : D == NORTH_WEST ? (b & ~make_bitboard(FILE_A)) << 7
+        : D == SOUTH_WEST ? (b & ~make_bitboard(FILE_A)) >> 9
         : 0;
 }
 

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -286,7 +286,7 @@ Value Endgame<KQKP>::operator()(const Position& pos) const {
 
   if (   relative_rank(weakSide, pawnSq) != RANK_7
       || distance(loserKSq, pawnSq) != 1
-      || !((FileABB | FileCBB | FileFBB | FileHBB) & pawnSq))
+      || !(make_bitboard(FILE_A, FILE_C, FILE_F, FILE_H) & pawnSq))
       result += QueenValueEg - PawnValueEg;
 
   return strongSide == pos.side_to_move() ? result : -result;
@@ -518,7 +518,7 @@ ScaleFactor Endgame<KRPKB>::operator()(const Position& pos) const {
   assert(verify_material(pos, weakSide, BishopValueMg, 0));
 
   // Test for a rook pawn
-  if (pos.pieces(PAWN) & (FileABB | FileHBB))
+  if (pos.pieces(PAWN) & make_bitboard(FILE_A, FILE_H))
   {
       Square ksq = pos.square<KING>(weakSide);
       Square bsq = pos.square<BISHOP>(weakSide);
@@ -599,7 +599,7 @@ ScaleFactor Endgame<KPsK>::operator()(const Position& pos) const {
   // If all pawns are ahead of the king, on a single rook file and
   // the king is within one file of the pawns, it's a draw.
   if (   !(pawns & ~forward_ranks_bb(weakSide, ksq))
-      && !((pawns & ~FileABB) && (pawns & ~FileHBB))
+      && !((pawns & ~make_bitboard(FILE_A)) && (pawns & ~make_bitboard(FILE_H)))
       &&  distance<File>(ksq, lsb(pawns)) <= 1)
       return SCALE_FACTOR_DRAW;
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -74,10 +74,10 @@ using namespace Trace;
 
 namespace {
 
-  constexpr Bitboard QueenSide   = FileABB | FileBBB | FileCBB | FileDBB;
-  constexpr Bitboard CenterFiles = FileCBB | FileDBB | FileEBB | FileFBB;
-  constexpr Bitboard KingSide    = FileEBB | FileFBB | FileGBB | FileHBB;
-  constexpr Bitboard Center      = (FileDBB | FileEBB) & (Rank4BB | Rank5BB);
+  constexpr Bitboard QueenSide   = make_bitboard(FILE_A, FILE_B, FILE_C, FILE_D);
+  constexpr Bitboard CenterFiles = make_bitboard(FILE_C, FILE_D, FILE_E, FILE_F);
+  constexpr Bitboard KingSide    = make_bitboard(FILE_E, FILE_F, FILE_G, FILE_H);
+  constexpr Bitboard Center      = make_bitboard(SQ_D4, SQ_E4, SQ_D5, SQ_E5);
 
   constexpr Bitboard KingFlank[FILE_NB] = {
     QueenSide,   QueenSide, QueenSide,
@@ -253,7 +253,8 @@ namespace {
     constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
     constexpr Direction Up   = (Us == WHITE ? NORTH : SOUTH);
     constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
-    constexpr Bitboard LowRanks = (Us == WHITE ? Rank2BB | Rank3BB: Rank7BB | Rank6BB);
+    constexpr Bitboard LowRanks = (Us == WHITE ? make_bitboard(RANK_2, RANK_3)
+                                               : make_bitboard(RANK_7, RANK_6));
 
     // Find our pawns that are blocked or on the first two ranks
     Bitboard b = pos.pieces(Us, PAWN) & (shift<Down>(pos.pieces()) | LowRanks);
@@ -288,8 +289,8 @@ namespace {
   Score Evaluation<T>::pieces() {
 
     constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
-    constexpr Bitboard OutpostRanks = (Us == WHITE ? Rank4BB | Rank5BB | Rank6BB
-                                               : Rank5BB | Rank4BB | Rank3BB);
+    constexpr Bitboard OutpostRanks = (Us == WHITE ? make_bitboard(RANK_4, RANK_5, RANK_6)
+                                                   : make_bitboard(RANK_5, RANK_4, RANK_3));
     const Square* pl = pos.squares<Pt>(Us);
 
     Bitboard b, bb;
@@ -405,8 +406,8 @@ namespace {
   Score Evaluation<T>::king() const {
 
     constexpr Color    Them = (Us == WHITE ? BLACK : WHITE);
-    constexpr Bitboard Camp = (Us == WHITE ? AllSquares ^ Rank6BB ^ Rank7BB ^ Rank8BB
-                                       : AllSquares ^ Rank1BB ^ Rank2BB ^ Rank3BB);
+    constexpr Bitboard Camp = (Us == WHITE ? ~make_bitboard(RANK_6, RANK_7, RANK_8)
+                                           : ~make_bitboard(RANK_1, RANK_2, RANK_3));
 
     const Square ksq = pos.square<KING>(Us);
     Bitboard weak, b, b1, b2, safe, unsafeChecks, pinned;
@@ -506,9 +507,9 @@ namespace {
   template<Tracing T> template<Color Us>
   Score Evaluation<T>::threats() const {
 
-    constexpr Color     Them     = (Us == WHITE ? BLACK   : WHITE);
-    constexpr Direction Up       = (Us == WHITE ? NORTH   : SOUTH);
-    constexpr Bitboard  TRank3BB = (Us == WHITE ? Rank3BB : Rank6BB);
+    constexpr Color     Them     =              (Us == WHITE ? BLACK  : WHITE);
+    constexpr Direction Up       =              (Us == WHITE ? NORTH  : SOUTH);
+    constexpr Bitboard  TRank3BB = make_bitboard(Us == WHITE ? RANK_3 : RANK_6);
 
     Bitboard b, weak, defended, nonPawnEnemies, stronglyProtected, safeThreats;
     Score score = SCORE_ZERO;
@@ -717,8 +718,8 @@ namespace {
 
     constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
     constexpr Bitboard SpaceMask =
-      Us == WHITE ? CenterFiles & (Rank2BB | Rank3BB | Rank4BB)
-                  : CenterFiles & (Rank7BB | Rank6BB | Rank5BB);
+      Us == WHITE ? CenterFiles & make_bitboard(RANK_2, RANK_3, RANK_4)
+                  : CenterFiles & make_bitboard(RANK_7, RANK_6, RANK_5);
 
     if (pos.non_pawn_material() < SpaceThreshold)
         return SCORE_ZERO;

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -94,13 +94,13 @@ namespace {
 
     // Compute our parametrized parameters at compile time, named according to
     // the point of view of white side.
-    constexpr Color     Them     = (Us == WHITE ? BLACK      : WHITE);
-    constexpr Bitboard  TRank8BB = (Us == WHITE ? Rank8BB    : Rank1BB);
-    constexpr Bitboard  TRank7BB = (Us == WHITE ? Rank7BB    : Rank2BB);
-    constexpr Bitboard  TRank3BB = (Us == WHITE ? Rank3BB    : Rank6BB);
-    constexpr Direction Up       = (Us == WHITE ? NORTH      : SOUTH);
-    constexpr Direction UpRight  = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
-    constexpr Direction UpLeft   = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
+    constexpr Color     Them     =              (Us == WHITE ? BLACK      : WHITE);
+    constexpr Bitboard  TRank8BB = make_bitboard(Us == WHITE ? RANK_8     : RANK_1);
+    constexpr Bitboard  TRank7BB = make_bitboard(Us == WHITE ? RANK_7     : RANK_2);
+    constexpr Bitboard  TRank3BB = make_bitboard(Us == WHITE ? RANK_3     : RANK_6);
+    constexpr Direction Up       =              (Us == WHITE ? NORTH      : SOUTH);
+    constexpr Direction UpRight  =              (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
+    constexpr Direction UpLeft   =              (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
 
     Bitboard emptySquares;
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1163,7 +1163,7 @@ bool Position::pos_is_ok() const {
       || attackers_to(square<KING>(~sideToMove)) & pieces(sideToMove))
       assert(0 && "pos_is_ok: Kings");
 
-  if (   (pieces(PAWN) & (Rank1BB | Rank8BB))
+  if (   (pieces(PAWN) & make_bitboard(RANK_1, RANK_8))
       || pieceCount[W_PAWN] > 8
       || pieceCount[B_PAWN] > 8)
       assert(0 && "pos_is_ok: Pawns");


### PR DESCRIPTION
This patch overloads make_bitboard() to use not only squares but files and ranks as arguments also.
This enables construction of bitboards with mixed arguments like:
`constexpr Bitboard Edges = make_bitboard(FILE_A, FILE_H, RANK_1, RANK_8);`

All file and rank constexpr bitboards are retired.

No functional change.