### PR TITLE
Correctly prevent recursive verification in nmp.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -547,6 +547,7 @@ namespace {
     // Step 1. Initialize node
     Thread* thisThread = pos.this_thread();
     inCheck = pos.checkers();
+    Color us = pos.side_to_move();
     moveCount = captureCount = quietCount = ss->moveCount = 0;
     bestValue = -VALUE_INFINITE;
     maxValue = VALUE_INFINITE;
@@ -639,7 +640,7 @@ namespace {
             else if (!pos.capture_or_promotion(ttMove))
             {
                 int penalty = -stat_bonus(depth);
-                thisThread->mainHistory[pos.side_to_move()][from_to(ttMove)] << penalty;
+                thisThread->mainHistory[us][from_to(ttMove)] << penalty;
                 update_continuation_histories(ss, pos.moved_piece(ttMove), to_sq(ttMove), penalty);
             }
         }
@@ -749,8 +750,8 @@ namespace {
         &&  eval >= beta
         &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225
         && !excludedMove
-        &&  pos.non_pawn_material(pos.side_to_move())
-        && (ss->ply >= thisThread->nmp_ply || ss->ply % 2 != thisThread->nmp_odd))
+        &&  pos.non_pawn_material(us)
+        && (ss->ply > thisThread->nmp_min_ply || us != thisThread->nmp_color))
     {
         assert(eval - beta >= 0);
 
@@ -772,17 +773,17 @@ namespace {
             if (nullValue >= VALUE_MATE_IN_MAX_PLY)
                 nullValue = beta;
 
-            if (abs(beta) < VALUE_KNOWN_WIN && (depth < 12 * ONE_PLY || thisThread->nmp_ply))
+            if (abs(beta) < VALUE_KNOWN_WIN && (depth < 12 * ONE_PLY || thisThread->nmp_min_ply))
                 return nullValue;
 
             // Do verification search at high depths. Disable null move pruning
             // for side to move for the first part of the remaining search tree.
-            thisThread->nmp_ply = ss->ply + 3 * (depth-R) / 4;
-            thisThread->nmp_odd = ss->ply % 2;
+            thisThread->nmp_min_ply = ss->ply + 3 * (depth-R) / 4 - 1;
+            thisThread->nmp_color = us;
 
             Value v = search<NonPV>(pos, ss, beta-1, beta, depth-R, false);
 
-            thisThread->nmp_odd = thisThread->nmp_ply = 0;
+            thisThread->nmp_min_ply = 0;
 
             if (v >= beta)
                 return nullValue;
@@ -923,7 +924,7 @@ moves_loop: // When in check, search starts from here
 
       // Step 14. Pruning at shallow depth (~170 Elo)
       if (  !rootNode
-          && pos.non_pawn_material(pos.side_to_move())
+          && pos.non_pawn_material(us)
           && bestValue > VALUE_MATED_IN_MAX_PLY)
       {
           if (   !captureOrPromotion
@@ -1018,7 +1019,7 @@ moves_loop: // When in check, search starts from here
                        && !pos.see_ge(make_move(to_sq(move), from_sq(move))))
                   r -= 2 * ONE_PLY;
 
-              ss->statScore =  thisThread->mainHistory[~pos.side_to_move()][from_to(move)]
+              ss->statScore =  thisThread->mainHistory[us][from_to(move)]
                              + (*contHist[0])[movedPiece][to_sq(move)]
                              + (*contHist[1])[movedPiece][to_sq(move)]
                              + (*contHist[3])[movedPiece][to_sq(move)]

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -773,11 +773,14 @@ namespace {
             if (nullValue >= VALUE_MATE_IN_MAX_PLY)
                 nullValue = beta;
 
-            if (abs(beta) < VALUE_KNOWN_WIN && (depth < 12 * ONE_PLY || thisThread->nmp_min_ply))
+            if (thisThread->nmp_min_ply || (abs(beta) < VALUE_KNOWN_WIN && depth < 12 * ONE_PLY))
                 return nullValue;
 
-            // Do verification search at high depths. Disable null move pruning
-            // for side to move for the first part of the remaining search tree.
+            // Recursive verification is not allowed
+            assert(!thisThread->nmp_min_ply);
+
+            // Do verification search at high depths, with null move pruning disabled
+            // for us, until ply exceeds nmp_min_ply.
             thisThread->nmp_min_ply = ss->ply + 3 * (depth-R) / 4 - 1;
             thisThread->nmp_color = us;
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -187,7 +187,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
 
   for (Thread* th : *this)
   {
-      th->nodes = th->tbHits = th->nmp_ply = th->nmp_odd = 0;
+      th->nodes = th->tbHits = th->nmp_min_ply = 0;
       th->rootDepth = th->completedDepth = DEPTH_ZERO;
       th->rootMoves = rootMoves;
       th->rootPos.set(pos.fen(), pos.is_chess960(), &setupStates->back(), th);

--- a/src/thread.h
+++ b/src/thread.h
@@ -61,7 +61,8 @@ public:
   Material::Table materialTable;
   Endgames endgames;
   size_t PVIdx, PVLast;
-  int selDepth, nmp_ply, nmp_odd;
+  int selDepth, nmp_min_ply;
+  Color nmp_color;
   std::atomic<uint64_t> nodes, tbHits;
 
   Position rootPos;


### PR DESCRIPTION
As discussed with @pb00068, the condition to prevent recursive verification was not completely correct. This patch corrects that condition, and adds an assert. In the current implementation, recursive verification needs to be avoided in order not to break the verification of the move closer to the root (i.e. to not set thisThread->nmp_min_ply to zero prematurely).

This patch is tested as a bug fix, based on and tested against PR #1609 .

passed STC:
http://tests.stockfishchess.org/tests/view/5b050f170ebc5914abc129c5
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 7875 W: 1669 L: 1523 D: 4683

passed LTC:
http://tests.stockfishchess.org/tests/view/5b0513970ebc5914abc129cd
LLR: 3.00 (-2.94,2.94) [-3.00,1.00]
Total: 24048 W: 3525 L: 3407 D: 17116

changing at high depth, bench: 4484288