### PR TITLE
Simplify cycle detection

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -130,19 +130,6 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
 }
 
 
-// Marcel van Kervinck's cuckoo algorithm for fast detection of "upcoming repetition"
-// situations. Description of the algorithm in the following paper:
-// https://marcelk.net/2013-04-06/paper/upcoming-rep-v2.pdf
-
-// First and second hash functions for indexing the cuckoo tables
-inline int H1(Key h) { return h & 0x1fff; }
-inline int H2(Key h) { return (h >> 16) & 0x1fff; }
-
-// Cuckoo tables with Zobrist hashes of valid reversible moves, and the moves themselves
-Key cuckoo[8192];
-Move cuckooMove[8192];
-
-
 /// Position::init() initializes at startup the various arrays used to compute
 /// hash keys.
 
@@ -170,28 +157,6 @@ void Position::init() {
 
   Zobrist::side = rng.rand<Key>();
   Zobrist::noPawns = rng.rand<Key>();
-
-  // Prepare the cuckoo tables
-  int count = 0;
-  for (Piece pc : Pieces)
-      for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
-          for (Square s2 = Square(s1 + 1); s2 <= SQ_H8; ++s2)
-              if (PseudoAttacks[type_of(pc)][s1] & s2)
-              {
-                  Move move = make_move(s1, s2);
-                  Key key = Zobrist::psq[pc][s1] ^ Zobrist::psq[pc][s2] ^ Zobrist::side;
-                  int i = H1(key);
-                  while (true)
-                  {
-                      std::swap(cuckoo[i], key);
-                      std::swap(cuckooMove[i], move);
-                      if (move == 0)   // Arrived at empty slot ?
-                          break;
-                      i = (i == H1(key)) ? H2(key) : H1(key); // Push victim to alternative slot
-                  }
-                  count++;
-             }
-  assert(count == 3668);
 }
 
 
@@ -1167,59 +1132,6 @@ bool Position::has_repeated() const {
         stc = stc->previous;
     }
 }
-
-
-/// Position::has_game_cycle() tests if the position has a move which draws by repetition,
-/// or an earlier position has a move that directly reaches the current position.
-
-bool Position::has_game_cycle(int ply) const {
-
-  int j;
-
-  int end = std::min(st->rule50, st->pliesFromNull);
-
-  if (end < 3)
-    return false;
-
-  Key originalKey = st->key;
-  StateInfo* stp = st->previous;
-
-  for (int i = 3; i <= end; i += 2)
-  {
-      stp = stp->previous->previous;
-
-      Key moveKey = originalKey ^ stp->key;
-      if (   (j = H1(moveKey), cuckoo[j] == moveKey)
-          || (j = H2(moveKey), cuckoo[j] == moveKey))
-      {
-          Move move = cuckooMove[j];
-          Square s1 = from_sq(move);
-          Square s2 = to_sq(move);
-
-          if (!(between_bb(s1, s2) & pieces()))
-          {
-              // In the cuckoo table, both moves Rc1c5 and Rc5c1 are stored in the same
-              // location. We select the legal one by reversing the move variable if necessary.
-              if (empty(s1))
-                  move = make_move(s2, s1);
-
-              if (ply > i)
-                  return true;
-
-              // For repetitions before or at the root, require one more
-              StateInfo* next_stp = stp;
-              for (int k = i + 2; k <= end; k += 2)
-              {
-                  next_stp = next_stp->previous->previous;
-                  if (next_stp->key == stp->key)
-                     return true;
-              }
-          }
-      }
-  }
-  return false;
-}
-
 
 /// Position::flip() flips position with the white and black sides reversed. This
 /// is only useful for debugging e.g. for finding evaluation symmetry bugs.

--- a/src/position.h
+++ b/src/position.h
@@ -152,7 +152,7 @@ public:
   bool is_chess960() const;
   Thread* this_thread() const;
   bool is_draw(int ply) const;
-  bool has_game_cycle(int ply) const;
+  bool cycling_moves(int ply, Move pMove, Move ppMove, Move pppMove) const;
   bool has_repeated() const;
   int rule50_count() const;
   Score psq_score() const;
@@ -373,6 +373,18 @@ inline Piece Position::captured_piece() const {
 
 inline Thread* Position::this_thread() const {
   return thisThread;
+}
+
+/// Position::cycling_moves() tests if the position the given
+/// moves led to has a move forming a cycle (repeating)
+
+inline bool Position::cycling_moves(int ply, Move pMove, Move ppMove, Move pppMove) const {
+
+    return st->rule50 >= 3 && st->pliesFromNull >= 3 && ply > 3
+           && from_sq(pppMove) == to_sq(pMove)
+           && to_sq(pppMove) == from_sq(pMove)
+           && !(between_bb(from_sq(ppMove), to_sq(ppMove)) & to_sq(pMove))
+           && st->previous->castlingRights == st->previous->previous->previous->castlingRights;
 }
 
 inline void Position::put_piece(Piece pc, Square s) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -579,11 +579,9 @@ namespace {
         if (alpha >= beta)
             return alpha;
 
-        // Check if there exists a move which draws by repetition, or an alternative
-        // earlier move to this position.
-        if (   pos.rule50_count() >= 3
-            && alpha < VALUE_DRAW
-            && pos.has_game_cycle(ss->ply))
+        // Check if there exists a move which draws by repetition
+        if (alpha < VALUE_DRAW
+            && pos.cycling_moves(ss->ply, (ss-1)->currentMove, (ss-2)->currentMove, (ss-3)->currentMove))
         {
             alpha = VALUE_DRAW;
             if (alpha >= beta)
@@ -1232,6 +1230,15 @@ moves_loop: // When in check, search starts from here
     if (   pos.is_draw(ss->ply)
         || ss->ply >= MAX_PLY)
         return (ss->ply >= MAX_PLY && !inCheck) ? evaluate(pos) : VALUE_DRAW;
+
+    // Check if there exists a move which draws by repetition
+    if (alpha < VALUE_DRAW
+        && pos.cycling_moves(ss->ply, (ss-1)->currentMove, (ss-2)->currentMove, (ss-3)->currentMove))
+    {
+        alpha = VALUE_DRAW;
+        if (alpha >= beta)
+            return alpha;
+    }
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 


### PR DESCRIPTION
Simplify cycle detection.

First version passed the following tests

http://tests.stockfishchess.org/tests/view/5b07df790ebc5914abc12ca4
STC:
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 46119 W: 9224 L: 9149 D: 27746 

http://tests.stockfishchess.org/tests/view/5b07f7300ebc5914abc12cb3
LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 85099 W: 12437 L: 12409 D: 60253 

There was a minor bug, which is fixed in the PR, and which passed another SPRT against master to check nothing was wrong with the fix.

http://tests.stockfishchess.org/tests/view/5b0f81bb0ebc596ad1d281da
STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 41112 W: 8251 L: 8166 D: 24695 

Bench : 4704361