### PR TITLE
Simplify depth reduction in IID.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -834,8 +834,7 @@ namespace {
     if (    depth >= 8 * ONE_PLY
         && !ttMove)
     {
-        Depth d = 3 * depth / 4 - 2 * ONE_PLY;
-        search<NT>(pos, ss, alpha, beta, d, cutNode);
+        search<NT>(pos, ss, alpha, beta, depth - 7 * ONE_PLY, cutNode);
 
         tte = TT.probe(posKey, ttHit);
         ttValue = ttHit ? value_from_tt(tte->value(), ss->ply) : VALUE_NONE;


### PR DESCRIPTION
Use a constant reduction instead of a depth dependent reduction.

passed STC:
http://tests.stockfishchess.org/tests/view/5b06eb600ebc5914abc12ba8
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 58086 W: 11710 L: 11657 D: 34719

passed LTC:
http://tests.stockfishchess.org/tests/view/5b07b25e0ebc5914abc12c6d
LLR: 3.09 (-2.94,2.94) [-3.00,1.00]
Total: 110414 W: 16217 L: 16219 D: 77978

Bench: 4521056