### PR TITLE
Simplify HinderPassedPawn - only look for one instance

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -632,8 +632,7 @@ namespace {
 
         assert(!(pos.pieces(Them, PAWN) & forward_file_bb(Us, s + Up)));
 
-        bb = forward_file_bb(Us, s) & pos.pieces(Them);
-        score -= HinderPassedPawn * popcount(bb);
+        score -= HinderPassedPawn * bool(forward_file_bb(Us, s) & pos.pieces(Them));
 
         int r = relative_rank(Us, s);
         int w = PassedDanger[r];


### PR DESCRIPTION
Changing this popcount to a simple bool should be faster, but only looks for one instance.  The tests seem to indicate that this is a strong patch.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 10821 W: 2475 L: 2332 D: 6014 
http://tests.stockfishchess.org/tests/view/5b58c7f50ebc5902bdb890e0

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 11338 W: 1997 L: 1861 D: 7480
http://tests.stockfishchess.org/tests/view/5b58cfdc0ebc5902bdb891b1

bench 4644049