### PR TITLE
Simplify cmh pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -935,8 +935,7 @@ moves_loop: // When in check, search starts from here
               int lmrDepth = std::max(newDepth - reduction<PvNode>(improving, depth, moveCount), DEPTH_ZERO) / ONE_PLY;
 
               // Countermoves based pruning (~20 Elo)
-              if (   lmrDepth < 4
-                  && (lmrDepth < 3 || ((ss - 1)->statScore > 0 && !PvNode))
+              if (   lmrDepth < 3 + bool((ss - 1)->statScore > 0)
                   && (*contHist[0])[movedPiece][to_sq(move)] < CounterMovePruneThreshold
                   && (*contHist[1])[movedPiece][to_sq(move)] < CounterMovePruneThreshold)
                   continue;


### PR DESCRIPTION
Simplify cmh pruning by removing PvNode exception

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 9935 W: 2330 L: 2184 D: 5421
http://tests.stockfishchess.org/tests/view/5b587dc00ebc5902bdb88424


LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 20635 W: 3585 L: 3464 D: 13586
http://tests.stockfishchess.org/tests/view/5b58910a0ebc5902bdb885b9

Bench: 4327937
