### PR TITLE
Slight decrease of overload value

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -164,7 +164,7 @@ namespace {
   constexpr Score KnightOnQueen      = S( 21, 11);
   constexpr Score LongDiagonalBishop = S( 22,  0);
   constexpr Score MinorBehindPawn    = S( 16,  0);
-  constexpr Score Overload           = S( 16,  7);
+  constexpr Score Overload           = S( 13,  6);
   constexpr Score PawnlessFlank      = S( 20, 80);
   constexpr Score RookOnPawn         = S(  8, 24);
   constexpr Score SliderOnQueen      = S( 42, 21);


### PR DESCRIPTION
Set overload value to S(13,6)

STC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 27606 W: 6371 L: 6094 D: 15141
http://tests.stockfishchess.org/tests/view/5b5455840ebc5902bdb82425

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 112435 W: 19442 L: 18921 D: 74072
http://tests.stockfishchess.org/tests/view/5b546d4a0ebc5902bdb82741

Bench: 4937000