### PR TITLE
Remove maximum limit on complexity

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -770,9 +770,8 @@ namespace {
                     -136 ;
 
     // Now apply the bonus: note that we find the attacking side by extracting
-    // the sign of the endgame value, and that we carefully cap the bonus so
-    // that the endgame score will never change sign after the bonus.
-    int v = ((eg > 0) - (eg < 0)) * std::max(complexity, -abs(eg));
+    // the sign of the endgame value.
+    int v = ((eg > 0) - (eg < 0)) * complexity;
 
     if (T)
         Trace::add(INITIATIVE, make_score(0, v));


### PR DESCRIPTION
Currently, we take the max of complexity and -abs(eg).
The comment explains that this is so that the eg value does not change
sign due to complexity. This test indicates that this is unnecessary.

STC:
http://tests.stockfishchess.org/tests/view/5b7fcc7b0ebc5902bdbb41b1
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 9706 W: 2165 L: 2020 D: 5521

LTC:
http://tests.stockfishchess.org/tests/view/5b7fdd630ebc5902bdbb42e4
LLR: 3.00 (-2.94,2.94) [-3.00,1.00]
Total: 72005 W: 11833 L: 11791 D: 48381

Also thanks to Vizvezdenec for running LTC while I was away.

Bench: 4646359