### PR TITLE
Remove a superfluous subtrahend

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -751,7 +751,7 @@ namespace {
         &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225
         && !excludedMove
         &&  pos.non_pawn_material(us)
-        && (ss->ply > thisThread->nmpMinPly || us != thisThread->nmpColor))
+        && (ss->ply >= thisThread->nmpMinPly || us != thisThread->nmpColor))
     {
         assert(eval - beta >= 0);
 
@@ -780,7 +780,7 @@ namespace {
 
             // Do verification search at high depths, with null move pruning disabled
             // for us, until ply exceeds nmpMinPly.
-            thisThread->nmpMinPly = ss->ply + 3 * (depth-R) / 4 - 1;
+            thisThread->nmpMinPly = ss->ply + 3 * (depth-R) / 4;
             thisThread->nmpColor = us;
 
             Value v = search<NonPV>(pos, ss, beta-1, beta, depth-R, false);


### PR DESCRIPTION
The '- 1' subtrahend in line 783 was introduced for guarding against null move search at root, which would be nonsense. But this is actually already guaranteed by the !PvNode condition on line 747 (see discussion at #1609).

no functional change