### PR TITLE
Simplify ThreatByKing to be a single Score.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -140,10 +140,6 @@ namespace {
     S(0, 0), S(0, 24), S(38, 71), S(38, 61), S(0, 38), S(36, 38)
   };
 
-  // ThreatByKing[on one/on many] contains bonuses for king attacks on
-  // pawns or pieces which are not pawn-defended.
-  constexpr Score ThreatByKing[] = { S(30, 62), S(-9, 160) };
-
   // PassedRank[Rank] contains a bonus according to the rank of a passed pawn
   constexpr Score PassedRank[RANK_NB] = {
     S(0, 0), S(4, 17), S(7, 20), S(14, 36), S(42, 62), S(165, 171), S(279, 252)
@@ -175,6 +171,7 @@ namespace {
   constexpr Score PawnlessFlank      = S( 20, 80);
   constexpr Score RookOnPawn         = S(  8, 24);
   constexpr Score SliderOnQueen      = S( 42, 21);
+  constexpr Score ThreatByKing       = S( 30, 62);
   constexpr Score ThreatByPawnPush   = S( 49, 30);
   constexpr Score ThreatByRank       = S( 16,  3);
   constexpr Score ThreatBySafePawn   = S(165,133);
@@ -560,7 +557,7 @@ namespace {
 
         b = weak & attackedBy[Us][KING];
         if (b)
-            score += ThreatByKing[more_than_one(b)];
+            score += ThreatByKing;
 
         score += Hanging * popcount(weak & ~attackedBy[Them][ALL_PIECES]);
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -171,7 +171,7 @@ namespace {
   constexpr Score PawnlessFlank      = S( 20, 80);
   constexpr Score RookOnPawn         = S(  8, 24);
   constexpr Score SliderOnQueen      = S( 42, 21);
-  constexpr Score ThreatByKing       = S( 30, 62);
+  constexpr Score ThreatByKing       = S( 31, 75);
   constexpr Score ThreatByPawnPush   = S( 49, 30);
   constexpr Score ThreatByRank       = S( 16,  3);
   constexpr Score ThreatBySafePawn   = S(165,133);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -555,8 +555,7 @@ namespace {
                 score += ThreatByRank * (int)relative_rank(Them, s);
         }
 
-        b = weak & attackedBy[Us][KING];
-        if (b)
+        if (weak & attackedBy[Us][KING])
             score += ThreatByKing;
 
         score += Hanging * popcount(weak & ~attackedBy[Them][ALL_PIECES]);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -555,6 +555,7 @@ namespace {
                 score += ThreatByRank * (int)relative_rank(Them, s);
         }
 
+        // Bonus for king attacks on pawns or pieces which are not pawn-defended
         if (weak & attackedBy[Us][KING])
             score += ThreatByKing;
 


### PR DESCRIPTION
In the current master, ThreatByKing is an array of two Scores, one for when we have a single attack and one for when we have many.  The latter case is very rarely called during bench and was recently given a strange negative value during a tuning run, as pointed out by @candirufish on efd4ca2.  Here, we simplify away this second case entirely, and increase the remaining ThreatByKing to compensate.

Although I derived the parameter tweak independently, with the goal of preserving the same average bonus, I later noticed that a very similar Score had already been derived by an ongoing SPSA tuning session.  I therefore recognize @candirufish for first discovering these values.

I would also like to thank @Rocky640 for valuable feedback that pointed me in the direction of ThreatByKing.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 7677 W: 1772 L: 1623 D: 4282
http://tests.stockfishchess.org/tests/view/5b3db0320ebc5902b9ffe97a

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 108031 W: 18329 L: 18350 D: 71352
http://tests.stockfishchess.org/tests/view/5b3dbf4b0ebc5902b9ffe9db

Bench: 4678861