### PR TITLE
LMR Capture Tweak

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -992,7 +992,13 @@ moves_loop: // When in check, search starts from here
           Depth r = reduction<PvNode>(improving, depth, moveCount);
 
           if (captureOrPromotion) // (~5 Elo)
+          {
+              //Increase reduction by comparing opponent's stat score
+              if ((ss-1)->statScore >= 0 && thisThread->captureHistory[movedPiece][to_sq(move)][type_of(pos.captured_piece())] < 0)
+                  r += ONE_PLY;
+                            
               r -= r ? ONE_PLY : DEPTH_ZERO;
+          }
           else
           {
               // Decrease reduction if opponent's move count is high (~5 Elo)


### PR DESCRIPTION
Increase capture reduction by comparing opponent's stat score

STC: (Yellow)
LLR: -2.96 (-2.94,2.94) [0.00,5.00]
Total: 92291 W: 18647 L: 18350 D: 55294
http://tests.stockfishchess.org/tests/view/5b04225e0ebc5914abc1291b

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 20176 W: 3061 L: 2868 D: 14247
http://tests.stockfishchess.org/tests/view/5b04bb3f0ebc5914abc129a3

Bench:  4772459