### PR TITLE
Fix 'make strip' for mingw.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,11 @@
 ### ==========================================================================
 
 ### Executable name
+ifeq ($(COMP),mingw)
+EXE = stockfish.exe
+else
 EXE = stockfish
+endif
 
 ### Installation dir definitions
 PREFIX = /usr/local
@@ -437,7 +441,7 @@ clean: objclean profileclean
 
 # clean binaries and objects
 objclean:
-	@rm -f $(EXE) $(EXE).exe *.o ./syzygy/*.o
+	@rm -f $(EXE) *.o ./syzygy/*.o
 
 # clean auxiliary profiling files
 profileclean:


### PR DESCRIPTION
Currently the make strip target is broken on mingw as the exe name is wrong (stockfish instead of stockfish.exe).

Needs some testing by mingw users (both profile-build and strip, native and cross).

No functional change.