### PR TITLE
Is the progressKey unnecessary?

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -130,8 +130,8 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
 }
 
 
-// Marcel van Kervink's cuckoo algorithm for fast detection of "upcoming repetition"/
-// "no progress" situations. Description of the algorithm in the following paper:
+// Marcel van Kervinck's cuckoo algorithm for fast detection of "upcoming repetition"
+// situations. Description of the algorithm in the following paper:
 // https://marcelk.net/2013-04-06/paper/upcoming-rep-v2.pdf
 
 // First and second hash functions for indexing the cuckoo tables

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1192,8 +1192,14 @@ bool Position::has_game_cycle(int ply) const {
       if (   (j = H1(moveKey), cuckoo[j] == moveKey)
           || (j = H2(moveKey), cuckoo[j] == moveKey))
       {
-          Move m = Move(cuckooMove[j]);
-          if (!(between_bb(from_sq(m), to_sq(m)) & pieces()))
+          Move move = cuckooMove[j];
+
+          Square from = from_sq(move);
+          Square to = to_sq(move);
+          if (empty(from))
+              move = make_move(to, from);
+          
+          if (!(between_bb(from, to) & pieces()))
           {
               if (ply > i)
                   return true;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1193,14 +1193,15 @@ bool Position::has_game_cycle(int ply) const {
           || (j = H2(moveKey), cuckoo[j] == moveKey))
       {
           Move move = cuckooMove[j];
-
           Square from = from_sq(move);
           Square to = to_sq(move);
-          if (empty(from))
-              move = make_move(to, from);
-          
+
           if (!(between_bb(from, to) & pieces()))
           {
+              // Take care to reverse the move in the no-progress case (opponent to move)
+              if (empty(from))
+                  move = make_move(to, from);
+
               if (ply > i)
                   return true;
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -135,8 +135,8 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
 // https://marcelk.net/2013-04-06/paper/upcoming-rep-v2.pdf
 
 // First and second hash functions for indexing the cuckoo tables
-inline Key H1(Key h) { return h & 0x1fff; }
-inline Key H2(Key h) { return (h >> 16) & 0x1fff; }
+inline int H1(Key h) { return h & 0x1fff; }
+inline int H2(Key h) { return (h >> 16) & 0x1fff; }
 
 // Cuckoo tables with Zobrist hashes of valid reversible moves, and the moves themselves
 Key cuckoo[8192];
@@ -180,7 +180,7 @@ void Position::init() {
               {
                   Move move = make_move(s1, s2);
                   Key key = Zobrist::psq[pc][s1] ^ Zobrist::psq[pc][s2] ^ Zobrist::side;
-                  unsigned int i = H1(key);
+                  int i = H1(key);
                   while (true)
                   {
                       std::swap(cuckoo[i], key);
@@ -1148,9 +1148,9 @@ bool Position::has_repeated() const {
     StateInfo* stc = st;
     while (true)
     {
-        int i = 4, e = std::min(stc->rule50, stc->pliesFromNull);
+        int i = 4, end = std::min(stc->rule50, stc->pliesFromNull);
 
-        if (e < i)
+        if (end < i)
             return false;
 
         StateInfo* stp = st->previous->previous;
@@ -1162,7 +1162,7 @@ bool Position::has_repeated() const {
                 return true;
 
             i += 2;
-        } while (i <= e);
+        } while (i <= end);
 
         stc = stc->previous;
     }
@@ -1174,7 +1174,7 @@ bool Position::has_repeated() const {
 
 bool Position::has_game_cycle(int ply) const {
 
-  unsigned int j;
+  int j;
 
   int end = std::min(st->rule50, st->pliesFromNull);
 


### PR DESCRIPTION
Simplifying away all the progressKey stuff gives exactly the same bench, without 
any speed impact. Tested for speed against master with two benches at depth 22 
ran in parallel:

**testedpatch**
Total time (ms) : 92350
Nodes searched  : 178962949
Nodes/second    : 1937877

**master**
Total time (ms) : 92358
Nodes searched  : 178962949
Nodes/second    : 1937709

No functional change.