### PR TITLE
Fix MSVC errors in tbprobe.cpp

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1153,7 +1153,7 @@ WDLScore search(Position& pos, ProbeState* result) {
         moveCount++;
 
         pos.do_move(move, st);
-        value = -search(pos, result);
+        value = -::search(pos, result);
         pos.undo_move(move);
 
         if (*result == FAIL)


### PR DESCRIPTION
Fix for below errors that showed up after updating to latest MSVC.
tbprobe.cpp(1156): error C2672: 'search': no matching overloaded function found
tbprobe.cpp(1198): error C2783: 'Tablebases::WDLScore `anonymous-namespace'::search(Position &,Tablebases::ProbeState *)': could not deduce template argument for 'CheckZeroingMoves'

No functional change.

bench: 5244314