### PR TITLE
Tweak the connected[] array value for pawns on rank 5

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -179,7 +179,7 @@ namespace Pawns {
 
 void init() {
 
-  static constexpr int Seed[RANK_NB] = { 0, 13, 24, 18, 76, 100, 175, 330 };
+  static constexpr int Seed[RANK_NB] = { 0, 13, 24, 18, 65, 100, 175, 330 };
 
   for (int opposed = 0; opposed <= 1; ++opposed)
       for (int phalanx = 0; phalanx <= 1; ++phalanx)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -179,7 +179,7 @@ namespace Pawns {
 
 void init() {
 
-  static constexpr int Seed[RANK_NB] = { 0, 13, 24, 18, 65, 100, 175, 330 };
+  static constexpr int Seed[RANK_NB] = { 0, 13, 24, 18, 55, 100, 175, 330 };
 
   for (int opposed = 0; opposed <= 1; ++opposed)
       for (int phalanx = 0; phalanx <= 1; ++phalanx)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -179,7 +179,7 @@ namespace Pawns {
 
 void init() {
 
-  static constexpr int Seed[RANK_NB] = { 0, 13, 24, 18, 55, 100, 175, 330 };
+  static constexpr int Seed[RANK_NB] = { 0, 13, 24, 18, 65, 100, 175, 330 };
 
   for (int opposed = 0; opposed <= 1; ++opposed)
       for (int phalanx = 0; phalanx <= 1; ++phalanx)


### PR DESCRIPTION
A recent tuning session by Jerry Donald Watson suggested that the
value for the pawns on the fifth rank in the connected[] array were
a little bit too high in master. We lower here this value from 75 to 65.

STC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 27399 W: 5646 L: 5384 D: 16369
http://tests.stockfishchess.org/tests/view/5aea17c50ebc5902a1bed396

LTC:
LLR: 3.66 (-2.94,2.94) [0.00,4.00]
Total: 95590 W: 14529 L: 14062 D: 66999
http://tests.stockfishchess.org/tests/view/5aea34a40ebc5902a104ebe5

Closes https://github.com/official-stockfish/Stockfish/pull/1580

Bench: 5186783