### PR TITLE
Reallocate TT on threadpool resize.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,7 +44,6 @@ int main(int argc, char* argv[]) {
   Search::init();
   Pawns::init();
   Tablebases::init(Options["SyzygyPath"]); // After Bitboards are set
-  TT.resize(Options["Hash"]);
   Threads.set(Options["Threads"]);
   Search::clear(); // After threads are up
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -26,6 +26,7 @@
 #include "thread.h"
 #include "uci.h"
 #include "syzygy/tbprobe.h"
+#include "tt.h"
 
 ThreadPool Threads; // Global object
 
@@ -136,6 +137,9 @@ void ThreadPool::set(size_t requested) {
           push_back(new Thread(size()));
       clear();
   }
+
+  // reallocate the hash with the new threadpool size.
+  TT.resize(Options["Hash"]);
 }
 
 /// ThreadPool::clear() sets threadPool data to initial values.

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -36,12 +36,7 @@ TranspositionTable TT; // Our global transposition table
 
 void TranspositionTable::resize(size_t mbSize) {
 
-  size_t newClusterCount = mbSize * 1024 * 1024 / sizeof(Cluster);
-
-  if (newClusterCount == clusterCount)
-      return;
-
-  clusterCount = newClusterCount;
+  clusterCount = mbSize * 1024 * 1024 / sizeof(Cluster);
 
   free(mem);
   mem = malloc(clusterCount * sizeof(Cluster) + CacheLineSize - 1);


### PR DESCRIPTION
Makes sure the potential benefit of first touch does not depend on the order of the UCI commands Threads and Hash, by reallocating the hash if a Threads is issued. The cost is zeroing the TT once more than needed. In case the prefered order (first Threads than Hash) is employed, this amounts to zeroing the default sized TT (16Mb), which is essentially instantaneous.

Follow up for https://github.com/official-stockfish/Stockfish/pull/1601 where additional data and discussion is available.

No functional change.