### PR TITLE
Non-linear bonus for pawn count

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -91,8 +91,8 @@ namespace {
 
     constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
 
-    //int bonus = PawnCount[pieceCount[Us][PAWN]];
-    int bonus = 0;
+    int bonus = PawnCount[pieceCount[Us][PAWN]];
+    //int bonus = 0;
 
     // Second-degree polynomial material imbalance, by Tord Romstad
     for (int pt1 = NO_PIECE_TYPE; pt1 <= QUEEN; ++pt1)

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -53,8 +53,6 @@ namespace {
     {  97,  100, -42,   137,  268,    0 }  // Queen
   };
 
-  constexpr int PawnCount[] = { 0, 304,  144, -320, -560, -704, -672, -464, -320 };
-
   // Endgame evaluation and scaling functions are accessed directly and not through
   // the function maps because they correspond to more than one material hash key.
   Endgame<KXK>    EvaluateKXK[] = { Endgame<KXK>(WHITE),    Endgame<KXK>(BLACK) };
@@ -91,8 +89,7 @@ namespace {
 
     constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
 
-    int bonus = PawnCount[pieceCount[Us][PAWN]];
-    //int bonus = 0;
+    int bonus = 0;
 
     // Second-degree polynomial material imbalance, by Tord Romstad
     for (int pt1 = NO_PIECE_TYPE; pt1 <= QUEEN; ++pt1)

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -53,6 +53,8 @@ namespace {
     {  97,  100, -42,   137,  268,    0 }  // Queen
   };
 
+  constexpr int PawnCount[] = { 0, 304,  144, -320, -560, -704, -672, -464, -320 };
+
   // Endgame evaluation and scaling functions are accessed directly and not through
   // the function maps because they correspond to more than one material hash key.
   Endgame<KXK>    EvaluateKXK[] = { Endgame<KXK>(WHITE),    Endgame<KXK>(BLACK) };
@@ -89,7 +91,7 @@ namespace {
 
     constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
 
-    int bonus = 0;
+    int bonus = PawnCount[pieceCount[Us][PAWN]];
 
     // Second-degree polynomial material imbalance, by Tord Romstad
     for (int pt1 = NO_PIECE_TYPE; pt1 <= QUEEN; ++pt1)

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -34,11 +34,11 @@ namespace {
   constexpr int QuadraticOurs[][PIECE_TYPE_NB] = {
     //            OUR PIECES
     // pair pawn knight bishop rook queen
-    {1667                               }, // Bishop pair
+    {1443                               }, // Bishop pair
     {  40,    0                         }, // Pawn
-    {  32,  255,  -3                    }, // Knight      OUR PIECES
+    {  32,  255, -67                    }, // Knight      OUR PIECES
     {   0,  104,   4,    0              }, // Bishop
-    { -26,   -2,  47,   105,  -149      }, // Rook
+    { -26,   -2,  47,   105,  -221      }, // Rook
     {-189,   24, 117,   133,  -134, -10 }  // Queen
   };
 
@@ -91,7 +91,8 @@ namespace {
 
     constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
 
-    int bonus = PawnCount[pieceCount[Us][PAWN]];
+    //int bonus = PawnCount[pieceCount[Us][PAWN]];
+    int bonus = 0;
 
     // Second-degree polynomial material imbalance, by Tord Romstad
     for (int pt1 = NO_PIECE_TYPE; pt1 <= QUEEN; ++pt1)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -258,7 +258,7 @@ void MainThread::search() {
 
       // Vote according to score and depth
       for (Thread* th : Threads)
-          votes[th->rootMoves[0].pv[0]] +=  int(th->rootMoves[0].score - minScore)  
+          votes[th->rootMoves[0].pv[0]] +=  int(th->rootMoves[0].score - minScore)
                                           + int(th->completedDepth);
 
       // Select best thread

--- a/src/types.h
+++ b/src/types.h
@@ -184,7 +184,7 @@ enum Value : int {
 
   PawnValueMg   = 175,   PawnValueEg   = 240,
   KnightValueMg = 784,   KnightValueEg = 868,
-  BishopValueMg = 842,   BishopValueEg = 907,
+  BishopValueMg = 831,   BishopValueEg = 919,
   RookValueMg   = 1286,  RookValueEg   = 1378,
   QueenValueMg  = 2527,  QueenValueEg  = 2697,
 

--- a/src/types.h
+++ b/src/types.h
@@ -183,10 +183,10 @@ enum Value : int {
   VALUE_MATED_IN_MAX_PLY = -VALUE_MATE + 2 * MAX_PLY,
 
   PawnValueMg   = 175,   PawnValueEg   = 240,
-  KnightValueMg = 764,   KnightValueEg = 848,
-  BishopValueMg = 815,   BishopValueEg = 905,
-  RookValueMg   = 1282,  RookValueEg   = 1373,
-  QueenValueMg  = 2500,  QueenValueEg  = 2670,
+  KnightValueMg = 784,   KnightValueEg = 868,
+  BishopValueMg = 842,   BishopValueEg = 907,
+  RookValueMg   = 1286,  RookValueEg   = 1378,
+  QueenValueMg  = 2527,  QueenValueEg  = 2697,
 
   MidgameLimit  = 15258, EndgameLimit  = 3915
 };


### PR DESCRIPTION
This patch introduces a non-linear bonus for pawns, along with some
(linear) corrections for the other pieces types. 

The original values were obtained by a massive non-linear tuning of both
pawns and other pieces by GuardianRM, while Alain Savard and Chris Cain
later simplified the patch by observing that, apart from the pawn case, the
tuned corrections were in fact almost affine and could be incorporated in
our current code base via the piece values in types.h (offset) and the diagonal
of the quadratic matrix (slope). See discussion in PR#1725 :
https://github.com/official-stockfish/Stockfish/pull/1725

STC: 
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 42948 W: 9662 L: 9317 D: 23969
http://tests.stockfishchess.org/tests/view/5b6ff6e60ebc5902bdba1d87

LTC: 
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 19683 W: 3409 L: 3206 D: 13068
http://tests.stockfishchess.org/tests/view/5b702dbd0ebc5902bdba216b

How to continue from there?
• Maybe the non-linearity for the pawn value could be somewhat tempered
  again and a simpler linear correction for pawns would work?

Closes https://github.com/official-stockfish/Stockfish/pull/1734

Bench: 4681496