### PR TITLE
MPI/Cluster implementation for Stockfish

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -36,7 +36,7 @@ BINDIR = $(PREFIX)/bin
 PGOBENCH = ./$(EXE) bench
 
 ### Object files
-OBJS = benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o \
+OBJS = benchmark.o bitbase.o bitboard.o cluster.o endgame.o evaluate.o main.o \
 	material.o misc.o movegen.o movepick.o pawns.o position.o psqt.o \
 	search.o thread.o timeman.o tt.o uci.o ucioption.o syzygy/tbprobe.o
 
@@ -64,6 +64,7 @@ endif
 # popcnt = yes/no     --- -DUSE_POPCNT     --- Use popcnt asm-instruction
 # sse = yes/no        --- -msse            --- Use Intel Streaming SIMD Extensions
 # pext = yes/no       --- -DUSE_PEXT       --- Use pext x86_64 asm-instruction
+# mpi = yes/no        --- -DUSE_MPI        --- Use Message Passing Interface
 #
 # Note that Makefile is space sensitive, so when adding new architectures
 # or modifying existing flags, you have to make sure there are no extra spaces
@@ -78,6 +79,7 @@ prefetch = no
 popcnt = no
 sse = no
 pext = no
+mpi = no
 
 ### 2.2 Architecture specific
 
@@ -354,6 +356,15 @@ ifeq ($(OS), Android)
 	LDFLAGS += -fPIE -pie
 endif
 
+### 3.10 MPI
+ifeq ($(CXX),$(filter $(CXX),mpicxx mpic++ mpiCC))
+	mpi = yes
+endif
+
+ifeq ($(mpi),yes)
+	CXXFLAGS += -DUSE_MPI
+endif
+
 
 ### ==========================================================================
 ### Section 4. Public targets
@@ -472,6 +483,7 @@ config-sanity:
 	@echo "popcnt: '$(popcnt)'"
 	@echo "sse: '$(sse)'"
 	@echo "pext: '$(pext)'"
