### PR TITLE
Bugfix of Position::has_repeated()

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1153,7 +1153,7 @@ bool Position::has_repeated() const {
         if (end < i)
             return false;
 
-        StateInfo* stp = st->previous->previous;
+        StateInfo* stp = stc->previous->previous;
 
         do {
             stp = stp->previous->previous;


### PR DESCRIPTION
Fix a possible oversight from the TB root ranking patch.
When stepping back a position, we must start to check for a repetition
from this new position.

No functional change.