### PR TITLE
KingPawn Tuned Values (t2m)

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -142,32 +142,32 @@ namespace {
 
   // ThreatByKing[on one/on many] contains bonuses for king attacks on
   // pawns or pieces which are not pawn-defended.
-  constexpr Score ThreatByKing[] = { S(3, 65), S(9, 145) };
+  constexpr Score ThreatByKing[] = { S(25, 57), S(4, 139) };
 
   // PassedRank[Rank] contains a bonus according to the rank of a passed pawn
   constexpr Score PassedRank[RANK_NB] = {
-    S(0, 0), S(5, 7), S(5, 13), S(18, 23), S(74, 58), S(164, 166), S(268, 243)
+    S(0, 0), S(7, 10), S(-12, 26), S(3, 31), S(42, 63), S(178, 167), S(279, 244)
   };
 
   // PassedFile[File] contains a bonus according to the file of a passed pawn
   constexpr Score PassedFile[FILE_NB] = {
-    S( 15,  7), S(-5, 14), S( 1, -5), S(-22,-11),
-    S(-22,-11), S( 1, -5), S(-5, 14), S( 15,  7)
+    S( 17,  3), S(0, 10), S( 1, -23), S(-16,-20),
+    S(-17,-8), S( 3, -1), S(-8, 4), S( 17,  9)
   };
 
   // PassedDanger[Rank] contains a term to weight the passed score
   constexpr int PassedDanger[RANK_NB] = { 0, 0, 0, 3, 6, 12, 21 };
 
   // KingProtector[PieceType-2] contains a penalty according to distance from king
-  constexpr Score KingProtector[] = { S(3, 5), S(4, 3), S(3, 0), S(1, -1) };
+  constexpr Score KingProtector[] = { S(3, 5), S(5, 3), S(3, 0), S(0, -2) };
 
   // Assorted bonuses and penalties
   constexpr Score BishopPawns        = S(  3,  5);
-  constexpr Score CloseEnemies       = S(  7,  0);
+  constexpr Score CloseEnemies       = S(  8,  0);
   constexpr Score Connectivity       = S(  3,  1);
   constexpr Score CorneredBishop     = S( 50, 50);
   constexpr Score Hanging            = S( 52, 30);
-  constexpr Score HinderPassedPawn   = S(  8,  1);
+  constexpr Score HinderPassedPawn   = S(  5,  2);
   constexpr Score KnightOnQueen      = S( 21, 11);
   constexpr Score LongDiagonalBishop = S( 22,  0);
   constexpr Score MinorBehindPawn    = S( 16,  0);
@@ -175,12 +175,12 @@ namespace {
   constexpr Score PawnlessFlank      = S( 20, 80);
   constexpr Score RookOnPawn         = S(  8, 24);
   constexpr Score SliderOnQueen      = S( 42, 21);
-  constexpr Score ThreatByPawnPush   = S( 47, 26);
+  constexpr Score ThreatByPawnPush   = S( 49, 30);
   constexpr Score ThreatByRank       = S( 16,  3);
-  constexpr Score ThreatBySafePawn   = S(175,168);
+  constexpr Score ThreatBySafePawn   = S(186,140);
   constexpr Score TrappedRook        = S( 92,  0);
   constexpr Score WeakQueen          = S( 50, 10);
-  constexpr Score WeakUnopposedPawn  = S(  5, 25);
+  constexpr Score WeakUnopposedPawn  = S(  14, 19);
 
 #undef S
 
@@ -474,12 +474,12 @@ namespace {
         unsafeChecks &= mobilityArea[Them];
 
         kingDanger +=        kingAttackersCount[Them] * kingAttackersWeight[Them]
-                     + 102 * kingAttacksCount[Them]
-                     + 191 * popcount(kingRing[Us] & weak)
-                     + 143 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
-                     - 848 * !pos.count<QUEEN>(Them)
-                     -   9 * mg_value(score) / 8
-                     +  40;
+                     + 64 * kingAttacksCount[Them]
+                     + 182 * popcount(kingRing[Us] & weak)
+                     + 128 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
+                     - 857 * !pos.count<QUEEN>(Them)
+                     -   8 * mg_value(score) / 8
+                     +  31;
 
         // Transform the kingDanger units into a Score, and subtract it from the evaluation
         if (kingDanger > 0)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -146,13 +146,13 @@ namespace {
 
   // PassedRank[Rank] contains a bonus according to the rank of a passed pawn
   constexpr Score PassedRank[RANK_NB] = {
-    S(0, 0), S(7, 10), S(-12, 26), S(3, 31), S(42, 63), S(178, 167), S(279, 244)
+    S(0, 0), S(7, 10), S(7, 26), S(14, 31), S(42, 63), S(178, 167), S(279, 244)
   };
 
   // PassedFile[File] contains a bonus according to the file of a passed pawn
   constexpr Score PassedFile[FILE_NB] = {
-    S( 17,  3), S(0, 10), S( 1, -23), S(-16,-20),
-    S(-17,-8), S( 3, -1), S(-8, 4), S( 17,  9)
+    S( 17,  6), S(-4, 7), S( 2, -12), S(-17,-14),
+    S(-17,-14), S(2, -12), S(-4, 7), S( 17,  6)
   };
 
   // PassedDanger[Rank] contains a term to weight the passed score

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -32,9 +32,9 @@ namespace {
   #define S(mg, eg) make_score(mg, eg)
 
   // Pawn penalties
-  constexpr Score Isolated = S(13, 16);
-  constexpr Score Backward = S(17, 11);
-  constexpr Score Doubled  = S(13, 40);
+  constexpr Score Isolated = S(6, 16);
+  constexpr Score Backward = S(15, 21);
+  constexpr Score Doubled  = S(8, 44);
 
   // Connected pawn bonus by opposed, phalanx, #support and rank
   Score Connected[2][2][3][RANK_NB];
@@ -42,25 +42,25 @@ namespace {
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
-    { V(  7), V(76), V( 84), V( 38), V(  7), V( 30), V(-19) },
-    { V(-13), V(83), V( 42), V(-27), V(  2), V(-32), V(-45) },
-    { V(-26), V(63), V(  5), V(-44), V( -5), V(  2), V(-59) },
-    { V(-19), V(53), V(-11), V(-22), V(-12), V(-51), V(-60) }
+    { V(  28), V(79), V( 75), V( 46), V(  14), V( 31), V(-14) },
+    { V(-48), V(50), V( 29), V(-21), V(  -41), V(-23), V(-45) },
+    { V(-25), V(50), V(  17), V(-33), V( -5), V(  9), V(-35) },
+    { V(-29), V(57), V(-25), V(-48), V(-4), V(-46), V(-64) }
   };
 
   // Danger of enemy pawns moving toward our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where the enemy has no pawn, or their pawn
   // is behind our king.
   constexpr Value UnblockedStorm[int(FILE_NB) / 2][RANK_NB] = {
-    { V( 25), V( 79), V(107), V( 51), V( 27), V(  0), V(  0) },
-    { V(  5), V( 35), V(121), V( -2), V( 15), V(-10), V(-10) },
-    { V(-20), V( 22), V( 98), V( 36), V(  7), V(-20), V(-20) },
-    { V(-27), V( 24), V( 80), V( 25), V( -4), V(-30), V(-30) }
+    { V( 34), V( 58), V(113), V( 61), V( 37), V(  24), V(  21) },
+    { V(  23), V( 46), V(93), V( 10), V( 2), V(-20), V(6) },
+    { V(-6), V( 22), V( 106), V( 28), V(  6), V(-33), V(-1) },
+    { V(-17), V( 33), V( 71), V( 14), V( -9), V(-21), V(-16) }
   };
 
   // Danger of blocked enemy pawns storming our king, by rank
   constexpr Value BlockedStorm[RANK_NB] =
-    { V(  0), V(  0), V( 75), V(-10), V(-20), V(-20), V(-20) };
+    { V(  0), V(  0), V( 58), V(-13), V(-22), V(-3), V(-5) };
 
   #undef S
   #undef V


### PR DESCRIPTION
Various king and pawn tuned eval values after 505k 60 sec 600 nodes time spsa games. Adjusted passed rank and file values to be symmetrical.

after passed rank/file adjustment:
ltc:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 37906 W: 6953 L: 6668 D: 24285

raw tuned values:
stc:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 39515 W: 9227 L: 8900 D: 21388
ltc:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 14618 W: 2743 L: 2537 D: 9338