### PR TITLE
Simplify RookOnPawn (popcount -> bool)

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -374,7 +374,7 @@ namespace {
         {
             // Bonus for aligning rook with enemy pawns on the same rank/file
             if (relative_rank(Us, s) >= RANK_5)
-                score += RookOnPawn * popcount(pos.pieces(Them, PAWN) & PseudoAttacks[ROOK][s]);
+                score += RookOnPawn * bool(pos.pieces(Them, PAWN) & PseudoAttacks[ROOK][s]);
 
             // Bonus for rook on an open or semi-open file
             if (pe->semiopen_file(Us, file_of(s)))


### PR DESCRIPTION
This change is the same as master 95% of the time (for bench) and is much faster.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 72004 W: 16050 L: 16028 D: 39926 
http://tests.stockfishchess.org/tests/view/5b5930a80ebc5902bdb898c8

STC (accidental 2nd STC)
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 11706 W: 2698 L: 2556 D: 6452 
http://tests.stockfishchess.org/tests/view/5b59fa850ebc5902bdb8b5f7

bench 4462700