### PR TITLE
Tweak stat bonus

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -85,14 +85,14 @@ enum StatsParams { NOT_USED = 0 };
 /// unsuccessful during the current search, and is used for reduction and move
 /// ordering decisions. It uses 2 tables (one for each color) indexed by
 /// the move's from and to squares, see chessprogramming.wikispaces.com/Butterfly+Boards
-typedef Stats<int16_t, 10368, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)> ButterflyHistory;
+typedef Stats<int16_t, 10692, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)> ButterflyHistory;
 
 /// CounterMoveHistory stores counter moves indexed by [piece][to] of the previous
 /// move, see chessprogramming.wikispaces.com/Countermove+Heuristic
 typedef Stats<Move, NOT_USED, PIECE_NB, SQUARE_NB> CounterMoveHistory;
 
 /// CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
-typedef Stats<int16_t, 10368, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB> CapturePieceToHistory;
+typedef Stats<int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB> CapturePieceToHistory;
 
 /// PieceToHistory is like ButterflyHistory but is addressed by a move's [piece][to]
 typedef Stats<int16_t, 29952, PIECE_NB, SQUARE_NB> PieceToHistory;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -82,7 +82,7 @@ namespace {
   // History and stats update bonus, based on depth
   int stat_bonus(Depth depth) {
     int d = depth / ONE_PLY;
-    return d > 17 ? 0 : 31 * d * d + 62 * d - 62;
+    return d > 17 ? 0 : 33 * d * d + 66 * d - 66;
   }
 
   // Skill structure is used to implement strength limit

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -82,7 +82,7 @@ namespace {
   // History and stats update bonus, based on depth
   int stat_bonus(Depth depth) {
     int d = depth / ONE_PLY;
-    return d > 17 ? 0 : 32 * d * d + 64 * d - 64;
+    return d > 17 ? 0 : 31 * d * d + 62 * d - 62;
   }
 
   // Skill structure is used to implement strength limit


### PR DESCRIPTION
Increase stat bonus by 1/32 and adjust the table divisor of main and capture history to 10692.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 28437 W: 6444 L: 6166 D: 15827 
http://tests.stockfishchess.org/tests/view/5b579b4d0ebc5902bdb87139

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 111204 W: 19160 L: 18644 D: 73400 
http://tests.stockfishchess.org/tests/view/5b57a7c60ebc5902bdb872d3

Bench: 4778882