### PR TITLE
Stabilize appVeyor CI.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,9 +61,9 @@ build_script:
 
 before_test:
   - cd src/%CONFIGURATION%
+  - stockfish bench 2> out.txt >NUL
   - ps: |
       # Verify bench number
-      ./stockfish bench 2> out.txt 1> null
       $s = (gc "./out.txt" | out-string)
       $r = ($s -match 'Nodes searched \D+(\d+)' | % { $matches[1] })
       Write-Host "Engine bench:" $r


### PR DESCRIPTION
after a helpful suggestion from appveyor support staff, moving the stockfish execution from ps to cmd seems to work.

alternative to #1624 tested in #1637

No functional change.