### PR TITLE
Fix search result aggregation

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -58,8 +58,8 @@ static void BestMove(void* in, void* inout, int* len, MPI_Datatype* datatype) {
   MoveInfo* r = static_cast<MoveInfo*>(inout);
   for (int i=0; i < *len; ++i)
   {
-      if (    l[i].depth > r[i].depth
-          && (l[i].score >= r[i].score || l[i].score >= VALUE_MATE_IN_MAX_PLY))
+      if (    (l[i].depth > r[i].depth || (l[i].depth == r[i].depth && l[i].rank < r[i].rank))
+          && (l[i].score >= r[i].score))
          r[i] = l[i];
   }
 }
@@ -102,7 +102,7 @@ void init() {
 
   MPI_Type_create_hindexed_block(3, 1, MIdisps.data(), MPI_INT, &MIDatatype);
   MPI_Type_commit(&MIDatatype);
-  MPI_Op_create(BestMove, true, &BestMoveOp);
+  MPI_Op_create(BestMove, false, &BestMoveOp);
 
   MPI_Comm_dup(MPI_COMM_WORLD, &InputComm);
   MPI_Comm_dup(MPI_COMM_WORLD, &TTComm);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -281,7 +281,7 @@ void MainThread::search() {
 
   previousScore = static_cast<Value>(mi.score);
 
-  if (Cluster::is_root()) {
+  if (mi.rank == Cluster::rank()) {
       // Send again PV info if we have a new best thread
       if (bestThread != this)
           sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
@@ -352,7 +352,7 @@ void Thread::search() {
       // Distribute search depths across the helper threads
       if (idx + Cluster::rank() > 0)
       {
-          int i = (idx + Cluster::rank() - 1) % 20;
+          int i = (idx + Cluster::rank() * (int)Options["Threads"] - 1) % 20;
           if (((rootDepth / ONE_PLY + rootPos.game_ply() + SkipPhase[i]) / SkipSize[i]) % 2)
               continue;  // Retry with an incremented rootDepth
       }


### PR DESCRIPTION
This reverts my earlier change that only the root node gets to output best move after fixing problem with MPI_Allreduce by our custom operator(BestMoveOp). This function is not commutable and we must ensure that its output is consistent among all nodes.