### PR TITLE
Simplify Unblocked pawn storm array to one dimension

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -43,27 +43,34 @@ namespace {
   // Doubled pawn penalty
   constexpr Score Doubled = S(13, 40);
 
-  // Penalty for no pawns in shelter on a file by [file]
-  constexpr Value PawnlessFile[FILE_NB/2] = { V(25), V(  5), V(-20), V(-27)};
-
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
     { V(  7), V(76), V( 84), V( 38), V(  7), V( 30), V(-19) },
-    { V(-13-10), V(83-10), V( 42-10), V(-27-10), V(  2-10), V(-32-10), V(-45-10) },
-    { V(-26-20), V(63-20), V(  5-20), V(-44-20), V( -5-20), V(  2-20), V(-59-20) },
-    { V(-19-30), V(53-30), V(-11-30), V(-22-30), V(-12-30), V(-51-30), V(-60-30) }
+    { V(-13), V(83), V( 42), V(-27), V(  2), V(-32), V(-45) },
+    { V(-26), V(63), V(  5), V(-44), V( -5), V(  2), V(-59) },
+    { V(-19), V(53), V(-11), V(-22), V(-12), V(-51), V(-60) }
   };
+
+  // Storm value for no enemy pawn on a file by [distance from edge]
+  constexpr Value PawnlessFile[FILE_NB/2] = { V(25), V( 5), V(-20), V(-27)};
 
   // Danger of enemy pawns moving toward our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where the enemy has no pawn, or their pawn 
   // is behind our king.
-  constexpr Value UnblockedStorm[RANK_NB] =
-    { V(  0), V( 48), V( 96), V( 45), V( 27), V(  0), V(  0) };
+  constexpr Value UnblockedStorm[int(FILE_NB) / 2][RANK_NB] = {
+    { V(  0), V( 49), V( 96), V( 45), V( 27), V(  0), V(  0) },
+    { V(  0), V( 39), V( 86), V( 35), V( 17), V(-10), V(-10) },
+    { V(  0), V( 29), V( 76), V( 25), V(  7), V(-20), V(-20) },
+    { V(  0), V( 19), V( 66), V( 15), V( -3), V(-30), V(-30) }
+  };
 
   // Danger of blocked enemy pawns storming our king, by rank
-  constexpr Value BlockedStorm[RANK_NB] =
-    { V(  0), V(  0), V( 95), V( 10), V(  0), V(  0), V(  0) };
+  constexpr Value BlockedStorm[FILE_NB/2][RANK_NB] = {
+    { V(  0), V(  0), V( 75), V(-10), V(-20), V(-20), V(-20) },
+    { V(  0), V(  0), V( 75), V(-10), V(-20), V(-20), V(-20) },
+    { V(  0), V(  0), V( 75), V(-10), V(-20), V(-20), V(-20) },
+    { V(  0), V(  0), V( 75), V(-10), V(-20), V(-20), V(-20) } };
 
   #undef S
   #undef V
@@ -224,15 +231,16 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
   for (File f = File(center - 1); f <= File(center + 1); ++f)
   {
       int d = std::min(f, ~f);
+
       b = ourPawns & file_bb(f);
       int ourRank = b ? relative_rank(Us, backmost_sq(Us, b)) : RANK_1;
       safety += ShelterStrength[d][ourRank];
 
       b = theirPawns & file_bb(f);
       int theirRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : RANK_1;
-      safety -= theirRank ? ((shift<Down>(b) & ourPawns) ? BlockedStorm[theirRank]
-                                                       : UnblockedStorm[theirRank])
-                                                       : PawnlessFile[d];
+      safety -= theirRank ? ((ourRank && (ourRank == theirRank - 1)) ? 
+                     BlockedStorm[d][theirRank] : UnblockedStorm[d][theirRank]) :
+                     PawnlessFile[d];
   }
 
   return safety;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -43,20 +43,16 @@ namespace {
   // Doubled pawn penalty
   constexpr Score Doubled = S(13, 40);
 
-  // Penalty for no pawns on a file by [us/them][file]
-  constexpr Value PawnlessFile[2][FILE_NB/2] = {{ V( 7), V(-13), V(-26), V(-19)},
-                                                { V(25), V(  5), V(-20), V(-27)}};
-
-  // file based king penalty for pawn storm
-  constexpr Value KingStormFile[FILE_NB/2] = { V(-30), V(-30), V(-60), V(-80) };
+  // Penalty for no pawns in shelter on a file by [file]
+  constexpr Value PawnlessFile[FILE_NB/2] = { V(25), V(  5), V(-20), V(-27)};
 
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
-    { V(  0), V(76), V( 84), V( 38), V(  7), V( 30), V(-19) },
-    { V(  0), V(83), V( 42), V(-27), V(  2), V(-32), V(-45) },
-    { V(  0), V(63), V(  5), V(-44), V( -5), V(  2), V(-59) },
-    { V(  0), V(53), V(-11), V(-22), V(-12), V(-51), V(-60) }
+    { V(  7), V(76), V( 84), V( 38), V(  7), V( 30), V(-19) },
+    { V(-13-10), V(83-10), V( 42-10), V(-27-10), V(  2-10), V(-32-10), V(-45-10) },
+    { V(-26-20), V(63-20), V(  5-20), V(-44-20), V( -5-20), V(  2-20), V(-59-20) },
+    { V(-19-30), V(53-30), V(-11-30), V(-22-30), V(-12-30), V(-51-30), V(-60-30) }
   };
 
   // Danger of enemy pawns moving toward our king by [distance from edge][rank].
