### PR TITLE
Remove distance between pawn and rook in KRKP endings

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -207,7 +207,6 @@ Value Endgame<KRKP>::operator()(const Position& pos) const {
 
   Square wksq = relative_square(strongSide, pos.square<KING>(strongSide));
   Square bksq = relative_square(strongSide, pos.square<KING>(weakSide));
-  Square rsq  = relative_square(strongSide, pos.square<ROOK>(strongSide));
   Square psq  = relative_square(strongSide, pos.square<PAWN>(weakSide));
 
   Square queeningSq = make_square(file_of(psq), RANK_1);
@@ -218,7 +217,7 @@ Value Endgame<KRKP>::operator()(const Position& pos) const {
       result = RookValueEg - distance(wksq, psq);
 
   // If the weaker side's king is too far from the pawn, it's a win.
-  else if (distance(bksq, psq) >= 3 + (pos.side_to_move() == weakside))
+  else if (distance(bksq, psq) >= 3 + (pos.side_to_move() == weakSide))
       result = RookValueEg - distance(wksq, psq);
 
   // If the pawn is far advanced and supported by the defending king,

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -197,8 +197,7 @@ Value Endgame<KPK>::operator()(const Position& pos) const {
 
 /// KR vs KP. This is a somewhat tricky endgame to evaluate precisely without
 /// a bitbase. The function below returns drawish scores when the pawn is
-/// far advanced with support of the king, while the attacking king is far
-/// away.
+/// far advanced with support of the king, while the attacking king is far away.
 template<>
 Value Endgame<KRKP>::operator()(const Position& pos) const {
 

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -217,10 +217,8 @@ Value Endgame<KRKP>::operator()(const Position& pos) const {
   if (wksq < psq && file_of(wksq) == file_of(psq))
       result = RookValueEg - distance(wksq, psq);
 
-  // If the weaker side's king is too far from the pawn and the rook,
-  // it's a win.
-  else if (   distance(bksq, psq) >= 3 + (pos.side_to_move() == weakSide)
-           && distance(bksq, rsq) >= 3)
+  // If the weaker side's king is too far from the pawn, it's a win.
+  else if (distance(bksq, psq) >= 3 + (pos.side_to_move() == weakside))
       result = RookValueEg - distance(wksq, psq);
 
   // If the pawn is far advanced and supported by the defending king,


### PR DESCRIPTION
Since the rook can move the distance of the board in one move, the distance between the weak side pawn and the strong side rook in a KRKP ending is probably not very relevant.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 28747 W: 5845 L: 5738 D: 17164
http://tests.stockfishchess.org/tests/view/5b1cb3380ebc5902ab9c6278

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 94522 W: 13838 L: 13824 D: 66860
http://tests.stockfishchess.org/tests/view/5b1d2c6c0ebc5902ab9c6a5b

bench 4754380