### PR TITLE
Fix a bug of outputting multiple lines of bestmove

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -279,7 +279,7 @@ void MainThread::search() {
   previousScore = static_cast<Value>(mi.score);
 
   // Send again PV info if we have a new best thread
-  if (mi.rank == Cluster::rank()) {
+  if (Cluster::is_root()) {
       if (bestThread != this)
           sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
 


### PR DESCRIPTION
My understanding of how this MPI implementation works is that the child nodes would broadcast and feed the root node with TT information, so only the mainThread on the root node may output the bestmove information.