@@ -225,23 +221,16 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
       safety += Value(374);
 
   File center = std::max(FILE_B, std::min(FILE_G, file_of(ksq)));
-  int d = std::min(center,~center);
-  safety -= KingStormFile[d];
-
   for (File f = File(center - 1); f <= File(center + 1); ++f)
   {
-      d = std::min(f, ~f);
-      safety += (b = ourPawns & file_bb(f)) ? 
-                ShelterStrength[d][relative_rank(Us, backmost_sq(Us, b))] :
-                PawnlessFile[0][d];
+      int d = std::min(f, ~f);
+      safety += ShelterStrength[d][relative_rank(Us, backmost_sq(Us, ourPawns & file_bb(f)))];
 
       b = theirPawns & file_bb(f);
       int theirRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : 0;
-      if (!theirRank)
-          safety -= PawnlessFile[1][d];
-      else 
-          safety -= (shift<Up>(ourPawns) & b) ? BlockedStorm[theirRank]
-                                              : UnblockedStorm[theirRank];
+      safety -= theirRank ? ((shift<Down>(b) & ourPawns) ? BlockedStorm[theirRank]
+                                                       : UnblockedStorm[theirRank])
+                                                       : PawnlessFile[d];
   }
 
   return safety;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -224,10 +224,12 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
   for (File f = File(center - 1); f <= File(center + 1); ++f)
   {
       int d = std::min(f, ~f);
-      safety += ShelterStrength[d][relative_rank(Us, backmost_sq(Us, ourPawns & file_bb(f)))];
+      b = ourPawns & file_bb(f);
+      int ourRank = b ? relative_rank(Us, backmost_sq(Us, b)) : RANK_1;
+      safety += ShelterStrength[d][ourRank];
 
       b = theirPawns & file_bb(f);
-      int theirRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : 0;
+      int theirRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : RANK_1;
       safety -= theirRank ? ((shift<Down>(b) & ourPawns) ? BlockedStorm[theirRank]
                                                        : UnblockedStorm[theirRank])
                                                        : PawnlessFile[d];

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -67,10 +67,10 @@ namespace {
 
   // Danger of blocked enemy pawns storming our king, by rank
   constexpr Value BlockedStorm[FILE_NB/2][RANK_NB] = {
+    { V(  0), V(  0), V( 95), V( 10), V(  0), V(  0), V(  0) },
+    { V(  0), V(  0), V( 85), V(  0), V(-10), V(-10), V(-10) },
     { V(  0), V(  0), V( 75), V(-10), V(-20), V(-20), V(-20) },
-    { V(  0), V(  0), V( 75), V(-10), V(-20), V(-20), V(-20) },
-    { V(  0), V(  0), V( 75), V(-10), V(-20), V(-20), V(-20) },
-    { V(  0), V(  0), V( 75), V(-10), V(-20), V(-20), V(-20) } };
+    { V(  0), V(  0), V( 65), V(-20), V(-30), V(-30), V(-30) } };
 
   #undef S
   #undef V
@@ -238,7 +238,7 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
 
       b = theirPawns & file_bb(f);
       int theirRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : RANK_1;
-      safety -= theirRank ? ((ourRank && (ourRank == theirRank - 1)) ? 
+      safety -= theirRank ? ((ourRank && (ourRank == theirRank - 1)) ?
                      BlockedStorm[d][theirRank] : UnblockedStorm[d][theirRank]) :
                      PawnlessFile[d];
   }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -43,28 +43,35 @@ namespace {
   // Doubled pawn penalty
   constexpr Score Doubled = S(13, 40);
 
+  // Penalty for no pawns on a file by [us/them][file]
+  constexpr Value PawnlessFile[2][FILE_NB/2] = {{ V( 7), V(-13), V(-26), V(-19)},
+                                                { V(25), V(  5), V(-20), V(-27)}};
+
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
-    { V(  7), V(76), V( 84), V( 38), V(  7), V( 30), V(-19) },
-    { V(-13), V(83), V( 42), V(-27), V(  2), V(-32), V(-45) },
-    { V(-26), V(63), V(  5), V(-44), V( -5), V(  2), V(-59) },
-    { V(-19), V(53), V(-11), V(-22), V(-12), V(-51), V(-60) }
+    { V(  0), V(76), V( 84), V( 38), V(  7), V( 30), V(-19) },
+    { V(  0), V(83), V( 42), V(-27), V(  2), V(-32), V(-45) },
+    { V(  0), V(63), V(  5), V(-44), V( -5), V(  2), V(-59) },
+    { V(  0), V(53), V(-11), V(-22), V(-12), V(-51), V(-60) }
   };
 
   // Danger of enemy pawns moving toward our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where the enemy has no pawn, or their pawn 
   // is behind our king.
   constexpr Value UnblockedStorm[int(FILE_NB) / 2][RANK_NB] = {
-    { V( 25), V( 79), V(107), V( 51), V( 27), V(  0), V(  0) },
-    { V(  5), V( 35), V(121), V( -2), V( 15), V(-10), V(-10) },
-    { V(-20), V( 22), V( 98), V( 36), V(  7), V(-20), V(-20) },
-    { V(-27), V( 24), V( 80), V( 25), V( -4), V(-30), V(-30) }
+    { V(  0), V( 48), V( 96), V( 45), V( 27), V(  0), V(  0) },
+    { V(  0), V( 38), V( 86), V( 35), V( 17), V(-10), V(-10) },
+    { V(  0), V( 28), V( 76), V( 25), V(  7), V(-20), V(-20) },
+    { V(  0), V( 18), V( 66), V( 15), V( -3), V(-30), V(-30) }
   };
 
   // Danger of blocked enemy pawns storming our king, by rank
-  constexpr Value BlockedStorm[RANK_NB] =
-    { V(  0), V(  0), V( 75), V(-10), V(-20), V(-20), V(-20) };
+  constexpr Value BlockedStorm[FILE_NB / 2][RANK_NB] = {
+    { V(  0), V(  0), V( 95), V( 10), V(  0), V(  0), V(  0) },
+    { V(  0), V(  0), V( 85), V(  0), V(-10), V(-10), V(-10) },
+    { V(  0), V(  0), V( 75), V(-10), V(-20), V(-20), V(-20) },
+    { V(  0), V(  0), V( 65), V(-20), V(-30), V(-30), V(-30) } };
 
   #undef S
   #undef V
@@ -224,15 +231,17 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
   File center = std::max(FILE_B, std::min(FILE_G, file_of(ksq)));
   for (File f = File(center - 1); f <= File(center + 1); ++f)
   {
+      int d = std::min(f, ~f);
       b = ourPawns & file_bb(f);
       int ourRank = b ? relative_rank(Us, backmost_sq(Us, b)) : 0;
+      safety += ourRank ? ShelterStrength[d][ourRank] : PawnlessFile[0][d];
 
       b = theirPawns & file_bb(f);
       int theirRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : 0;
-
-      int d = std::min(f, ~f);
-      safety += ShelterStrength[d][ourRank];
-      safety -= (ourRank && (ourRank == theirRank - 1)) ? BlockedStorm[theirRank]
+      if (!theirRank)
+          safety -= PawnlessFile[1][d];
+      else 
+          safety -= (ourRank && (ourRank == theirRank - 1)) ? BlockedStorm[d][theirRank]
                                                         : UnblockedStorm[d][theirRank];
   }
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -46,31 +46,22 @@ namespace {
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
-    { V(  7), V(76), V( 84), V( 38), V(  7), V( 30), V(-19) },
-    { V(-13), V(83), V( 42), V(-27), V(  2), V(-32), V(-45) },
-    { V(-26), V(63), V(  5), V(-44), V( -5), V(  2), V(-59) },
-    { V(-19), V(53), V(-11), V(-22), V(-12), V(-51), V(-60) }
+    { V( 7), V(76), V( 84), V( 38), V(  7), V( 30), V(-19) },
+    { V(-3), V(93), V( 52), V(-17), V( 12), V(-22), V(-35) },
+    { V(-6), V(83), V( 25), V(-24), V( 15), V( 22), V(-39) },
+    { V(11), V(83), V( 19), V(  8), V( 18), V(-21), V(-30) }
   };
 
-  // Storm value for no enemy pawn on a file by [distance from edge]
-  constexpr Value PawnlessFile[FILE_NB/2] = { V(25), V( 5), V(-20), V(-27)};
+  // Danger having no enemy pawn on a file by [distance from edge]
+  constexpr Value PawnlessFile[FILE_NB/2] = {V(25), V(15), V(0), V(3)};
 
-  // Danger of enemy pawns moving toward our king by [distance from edge][rank].
-  // RANK_1 = 0 is used for files where the enemy has no pawn, or their pawn 
-  // is behind our king.
-  constexpr Value UnblockedStorm[int(FILE_NB) / 2][RANK_NB] = {
-    { V(  0), V( 49), V( 96), V( 45), V( 27), V(  0), V(  0) },
-    { V(  0), V( 39), V( 86), V( 35), V( 17), V(-10), V(-10) },
-    { V(  0), V( 29), V( 76), V( 25), V(  7), V(-20), V(-20) },
-    { V(  0), V( 19), V( 66), V( 15), V( -3), V(-30), V(-30) }
-  };
+  // Danger of enemy pawns moving toward our king by rank.
+  constexpr Value UnblockedStorm[RANK_NB] =
+    { V(  0), V( 49), V( 96), V( 45), V( 27), V(  0), V(  0) };
 
-  // Danger of blocked enemy pawns storming our king, by rank
-  constexpr Value BlockedStorm[FILE_NB/2][RANK_NB] = {
-    { V(  0), V(  0), V( 95), V( 10), V(  0), V(  0), V(  0) },
-    { V(  0), V(  0), V( 85), V(  0), V(-10), V(-10), V(-10) },
-    { V(  0), V(  0), V( 75), V(-10), V(-20), V(-20), V(-20) },
-    { V(  0), V(  0), V( 65), V(-20), V(-30), V(-30), V(-30) } };
+  // Danger of blocked enemy pawns storming our king by rank
+  constexpr Value BlockedStorm[RANK_NB] =
+    { V(  0), V(  0), V( 95), V( 10), V(  0), V(  0), V(  0) };
 
   #undef S
   #undef V
@@ -239,7 +230,7 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
       b = theirPawns & file_bb(f);
       int theirRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : RANK_1;
       safety -= theirRank ? ((ourRank && (ourRank == theirRank - 1)) ?
-                     BlockedStorm[d][theirRank] : UnblockedStorm[d][theirRank]) :
+                     BlockedStorm[theirRank]: UnblockedStorm[theirRank]) :
                      PawnlessFile[d];
   }
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -52,10 +52,10 @@ namespace {
     { V(11), V(83), V( 19), V(  8), V( 18), V(-21), V(-30) }
   };
 
