### PR TITLE
Tune null move pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -734,7 +734,7 @@ namespace {
     // Step 9. Null move search with verification search (~40 Elo)
     if (   !PvNode
         && (ss-1)->currentMove != MOVE_NULL
-        && (ss-1)->statScore < 20000
+        && (ss-1)->statScore < 10000
         &&  eval >= beta
         &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225
         && !ss->excludedMove

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -734,7 +734,7 @@ namespace {
     // Step 9. Null move search with verification search (~40 Elo)
     if (   !PvNode
         && (ss-1)->currentMove != MOVE_NULL
-        && (ss-1)->statScore < 25000
+        && (ss-1)->statScore < 22500
         &&  eval >= beta
         &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225
         && !ss->excludedMove

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -734,7 +734,7 @@ namespace {
     // Step 9. Null move search with verification search (~40 Elo)
     if (   !PvNode
         && (ss-1)->currentMove != MOVE_NULL
-        && (ss-1)->statScore < 30000
+        && (ss-1)->statScore < 20000
         &&  eval >= beta
         &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225
         && !ss->excludedMove

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -734,7 +734,7 @@ namespace {
     // Step 9. Null move search with verification search (~40 Elo)
     if (   !PvNode
         && (ss-1)->currentMove != MOVE_NULL
-        && (ss-1)->statScore < 10000
+        && (ss-1)->statScore < 25000
         &&  eval >= beta
         &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225
         && !ss->excludedMove


### PR DESCRIPTION
Use a lower stat score threshold of 22500.

Failed yellow at STC after many games (~0.92 Elo):
LLR: -2.96 (-2.94,2.94) [0.00,4.00]
Total: 73978 W: 14947 L: 14834 D: 44197 
http://tests.stockfishchess.org/tests/view/5af2deec0ebc5968e6523f80

But scales good and passed LTC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 23147 W: 3453 L: 3237 D: 16457
http://tests.stockfishchess.org/tests/view/5af3cf820ebc5968e6524022

Bench: 4777674