### PR TITLE
Remove pawncount array in imbalance

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -34,12 +34,12 @@ namespace {
   constexpr int QuadraticOurs[][PIECE_TYPE_NB] = {
     //            OUR PIECES
     // pair pawn knight bishop rook queen
-    {1443                               }, // Bishop pair
-    {  40,    0                         }, // Pawn
-    {  32,  255, -67                    }, // Knight      OUR PIECES
+    {1438                               }, // Bishop pair
+    {  40,   38                         }, // Pawn
+    {  32,  255, -62                    }, // Knight      OUR PIECES
     {   0,  104,   4,    0              }, // Bishop
-    { -26,   -2,  47,   105,  -221      }, // Rook
-    {-189,   24, 117,   133,  -134, -10 }  // Queen
+    { -26,   -2,  47,   105,  -208      }, // Rook
+    {-189,   24, 117,   133,  -134, -6 }  // Queen
   };
 
   constexpr int QuadraticTheirs[][PIECE_TYPE_NB] = {
@@ -53,7 +53,7 @@ namespace {
     {  97,  100, -42,   137,  268,    0 }  // Queen
   };
 
-  constexpr int PawnCount[] = { 0, 304,  144, -320, -560, -704, -672, -464, -320 };
+  //constexpr int PawnCount[] = { 0, 304,  144, -320, -560, -704, -672, -464, -320 };
 
   // Endgame evaluation and scaling functions are accessed directly and not through
   // the function maps because they correspond to more than one material hash key.
@@ -91,7 +91,7 @@ namespace {
 
     constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
 
-    int bonus = PawnCount[pieceCount[Us][PAWN]];
+    int bonus = 0; //PawnCount[pieceCount[Us][PAWN]];
 
     // Second-degree polynomial material imbalance, by Tord Romstad
     for (int pt1 = NO_PIECE_TYPE; pt1 <= QUEEN; ++pt1)

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -39,7 +39,7 @@ namespace {
     {  32,  255, -62                    }, // Knight      OUR PIECES
     {   0,  104,   4,    0              }, // Bishop
     { -26,   -2,  47,   105,  -208      }, // Rook
-    {-189,   24, 117,   133,  -134, -6 }  // Queen
+    {-189,   24, 117,   133,  -134, -6  }  // Queen
   };
 
   constexpr int QuadraticTheirs[][PIECE_TYPE_NB] = {
@@ -52,8 +52,6 @@ namespace {
     {  46,   39,  24,   -24,    0       }, // Rook
     {  97,  100, -42,   137,  268,    0 }  // Queen
   };
-
-  //constexpr int PawnCount[] = { 0, 304,  144, -320, -560, -704, -672, -464, -320 };
 
   // Endgame evaluation and scaling functions are accessed directly and not through
   // the function maps because they correspond to more than one material hash key.
@@ -79,7 +77,7 @@ namespace {
   bool is_KQKRPs(const Position& pos, Color us) {
     return  !pos.count<PAWN>(us)
           && pos.non_pawn_material(us) == QueenValueMg
-          && pos.count<QUEEN>(us)  == 1
+          && pos.count<QUEEN>(us) == 1
           && pos.count<ROOK>(~us) == 1
           && pos.count<PAWN>(~us) >= 1;
   }
@@ -91,7 +89,7 @@ namespace {
 
     constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
 
-    int bonus = 0; //PawnCount[pieceCount[Us][PAWN]];
+    int bonus = 0;
 
     // Second-degree polynomial material imbalance, by Tord Romstad
     for (int pt1 = NO_PIECE_TYPE; pt1 <= QUEEN; ++pt1)

--- a/src/types.h
+++ b/src/types.h
@@ -182,7 +182,7 @@ enum Value : int {
   VALUE_MATE_IN_MAX_PLY  =  VALUE_MATE - 2 * MAX_PLY,
   VALUE_MATED_IN_MAX_PLY = -VALUE_MATE + 2 * MAX_PLY,
 
-  PawnValueMg   = 172-30,   PawnValueEg   = 237-30,
+  PawnValueMg   = 142,   PawnValueEg   = 207,
   KnightValueMg = 784,   KnightValueEg = 868,
   BishopValueMg = 828,   BishopValueEg = 916,
   RookValueMg   = 1286,  RookValueEg   = 1378,

--- a/src/types.h
+++ b/src/types.h
@@ -182,11 +182,11 @@ enum Value : int {
   VALUE_MATE_IN_MAX_PLY  =  VALUE_MATE - 2 * MAX_PLY,
   VALUE_MATED_IN_MAX_PLY = -VALUE_MATE + 2 * MAX_PLY,
 
-  PawnValueMg   = 175,   PawnValueEg   = 240,
+  PawnValueMg   = 172-30,   PawnValueEg   = 237-30,
   KnightValueMg = 784,   KnightValueEg = 868,
-  BishopValueMg = 831,   BishopValueEg = 919,
+  BishopValueMg = 828,   BishopValueEg = 916,
   RookValueMg   = 1286,  RookValueEg   = 1378,
-  QueenValueMg  = 2527,  QueenValueEg  = 2697,
+  QueenValueMg  = 2528,  QueenValueEg  = 2698,
 
   MidgameLimit  = 15258, EndgameLimit  = 3915
 };


### PR DESCRIPTION
This is a natural follow up to recent https://github.com/official-stockfish/Stockfish/commit/41cc4eb953b2574ea8858c6d52f09fb1574179c8
where values on the QuadraticOurs diagonal and some piece value deltas were changed

@Stefano80 tried to simplify the newly introduced pawncount using
QuadraticOurs[1][1] =52 and a -30 adjustment on pawn values 

His STC [-3,1] was green
http://tests.stockfishchess.org/tests/view/5b707f5b0ebc5902bdba2745
but not his LTC[-3,1]
http://tests.stockfishchess.org/tests/view/5b7095700ebc5902bdba2a49

So I started a 80000 30+0.3 SPSA on the QuadraticOurs diagonal and on the piece values
using @Stefano80 start values

SPSA gave the new values QuadraticOurs[1][1] =38 and a -33 on pawn values
(the other changes on QuadraticOurs were kept, but were not significant according to this test
http://tests.stockfishchess.org/tests/view/5b710ccb0ebc5902bdba2f27)

STC
http://tests.stockfishchess.org/tests/view/5b710b220ebc5902bdba2f19
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 50902 W: 11214 L: 11150 D: 28538

LTC
http://tests.stockfishchess.org/tests/view/5b7124ef0ebc5902bdba3106
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 34271 W: 5852 L: 5753 D: 22666

bench: 4738555

However, I'm a bit concerned about the new value for PawnValueEg,
since it is used for contempt and also to normalize the position scores output to users.