### PR TITLE
Include all blockers in king danger

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -420,7 +420,7 @@ namespace {
                                            : AllSquares ^ Rank1BB ^ Rank2BB ^ Rank3BB);
 
     const Square ksq = pos.square<KING>(Us);
-    Bitboard weak, b, b1, b2, safe, unsafeChecks, pinned;
+    Bitboard weak, b, b1, b2, safe, unsafeChecks;
 
     // King shelter and enemy pawns storm
     Score score = pe->king_safety<Us>(pos, ksq);
@@ -472,12 +472,11 @@ namespace {
         // Unsafe or occupied checking squares will also be considered, as long as
         // the square is in the attacker's mobility area.
         unsafeChecks &= mobilityArea[Them];
-        pinned = pos.blockers_for_king(Us) & pos.pieces(Us);
 
         kingDanger +=        kingAttackersCount[Them] * kingAttackersWeight[Them]
                      + 102 * kingAttacksCount[Them]
                      + 191 * popcount(kingRing[Us] & weak)
-                     + 143 * popcount(pinned | unsafeChecks)
+                     + 143 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
                      - 848 * !pos.count<QUEEN>(Them)
                      -   9 * mg_value(score) / 8
                      +  40;


### PR DESCRIPTION
Don't exclude blocking enemy pieces since they can result in discovered checks which are also bad.

STC  http://tests.stockfishchess.org/tests/view/5af35f9f0ebc5968e6523fe9
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 145781 W: 29368 L: 29478 D: 86935 

LTC http://tests.stockfishchess.org/tests/view/5af3cb430ebc5968e652401f
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 76398 W: 11272 L: 11232 D: 53894 

I also incorrectly scheduled STC with [0,5] which it failed.
http://tests.stockfishchess.org/tests/view/5af283c00ebc5968e6523f33
LLR: -2.94 (-2.94,2.94) [0.00,5.00]
Total: 12338 W: 2451 L: 2522 D: 7365 

Thanks to @vondele and @Rocky640 for a cleaner version and below comments!
```
Most of the pinned, (or for this PR, blocking) squares were already computed in the unsafeChecks.
The only missing squares in unsafeChecks are:
a) squares attacked by a Queen which are occupied by friendly piece or "unsafe"
adding such square never passed sprt[0,5]

b) squares not in mobilityArea[Us]

unsafeChecks are still useful when the checker is not aligned with the king, and the checking square is occupied by friendly piece or is "unsafe"
This is always the case for the Knight,

There is a strong relationship between the 2 things.
```

bench: 4698290