### PR TITLE
Delay determination of "backward" until relevant

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -154,8 +154,7 @@ namespace {
         else if (!neighbours)
             score -= Isolated, e->weakUnopposed[Us] += !opposed;
 
-        // A pawn is backward when it is behind all pawns of the same color on the
-        // adjacent files and cannot be safely advanced.
+        // Test for backward pawn
         else if (!lever && relative_rank(Us, s) < RANK_5)
         {
             // Find the backmost rank with neighbours or stoppers

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -166,7 +166,7 @@ namespace {
             if ((b | shift<Up>(b & adjacent_files_bb(f))) & stoppers)
             {
                score -= Backward, e->weakUnopposed[Us] += !opposed;
-               assert (!forward_ranks_bb(Them, s + Up) & neighbours);
+               assert (!(forward_ranks_bb(Them, s + Up) & neighbours));
             }
         }
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -165,7 +165,10 @@ namespace {
             // either there is a stopper in the way on this rank, or there is a
             // stopper on adjacent file which controls the way to that rank.
             if ((b | shift<Up>(b & adjacent_files_bb(f))) & stoppers)
+            {
                score -= Backward, e->weakUnopposed[Us] += !opposed;
+               assert (!forward_ranks_bb(Them, s + Up) & neighbours);
+            }
         }
 
         if (doubled && !supported)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -167,8 +167,6 @@ namespace {
             //backward = (b | shift<Up>(b & adjacent_files_bb(f))) & stoppers;
             if ((b | shift<Up>(b & adjacent_files_bb(f))) & stoppers)
                score -= Backward, e->weakUnopposed[Us] += !opposed;
-
-            assert(!(backward && (forward_ranks_bb(Them, s + Up) & neighbours)));
         }
 
         if (doubled && !supported)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -164,7 +164,6 @@ namespace {
             // The pawn is backward when it cannot safely progress to that rank:
             // either there is a stopper in the way on this rank, or there is a
             // stopper on adjacent file which controls the way to that rank.
-            //backward = (b | shift<Up>(b & adjacent_files_bb(f))) & stoppers;
             if ((b | shift<Up>(b & adjacent_files_bb(f))) & stoppers)
                score -= Backward, e->weakUnopposed[Us] += !opposed;
         }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -156,7 +156,7 @@ namespace {
 
         // A pawn is backward when it is behind all pawns of the same color on the
         // adjacent files and cannot be safely advanced.
-        else if (neighbours && !lever && relative_rank(Us, s) < RANK_5)
+        else if (!lever && relative_rank(Us, s) < RANK_5)
         {
             // Find the backmost rank with neighbours or stoppers
             b = rank_bb(backmost_sq(Us, neighbours | stoppers));


### PR DESCRIPTION
Non-functional simplification.  There is no need to determine whether a pawn is backward until it's relevant.  With this patch, if the pawn is isolated, supported or phalanx, we don't even determine its' backwardness.  Saves a little code and a few executable operations.

Passed STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 27015 W: 5610 L: 5499 D: 15906
http://tests.stockfishchess.org/tests/view/5ab54f9c0ebc590295d88480

Bench 5741807