### PR TITLE
Enable numa machinery only for MORE than 8 threads.

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -98,7 +98,7 @@ void Thread::idle_loop() {
   // some Windows NUMA hardware, for instance in fishtest. To make it simple,
   // just check if running threads are below a threshold, in this case all this
   // NUMA machinery is not needed.
-  if (Options["Threads"] >= 8)
+  if (Options["Threads"] > 8)
       WinProcGroup::bindThisThread(idx);
 
   while (true)

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -87,7 +87,7 @@ void TranspositionTable::clear() {
       threads.push_back(std::thread([this, idx]() {
 
           // Thread binding gives faster search on systems with a first-touch policy
-          if (Options["Threads"] >= 8)
+          if (Options["Threads"] > 8)
               WinProcGroup::bindThisThread(idx);
 
           // Each thread will zero its part of the hash table


### PR DESCRIPTION
Reason for the pull-request is that nowadays SMP tests are always done with 8 threads. 
That is a problem for multi-socket Windows machines running on fishtest.
No functional change.
Bench: 4136116