### PR TITLE
Increase outflanking weight to 12

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -770,9 +770,9 @@ namespace {
                             && (pos.pieces(PAWN) & KingSide);
 
     // Compute the initiative bonus for the attacking side
-    int complexity =   8 * outflanking
-                    +  8 * pe->pawn_asymmetry()
+    int complexity =   8 * pe->pawn_asymmetry()
                     + 12 * pos.count<PAWN>()
+                    + 12 * outflanking
                     + 16 * pawnsOnBothFlanks
                     + 48 * !pos.non_pawn_material()
                     -136 ;


### PR DESCRIPTION
Give more incentive to king activity in the endgame by increasing the weight of the "outflanking" variable from 8 to 12 in the function evaluate_initiative().

Finished yellow after 133102 games at STC:

LLR: -3.07 (-2.94,2.94) [0.00,4.00]
Total: 133102 W: 29535 L: 29179 D: 74388
http://tests.stockfishchess.org/tests/view/5b2b63fe0ebc5902b2e54475

Passed LTC:

LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 28027 W: 4918 L: 4672 D: 18437
http://tests.stockfishchess.org/tests/view/5b2ba39e0ebc5902b2e54a64

Closes https://github.com/official-stockfish/Stockfish/pull/1657

Bench: 4721753