### PR TITLE
Just use local variable excludedMove in NMP test

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -737,7 +737,7 @@ namespace {
         && (ss-1)->statScore < 22500
         &&  eval >= beta
         &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225
-        && !ss->excludedMove
+        && !excludedMove
         &&  pos.non_pawn_material(pos.side_to_move())
         && (ss->ply >= thisThread->nmp_ply || ss->ply % 2 != thisThread->nmp_odd))
     {


### PR DESCRIPTION
Seems simpler to use the local variable "excludedMove" than "ss->excludedMove".
This simplification does not change the bench.

bench: 4698290