### PR TITLE
More accurate depth output

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1070,6 +1070,7 @@ moves_loop: // When in check, search starts from here
           if (moveCount == 1 || value > alpha)
           {
               rm.score = value;
+              rm.depth = depth / ONE_PLY;
               rm.selDepth = thisThread->selDepth;
               rm.pv.resize(1);
 
@@ -1230,8 +1231,8 @@ moves_loop: // When in check, search starts from here
         && ttHit
         && tte->depth() >= ttDepth
         && ttValue != VALUE_NONE // Only in case of TT access race
-        && (ttValue >= beta ? (tte->bound() &  BOUND_LOWER)
-                            : (tte->bound() &  BOUND_UPPER)))
+        && (ttValue >= beta ? (tte->bound() & BOUND_LOWER)
+                            : (tte->bound() & BOUND_UPPER)))
         return ttValue;
 
     // Evaluate the position statically
@@ -1564,7 +1565,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
 
   for (size_t i = 0; i < multiPV; ++i)
   {
-      bool updated = (i <= PVIdx && rootMoves[i].score != -VALUE_INFINITE);
+      bool updated = (i <= PVIdx && rootMoves[i].score != -VALUE_INFINITE && rootMoves[i].depth >= depth / ONE_PLY);
 
       if (depth == ONE_PLY && !updated)
           continue;

--- a/src/search.h
+++ b/src/search.h
@@ -68,7 +68,7 @@ struct RootMove {
 
   Value score = -VALUE_INFINITE;
   Value previousScore = -VALUE_INFINITE;
-  int selDepth = 0;
+  int depth = 0, selDepth = 0;
   int TBRank;
   Value TBScore;
   std::vector<Move> pv;

--- a/src/uci.h
+++ b/src/uci.h
@@ -50,13 +50,13 @@ public:
   Option(bool v, OnChange = nullptr);
   Option(const char* v, OnChange = nullptr);
   Option(double v, int minv, int maxv, OnChange = nullptr);
-  Option(const char* v, const char *cur, OnChange = nullptr);
+  Option(const char* v, const char* cur, OnChange = nullptr);
 
   Option& operator=(const std::string&);
   void operator<<(const Option&);
   operator double() const;
   operator std::string() const;
-  bool operator==(const char*);
+  bool operator==(const char*) const;
 
 private:
   friend std::ostream& operator<<(std::ostream&, const OptionsMap&);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -134,7 +134,7 @@ Option::operator std::string() const {
   return currentValue;
 }
 
-bool Option::operator==(const char* s) {
+bool Option::operator==(const char* s) const {
   assert(type == "combo");
   return    !CaseInsensitiveLess()(currentValue, s)
          && !CaseInsensitiveLess()(s, currentValue);


### PR DESCRIPTION
When the search is stopped early (whether due to time management, the 'stop' command or any other reason) while searching with rootDepth X, a final 'info' command is sent before sending bestmove, and X is specified as the depth. However, in some cases this happens early enough in iteration X that the PV move hasn't actually been searched at depth X, and thus the printed PV and score is actually just the one from the (X-1) iteration. To me, it seems more accurate to report (X-1) as the depth in such cases, and that's what this patch does.

I've submitted this in order to get feedback as to whether changing this behaviour is actually considered desirable, and whether there might be a better way of doing it if so. If this patch is considered acceptable, I'm also requesting feedback on whether anyone sees any obvious negative impact of this patch that I've overlooked, and whether any SPRT testing is necessary.

This PR also contains fixes for a few minor code style inconsistencies.

No functional change.