### PR TITLE
Speed up parallel builds by parallelizing Link Time Optimization

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -335,13 +335,13 @@ ifeq ($(optimize),yes)
 ifeq ($(debug), no)
 	ifeq ($(comp),$(filter $(comp),gcc clang))
 		CXXFLAGS += -flto
-		LDFLAGS += $(CXXFLAGS)
+		LDFLAGS += -flto=jobserver
 	endif
 
 	ifeq ($(comp),mingw)
 	ifeq ($(KERNEL),Linux)
 		CXXFLAGS += -flto
-		LDFLAGS += $(CXXFLAGS)
+		LDFLAGS += -flto=jobserver
 	endif
 	endif
 endif
@@ -493,7 +493,7 @@ config-sanity:
 	@test "$(comp)" = "gcc" || test "$(comp)" = "icc" || test "$(comp)" = "mingw" || test "$(comp)" = "clang"
 
 $(EXE): $(OBJS)
-	$(CXX) -o $@ $(OBJS) $(LDFLAGS)
+	+$(CXX) -o $@ $(OBJS) $(LDFLAGS)
 
 clang-profile-make:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \


### PR DESCRIPTION
This patch speeds up parallel builds (with `make -j <n>`) by parallelizing LTO during the linking stage. When the linker is called with `-flto` it uses just a single thread for Link Time Optimization; by calling the linker with `-flto=jobserver` it uses the same number of threads as the parent make process uses. This greatly speeds up the build process depending on the number of threads used (`make profile-build ARCH=x86-64-bmi2 -j 16` finishes in 8 seconds on my i7)

This patch probably only works with GNU make and will use single thread LTO otherwise.

Non-functional.