### PR TITLE
Add support to the 'tune" branch for tuning doubles

### DIFF
--- a/src/tune.h
+++ b/src/tune.h
@@ -26,17 +26,17 @@
 #include <vector>
 
 typedef std::pair<int, int> Range; // Option's min-max values
-typedef Range (RangeFun) (int);
+typedef Range (RangeFun)(double);
 
 // Default Range function, to calculate Option's min-max values
-inline Range default_range(int v) {
+inline Range default_range(double v) {
   return v > 0 ? Range(0, 2 * v) : Range(2 * v, 0);
 }
 
 struct SetRange {
   explicit SetRange(RangeFun f) : fun(f) {}
   SetRange(int min, int max) : fun(nullptr), range(min, max) {}
-  Range operator()(int v) const { return fun ? fun(v) : range; }
+  Range operator()(double v) const { return fun ? fun(v) : range; }
 
   RangeFun* fun;
   Range range;
@@ -116,10 +116,11 @@ class Tune {
 
     static_assert(!std::is_const<T>::value, "Parameter cannot be const!");
 
-    static_assert(   std::is_same<T,   int>::value
-                  || std::is_same<T, Value>::value
-                  || std::is_same<T, Score>::value
-                  || std::is_same<T, PostUpdate>::value, "Parameter type not supported!");
+    static_assert(   std::is_same<T,    int>::value
+                  || std::is_same<T, double>::value
+                  || std::is_same<T,  Value>::value
+                  || std::is_same<T,  Score>::value
+                  || std::is_same<T,  PostUpdate>::value, "Parameter type not supported!");
 
     Entry(const std::string& n, T& v, const SetRange& r) : name(n), value(v), range(r) {}
     void operator=(const Entry&) = delete; // Because 'value' is a reference

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -187,7 +187,7 @@ Option& Option::operator=(const string& v) {
 bool Tune::update_on_last;
 const UCI::Option* LastOption = nullptr;
 BoolConditions Conditions;
-static std::map<std::string, int> TuneResults;
+static std::map<std::string, double> TuneResults;
 
 string Tune::next(string& names, bool pop) {
 
@@ -214,32 +214,39 @@ static void on_tune(const UCI::Option& o) {
       Tune::read_options();
 }
 
-static void make_option(const string& n, int v, const SetRange& r) {
+static void make_option(const string& name, double v, const SetRange& r) {
 
   // Do not generate option when there is nothing to tune (ie. min = max)
   if (r(v).first == r(v).second)
       return;
 
-  if (TuneResults.count(n))
-      v = TuneResults[n];
+  if (TuneResults.count(name))
+      v = TuneResults[name];
 
-  Options[n] << UCI::Option(v, r(v).first, r(v).second, on_tune);
-  LastOption = &Options[n];
+  Options[name] << UCI::Option(v, r(v).first, r(v).second, on_tune);
+  LastOption = &Options[name];
 
   // Print formatted parameters, ready to be copy-pasted in fishtest
-  std::cout << n << ","
-            << v << ","
+  std::cout << name << ","
+            << v    << ","
             << r(v).first << "," << r(v).second << ","
             << (r(v).second - r(v).first) / 20.0 << ","
             << "0.0020"
             << std::endl;
 }
 
+template<> void Tune::Entry<double>::init_option() { make_option(name, value, range); }
+
+template<> void Tune::Entry<double>::read_option() {
+  if (Options.count(name))
+      value = Options[name];
+}
+
 template<> void Tune::Entry<int>::init_option() { make_option(name, value, range); }
 
 template<> void Tune::Entry<int>::read_option() {
   if (Options.count(name))
-      value = Options[name];
+      value = int(Options[name]);
 }
 
 template<> void Tune::Entry<Value>::init_option() { make_option(name, value, range); }


### PR DESCRIPTION
Allow tuning variables of type "double" with the TUNE() macro.

This is the companion commit of the recent change in master, which
introduced the reading of UCI parameters of type "double":

https://github.com/official-stockfish/Stockfish/commit/82f7d507eaf83e27a33bf0b433be08d23320b6fe