### PR TITLE
Change Value type back to int

### DIFF
--- a/src/endgame.h
+++ b/src/endgame.h
@@ -65,7 +65,7 @@ enum EndgameCode {
 /// Endgame functions can be of two types depending on whether they return a
 /// Value or a ScaleFactor.
 template<EndgameCode E> using
-eg_type = typename std::conditional<(E < SCALING_FUNCTIONS), Value, ScaleFactor>::type;
+eg_type = typename std::conditional<(E < SCALING_FUNCTIONS), int, ScaleFactor>::type;
 
 
 /// Base and derived functors for endgame evaluation and scaling functions
@@ -111,7 +111,7 @@ class Endgames {
     map<T>()[Position().set(code, BLACK, &st).material_key()] = P(new Endgame<E>(BLACK));
   }
 
-  std::pair<Map<Value>, Map<ScaleFactor>> maps;
+  std::pair<Map<int>, Map<ScaleFactor>> maps;
 
 public:
   Endgames();

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -40,7 +40,7 @@ namespace Trace {
 
   Score scores[TERM_NB][COLOR_NB];
 
-  double to_cp(Value v) { return double(v) / PawnValueEg; }
+  double to_cp(int v) { return double(v) / PawnValueEg; }
 
   void add(int idx, Color c, Score s) {
     scores[idx][c] = s;
@@ -85,8 +85,8 @@ namespace {
   };
 
   // Threshold for lazy and space evaluation
-  constexpr Value LazyThreshold  = Value(1500);
-  constexpr Value SpaceThreshold = Value(12222);
+  constexpr int LazyThreshold  = 1500;
+  constexpr int SpaceThreshold = 12222;
 
   // KingAttackWeights[PieceType] contains king attack weights by piece type
   constexpr int KingAttackWeights[PIECE_TYPE_NB] = { 0, 0, 78, 56, 45, 11 };
@@ -192,7 +192,7 @@ namespace {
     Evaluation() = delete;
     explicit Evaluation(const Position& p) : pos(p) {}
     Evaluation& operator=(const Evaluation&) = delete;
-    Value value();
+    int value();
 
   private:
     template<Color Us> void initialize();
@@ -201,8 +201,8 @@ namespace {
     template<Color Us> Score threats() const;
     template<Color Us> Score passed() const;
     template<Color Us> Score space() const;
-    ScaleFactor scale_factor(Value eg) const;
-    Score initiative(Value eg) const;
+    ScaleFactor scale_factor(int eg) const;
+    Score initiative(int eg) const;
 
     const Position& pos;
     Material::Entry* me;
@@ -762,7 +762,7 @@ namespace {
   // known attacking/defending status of the players.
 
   template<Tracing T>
-  Score Evaluation<T>::initiative(Value eg) const {
+  Score Evaluation<T>::initiative(int eg) const {
 
     int outflanking =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
                      - distance<Rank>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
@@ -793,7 +793,7 @@ namespace {
   // Evaluation::scale_factor() computes the scale factor for the winning side
 
   template<Tracing T>
-  ScaleFactor Evaluation<T>::scale_factor(Value eg) const {
+  ScaleFactor Evaluation<T>::scale_factor(int eg) const {
 
     Color strongSide = eg > VALUE_DRAW ? WHITE : BLACK;
     int sf = me->scale_factor(pos, strongSide);
@@ -831,7 +831,7 @@ namespace {
   // of view of the side to move.
 
   template<Tracing T>
-  Value Evaluation<T>::value() {
+  int Evaluation<T>::value() {
 
     assert(!pos.checkers());
 
@@ -853,7 +853,7 @@ namespace {
     score += pe->pawn_score(WHITE) - pe->pawn_score(BLACK);
 
     // Early exit if score is high
-    Value v = (mg_value(score) + eg_value(score)) / 2;
+    int v = (mg_value(score) + eg_value(score)) / 2;
     if (abs(v) > LazyThreshold)
        return pos.side_to_move() == WHITE ? v : -v;
 
@@ -904,7 +904,7 @@ namespace {
 /// evaluate() is the evaluator for the outer world. It returns a static
 /// evaluation of the position from the point of view of the side to move.
 
-Value Eval::evaluate(const Position& pos) {
+int Eval::evaluate(const Position& pos) {
   return Evaluation<NO_TRACE>(pos).value();
 }
 
@@ -919,7 +919,7 @@ std::string Eval::trace(const Position& pos) {
 
   pos.this_thread()->contempt = SCORE_ZERO; // Reset any dynamic contempt
 
-  Value v = Evaluation<TRACE>(pos).value();
+  int v = Evaluation<TRACE>(pos).value();
 
   v = pos.side_to_move() == WHITE ? v : -v; // Trace scores are from white's point of view
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -30,11 +30,11 @@ class Position;
 
 namespace Eval {
 
-constexpr Value Tempo = Value(20); // Must be visible to search
+constexpr int Tempo = 20; // Must be visible to search
 
 std::string trace(const Position& pos);
 
-Value evaluate(const Position& pos);
+int evaluate(const Position& pos);
 }
 
 #endif // #ifndef EVALUATE_H_INCLUDED

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -130,9 +130,9 @@ Entry* probe(const Position& pos) {
   e->key = key;
   e->factor[WHITE] = e->factor[BLACK] = (uint8_t)SCALE_FACTOR_NORMAL;
 
-  Value npm_w = pos.non_pawn_material(WHITE);
-  Value npm_b = pos.non_pawn_material(BLACK);
-  Value npm = std::max(EndgameLimit, std::min(npm_w + npm_b, MidgameLimit));
+  int npm_w = pos.non_pawn_material(WHITE);
+  int npm_b = pos.non_pawn_material(BLACK);
+  int npm = std::max<int>(EndgameLimit, std::min<int>(npm_w + npm_b, MidgameLimit));
 
   // Map total non-pawn material into [PHASE_ENDGAME, PHASE_MIDGAME]
   e->gamePhase = Phase(((npm - EndgameLimit) * PHASE_MIDGAME) / (MidgameLimit - EndgameLimit));
@@ -140,7 +140,7 @@ Entry* probe(const Position& pos) {
   // Let's look if we have a specialized evaluation function for this particular
   // material configuration. Firstly we look for a fixed configuration one, then
   // for a generic one if the previous search failed.
-  if ((e->evaluationFunction = pos.this_thread()->endgames.probe<Value>(key)) != nullptr)
+  if ((e->evaluationFunction = pos.this_thread()->endgames.probe<int>(key)) != nullptr)
       return e;
 
   for (Color c = WHITE; c <= BLACK; ++c)

--- a/src/material.h
+++ b/src/material.h
@@ -42,7 +42,7 @@ struct Entry {
   Score imbalance() const { return make_score(value, value); }
   Phase game_phase() const { return gamePhase; }
   bool specialized_eval_exists() const { return evaluationFunction != nullptr; }
-  Value evaluate(const Position& pos) const { return (*evaluationFunction)(pos); }
+  int evaluate(const Position& pos) const { return (*evaluationFunction)(pos); }
 
   // scale_factor takes a position and a color as input and returns a scale factor
   // for the given color. We have to provide the position in addition to the color
@@ -56,7 +56,7 @@ struct Entry {
   }
 
   Key key;
-  EndgameBase<Value>* evaluationFunction;
+  EndgameBase<int>* evaluationFunction;
   EndgameBase<ScaleFactor>* scalingFunction[COLOR_NB]; // Could be one for each
                                                        // side (e.g. KPKP, KBPsKs)
   int16_t value;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -87,7 +87,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 
 /// MovePicker constructor for ProbCut: we generate captures with SEE greater
 /// than or equal to the given threshold.
-MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePieceToHistory* cph)
+MovePicker::MovePicker(const Position& p, Move ttm, int th, const CapturePieceToHistory* cph)
            : pos(p), captureHistory(cph), threshold(th) {
 
   assert(!pos.checkers());
@@ -123,7 +123,7 @@ void MovePicker::score() {
       {
           if (pos.capture(m))
               m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
-                       - Value(type_of(pos.moved_piece(m)));
+                       - type_of(pos.moved_piece(m));
           else
               m.value = (*mainHistory)[pos.side_to_move()][from_to(m)] - (1 << 28);
       }
@@ -174,7 +174,7 @@ top:
 
   case GOOD_CAPTURE:
       if (select<Best>([&](){
-                       return pos.see_ge(move, Value(-55 * (cur-1)->value / 1024)) ?
+                       return pos.see_ge(move, -55 * (cur-1)->value / 1024) ?
                               // Move losing capture to endBadCaptures to be tried later
                               true : (*endBadCaptures++ = move, false); }))
           return move;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -116,7 +116,7 @@ class MovePicker {
 public:
   MovePicker(const MovePicker&) = delete;
   MovePicker& operator=(const MovePicker&) = delete;
-  MovePicker(const Position&, Move, Value, const CapturePieceToHistory*);
+  MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*,  const CapturePieceToHistory*, Square);
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*, const CapturePieceToHistory*, const PieceToHistory**, Move, Move*);
   Move next_move(bool skipQuiets = false);
@@ -136,7 +136,7 @@ private:
   int stage;
   Move move;
   Square recaptureSquare;
-  Value threshold;
+  int threshold;
   Depth depth;
   ExtMove moves[MAX_MOVES];
 };

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -28,7 +28,6 @@
 
 namespace {
 
-  #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
   // Isolated pawn penalty
@@ -45,45 +44,44 @@ namespace {
 
   // Weakness of our pawn shelter in front of the king by [isKingFile][distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawns or our pawn is behind our king.
-  constexpr Value ShelterWeakness[][int(FILE_NB) / 2][RANK_NB] = {
-    { { V( 98), V(20), V(11), V(42), V( 83), V( 84), V(101) }, // Not On King file
-      { V(103), V( 8), V(33), V(86), V( 87), V(105), V(113) },
-      { V(100), V( 2), V(65), V(95), V( 59), V( 89), V(115) },
-      { V( 72), V( 6), V(52), V(74), V( 83), V( 84), V(112) } },
-    { { V(105), V(19), V( 3), V(27), V( 85), V( 93), V( 84) }, // On King file
-      { V(121), V( 7), V(33), V(95), V(112), V( 86), V( 72) },
-      { V(121), V(26), V(65), V(90), V( 65), V( 76), V(117) },
-      { V( 79), V( 0), V(45), V(65), V( 94), V( 92), V(105) } }
+  constexpr int ShelterWeakness[][int(FILE_NB) / 2][RANK_NB] = {
+    { {  98, 20, 11, 42,  83,  84, 101 }, // Not On King file
+      { 103,  8, 33, 86,  87, 105, 113 },
+      { 100,  2, 65, 95,  59,  89, 115 },
+      {  72,  6, 52, 74,  83,  84, 112 } },
+    { { 105, 19,  3, 27,  85,  93,  84 }, // On King file
+      { 121,  7, 33, 95, 112,  86,  72 },
+      { 121, 26, 65, 90,  65,  76, 117 },
+      {  79,  0, 45, 65,  94,  92, 105 } }
   };
 
   // Danger of enemy pawns moving toward our king by [type][distance from edge][rank].
   // For the unopposed and unblocked cases, RANK_1 = 0 is used when opponent has
   // no pawn on the given file, or their pawn is behind our king.
-  constexpr Value StormDanger[][4][RANK_NB] = {
-    { { V( 0),  V(-290), V(-274), V(57), V(41) },  // BlockedByKing
-      { V( 0),  V(  60), V( 144), V(39), V(13) },
-      { V( 0),  V(  65), V( 141), V(41), V(34) },
-      { V( 0),  V(  53), V( 127), V(56), V(14) } },
-    { { V( 4),  V(  73), V( 132), V(46), V(31) },  // Unopposed
-      { V( 1),  V(  64), V( 143), V(26), V(13) },
-      { V( 1),  V(  47), V( 110), V(44), V(24) },
-      { V( 0),  V(  72), V( 127), V(50), V(31) } },
-    { { V( 0),  V(   0), V(  19), V(23), V( 1) },  // BlockedByPawn
-      { V( 0),  V(   0), V(  88), V(27), V( 2) },
-      { V( 0),  V(   0), V( 101), V(16), V( 1) },
-      { V( 0),  V(   0), V( 111), V(22), V(15) } },
-    { { V(22),  V(  45), V( 104), V(62), V( 6) },  // Unblocked
-      { V(31),  V(  30), V(  99), V(39), V(19) },
-      { V(23),  V(  29), V(  96), V(41), V(15) },
-      { V(21),  V(  23), V( 116), V(41), V(15) } }
+  constexpr int StormDanger[][4][RANK_NB] = {
+    { {  0, -290, -274, 57, 41 },  // BlockedByKing
+      {  0,   60,  144, 39, 13 },
+      {  0,   65,  141, 41, 34 },
+      {  0,   53,  127, 56, 14 } },
+    { {  4,   73,  132, 46, 31 },  // Unopposed
+      {  1,   64,  143, 26, 13 },
+      {  1,   47,  110, 44, 24 },
+      {  0,   72,  127, 50, 31 } },
+    { {  0,    0,   19, 23,  1 },  // BlockedByPawn
+      {  0,    0,   88, 27,  2 },
+      {  0,    0,  101, 16,  1 },
+      {  0,    0,  111, 22, 15 } },
+    { { 22,   45,  104, 62,  6 },  // Unblocked
+      { 31,   30,   99, 39, 19 },
+      { 23,   29,   96, 41, 15 },
+      { 21,   23,  116, 41, 15 } }
   };
 
   // Max bonus for king safety. Corresponds to start position with all the pawns
   // in front of the king and no enemy pawn on the horizon.
-  constexpr Value MaxSafetyBonus = V(258);
+  constexpr int MaxSafetyBonus = 258;
 
   #undef S
-  #undef V
 
   template<Color Us>
   Score evaluate(const Position& pos, Pawns::Entry* e) {
@@ -234,7 +232,7 @@ Entry* probe(const Position& pos) {
 /// the king is on, as well as the two closest files.
 
 template<Color Us>
-Value Entry::shelter_storm(const Position& pos, Square ksq) {
+int Entry::shelter_storm(const Position& pos, Square ksq) {
 
   constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
 
@@ -246,7 +244,7 @@ Value Entry::shelter_storm(const Position& pos, Square ksq) {
                & (adjacent_files_bb(center) | file_bb(center));
   Bitboard ourPawns = b & pos.pieces(Us);
   Bitboard theirPawns = b & pos.pieces(Them);
-  Value safety = MaxSafetyBonus;
+  int safety = MaxSafetyBonus;
 
   for (File f = File(center - 1); f <= File(center + 1); ++f)
   {
@@ -283,7 +281,7 @@ Score Entry::do_king_safety(const Position& pos, Square ksq) {
   if (pawns)
       while (!(DistanceRingBB[ksq][minKingPawnDistance++] & pawns)) {}
 
-  Value bonus = shelter_storm<Us>(pos, ksq);
+  int bonus = shelter_storm<Us>(pos, ksq);
 
   // If we can castle use the bonus after the castling if it is bigger
   if (pos.can_castle(MakeCastling<Us, KING_SIDE>::right))

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -59,7 +59,7 @@ struct Entry {
   Score do_king_safety(const Position& pos, Square ksq);
 
   template<Color Us>
-  Value shelter_storm(const Position& pos, Square ksq);
+  int shelter_storm(const Position& pos, Square ksq);
 
   Key key;
   Score scores[COLOR_NB];

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -994,7 +994,7 @@ Key Position::key_after(Move m) const {
 /// SEE value of move is greater or equal to the given threshold. We'll use an
 /// algorithm similar to alpha-beta pruning with a null window.
 
-bool Position::see_ge(Move m, Value threshold) const {
+bool Position::see_ge(Move m, int threshold) const {
 
   assert(is_ok(m));
 
@@ -1007,7 +1007,7 @@ bool Position::see_ge(Move m, Value threshold) const {
   PieceType nextVictim = type_of(piece_on(from));
   Color us = color_of(piece_on(from));
   Color stm = ~us; // First consider opponent's move
-  Value balance;   // Values of the pieces taken by us minus opponent's ones
+  int balance;   // Values of the pieces taken by us minus opponent's ones
 
   // The opponent may be able to recapture so this is the best result
   // we can hope for.

--- a/src/position.h
+++ b/src/position.h
@@ -39,7 +39,7 @@ struct StateInfo {
   // Copied when making a move
   Key    pawnKey;
   Key    materialKey;
-  Value  nonPawnMaterial[COLOR_NB];
+  int    nonPawnMaterial[COLOR_NB];
   int    castlingRights;
   int    rule50;
   int    pliesFromNull;
@@ -138,7 +138,7 @@ public:
   void undo_null_move();
 
   // Static Exchange Evaluation
-  bool see_ge(Move m, Value threshold = VALUE_ZERO) const;
+  bool see_ge(Move m, int threshold = VALUE_ZERO) const;
 
   // Accessing hash keys
   Key key() const;
@@ -154,8 +154,8 @@ public:
   bool is_draw(int ply) const;
   int rule50_count() const;
   Score psq_score() const;
-  Value non_pawn_material(Color c) const;
-  Value non_pawn_material() const;
+  int non_pawn_material(Color c) const;
+  int non_pawn_material() const;
 
   // Position consistency check, for debugging
   bool pos_is_ok() const;
@@ -328,11 +328,11 @@ inline Score Position::psq_score() const {
   return st->psq;
 }
 
-inline Value Position::non_pawn_material(Color c) const {
+inline int Position::non_pawn_material(Color c) const {
   return st->nonPawnMaterial[c];
 }
 
-inline Value Position::non_pawn_material() const {
+inline int Position::non_pawn_material() const {
   return st->nonPawnMaterial[WHITE] + st->nonPawnMaterial[BLACK];
 }
 

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-Value PieceValue[PHASE_NB][PIECE_NB] = {
+int PieceValue[PHASE_NB][PIECE_NB] = {
   { VALUE_ZERO, PawnValueMg, KnightValueMg, BishopValueMg, RookValueMg, QueenValueMg },
   { VALUE_ZERO, PawnValueEg, KnightValueEg, BishopValueEg, RookValueEg, QueenValueEg }
 };

--- a/src/search.h
+++ b/src/search.h
@@ -46,7 +46,7 @@ struct Stack {
   Move currentMove;
   Move excludedMove;
   Move killers[2];
-  Value staticEval;
+  int staticEval;
   int statScore;
   int moveCount;
 };
@@ -66,8 +66,8 @@ struct RootMove {
                             : m.previousScore < previousScore;
   }
 
-  Value score = -VALUE_INFINITE;
-  Value previousScore = -VALUE_INFINITE;
+  int score = -VALUE_INFINITE;
+  int previousScore = -VALUE_INFINITE;
   int selDepth = 0;
   std::vector<Move> pv;
 };

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -210,7 +210,7 @@ int MapKK[10][SQUARE_NB]; // [MapA1D1D4][SQUARE_NB]
 bool pawns_comp(Square i, Square j) { return MapPawns[i] < MapPawns[j]; }
 int off_A1H8(Square sq) { return int(rank_of(sq)) - file_of(sq); }
 
-constexpr Value WDL_to_value[] = {
+constexpr int WDL_to_value[] = {
    -VALUE_MATE + MAX_PLY + 1,
     VALUE_DRAW - 2,
     VALUE_DRAW,
@@ -1442,7 +1442,7 @@ static int has_repeated(StateInfo *st)
 //
 // A return value false indicates that not all probes were successful and that
 // no moves were filtered out.
-bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves, Value& score)
+bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves, int& score)
 {
     assert(rootMoves.size());
 
@@ -1486,7 +1486,7 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves, Value& 
         if (result == FAIL)
             return false;
 
-        rootMoves[i].score = (Value)v;
+        rootMoves[i].score = v;
     }
 
     // Obtain 50-move counter for the root position.
@@ -1509,9 +1509,9 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves, Value& 
     // score to show how close it is to winning or losing.
     // NOTE: int(PawnValueEg) is used as scaling factor in score_to_uci().
     if (wdl == WDLCursedWin && dtz <= 100)
-        score = (Value)(((200 - dtz - cnt50) * int(PawnValueEg)) / 200);
+        score = (((200 - dtz - cnt50) * PawnValueEg) / 200);
     else if (wdl == WDLBlessedLoss && dtz >= -100)
-        score = -(Value)(((200 + dtz - cnt50) * int(PawnValueEg)) / 200);
+        score = -(((200 + dtz - cnt50) * PawnValueEg) / 200);
 
     // Now be a bit smart about filtering out moves.
     size_t j = 0;
@@ -1575,7 +1575,7 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves, Value& 
 //
 // A return value false indicates that not all probes were successful and that
 // no moves were filtered out.
-bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, Value& score)
+bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, int& score)
 {
     ProbeState result;
 
@@ -1600,7 +1600,7 @@ bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, Val
         if (result == FAIL)
             return false;
 
-        rootMoves[i].score = (Value)v;
+        rootMoves[i].score = v;
 
         if (v > best)
             best = v;

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -49,8 +49,8 @@ extern int MaxCardinality;
 void init(const std::string& paths);
 WDLScore probe_wdl(Position& pos, ProbeState* result);
 int probe_dtz(Position& pos, ProbeState* result);
-bool root_probe(Position& pos, Search::RootMoves& rootMoves, Value& score);
-bool root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, Value& score);
+bool root_probe(Position& pos, Search::RootMoves& rootMoves, int& score);
+bool root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, int& score);
 void filter_root_moves(Position& pos, Search::RootMoves& rootMoves);
 
 inline std::ostream& operator<<(std::ostream& os, const WDLScore v) {

--- a/src/thread.h
+++ b/src/thread.h
@@ -86,7 +86,7 @@ struct MainThread : public Thread {
 
   bool failedLow;
   double bestMoveChanges, previousTimeReduction;
-  Value previousScore;
+  int previousScore;
   int callsCnt;
 };
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -37,12 +37,12 @@
 struct TTEntry {
 
   Move  move()  const { return (Move )move16; }
-  Value value() const { return (Value)value16; }
-  Value eval()  const { return (Value)eval16; }
+  int   value() const { return value16; }
+  int   eval()  const { return eval16; }
   Depth depth() const { return (Depth)(depth8 * int(ONE_PLY)); }
   Bound bound() const { return (Bound)(genBound8 & 0x3); }
 
-  void save(Key k, Value v, Bound b, Depth d, Move m, Value ev, uint8_t g) {
+  void save(Key k, int v, Bound b, Depth d, Move m, int ev, uint8_t g) {
 
     assert(d / ONE_PLY * ONE_PLY == d);
 

--- a/src/types.h
+++ b/src/types.h
@@ -172,7 +172,7 @@ enum Bound {
   BOUND_EXACT = BOUND_UPPER | BOUND_LOWER
 };
 
-enum Value : int {
+constexpr int
   VALUE_ZERO      = 0,
   VALUE_DRAW      = 0,
   VALUE_KNOWN_WIN = 10000,
@@ -189,8 +189,7 @@ enum Value : int {
   RookValueMg   = 1282,  RookValueEg   = 1373,
   QueenValueMg  = 2500,  QueenValueEg  = 2670,
 
-  MidgameLimit  = 15258, EndgameLimit  = 3915
-};
+  MidgameLimit  = 15258, EndgameLimit  = 3915;
 
 enum PieceType {
   NO_PIECE_TYPE, PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING,
@@ -205,7 +204,7 @@ enum Piece {
   PIECE_NB = 16
 };
 
-extern Value PieceValue[PHASE_NB][PIECE_NB];
+extern int PieceValue[PHASE_NB][PIECE_NB];
 
 enum Depth : int {
 
@@ -270,14 +269,14 @@ constexpr Score make_score(int mg, int eg) {
 /// Extracting the signed lower and upper 16 bits is not so trivial because
 /// according to the standard a simple cast to short is implementation defined
 /// and so is a right shift of a signed integer.
-inline Value eg_value(Score s) {
+inline int eg_value(Score s) {
   union { uint16_t u; int16_t s; } eg = { uint16_t(unsigned(s + 0x8000) >> 16) };
-  return Value(eg.s);
+  return eg.s;
 }
 
-inline Value mg_value(Score s) {
+inline int mg_value(Score s) {
   union { uint16_t u; int16_t s; } mg = { uint16_t(unsigned(s)) };
-  return Value(mg.s);
+  return mg.s;
 }
 
 #define ENABLE_BASE_OPERATORS_ON(T)                                \
@@ -301,7 +300,6 @@ constexpr int operator/(T d1, T d2) { return int(d1) / int(d2); }  \
 inline T& operator*=(T& d, int i) { return d = T(int(d) * i); }    \
 inline T& operator/=(T& d, int i) { return d = T(int(d) / i); }
 
-ENABLE_FULL_OPERATORS_ON(Value)
 ENABLE_FULL_OPERATORS_ON(Depth)
 ENABLE_FULL_OPERATORS_ON(Direction)
 
@@ -317,12 +315,6 @@ ENABLE_BASE_OPERATORS_ON(Score)
 #undef ENABLE_FULL_OPERATORS_ON
 #undef ENABLE_INCR_OPERATORS_ON
 #undef ENABLE_BASE_OPERATORS_ON
-
-/// Additional operators to add integers to a Value
-constexpr Value operator+(Value v, int i) { return Value(int(v) + i); }
-constexpr Value operator-(Value v, int i) { return Value(int(v) - i); }
-inline Value& operator+=(Value& v, int i) { return v = v + i; }
-inline Value& operator-=(Value& v, int i) { return v = v - i; }
 
 /// Additional operators to add a Direction to a Square
 inline Square operator+(Square s, Direction d) { return Square(int(s) + int(d)); }
@@ -371,11 +363,11 @@ constexpr CastlingRight operator|(Color c, CastlingSide s) {
   return CastlingRight(WHITE_OO << ((s == QUEEN_SIDE) + 2 * c));
 }
 
-constexpr Value mate_in(int ply) {
+constexpr int mate_in(int ply) {
   return VALUE_MATE - ply;
 }
 
-constexpr Value mated_in(int ply) {
+constexpr int mated_in(int ply) {
   return -VALUE_MATE + ply;
 }
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -250,7 +250,7 @@ void UCI::loop(int argc, char* argv[]) {
 /// mate <y>  Mate in y moves, not plies. If the engine is getting mated
 ///           use negative values for y.
 
-string UCI::value(Value v) {
+string UCI::value(int v) {
 
   assert(-VALUE_INFINITE < v && v < VALUE_INFINITE);
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -67,10 +67,10 @@ private:
 
 void init(OptionsMap&);
 void loop(int argc, char* argv[]);
-std::string value(Value v);
+std::string value(int v);
 std::string square(Square s);
 std::string move(Move m, bool chess960);
-std::string pv(const Position& pos, Depth depth, Value alpha, Value beta);
+std::string pv(const Position& pos, Depth depth, int alpha, int beta);
 Move to_move(const Position& pos, std::string& str);
 
 } // namespace UCI


### PR DESCRIPTION
I'm not sure this enumeration/type does very much.  It's probably supposed to be self-documenting, but is a "value" any more clear than an int?  Also, any clarity lost can easily be fixed with an appropriate variable name.  This is a non-functional simplification.

Changing back to int, removes LOTS of preprocessor directives and type casts as well as special operators to add ints to Values (which is kind of annoying).  Removes about 10 lines of code and lots of noisy code in between.

On my machine, this is 1.5% faster as well (+17k nps).

Bench 5351765