### PR TITLE
Capture Stat Tweak

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1155,8 +1155,8 @@ moves_loop: // When in check, search starts from here
         if (!pos.capture_or_promotion(bestMove))
             update_quiet_stats(pos, ss, bestMove, quietsSearched, quietCount,
                                stat_bonus(depth + (bestValue > beta + PawnValueMg ? ONE_PLY : DEPTH_ZERO)));
-        else
-            update_capture_stats(pos, bestMove, capturesSearched, captureCount, stat_bonus(depth + ONE_PLY));
+     
+        update_capture_stats(pos, bestMove, capturesSearched, captureCount, stat_bonus(depth + ONE_PLY));
 
         // Extra penalty for a quiet TT move in previous ply when it gets refuted
         if ((ss-1)->moveCount == 1 && !pos.captured_piece())
@@ -1448,7 +1448,9 @@ moves_loop: // When in check, search starts from here
       CapturePieceToHistory& captureHistory =  pos.this_thread()->captureHistory;
       Piece moved_piece = pos.moved_piece(move);
       PieceType captured = type_of(pos.piece_on(to_sq(move)));
-      captureHistory[moved_piece][to_sq(move)][captured] << bonus;
+    
+      if (pos.capture_or_promotion(move))
+          captureHistory[moved_piece][to_sq(move)][captured] << bonus;
 
       // Decrease all the other played capture moves
       for (int i = 0; i < captureCnt; ++i)


### PR DESCRIPTION
Penalize capture moves that fail to create a cutoff even at quiet move cutoff.

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 19004 W: 4284 L: 4059 D: 10661
http://tests.stockfishchess.org/tests/view/5b3a7d4d0ebc5902b9ffb6ea

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 23100 W: 3981 L: 3765 D: 15354
http://tests.stockfishchess.org/tests/view/5b3aa4550ebc5902b9ffb8cf

Bench:  5232010