### PR TITLE
Apply KingProtector penalty to knights and bishops only

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -158,8 +158,8 @@ namespace {
   // PassedDanger[Rank] contains a term to weight the passed score
   constexpr int PassedDanger[RANK_NB] = { 0, 0, 0, 2, 7, 12, 19 };
 
-  // KingProtector[PieceType-2] contains a penalty according to distance from king
-  constexpr Score KingProtector[] = { S(4, 6), S(6, 3), S(1, 0), S(0, -2) };
+  // KingProtector[knight/bishop] contains a penalty according to distance from king
+  constexpr Score KingProtector[] = { S(4, 6), S(6, 3) };
 
   // Assorted bonuses and penalties
   constexpr Score BishopPawns        = S(  3,  5);
@@ -330,9 +330,6 @@ namespace {
 
         mobility[Us] += MobilityBonus[Pt - 2][mob];
 
-        // Penalty if the piece is far from the king
-        score -= KingProtector[Pt - 2] * distance(s, pos.square<KING>(Us));
-
         if (Pt == BISHOP || Pt == KNIGHT)
         {
             // Bonus if piece is on an outpost square or can reach one
@@ -347,6 +344,9 @@ namespace {
             if (    relative_rank(Us, s) < RANK_5
                 && (pos.pieces(PAWN) & (s + pawn_push(Us))))
                 score += MinorBehindPawn;
+
+            // Penalty if the piece is far from the king
+            score -= KingProtector[Pt == BISHOP] * distance(s, pos.square<KING>(Us));
 
             if (Pt == BISHOP)
             {


### PR DESCRIPTION
Recent tuning results implied this penalty is more important for knights and bishops,
and almost negligible for rooks and queen.

Passed as simplification both
STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 20873 W: 4592 L: 4469 D: 11812
http://tests.stockfishchess.org/tests/view/5b2fb4d00ebc5902b2e57e84

and LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 46069 W: 7949 L: 7870 D: 30250
http://tests.stockfishchess.org/tests/view/5b2fcc4b0ebc5902b2e580c5

Bench: 4596911