### PR TITLE
Simplify Shelter forward_ranks

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -208,7 +208,7 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
   constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
   constexpr Bitboard  BlockRanks = (Us == WHITE ? Rank1BB | Rank2BB : Rank8BB | Rank7BB);
 
-  Bitboard b = pos.pieces(PAWN) & (forward_ranks_bb(Us, ksq) | rank_bb(ksq));
+  Bitboard b = pos.pieces(PAWN) & ~forward_ranks_bb(Them, ksq);
   Bitboard ourPawns = b & pos.pieces(Us);
   Bitboard theirPawns = b & pos.pieces(Them);
 


### PR DESCRIPTION
This is a non-functional simplification.

This change replaces an 'OR' and a lookup (rank_bb(ksq)) with a bitwise ~.  This is fewer operations and is probably faster.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 25441 W: 5689 L: 5575 D: 14177 
http://tests.stockfishchess.org/tests/view/5b52d05a0ebc5902bdb8010e

Bench 5010472