### PR TITLE
Simplify Pawn Storm for unblocked.

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -232,7 +232,7 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
       safety += ShelterStrength[d][ourRank];
       if (ourRank || theirRank)
          safety -= (ourRank && (ourRank == theirRank - 1)) ?
-            BlockedByPawn[d][theirRank] : (Unblocked[theirRank] - 2*d);
+            BlockedByPawn[d][theirRank] : Unblocked[theirRank] - 2*d;
   }
 
   return safety;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -229,8 +229,8 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
 
       int d = std::min(f, ~f);
 
-      safety += ShelterStrength[d][ourRank] - (ourRank && (ourRank == theirRank - 1)) ?
-         BlockedByPawn[d][theirRank] : Unblocked[theirRank];
+      safety += ShelterStrength[d][ourRank] - ((ourRank && (ourRank == theirRank - 1)) ?
+         BlockedByPawn[d][theirRank] : Unblocked[theirRank]);
   }
 
   return safety;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -47,9 +47,9 @@ namespace {
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
     { V( 7), V(76), V(84), V( 38), V( 7), V( 30), V(-19) },
-    { V(-3), V(93), V(52), V(-17), V(12), V(-22), V(-35) },
-    { V(-6), V(83), V(25), V(-24), V(15), V( 22), V(-39) },
-    { V(11), V(83), V(19), V(  8), V(18), V(-21), V(-30) }
+    { V(-1), V(95), V(54), V(-15), V(14), V(-20), V(-33) },
+    { V(-2), V(87), V(29), V(-20), V(19), V( 26), V(-35) },
+    { V(17), V(89), V(25), V( 14), V(24), V(-15), V(-24) }
   };
 
   // Danger of unblocked enemy pawns moving toward our king by rank.
@@ -58,10 +58,10 @@ namespace {
 
   // Danger of blocked enemy pawns ahead of king by [distance from edge][rank]
   constexpr Value BlockedByPawn[FILE_NB / 2][RANK_NB] =
-    { { V( 0),  V(  0), V( 37), V(  5), V(-48) },
-      { V( 0),  V(  0), V( 68), V(-12), V( 13) },
-      { V( 0),  V(  0), V(111), V(-25), V( -3) },
-      { V( 0),  V(  0), V(108), V( 14), V( 21) } };
+    { { V( 0),  V(  0), V( 37), V(  5), V(-48) }, //, V( 0), V( 0) },
+      { V( 0),  V(  0), V( 70), V(-10), V( 15) }, //, V( 2), V( 2) },
+      { V( 0),  V(  0), V(115), V(-21), V(  1) }, //, V( 4), V( 4) },
+      { V( 0),  V(  0), V(114), V( 20), V( 27) }, }; //, V( 6), V( 6) } };
 
   #undef S
   #undef V
@@ -230,9 +230,8 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
       int d = std::min(f, ~f);
 
       safety += ShelterStrength[d][ourRank];
-      if (ourRank || theirRank)
-         safety -= (ourRank && (ourRank == theirRank - 1)) ?
-            BlockedByPawn[d][theirRank] : Unblocked[theirRank] - 2*d;
+      safety -= (ourRank && (ourRank == theirRank - 1)) ?
+            BlockedByPawn[d][theirRank] : Unblocked[theirRank];
   }
 
   return safety;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -58,10 +58,10 @@ namespace {
 
   // Danger of blocked enemy pawns ahead of king by [distance from edge][rank]
   constexpr Value BlockedByPawn[FILE_NB / 2][RANK_NB] =
-    { { V( 0),  V(  0), V( 37), V(  5), V(-48) }, //, V( 0), V( 0) },
-      { V( 0),  V(  0), V( 70), V(-10), V( 15) }, //, V( 2), V( 2) },
-      { V( 0),  V(  0), V(115), V(-21), V(  1) }, //, V( 4), V( 4) },
-      { V( 0),  V(  0), V(114), V( 20), V( 27) }, }; //, V( 6), V( 6) } };
+    { { V( 0),  V(  0), V( 37), V(  5), V(-48) , V( 0), V( 0) },
+      { V( 0),  V(  0), V( 70), V(-10), V( 15) , V( 2), V( 2) },
+      { V( 0),  V(  0), V(115), V(-21), V(  1) , V( 4), V( 4) },
+      { V( 0),  V(  0), V(114), V( 20), V( 27) , V( 6), V( 6) } };
 
   #undef S
   #undef V

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -229,9 +229,8 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
 
       int d = std::min(f, ~f);
 
-      safety += ShelterStrength[d][ourRank];
-      safety -= (ourRank && (ourRank == theirRank - 1)) ?
-            BlockedByPawn[d][theirRank] : Unblocked[theirRank];
+      safety += ShelterStrength[d][ourRank] - (ourRank && (ourRank == theirRank - 1)) ?
+         BlockedByPawn[d][theirRank] : Unblocked[theirRank];
   }
 
   return safety;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -52,18 +52,16 @@ namespace {
     { V(11), V(83), V(19), V(  8), V(18), V(-21), V(-30) }
   };
 
