### PR TITLE
Move (ss+1)->pv initialization out of moves loop

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -861,6 +861,10 @@ moves_loop: // When in check, search starts from here
     ttCapture = false;
     pvExact = PvNode && ttHit && tte->bound() == BOUND_EXACT;
 
+    if (PvNode)
+       (ss+1)->pv = nullptr;
+
+
     // Step 12. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
     while ((move = mp.next_move(skipQuiets)) != MOVE_NONE)
@@ -884,8 +888,6 @@ moves_loop: // When in check, search starts from here
           sync_cout << "info depth " << depth / ONE_PLY
                     << " currmove " << UCI::move(move, pos.is_chess960())
                     << " currmovenumber " << moveCount + thisThread->pvIdx << sync_endl;
-      if (PvNode)
-          (ss+1)->pv = nullptr;
 
       extension = DEPTH_ZERO;
       captureOrPromotion = pos.capture_or_promotion(move);


### PR DESCRIPTION
no functional change, verified with bench-runs at depth 17 
(Nodes searched in both versions : 23281477)

Opened PR directly without test, because I cannot see any possible speed loss or other issues.

bench:  4457440