+	@echo "mpi: '$(mpi)'"
 	@echo ""
 	@echo "Flags:"
 	@echo "CXX: $(CXX)"

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -1,0 +1,197 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2008 Tord Romstad (Glaurung author)
+  Copyright (C) 2008-2015 Marco Costalba, Joona Kiiski, Tord Romstad
+  Copyright (C) 2015-2018 Marco Costalba, Joona Kiiski, Gary Linscott, Tord Romstad
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_MPI
+
+#include <array>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <istream>
+#include <mpi.h>
+#include <string>
+#include <vector>
+
+#include "cluster.h"
+#include "thread.h"
+#include "tt.h"
+
+namespace Cluster {
+
+static int world_rank = MPI_PROC_NULL;
+static int world_size = 0;
+
+static MPI_Comm InputComm = MPI_COMM_NULL;
+static MPI_Comm TTComm = MPI_COMM_NULL;
+static MPI_Comm MoveComm = MPI_COMM_NULL;
+
+static MPI_Datatype TTEntryDatatype = MPI_DATATYPE_NULL;
+static std::vector<TTEntry> TTBuff;
+
+static MPI_Op BestMoveOp = MPI_OP_NULL;
+static MPI_Datatype MIDatatype = MPI_DATATYPE_NULL;
+
+static void BestMove(void* in, void* inout, int* len, MPI_Datatype* datatype) {
+  if (*datatype != MIDatatype)
+      MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  MoveInfo* l = static_cast<MoveInfo*>(in);
+  MoveInfo* r = static_cast<MoveInfo*>(inout);
+  for (int i=0; i < *len; ++i)
+  {
+      if (    l[i].depth > r[i].depth
+          && (l[i].score >= r[i].score || l[i].score >= VALUE_MATE_IN_MAX_PLY))
+         r[i] = l[i];
+  }
+}
+
+void init() {
+  int thread_support;
+  constexpr std::array<int, 6> TTblocklens = {1, 1, 1, 1, 1, 1};
+  const std::array<MPI_Aint, 6> TTdisps = {offsetof(TTEntry, key16),
+                                           offsetof(TTEntry, move16),
+                                           offsetof(TTEntry, value16),
+                                           offsetof(TTEntry, eval16),
+                                           offsetof(TTEntry, genBound8),
+                                           offsetof(TTEntry, depth8)};
+  const std::array<MPI_Datatype, 6> TTtypes = {MPI_UINT16_T,
+                                               MPI_UINT16_T,
+                                               MPI_INT16_T,
+                                               MPI_INT16_T,
+                                               MPI_UINT8_T,
+                                               MPI_INT8_T};
+  const std::array<MPI_Aint, 3> MIdisps = {offsetof(MoveInfo, depth),
+                                           offsetof(MoveInfo, score),
+                                           offsetof(MoveInfo, rank)};
+
+  MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &thread_support);
+  if (thread_support < MPI_THREAD_MULTIPLE)
+  {
+      std::cerr << "Stockfish requires support for MPI_THREAD_MULTIPLE."
+                << std::endl;
+      std::exit(EXIT_FAILURE);
+  }
+
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+
+  TTBuff.resize(TTSendBufferSize * world_size);
+
+  MPI_Type_create_struct(6, TTblocklens.data(), TTdisps.data(), TTtypes.data(),
+                         &TTEntryDatatype);
+  MPI_Type_commit(&TTEntryDatatype);
+
+  MPI_Type_create_hindexed_block(3, 1, MIdisps.data(), MPI_INT, &MIDatatype);
+  MPI_Type_commit(&MIDatatype);
+  MPI_Op_create(BestMove, true, &BestMoveOp);
+
+  MPI_Comm_dup(MPI_COMM_WORLD, &InputComm);
+  MPI_Comm_dup(MPI_COMM_WORLD, &TTComm);
+  MPI_Comm_dup(MPI_COMM_WORLD, &MoveComm);
+}
+
+void finalize() {
+  MPI_Finalize();
+}
+
+bool getline(std::istream& input, std::string& str) {
+  int size;
+  std::vector<char> vec;
+  bool state;
+
+  if (is_root())
+  {
+      state = static_cast<bool>(std::getline(input, str));
+      vec.assign(str.begin(), str.end());
+      size = vec.size();
+  }
+  MPI_Bcast(&size, 1, MPI_UNSIGNED_LONG, 0, InputComm);
+  if (!is_root())
+      vec.resize(size);
+  MPI_Bcast(vec.data(), size, MPI_CHAR, 0, InputComm);
+  if (!is_root())
+      str.assign(vec.begin(), vec.end());
+  MPI_Bcast(&state, 1, MPI_CXX_BOOL, 0, InputComm);
+  return state;
+}
+
+int size() {
+  return world_size;
+}
+
+int rank() {
+  return world_rank;
+}
+
+void save(Thread* thread, TTEntry* tte,
+          Key k, Value v, Bound b, Depth d, Move m, Value ev, uint8_t g) {
+  tte->save(k, v, b, d, m, ev, g);
+  // Try to add to thread's send buffer
+  {
+      std::lock_guard<Mutex> lk(thread->ttBuffer.mutex);
+      thread->ttBuffer.buffer.replace(*tte);
+  }
+
+  // Communicate on main search thread
+  if (thread == Threads.main()) {
+      static MPI_Request req = MPI_REQUEST_NULL;
+      static TTSendBuffer<TTSendBufferSize> send_buff = {};
+      int flag;
+      bool found;
+      TTEntry* replace_tte;
+
+      // Test communication status
+      MPI_Test(&req, &flag, MPI_STATUS_IGNORE);
+
+      // Current communication is complete
+      if (flag) {
+          // Save all recieved entries
+          for (auto&& e : TTBuff) {
+              replace_tte = TT.probe(e.key(), found);
+              replace_tte->save(e.key(), e.value(), e.bound(), e.depth(),
+                                e.move(), e.eval(), e.gen());
+          }
+
+          // Reset send buffer
+          send_buff = {};
+
+          // Build up new send buffer: best 16 found across all threads
+          for (auto&& th : Threads) {
+              std::lock_guard<Mutex> lk(th->ttBuffer.mutex);
+              for (auto&& e : th->ttBuffer.buffer)
+                  send_buff.replace(e);
+              // Reset thread's send buffer
+              th->ttBuffer.buffer = {};
+          }
+
+          // Start next communication
+          MPI_Iallgather(send_buff.data(), send_buff.size(), TTEntryDatatype,
+                         TTBuff.data(), TTSendBufferSize, TTEntryDatatype,
+                         TTComm, &req);
+      }
+  }
+}
+
+void reduce_moves(MoveInfo& mi) {
+  MPI_Allreduce(MPI_IN_PLACE, &mi, 1, MIDatatype, BestMoveOp, MoveComm);
+}
+
+}
+
+#endif // USE_MPI

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -1,0 +1,94 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2008 Tord Romstad (Glaurung author)
+  Copyright (C) 2008-2015 Marco Costalba, Joona Kiiski, Tord Romstad
+  Copyright (C) 2015-2017 Marco Costalba, Joona Kiiski, Gary Linscott, Tord Romstad
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CLUSTER_H_INCLUDED
+#define CLUSTER_H_INCLUDED
+
+#include <algorithm>
+#include <array>
+#include <istream>
+#include <string>
+
+#include "tt.h"
+
+class Thread;
+
+namespace Cluster {
+
+struct MoveInfo {
+  int depth;
+  int score;
+  int rank;
+};
+
+#ifdef USE_MPI
+constexpr std::size_t TTSendBufferSize = 16;
+template <std::size_t N> class TTSendBuffer : public std::array<TTEntry, N> {
+  struct Compare {
+      inline bool operator()(const TTEntry& lhs, const TTEntry& rhs) {
+          return lhs.depth() > rhs.depth();
+      }
+  };
+  Compare compare;
+
+public:
+  bool replace(const TTEntry& value) {
+      if (compare(value, this->front())) {
+          std::pop_heap(this->begin(), this->end(), compare);
+          this->back() = value;
+          std::push_heap(this->begin(), this->end(), compare);
+          return true;
+      }
+      return false;
+  }
+};
+
+void init();
+void finalize();
+bool getline(std::istream& input, std::string& str);
+int size();
+int rank();
+inline bool is_root() { return rank() == 0; }
+void save(Thread* thread, TTEntry* tte,
+          Key k, Value v, Bound b, Depth d, Move m, Value ev, uint8_t g);
+void reduce_moves(MoveInfo& mi);
+
+#else
+
+inline void init() { }
+inline void finalize() { }
+inline bool getline(std::istream& input, std::string& str) {
+  return static_cast<bool>(std::getline(input, str));
+}
+constexpr int size() { return 1; }
+constexpr int rank() { return 0; }
+constexpr bool is_root() { return true; }
+inline void save(Thread* thread, TTEntry* tte,
+          Key k, Value v, Bound b, Depth d, Move m, Value ev, uint8_t g) {
+  (void)thread;
+  tte->save(k, v, b, d, m, ev, g);
+}
+inline void reduce_moves(MoveInfo&) { }
+
+#endif /* USE_MPI */
+
+}
+
+#endif // #ifndef CLUSTER_H_INCLUDED

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@
 #include "tt.h"
 #include "uci.h"
 #include "syzygy/tbprobe.h"
