### PR TITLE
Reset negative statScore on fail high - Bench:  5170165

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1085,6 +1085,7 @@ moves_loop: // When in check, search starts from here
               else
               {
                   assert(value >= beta); // Fail high
+                  ss->statScore = std::max(ss->statScore, 0);
                   break;
               }
           }


### PR DESCRIPTION
Reset negative statScore on fail high

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 9073 W: 1937 L: 1766 D: 5370

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 53530 W: 8139 L: 7823 D: 37568

Bench:  5170165