### PR TITLE
Further documentation and coding style on TB code

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char* argv[]) {
   Bitbases::init();
   Search::init();
   Pawns::init();
-  Tablebases::init(Options["SyzygyPath"]);
+  Tablebases::init(Options["SyzygyPath"]); // After Bitboards are set
   TT.resize(Options["Hash"]);
   Threads.set(Options["Threads"]);
   Search::clear(); // After threads are up

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -383,36 +383,35 @@ TBTable<Type>::~TBTable() {
 // init time.
 class TBTables {
 
-    typedef std::pair<TBTable<WDL>*, TBTable<DTZ>*> EntryPair;
-    typedef std::pair<Key, EntryPair> Entry;
+    typedef std::tuple<Key, TBTable<WDL>*, TBTable<DTZ>*> Entry;
 
-    static const int TBHASHBITS = 10;
-    static const int HSHMAX     = 5;
+    static const int Size = 1 << 12; // 4K table, indexed by key's 12 lsb
 
-    Entry hashTable[1 << TBHASHBITS][HSHMAX];
+    Entry hashTable[Size];
 
     std::deque<TBTable<WDL>> wdlTable;
     std::deque<TBTable<DTZ>> dtzTable;
 
     void insert(Key key, TBTable<WDL>* wdl, TBTable<DTZ>* dtz) {
-        for (Entry& entry : hashTable[key >> (64 - TBHASHBITS)])
-            if (!entry.second.first || entry.first == key) {
-                entry = std::make_pair(key, std::make_pair(wdl, dtz));
+        // Ensure last element is empty to avoid overflow when looking up
+        for (Entry* entry = &hashTable[(uint32_t)key & (Size - 1)]; entry - hashTable < Size - 1; ++entry)
+            if (!std::get<1>(*entry) || std::get<0>(*entry) == key) {
+                *entry = std::make_tuple(key, wdl, dtz);
                 return;
             }
-
-        std::cerr << "HSHMAX too low!" << std::endl;
+        std::cerr << "TB hash table size too low!" << std::endl;
         exit(1);
     }
 
 public:
     template<TBType Type>
     TBTable<Type>* get(Key key) {
-        for (Entry& entry : hashTable[key >> (64 - TBHASHBITS)])
-            if (entry.first == key)
-                return std::get<Type>(entry.second);
-
-        return nullptr;
+        for (Entry* entry = &hashTable[(uint32_t)key & (Size - 1)]; ; ++entry) {
+            if (std::get<0>(*entry) == key)
+                return std::get<Type == WDL ? 1 : 2>(*entry);
+            if (!std::get<1>(*entry))
+                return nullptr;
+        }
     }
 
     void clear() {
@@ -1121,7 +1120,7 @@ T probe_table(const Position& pos, ProbeState* result, WDLScore wdl = WDLDraw) {
     if (!entry || !mapped(*entry, pos))
         return *result = FAIL, T();
 
-    return do_probe_table(pos, entry, wdl, result);
+    return do_probe_table<Type>(pos, entry, wdl, result);
 }
 
 // For a position where the side to move has a winning capture it is not necessary


### PR DESCRIPTION
This series, split in 3 commits, adds some documentation and code cleanup to TB.

Noteworthy is the use of a single array for hash, instead of 2 dim array. This implementation is the most idiomatic and efficient. I have isolated out the change in a single commit (see log message for details).

I have tested on 5-men and no functional and no slowdown reported. It should be verified on 6-men that the new hash does not overflow. It is enough to run ./stockfish with 6-men available: if it does not assert at startup it means everything is ok with 6-men too.
