### PR TITLE
Always use pawn number contribution when scaling evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -812,10 +812,8 @@ namespace {
             else
                 sf = 46;
         }
-        // Endings where weaker side can place his king in front of the enemy's
-        // pawns are drawish.
-        else if (    abs(eg) <= BishopValueEg
-                 &&  pos.count<PAWN>(strongSide) <= 2
+        // Endings where weaker side can stop one of the enemy's pawn are drawish.
+        else if (    pos.count<PAWN>(strongSide) <= 2
                  && !pos.pawn_passed(~strongSide, pos.square<KING>(~strongSide)))
             sf = 37 + 7 * pos.count<PAWN>(strongSide);
     }


### PR DESCRIPTION
Passed [STC](http://tests.stockfishchess.org/tests/view/5adc6fc50ebc591b19ef617a)
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 39009 W: 7944 L: 7856 D: 23209 

Passed [LTC](http://tests.stockfishchess.org/tests/view/5adc7c260ebc591b19ef618b)
LLR: 2.96 (-2.94,2.94) [-3.00,1.00] 
Total: 47859 W: 7170 L: 7089 D: 33600

Removes the artificial restriction in `evaluate_scale_factor` based on endgame score. This is a further step in the long quest for a simple way of determining scale factors.
