### PR TITLE
Shrink tablebase hash table

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -393,14 +393,26 @@ class TBTables {
     std::deque<TBTable<DTZ>> dtzTable;
 
     void insert(Key key, TBTable<WDL>* wdl, TBTable<DTZ>* dtz) {
-        Entry* entry = &hashTable[(uint32_t)key & (Size - 1)];
+        uint32_t home_bucket = (uint32_t)key & (Size - 1);
+        Entry entry = std::make_tuple(key, wdl, dtz);
 
         // Ensure last element is empty to avoid overflow when looking up
-        for ( ; entry - hashTable < Size + Overflow - 1; ++entry)
-            if (std::get<KEY>(*entry) == key || !std::get<WDL>(*entry)) {
-                *entry = std::make_tuple(key, wdl, dtz);
+        for (uint32_t bucket = home_bucket; bucket < Size + Overflow - 1; ++bucket) {
+            Key other_key = std::get<KEY>(hashTable[bucket]);
+            if (other_key == key || !std::get<WDL>(hashTable[bucket])) {
+                hashTable[bucket] = entry;
                 return;
             }
+
+            // Robin Hood hashing: If we've probed for longer than this element,
+            // insert here and search for a new spot for the other element instead.
+            uint32_t other_home_bucket = (uint32_t)other_key & (Size - 1);
+            if (other_home_bucket > home_bucket) {
+                swap(entry, hashTable[bucket]);
+                key = other_key;
+                home_bucket = other_home_bucket;
+            }
+        }
         std::cerr << "TB hash table size too low!" << std::endl;
         exit(1);
     }

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -384,9 +384,10 @@ class TBTables {
 
     typedef std::tuple<Key, TBTable<WDL>*, TBTable<DTZ>*> Entry;
 
-    static const int Size = 1 << 16; // 64K table, indexed by key's 16 lsb
+    static const int Size = 1 << 12; // 4K table, indexed by key's 12 lsb
+    static const int Overflow = 1;  // Number of elements allowed to map to the last bucket
 
-    Entry hashTable[Size];
+    Entry hashTable[Size + Overflow];
 
     std::deque<TBTable<WDL>> wdlTable;
     std::deque<TBTable<DTZ>> dtzTable;
@@ -395,7 +396,7 @@ class TBTables {
         Entry* entry = &hashTable[(uint32_t)key & (Size - 1)];
 
         // Ensure last element is empty to avoid overflow when looking up
-        for ( ; entry - hashTable < Size - 1; ++entry)
+        for ( ; entry - hashTable < Size + Overflow - 1; ++entry)
             if (std::get<KEY>(*entry) == key || !std::get<WDL>(*entry)) {
                 *entry = std::make_tuple(key, wdl, dtz);
                 return;


### PR DESCRIPTION
The recent 7-man Syzygy patch increased the size of the hash table of the tablebases significantly. Bring it down to 4096 entries again by means of a single overflow slot (to avoid the crash when probing past the last entry) and Robin Hood hashing (to avoid the bad worst-case probe lengths), avoiding unneeded cache blowup.