### PR TITLE
Remove condition for pawn threats

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -580,9 +580,7 @@ namespace {
         & (attackedBy[Us][ALL_PIECES] | ~attackedBy[Them][ALL_PIECES]);
 
     // Bonus for safe pawn threats on the next move
-    b =   pawn_attacks_bb<Us>(b)
-       &  pos.pieces(Them)
-       & ~attackedBy[Us][PAWN];
+    b =   pawn_attacks_bb<Us>(b) & pos.pieces(Them);
 
     score += ThreatByPawnPush * popcount(b);
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -580,7 +580,7 @@ namespace {
         & (attackedBy[Us][ALL_PIECES] | ~attackedBy[Them][ALL_PIECES]);
 
     // Bonus for safe pawn threats on the next move
-    b =   pawn_attacks_bb<Us>(b) & pos.pieces(Them);
+    b = pawn_attacks_bb<Us>(b) & pos.pieces(Them);
 
     score += ThreatByPawnPush * popcount(b);
 


### PR DESCRIPTION
It appears as though removing squares that are already attacked by our pawns can be removed.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 51242 W: 11503 L: 11440 D: 28299 
http://tests.stockfishchess.org/tests/view/5b58b5a40ebc5902bdb88f52

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 35246 W: 6063 L: 5966 D: 23217
http://tests.stockfishchess.org/tests/view/5b58f8e20ebc5902bdb8959b

Bench 4913131