### PR TITLE
Set bits instead of clearing bits in semiopenfiles

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -93,8 +93,7 @@ namespace {
     Bitboard ourPawns   = pos.pieces(  Us, PAWN);
     Bitboard theirPawns = pos.pieces(Them, PAWN);
 
-    e->passedPawns[Us] = e->pawnAttacksSpan[Us] = e->weakUnopposed[Us] = 0;
-    e->semiopenFiles[Us] = 0xFF;
+    e->passedPawns[Us] = e->pawnAttacksSpan[Us] = e->weakUnopposed[Us] = e->semiopenFiles[Us] = 0;
     e->kingSquares[Us]   = SQ_NONE;
     e->pawnAttacks[Us]   = pawn_attacks_bb<Us>(ourPawns);
     e->pawnsOnSquares[Us][BLACK] = popcount(ourPawns & DarkSquares);
@@ -107,7 +106,7 @@ namespace {
 
         File f = file_of(s);
 
-        e->semiopenFiles[Us]   &= ~(1 << f);
+        e->semiopenFiles[Us] |= (1 << f);
         e->pawnAttacksSpan[Us] |= pawn_attack_span(Us, s);
 
         // Flag the pawn
@@ -169,6 +168,7 @@ namespace {
         if (doubled && !supported)
             score -= Doubled;
     }
+    e->semiopenFiles[Us] = ~(e->semiopenFiles[Us]);
 
     return score;
   }

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -41,7 +41,7 @@ struct Entry {
   int pawn_asymmetry() const { return asymmetry; }
   int open_files() const { return openFiles; }
 
-  int semiopen_file(Color c, File f) const {
+  uint8_t semiopen_file(Color c, File f) const {
     return semiopenFiles[c] & (1 << f);
   }
 
@@ -70,7 +70,7 @@ struct Entry {
   Score kingSafety[COLOR_NB];
   int weakUnopposed[COLOR_NB];
   int castlingRights[COLOR_NB];
-  int semiopenFiles[COLOR_NB];
+  uint8_t semiopenFiles[COLOR_NB];
   int pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
   int asymmetry;
   int openFiles;


### PR DESCRIPTION
Instead of setting semiopenFiles to 0xFF and clearing bits for existing pawns, it seems faster to set bits for existing pawns and ~ at the end.  Hard to believe it makes much difference, but it seems faster on my machine.  I'm just posting here to see if others see the same (which is what the README says to do).

200 runs of psybench:
base: 1271642 +/- 6216
test: 1294405 +/- 6458
diff:     +22763 +/ 751.
speedup   = 0.0179
P(speedup > 0) = 1.000

