### PR TITLE
Retire RookOnPawn as a separate Score.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -371,7 +371,7 @@ namespace {
 
         if (Pt == ROOK)
         {
-            // Bonus for aligning rook with enemy pawns on the same rank/file 
+            // Bonus for aligning rook with enemy pawns on the same rank/file
             if (relative_rank(Us, s) >= RANK_5)
                 score += ThreatByRook[PAWN] * popcount(pos.pieces(Them, PAWN) & PseudoAttacks[ROOK][s]);
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -371,7 +371,7 @@ namespace {
 
         if (Pt == ROOK)
         {
-            // Bonus for aligning rook with enemy pawns on the same rank/file
+            // Bonus for aligning rook with enemy pawns on the same rank/file 
             if (relative_rank(Us, s) >= RANK_5)
                 score += ThreatByRook[PAWN] * popcount(pos.pieces(Them, PAWN) & PseudoAttacks[ROOK][s]);
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -133,11 +133,11 @@ namespace {
   // which piece type attacks which one. Attacks on lesser pieces which are
   // pawn-defended are not considered.
   constexpr Score ThreatByMinor[PIECE_TYPE_NB] = {
-    S(0, 0), S(0, 31), S(39, 42), S(57, 44), S(68, 112), S(47, 120)
+    S(0, 0), S(6, 31), S(39, 42), S(57, 44), S(68, 112), S(47, 120)
   };
 
   constexpr Score ThreatByRook[PIECE_TYPE_NB] = {
-    S(0, 0), S(0, 24), S(38, 71), S(38, 61), S(0, 38), S(36, 38)
+    S(0, 0), S(6, 24), S(38, 71), S(38, 61), S(0, 38), S(36, 38)
   };
 
   // PassedRank[Rank] contains a bonus according to the rank of a passed pawn
@@ -166,7 +166,6 @@ namespace {
   constexpr Score MinorBehindPawn    = S( 16,  0);
   constexpr Score Overload           = S( 13,  6);
   constexpr Score PawnlessFlank      = S( 20, 80);
-  constexpr Score RookOnPawn         = S(  8, 24);
   constexpr Score SliderOnQueen      = S( 42, 21);
   constexpr Score ThreatByKing       = S( 23, 76);
   constexpr Score ThreatByPawnPush   = S( 45, 40);
@@ -374,7 +373,7 @@ namespace {
         {
             // Bonus for aligning rook with enemy pawns on the same rank/file
             if (relative_rank(Us, s) >= RANK_5)
-                score += RookOnPawn * popcount(pos.pieces(Them, PAWN) & PseudoAttacks[ROOK][s]);
+                score += ThreatByRook[PAWN] * popcount(pos.pieces(Them, PAWN) & PseudoAttacks[ROOK][s]);
 
             // Bonus for rook on an open or semi-open file
             if (pe->semiopen_file(Us, file_of(s)))


### PR DESCRIPTION
In master, RookOnPawn's value of S(8, 24) is already conspicuously close to ThreatByRook[PAWN]'s value, S(0, 24); in addition, these two bonuses are conceptually very close.  Moreover, previous tests have shown that nonzero middlegame components can be introduced into ThreatByMinor[PAWN] and ThreatByRook[PAWN] without regression, and possibly with some small Elo gain.  The resulting ThreatByRook[PAWN] can entirely replace the RookOnPawn score, thus taking a step towards unifying these ideas.

Here, we eliminate the redundant RookOnPawn Score and increase the middlegame components of ThreatByMinor[PAWN] and ThreatByRook[PAWN] to compensate.

STC: 
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 26090 W: 5827 L: 5714 D: 14549
http://tests.stockfishchess.org/tests/view/5b5960a00ebc5902bdb89b91

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 54991 W: 9381 L: 9316 D: 36294
http://tests.stockfishchess.org/tests/view/5b59f5bc0ebc5902bdb8b510

Bench: 4544321