### PR TITLE
Non functional LMR rewrite.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -985,11 +985,9 @@ moves_loop: // When in check, search starts from here
 
           if (captureOrPromotion) // (~5 Elo)
           {
-              // Increase reduction by comparing opponent's stat score
-              if ((ss-1)->statScore >= 0)
-                  r += ONE_PLY;
-
-              r -= r ? ONE_PLY : DEPTH_ZERO;
+              // Decrease reduction by comparing opponent's stat score
+              if ((ss-1)->statScore < 0)
+                  r -= ONE_PLY;
           }
           else
           {
@@ -1030,10 +1028,10 @@ moves_loop: // When in check, search starts from here
                   r += ONE_PLY;
 
               // Decrease/increase reduction for moves with a good/bad history (~30 Elo)
-              r = std::max(DEPTH_ZERO, (r / ONE_PLY - ss->statScore / 20000) * ONE_PLY);
+              r -= ss->statScore / 20000 * ONE_PLY;
           }
 
-          Depth d = std::max(newDepth - r, ONE_PLY);
+          Depth d = std::max(newDepth - std::max(r, DEPTH_ZERO), ONE_PLY);
 
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, d, true);
 


### PR DESCRIPTION
This is a more logical and robust LMR implementation by unifying the check for non-negativity of reductions. In current master for captures a special handling was used. This was a source of errors if you add there new rules and doesn't correctly handle the check. This change allowed also to simplify the capture branch.

STC for non-regression:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 13556 W: 3082 L: 2944 D: 7530 
http://tests.stockfishchess.org/tests/view/5b5490100ebc5902bdb82bbe

No functional change. 