### PR TITLE
Simplify HinderPassedPawn bonus

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -647,7 +647,7 @@ namespace {
 
         assert(!(pos.pieces(Them, PAWN) & forward_file_bb(Us, s + Up)));
 
-        bb = forward_file_bb(Us, s) & (attackedBy[Them][ALL_PIECES] | pos.pieces(Them));
+        bb = forward_file_bb(Us, s) & pos.pieces(Them);
         score -= HinderPassedPawn * popcount(bb);
 
         int r = relative_rank(Us, s);


### PR DESCRIPTION
Make sure each piece is not scored more than once as a passed pawn "hinderer",
by scoring only the blockers along the passed pawn path.

Passed STC as a simplification
http://tests.stockfishchess.org/tests/view/5b3016d00ebc5902b2e58552
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 75388 W: 16656 L: 16641 D: 42091

Passed LTC as a simplification
http://tests.stockfishchess.org/tests/view/5b302ed90ebc5902b2e587fc
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 49157 W: 8460 L: 8386 D: 32311

Current master was also counting the number of attacks along a passed pawn path,
which might be misleading:

a) a defender might be counted many times for the same pawn path
    for example a White rook on a1 attacking a black pawn on a7 would score the bonus * 6
    but would be probably better placed on a8

b) a defender might be counted on different pawn paths and might be overloaded
    (for example a Ke4 or Qe4 against pawns on d6  and f6 would score the bonus * 6)

Counting each blocker or attacker only once is more complicated, and does not help either.
http://tests.stockfishchess.org/tests/view/5b2ff1cb0ebc5902b2e582b2

Inspired by TCEC Game 29

After this small simplification, there might be ways to increase the HinderPassedPawn penalty.