### PR TITLE
tweak1

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -723,8 +723,8 @@ namespace {
     else
     {
         int p = (ss-1)->statScore;
-        int malus = p > 0 ? (p + 5000) / 1024 :
-                    p < 0 ? (p - 5000) / 1024 : 0;
+        int malus = p > 0 ? (p + 2500) / 512 :
+                    p < 0 ? (p - 2500) / 512 : 0;
 
         ss->staticEval = eval = (ss-1)->currentMove != MOVE_NULL ? (pureStaticEval = evaluate(pos)) - malus
                                                                  : (pureStaticEval = -(ss-1)->staticEval + 2 * Eval::Tempo);


### PR DESCRIPTION
Tweak on top of latest elo gain by snicolet
STC
http://tests.stockfishchess.org/tests/view/5b830a810ebc5902bdbb7e9c
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 27797 W: 6113 L: 5842 D: 15842
LTC
http://tests.stockfishchess.org/tests/view/5b831f2c0ebc5902bdbb8038
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 13655 W: 2294 L: 2099 D: 9262
I think that more elo can be found in tweaks of this parameters so I plan to further do some "hand-tuning", including increasing/decreasing ratio of 2 constants and making malus assimetric to 0.

Bench: 4172767