### PR TITLE
Remove offset in thread redistribution scheme.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -331,7 +331,7 @@ void Thread::search() {
       if (idx > 0)
       {
           int i = (idx - 1) % 20;
-          if (((rootDepth / ONE_PLY + rootPos.game_ply() + SkipPhase[i]) / SkipSize[i]) % 2)
+          if (((rootDepth / ONE_PLY + SkipPhase[i]) / SkipSize[i]) % 2)
               continue;  // Retry with an incremented rootDepth
       }
 


### PR DESCRIPTION
doesn't have a benefit.

passed STC (8 threads):
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 19574 W: 4028 L: 3904 D: 11642
http://tests.stockfishchess.org/tests/view/5b3e48950ebc5902b9fff080

passed LTC (8 threads):
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 21293 W: 3626 L: 3506 D: 14161
http://tests.stockfishchess.org/tests/view/5b3eefd60ebc5902b9fffa81

No functional change single threaded.