### PR TITLE
Use threads to clear the TT faster.

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -23,6 +23,7 @@
 #include <thread>
 
 #include "bitboard.h"
+#include "misc.h"
 #include "tt.h"
 #include "uci.h"
 
@@ -72,7 +73,11 @@ void TranspositionTable::clear() {
                    len =    idx != Options["Threads"] - 1 ?
                             stride :
                             clusterCount - start;
-      threads.push_back(std::thread(std::memset, &table[start], 0, len * sizeof(Cluster)));
+      threads.push_back(std::thread([&]() {
+          if (Options["Threads"] >= 8)
+              WinProcGroup::bindThisThread(idx);
+          std::memset(&table[start], 0, len * sizeof(Cluster));
+      }));
   }
 
   for (std::thread& th: threads)

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -73,7 +73,7 @@ void TranspositionTable::clear() {
                    len =    idx != Options["Threads"] - 1 ?
                             stride :
                             clusterCount - start;
-      threads.push_back(std::thread([&]() {
+      threads.push_back(std::thread([this, idx, start, len]() {
           if (Options["Threads"] >= 8)
               WinProcGroup::bindThisThread(idx);
           std::memset(&table[start], 0, len * sizeof(Cluster));

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -20,9 +20,11 @@
 
 #include <cstring>   // For std::memset
 #include <iostream>
+#include <thread>
 
 #include "bitboard.h"
 #include "tt.h"
+#include "uci.h"
 
 TranspositionTable TT; // Our global transposition table
 
@@ -58,12 +60,24 @@ void TranspositionTable::resize(size_t mbSize) {
 /// TranspositionTable::clear() overwrites the entire transposition table
 /// with zeros. It is called whenever the table is resized, or when the
 /// user asks the program to clear the table (from the UCI interface).
+/// It starts as many threads as allowed by the Threads option.
 
 void TranspositionTable::clear() {
 
-  std::memset(table, 0, clusterCount * sizeof(Cluster));
-}
+  const size_t stride = clusterCount / Options["Threads"];
+  std::vector<std::thread> threads;
+  for (size_t idx = 0; idx < Options["Threads"]; idx++)
+  {
+      const size_t start =  stride * idx,
+                   len =    idx != Options["Threads"] - 1 ?
+                            stride :
+                            clusterCount - start;
+      threads.push_back(std::thread(std::memset, &table[start], 0, len * sizeof(Cluster)));
+  }
 
+  for (std::thread& th: threads)
+      th.join();
+}
 
 /// TranspositionTable::probe() looks up the current position in the transposition
 /// table. It returns true and a pointer to the TTEntry if the position is found.


### PR DESCRIPTION
Stockfish currently takes a while to clear the TT when using larger hash sizes.

On one machine with 128 GB hash it takes about 50 seconds with a single thread,
allowing it to use all allocated cores brought that time down to 4 seconds.

No functional change