### PR TITLE
Sf asymmetry5

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -787,6 +787,7 @@ namespace {
   ScaleFactor Evaluation<T>::scale_factor(Value eg) const {
 
     Color strongSide = eg > VALUE_DRAW ? WHITE : BLACK;
+    Color weakSide = eg < VALUE_DRAW ? WHITE : BLACK;
     int sf = me->scale_factor(pos, strongSide);
 
     // If scale is not already specific, scale down the endgame via general heuristics
@@ -795,9 +796,12 @@ namespace {
         if (   pos.opposite_bishops()
             && pos.non_pawn_material(WHITE) == BishopValueMg
             && pos.non_pawn_material(BLACK) == BishopValueMg)
-            sf = 15+4*pe->pawn_asymmetry();
+            sf = 31;
         else
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
+        if (   pos.non_pawn_material(strongSide) == RookValueMg
+            && pos.non_pawn_material(weakSide) == BishopValueMg)
+            sf = 35 + 2 * pe->pawn_asymmetry();
     }
 
     return ScaleFactor(sf);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -801,7 +801,7 @@ namespace {
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
         if (   pos.non_pawn_material(strongSide) == RookValueMg
             && pos.non_pawn_material(weakSide) == BishopValueMg)
-            sf = 20 + 6 * pe->pawn_asymmetry();
+            sf = 20 + 2 * pe->pawn_asymmetry() + 2 * pos.count<PAWN>(strongSide);
     }
 
     return ScaleFactor(sf);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -801,7 +801,7 @@ namespace {
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
         if (   pos.non_pawn_material(strongSide) == RookValueMg
             && pos.non_pawn_material(weakSide) == BishopValueMg)
-            sf = 40 + 2*pos.count<PAWN>(strongSide);
+            sf = 30 + 4*pos.count<PAWN>(strongSide);
     }
 
     return ScaleFactor(sf);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -787,7 +787,6 @@ namespace {
   ScaleFactor Evaluation<T>::scale_factor(Value eg) const {
 
     Color strongSide = eg > VALUE_DRAW ? WHITE : BLACK;
-    Color weakSide = eg < VALUE_DRAW ? WHITE : BLACK;
     int sf = me->scale_factor(pos, strongSide);
 
     // If scale is not already specific, scale down the endgame via general heuristics
@@ -796,12 +795,9 @@ namespace {
         if (   pos.opposite_bishops()
             && pos.non_pawn_material(WHITE) == BishopValueMg
             && pos.non_pawn_material(BLACK) == BishopValueMg)
-            sf = 31;
+            sf = 15+4*pe->pawn_asymmetry();
         else
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
-        if (   pos.non_pawn_material(strongSide) == RookValueMg
-            && pos.non_pawn_material(weakSide) == BishopValueMg)
-            sf = 30 + 3 * pe->pawn_asymmetry();
     }
 
     return ScaleFactor(sf);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -787,7 +787,6 @@ namespace {
   ScaleFactor Evaluation<T>::scale_factor(Value eg) const {
 
     Color strongSide = eg > VALUE_DRAW ? WHITE : BLACK;
-    Color weakSide = eg < VALUE_DRAW ? WHITE : BLACK;
     int sf = me->scale_factor(pos, strongSide);
 
     // If scale is not already specific, scale down the endgame via general heuristics
@@ -796,12 +795,9 @@ namespace {
         if (   pos.opposite_bishops()
             && pos.non_pawn_material(WHITE) == BishopValueMg
             && pos.non_pawn_material(BLACK) == BishopValueMg)
-            sf = 31;
+            sf = 20 + 2 * pe->pawn_asymmetry();
         else
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
-        if (   pos.non_pawn_material(strongSide) == RookValueMg
-            && pos.non_pawn_material(weakSide) == BishopValueMg)
-            sf = 20 + 6*pos.count<PAWN>(strongSide);
     }
 
     return ScaleFactor(sf);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -801,7 +801,7 @@ namespace {
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
         if (   pos.non_pawn_material(strongSide) == RookValueMg
             && pos.non_pawn_material(weakSide) == KnightValueMg)
-            sf = 60 + 6 * pos.count<PAWN>(strongSide);
+            sf = 60 + 4 * pe->pawn_asymmetry();
     }
 
     return ScaleFactor(sf);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -801,7 +801,7 @@ namespace {
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
         if (   pos.non_pawn_material(strongSide) == RookValueMg
             && pos.non_pawn_material(weakSide) == BishopValueMg)
-            sf = 24 + 4 * pe->pawn_asymmetry();
+            sf = 30 + 3 * pe->pawn_asymmetry();
     }
 
     return ScaleFactor(sf);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -801,7 +801,7 @@ namespace {
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
         if (   pos.non_pawn_material(strongSide) == RookValueMg
             && pos.non_pawn_material(weakSide) == BishopValueMg)
-            sf = 30 + 4*pos.count<PAWN>(strongSide);
+            sf = 20 + 6*pos.count<PAWN>(strongSide);
     }
 
     return ScaleFactor(sf);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -787,6 +787,7 @@ namespace {
   ScaleFactor Evaluation<T>::scale_factor(Value eg) const {
 
     Color strongSide = eg > VALUE_DRAW ? WHITE : BLACK;
+    Color weakSide = eg < VALUE_DRAW ? WHITE : BLACK;
     int sf = me->scale_factor(pos, strongSide);
 
     // If scale is not already specific, scale down the endgame via general heuristics
@@ -795,9 +796,12 @@ namespace {
         if (   pos.opposite_bishops()
             && pos.non_pawn_material(WHITE) == BishopValueMg
             && pos.non_pawn_material(BLACK) == BishopValueMg)
-            sf = 20 + 2 * pe->pawn_asymmetry();
+            sf = 31;
         else
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
+        if (   pos.non_pawn_material(strongSide) == RookValueMg
+            && pos.non_pawn_material(weakSide) == KnightValueMg)
+            sf = 60 + 6 * pos.count<PAWN>(strongSide);
     }
 
     return ScaleFactor(sf);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -801,7 +801,7 @@ namespace {
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
         if (   pos.non_pawn_material(strongSide) == RookValueMg
             && pos.non_pawn_material(weakSide) == BishopValueMg)
-            sf = 20 + 2 * pe->pawn_asymmetry() + 2 * pos.count<PAWN>(strongSide);
+            sf = 24 + 4 * pe->pawn_asymmetry();
     }
 
     return ScaleFactor(sf);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -787,7 +787,6 @@ namespace {
   ScaleFactor Evaluation<T>::scale_factor(Value eg) const {
 
     Color strongSide = eg > VALUE_DRAW ? WHITE : BLACK;
-    Color weakSide = eg < VALUE_DRAW ? WHITE : BLACK;
     int sf = me->scale_factor(pos, strongSide);
 
     // If scale is not already specific, scale down the endgame via general heuristics
@@ -796,12 +795,10 @@ namespace {
         if (   pos.opposite_bishops()
             && pos.non_pawn_material(WHITE) == BishopValueMg
             && pos.non_pawn_material(BLACK) == BishopValueMg)
-            sf = 31;
+            sf = 8 + 4*pe->pawn_asymmetry();
         else
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
-        if (   pos.non_pawn_material(strongSide) == RookValueMg
-            && pos.non_pawn_material(weakSide) == BishopValueMg)
-            sf = 35 + 2 * pe->pawn_asymmetry();
+
     }
 
     return ScaleFactor(sf);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -787,6 +787,7 @@ namespace {
   ScaleFactor Evaluation<T>::scale_factor(Value eg) const {
 
     Color strongSide = eg > VALUE_DRAW ? WHITE : BLACK;
+    Color weakSide = eg < VALUE_DRAW ? WHITE : BLACK;
     int sf = me->scale_factor(pos, strongSide);
 
     // If scale is not already specific, scale down the endgame via general heuristics
@@ -795,9 +796,12 @@ namespace {
         if (   pos.opposite_bishops()
             && pos.non_pawn_material(WHITE) == BishopValueMg
             && pos.non_pawn_material(BLACK) == BishopValueMg)
-            sf = 25 + pe->pawn_asymmetry();
+            sf = 31;
         else
-            sf = std::min(35 + pe->pawn_asymmetry() + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
+            sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
+        if (   pos.non_pawn_material(strongSide) == RookValueMg
+            && pos.non_pawn_material(weakSide) == BishopValueMg)
+            sf = 40 + 2*pos.count<PAWN>(strongSide);
     }
 
     return ScaleFactor(sf);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -795,9 +795,9 @@ namespace {
         if (   pos.opposite_bishops()
             && pos.non_pawn_material(WHITE) == BishopValueMg
             && pos.non_pawn_material(BLACK) == BishopValueMg)
-            sf = 28 + pe->pawn_asymmetry();
+            sf = 25 + pe->pawn_asymmetry();
         else
-            sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
+            sf = std::min(35 + pe->pawn_asymmetry() + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
     }
 
     return ScaleFactor(sf);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -800,8 +800,8 @@ namespace {
         else
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
         if (   pos.non_pawn_material(strongSide) == RookValueMg
-            && pos.non_pawn_material(weakSide) == KnightValueMg)
-            sf = 60 + 4 * pe->pawn_asymmetry();
+            && pos.non_pawn_material(weakSide) == BishopValueMg)
+            sf = 20 + 6 * pe->pawn_asymmetry();
     }
 
     return ScaleFactor(sf);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -795,7 +795,7 @@ namespace {
         if (   pos.opposite_bishops()
             && pos.non_pawn_material(WHITE) == BishopValueMg
             && pos.non_pawn_material(BLACK) == BishopValueMg)
-            sf = 31;
+            sf = 28 + pe->pawn_asymmetry();
         else
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
     }


### PR DESCRIPTION
Make scale factor of opposite colored bishops endgame dependant on asymmetry of pawn structure.
STC 
http://tests.stockfishchess.org/tests/view/5b92a2a80ebc592cf2753dd4
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 31490 W: 6870 L: 6587 D: 18033 
LTC 
http://tests.stockfishchess.org/tests/view/5b92f8170ebc592cf2754438
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 54928 W: 8988 L: 8653 D: 37287 
In my opinion this patch shows that SF can use some more complicated endgame heuristics to evaluate endgames better from the distance. 