### PR TITLE
Make ONE_PLY value independent again.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -804,7 +804,7 @@ namespace {
         && !ttMove
         && (PvNode || ss->staticEval + 128 >= beta))
     {
-        Depth d = 3 * depth / 4 - 2 * ONE_PLY;
+        Depth d = (3 * depth / (4 * ONE_PLY) - 2) * ONE_PLY;
         search<NT>(pos, ss, alpha, beta, d, cutNode, true);
 
         tte = TT.probe(posKey, ttHit);
@@ -874,8 +874,9 @@ moves_loop: // When in check, search starts from here
           &&  pos.legal(move))
       {
           Value rBeta = std::max(ttValue - 2 * depth / ONE_PLY, -VALUE_MATE);
+          Depth d = (depth / (2 * ONE_PLY)) * ONE_PLY;
           ss->excludedMove = move;
-          value = search<NonPV>(pos, ss, rBeta - 1, rBeta, depth / 2, cutNode, true);
+          value = search<NonPV>(pos, ss, rBeta - 1, rBeta, d, cutNode, true);
           ss->excludedMove = MOVE_NONE;
 
           if (value < rBeta)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -747,7 +747,7 @@ namespace {
 
             // Do verification search at high depths. Disable null move pruning
             // for side to move for the first part of the remaining search tree.
-            thisThread->nmp_ply = ss->ply + 3 * (depth-R) / 4;
+            thisThread->nmp_ply = ss->ply + 3 * (depth-R) / (4 * ONE_PLY);
             thisThread->nmp_odd = ss->ply % 2;
 
             Value v = search<NonPV>(pos, ss, beta-1, beta, depth-R, false, true);


### PR DESCRIPTION
The two depth calculations in IID and Singular Extension search
were mistakenly changed by a recent commit https://github.com/official-stockfish/Stockfish/commit/4c57cf0ead29536504ca452b876d350a8e2edbdc, firing an assertion now
when ONE_PLY is set to 2.
Revert the changes.

Also fix the calculation of 'nmp_ply' in null-move pruning search,
as suggested by Ronald de Man.

No functional change.