### PR TITLE
Do !rkUs instead of (rkUs == RANK_1)

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -259,7 +259,7 @@ Value Entry::shelter_storm(const Position& pos, Square ksq) {
       safety -=  ShelterWeakness[f == file_of(ksq)][d][rkUs]
                + StormDanger
                  [(shift<Down>(b) & ksq) ? BlockedByKing :
-                  rkUs   == RANK_1       ? Unopposed     :
+                  !rkUs                  ? Unopposed     :
                   rkThem == (rkUs + 1)   ? BlockedByPawn : Unblocked]
                  [d][rkThem];
   }


### PR DESCRIPTION
Non-functional simplification.  This is pretty insignificant, but it IS something.

!rkUs is one instructions less than (rkUs == RANK_1)

perf tool on my linux box: 11,066,809,101 cycles down to 10,806,912,804.

Bench: 5351765