### PR TITLE
Tweak reductions formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -153,7 +153,7 @@ void Search::init() {
       for (int d = 1; d < 64; ++d)
           for (int mc = 1; mc < 64; ++mc)
           {
-              double r = log(0.82 * d + 0.18) * log(mc) / 1.95;
+              double r = log(0.94 * d + 0.06) * log(mc) / 1.95;
 
               Reductions[NonPV][imp][d][mc] = int(std::round(r));
               Reductions[PV][imp][d][mc] = std::max(Reductions[NonPV][imp][d][mc] - 1, 0);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -153,7 +153,7 @@ void Search::init() {
       for (int d = 1; d < 64; ++d)
           for (int mc = 1; mc < 64; ++mc)
           {
-              double r = log(0.88 * d + 0.12) * log(mc) / 1.95;
+              double r = log(0.82 * d + 0.18) * log(mc) / 1.95;
 
               Reductions[NonPV][imp][d][mc] = int(std::round(r));
               Reductions[PV][imp][d][mc] = std::max(Reductions[NonPV][imp][d][mc] - 1, 0);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -153,7 +153,7 @@ void Search::init() {
       for (int d = 1; d < 64; ++d)
           for (int mc = 1; mc < 64; ++mc)
           {
-              double r = log(d) * log(mc) / 1.95;
+              double r = log(0.88 * d + 0.12) * log(mc) / 1.95;
 
               Reductions[NonPV][imp][d][mc] = int(std::round(r));
               Reductions[PV][imp][d][mc] = std::max(Reductions[NonPV][imp][d][mc] - 1, 0);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -153,7 +153,7 @@ void Search::init() {
       for (int d = 1; d < 64; ++d)
           for (int mc = 1; mc < 64; ++mc)
           {
-              double r = log(1.06 * d - 0.06) * log(mc) / 1.95;
+              double r = log(d > 1 ? 0.88 * d + 0.24 : d) * log(mc) / 1.95;
 
               Reductions[NonPV][imp][d][mc] = int(std::round(r));
               Reductions[PV][imp][d][mc] = std::max(Reductions[NonPV][imp][d][mc] - 1, 0);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -153,7 +153,7 @@ void Search::init() {
       for (int d = 1; d < 64; ++d)
           for (int mc = 1; mc < 64; ++mc)
           {
-              double r = log(0.94 * d + 0.06) * log(mc) / 1.95;
+              double r = log(1.06 * d - 0.06) * log(mc) / 1.95;
 
               Reductions[NonPV][imp][d][mc] = int(std::round(r));
               Reductions[PV][imp][d][mc] = std::max(Reductions[NonPV][imp][d][mc] - 1, 0);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -153,7 +153,7 @@ void Search::init() {
       for (int d = 1; d < 64; ++d)
           for (int mc = 1; mc < 64; ++mc)
           {
-              double r = log(d > 1 ? 0.88 * d + 0.24 : d) * log(mc) / 1.95;
+              double r = log(d > 2 ? 0.88 * d + 0.36 : d) * log(mc) / 1.95;
 
               Reductions[NonPV][imp][d][mc] = int(std::round(r));
               Reductions[PV][imp][d][mc] = std::max(Reductions[NonPV][imp][d][mc] - 1, 0);


### PR DESCRIPTION
Replace the depth part in the reduction formula for higher depths with a slower growing linear function. So for depth > 3 less reductions are used.

What we can try next:
- move the break point to even higher depths
- tweak the slope for lower and higher depth
- possible even use a further higher depth threshold for a another even slower growing function 

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 25317 W: 5763 L: 5505 D: 14049
http://tests.stockfishchess.org/tests/view/5b54f9f70ebc5902bdb840ed

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 7451 W: 1320 L: 1167 D: 4964 
http://tests.stockfishchess.org/tests/view/5b54feeb0ebc5902bdb84244

Bench 4617359