-  // Danger of enemy pawns moving toward our king.
-  // For calculating the danger of unblocked pawns, for each file, 
-  // multiply a distance from edge to a step value(1) and add it to the base (0);
-  // RANK_1 is used when the opponent has no pawn on the file
-  constexpr Value Unblocked[RANK_NB] = {V(19-19), V(61-19), V(124-19), V(60-19), V(33-19), V( 0-19), V( 0-19)};
+  // Danger of unblocked enemy pawns moving toward our king by rank.
+  // RANK_1 is used when there is no enemy pawn on the file
+  constexpr Value Unblocked[RANK_NB] = {V(19), V(61), V(124), V(60), V(33)};
 
-  // The danger of pawns blocked by pawns by [distance from edge][rank]
+  // Danger of blocked enemy pawns ahead of king by [distance from edge][rank]
   constexpr Value BlockedByPawn[FILE_NB / 2][RANK_NB] =
-    { { V( 0),  V(  0), V( 37-19), V(  5-19), V(-48-19) },
-      { V( 0),  V(  0), V( 68-19), V(-12-19), V( 13-19) },
-      { V( 0),  V(  0), V(111-19), V(-25-19), V( -3-19) },
-      { V( 0),  V(  0), V(108-19), V( 14-19), V( 21-19) } };
+    { { V( 0),  V(  0), V( 37), V(  5), V(-48) },
+      { V( 0),  V(  0), V( 68), V(-12), V( 13) },
+      { V( 0),  V(  0), V(111), V(-25), V( -3) },
+      { V( 0),  V(  0), V(108), V( 14), V( 21) } };
 
   #undef S
   #undef V
@@ -215,7 +213,7 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
   Bitboard ourPawns = b & pos.pieces(Us);
   Bitboard theirPawns = b & pos.pieces(Them);
 
-  Value safety = (ourPawns & file_bb(ksq)) ? Value(5-19*3) : Value(-5-19*3);
+  Value safety = (ourPawns & file_bb(ksq)) ? Value(5) : Value(-5);
 
   if (shift<Down>(theirPawns) & (FileABB | FileHBB) & BlockRanks & ksq)
       safety += Value(374);
@@ -233,8 +231,8 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
 
       safety += ShelterStrength[d][ourRank];
       if (ourRank || theirRank)
-         safety -= (ourRank && (ourRank == theirRank - 1)) ? BlockedByPawn[d][theirRank] : 
-                   (Unblocked[theirRank] - 2*d);
+         safety -= (ourRank && (ourRank == theirRank - 1)) ?
+            BlockedByPawn[d][theirRank] : (Unblocked[theirRank] - 2*d);
   }
 
   return safety;


### PR DESCRIPTION
This is a simplification of the pawn storm danger array.  The distance from edge part of the value is represented using a -2 * distance from a default value (in the array).  Thus, the pawn storm danger value for unblocked is now one dimensional.  I tried a number of slight variations, all of which were horrible. 
This one performs especially well and I'm not sure I understand why.  Earlier versions were ps_unblocked9.  Final version in ps_unblocked11.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 17834 W: 3675 L: 3547 D: 10612
http://tests.stockfishchess.org/tests/view/5af791900ebc5968e65242d3

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 55438 W: 8326 L: 8256 D: 38856
http://tests.stockfishchess.org/tests/view/5af7bc0f0ebc591fdf408b15

A second STC to verify with an updated master:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 6895 W: 1522 L: 1373 D: 4000
http://tests.stockfishchess.org/tests/view/5afc2dae0ebc591fdf408e16