### PR TITLE
Remove PawnsOnBothFlanks

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -758,16 +758,12 @@ namespace {
     int outflanking =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
                      - distance<Rank>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
 
-    bool pawnsOnBothFlanks =   (pos.pieces(PAWN) & QueenSide)
-                            && (pos.pieces(PAWN) & KingSide);
-
     // Compute the initiative bonus for the attacking side
     int complexity =   8 * pe->pawn_asymmetry()
                     + 12 * pos.count<PAWN>()
                     + 12 * outflanking
-                    + 16 * pawnsOnBothFlanks
                     + 48 * !pos.non_pawn_material()
-                    -136 ;
+                    -110 ;
 
     // Now apply the bonus: note that we find the attacking side by extracting
     // the sign of the endgame value, and that we carefully cap the bonus so

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -763,7 +763,7 @@ namespace {
                     + 12 * pos.count<PAWN>()
                     + 12 * outflanking
                     + 48 * !pos.non_pawn_material()
-                    -110 ;
+                    -130 ;
 
     // Now apply the bonus: note that we find the attacking side by extracting
     // the sign of the endgame value, and that we carefully cap the bonus so

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -763,7 +763,7 @@ namespace {
                     + 12 * pos.count<PAWN>()
                     + 12 * outflanking
                     + 48 * !pos.non_pawn_material()
-                    -130 ;
+                    -110 ;
 
     // Now apply the bonus: note that we find the attacking side by extracting
     // the sign of the endgame value, and that we carefully cap the bonus so


### PR DESCRIPTION
It looks like this can be removed.  A barrage of tests seem to confirm that the adjustment to -110 does not gain elo to offset any potential loss by removing PawnsOnBothFlanks.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 22014 W: 4760 L: 4639 D: 12615
http://tests.stockfishchess.org/tests/view/5b7f50cc0ebc5902bdbb3a3e

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 40561 W: 6667 L: 6577 D: 27317 
http://tests.stockfishchess.org/tests/view/5b801f9f0ebc5902bdbb4467

A barrage of 0,4 tests on the -136 value are in my ps_tunetests branch.
http://tests.stockfishchess.org/tests/user/protonspring

Bench 4665260
