### PR TITLE
make DistanceRing more consistent

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -116,7 +116,7 @@ void Bitboards::init() {
           if (s1 != s2)
           {
               SquareDistance[s1][s2] = std::max(distance<File>(s1, s2), distance<Rank>(s1, s2));
-              DistanceRingBB[s1][SquareDistance[s1][s2] - 1] |= s2;
+              DistanceRingBB[s1][SquareDistance[s1][s2]] |= s2;
           }
 
   int steps[][5] = { {}, { 7, 9 }, { 6, 10, 15, 17 }, {}, {}, {}, { 1, 7, 8, 9 } };

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -245,7 +245,7 @@ Score Entry::do_king_safety(const Position& pos, Square ksq) {
 
   Bitboard pawns = pos.pieces(Us, PAWN);
   if (pawns)
-      while (!(DistanceRingBB[ksq][minKingPawnDistance++] & pawns)) {}
+      while (!(DistanceRingBB[ksq][++minKingPawnDistance] & pawns)) {}
 
   Value bonus = evaluate_shelter<Us>(pos, ksq);
 


### PR DESCRIPTION
This is a non-functional change.  By pre-incrementing minKingPawnDistance instead of post-incrementing, we can remove this -1.

This also makes DistanceRing more consistent with the rest of stockfish since it now holds an actual "distance" instead of a less natural distance-1.
