### PR TITLE
reduce scope of variables

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -60,20 +60,17 @@ void TranspositionTable::resize(size_t mbSize) {
 
 void TranspositionTable::clear() {
 
-  const size_t stride = clusterCount / Options["Threads"];
   std::vector<std::thread> threads;
   for (size_t idx = 0; idx < Options["Threads"]; idx++)
-  {
-      const size_t start =  stride * idx,
-                   len =    idx != Options["Threads"] - 1 ?
-                            stride :
-                            clusterCount - start;
-      threads.push_back(std::thread([this, idx, start, len]() {
+      threads.push_back(std::thread([this, idx]() {
+          const size_t stride = clusterCount / Options["Threads"],
+                       start  = stride * idx,
+                       len    = idx != Options["Threads"] - 1 ?
+                                stride : clusterCount - start;
           if (Options["Threads"] >= 8)
               WinProcGroup::bindThisThread(idx);
           std::memset(&table[start], 0, len * sizeof(Cluster));
       }));
-  }
 
   for (std::thread& th: threads)
       th.join();


### PR DESCRIPTION
small cleanup TranspositionTable:clear().

No functional change.