### PR TITLE
Allow Position::init() to be called multiple times.

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -168,6 +168,8 @@ void Position::init() {
   Zobrist::noPawns = rng.rand<Key>();
 
   // Prepare the cuckoo tables
+  std::memset(cuckoo, 0, sizeof(cuckoo));
+  std::memset(cuckooMove, 0, sizeof(cuckooMove));
   int count = 0;
   for (Piece pc : Pieces)
       for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)


### PR DESCRIPTION
For the rationale to allow this, see commit
a66c73deef420104e74b6645ee60e20b37fd8549

This was broken when cuckoo hashing was added, and
subtly broke (for example) lichess' Android application,
thus illustrating the original judgement was sound.

No functional change.