### PR TITLE
Change passed pawn definition to include unsupported levers

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -151,7 +151,6 @@ namespace {
         // not attacked more times than defended.
         if (   !(stoppers ^ lever ^ leverPush)
             && !(ourPawns & forward_file_bb(Us, s))
-            && popcount(supported) >= popcount(lever)
             && popcount(phalanx)   >= popcount(leverPush))
             e->passedPawns[Us] |= s;
 


### PR DESCRIPTION
We now include unsupported levers in the passed pawns bitboard if otherwise unblocked.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 17052 W: 3519 L: 3390 D: 10143
http://tests.stockfishchess.org/tests/view/5abc9e920ebc5902926cf19b

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 8755 W: 1399 L: 1261 D: 6095
http://tests.stockfishchess.org/tests/view/5abca1960ebc5902926cf1aa

Ideas for future work:
- investigate the scaling of the different types of passed and candidate passed pawns.
- as this is a significant change to the scoring of passed pawns, we could look at retuning the passed pawn weights.

Bench: 5174996
Co-Authored-By: Rocky640 <rocky640@users.noreply.github.com>