### PR TITLE
Integrate syzygy in automated testing (v2).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-7', 'g++-7-multilib', 'g++-multilib', 'valgrind', 'expect']
+          packages: ['g++-7', 'g++-7-multilib', 'g++-multilib', 'valgrind', 'expect', 'curl']
       env:
         - COMPILER=g++-7
         - COMP=gcc
@@ -19,7 +19,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
-          packages: ['clang-5.0', 'llvm-5.0-dev', 'g++-multilib', 'valgrind', 'expect']
+          packages: ['clang-5.0', 'llvm-5.0-dev', 'g++-multilib', 'valgrind', 'expect', 'curl']
       env:
         - COMPILER=clang++-5.0
         - COMP=clang

--- a/tests/instrumented.sh
+++ b/tests/instrumented.sh
@@ -108,13 +108,33 @@ cat << EOF > game.exp
  exit \$value
 EOF
 
-for exps in game.exp
+#download TB as needed
+if [ ! -d ../tests/syzygy ]; then
+   curl -sL https://api.github.com/repos/niklasf/python-chess/tarball/9b9aa13f9f36d08aadfabff872882f4ab1494e95 | tar -xzf -
+   mv niklasf-python-chess-9b9aa13 ../tests/syzygy
+fi
+
+cat << EOF > syzygy.exp
+ set timeout 240
+ spawn $exeprefix ./stockfish
+ send "uci\n"
+ send "setoption name SyzygyPath value ../tests/syzygy/\n"
+ send "bench 128 1 10 default depth\n"
+ send "quit\n"
+ expect eof
+
+ # return error code of the spawned program, useful for valgrind
+ lassign [wait] pid spawnid os_error_flag value
+ exit \$value
+EOF
+
+for exp in game.exp syzygy.exp
 do
 
-  echo "$prefix expect $exps $postfix"
-  eval "$prefix expect $exps $postfix"
+  echo "$prefix expect $exp $postfix"
+  eval "$prefix expect $exp $postfix"
 
-  rm $exps
+  rm $exp
 
 done
 

--- a/tests/instrumented.sh
+++ b/tests/instrumented.sh
@@ -119,6 +119,7 @@ cat << EOF > syzygy.exp
  spawn $exeprefix ./stockfish
  send "uci\n"
  send "setoption name SyzygyPath value ../tests/syzygy/\n"
+ expect "info string Found 35 tablebases" {} timeout {exit 1}
  send "bench 128 1 10 default depth\n"
  send "quit\n"
  expect eof


### PR DESCRIPTION
extends valgrind/sanitizer testing to cover syzygy code.

script downloads 4 man syzygy as needed.

Alternative to #1490. Download needs ~2s, relies on the upstream repo remaining available.

possible follow-ups:

 * verify unchanged bench with TB.
 * include more TB sensitive positions in bench.

No functional change.