### PR TITLE
verify ONE_PLY invariance in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ script:
   # Verify bench number against various builds
   - export CXXFLAGS=-Werror
   - make clean && make -j2 ARCH=x86-64 optimize=no debug=yes build && ../tests/signature.sh $benchref
+  - make clean && CXXFLAGS=-DONE_PLY_VALUE=2 make -j2 ARCH=x86-64 optimize=no debug=yes build && ../tests/signature.sh $benchref
   - make clean && make -j2 ARCH=x86-32 optimize=no debug=yes build && ../tests/signature.sh $benchref
   - make clean && make -j2 ARCH=x86-32 build && ../tests/signature.sh $benchref
   - make clean && make -j2 ARCH=x86-64 build && ../tests/signature.sh $benchref

--- a/src/types.h
+++ b/src/types.h
@@ -208,8 +208,12 @@ enum Piece {
 extern Value PieceValue[PHASE_NB][PIECE_NB];
 
 enum Depth : int {
-
-  ONE_PLY = 1,
+// ONE_PLY_VALUE can be defined externally,
+// which is currently used in travis CI to check bench invariance.
+#if !defined(ONE_PLY_VALUE)
+#define ONE_PLY_VALUE 1
+#endif
+  ONE_PLY = ONE_PLY_VALUE,
 
   DEPTH_ZERO          =  0 * ONE_PLY,
   DEPTH_QS_CHECKS     =  0 * ONE_PLY,


### PR DESCRIPTION
To avoid recurring errors verify that bench is invariant under the value of ONE_PLY.

Adds ~30s to CI testing (one compile and a bench).

Should fail CI until #1543 is merged.

No functional change.