### PR TITLE
Simplify Overload condition

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -560,7 +560,7 @@ namespace {
 
         score += Hanging * popcount(weak & ~attackedBy[Them][ALL_PIECES]);
 
-        // Bonus for overload (non-pawn enemies attacked and defended exactly once)
+        // Bonus for overload (non-pawn enemies attacked once or more and defended exactly once)
         b =  nonPawnEnemies
            & attackedBy[Us][ALL_PIECES]
            & attackedBy[Them][ALL_PIECES] & ~attackedBy2[Them];

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -558,11 +558,11 @@ namespace {
         if (weak & attackedBy[Us][KING])
             score += ThreatByKing;
 
-        score += Hanging * popcount(weak & (~attackedBy[Them][ALL_PIECES] | (attackedBy[Them][KING] & attackedBy2[Us] & ~attackedBy2[Them])));
+        score += Hanging * popcount(weak & ~attackedBy[Them][ALL_PIECES]);
 
         // Bonus for overload (non-pawn enemies attacked and defended exactly once)
         b =  nonPawnEnemies
-           & attackedBy[Us][ALL_PIECES]   & ~attackedBy2[Us]
+           & attackedBy[Us][ALL_PIECES]
            & attackedBy[Them][ALL_PIECES] & ~attackedBy2[Them];
         score += Overload * popcount(b);
     }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -558,7 +558,7 @@ namespace {
         if (weak & attackedBy[Us][KING])
             score += ThreatByKing;
 
-        score += Hanging * popcount(weak & ~attackedBy[Them][ALL_PIECES]);
+        score += Hanging * popcount(weak & (~attackedBy[Them][ALL_PIECES] | (attackedBy[Them][KING] & attackedBy2[Us] & ~attackedBy2[Them])));
 
         // Bonus for overload (non-pawn enemies attacked and defended exactly once)
         b =  nonPawnEnemies


### PR DESCRIPTION
Extend the bonus for Overload to cases where our side has more than one attacker to a non pawn piece.
Based on an idea by Bryan in the forum. For instance, now black gets the overload bonus in this position: 8/5R1k/6pb/p6p/P1N4P/1Pp5/2K3P1/2N4r b - - 6 46 because two black pieces are attacking the knight on c1 that is defended only by the king.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 57446 W: 12762 L: 12711 D: 31973
http://tests.stockfishchess.org/tests/view/5b4ca9970ebc5902bdb77a88

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 42113 W: 7295 L: 7209 D: 27609
http://tests.stockfishchess.org/tests/view/5b4ccea00ebc5902bdb77f69

Bench: 4667263
