### PR TITLE
Remove -5,5 safety initialization.

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -42,10 +42,10 @@ namespace {
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
-    { V(-10), V( 81), V( 93), V( 58), V( 39), V( 18), V(  25) },
-    { V(-47), V( 61), V( 35), V(-49), V(-29), V(-11), V( -63) },
-    { V(-14), V( 75), V( 23), V( -2), V( 32), V(  3), V( -45) },
-    { V(-43), V(-13), V(-29), V(-52), V(-48), V(-67), V(-166) }
+    { V(-12), V( 81), V( 93), V( 58), V( 39), V( 18), V(  25) },
+    { V(-49), V( 61), V( 35), V(-49), V(-29), V(-11), V( -63) },
+    { V(-16), V( 75), V( 23), V( -2), V( 32), V(  3), V( -45) },
+    { V(-45), V(-13), V(-29), V(-52), V(-48), V(-67), V(-166) }
   };
 
   // Danger of enemy pawns moving toward our king by [distance from edge][rank].

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -42,10 +42,10 @@ namespace {
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
-    { V( -8), V( 81), V( 93), V( 58), V( 39), V( 18), V(  25) },
-    { V(-45), V( 61), V( 35), V(-49), V(-29), V(-11), V( -63) },
-    { V(-12), V( 75), V( 23), V( -2), V( 32), V(  3), V( -45) },
-    { V(-41), V(-13), V(-29), V(-52), V(-48), V(-67), V(-166) }
+    { V(-10), V( 81), V( 93), V( 58), V( 39), V( 18), V(  25) },
+    { V(-47), V( 61), V( 35), V(-49), V(-29), V(-11), V( -63) },
+    { V(-14), V( 75), V( 23), V( -2), V( 32), V(  3), V( -45) },
+    { V(-43), V(-13), V(-29), V(-52), V(-48), V(-67), V(-166) }
   };
 
   // Danger of enemy pawns moving toward our king by [distance from edge][rank].

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -42,10 +42,10 @@ namespace {
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
-    { V(-12), V( 81), V( 93), V( 58), V( 39), V( 18), V(  25) },
-    { V(-49), V( 61), V( 35), V(-49), V(-29), V(-11), V( -63) },
-    { V(-16), V( 75), V( 23), V( -2), V( 32), V(  3), V( -45) },
-    { V(-45), V(-13), V(-29), V(-52), V(-48), V(-67), V(-166) }
+    { V( -8), V( 81), V( 93), V( 58), V( 39), V( 18), V(  25) },
+    { V(-45), V( 61), V( 35), V(-49), V(-29), V(-11), V( -63) },
+    { V(-12), V( 75), V( 23), V( -2), V( 32), V(  3), V( -45) },
+    { V(-41), V(-13), V(-29), V(-52), V(-48), V(-67), V(-166) }
   };
 
   // Danger of enemy pawns moving toward our king by [distance from edge][rank].
@@ -212,7 +212,7 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
   Bitboard theirPawns = b & pos.pieces(Them);
 
   Value safety = (shift<Down>(theirPawns) & (FileABB | FileHBB) & BlockRanks & ksq) ?
-      Value(374) : Value(10);
+      Value(374) : Value(5);
 
   File center = std::max(FILE_B, std::min(FILE_G, file_of(ksq)));
   for (File f = File(center - 1); f <= File(center + 1); ++f)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -42,10 +42,10 @@ namespace {
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
-    { V( -3), V( 81), V( 93), V( 58), V( 39), V( 18), V(  25) },
-    { V(-40), V( 61), V( 35), V(-49), V(-29), V(-11), V( -63) },
-    { V( -7), V( 75), V( 23), V( -2), V( 32), V(  3), V( -45) },
-    { V(-36), V(-13), V(-29), V(-52), V(-48), V(-67), V(-166) }
+    { V(-10), V( 81), V( 93), V( 58), V( 39), V( 18), V(  25) },
+    { V(-47), V( 61), V( 35), V(-49), V(-29), V(-11), V( -63) },
+    { V(-14), V( 75), V( 23), V( -2), V( 32), V(  3), V( -45) },
+    { V(-43), V(-13), V(-29), V(-52), V(-48), V(-67), V(-166) }
   };
 
   // Danger of enemy pawns moving toward our king by [distance from edge][rank].
@@ -211,10 +211,8 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
   Bitboard ourPawns = b & pos.pieces(Us);
   Bitboard theirPawns = b & pos.pieces(Them);
 
-  Value safety = (ourPawns & file_bb(ksq)) ? Value(5) : Value(-5);
-
-  if (shift<Down>(theirPawns) & (FileABB | FileHBB) & BlockRanks & ksq)
-      safety += Value(374);
+  Value safety = (shift<Down>(theirPawns) & (FileABB | FileHBB) & BlockRanks & ksq) ?
+      Value(374) : Value(0);
 
   File center = std::max(FILE_B, std::min(FILE_G, file_of(ksq)));
   for (File f = File(center - 1); f <= File(center + 1); ++f)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -212,7 +212,7 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
   Bitboard theirPawns = b & pos.pieces(Them);
 
   Value safety = (shift<Down>(theirPawns) & (FileABB | FileHBB) & BlockRanks & ksq) ?
-      Value(374) : Value(0);
+      Value(374) : Value(10);
 
   File center = std::max(FILE_B, std::min(FILE_G, file_of(ksq)));
   for (File f = File(center - 1); f <= File(center + 1); ++f)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -42,10 +42,10 @@ namespace {
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
-    { V(-10), V( 81), V( 93), V( 58), V( 39), V( 18), V(  25) },
-    { V(-47), V( 61), V( 35), V(-49), V(-29), V(-11), V( -63) },
-    { V(-14), V( 75), V( 23), V( -2), V( 32), V(  3), V( -45) },
-    { V(-43), V(-13), V(-29), V(-52), V(-48), V(-67), V(-166) }
+    { V( -6), V( 81), V( 93), V( 58), V( 39), V( 18), V(  25) },
+    { V(-43), V( 61), V( 35), V(-49), V(-29), V(-11), V( -63) },
+    { V(-10), V( 75), V( 23), V( -2), V( 32), V(  3), V( -45) },
+    { V(-39), V(-13), V(-29), V(-52), V(-48), V(-67), V(-166) }
   };
 
   // Danger of enemy pawns moving toward our king by [distance from edge][rank].


### PR DESCRIPTION
Removes the -5,5 initialization of safety.

STC
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 17069 W: 3782 L: 3652 D: 9635
http://tests.stockfishchess.org/tests/view/5b75eb0d0ebc5902bdba8f3d

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 42639 W: 6973 L: 6887 D: 28779
http://tests.stockfishchess.org/tests/view/5b75fd7f0ebc5902bdba906b

Bench  4639508