### PR TITLE
Tuned Values after 2 million spsa games

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -142,28 +142,29 @@ namespace {
 
   // PassedRank[Rank] contains a bonus according to the rank of a passed pawn
   constexpr Score PassedRank[RANK_NB] = {
-    S(0, 0), S(4, 17), S(7, 20), S(14, 36), S(42, 62), S(165, 171), S(279, 252)
+    S(0, 0), S(5, 18), S(12, 23), S(10, 31), S(57, 62), S(163, 167), S(271, 250)
   };
 
   // PassedFile[File] contains a bonus according to the file of a passed pawn
   constexpr Score PassedFile[FILE_NB] = {
-    S( 11, 14), S( 0, -5), S(-2, -8), S(-25,-13),
-    S(-25,-13), S(-2, -8), S( 0, -5), S( 11, 14)
+	S( -1, 7), S( 0, 9), S(-9, -8), S(-30,-14),
+	S(-30,-14),S(-9, -8),S( 0,  9), S( -1, 7)
   };
 
   // PassedDanger[Rank] contains a term to weight the passed score
-  constexpr int PassedDanger[RANK_NB] = { 0, 0, 0, 2, 7, 12, 19 };
+  constexpr int PassedDanger[RANK_NB] = { 0, 0, 0, 3, 7, 11, 20 };
+
 
   // KingProtector[knight/bishop] contains a penalty according to distance from king
-  constexpr Score KingProtector[] = { S(4, 6), S(6, 3) };
+  constexpr Score KingProtector[] = { S(5, 6), S(6, 5) };
 
   // Assorted bonuses and penalties
-  constexpr Score BishopPawns        = S(  3,  5);
-  constexpr Score CloseEnemies       = S(  8,  0);
+  constexpr Score BishopPawns        = S(  3,  7);
+  constexpr Score CloseEnemies       = S(  6,  0);
   constexpr Score Connectivity       = S(  3,  1);
   constexpr Score CorneredBishop     = S( 50, 50);
   constexpr Score Hanging            = S( 52, 30);
-  constexpr Score HinderPassedPawn   = S(  5, -1);
+  constexpr Score HinderPassedPawn   = S(  4,  0);
   constexpr Score KnightOnQueen      = S( 21, 11);
   constexpr Score LongDiagonalBishop = S( 22,  0);
   constexpr Score MinorBehindPawn    = S( 16,  0);
@@ -171,13 +172,13 @@ namespace {
   constexpr Score PawnlessFlank      = S( 20, 80);
   constexpr Score RookOnPawn         = S(  8, 24);
   constexpr Score SliderOnQueen      = S( 42, 21);
-  constexpr Score ThreatByKing       = S( 31, 75);
-  constexpr Score ThreatByPawnPush   = S( 49, 30);
+  constexpr Score ThreatByKing       = S( 23, 76);
+  constexpr Score ThreatByPawnPush   = S( 45, 40);
   constexpr Score ThreatByRank       = S( 16,  3);
-  constexpr Score ThreatBySafePawn   = S(165,133);
+  constexpr Score ThreatBySafePawn   = S(173,102);
   constexpr Score TrappedRook        = S( 92,  0);
   constexpr Score WeakQueen          = S( 50, 10);
-  constexpr Score WeakUnopposedPawn  = S(  5, 26);
+  constexpr Score WeakUnopposedPawn  = S(  5, 29);
 
 #undef S
 
@@ -471,12 +472,12 @@ namespace {
         unsafeChecks &= mobilityArea[Them];
 
         kingDanger +=        kingAttackersCount[Them] * kingAttackersWeight[Them]
-                     + 64  * kingAttacksCount[Them]
-                     + 183 * popcount(kingRing[Us] & weak)
-                     + 122 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
-                     - 860 * !pos.count<QUEEN>(Them)
-                     -   7 * mg_value(score) / 8
-                     +  17 ;
+                   + 69  * kingAttacksCount[Them]
+                   + 185  * popcount(kingRing[Us] & weak)
+                   + 129  * popcount(pos.blockers_for_king(Us) | unsafeChecks)
+                   - 873  * !pos.count<QUEEN>(Them)
+                   - 6  * mg_value(score) / 8
+                   -2;
 
         // Transform the kingDanger units into a Score, and subtract it from the evaluation
         if (kingDanger > 0)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -32,35 +32,35 @@ namespace {
   #define S(mg, eg) make_score(mg, eg)
 
   // Pawn penalties
-  constexpr Score Isolated = S( 4, 20);
-  constexpr Score Backward = S(21, 22);
-  constexpr Score Doubled  = S(12, 54);
+ constexpr Score Isolated = S( 5, 15);
+ constexpr Score Backward = S(9, 24);
+ constexpr Score Doubled  = S(11, 56);
 
   // Connected pawn bonus by opposed, phalanx, #support and rank
   Score Connected[2][2][3][RANK_NB];
 
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
-  constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
-    { V( 16), V(82), V( 83), V( 47), V( 19), V( 44), V(  4) },
-    { V(-51), V(56), V( 33), V(-58), V(-57), V(-50), V(-39) },
-    { V(-20), V(71), V( 16), V(-10), V( 13), V( 19), V(-30) },
-    { V(-29), V(12), V(-21), V(-40), V(-15), V(-77), V(-91) }
+  constexpr  Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
+    { V( -3), V(81), V( 93), V( 58), V( 39), V( 18), V(  25) },
+    { V(-40), V(61), V( 35), V(-49), V(-29), V(-11), V(-63) },
+    { V(-7), V(75), V( 23), V(-2), V( 32), V( 3), V(-45) },
+    { V(-36), V(-13), V(-29), V(-52), V(-48), V(-67), V(-166) }
   };
 
   // Danger of enemy pawns moving toward our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where the enemy has no pawn, or their pawn
   // is behind our king.
   constexpr Value UnblockedStorm[int(FILE_NB) / 2][RANK_NB] = {
-    { V(54), V( 48), V( 99), V(91), V(42), V( 32), V( 31) },
-    { V(34), V( 27), V(105), V(38), V(32), V(-19), V(  3) },
-    { V(-4), V( 28), V( 87), V(18), V(-3), V(-14), V(-11) },
-    { V(-5), V( 22), V( 75), V(14), V( 2), V( -5), V(-19) }
+    { V(89), V( 107), V( 123), V(93), V(57), V( 45), V( 51) },
+    { V(44), V( -18), V(123), V(46), V(39), V(-7), V(  23) },
+    { V(4), V( 52), V( 162), V(37), V(7), V(-14), V(-2) },
+    { V(-10), V( -14), V( 90), V(15), V( 2), V( -7), V(-16) }
   };
 
   // Danger of blocked enemy pawns storming our king, by rank
   constexpr Value BlockedStorm[RANK_NB] =
-    { V(0), V(0), V( 81), V(-9), V(-5), V(-1), V(26) };
+    { V(0), V(0), V( 66), V(6), V(5), V(1), V(15) };
 
   #undef S
   #undef V


### PR DESCRIPTION
Various king and pawn eval values tuned after 2 million games. Rounding slightly adjusted.

LTC: http://tests.stockfishchess.org/tests/view/5b477a260ebc5978f4be3ed4
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 32783 W: 5852 L: 5588 D: 21343

STC: http://tests.stockfishchess.org/tests/view/5b472d420ebc5978f4be3e4d
LLR: 3.23 (-2.94,2.94) [0.00,4.00]
Total: 44380 W: 10201 L: 9841 D: 24338

bench: 5103722
