### PR TITLE
[AppVeyor bug] Move bench output on stdout.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,7 @@ before_test:
   - cd src/%CONFIGURATION%
   - ps: |
       # Verify bench number
-      ./stockfish bench 2> out.txt 1> null
+      ./stockfish bench 2>&1 1> out.txt
       $s = (gc "./out.txt" | out-string)
       $r = ($s -match 'Nodes searched \D+(\d+)' | % { $matches[1] })
       Write-Host "Engine bench:" $r

--- a/src/Makefile
+++ b/src/Makefile
@@ -418,7 +418,7 @@ profile-build: config-sanity objclean profileclean
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_make)
 	@echo ""
 	@echo "Step 2/4. Running benchmark for pgo-build ..."
-	$(PGOBENCH) > /dev/null
+	$(PGOBENCH) | grep "Nodes searched  :"
 	@echo ""
 	@echo "Step 3/4. Building optimized executable ..."
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) objclean

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -157,7 +157,7 @@ namespace {
 
         if (token == "go")
         {
-            cerr << "\nPosition: " << cnt++ << '/' << num << endl;
+            sync_cout << "\nPosition: " << cnt++ << '/' << num << sync_endl;
             go(pos, is, states);
             Threads.main()->wait_for_search_finished();
             nodes += Threads.nodes_searched();
@@ -171,10 +171,10 @@ namespace {
 
     dbg_print(); // Just before exiting
 
-    cerr << "\n==========================="
+    sync_cout << "\n==========================="
          << "\nTotal time (ms) : " << elapsed
          << "\nNodes searched  : " << nodes
-         << "\nNodes/second    : " << 1000 * nodes / elapsed << endl;
+         << "\nNodes/second    : " << 1000 * nodes / elapsed << sync_endl;
   }
 
 } // namespace


### PR DESCRIPTION
after some testing in #1622 the failing CI based on appveyor seems due to spurious newlines in the output that is written to stderr. As a workaround, this patch moves the bench output fully to stdout. It is not obvious why this output ended up on stderr, given this is not related to an error, but this was introduced long ago (2b32571de88837ef5739348b8a3c951590a94205) together with a feature that since has been removed. As such reverting this back to stdout makes sense, independently from the CI failure that it fixes. Small changes to the appveyor config file and the Makefile are needed as a follow-up, so that the bench output is still available in CI, and from a profile-build respectively.

This thus fixes issue #1615

No functional change.