### PR TITLE
Pruning Tweak- Bench:  4794161

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -935,7 +935,8 @@ moves_loop: // When in check, search starts from here
               int lmrDepth = std::max(newDepth - reduction<PvNode>(improving, depth, moveCount), DEPTH_ZERO) / ONE_PLY;
 
               // Countermoves based pruning (~20 Elo)
-              if (   lmrDepth < 3
+              if (   lmrDepth < 4
+                  && (lmrDepth < 3 || ((ss - 1)->statScore > 0 && !PvNode))
                   && (*contHist[0])[movedPiece][to_sq(move)] < CounterMovePruneThreshold
                   && (*contHist[1])[movedPiece][to_sq(move)] < CounterMovePruneThreshold)
                   continue;


### PR DESCRIPTION
CMH Pruning Tweak


STC: (Yellow)
LLR: -2.96 (-2.94,2.94) [0.00,5.00]
Total: 40124 W: 8817 L: 8751 D: 22556
http://tests.stockfishchess.org/tests/view/5b5690180ebc5902bdb85c8a


LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 21599 W: 3811 L: 3599 D: 14189
http://tests.stockfishchess.org/tests/view/5b5757010ebc5902bdb86b1f

Bench:  4794161