### PR TITLE
simplify capture pruning margin formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -71,16 +71,6 @@ namespace {
     return Value((175 - 50 * improving) * d / ONE_PLY);
   }
 
-  // Margin for pruning capturing moves: almost linear in depth
-  constexpr int CapturePruneMargin[] = { 0,
-                                         1 * PawnValueEg * 1055 / 1000,
-                                         2 * PawnValueEg * 1042 / 1000,
-                                         3 * PawnValueEg * 963  / 1000,
-                                         4 * PawnValueEg * 1038 / 1000,
-                                         5 * PawnValueEg * 950  / 1000,
-                                         6 * PawnValueEg * 930  / 1000
-                                       };
-
   // Futility and reductions lookup tables, initialized at startup
   int FutilityMoveCounts[2][16]; // [improving][depth]
   int Reductions[2][2][64][64];  // [pv][improving][depth][moveNumber]
@@ -962,7 +952,7 @@ moves_loop: // When in check, search starts from here
           }
           else if (    depth < 7 * ONE_PLY // (~20 Elo)
                    && !extension
-                   && !pos.see_ge(move, -Value(CapturePruneMargin[depth / ONE_PLY])))
+                   && !pos.see_ge(move, -Value(PawnValueEg * (depth / ONE_PLY))))
                   continue;
       }
 


### PR DESCRIPTION
Using just PawnValueEg as Capture Prune Margin.

Tested as simplification:
STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 20833 W: 4218 L: 4096 D: 12519
LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 27050 W: 3975 L: 3864 D: 19211

bench: 5009148