### PR TITLE
Alternative forumla for dynamic contempt

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -379,7 +379,7 @@ void Thread::search() {
               beta  = std::min(previousScore + delta, VALUE_INFINITE);
 
               // Adjust contempt based on root move's previousScore (dynamic contempt)
-              int dct = ct + int(std::round(48 * atan(float(previousScore) / 128)));
+              int dct = ct + 88 * previousScore / (std::abs(previousScore) + 200);
 
               contempt = (us == WHITE ?  make_score(dct, dct / 2)
                                       : -make_score(dct, dct / 2));


### PR DESCRIPTION
Replace the forumla involving arctan with something having similar
behaviour that can be implemented using integer-only operations.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 34781 W: 7189 L: 7093 D: 20499
http://tests.stockfishchess.org/tests/view/5ad7c95f0ebc595700526e76

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 39743 W: 5950 L: 5857 D: 27936
http://tests.stockfishchess.org/tests/view/5ad886ee0ebc595700526e9b

Bench: 5236139