### PR TITLE
quiet move soft fail high bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1164,7 +1164,8 @@ moves_loop: // When in check, search starts from here
     {
         // Quiet best move: update move sorting heuristics
         if (!pos.capture_or_promotion(bestMove))
-            update_quiet_stats(pos, ss, bestMove, quietsSearched, quietCount, stat_bonus(depth));
+            update_quiet_stats(pos, ss, bestMove, quietsSearched, quietCount, 
+								 stat_bonus(depth + bool(bestValue > beta + PawnValueMg) * ONE_PLY));
         else
             update_capture_stats(pos, bestMove, capturesSearched, captureCount,
                                  stat_bonus(depth + (bestValue > beta + KnightValueMg ? ONE_PLY : DEPTH_ZERO)));


### PR DESCRIPTION
Extra bonus for quiet move creating a huge soft fail high. (triggered in 21% of quiet bestmoves on a normal bench run). Pb00067 original idea using PawnValueMg.

ltc:
LLR: 2.94 (-2.94,2.94) [0.00,5.00]
Total: 157289 W: 23200 L: 22518 D: 111571
stc:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 138207 W: 28060 L: 27295 D: 82852

bench:  5041016