### PR TITLE
Re-introduce "keep pawns on both flanks"

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -758,12 +758,16 @@ namespace {
     int outflanking =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
                      - distance<Rank>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
 
+    bool pawnsOnBothFlanks =   (pos.pieces(PAWN) & QueenSide)		
+                            && (pos.pieces(PAWN) & KingSide);
+
     // Compute the initiative bonus for the attacking side
     int complexity =   8 * pe->pawn_asymmetry()
                     + 12 * pos.count<PAWN>()
                     + 12 * outflanking
+                    + 16 * pawnsOnBothFlanks
                     + 48 * !pos.non_pawn_material()
-                    -110 ;
+                    -118 ;
 
     // Now apply the bonus: note that we find the attacking side by extracting
     // the sign of the endgame value, and that we carefully cap the bonus so


### PR DESCRIPTION
Re-introduce the "keep pawns on both flanks" idea.

STC yellow:
LLR: -2.95 (-2.94,2.94) [0.00,5.00]
Total: 93279 W: 20175 L: 19853 D: 53251
http://tests.stockfishchess.org/tests/view/5b8a00370ebc592cf274916a

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 11440 W: 1960 L: 1792 D: 7688
http://tests.stockfishchess.org/tests/view/5b8a329f0ebc592cf2749615

Closes https://github.com/official-stockfish/Stockfish/pull/1761

Bench: 4609645