### PR TITLE
Simplify Singular Extension condition.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -818,6 +818,7 @@ moves_loop: // When in check, search starts from here
     Move countermove = thisThread->counterMoves[pos.piece_on(prevSq)][prevSq];
 
     MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory, &thisThread->captureHistory, contHist, countermove, ss->killers);
+    value = bestValue; // Workaround a bogus 'uninitialized' warning under gcc
 
     skipQuiets = false;
     ttCapture = false;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -521,7 +521,7 @@ namespace {
     Move ttMove, move, excludedMove, bestMove;
     Depth extension, newDepth;
     Value bestValue, value, ttValue, eval, maxValue;
-    bool ttHit, inCheck, givesCheck, singularExtensionNode, improving;
+    bool ttHit, inCheck, givesCheck, improving;
     bool captureOrPromotion, doFullDepthSearch, moveCountPruning, skipQuiets, ttCapture, pvExact;
     Piece movedPiece;
     int moveCount, captureCount, quietCount;
@@ -818,15 +818,7 @@ moves_loop: // When in check, search starts from here
     Move countermove = thisThread->counterMoves[pos.piece_on(prevSq)][prevSq];
 
     MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory, &thisThread->captureHistory, contHist, countermove, ss->killers);
-    value = bestValue; // Workaround a bogus 'uninitialized' warning under gcc
 
-    singularExtensionNode =   !rootNode
-                           &&  depth >= 8 * ONE_PLY
-                           &&  ttMove != MOVE_NONE
-                           &&  ttValue != VALUE_NONE
-                           && !excludedMove // Recursive singular search is not allowed
-                           && (tte->bound() & BOUND_LOWER)
-                           &&  tte->depth() >= depth - 3 * ONE_PLY;
     skipQuiets = false;
     ttCapture = false;
     pvExact = PvNode && ttHit && tte->bound() == BOUND_EXACT;
@@ -871,8 +863,13 @@ moves_loop: // When in check, search starts from here
       // that move is singular and should be extended. To verify this we do a
       // reduced search on on all the other moves but the ttMove and if the
       // result is lower than ttValue minus a margin then we will extend the ttMove.
-      if (    singularExtensionNode
-          &&  move == ttMove
+      if (    move == ttMove
+          && !rootNode
+          && !excludedMove // Recursive singular search is not allowed
+          &&  depth >= 8 * ONE_PLY
+          &&  ttValue != VALUE_NONE
+          && (tte->bound() & BOUND_LOWER)
+          &&  tte->depth() >= depth - 3 * ONE_PLY
           &&  pos.legal(move))
       {
           Value rBeta = std::max(ttValue - 2 * depth / ONE_PLY, -VALUE_MATE);


### PR DESCRIPTION
Avoid defining and hoisting a singly used variable, removes on condition.

passed STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 53489 W: 10814 L: 10752 D: 31923
http://tests.stockfishchess.org/tests/view/5ac08a8d0ebc590e9457cd94

No functional change.