### PR TITLE
Candidate Passed Pawn

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -151,7 +151,7 @@ namespace {
         // not attacked more times than defended.
         if (   !(stoppers ^ lever ^ leverPush)
             && !(ourPawns & forward_file_bb(Us, s))
-            && popcount(supported) >= popcount(lever)
+            && popcount(supported) >= popcount(lever) - 1
             && popcount(phalanx)   >= popcount(leverPush))
             e->passedPawns[Us] |= s;
 


### PR DESCRIPTION
Include some not fully supported levers in the (candidate) passed pawns
bitboard, if otherwise unblocked. Maybe levers are usually very short
lived, and some inaccuracy in the lever balance for the definition of
candidate passed pawns just triggers a deeper search.

Here is a example of a case where the patch has an effect on the definition
of candidate passers: White c5/e5 pawns, against Black d6 pawn. Let's say
we want to test if e5 is a candidate passer. The previous master looks
only at files d, e and f (which is already very good) and reject e5 as
a candidate. However, the lever d6 is challenged by 2 pawns, so it should
not fully count. Indirectly, this patch will view such case (and a few more)
to be scored as candidates.

STC
http://tests.stockfishchess.org/tests/view/5abcd55d0ebc5902926cf1e1
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 16492 W: 3419 L: 3198 D: 9875

LTC
http://tests.stockfishchess.org/tests/view/5abce1360ebc5902926cf1e6
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 21156 W: 3201 L: 2990 D: 14965

This was inspired by this test of Jerry Donald Watson, except the case of
zero supporting pawns against two levers is excluded, and it seems that
not excluding that case is bad, while excluding is it beneficial. See the
following tests on fishtest:

https://github.com/official-stockfish/Stockfish/pull/1519
http://tests.stockfishchess.org/tests/view/5abccd850ebc5902926cf1dd
http://tests.stockfishchess.org/tests/view/5abcdd490ebc5902926cf1e4

Closes https://github.com/official-stockfish/Stockfish/pull/1521

Bench: 5568461

----

Comments by Jerry Donald Watson:

> My thinking as to why this works (could be completely wrong but this is how I think of it):
> 
> The evaluation is either called in an interior node or in the qsearch. The calls at the end of the qsearch are the more important as they ultimately determine the scoring of each move, whereas the internal values are mainly used for pruning decisions with a margin. Some strong engines don't even call the eval at all nodes. Now the whole point of the qsearch is to find quiet positions where captures do not change the evaluation of the position with regards to the search bounds - i.e. if there were good captures they would be tried.* So when a candidate lever appears in the evaluation at the end of the qsearch, the qsearch has guaranteed that it cannot just be captured, or if it can, this does not take the score past the search bounds. Practically this may mean that the side with the candidate lever has the turn, or perhaps the stopping lever pawn is pinned, or that side is forced for other reasons to make some other move (e.g. d6 can only take one of the pawns in the example above).
> 
> Hence granting the full score for only one lever defender makes some sense, at least, to me.
> 
> IMO this is also why huge bonuses for possible captures in the evaluation (e.g. threat on queen and our turn), etc. don't tend to work. Such things are best left to the search to figure out.