### PR TITLE
Use std::atan (::atan is double-only)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -361,7 +361,7 @@ void Thread::search() {
               ct =  Options["Contempt"] * PawnValueEg / 100; // From centipawns
 
               // Adjust contempt based on root move's previousScore (dynamic contempt)
-              ct += int(std::round(48 * atan(float(previousScore) / 128)));
+              ct += int(std::round(48 * std::atan(float(previousScore) / 128)));
 
               contempt = (us == WHITE ?  make_score(ct, ct / 2)
                                       : -make_score(ct, ct / 2));


### PR DESCRIPTION
`::atan` is the C version of the `atan` function and is not overloaded (it only works with doubles, `::atanf` is for floats). Therefore the current code first casts the score to `float`, divides it by `128.0F`, then converts it to `double` and the rest of the computation is done with double precision. The cast to `float` indicates that this was not the intended behavior (and it is also a waste).

This patch switches to`std::atan`, which is the C++ version of this function and has overloads for both `float` and `double` and thus behaves as expected.

This seems to be a non-functional change (bench stays the same), although the resulting values might be slightly different in some corner case.

[Compiler Explorer link (for assembly output difference)](https://godbolt.org/g/Ka7q2S)