### PR TITLE
Rank threats on pinned pawns 

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -538,10 +538,9 @@ namespace {
         {
             Square s = pop_lsb(&b);
             score += ThreatByMinor[type_of(pos.piece_on(s))];
-            if (type_of(pos.piece_on(s)) != PAWN)
+            if (    type_of(pos.piece_on(s)) != PAWN
+                || (pos.blockers_for_king(Them) & s))
                 score += ThreatByRank * (int)relative_rank(Them, s);
-            else
-                score += ThreatByRank * (int)relative_rank(Them, s) / 4;
         }
 
         b = weak & attackedBy[Us][ROOK];
@@ -549,10 +548,9 @@ namespace {
         {
             Square s = pop_lsb(&b);
             score += ThreatByRook[type_of(pos.piece_on(s))];
-            if (type_of(pos.piece_on(s)) != PAWN)
+            if (    type_of(pos.piece_on(s)) != PAWN
+                || (pos.blockers_for_king(Them) & s))
                 score += ThreatByRank * (int)relative_rank(Them, s);
-            else
-                score += ThreatByRank * (int)relative_rank(Them, s) / 4;
         }
 
         // Bonus for king attacks on pawns or pieces which are not pawn-defended

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -540,8 +540,6 @@ namespace {
             score += ThreatByMinor[type_of(pos.piece_on(s))];
             if (type_of(pos.piece_on(s)) != PAWN)
                 score += ThreatByRank * (int)relative_rank(Them, s);
-            else
-                score += ThreatByRank * (int)relative_rank(Them, s) / 2;
         }
 
         b = weak & attackedBy[Us][ROOK];
@@ -549,10 +547,9 @@ namespace {
         {
             Square s = pop_lsb(&b);
             score += ThreatByRook[type_of(pos.piece_on(s))];
-            if (type_of(pos.piece_on(s)) != PAWN)
+            if (    type_of(pos.piece_on(s)) != PAWN
+                || (forward_file_bb(Them, s) & pos.pieces(Us, ROOK)))
                 score += ThreatByRank * (int)relative_rank(Them, s);
-            else
-                score += ThreatByRank * (int)relative_rank(Them, s) / 2;
         }
 
         // Bonus for king attacks on pawns or pieces which are not pawn-defended

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -540,6 +540,9 @@ namespace {
             score += ThreatByMinor[type_of(pos.piece_on(s))];
             if (type_of(pos.piece_on(s)) != PAWN)
                 score += ThreatByRank * (int)relative_rank(Them, s);
+
+            else if (pos.blockers_for_king(Them) & s)
+                score += ThreatByRank * (int)relative_rank(Them, s) / 2;
         }
 
         b = weak & attackedBy[Us][ROOK];
@@ -547,9 +550,11 @@ namespace {
         {
             Square s = pop_lsb(&b);
             score += ThreatByRook[type_of(pos.piece_on(s))];
-            if (    type_of(pos.piece_on(s)) != PAWN
-                || (pos.blockers_for_king(Them) & s))
+            if (type_of(pos.piece_on(s)) != PAWN)
                 score += ThreatByRank * (int)relative_rank(Them, s);
+
+            else if (pos.blockers_for_king(Them) & s)
+                score += ThreatByRank * (int)relative_rank(Them, s) / 2;
         }
 
         // Bonus for king attacks on pawns or pieces which are not pawn-defended

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -548,8 +548,7 @@ namespace {
         {
             Square s = pop_lsb(&b);
             score += ThreatByRook[type_of(pos.piece_on(s))];
-            if (    type_of(pos.piece_on(s)) != PAWN
-                || (pos.blockers_for_king(Them) & s))
+            if (type_of(pos.piece_on(s)) != PAWN)
                 score += ThreatByRank * (int)relative_rank(Them, s);
         }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -538,8 +538,7 @@ namespace {
         {
             Square s = pop_lsb(&b);
             score += ThreatByMinor[type_of(pos.piece_on(s))];
-            if (    type_of(pos.piece_on(s)) != PAWN
-                || (pos.blockers_for_king(Them) & s))
+            if (type_of(pos.piece_on(s)) != PAWN)
                 score += ThreatByRank * (int)relative_rank(Them, s);
         }
 
@@ -548,7 +547,8 @@ namespace {
         {
             Square s = pop_lsb(&b);
             score += ThreatByRook[type_of(pos.piece_on(s))];
-            if (type_of(pos.piece_on(s)) != PAWN)
+            if (    type_of(pos.piece_on(s)) != PAWN
+                || (pos.blockers_for_king(Them) & s))
                 score += ThreatByRank * (int)relative_rank(Them, s);
         }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -540,6 +540,8 @@ namespace {
             score += ThreatByMinor[type_of(pos.piece_on(s))];
             if (type_of(pos.piece_on(s)) != PAWN)
                 score += ThreatByRank * (int)relative_rank(Them, s);
+            else
+                score += ThreatByRank * (int)relative_rank(Them, s) / 4;
         }
 
         b = weak & attackedBy[Us][ROOK];
@@ -547,9 +549,10 @@ namespace {
         {
             Square s = pop_lsb(&b);
             score += ThreatByRook[type_of(pos.piece_on(s))];
-            if (    type_of(pos.piece_on(s)) != PAWN
-                || (forward_file_bb(Them, s) & pos.pieces(Us, ROOK)))
+            if (type_of(pos.piece_on(s)) != PAWN)
                 score += ThreatByRank * (int)relative_rank(Them, s);
+            else
+                score += ThreatByRank * (int)relative_rank(Them, s) / 4;
         }
 
         // Bonus for king attacks on pawns or pieces which are not pawn-defended

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -540,6 +540,8 @@ namespace {
             score += ThreatByMinor[type_of(pos.piece_on(s))];
             if (type_of(pos.piece_on(s)) != PAWN)
                 score += ThreatByRank * (int)relative_rank(Them, s);
+            else
+                score += ThreatByRank * (int)relative_rank(Them, s) / 2;
         }
 
         b = weak & attackedBy[Us][ROOK];
@@ -549,6 +551,8 @@ namespace {
             score += ThreatByRook[type_of(pos.piece_on(s))];
             if (type_of(pos.piece_on(s)) != PAWN)
                 score += ThreatByRank * (int)relative_rank(Them, s);
+            else
+                score += ThreatByRank * (int)relative_rank(Them, s) / 2;
         }
 
         // Bonus for king attacks on pawns or pieces which are not pawn-defended


### PR DESCRIPTION
Add for pinned pawns half of the standard rank based threat bonus.

STC:
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 44010 W: 9987 L: 9635 D: 24388 
http://tests.stockfishchess.org/tests/view/5b58aa780ebc5902bdb88c7a

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 29475 W: 5089 L: 4847 D: 19539 
http://tests.stockfishchess.org/tests/view/5b58b56c0ebc5902bdb88f37

Bench: 4503866