### PR TITLE
Simplify the "overload" bonus

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -157,7 +157,6 @@ namespace {
   // Assorted bonuses and penalties
   constexpr Score BishopPawns        = S(  3,  7);
   constexpr Score CloseEnemies       = S(  6,  0);
-  constexpr Score Connectivity       = S(  3,  1);
   constexpr Score CorneredBishop     = S( 50, 50);
   constexpr Score Hanging            = S( 52, 30);
   constexpr Score HinderPassedPawn   = S(  4,  0);
@@ -165,7 +164,7 @@ namespace {
   constexpr Score KnightOnQueen      = S( 21, 11);
   constexpr Score LongDiagonalBishop = S( 22,  0);
   constexpr Score MinorBehindPawn    = S( 16,  0);
-  constexpr Score Overload           = S( 10,  5);
+  constexpr Score Overload           = S( 16,  7);
   constexpr Score PawnlessFlank      = S( 20, 80);
   constexpr Score RookOnPawn         = S(  8, 24);
   constexpr Score SliderOnQueen      = S( 42, 21);
@@ -606,10 +605,6 @@ namespace {
 
         score += SliderOnQueen * popcount(b & safeThreats & attackedBy2[Us]);
     }
-
-    // Connectivity: ensure that knights, bishops, rooks, and queens are protected
-    b = (pos.pieces(Us) ^ pos.pieces(Us, PAWN, KING)) & attackedBy[Us][ALL_PIECES];
-    score += Connectivity * popcount(b);
 
     if (T)
         Trace::add(THREAT, Us, score);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -557,10 +557,7 @@ namespace {
 
         score += Hanging * popcount(weak & ~attackedBy[Them][ALL_PIECES]);
 
-        // Bonus for overload (non-pawn enemies attacked once or more and defended exactly once)
-        b =  nonPawnEnemies
-           & attackedBy[Us][ALL_PIECES]
-           & attackedBy[Them][ALL_PIECES] & ~attackedBy2[Them];
+        b =  weak & nonPawnEnemies & attackedBy[Them][ALL_PIECES];
         score += Overload * popcount(b);
     }
 


### PR DESCRIPTION
http://tests.stockfishchess.org/tests/view/5b527b440ebc5902bdb7f7db
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 10925 W: 2517 L: 2374 D: 6034

http://tests.stockfishchess.org/tests/view/5b527f930ebc5902bdb7f883
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 15569 W: 2697 L: 2568 D: 10304

Tested against #1686 

Bench: 5010472