### PR TITLE
Fix bug with "excludedMove" for probcut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -812,7 +812,7 @@ namespace {
             if (pos.legal(move))
             {
                 if (move == excludedMove)
-                     continue;
+                    continue;
 
                 probCutCount++;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -812,7 +812,7 @@ namespace {
             if (pos.legal(move))
             {
                 if (move == excludedMove)
-                    continue;
+                     continue;
 
                 probCutCount++;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -620,6 +620,8 @@ namespace {
     excludedMove = ss->excludedMove;
     posKey = pos.key() ^ Key(excludedMove << 16); // Isn't a very good hash
     tte = TT.probe(posKey, ttHit);
+    if (excludedMove)
+       ttHit = false;
     ttValue = ttHit ? value_from_tt(tte->value(), ss->ply) : VALUE_NONE;
     ttMove =  rootNode ? thisThread->rootMoves[thisThread->pvIdx].pv[0]
             : ttHit    ? tte->move() : MOVE_NONE;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -809,11 +809,11 @@ namespace {
 
         while (  (move = mp.next_move()) != MOVE_NONE
                && probCutCount < 3)
+        {
+            if (move == excludedMove)
+                continue;
             if (pos.legal(move))
             {
-                if (move == excludedMove)
-                     continue;
-
                 probCutCount++;
 
                 ss->currentMove = move;
@@ -835,6 +835,7 @@ namespace {
                 if (value >= rbeta)
                     return value;
             }
+	     }
     }
 
     // Step 11. Internal iterative deepening (~2 Elo)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -620,8 +620,6 @@ namespace {
     excludedMove = ss->excludedMove;
     posKey = pos.key() ^ Key(excludedMove << 16); // Isn't a very good hash
     tte = TT.probe(posKey, ttHit);
-    if (excludedMove)
-       ttHit = false;
     ttValue = ttHit ? value_from_tt(tte->value(), ss->ply) : VALUE_NONE;
     ttMove =  rootNode ? thisThread->rootMoves[thisThread->pvIdx].pv[0]
             : ttHit    ? tte->move() : MOVE_NONE;
@@ -813,6 +811,9 @@ namespace {
                && probCutCount < 3)
             if (pos.legal(move))
             {
+                if (move == excludedMove)
+                    continue;
+
                 probCutCount++;
 
                 ss->currentMove = move;


### PR DESCRIPTION
Bugfix : 
"excludedMove" must be skipped in probcut loop too. If it is not skipped, the probcut can exit quickly with wrong return value corresponding to the excluded move.

See (https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/GGithf_VwSU)

STC : 
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 17130 W: 3747 L: 3617 D: 9766 
http://tests.stockfishchess.org/tests/view/5b8460c40ebc5902bdbb999a

LTC : 
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 12387 W: 2064 L: 1930 D: 8393 
http://tests.stockfishchess.org/tests/view/5b8466f90ebc5902bdbb9a21

To go further : it can be perhaps useful to tune the singular extension search parameters. 

Bench: 4694445