### PR TITLE
Change stat bonus dependent on best value margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -90,9 +90,9 @@ namespace {
   }
 
   // History and stats update bonus, based on depth
-  int stat_bonus(Depth depth) {
+  int stat_bonus(Depth depth, int margin) {
     int d = depth / ONE_PLY;
-    return d > 17 ? 0 : 32 * d * d + 64 * d - 64;
+    return std::min(10272, 32 * d * d + (64 + margin) * d - 64);
   }
 
   // Skill structure is used to implement strength limit
@@ -631,16 +631,16 @@ namespace {
             if (ttValue >= beta)
             {
                 if (!pos.capture_or_promotion(ttMove))
-                    update_quiet_stats(pos, ss, ttMove, nullptr, 0, stat_bonus(depth));
+                    update_quiet_stats(pos, ss, ttMove, nullptr, 0, stat_bonus(depth, (ttValue - beta)/64));
 
                 // Extra penalty for a quiet TT move in previous ply when it gets refuted
                 if ((ss-1)->moveCount == 1 && !pos.captured_piece())
-                    update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth + ONE_PLY));
+                    update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth + ONE_PLY, VALUE_ZERO));
             }
             // Penalty for a quiet ttMove that fails low
             else if (!pos.capture_or_promotion(ttMove))
             {
-                int penalty = -stat_bonus(depth);
+                int penalty = -stat_bonus(depth, (alpha - ttValue)/36);
                 thisThread->mainHistory[us][from_to(ttMove)] << penalty;
                 update_continuation_histories(ss, pos.moved_piece(ttMove), to_sq(ttMove), penalty);
             }
@@ -1164,20 +1164,20 @@ moves_loop: // When in check, search starts from here
     {
         // Quiet best move: update move sorting heuristics
         if (!pos.capture_or_promotion(bestMove))
-            update_quiet_stats(pos, ss, bestMove, quietsSearched, quietCount, 
-							   stat_bonus(depth + (bestValue > beta + PawnValueMg ? ONE_PLY : DEPTH_ZERO)));
+            update_quiet_stats(pos, ss, bestMove, quietsSearched, quietCount, stat_bonus(depth, (bestValue - beta)/64));
         else
-            update_capture_stats(pos, bestMove, capturesSearched, captureCount, stat_bonus(depth + ONE_PLY));
+
+            update_capture_stats(pos, bestMove, capturesSearched, captureCount, stat_bonus(depth, (bestValue - beta)/36));
 
         // Extra penalty for a quiet TT move in previous ply when it gets refuted
         if ((ss-1)->moveCount == 1 && !pos.captured_piece())
-            update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth + ONE_PLY));
+            update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth + ONE_PLY, VALUE_ZERO));
     }
     // Bonus for prior countermove that caused the fail low
     else if (   (depth >= 3 * ONE_PLY || PvNode)
              && !pos.captured_piece()
              && is_ok((ss-1)->currentMove))
-        update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, stat_bonus(depth));
+        update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, stat_bonus(depth, VALUE_ZERO));
 
     if (PvNode)
         bestValue = std::min(bestValue, maxValue);


### PR DESCRIPTION
[STC](http://tests.stockfishchess.org/tests/view/5b1589490ebc5902a84dccf8)
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 67044 W: 13694 L: 13256 D: 40094 

[LTC](http://tests.stockfishchess.org/tests/view/5b1604220ebc5902a84dd4d5)
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 17293 W: 2565 L: 2384 D: 12344 

This patch is conceptually similar to this competing passed [LTC](http://tests.stockfishchess.org/tests/view/5b149dde0ebc5902a8b41c5a) patch.

There, in the case of soft fail high, the equivalent depth for the stat bonus was increased by 1. The threshold for which this increase is done depends or whether we are searching a quiet move (the patch) or a capture (current master). It is not done in TT-cutoffs.

This patch just includes the margin of best value in the stat bonus. To do this, some changes are required in the code.

1) `stat_bonus` must accept the margin as an additional parameter.
2) when 1) is implemented the overflow guard `d > 17` must be replaced by an overflow guard directly on the value of the bonus. For consistency, it has been implemented by saturating instead of returning 0.

**Criticisms of the patch**
There have been criticisms of the patch, since it changes different things at once, thus violating the "test one idea at once" principle. In my opinion, this does not apply here, since the idea which is tested is only one: "If we are outdside the search window by some margin, let us apply a bonus on the stats scaling with that margin". This is the same idea as in the concurrent [PR](https://github.com/official-stockfish/Stockfish/pull/1636). There it has been decided to tweak the depth which is considered for the stats bonus depending on the margin. In my opinion, the design choice is suboptimal: if the idea is to have the stat bonus depend both both on depth and margin, than this should be explicitly stated in the function signature and not hidden in the implementation details. And if this is done for the current implementation in master, then the competing PR becomes as invasive as this PR.

For doing it properly, it is also necessary to change the logic of the overflow guard from guarding against the depth to guarding against the returned value. In my opinion, this patch improves the current  in master and exposes some shortcomings mentioned in this [discussion](https://github.com/Stefano80/Stockfish/commit/40626da21e6c6ee0f3f3a5e0a7180310288c5a5f).

By the way, this patch performed much better than the competing PR both on STC and LTC.

**Further work**
One obvious thing to do is to tune the factor which the margin is taken into account for the different cases. The proposed implementation introduces a quadratic dependency in depth*margin, maybe there is room for having a complete quadratic polynomial in depth and margin.
Furthermore, the difficulties in the implementation of the overflow guard, as well as the invasivity of the patch point in my opinion to the fact that the management of the stats should be moved to a dedicated class, as we do for the time management.
