### PR TITLE
Make time checks dependent on EGTB probes.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1536,8 +1536,13 @@ moves_loop: // When in check, search starts from here
 
 void MainThread::check_time() {
 
-  if (--callsCnt > 0)
+  static uint64_t lastTbHits = 0;
+  uint64_t nowTbHits = tbHits.load(std::memory_order_relaxed);
+
+  if (--callsCnt > 0 && nowTbHits == lastTbHits)
       return;
+
+  lastTbHits = nowTbHits;
 
   // When using nodes, ensure checking rate is not lower than 0.1% of nodes
   callsCnt = Limits.nodes ? std::min(1024, int(Limits.nodes / 1024)) : 1024;

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1467,7 +1467,8 @@ int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
 // Use the DTZ tables to rank root moves.
 //
 // A return value false indicates that not all probes were successful.
-bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
+bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves,
+                            MainThread* main) {
 
     ProbeState result;
     StateInfo st;
@@ -1526,6 +1527,9 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
                    : r == 0     ? VALUE_DRAW
                    : r > -bound ? Value((std::min(-3, r + 800) * int(PawnValueEg)) / 200)
                    :             -VALUE_MATE + MAX_PLY + 1;
+
+        if (main->check_time())
+            return false;
     }
 
     return true;
@@ -1536,7 +1540,8 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
 // This is a fallback for the case that some or all DTZ tables are missing.
 //
 // A return value false indicates that not all probes were successful.
-bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves) {
+bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves,
+                                MainThread* main) {
 
     static const int WDL_to_rank[] = { -1000, -899, 0, 899, 1000 };
 
@@ -1563,6 +1568,9 @@ bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves) {
             wdl =  wdl > WDLDraw ? WDLWin
                  : wdl < WDLDraw ? WDLLoss : WDLDraw;
         m.tbScore = WDL_to_value[wdl + 2];
+
+        if (main->check_time())
+            return false;
     }
 
     return true;

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1528,6 +1528,8 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves,
                    : r > -bound ? Value((std::min(-3, r + 800) * int(PawnValueEg)) / 200)
                    :             -VALUE_MATE + MAX_PLY + 1;
 
+        // Force time check
+        main->callsCnt = 0;
         if (main->check_time())
             return false;
     }
@@ -1569,6 +1571,8 @@ bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves,
                  : wdl < WDLDraw ? WDLLoss : WDLDraw;
         m.tbScore = WDL_to_value[wdl + 2];
 
+        // Force time check
+        main->callsCnt = 0;
         if (main->check_time())
             return false;
     }

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -23,6 +23,7 @@
 #include <ostream>
 
 #include "../search.h"
+#include "../thread.h"
 
 namespace Tablebases {
 
@@ -49,9 +50,12 @@ extern int MaxCardinality;
 void init(const std::string& paths);
 WDLScore probe_wdl(Position& pos, ProbeState* result);
 int probe_dtz(Position& pos, ProbeState* result);
-bool root_probe(Position& pos, Search::RootMoves& rootMoves);
-bool root_probe_wdl(Position& pos, Search::RootMoves& rootMoves);
-void rank_root_moves(Position& pos, Search::RootMoves& rootMoves);
+bool root_probe(Position& pos, Search::RootMoves& rootMoves,
+                MainThread* main);
+bool root_probe_wdl(Position& pos, Search::RootMoves& rootMoves,
+                    MainThread* main);
+void rank_root_moves(Position& pos, Search::RootMoves& rootMoves,
+                     MainThread* main);
 
 inline std::ostream& operator<<(std::ostream& os, const WDLScore v) {
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -173,7 +173,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
           rootMoves.emplace_back(m);
 
   if (!rootMoves.empty())
-      Tablebases::rank_root_moves(pos, rootMoves);
+      Tablebases::rank_root_moves(pos, rootMoves, main());
 
   // After ownership transfer 'states' becomes empty, so if we stop the search
   // and call 'go' again without setting a new position states.get() == NULL.

--- a/src/thread.h
+++ b/src/thread.h
@@ -83,7 +83,8 @@ struct MainThread : public Thread {
   using Thread::Thread;
 
   void search() override;
-  void check_time();
+  bool should_check_time();
+  bool check_time();
 
   double bestMoveChanges, previousTimeReduction;
   Value previousScore;

--- a/src/thread.h
+++ b/src/thread.h
@@ -83,7 +83,6 @@ struct MainThread : public Thread {
   using Thread::Thread;
 
   void search() override;
-  bool should_check_time();
   bool check_time();
 
   double bestMoveChanges, previousTimeReduction;


### PR DESCRIPTION
Continuation of issue #1471.

I have a more convenient testing setup with cutechess now, which allows easy verification that this is a huge improvement.

The first commit is essentially the proposal done in #1471 but with test results. The second commit fixes the edge case of filtering the moves at the root.

Even with these, there are still some forfeits on time. I guess it's because disk access time can be unbounded with other processes running. But it's still a massive improvement. And note these tests were done with 7200 RPM drives. Many people are stuck with 5400 RPM ones.