+#include "cluster.h"
 
 namespace PSQT {
   void init();
@@ -34,7 +35,9 @@ namespace PSQT {
 
 int main(int argc, char* argv[]) {
 
-  std::cout << engine_info() << std::endl;
+  Cluster::init();
+  if (Cluster::is_root())
+      std::cout << engine_info() << std::endl;
 
   UCI::init(Options);
   PSQT::init();
@@ -51,5 +54,6 @@ int main(int argc, char* argv[]) {
   UCI::loop(argc, argv);
 
   Threads.set(0);
+  Cluster::finalize();
   return 0;
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "cluster.h"
 #include "evaluate.h"
 #include "misc.h"
 #include "movegen.h"
@@ -146,7 +147,7 @@ namespace {
             nodes += cnt;
             pos.undo_move(m);
         }
-        if (Root)
+        if (Root && Cluster::is_root())
             sync_cout << UCI::move(m, pos.is_chess960()) << ": " << cnt << sync_endl;
     }
     return nodes;
@@ -201,7 +202,8 @@ void MainThread::search() {
   if (Limits.perft)
   {
       nodes = perft<true>(rootPos, Limits.perft * ONE_PLY);
-      sync_cout << "\nNodes searched: " << nodes << "\n" << sync_endl;
+      if (Cluster::is_root())
+          sync_cout << "\nNodes searched: " << nodes << "\n" << sync_endl;
       return;
   }
 
@@ -212,9 +214,10 @@ void MainThread::search() {
   if (rootMoves.empty())
   {
       rootMoves.emplace_back(MOVE_NONE);
-      sync_cout << "info depth 0 score "
-                << UCI::value(rootPos.checkers() ? -VALUE_MATE : VALUE_DRAW)
-                << sync_endl;
+      if (Cluster::is_root())
+          sync_cout << "info depth 0 score "
+                    << UCI::value(rootPos.checkers() ? -VALUE_MATE : VALUE_DRAW)
+                    << sync_endl;
   }
   else
   {
@@ -268,18 +271,25 @@ void MainThread::search() {
       }
   }
 
-  previousScore = bestThread->rootMoves[0].score;
+  Cluster::MoveInfo mi{bestThread->completedDepth,
+                       bestThread->rootMoves[0].score,
+                       Cluster::rank()};
+  Cluster::reduce_moves(mi);
+
+  previousScore = static_cast<Value>(mi.score);
 
   // Send again PV info if we have a new best thread
-  if (bestThread != this)
-      sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
+  if (mi.rank == Cluster::rank()) {
+      if (bestThread != this)
+          sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
 
-  sync_cout << "bestmove " << UCI::move(bestThread->rootMoves[0].pv[0], rootPos.is_chess960());
+      sync_cout << "bestmove " << UCI::move(bestThread->rootMoves[0].pv[0], rootPos.is_chess960());
 
-  if (bestThread->rootMoves[0].pv.size() > 1 || bestThread->rootMoves[0].extract_ponder_from_tt(rootPos))
-      std::cout << " ponder " << UCI::move(bestThread->rootMoves[0].pv[1], rootPos.is_chess960());
+      if (bestThread->rootMoves[0].pv.size() > 1 || bestThread->rootMoves[0].extract_ponder_from_tt(rootPos))
+          std::cout << " ponder " << UCI::move(bestThread->rootMoves[0].pv[1], rootPos.is_chess960());
 
-  std::cout << sync_endl;
+      std::cout << sync_endl;
+  }
 }
 
 
@@ -337,9 +347,9 @@ void Thread::search() {
          && !(Limits.depth && mainThread && rootDepth / ONE_PLY > Limits.depth))
   {
       // Distribute search depths across the helper threads
-      if (idx > 0)
+      if (idx + Cluster::rank() > 0)
       {
-          int i = (idx - 1) % 20;
+          int i = (idx + Cluster::rank() - 1) % 20;
           if (((rootDepth / ONE_PLY + rootPos.game_ply() + SkipPhase[i]) / SkipSize[i]) % 2)
               continue;  // Retry with an incremented rootDepth
       }
@@ -408,7 +418,8 @@ void Thread::search() {
 
               // When failing high/low give some update (without cluttering
               // the UI) before a re-search.
-              if (   mainThread
+              if (   Cluster::is_root()
+                  && mainThread
                   && multiPV == 1
                   && (bestValue <= alpha || bestValue >= beta)
                   && Time.elapsed() > 3000)
@@ -440,7 +451,7 @@ void Thread::search() {
           // Sort the PV lines searched so far and update the GUI
           std::stable_sort(rootMoves.begin() + PVFirst, rootMoves.begin() + PVIdx + 1);
 
-          if (    mainThread
+          if (    Cluster::is_root() && mainThread
               && (Threads.stop || PVIdx + 1 == multiPV || Time.elapsed() > 3000))
               sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
       }
@@ -664,9 +675,11 @@ namespace {
                 if (    b == BOUND_EXACT
                     || (b == BOUND_LOWER ? value >= beta : value <= alpha))
                 {
-                    tte->save(posKey, value_to_tt(value, ss->ply), b,
-                              std::min(DEPTH_MAX - ONE_PLY, depth + 6 * ONE_PLY),
-                              MOVE_NONE, VALUE_NONE, TT.generation());
+                    Cluster::save(thisThread, tte,
+                                  posKey, value_to_tt(value, ss->ply), b,
+                                  std::min(DEPTH_MAX - ONE_PLY,
+                                           depth + 6 * ONE_PLY),
+                                  MOVE_NONE, VALUE_NONE, TT.generation());
 
                     return value;
                 }
@@ -706,8 +719,9 @@ namespace {
         (ss-1)->currentMove != MOVE_NULL ? evaluate(pos)
                                          : -(ss-1)->staticEval + 2 * Eval::Tempo;
 
-        tte->save(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE,
-                  ss->staticEval, TT.generation());
+        Cluster::save(thisThread, tte,
+                      posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE,
+                      ss->staticEval, TT.generation());
     }
 
     improving =   ss->staticEval >= (ss-2)->staticEval
@@ -864,7 +878,7 @@ moves_loop: // When in check, search starts from here
 
       ss->moveCount = ++moveCount;
 
-      if (rootNode && thisThread == Threads.main() && Time.elapsed() > 3000)
+      if (rootNode && Cluster::is_root() && thisThread == Threads.main() && Time.elapsed() > 3000)
           sync_cout << "info depth " << depth / ONE_PLY
                     << " currmove " << UCI::move(move, pos.is_chess960())
                     << " currmovenumber " << moveCount + thisThread->PVIdx << sync_endl;
@@ -1163,10 +1177,11 @@ moves_loop: // When in check, search starts from here
         bestValue = std::min(bestValue, maxValue);
 
     if (!excludedMove)
-        tte->save(posKey, value_to_tt(bestValue, ss->ply),
-                  bestValue >= beta ? BOUND_LOWER :
-                  PvNode && bestMove ? BOUND_EXACT : BOUND_UPPER,
-                  depth, bestMove, ss->staticEval, TT.generation());
+        Cluster::save(thisThread, tte,
+                      posKey, value_to_tt(bestValue, ss->ply),
+                      bestValue >= beta ? BOUND_LOWER :
+                      PvNode && bestMove ? BOUND_EXACT : BOUND_UPPER,
+                      depth, bestMove, ss->staticEval, TT.generation());
 
     assert(bestValue > -VALUE_INFINITE && bestValue < VALUE_INFINITE);
 
@@ -1195,6 +1210,7 @@ moves_loop: // When in check, search starts from here
     Value bestValue, value, ttValue, futilityValue, futilityBase, oldAlpha;
     bool ttHit, inCheck, givesCheck, evasionPrunable;
     int moveCount;
+    Thread* thisThread = pos.this_thread();
 
     if (PvNode)
     {
@@ -1262,8 +1278,10 @@ moves_loop: // When in check, search starts from here
         if (bestValue >= beta)
         {
             if (!ttHit)
-                tte->save(posKey, value_to_tt(bestValue, ss->ply), BOUND_LOWER,
-                          DEPTH_NONE, MOVE_NONE, ss->staticEval, TT.generation());
+                Cluster::save(thisThread, tte,
+                              posKey, value_to_tt(bestValue, ss->ply),
+                              BOUND_LOWER, DEPTH_NONE, MOVE_NONE,
+                              ss->staticEval, TT.generation());
 
             return bestValue;
         }
@@ -1361,8 +1379,10 @@ moves_loop: // When in check, search starts from here
               }
               else // Fail high
               {
-                  tte->save(posKey, value_to_tt(value, ss->ply), BOUND_LOWER,
-                            ttDepth, move, ss->staticEval, TT.generation());
+                  Cluster::save(thisThread, tte,
+                                posKey, value_to_tt(value, ss->ply),
+                                BOUND_LOWER, ttDepth, move, ss->staticEval,
+                                TT.generation());
 
                   return value;
               }
@@ -1375,9 +1395,10 @@ moves_loop: // When in check, search starts from here
     if (inCheck && bestValue == -VALUE_INFINITE)
         return mated_in(ss->ply); // Plies to mate from the root
 
-    tte->save(posKey, value_to_tt(bestValue, ss->ply),
-              PvNode && bestValue > oldAlpha ? BOUND_EXACT : BOUND_UPPER,
-              ttDepth, bestMove, ss->staticEval, TT.generation());
+    Cluster::save(thisThread, tte,
+                  posKey, value_to_tt(bestValue, ss->ply),
+                  PvNode && bestValue > oldAlpha ? BOUND_EXACT : BOUND_UPPER,
+                  ttDepth, bestMove, ss->staticEval, TT.generation());
 
     assert(bestValue > -VALUE_INFINITE && bestValue < VALUE_INFINITE);
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -29,6 +29,7 @@
 #include <type_traits>
 
 #include "../bitboard.h"
+#include "../cluster.h"
 #include "../movegen.h"
 #include "../position.h"
 #include "../search.h"
@@ -1333,7 +1334,8 @@ void Tablebases::init(const std::string& paths) {
         }
     }
 
-    sync_cout << "info string Found " << TBTables.size() << " tablebases" << sync_endl;
+    if (Cluster::is_root())
+        sync_cout << "info string Found " << TBTables.size() << " tablebases" << sync_endl;
 }
 
 // Probe the WDL table for a particular position.

--- a/src/thread.h
+++ b/src/thread.h
@@ -27,6 +27,7 @@
 #include <thread>
 #include <vector>
 
+#include "cluster.h"
 #include "material.h"
 #include "movepick.h"
 #include "pawns.h"
@@ -72,6 +73,13 @@ public:
   CapturePieceToHistory captureHistory;
   ContinuationHistory contHistory;
   Score contempt;
+
+#ifdef USE_MPI
+  struct {
+      Mutex mutex;
+      Cluster::TTSendBuffer<Cluster::TTSendBufferSize> buffer = {};
+  } ttBuffer;
+#endif
 };
 
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -24,6 +24,11 @@
 #include "misc.h"
 #include "types.h"
 
+namespace Cluster {
+  void init();
+}
+//void Cluster::init();
+
 /// TTEntry struct is the 10 bytes transposition table entry, defined as below:
 ///
 /// key        16 bit
@@ -36,11 +41,13 @@
 
 struct TTEntry {
 
+  Key   key()   const { return (Key  )(key16) << 48; }
   Move  move()  const { return (Move )move16; }
   Value value() const { return (Value)value16; }
   Value eval()  const { return (Value)eval16; }
   Depth depth() const { return (Depth)(depth8 * int(ONE_PLY)); }
   Bound bound() const { return (Bound)(genBound8 & 0x3); }
+  uint8_t gen() const { return (uint8_t)(genBound8 & 0xFC); }
 
   void save(Key k, Value v, Bound b, Depth d, Move m, Value ev, uint8_t g) {
 
@@ -66,6 +73,7 @@ struct TTEntry {
 
 private:
   friend class TranspositionTable;
+  friend void Cluster::init();
 
   uint16_t key16;
   uint16_t move16;
@@ -84,6 +92,8 @@ private:
 /// prefetched, as soon as possible.
 
 class TranspositionTable {
+
+  friend void Cluster::init();
 
   static constexpr int CacheLineSize = 64;
   static constexpr int ClusterSize = 3;


### PR DESCRIPTION
Based on Peter Österlund's "Lazy Cluster" algorithm, but with some simplifications.
To compile, point COMPCXX to the MPI C++ compiler wrapper (`mpicxx`) during compilation.
To run, execute `mpiexec -n <NODES> /path/to/stockfish`.
To ensure that one process is launched per node or per socket/NUMA node (to use threads locally), it may be necessary to add implementation-specific commands (e.g. `--map-by ppr:1:node` in Open MPI, or `-ppn 1` for MPICH).

This isn't quite the cleanest, but it appears to work.
I'm still working on testing the changes—I can't use fishtest directly, since it isn't set up to compile with MPI and doesn't have access to a cluster. I could use cutechess-cli to run a bunch of tests, if I'm given the correct commands (equivalent to what is done in [fishtest](https://github.com/glinscott/fishtest/blob/17210c6d7ce1670f4a6f070c8950fbdabd7d2feb/worker/games.py#L473-L479)).
I'd appreciate some help in evaluating the performance improvement of using multiple nodes!