### PR TITLE
Simplify saving a TT entry.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -670,7 +670,7 @@ namespace {
                 {
                     tte->save(posKey, value_to_tt(value, ss->ply), b,
                               std::min(DEPTH_MAX - ONE_PLY, depth + 6 * ONE_PLY),
-                              MOVE_NONE, VALUE_NONE, TT.generation());
+                              MOVE_NONE, VALUE_NONE);
 
                     return value;
                 }
@@ -711,7 +711,7 @@ namespace {
                                          : -(ss-1)->staticEval + 2 * Eval::Tempo;
 
         tte->save(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE,
-                  ss->staticEval, TT.generation());
+                  ss->staticEval);
     }
 
     // Step 7. Razoring (~2 Elo)
@@ -1175,7 +1175,7 @@ moves_loop: // When in check, search starts from here
         tte->save(posKey, value_to_tt(bestValue, ss->ply),
                   bestValue >= beta ? BOUND_LOWER :
                   PvNode && bestMove ? BOUND_EXACT : BOUND_UPPER,
-                  depth, bestMove, ss->staticEval, TT.generation());
+                  depth, bestMove, ss->staticEval);
 
     assert(bestValue > -VALUE_INFINITE && bestValue < VALUE_INFINITE);
 
@@ -1272,7 +1272,7 @@ moves_loop: // When in check, search starts from here
         {
             if (!ttHit)
                 tte->save(posKey, value_to_tt(bestValue, ss->ply), BOUND_LOWER,
-                          DEPTH_NONE, MOVE_NONE, ss->staticEval, TT.generation());
+                          DEPTH_NONE, MOVE_NONE, ss->staticEval);
 
             return bestValue;
         }
@@ -1371,7 +1371,7 @@ moves_loop: // When in check, search starts from here
               else // Fail high
               {
                   tte->save(posKey, value_to_tt(value, ss->ply), BOUND_LOWER,
-                            ttDepth, move, ss->staticEval, TT.generation());
+                            ttDepth, move, ss->staticEval);
 
                   return value;
               }
@@ -1386,7 +1386,7 @@ moves_loop: // When in check, search starts from here
 
     tte->save(posKey, value_to_tt(bestValue, ss->ply),
               PvNode && bestValue > oldAlpha ? BOUND_EXACT : BOUND_UPPER,
-              ttDepth, bestMove, ss->staticEval, TT.generation());
+              ttDepth, bestMove, ss->staticEval);
 
     assert(bestValue > -VALUE_INFINITE && bestValue < VALUE_INFINITE);
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -29,6 +29,30 @@
 
 TranspositionTable TT; // Our global transposition table
 
+/// TTEntry::save saves a TTEntry
+void TTEntry::save(Key k, Value v, Bound b, Depth d, Move m, Value ev) {
+
+  assert(d / ONE_PLY * ONE_PLY == d);
+  uint8_t g = TT.generation();
+
+  // Preserve any existing move for the same position
+  if (m || (k >> 48) != key16)
+      move16 = (uint16_t)m;
+
+  // Overwrite less valuable entries
+  if (  (k >> 48) != key16
+      || d / ONE_PLY > depth8 - 4
+   /* || g != (genBound8 & 0xFC) // Matching non-zero keys are already refreshed by probe() */
+      || b == BOUND_EXACT)
+  {
+      key16     = (uint16_t)(k >> 48);
+      value16   = (int16_t)v;
+      eval16    = (int16_t)ev;
+      genBound8 = (uint8_t)(g | b);
+      depth8    = (int8_t)(d / ONE_PLY);
+  }
+}
+
 
 /// TranspositionTable::resize() sets the size of the transposition table,
 /// measured in megabytes. Transposition table consists of a power of 2 number

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -33,7 +33,6 @@ TranspositionTable TT; // Our global transposition table
 void TTEntry::save(Key k, Value v, Bound b, Depth d, Move m, Value ev) {
 
   assert(d / ONE_PLY * ONE_PLY == d);
-  uint8_t g = TT.generation();
 
   // Preserve any existing move for the same position
   if (m || (k >> 48) != key16)
@@ -42,13 +41,12 @@ void TTEntry::save(Key k, Value v, Bound b, Depth d, Move m, Value ev) {
   // Overwrite less valuable entries
   if (  (k >> 48) != key16
       || d / ONE_PLY > depth8 - 4
-   /* || g != (genBound8 & 0xFC) // Matching non-zero keys are already refreshed by probe() */
       || b == BOUND_EXACT)
   {
       key16     = (uint16_t)(k >> 48);
       value16   = (int16_t)v;
       eval16    = (int16_t)ev;
-      genBound8 = (uint8_t)(g | b);
+      genBound8 = (uint8_t)(TT.generation8 | b);
       depth8    = (int8_t)(d / ONE_PLY);
   }
 }

--- a/src/tt.h
+++ b/src/tt.h
@@ -88,7 +88,7 @@ public:
   }
 
 private:
-  friend TTEntry;
+  friend struct TTEntry;
 
   size_t clusterCount;
   Cluster* table;

--- a/src/tt.h
+++ b/src/tt.h
@@ -77,7 +77,6 @@ class TranspositionTable {
 public:
  ~TranspositionTable() { free(mem); }
   void new_search() { generation8 += 4; } // Lower 2 bits are used by Bound
-  uint8_t generation() const { return generation8; }
   TTEntry* probe(const Key key, bool& found) const;
   int hashfull() const;
   void resize(size_t mbSize);
@@ -89,6 +88,8 @@ public:
   }
 
 private:
+  friend TTEntry;
+
   size_t clusterCount;
   Cluster* table;
   void* mem;

--- a/src/tt.h
+++ b/src/tt.h
@@ -41,28 +41,7 @@ struct TTEntry {
   Value eval()  const { return (Value)eval16; }
   Depth depth() const { return (Depth)(depth8 * int(ONE_PLY)); }
   Bound bound() const { return (Bound)(genBound8 & 0x3); }
-
-  void save(Key k, Value v, Bound b, Depth d, Move m, Value ev, uint8_t g) {
-
-    assert(d / ONE_PLY * ONE_PLY == d);
-
-    // Preserve any existing move for the same position
-    if (m || (k >> 48) != key16)
-        move16 = (uint16_t)m;
-
-    // Don't overwrite more valuable entries
-    if (  (k >> 48) != key16
-        || d / ONE_PLY > depth8 - 4
-     /* || g != (genBound8 & 0xFC) // Matching non-zero keys are already refreshed by probe() */
-        || b == BOUND_EXACT)
-    {
-        key16     = (uint16_t)(k >> 48);
-        value16   = (int16_t)v;
-        eval16    = (int16_t)ev;
-        genBound8 = (uint8_t)(g | b);
-        depth8    = (int8_t)(d / ONE_PLY);
-    }
-  }
+  void save(Key k, Value v, Bound b, Depth d, Move m, Value ev);
 
 private:
   friend class TranspositionTable;


### PR DESCRIPTION
Avoid passing TT.generation() to TTEntry::save() at every call,
moving the implementation of TTEntry::save from tt.h to tt.cpp.

tested for no regression:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 53787 W: 11948 L: 11890 D: 29949
http://tests.stockfishchess.org/tests/view/5b2ff37f0ebc5902b2e582fe

No functional change.