### PR TITLE
Fix condition for error message of signature script

### DIFF
--- a/tests/signature.sh
+++ b/tests/signature.sh
@@ -16,7 +16,7 @@ signature=`./stockfish bench 2>&1 | grep "Nodes searched  : " | awk '{print $4}'
 if [ $# -gt 0 ]; then
    # compare to given reference
    if [ "$1" != "$signature" ]; then
-      if [ "x$1" == "x" ]; then
+      if [ -z "$signature" ]; then
          echo "No signature obtained from bench. Code crashed or assert triggered ?"
       else
          echo "signature mismatch: reference $1 obtained: $signature ."


### PR DESCRIPTION
Use obtained bench instead of reference bench when checking for crash.

No functional change.