### PR TITLE
Revert "Tweak reductions formula: 0.88 * depth + 0.12". bench 4491691

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -153,8 +153,7 @@ void Search::init() {
       for (int d = 1; d < 64; ++d)
           for (int mc = 1; mc < 64; ++mc)
           {
-              double slope = d > 2 ? 0.88 * d + 0.36 : d;
-              double r = log(slope) * log(mc) / 1.95;
+              double r = log(d) * log(mc) / 1.95;
 
               Reductions[NonPV][imp][d][mc] = int(std::round(r));
               Reductions[PV][imp][d][mc] = std::max(Reductions[NonPV][imp][d][mc] - 1, 0);


### PR DESCRIPTION
A VLTC test shows bad scaling. Also a LTC regression test gives negative result so the original fast passing LTC was a big fluke. So revert this patch.

LTC regression test
ELO: -1.83 +-2.1 (95%) LOS: 4.3%
Total: 36018 W: 6018 L: 6208 D: 23792 
http://tests.stockfishchess.org/tests/view/5b55f8110ebc5902bdb8526f

VLTC(180+1.8):
LLR: -1.59 (-2.94,2.94) [0.00,5.00]
Total: 14968 W: 2247 L: 2257 D: 10464 
http://tests.stockfishchess.org/tests/view/5b559ffa0ebc5902bdb84f36

Bench: 4491691