### PR TITLE
Use an affine formula to mix stats and eval

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -725,7 +725,7 @@ namespace {
         int p = (ss-1)->statScore;
 
         ss->staticEval = eval =
-        (ss-1)->currentMove != MOVE_NULL ? evaluate(pos) - (p > 0 ? 5 + p / 1024 : 0)
+        (ss-1)->currentMove != MOVE_NULL ? evaluate(pos) - (5 + p / 1024)
                                          : -(ss-1)->staticEval + 2 * Eval::Tempo;
 
         tte->save(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE,

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -725,7 +725,7 @@ namespace {
         int p = (ss-1)->statScore;
 
         ss->staticEval = eval =
-        (ss-1)->currentMove != MOVE_NULL ? evaluate(pos) - (5 + p / 1024)
+        (ss-1)->currentMove != MOVE_NULL ? evaluate(pos) - (p + 5000 * ((p > 0)-(p < 0))) / 1024
                                          : -(ss-1)->staticEval + 2 * Eval::Tempo;
 
         tte->save(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE,

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -722,8 +722,10 @@ namespace {
     }
     else
     {
+        int p = (ss-1)->statScore;
+
         ss->staticEval = eval =
-        (ss-1)->currentMove != MOVE_NULL ? evaluate(pos) - 10 * ((ss-1)->statScore > 0)
+        (ss-1)->currentMove != MOVE_NULL ? evaluate(pos) - (p > 0 ? 5 + p / 1024 : 0)
                                          : -(ss-1)->staticEval + 2 * Eval::Tempo;
 
         tte->save(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE,


### PR DESCRIPTION
Follow-up for the previous patch: we use an affine formula to mix stats 
and evaluation in search. The idea is to give a bonus if the previous
move of the opponent was historically bad, and a malus if the previous
move of the opponent was historically good.

More precisely, if x is the stat score of the previous move by the opponent, 
we implement the following formulas to tweak the evaluation at an internal 
node of the tree for our pruning decisions at this node:
   
if x = 0, use v' = eval(P)
if x > 0, use v' = eval(P) - 5 - x/1024
if x < 0, use v' = eval(P) + 5 - x/1024

For reference, the previous master had this simpler rules:

if x > 0, use v' = eval(P) - 10
if x <= 0, use v' = eval(P)

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 29322 W: 6359 L: 6088 D: 16875
http://tests.stockfishchess.org/tests/view/5b76a5980ebc5902bdba957f

LTC: 
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 30893 W: 5154 L: 4910 D: 20829
http://tests.stockfishchess.org/tests/view/5b76ca6d0ebc5902bdba9914

Closes https://github.com/official-stockfish/Stockfish/pull/1740

Bench: 4592766