### PR TITLE
Better evasion move sorting. 

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -73,8 +73,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 
 /// MovePicker constructor for quiescence search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
-                       const CapturePieceToHistory* cph, Square rs)
-           : pos(p), mainHistory(mh), captureHistory(cph), recaptureSquare(rs), depth(d) {
+                       const CapturePieceToHistory* cph, const PieceToHistory** ch, Square rs)
+           : pos(p), mainHistory(mh), captureHistory(cph), contHistory(ch), recaptureSquare(rs), depth(d) {
 
   assert(d <= DEPTH_ZERO);
 
@@ -125,7 +125,9 @@ void MovePicker::score() {
               m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
                        - Value(type_of(pos.moved_piece(m)));
           else
-              m.value = (*mainHistory)[pos.side_to_move()][from_to(m)] - (1 << 28);
+              m.value =  (*mainHistory)[pos.side_to_move()][from_to(m)]
+                       + (*contHistory[0])[pos.moved_piece(m)][to_sq(m)]
+                       - (1 << 28);
       }
 }
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -119,6 +119,7 @@ public:
   MovePicker(const Position&, Move, Value, const CapturePieceToHistory*);
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*,
                                            const CapturePieceToHistory*,
+                                           const PieceToHistory**,
                                            Square);
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*,
                                            const CapturePieceToHistory*,


### PR DESCRIPTION
Use in addition the counter move history table for sorting quiet evasion moves in main and quience search.

STC
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 73284 W: 16433 L: 15938 D: 40913
http://tests.stockfishchess.org/tests/view/5b4f526e0ebc5902bdb7a401

LTC
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 12135 W: 2171 L: 1997 D: 7967
http://tests.stockfishchess.org/tests/view/5b4fc0ef0ebc5902bdb7ae0e

Bench 4817583