### PR TITLE
Remove lmrDepth restriction on quiet see pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -947,8 +947,7 @@ moves_loop: // When in check, search starts from here
                   continue;
 
               // Prune moves with negative SEE (~10 Elo)
-              if (   lmrDepth < 8
-                  && !pos.see_ge(move, Value(-35 * lmrDepth * lmrDepth)))
+              if (!pos.see_ge(move, Value(-29 * lmrDepth * lmrDepth)))
                   continue;
           }
           else if (    depth < 7 * ONE_PLY // (~20 Elo)


### PR DESCRIPTION
And tweak the threshold value. With this threshold and the current piece values, this permits see pruning on quiets to be done up to an lmrDepth of 9 (beyond that the threshold is below -QueenValueMg and see_ge will pass unconditionally).

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 110316 W: 24612 L: 24667 D: 61037

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 17352 W: 2968 L: 2842 D: 11542

Bench: 4784753