### PR TITLE
Revert "Allow UCI parameters to be double"

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -308,7 +308,7 @@ void Thread::search() {
 
   multiPV = std::min(multiPV, rootMoves.size());
 
-  int ct = int(Options["Contempt"]) * PawnValueEg / 100; // From centipawns
+  int ct = Options["Contempt"] * PawnValueEg / 100; // From centipawns
 
   // In analysis mode, adjust contempt in accordance with user preference
   if (Limits.infinite || Options["UCI_AnalyseMode"])
@@ -1652,9 +1652,9 @@ bool RootMove::extract_ponder_from_tt(Position& pos) {
 void Tablebases::rank_root_moves(Position& pos, Search::RootMoves& rootMoves) {
 
     RootInTB = false;
-    UseRule50 = bool(Options["Syzygy50MoveRule"]);
-    ProbeDepth = int(Options["SyzygyProbeDepth"]) * ONE_PLY;
-    Cardinality = int(Options["SyzygyProbeLimit"]);
+    UseRule50 = Options["Syzygy50MoveRule"];
+    ProbeDepth = Options["SyzygyProbeDepth"] * ONE_PLY;
+    Cardinality = Options["SyzygyProbeLimit"];
     bool dtz_available = true;
 
     // Tables with fewer pieces than SyzygyProbeLimit are searched with

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -82,7 +82,7 @@ void TranspositionTable::clear() {
 
   std::vector<std::thread> threads;
 
-  for (size_t idx = 0; idx < Options["Threads"]; idx++)
+  for (int idx = 0; idx < Options["Threads"]; idx++)
   {
       threads.push_back(std::thread([this, idx]() {
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -49,12 +49,12 @@ public:
   Option(OnChange = nullptr);
   Option(bool v, OnChange = nullptr);
   Option(const char* v, OnChange = nullptr);
-  Option(double v, int minv, int maxv, OnChange = nullptr);
+  Option(int v, int minv, int maxv, OnChange = nullptr);
   Option(const char* v, const char* cur, OnChange = nullptr);
 
   Option& operator=(const std::string&);
   void operator<<(const Option&);
-  operator double() const;
+  operator int() const;
   operator std::string() const;
   bool operator==(const char*) const;
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -92,13 +92,11 @@ std::ostream& operator<<(std::ostream& os, const OptionsMap& om) {
               const Option& o = it.second;
               os << "\noption name " << it.first << " type " << o.type;
 
-              if (o.type == "string" || o.type == "check" || o.type == "combo")
+              if (o.type != "button")
                   os << " default " << o.defaultValue;
 
               if (o.type == "spin")
-                  os << " default " << int(stof(o.defaultValue))
-                     << " min "     << o.min
-                     << " max "     << o.max;
+                  os << " min " << o.min << " max " << o.max;
 
               break;
           }
@@ -118,15 +116,15 @@ Option::Option(bool v, OnChange f) : type("check"), min(0), max(0), on_change(f)
 Option::Option(OnChange f) : type("button"), min(0), max(0), on_change(f)
 {}
 
-Option::Option(double v, int minv, int maxv, OnChange f) : type("spin"), min(minv), max(maxv), on_change(f)
+Option::Option(int v, int minv, int maxv, OnChange f) : type("spin"), min(minv), max(maxv), on_change(f)
 { defaultValue = currentValue = std::to_string(v); }
 
 Option::Option(const char* v, const char* cur, OnChange f) : type("combo"), min(0), max(0), on_change(f)
 { defaultValue = v; currentValue = cur; }
 
-Option::operator double() const {
+Option::operator int() const {
   assert(type == "check" || type == "spin");
-  return (type == "spin" ? stof(currentValue) : currentValue == "true");
+  return (type == "spin" ? stoi(currentValue) : currentValue == "true");
 }
 
 Option::operator std::string() const {
@@ -162,7 +160,7 @@ Option& Option::operator=(const string& v) {
 
   if (   (type != "button" && v.empty())
       || (type == "check" && v != "true" && v != "false")
-      || (type == "spin" && (stof(v) < min || stof(v) > max)))
+      || (type == "spin" && (stoi(v) < min || stoi(v) > max)))
       return *this;
 
   if (type != "button")


### PR DESCRIPTION
This reverts commit 82f7d507eaf83e27a33bf0b433be08d23320b6fe.

Many valid points as following:

1. Almost all eval and search parameters are of type 'int' and whether
   you do the conversion to int inside the tuning algorithm or inside SF,
   seems to not make any difference. (joergoster)

2. Another way to put it is that the objective function we are tuning is
   constant by parts : an input value of 1.3 or 0.6 result in exactly the
   same value of the objective function. Since SPSA converges towards a
   local optimum, our version of SPSA can theorically converge to (almost)
   any value. (Hanamuke)

3. Unless you rewrite the whole evaluation to calculate with doubles instead
   of integers, you are only deceiving yourself with an imagined higher
   precision which simply is not there. The tuner still calculates with the
   correct 'real' numbers, and not with the rounded integer values. (joergoster)

My view is that the cases where you can genuinely tune doubles are extremely rare,
like https://github.com/snicolet/Stockfish/commit/961f8bc91052a159d7be9 and also
in these cases you can use scaling. But in most cases internal parameters are integers
and (main point) you will round to integers anyhow in the final patch to commit.

Secondary and admittely less important points are regardng coding style: UCI protocol
strictly defines parameters as integers and you need a very good reason to not following
this guideline. Moreover to convey to doubles you need a bunch of C-style casts here
and there and still have warnings (as reported by mstembera for MSVC).

But the most sensible point to me is what Joerg very well said: "Unless you rewrite the
whole evaluation to calculate with doubles instead of integers, you are only deceiving
yourself with an imagined higher precision which simply is not there."

No functional change.