### PR TITLE
fix excluded move key

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -580,7 +580,7 @@ namespace {
     // search to overwrite a previous full search TT value, so we use a different
     // position key in case of an excluded move.
     excludedMove = ss->excludedMove;
-    posKey = pos.key() ^ Key(excludedMove << 16); // Isn't a very good hash
+    posKey = pos.key() ^ (Key(excludedMove) << 16); // Isn't a very good hash
     tte = TT.probe(posKey, ttHit);
     ttValue = ttHit ? value_from_tt(tte->value(), ss->ply) : VALUE_NONE;
     ttMove =  rootNode ? thisThread->rootMoves[thisThread->PVIdx].pv[0]

--- a/src/types.h
+++ b/src/types.h
@@ -115,12 +115,12 @@ constexpr int MAX_PLY   = 128;
 /// any normal move destination square is always different from origin square
 /// while MOVE_NONE and MOVE_NULL have the same origin and destination square.
 
-enum Move : int {
+enum Move : uint32_t {
   MOVE_NONE,
   MOVE_NULL = 65
 };
 
-enum MoveType {
+enum MoveType : uint32_t {
   NORMAL,
   PROMOTION = 1 << 14,
   ENPASSANT = 2 << 14,


### PR DESCRIPTION
The current code first takes the 32 bit int excludedMove, shifts it to the left 16, then sign extends the shifted quantity to 64 bits. This is dumb. Why not just shift the unsigned quantity to the left 16?

EDIT: Maybe I should make it clear that this is a functional change.

EDIT: Let's make it very clear why this is a functional change. When the move type is castling or enpassant, the quantity `move<<16` is negative (if int's are 32 bits, likely) or undefined (if int's are 16 bits, unlikely). Thus, the key passed either has its top 32 bits flipped (likely) or is undefined (unlikely).

Here is proof that an excluded move of type castling or enpassent can affect the search. First of all, my box has 32 bit ints so move<<16 is defined. The command sequence
`position startpos moves h2h3 h7h6 b1c3 e7e5 e2e3 d7d5 d1h5 g7g5 d2d4 e5e4 h5d1 g8f6 b2b3 c8e6 c1b2 b8c6 g1e2 f8d6`
`go depth 18`
will search 3168908 positions in master but 3168899 in the patch.