### PR TITLE
Move countermove/killer comparison to search

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -182,12 +182,6 @@ top:
       // Prepare the pointers to loop over the refutations array
       cur = std::begin(refutations);
       endMoves = std::end(refutations);
-
-      // If the countermove is the same as a killer, skip it
-      if (   refutations[0].move == refutations[2].move
-          || refutations[1].move == refutations[2].move)
-          --endMoves;
-
       ++stage;
       /* fallthrough */
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -846,6 +846,8 @@ moves_loop: // When in check, search starts from here
 
     const PieceToHistory* contHist[] = { (ss-1)->contHistory, (ss-2)->contHistory, nullptr, (ss-4)->contHistory };
     Move countermove = thisThread->counterMoves[pos.piece_on(prevSq)][prevSq];
+    if ((countermove == ss->killers[0]) || (countermove == ss->killers[1]))
+       countermove = MOVE_NONE;
 
     MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory,
                                       &thisThread->captureHistory,


### PR DESCRIPTION
Non-functional.  I hope this isn't too trivial, but this check of countermove/killers seems out of place in movepick.cpp.  Isn't it much better in search by the assignment of the countermove (or could be integrated into the countermove assignment)?

The code in movepick already ignores the move it is is a MOVE_NONE, so setting the countermove to MOVE_NONE by the assignment seems more clear or natural.

It's also barely faster on my machine (probably not too relevant):
20 runs of psybench:
base 1346143 +/- 23827
test 1367173 +/- 25072
diff  +21010  +/- 2549
speedup = +0.0156
P(speedup > 0) = 1.0000

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 48326 W: 9680 L: 9609 D: 29037
http://tests.stockfishchess.org/tests/view/5b1a8d640ebc5902ab9c45f5