### PR TITLE
Precalculate KingRings

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -39,6 +39,7 @@ Bitboard PassedPawnMask[COLOR_NB][SQUARE_NB];
 Bitboard PawnAttackSpan[COLOR_NB][SQUARE_NB];
 Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 Bitboard PawnAttacks[COLOR_NB][SQUARE_NB];
+Bitboard KingRing[COLOR_NB][SQUARE_NB];
 
 Magic RookMagics[SQUARE_NB];
 Magic BishopMagics[SQUARE_NB];
@@ -157,6 +158,19 @@ void Bitboards::init() {
               LineBB[s1][s2] = (attacks_bb(pt, s1, 0) & attacks_bb(pt, s2, 0)) | s1 | s2;
               BetweenBB[s1][s2] = attacks_bb(pt, s1, SquareBB[s2]) & attacks_bb(pt, s2, SquareBB[s1]);
           }
+
+      //Calculate KingRings (shift 1 from edges, except RANK_8)
+      for (Color c = WHITE; c <= BLACK; ++c)
+      {
+         KingRing[c][s1] = PseudoAttacks[KING][s1];
+         if (relative_rank(c,s1) == RANK_1)
+            KingRing[c][s1] |= (c == WHITE) ? shift<NORTH>(KingRing[c][s1]):
+                                              shift<SOUTH>(KingRing[c][s1]);
+         if (file_of(s1) == FILE_H)
+            KingRing[c][s1] |= shift<WEST>(KingRing[c][s1]);
+         if (file_of(s1) == FILE_A)
+            KingRing[c][s1] |= shift<EAST>(KingRing[c][s1]);
+      }
   }
 }
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -75,6 +75,7 @@ extern Bitboard PassedPawnMask[COLOR_NB][SQUARE_NB];
 extern Bitboard PawnAttackSpan[COLOR_NB][SQUARE_NB];
 extern Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 extern Bitboard PawnAttacks[COLOR_NB][SQUARE_NB];
+extern Bitboard KingRing[COLOR_NB][SQUARE_NB];
 
 
 /// Magic holds all magic bitboards relevant data for a single square

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -251,7 +251,6 @@ namespace {
   void Evaluation<T>::initialize() {
 
     constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
-    constexpr Direction Up   = (Us == WHITE ? NORTH : SOUTH);
     constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
     constexpr Bitboard LowRanks = (Us == WHITE ? Rank2BB | Rank3BB: Rank7BB | Rank6BB);
 
@@ -271,21 +270,12 @@ namespace {
     // Init our king safety tables only if we are going to use them
     if (pos.non_pawn_material(Them) >= RookValueMg + KnightValueMg)
     {
-        kingRing[Us] = attackedBy[Us][KING];
-        if (relative_rank(Us, pos.square<KING>(Us)) == RANK_1)
-            kingRing[Us] |= shift<Up>(kingRing[Us]);
-
-        if (file_of(pos.square<KING>(Us)) == FILE_H)
-            kingRing[Us] |= shift<WEST>(kingRing[Us]);
-
-        else if (file_of(pos.square<KING>(Us)) == FILE_A)
-            kingRing[Us] |= shift<EAST>(kingRing[Us]);
-
+        kingRing[Us] = KingRing[Us][pos.square<KING>(Us)];
         kingAttackersCount[Them] = popcount(kingRing[Us] & pe->pawn_attacks(Them));
         kingAttacksCount[Them] = kingAttackersWeight[Them] = 0;
     }
     else
-        kingRing[Us] = kingAttackersCount[Them] = 0;
+       kingRing[Us] = kingAttacksCount[Them] = kingAttackersCount[Them] = 0;
   }
 
 


### PR DESCRIPTION
This is a non-functional speedup.  Precalculate all of the king rings in init so that in evaluate.cpp, we can just pull the array value.  This is not done frequent enough such that it would pass 0,4, but it is faster on my machine and was yellow for each of three independent tests.

It also looks like I inadvertently set  kingAttacksCount[Them] to 0 if the condition is not met which is different from master, but did not change the bench.

My psybench of 200 runs:
base 1549456 +/- 15k
test 1557407  +/- 15k
diff: +7942

STC [0,4] failed yellow:
LLR: -2.95 (-2.94,2.94) [0.00,4.00]
Total: 69552 W: 15317 L: 15207 D: 39028
http://tests.stockfishchess.org/tests/view/5b3bf6110ebc5902b9ffca32
