### PR TITLE
Combo of several promising parameter tweaks

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -158,7 +158,7 @@ namespace {
   constexpr Score BishopPawns        = S(  3,  7);
   constexpr Score CloseEnemies       = S(  6,  0);
   constexpr Score CorneredBishop     = S( 50, 50);
-  constexpr Score Hanging            = S( 52, 30);
+  constexpr Score Hanging            = S( 57, 32);
   constexpr Score HinderPassedPawn   = S(  8,  0);
   constexpr Score KingProtector      = S(  6,  6);
   constexpr Score KnightOnQueen      = S( 21, 11);
@@ -166,7 +166,7 @@ namespace {
   constexpr Score MinorBehindPawn    = S( 16,  0);
   constexpr Score Overload           = S( 13,  6);
   constexpr Score PawnlessFlank      = S( 19, 84);
-  constexpr Score RookOnPawn         = S(  8, 24);
+  constexpr Score RookOnPawn         = S( 10, 30);
   constexpr Score SliderOnQueen      = S( 42, 21);
   constexpr Score ThreatByKing       = S( 23, 76);
   constexpr Score ThreatByPawnPush   = S( 45, 40);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -82,7 +82,7 @@ namespace {
   // History and stats update bonus, based on depth
   int stat_bonus(Depth depth) {
     int d = depth / ONE_PLY;
-    return d > 17 ? 0 : 33 * d * d + 66 * d - 66;
+    return d > 17 ? 0 : 29 * d * d + 138 * d - 134;
   }
 
   // Skill structure is used to implement strength limit
@@ -263,10 +263,8 @@ void MainThread::search() {
 
       // Select best thread
       int bestVote = votes[this->rootMoves[0].pv[0]];
-      for (Thread* th : Threads)
-      {
-          if (votes[th->rootMoves[0].pv[0]] > bestVote)
-          {
+      for (Thread* th : Threads){
+          if (votes[th->rootMoves[0].pv[0]] > bestVote){
               bestVote = votes[th->rootMoves[0].pv[0]];
               bestThread = th;
           }
@@ -753,7 +751,7 @@ namespace {
     // Step 9. Null move search with verification search (~40 Elo)
     if (   !PvNode
         && (ss-1)->currentMove != MOVE_NULL
-        && (ss-1)->statScore < 22500
+        && (ss-1)->statScore < 23200
         &&  eval >= beta
         &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225
         && !excludedMove

--- a/src/types.h
+++ b/src/types.h
@@ -182,9 +182,9 @@ enum Value : int {
   VALUE_MATE_IN_MAX_PLY  =  VALUE_MATE - 2 * MAX_PLY,
   VALUE_MATED_IN_MAX_PLY = -VALUE_MATE + 2 * MAX_PLY,
 
-  PawnValueMg   = 171,   PawnValueEg   = 240,
+  PawnValueMg   = 175,   PawnValueEg   = 240,
   KnightValueMg = 764,   KnightValueEg = 848,
-  BishopValueMg = 826,   BishopValueEg = 891,
+  BishopValueMg = 815,   BishopValueEg = 905,
   RookValueMg   = 1282,  RookValueEg   = 1373,
   QueenValueMg  = 2500,  QueenValueEg  = 2670,
 


### PR DESCRIPTION
Combo of several tuning patches which finished yellow at LTC (and a cosmetic fix while there).

[STC](http://tests.stockfishchess.org/tests/view/5b6ead340ebc5902bdba14ce)
LR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 10668 W: 2445 L: 2239 D: 5984 
Elo: 6.25 [1.76,10.69] (95%)

[LTC](http://tests.stockfishchess.org/tests/view/5b6eb50e0ebc5902bdba151f)
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 23761 W: 4155 L: 3923 D: 15683
Elo: 3.02 [0.29,5.67] (95%)

Original patches:
- [Piece values](http://tests.stockfishchess.org/tests/view/5b6d2cc00ebc5902bdba02d5) by Stefano Cardanobile
- [Stat bonus](http://tests.stockfishchess.org/tests/view/5b6adbc90ebc5902bdb9da73) by Stefan Geschwentner
- [Rook on pawn](http://tests.stockfishchess.org/tests/view/5b62a95b0ebc5902bdb961c0) by Mark Tenzer
- [Hanging bonus](http://tests.stockfishchess.org/tests/view/5b5d2fa00ebc5902bdb90855) by Ivan Ilvec
- [ss tweak](http://tests.stockfishchess.org/tests/view/5b58b7240ebc5902bdb89025) by miguel-l