### PR TITLE
Use single value for KingProtector

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -82,6 +82,7 @@ Mark Tenzer (31m059)
 Michael Byrne (MichaelB7)
 Michael Stembera (mstembera)
 Michel Van den Bergh (vdbergh)
+Miguel Lahoz (miguel-l)
 Mikael Bäckman (mbootsector)
 Mike Whiteley (protonspring)
 Miroslav Fontán (Hexik)
@@ -118,4 +119,3 @@ Tom Vijlbrief (tomtor)
 Torsten Franz (torfranz)
 Uri Blass (uriblass)
 Vince Negri
-xoroshiro

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -154,9 +154,6 @@ namespace {
   // PassedDanger[Rank] contains a term to weight the passed score
   constexpr int PassedDanger[RANK_NB] = { 0, 0, 0, 3, 7, 11, 20 };
 
-  // KingProtector[knight/bishop] contains a penalty according to distance from king
-  constexpr Score KingProtector[] = { S(5, 6), S(6, 5) };
-
   // Assorted bonuses and penalties
   constexpr Score BishopPawns        = S(  3,  7);
   constexpr Score CloseEnemies       = S(  6,  0);
@@ -164,6 +161,7 @@ namespace {
   constexpr Score CorneredBishop     = S( 50, 50);
   constexpr Score Hanging            = S( 52, 30);
   constexpr Score HinderPassedPawn   = S(  4,  0);
+  constexpr Score KingProtector      = S(  6,  6);
   constexpr Score KnightOnQueen      = S( 21, 11);
   constexpr Score LongDiagonalBishop = S( 22,  0);
   constexpr Score MinorBehindPawn    = S( 16,  0);
@@ -342,7 +340,7 @@ namespace {
                 score += MinorBehindPawn;
 
             // Penalty if the piece is far from the king
-            score -= KingProtector[Pt == BISHOP] * distance(s, pos.square<KING>(Us));
+            score -= KingProtector * distance(s, pos.square<KING>(Us));
 
             if (Pt == BISHOP)
             {


### PR DESCRIPTION
After some recent big tuning session, the values for King Protector were simplified to only be used on minor pieces.
This functional simplification tries to further simplify by just using a single value, since current S(6,5) and S(5,6) are close to each other.
S(6,6) ended up passing, although S(5,5) was also tried and failed STC.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 14261 W: 3288 L: 3151 D: 7822
http://tests.stockfishchess.org/tests/view/5b4ccdf50ebc5902bdb77f65

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 19606 W: 3396 L: 3273 D: 12937
http://tests.stockfishchess.org/tests/view/5b4ce4280ebc5902bdb7803b

Bench: 4766675