### PR TITLE
Simplifiy IID condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -818,9 +818,8 @@ namespace {
     }
 
     // Step 11. Internal iterative deepening (skipped when in check, ~2 Elo)
-    if (    depth >= 6 * ONE_PLY
-        && !ttMove
-        && (PvNode || ss->staticEval + 128 >= beta))
+    if (    depth >= 8 * ONE_PLY
+        && !ttMove)
     {
         Depth d = 3 * depth / 4 - 2 * ONE_PLY;
         search<NT>(pos, ss, alpha, beta, d, cutNode, true);


### PR DESCRIPTION
do IID for all sufficiently deep searches without TT move.

passed STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 25494 W: 5313 L: 5199 D: 14982
http://tests.stockfishchess.org/tests/view/5ae1e8dd0ebc596317520583

passed LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 80582 W: 12162 L: 12130 D: 56290
http://tests.stockfishchess.org/tests/view/5ae1f5ab0ebc5963175205a4

Bench: 4966970