### PR TITLE
Simplify Capture Bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1166,8 +1166,7 @@ moves_loop: // When in check, search starts from here
         if (!pos.capture_or_promotion(bestMove))
             update_quiet_stats(pos, ss, bestMove, quietsSearched, quietCount, stat_bonus(depth));
         else
-            update_capture_stats(pos, bestMove, capturesSearched, captureCount,
-                                 stat_bonus(depth + (bestValue > beta + KnightValueMg ? ONE_PLY : DEPTH_ZERO)));
+            update_capture_stats(pos, bestMove, capturesSearched, captureCount, stat_bonus(depth + ONE_PLY));
 
         // Extra penalty for a quiet TT move in previous ply when it gets refuted
         if ((ss-1)->moveCount == 1 && !pos.captured_piece())


### PR DESCRIPTION
Simplify capture bonus by simply adding ONE_DEPTH instead of being dependent on BestValue

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 24419 W: 4939 L: 4824 D: 14656
http://tests.stockfishchess.org/tests/view/5b16b2040ebc5963ba37e2a5


LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 44560 W: 6524 L: 6438 D: 31598
http://tests.stockfishchess.org/tests/view/5b16ccc00ebc59214346d403

Bench:  4782637