### PR TITLE
Change reduction/improving interaction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -160,7 +160,7 @@ void Search::init() {
               Reductions[PV][imp][d][mc] = std::max(Reductions[NonPV][imp][d][mc] - 1, 0);
 
               // Increase reduction for non-PV nodes when eval is not improving
-              if (!imp && Reductions[NonPV][imp][d][mc] >= 2)
+              if (!imp && r > 1.0)
                 Reductions[NonPV][imp][d][mc]++;
           }
 


### PR DESCRIPTION
Adjust criterion for applying extra reduction if not improving.
We now add an extra ply of reduction if r > 1.0, instead of the previous condition Reductions[NonPV][imp][d][mc] >= 2.

Why does this work? Previously, reductions when not improving had a discontinuity as the depth and/or move count increases due to the Reductions[NonPV][imp][d][mc] >= 2 condition. Hence, values of r such that 0.5 < r < 1.5 would be mapped to a reduction of 1, while 1.5 < r < 2.5 would be mapped to a reduction of 3. This patch allows values of r satisfying 1.0 < r < 1.5 to be mapped to a reduction of 2, making the reduction formula more continuous.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 35908 W: 7382 L: 7087 D: 21439
http://tests.stockfishchess.org/tests/view/5aba723a0ebc5902a4743e8f

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 23087 W: 3584 L: 3378 D: 16125
http://tests.stockfishchess.org/tests/view/5aba89070ebc5902a4743ea9

Ideas for future work:
- We could look at retuning the LMR formula.
- We could look at adjusting the reductions in PV nodes if not improving.

Bench: 5326261