### PR TITLE
Simplify Shelter - Always do strength and danger

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -233,7 +233,7 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
 
       int d = std::min(f, ~f);
 
-      safety += ShelterStrength[d][ourRank] - 
+      safety += ShelterStrength[d][ourRank] -
          StormDanger[ourRank && (ourRank == theirRank - 1) ? BlockedByPawn : UnBlocked][d][theirRank];
   }
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -233,9 +233,8 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
 
       int d = std::min(f, ~f);
 
-      safety += ShelterStrength[d][ourRank];
-      if (ourRank || theirRank)
-         safety -= StormDanger[ourRank && (ourRank == theirRank - 1) ? BlockedByPawn : UnBlocked][d][theirRank];
+      safety += ShelterStrength[d][ourRank] - 
+         StormDanger[ourRank && (ourRank == theirRank - 1) ? BlockedByPawn : UnBlocked][d][theirRank];
   }
 
   return safety;


### PR DESCRIPTION
This check of pawns before subtracting danger can be removed.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 21174 W: 4361 L: 4239 D: 12574
http://tests.stockfishchess.org/tests/view/5b00b9f90ebc5914abc12680

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 56980 W: 8377 L: 8309 D: 40294
http://tests.stockfishchess.org/tests/view/5b00ca750ebc5914abc12683