### PR TITLE
Simple razoring: depth 1 only, no distinction between PV / NonPV

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -732,7 +732,7 @@ namespace {
     // Step 7. Razoring (~2 Elo)
     if (   depth < 2 * ONE_PLY
         && eval <= alpha - RazorMargin)
-        return qsearch<NonPV>(pos, ss, alpha, beta);
+        return qsearch<NonPV>(pos, ss, alpha, alpha+1);
 
     improving =   ss->staticEval >= (ss-2)->staticEval
                || (ss-2)->staticEval == VALUE_NONE;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -732,7 +732,7 @@ namespace {
     // Step 7. Razoring (~2 Elo)
     if (   depth < 2 * ONE_PLY
         && eval <= alpha - RazorMargin)
-        return qsearch<NonPV>(pos, ss, alpha, alpha+1);
+        return qsearch<NT>(pos, ss, alpha, beta);
 
     improving =   ss->staticEval >= (ss-2)->staticEval
                || (ss-2)->staticEval == VALUE_NONE;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -66,7 +66,7 @@ namespace {
   constexpr int SkipPhase[] = { 0, 1, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7 };
 
   // Razor and futility margins
-  constexpr int RazorMargin[] = {0, 590, 604};
+  constexpr int RazorMargin = 600;
   Value futility_margin(Depth d, bool improving) {
     return Value((175 - 50 * improving) * d / ONE_PLY);
   }
@@ -730,15 +730,9 @@ namespace {
     }
 
     // Step 7. Razoring (~2 Elo)
-    if (  !PvNode
-        && depth < 3 * ONE_PLY
-        && eval <= alpha - RazorMargin[depth / ONE_PLY])
-    {
-        Value ralpha = alpha - (depth >= 2 * ONE_PLY) * RazorMargin[depth / ONE_PLY];
-        Value v = qsearch<NonPV>(pos, ss, ralpha, ralpha+1);
-        if (depth < 2 * ONE_PLY || v <= ralpha)
-            return v;
-    }
+    if (   depth < 2 * ONE_PLY
+        && eval <= alpha - RazorMargin)
+        return qsearch<NonPV>(pos, ss, alpha, beta);
 
     improving =   ss->staticEval >= (ss-2)->staticEval
                || (ss-2)->staticEval == VALUE_NONE;


### PR DESCRIPTION
We simplify the razoring logic by applying it to all nodes at depth 1 only. An added advantage is that only one razor margin is needed now, and we treat PV and Non-PV nodes in the same manner.

How to continue? 
- There may be some conditions in which depth 2 razoring is beneficial.
- We can see whether the razor margin can be tuned, perhaps even with a different value for PV nodes.
- Perhaps we can unify the treatment of PV and Non-PV nodes in other parts of the search as well.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 5474 W: 1281 L: 1127 D: 3066 
http://tests.stockfishchess.org/tests/view/5b6de3b20ebc5902bdba0d1e

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 62670 W: 10749 L: 10697 D: 41224 
http://tests.stockfishchess.org/tests/view/5b6dee340ebc5902bdba0eb0

In addition, we ran a fixed LTC test against a similar patch which also passed SPRT [-3, 1]:

ELO: 0.23 +-2.1 (95%) LOS: 58.6%
Total: 36412 W: 6168 L: 6144 D: 24100 
http://tests.stockfishchess.org/tests/view/5b6e83940ebc5902bdba1485

We are opting for this patch as the more logical and simple of the two and it appears to be no less strong. Thanks in particular to @DU-jdto for input into this patch. 

Bench: 4476945