### PR TITLE
StatScore Reset

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1117,7 +1117,7 @@ moves_loop: // When in check, search starts from here
               else
               {
                   assert(value >= beta); // Fail high
-                  ss->statScore = std::max(ss->statScore, 0);
+                  ss->statScore = 0;
                   break;
               }
           }


### PR DESCRIPTION
Simply reset StatScore to 0 at cutoff.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 43154 W: 8706 L: 8625 D: 25823

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 48155 W: 7036 L: 6955 D: 34164