### PR TITLE
Simplify BlockedByKing in pawn storms

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -237,7 +237,7 @@ template<Color Us>
 Value Entry::shelter_storm(const Position& pos, Square ksq) {
 
   constexpr Color Them   = (Us == WHITE ? BLACK : WHITE);
-  constexpr Direction Up = (Us == WHITE ? NORTH : SOUTH);
+  constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
 
   enum { BlockedByKing, Unopposed, BlockedByPawn, Unblocked };
 
@@ -260,9 +260,9 @@ Value Entry::shelter_storm(const Position& pos, Square ksq) {
       int d = std::min(f, ~f);
       safety -=  ShelterWeakness[f == file_of(ksq)][d][rkUs]
                + StormDanger
-                 [b && (ksq == (frontmost_sq(Them,b) - Up)) ? BlockedByKing  :
-                  rkUs   == RANK_1                          ? Unopposed :
-                  rkThem == rkUs + 1                        ? BlockedByPawn  : Unblocked]
+                 [(shift<Down>(b) & ksq) ? BlockedByKing  :
+                  rkUs   == RANK_1       ? Unopposed :
+                  rkThem == rkUs + 1     ? BlockedByPawn  : Unblocked]
                  [d][rkThem];
   }
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -236,7 +236,7 @@ Entry* probe(const Position& pos) {
 template<Color Us>
 Value Entry::shelter_storm(const Position& pos, Square ksq) {
 
-  constexpr Color Them   = (Us == WHITE ? BLACK : WHITE);
+  constexpr Color   Them   = (Us == WHITE ? BLACK : WHITE);
   constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
 
   enum { BlockedByKing, Unopposed, BlockedByPawn, Unblocked };
@@ -260,9 +260,9 @@ Value Entry::shelter_storm(const Position& pos, Square ksq) {
       int d = std::min(f, ~f);
       safety -=  ShelterWeakness[f == file_of(ksq)][d][rkUs]
                + StormDanger
-                 [(shift<Down>(b) & ksq) ? BlockedByKing  :
-                  rkUs   == RANK_1       ? Unopposed :
-                  rkThem == rkUs + 1     ? BlockedByPawn  : Unblocked]
+                 [(shift<Down>(b) & ksq) ? BlockedByKing :
+                      rkUs   == RANK_1   ? Unopposed     :
+                      rkThem == rkUs + 1 ? BlockedByPawn : Unblocked]
                  [d][rkThem];
   }
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -260,9 +260,9 @@ Value Entry::shelter_storm(const Position& pos, Square ksq) {
       int d = std::min(f, ~f);
       safety -=  ShelterWeakness[f == file_of(ksq)][d][rkUs]
                + StormDanger
-                 [ksq    == (frontmost_sq(Them,b) - Up) ? BlockedByKing  :
-                  rkUs   == RANK_1                      ? Unopposed :
-                  rkThem == rkUs + 1                    ? BlockedByPawn  : Unblocked]
+                 [b && (ksq == (frontmost_sq(Them,b) - Up)) ? BlockedByKing  :
+                  rkUs   == RANK_1                          ? Unopposed :
+                  rkThem == rkUs + 1                        ? BlockedByPawn  : Unblocked]
                  [d][rkThem];
   }
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -236,7 +236,8 @@ Entry* probe(const Position& pos) {
 template<Color Us>
 Value Entry::shelter_storm(const Position& pos, Square ksq) {
 
-  constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
+  constexpr Color Them   = (Us == WHITE ? BLACK : WHITE);
+  constexpr Direction Up = (Us == WHITE ? NORTH : SOUTH);
 
   enum { BlockedByKing, Unopposed, BlockedByPawn, Unblocked };
 
@@ -259,9 +260,9 @@ Value Entry::shelter_storm(const Position& pos, Square ksq) {
       int d = std::min(f, ~f);
       safety -=  ShelterWeakness[f == file_of(ksq)][d][rkUs]
                + StormDanger
-                 [f == file_of(ksq) && rkThem == relative_rank(Us, ksq) + 1 ? BlockedByKing  :
-                  rkUs   == RANK_1                                          ? Unopposed :
-                  rkThem == rkUs + 1                                        ? BlockedByPawn  : Unblocked]
+                 [ksq    == (frontmost_sq(Them,b) - Up) ? BlockedByKing  :
+                  rkUs   == RANK_1                      ? Unopposed :
+                  rkThem == rkUs + 1                    ? BlockedByPawn  : Unblocked]
                  [d][rkThem];
   }
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -236,7 +236,7 @@ Entry* probe(const Position& pos) {
 template<Color Us>
 Value Entry::shelter_storm(const Position& pos, Square ksq) {
 
-  constexpr Color   Them   = (Us == WHITE ? BLACK : WHITE);
+  constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
   constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
 
   enum { BlockedByKing, Unopposed, BlockedByPawn, Unblocked };


### PR DESCRIPTION
(updated comment from updates)
This patch is non-functional.  Current master does four operations to determine whether an enemy pawn on this file is blocked by the king or not.   (f == file_of(ksq) && rkThem == relative_rank(Us, ksq) + 1 )

By adding a direction (based on the template color), this is reduced to one operation.  This works because b is limited to enemy pawns that are ahead of the king and on the current file.
shift\<Down\>(b) & ksq  

I've added a line of code, but the number of executing instructions is reduced (I think).  I'm not sure if this counts as a simplification, but it should theoretically be a little faster (barely).  The code line length is also reduced making it a little easier to read.

Bench: 5351765