### PR TITLE
Add Custom uci runtime variables

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -25,7 +25,7 @@
 #include <string>
 
 #include "types.h"
-
+#include "uci.h"
 class Position;
 
 namespace Eval {

--- a/src/misc.h
+++ b/src/misc.h
@@ -28,7 +28,7 @@
 #include <vector>
 
 #include "types.h"
-
+#include "uci.h"
 const std::string engine_info(bool to_uci = false);
 void prefetch(void* addr);
 void prefetch2(void* addr);

--- a/src/position.h
+++ b/src/position.h
@@ -28,7 +28,7 @@
 
 #include "bitboard.h"
 #include "types.h"
-
+#include "uci.h"
 
 /// StateInfo struct stores information needed to restore a Position object to
 /// its previous state when we retract a move. Whenever a move is made on the

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -21,7 +21,7 @@
 #include <algorithm>
 
 #include "types.h"
-
+#include "uci.h"
 Value PieceValue[PHASE_NB][PIECE_NB] = {
   { VALUE_ZERO, PawnValueMg, KnightValueMg, BishopValueMg, RookValueMg, QueenValueMg },
   { VALUE_ZERO, PawnValueEg, KnightValueEg, BishopValueEg, RookValueEg, QueenValueEg }

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,7 +21,7 @@
 #include <algorithm>
 #include <cassert>
 #include <ostream>
-
+#include <climits>
 #include "misc.h"
 #include "search.h"
 #include "thread.h"
@@ -75,6 +75,15 @@ void init(OptionsMap& o) {
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(6, 0, 6);
+  o["A"]              << Option(0, INT_MIN, INT_MAX);
+  o["B"]              << Option(0, INT_MIN, INT_MAX);
+  o["C"]              << Option(0, INT_MIN, INT_MAX);
+  o["D"]              << Option(0, INT_MIN, INT_MAX);
+  o["E"]              << Option(0, INT_MIN, INT_MAX);
+  o["F"]              << Option(0, INT_MIN, INT_MAX);
+  o["G"]              << Option(0, INT_MIN, INT_MAX);
+  o["H"]              << Option(0, INT_MIN, INT_MAX);
+  
 }
 
 


### PR DESCRIPTION
This patch adds 8 int UCI variables that can be used in any code inside Stockfish.
This simplifies the workflow of testing and tuning integer variables locally(instead of compiling statically e.g. `#define` it allows the affected values to be dynamically set at runtime).
UCI variables can be used with build scripts that allow building one stockfish binary to test with thousands of different variables set by e.g. cutechess-cli(option.A=x) or another UCI interface.


No functional change.
 