### PR TITLE
Move BlockRanks(Squares) to compile time

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -206,7 +206,8 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
 
   constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
   constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
-  constexpr Bitboard  BlockRanks = (Us == WHITE ? Rank1BB | Rank2BB : Rank8BB | Rank7BB);
+  constexpr Bitboard  BlockSquares = (FileABB | FileHBB) &
+                 (Us == WHITE ? Rank1BB | Rank2BB : Rank7BB | Rank8BB);
 
   Bitboard b = pos.pieces(PAWN) & (forward_ranks_bb(Us, ksq) | rank_bb(ksq));
   Bitboard ourPawns = b & pos.pieces(Us);
@@ -214,7 +215,7 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
 
   Value safety = (ourPawns & file_bb(ksq)) ? Value(5) : Value(-5);
 
-  if (shift<Down>(theirPawns) & (FileABB | FileHBB) & BlockRanks & ksq)
+  if (shift<Down>(theirPawns) & BlockSquares & ksq)
       safety += Value(374);
 
   File center = std::max(FILE_B, std::min(FILE_G, file_of(ksq)));


### PR DESCRIPTION
This is a non-functional simplification and moves the determination of king block squares to compile time.

Eliminates the (FileABB | FileHBB) operation which should be a bit faster.