### PR TITLE
Convert doubled pawn bitboard to bool

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -71,10 +71,10 @@ namespace {
     constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
     constexpr Direction Up   = (Us == WHITE ? NORTH : SOUTH);
 
-    Bitboard b, neighbours, stoppers, doubled, supported, phalanx;
+    Bitboard b, neighbours, stoppers, supported, phalanx;
     Bitboard lever, leverPush;
     Square s;
-    bool opposed, backward;
+    bool opposed, backward, doubled;
     Score score = SCORE_ZERO;
     const Square* pl = pos.squares<PAWN>(Us);
 


### PR DESCRIPTION
Since the bitboard is only used as a boolean value, I would suggest to define it as `bool` instead of `Bitboard`.

No functional change.

Edit: Travis CI only failed due to technical issues.