### PR TITLE
Move PawnlessFlanks from Evaluation to Pawns.

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -60,6 +60,17 @@ constexpr Bitboard Rank6BB = Rank1BB << (8 * 5);
 constexpr Bitboard Rank7BB = Rank1BB << (8 * 6);
 constexpr Bitboard Rank8BB = Rank1BB << (8 * 7);
 
+constexpr Bitboard QueenSide   = FileABB | FileBBB | FileCBB | FileDBB;
+constexpr Bitboard CenterFiles = FileCBB | FileDBB | FileEBB | FileFBB;
+constexpr Bitboard KingSide    = FileEBB | FileFBB | FileGBB | FileHBB;
+constexpr Bitboard Center      = (FileDBB | FileEBB) & (Rank4BB | Rank5BB);
+
+constexpr Bitboard KingFlank[FILE_NB] = {
+  QueenSide,   QueenSide, QueenSide,
+  CenterFiles, CenterFiles,
+  KingSide,    KingSide,  KingSide
+};
+
 extern int SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -172,7 +172,7 @@ namespace {
   constexpr Score LongDiagonalBishop = S( 22,  0);
   constexpr Score MinorBehindPawn    = S( 16,  0);
   constexpr Score Overload           = S( 10,  5);
-  constexpr Score PawnlessFlank      = S( 20, 80);
+  constexpr Score PawnlessFlank      = S( 20,  0);
   constexpr Score RookOnPawn         = S(  8, 24);
   constexpr Score SliderOnQueen      = S( 42, 21);
   constexpr Score ThreatByPawnPush   = S( 47, 26);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -73,17 +73,6 @@ using namespace Trace;
 
 namespace {
 
-  constexpr Bitboard QueenSide   = FileABB | FileBBB | FileCBB | FileDBB;
-  constexpr Bitboard CenterFiles = FileCBB | FileDBB | FileEBB | FileFBB;
-  constexpr Bitboard KingSide    = FileEBB | FileFBB | FileGBB | FileHBB;
-  constexpr Bitboard Center      = (FileDBB | FileEBB) & (Rank4BB | Rank5BB);
-
-  constexpr Bitboard KingFlank[FILE_NB] = {
-    QueenSide,   QueenSide, QueenSide,
-    CenterFiles, CenterFiles,
-    KingSide,    KingSide,  KingSide
-  };
-
   // Threshold for lazy and space evaluation
   constexpr Value LazyThreshold  = Value(1500);
   constexpr Value SpaceThreshold = Value(12222);
@@ -172,7 +161,6 @@ namespace {
   constexpr Score LongDiagonalBishop = S( 22,  0);
   constexpr Score MinorBehindPawn    = S( 16,  0);
   constexpr Score Overload           = S( 10,  5);
-  constexpr Score PawnlessFlank      = S( 20,  0);
   constexpr Score RookOnPawn         = S(  8, 24);
   constexpr Score SliderOnQueen      = S( 42, 21);
   constexpr Score ThreatByPawnPush   = S( 47, 26);
@@ -488,14 +476,9 @@ namespace {
         }
     }
 
-    Bitboard kf = KingFlank[file_of(ksq)];
-
-    // Penalty when our king is on a pawnless flank
-    if (!(pos.pieces(PAWN) & kf))
-        score -= PawnlessFlank;
-
     // Find the squares that opponent attacks in our king flank, and the squares
     // which are attacked twice in that flank but not defended by our pawns.
+    Bitboard kf = KingFlank[file_of(ksq)];
     b1 = attackedBy[Them][ALL_PIECES] & kf & Camp;
     b2 = b1 & attackedBy2[Them] & ~attackedBy[Us][PAWN];
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -31,19 +31,13 @@ namespace {
   #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
-  constexpr Score PawnlessFlank  = S(  6, 80);
-
-  // Isolated pawn penalty
+  constexpr Score PawnlessFlank  = S(  23, 86); //king on a pawnless flank
   constexpr Score Isolated = S(13, 18);
-
-  // Backward pawn penalty
   constexpr Score Backward = S(24, 12);
+  constexpr Score Doubled = S(18, 38);
 
   // Connected pawn bonus by opposed, phalanx, #support and rank
   Score Connected[2][2][3][RANK_NB];
-
-  // Doubled pawn penalty
-  constexpr Score Doubled = S(18, 38);
 
   // Weakness of our pawn shelter in front of the king by [isKingFile][distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawns or our pawn is behind our king.
@@ -59,8 +53,7 @@ namespace {
   };
 
   // Danger of enemy pawns moving toward our king by [type][distance from edge][rank].
-  // For the unopposed and unblocked cases, RANK_1 = 0 is used when opponent has
-  // no pawn on the given file, or their pawn is behind our king.
+  // RANK_1 = opponent has no pawn on the given file, or their pawn is behind our king.
   constexpr Value StormDanger[][4][RANK_NB] = {
     { { V( 0),  V(-290), V(-274), V(57), V(41) },  // BlockedByKing
       { V( 0),  V(  60), V( 144), V(39), V(13) },
@@ -93,12 +86,12 @@ namespace {
     constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
     constexpr Direction Up   = (Us == WHITE ? NORTH : SOUTH);
 
-    Bitboard b, neighbours, stoppers, doubled, supported, phalanx;
-    Bitboard lever, leverPush;
     Square s;
     bool opposed, backward;
     Score score = SCORE_ZERO;
     const Square* pl = pos.squares<PAWN>(Us);
+    Bitboard b, neighbours, stoppers, doubled, supported, phalanx;
+    Bitboard lever, leverPush;
 
     Bitboard ourPawns   = pos.pieces(  Us, PAWN);
     Bitboard theirPawns = pos.pieces(Them, PAWN);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -31,7 +31,7 @@ namespace {
   #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
-  constexpr Score PawnlessFlank  = S(  20, 80); //king on a pawnless flank
+  constexpr Score PawnlessFlank  = S( 24, 80); //king on a pawnless flank
   constexpr Score Isolated = S(13, 18);
   constexpr Score Backward = S(24, 12);
   constexpr Score Doubled = S(18, 38);
@@ -290,8 +290,7 @@ Score Entry::do_king_safety(const Position& pos, Square ksq) {
   Score score = make_score(bonus, -16 * minKingPawnDistance);
 
   // Penalty when our king is on a pawnless flank
-  Bitboard kf = KingFlank[file_of(ksq)];
-  if (!(pos.pieces(PAWN) & kf))
+  if (!(pos.pieces(PAWN) & KingFlank[file_of(ksq)]))
       score -= PawnlessFlank;
 
   return score;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -31,7 +31,7 @@ namespace {
   #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
-  constexpr Score PawnlessFlank  = S( 30, 80); //king on a pawnless flank
+  constexpr Score PawnlessFlank  = S( 21, 90); //king on a pawnless flank
   constexpr Score Isolated = S(13, 18);
   constexpr Score Backward = S(24, 12);
   constexpr Score Doubled = S(18, 38);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -31,7 +31,7 @@ namespace {
   #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
-  constexpr Score PawnlessFlank  = S(  23, 86); //king on a pawnless flank
+  constexpr Score PawnlessFlank  = S(  22, 84); //king on a pawnless flank
   constexpr Score Isolated = S(13, 18);
   constexpr Score Backward = S(24, 12);
   constexpr Score Doubled = S(18, 38);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -31,7 +31,7 @@ namespace {
   #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
-  constexpr Score PawnlessFlank  = S( 18, 80);
+  constexpr Score PawnlessFlank  = S(  6, 80);
 
   // Isolated pawn penalty
   constexpr Score Isolated = S(13, 18);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -31,7 +31,7 @@ namespace {
   #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
-  constexpr Score PawnlessFlank  = S( 12, 80); //king on a pawnless flank
+  constexpr Score PawnlessFlank  = S( 19, 76); //king on a pawnless flank
   constexpr Score Isolated = S(13, 18);
   constexpr Score Backward = S(24, 12);
   constexpr Score Doubled = S(18, 38);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -31,6 +31,17 @@ namespace {
   #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
+  constexpr Bitboard QueenSide   = FileABB | FileBBB | FileCBB | FileDBB;
+  constexpr Bitboard CenterFiles = FileCBB | FileDBB | FileEBB | FileFBB;
+  constexpr Bitboard KingSide    = FileEBB | FileFBB | FileGBB | FileHBB;
+  constexpr Bitboard Center      = (FileDBB | FileEBB) & (Rank4BB | Rank5BB);
+  constexpr Bitboard KingFlank[FILE_NB] = {
+    QueenSide,   QueenSide, QueenSide,
+    CenterFiles, CenterFiles,
+    KingSide,    KingSide,  KingSide
+  };
+  constexpr Score PawnlessFlank  = S( 0, 80);
+
   // Isolated pawn penalty
   constexpr Score Isolated = S(13, 18);
 
@@ -291,6 +302,11 @@ Score Entry::do_king_safety(const Position& pos, Square ksq) {
 
   if (pos.can_castle(MakeCastling<Us, QUEEN_SIDE>::right))
       bonus = std::max(bonus, shelter_storm<Us>(pos, relative_square(Us, SQ_C1)));
+
+  // Penalty when our king is on a pawnless flank
+  Bitboard kf = KingFlank[file_of(ksq)];
+  if (!(pos.pieces(PAWN) & kf))
+      bonus -= PawnlessFlank;
 
   return make_score(bonus, -16 * minKingPawnDistance);
 }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -31,7 +31,7 @@ namespace {
   #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
-  constexpr Score PawnlessFlank  = S( 21, 90); //king on a pawnless flank
+  constexpr Score PawnlessFlank  = S( 17, 80); //king on a pawnless flank
   constexpr Score Isolated = S(13, 18);
   constexpr Score Backward = S(24, 12);
   constexpr Score Doubled = S(18, 38);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -31,7 +31,7 @@ namespace {
   #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
-  constexpr Score PawnlessFlank  = S( 17, 80); //king on a pawnless flank
+  constexpr Score PawnlessFlank  = S( 12, 80); //king on a pawnless flank
   constexpr Score Isolated = S(13, 18);
   constexpr Score Backward = S(24, 12);
   constexpr Score Doubled = S(18, 38);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -31,7 +31,7 @@ namespace {
   #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
-  constexpr Score PawnlessFlank  = S( 24, 80); //king on a pawnless flank
+  constexpr Score PawnlessFlank  = S( 30, 80); //king on a pawnless flank
   constexpr Score Isolated = S(13, 18);
   constexpr Score Backward = S(24, 12);
   constexpr Score Doubled = S(18, 38);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -292,7 +292,7 @@ Score Entry::do_king_safety(const Position& pos, Square ksq) {
   // Penalty when our king is on a pawnless flank
   Bitboard kf = KingFlank[file_of(ksq)];
   if (!(pos.pieces(PAWN) & kf))
-      bonus -= PawnlessFlank;
+      score -= PawnlessFlank;
 
   return score;
 }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -31,7 +31,7 @@ namespace {
   #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
-  constexpr Score PawnlessFlank  = S( 22, 80);
+  constexpr Score PawnlessFlank  = S( 18, 80);
 
   // Isolated pawn penalty
   constexpr Score Isolated = S(13, 18);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -287,12 +287,14 @@ Score Entry::do_king_safety(const Position& pos, Square ksq) {
   if (pos.can_castle(MakeCastling<Us, QUEEN_SIDE>::right))
       bonus = std::max(bonus, shelter_storm<Us>(pos, relative_square(Us, SQ_C1)));
 
+  Score score = make_score(bonus, -16 * minKingPawnDistance);
+
   // Penalty when our king is on a pawnless flank
   Bitboard kf = KingFlank[file_of(ksq)];
   if (!(pos.pieces(PAWN) & kf))
       bonus -= PawnlessFlank;
 
-  return make_score(bonus, -16 * minKingPawnDistance);
+  return score;
 }
 
 // Explicit template instantiation

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -31,16 +31,7 @@ namespace {
   #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
-  constexpr Bitboard QueenSide   = FileABB | FileBBB | FileCBB | FileDBB;
-  constexpr Bitboard CenterFiles = FileCBB | FileDBB | FileEBB | FileFBB;
-  constexpr Bitboard KingSide    = FileEBB | FileFBB | FileGBB | FileHBB;
-  constexpr Bitboard Center      = (FileDBB | FileEBB) & (Rank4BB | Rank5BB);
-  constexpr Bitboard KingFlank[FILE_NB] = {
-    QueenSide,   QueenSide, QueenSide,
-    CenterFiles, CenterFiles,
-    KingSide,    KingSide,  KingSide
-  };
-  constexpr Score PawnlessFlank  = S( 0, 80);
+  constexpr Score PawnlessFlank  = S( 22, 80);
 
   // Isolated pawn penalty
   constexpr Score Isolated = S(13, 18);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -31,7 +31,7 @@ namespace {
   #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
-  constexpr Score PawnlessFlank  = S(  22, 84); //king on a pawnless flank
+  constexpr Score PawnlessFlank  = S(  20, 80); //king on a pawnless flank
   constexpr Score Isolated = S(13, 18);
   constexpr Score Backward = S(24, 12);
   constexpr Score Doubled = S(18, 38);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -31,7 +31,7 @@ namespace {
   #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
-  constexpr Score PawnlessFlank  = S( 19, 76); //king on a pawnless flank
+  constexpr Score PawnlessFlank  = S( 15, 76); //king on a pawnless flank
   constexpr Score Isolated = S(13, 18);
   constexpr Score Backward = S(24, 12);
   constexpr Score Doubled = S(18, 38);


### PR DESCRIPTION
This is not a classical simplification.  It does not reduce the code, but reduces the instructions performed during execution.  On my count in bench, PawnlessFlank is applied about 5 million times in evaluate.cpp, but is only applied 1.5 million times in pawns. The bench is not the same because PawnlessFlanks is now part of the KingDanger metric (which is probably where it should be as well).  Hence, the slightly adjusted score.

It unwinds some convoluted math and moves PawnlessFlank to pawns where it belongs, because it only depends on pawns and king.  See locutus2's comment below which is very articulate.

STC: 
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 55340 W: 11151 L: 11093 D: 33096
http://tests.stockfishchess.org/tests/view/5ad18d120ebc594bca9c0a06

LTC: 
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 28990 W: 4342 L: 4233 D: 20415
http://tests.stockfishchess.org/tests/view/5ad1975a0ebc594bca9c0a0a

Bench: 4708980