### PR TITLE
Tweak queen values for midgame and endgame

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -186,7 +186,7 @@ enum Value : int {
   PawnValueMg   = 171,   PawnValueEg   = 240,
   KnightValueMg = 764,   KnightValueEg = 848,
   BishopValueMg = 826,   BishopValueEg = 891,
-  RookValueMg   = 1282,  RookValueEg   = 1400,
+  RookValueMg   = 1282,  RookValueEg   = 1350,
   QueenValueMg  = 2500,  QueenValueEg  = 2670,
 
   MidgameLimit  = 15258, EndgameLimit  = 3915

--- a/src/types.h
+++ b/src/types.h
@@ -186,7 +186,7 @@ enum Value : int {
   PawnValueMg   = 171,   PawnValueEg   = 240,
   KnightValueMg = 764,   KnightValueEg = 848,
   BishopValueMg = 826,   BishopValueEg = 891,
-  RookValueMg   = 1260,  RookValueEg   = 1373,
+  RookValueMg   = 1282,  RookValueEg   = 1400,
   QueenValueMg  = 2500,  QueenValueEg  = 2670,
 
   MidgameLimit  = 15258, EndgameLimit  = 3915

--- a/src/types.h
+++ b/src/types.h
@@ -186,7 +186,7 @@ enum Value : int {
   PawnValueMg   = 171,   PawnValueEg   = 240,
   KnightValueMg = 764,   KnightValueEg = 848,
   BishopValueMg = 826,   BishopValueEg = 891,
-  RookValueMg   = 1282,  RookValueEg   = 1373,
+  RookValueMg   = 1300,  RookValueEg   = 1373,
   QueenValueMg  = 2500,  QueenValueEg  = 2670,
 
   MidgameLimit  = 15258, EndgameLimit  = 3915

--- a/src/types.h
+++ b/src/types.h
@@ -186,7 +186,7 @@ enum Value : int {
   PawnValueMg   = 171,   PawnValueEg   = 240,
   KnightValueMg = 764,   KnightValueEg = 848,
   BishopValueMg = 826,   BishopValueEg = 891,
-  RookValueMg   = 1300,  RookValueEg   = 1373,
+  RookValueMg   = 1260,  RookValueEg   = 1373,
   QueenValueMg  = 2500,  QueenValueEg  = 2670,
 
   MidgameLimit  = 15258, EndgameLimit  = 3915


### PR DESCRIPTION
Queen MG -1% EG +1%. 

The tests for this patch are still running, I open the PR in case @snicolet wants to make a emergency merge.

The [STC](http://tests.stockfishchess.org/tests/view/5ab6b66b0ebc5902932cbd19) failed, the [LTC](http://tests.stockfishchess.org/tests/view/5ab73faa0ebc5902932cbdca) is looking good so far.

I am on leave today, so I open here to make this small improvement possible (if this turns to be one, of course).