### PR TITLE
Consolidate pawn storm types

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -56,18 +56,14 @@ namespace {
   // For the unopposed and unblocked cases, RANK_1 = 0 is used when opponent has
   // no pawn on the given file, or their pawn is behind our king.
   constexpr Value StormDanger[][4][RANK_NB] = {
-    { { V(11),  V( 79), V(132), V( 68), V( 33) },  // Unopposed
-      { V( 4),  V(104), V(155), V(  4), V( 21) },
-      { V(-7),  V( 59), V(142), V( 45), V( 30) },
-      { V( 0),  V( 62), V(113), V( 43), V( 13) } },
-    { { V( 0),  V(  0), V( 37), V(  5), V(-48) },  // BlockedByPawn
+    { { V(25),  V( 79), V(107), V( 51), V( 27) },  // UnBlocked
+      { V(15),  V( 45), V(131), V(  8), V( 25) },
+      { V( 0),  V( 42), V(118), V( 56), V( 27) },
+      { V( 3),  V( 54), V(110), V( 55), V( 26) } },
+    { { V( 0),  V(  0), V( 37), V(  5), V(-48) },  // Blocked
       { V( 0),  V(  0), V( 68), V(-12), V( 13) },
       { V( 0),  V(  0), V(111), V(-25), V( -3) },
-      { V( 0),  V(  0), V(108), V( 14), V( 21) } },
-    { { V(38),  V( 78), V( 83), V( 35), V( 22) },  // Unblocked
-      { V(33),  V(-15), V(108), V( 12), V( 28) },
-      { V( 8),  V( 25), V( 94), V( 68), V( 25) },
-      { V( 6),  V( 48), V(120), V( 68), V( 40) } }
+      { V( 0),  V(  0), V(108), V( 14), V( 21) } }
   };
 
   #undef S
@@ -212,7 +208,7 @@ Entry* probe(const Position& pos) {
 template<Color Us>
 Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
 
-  enum { Unopposed, BlockedByPawn, Unblocked };
+  enum { UnBlocked, Blocked };
   constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
   constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
   constexpr Bitboard  BlockRanks = (Us == WHITE ? Rank1BB | Rank2BB : Rank8BB | Rank7BB);
@@ -229,17 +225,16 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
   File center = std::max(FILE_B, std::min(FILE_G, file_of(ksq)));
   for (File f = File(center - 1); f <= File(center + 1); ++f)
   {
+      int d = std::min(f, ~f);
+
       b = ourPawns & file_bb(f);
       Rank rkUs = b ? relative_rank(Us, backmost_sq(Us, b)) : RANK_1;
+      safety +=  ShelterStrength[d][rkUs];
 
       b = theirPawns & file_bb(f);
       Rank rkThem = b ? relative_rank(Us, frontmost_sq(Them, b)) : RANK_1;
-
-      int d = std::min(f, ~f);
-      safety +=  ShelterStrength[d][rkUs]
-               - StormDanger[rkUs == RANK_1     ? Unopposed     :
-                             rkUs == rkThem - 1 ? BlockedByPawn : Unblocked]
-                            [d][rkThem];
+      if (rkUs || rkThem)
+         safety -= StormDanger[rkUs && (rkUs == rkThem - 1) ? Blocked : UnBlocked][d][rkThem];
   }
 
   return safety;


### PR DESCRIPTION
The Unopposed and Unblocked pawn storm types are mathematically similar enough to combine with no elo loss.  This simplifies the pawn storm types to Blocked and UnBlocked.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 116869 W: 23549 L: 23605 D: 69715
http://tests.stockfishchess.org/tests/view/5af2def90ebc5968e6523f82

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 39912 W: 6090 L: 5998 D: 27824
http://tests.stockfishchess.org/tests/view/5af3b2e20ebc5968e6524013

Bench 5111029