### PR TITLE
Simplify KRKP ending

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -214,7 +214,7 @@ Value Endgame<KRKP>::operator()(const Position& pos) const {
   Value result;
 
   // If the stronger side's king is in front of the pawn, it's a win
-  if (wksq < psq && file_of(wksq) == file_of(psq))
+  if (forward_file_bb(BLACK,psq) & wksq)
       result = RookValueEg - distance(wksq, psq);
 
   // If the weaker side's king is too far from the pawn and the rook,


### PR DESCRIPTION
This is non-functional.  I believe using foward_file_bb here is fewer instructions.

GOOD) fewer instructions and probably more clear (debatable).

BAD) Possible that a lookup is slower than a few local operations, but the forward_file_bb table is probably used often enough that it is always cached.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 21004 W: 4263 L: 4141 D: 12600
http://tests.stockfishchess.org/tests/view/5b1cad830ebc5902ab9c6239