### PR TITLE
Simplify LMR for captures

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -996,8 +996,7 @@ moves_loop: // When in check, search starts from here
           if (captureOrPromotion) // (~5 Elo)
           {
               // Increase reduction by comparing opponent's stat score
-              if (   (ss-1)->statScore >= 0
-                  && thisThread->captureHistory[movedPiece][to_sq(move)][type_of(pos.captured_piece())] < 0)
+              if ((ss-1)->statScore >= 0)
                   r += ONE_PLY;
 
               r -= r ? ONE_PLY : DEPTH_ZERO;


### PR DESCRIPTION
Simplify LMR for captures by removing capture's stat score logic for reduction.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 37068 W: 7462 L: 7370 D: 22236
http://tests.stockfishchess.org/tests/view/5b115bc30ebc591af58a6fd2

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 80061 W: 11706 L: 11671 D: 56684
http://tests.stockfishchess.org/tests/view/5b117f590ebc59033d2d5315

Bench:  4470519