### PR TITLE
use cycle detection to bound search value

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -130,6 +130,13 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
 }
 
 
+// Marcel Kervink's algorithm for Deep Blue’s "upcoming repetition" / "no progress" detectors
+Key cuckoo[0x2000];             // Cuckoo table with Zobrist hashes of valid reversible moves
+int16_t cuckooMove[0x2000];     // The move for cuckoo[i]
+#define H1(h)( (h)     &0x1fff) // First hash function for indexing the cuckoo table
+#define H2(h)(((h)>>16)&0x1fff) // Second hash function
+
+
 /// Position::init() initializes at startup the various arrays used to compute
 /// hash keys.
 
@@ -157,6 +164,31 @@ void Position::init() {
 
   Zobrist::side = rng.rand<Key>();
   Zobrist::noPawns = rng.rand<Key>();
+
+  int num = 0;
+  for (Piece pc : Pieces)
+  {
+      for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
+      {
+          Bitboard b = PseudoAttacks[type_of(pc)][s1] & ~(SquareBB[s1]-1);
+          while (b)
+          {
+              Square s2 = pop_lsb(&b);
+              int16_t move16 = make_move(s1, s2);
+              Key moveKey = Zobrist::psq[pc][s1] ^ Zobrist::psq[pc][s2] ^ Zobrist::side;
+              unsigned int i = H1(moveKey);
+              while(true)
+              {   // Insert in cuckoo table
+                  std::swap(cuckoo[i], moveKey);
+                  std::swap(cuckooMove[i], move16);
+                  if (moveKey == 0) break; // Arrived at empty; slot so we are done for this move
+                  i = (i == H1(moveKey)) ? H2(moveKey) : H1(moveKey); // Push victim to alternative slot
+              }
+              num++;
+          }
+      }
+  }
+  assert(num == 3668);
 }
 
 
@@ -1131,6 +1163,53 @@ bool Position::has_repeated() const {
 
         stc = stc->previous;
     }
+}
+
+
+/// Position::has_game_cycle() tests if the position has a move which draws by repetition,
+/// or an earlier position has a move that directly reaches this one.
+
+bool Position::has_game_cycle(int ply) const {
+
+  int end = std::min(st->rule50, st->pliesFromNull);
+
+  if (end < 3)
+    return false;
+
+  Key originalKey = st->key;
+  StateInfo* stp = st->previous;
+  Key progressKey = stp->key ^ Zobrist::side;
+
+  for (int i = 3; i <= end; i += 2)
+  {
+      stp = stp->previous;
+      progressKey ^= stp->key ^ Zobrist::side;
+      stp = stp->previous;
+      // "originalKey ==" detects upcoming repetition, "progressKey ==" detects no-progress
+      if (originalKey == (progressKey ^ stp->key) || progressKey == Zobrist::side)
+      {
+          Key moveKey = originalKey ^ stp->key;
+          unsigned int j = H1(moveKey);
+          if (cuckoo[j] == moveKey || (j = H2(moveKey), cuckoo[j] == moveKey))
+          {
+              Move m = Move(cuckooMove[j]);
+              if (!(between_bb(from_sq(m), to_sq(m)) & pieces())) {
+                  if (ply > i)
+                      return true;
+                  // For repetitions before or at the root, require one more.
+                  StateInfo* next_stp = stp;
+                  for (int k = i+2; k <= end; k += 2)
+                  {
+                      next_stp = next_stp->previous->previous;
+                      if (next_stp->key == stp->key)
+                         return true;
+                  }
+              }
+          }
+      }
+      progressKey ^= stp->key;
+  }
+  return false;
 }
 
 

--- a/src/position.h
+++ b/src/position.h
@@ -152,6 +152,7 @@ public:
   bool is_chess960() const;
   Thread* this_thread() const;
   bool is_draw(int ply) const;
+  bool has_game_cycle(int ply) const;
   bool has_repeated() const;
   int rule50_count() const;
   Score psq_score() const;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -577,6 +577,16 @@ namespace {
         beta = std::min(mate_in(ss->ply+1), beta);
         if (alpha >= beta)
             return alpha;
+
+        // Check for a move which draws by repetition, or an alternative earlier move to this position
+        if (   pos.rule50_count() >= 3
+            && alpha < VALUE_DRAW
+            && pos.has_game_cycle(ss->ply))
+        {
+            alpha = VALUE_DRAW;
+            if (alpha >= beta)
+                return alpha;
+        }
     }
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
@@ -1212,6 +1222,16 @@ moves_loop: // When in check, search starts from here
     if (   pos.is_draw(ss->ply)
         || ss->ply >= MAX_PLY)
         return (ss->ply >= MAX_PLY && !inCheck) ? evaluate(pos) : VALUE_DRAW;
+
+    // Check for a move which draws by repetition, or an alternative earlier move to this position
+    if (   pos.rule50_count() >= 3
+        && alpha < VALUE_DRAW
+        && pos.has_game_cycle(ss->ply))
+    {
+        alpha = VALUE_DRAW;
+        if (alpha >= beta)
+            return alpha;
+    }
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 


### PR DESCRIPTION
A position which has a move which draws by repetition, or which could have been reached from an earlier position in the game tree, is considered to be at least a draw for the side to move.

cycle detection algorithm: https://marcelk.net/2013-04-06/paper/upcoming-rep-v2.pdf 

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 37354 W: 7732 L: 7429 D: 22193
http://tests.stockfishchess.org/tests/view/5ae77e770ebc5926dba90ddc

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 50010 W: 7499 L: 7198 D: 35313 
http://tests.stockfishchess.org/tests/view/5ae7a6720ebc5926dba90dfc

How could we continue after the patch:
The code in search and qsearch that checks for cycles has numerous possible variants. Perhaps the check need not be done in both places.

The biggest improvement would be to get "no progress" to be of actual benefit, and it would be helpful understand why it (probably)  isn't. Perhaps there is an interaction with the transposition table or the (fantastically complex) tree search. Perhaps this would be hard to fix, but perhaps there is a simple oversight.

Bench: 4756432