### PR TITLE
Remove depth condition for pruning captures.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -951,8 +951,7 @@ moves_loop: // When in check, search starts from here
                   && !pos.see_ge(move, Value(-35 * lmrDepth * lmrDepth)))
                   continue;
           }
-          else if (    depth < 7 * ONE_PLY // (~20 Elo)
-                   && !extension
+          else if (   !extension // (~20 Elo)
                    && !pos.see_ge(move, -Value(PawnValueEg * (depth / ONE_PLY))))
                   continue;
       }


### PR DESCRIPTION
the SEE condition alone is sufficient.

passed STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 109863 W: 24339 L: 24392 D: 61132
http://tests.stockfishchess.org/tests/view/5b1f5b000ebc5902ab9c8668

passed LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 23390 W: 4020 L: 3903 D: 15467
http://tests.stockfishchess.org/tests/view/5b1f94b40ebc5902ab9c8b5e

Bench: 4834747