### PR TITLE
Remove rank limitation for MinorBehindPawn

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -291,7 +291,7 @@ namespace {
   Score Evaluation<T>::pieces() {
 
     constexpr Color     Them        = (Us == WHITE ? BLACK : WHITE);
-    constexpr Direction Up          = (Us == WHITE ? NORTH : SOUTH);
+    constexpr Direction Down        = (Us == WHITE ? SOUTH : NORTH);
     constexpr Bitboard OutpostRanks = (Us == WHITE ? Rank4BB | Rank5BB | Rank6BB
                                                    : Rank5BB | Rank4BB | Rank3BB);
     const Square* pl = pos.squares<Pt>(Us);
@@ -338,7 +338,7 @@ namespace {
                 score += Outpost[Pt == BISHOP][bool(attackedBy[Us][PAWN] & bb)];
 
             // Bonus when behind a pawn
-            if (pos.pieces(PAWN) & (s + Up))
+            if (shift<Down>(pos.pieces(PAWN)) & s)
                 score += MinorBehindPawn;
 
             // Penalty if the piece is far from the king
@@ -348,7 +348,7 @@ namespace {
             {
                 // Penalty according to number of pawns on the same color square as the
                 // bishop, bigger when the center files are blocked with pawns.
-                Bitboard blocked = shift<Up>(pos.pieces(Us, PAWN)) & pos.pieces();
+                Bitboard blocked = pos.pieces(Us, PAWN) & shift<Down>(pos.pieces());
 
                 score -= BishopPawns * pe->pawns_on_same_color_squares(Us, s)
                                      * (1 + popcount(blocked & CenterFiles));

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -337,7 +337,7 @@ namespace {
             else if (bb &= b & ~pos.pieces(Us))
                 score += Outpost[Pt == BISHOP][bool(attackedBy[Us][PAWN] & bb)];
 
-            // Bonus when behind a pawn
+            // Knight and Bishop bonus for being right behind a pawn
             if (shift<Down>(pos.pieces(PAWN)) & s)
                 score += MinorBehindPawn;
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -290,8 +290,8 @@ namespace {
   template<Tracing T> template<Color Us, PieceType Pt>
   Score Evaluation<T>::pieces() {
 
-    constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
-    constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
+    constexpr Color     Them        = (Us == WHITE ? BLACK : WHITE);
+    constexpr Direction Up          = (Us == WHITE ? NORTH : SOUTH);
     constexpr Bitboard OutpostRanks = (Us == WHITE ? Rank4BB | Rank5BB | Rank6BB
                                                    : Rank5BB | Rank4BB | Rank3BB);
     const Square* pl = pos.squares<Pt>(Us);
@@ -338,8 +338,7 @@ namespace {
                 score += Outpost[Pt == BISHOP][bool(attackedBy[Us][PAWN] & bb)];
 
             // Bonus when behind a pawn
-            if (    relative_rank(Us, s) < RANK_5
-                && (pos.pieces(PAWN) & (s + pawn_push(Us))))
+            if (pos.pieces(PAWN) & (s + Up))
                 score += MinorBehindPawn;
 
             // Penalty if the piece is far from the king
@@ -349,7 +348,7 @@ namespace {
             {
                 // Penalty according to number of pawns on the same color square as the
                 // bishop, bigger when the center files are blocked with pawns.
-                Bitboard blocked = pos.pieces(Us, PAWN) & shift<Down>(pos.pieces());
+                Bitboard blocked = shift<Up>(pos.pieces(Us, PAWN)) & pos.pieces();
 
                 score -= BishopPawns * pe->pawns_on_same_color_squares(Us, s)
                                      * (1 + popcount(blocked & CenterFiles));


### PR DESCRIPTION
This is a functional simplification.  It seems like the rank restriction for MinorBehindPawn can be removed.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 61195 W: 13404 L: 13360 D: 34431
http://tests.stockfishchess.org/tests/view/5b47e6f00ebc5978f4be3fc0

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 31701 W: 5367 L: 5264 D: 21070
http://tests.stockfishchess.org/tests/view/5b48a2cb0ebc5978f4be4769

bench 4612953