### PR TITLE
MSVC error fix

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -951,7 +951,7 @@ moves_loop: // When in check, search starts from here
                   continue;
           }
           else if (   !extension // (~20 Elo)
-                   && !pos.see_ge(move, -Value(PawnValueEg * (depth / ONE_PLY))))
+                   && !pos.see_ge(move, -PawnValueEg * (depth / ONE_PLY)))
                   continue;
       }
 


### PR DESCRIPTION
Fix MSVC error
search.cpp(956): error C2660: 'operator *': function does not take 1 arguments
types.h(303): note: see declaration of 'operator *'
introduced in commit
https://github.com/official-stockfish/Stockfish/commit/88de112b84a5285c2afb3e075a05c2ab8ad3fd33

Also move negative sign inside Value() cast for consistency with same see_ge() call just above.

No functional change.
bench: 5069074