### PR TITLE
Refactoring of scale factor evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -796,27 +796,13 @@ namespace {
   ScaleFactor Evaluation<T>::scale_factor(Value eg) const {
 
     Color strongSide = eg > VALUE_DRAW ? WHITE : BLACK;
-    int sf = me->scale_factor(pos, strongSide);
+
+    if (me->scale_factor(pos, strongSide) != SCALE_FACTOR_NORMAL)
+       return me->scale_factor(pos, strongSide);
 
     // If scale is not already specific, scale down the endgame via general heuristics
-    if (sf == SCALE_FACTOR_NORMAL)
-    {
-        if (pos.opposite_bishops())
-        {
-            // Endgame with opposite-colored bishops and no other pieces is almost a draw
-            if (   pos.non_pawn_material(WHITE) == BishopValueMg
-                && pos.non_pawn_material(BLACK) == BishopValueMg)
-                sf = 31;
-
-            // Endgame with opposite-colored bishops, but also other pieces. Still
-            // a bit drawish, but not as drawish as with only the two bishops.
-            else
-                sf = 46;
-        }
-        else
-            sf = std::min(40 + 7 * pos.count<PAWN>(strongSide), sf);
-    }
-
+    int sf = pos.opposite_bishops()? me->piece_types() == 1? 31: 46
+                                   : std::min(40 + 7 * pos.count<PAWN>(strongSide), int(SCALE_FACTOR_NORMAL));
     return ScaleFactor(sf);
   }
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -218,9 +218,8 @@ Entry* probe(const Position& pos) {
   e->value = int16_t((imbalance<WHITE>(pieceCount) - imbalance<BLACK>(pieceCount)) / 16);
 
   e->pieceTypes = 0;
-  for (int pt = KNIGHT; pt <= QUEEN; ++pt)
-      e->pieceTypes += pieceCount[WHITE][pt] || pieceCount[BLACK][pt];
-
+  for (PieceType pt = KNIGHT; pt <= QUEEN; ++pt)
+      e->pieceTypes += (pos.pieces(pt) != 0);
 
   return e;
 }

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -216,6 +216,12 @@ Entry* probe(const Position& pos) {
     pos.count<BISHOP>(BLACK)    , pos.count<ROOK>(BLACK), pos.count<QUEEN >(BLACK) } };
 
   e->value = int16_t((imbalance<WHITE>(pieceCount) - imbalance<BLACK>(pieceCount)) / 16);
+
+  e->pieceTypes = false;
+  for (int pt = KNIGHT; pt <= QUEEN; ++pt)
+      e->pieceTypes += pieceCount[WHITE][pt] || pieceCount[BLACK][pt];
+
+
   return e;
 }
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -217,7 +217,7 @@ Entry* probe(const Position& pos) {
 
   e->value = int16_t((imbalance<WHITE>(pieceCount) - imbalance<BLACK>(pieceCount)) / 16);
 
-  e->pieceTypes = false;
+  e->pieceTypes = 0;
   for (int pt = KNIGHT; pt <= QUEEN; ++pt)
       e->pieceTypes += pieceCount[WHITE][pt] || pieceCount[BLACK][pt];
 

--- a/src/material.h
+++ b/src/material.h
@@ -40,6 +40,7 @@ namespace Material {
 struct Entry {
 
   Score imbalance() const { return make_score(value, value); }
+  int piece_types() const { return pieceTypes; }
   Phase game_phase() const { return gamePhase; }
   bool specialized_eval_exists() const { return evaluationFunction != nullptr; }
   Value evaluate(const Position& pos) const { return (*evaluationFunction)(pos); }
@@ -62,6 +63,7 @@ struct Entry {
   int16_t value;
   uint8_t factor[COLOR_NB];
   Phase gamePhase;
+  int pieceTypes;
 };
 
 typedef HashTable<Entry, 8192> Table;


### PR DESCRIPTION
This is a proposal of a refactoring of the scale factor function.

It consists of two main parts:
1) adding a helper function to the `material` entry counting the number of piece types on the board
2) using arithmetic conditional statements in the `evaluate_scale_factor`

I like this version more than master because of two reasons:
1) it is more compact, saving 2 non comment LOCs
2) it adds a helper function which could be used in other contexts like initiative

I would like to have it open for some time to collect feedback.