-  // Danger having no enemy pawn on a file by [distance from edge]
+  // Danger having no enemy pawn in pawn storm by file [distance from edge]
   constexpr Value PawnlessFile[FILE_NB/2] = {V(27), V(16), V(-2), V(-8)};
 
-  // Danger of enemy pawns moving toward our king by rank.
+  // Danger of unblocked enemy pawns storming our king by rank
   constexpr Value UnblockedStorm[RANK_NB] =
     { V(  0), V( 64), V(104), V( 45), V( 22), V(-10), V( -6) };
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -53,15 +53,15 @@ namespace {
   };
 
   // Danger having no enemy pawn on a file by [distance from edge]
-  constexpr Value PawnlessFile[FILE_NB/2] = {V(25), V(15), V(0), V(3)};
+  constexpr Value PawnlessFile[FILE_NB/2] = {V(27), V(16), V(-2), V(-8)};
 
   // Danger of enemy pawns moving toward our king by rank.
   constexpr Value UnblockedStorm[RANK_NB] =
-    { V(  0), V( 49), V( 96), V( 45), V( 27), V(  0), V(  0) };
+    { V(  0), V( 64), V(104), V( 45), V( 22), V(-10), V( -6) };
 
   // Danger of blocked enemy pawns storming our king by rank
   constexpr Value BlockedStorm[RANK_NB] =
-    { V(  0), V(  0), V( 95), V( 10), V(  0), V(  0), V(  0) };
+    { V(  0), V(  0), V( 82), V( -4), V( -5), V(  5), V(  1) };
 
   #undef S
   #undef V


### PR DESCRIPTION
By using an additional array for NO enemy pawns on a storm file, the Unblocked pawn storm array is also simplified to one dimension with no offset value.

GOOD) The "distance from edge" is removed entirely from the blocked/unblocked pawn storm arrays.  In the end it turns out the distance from edge was illusory with previous array values just cancelling each other out.  Paves the way for further simplifications.

BAD) There is another one-dimensional array called Pawnless, which stores a per file danger value where there is no enemy pawn on a storming file.  This is a little extra, but it is more clear what is going on.  The amount of code is still less with many of the additions being space and comments.  There is a little more logic in the pawn storm loop.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 3807 W: 851 L: 697 D: 2259
http://tests.stockfishchess.org/tests/view/5b0eae480ebc596ad1d274ca

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 94076 W: 13835 L: 13820 D: 66421
http://tests.stockfishchess.org/tests/view/5b0eb3d90ebc596ad1d27563

Bench 4746228
