### PR TITLE
Reduce depth after fail high

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -401,10 +401,10 @@ void Thread::search() {
           // Start with a small aspiration window and, in the case of a fail
           // high/low, re-search with a bigger window until we don't fail
           // high/low anymore.
-          int failHighCnt = 0;
+          bool failedHigh = false;
           while (true)
           {
-              Depth adjustedDepth = std::max(ONE_PLY, rootDepth - failHighCnt * ONE_PLY);
+              Depth adjustedDepth = std::max(ONE_PLY, rootDepth - failedHigh * 2 * ONE_PLY);
               bestValue = ::search<PV>(rootPos, ss, alpha, beta, adjustedDepth, false);
 
               // Bring the best move to the front. It is critical that sorting
@@ -435,7 +435,7 @@ void Thread::search() {
               {
                   beta = (alpha + beta) / 2;
                   alpha = std::max(bestValue - delta, -VALUE_INFINITE);
-                  failHighCnt = 0;
+                  failedHigh = false;
 
                   if (mainThread)
                   {
@@ -446,7 +446,7 @@ void Thread::search() {
               else if (bestValue >= beta)
               {
                   beta = std::min(bestValue + delta, VALUE_INFINITE);
-                  ++failHighCnt;
+                  failedHigh = true;
               }
               else
                   break;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -404,7 +404,7 @@ void Thread::search() {
           int failedHighCnt = 0;
           while (true)
           {
-              Depth adjustedDepth = std::max(ONE_PLY, rootDepth - std::min(failedHighCnt, 4) * ONE_PLY);
+              Depth adjustedDepth = std::max(ONE_PLY, rootDepth - failedHighCnt * ONE_PLY);
               bestValue = ::search<PV>(rootPos, ss, alpha, beta, adjustedDepth, false);
 
               // Bring the best move to the front. It is critical that sorting

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -368,6 +368,7 @@ void Thread::search() {
 
       size_t pvFirst = 0;
       pvLast = 0;
+      Depth adjustedDepth = rootDepth;
 
       // MultiPV loop. We perform a full root search for each PV line
       for (pvIdx = 0; pvIdx < multiPV && !Threads.stop; ++pvIdx)
@@ -404,7 +405,7 @@ void Thread::search() {
           int failedHighCnt = 0;
           while (true)
           {
-              Depth adjustedDepth = std::max(ONE_PLY, rootDepth - failedHighCnt * ONE_PLY);
+              adjustedDepth = std::max(ONE_PLY, rootDepth - failedHighCnt * ONE_PLY);
               bestValue = ::search<PV>(rootPos, ss, alpha, beta, adjustedDepth, false);
 
               // Bring the best move to the front. It is critical that sorting
@@ -461,15 +462,15 @@ void Thread::search() {
 
           if (    mainThread
               && (Threads.stop || pvIdx + 1 == multiPV || Time.elapsed() > 3000))
-              sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
+              sync_cout << UCI::pv(rootPos, adjustedDepth, alpha, beta) << sync_endl;
       }
 
       if (!Threads.stop)
-          completedDepth = rootDepth;
+          completedDepth = adjustedDepth;
 
       if (rootMoves[0].pv[0] != lastBestMove) {
          lastBestMove = rootMoves[0].pv[0];
-         lastBestMoveDepth = rootDepth;
+         lastBestMoveDepth = adjustedDepth;
       }
 
       // Have we found a "mate in x"?

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -401,10 +401,10 @@ void Thread::search() {
           // Start with a small aspiration window and, in the case of a fail
           // high/low, re-search with a bigger window until we don't fail
           // high/low anymore.
-          bool failedHigh = false;
+          int failedHighCnt = 0;
           while (true)
           {
-              Depth adjustedDepth = std::max(ONE_PLY, rootDepth - failedHigh * 3 * ONE_PLY);
+              Depth adjustedDepth = std::max(ONE_PLY, rootDepth - std::min(failedHighCnt, 4) * ONE_PLY);
               bestValue = ::search<PV>(rootPos, ss, alpha, beta, adjustedDepth, false);
 
               // Bring the best move to the front. It is critical that sorting
@@ -435,7 +435,7 @@ void Thread::search() {
               {
                   beta = (alpha + beta) / 2;
                   alpha = std::max(bestValue - delta, -VALUE_INFINITE);
-                  failedHigh = false;
+                  failedHighCnt = 0;
 
                   if (mainThread)
                   {
@@ -446,7 +446,7 @@ void Thread::search() {
               else if (bestValue >= beta)
               {
                   beta = std::min(bestValue + delta, VALUE_INFINITE);
-                  failedHigh = true;
+                  ++failedHighCnt;
               }
               else
                   break;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -401,9 +401,11 @@ void Thread::search() {
           // Start with a small aspiration window and, in the case of a fail
           // high/low, re-search with a bigger window until we don't fail
           // high/low anymore.
+          int failHighCnt = 0;
           while (true)
           {
-              bestValue = ::search<PV>(rootPos, ss, alpha, beta, rootDepth, false);
+              Depth adjustedDepth = std::max(ONE_PLY, rootDepth - failHighCnt * ONE_PLY);
+              bestValue = ::search<PV>(rootPos, ss, alpha, beta, adjustedDepth, false);
 
               // Bring the best move to the front. It is critical that sorting
               // is done with a stable algorithm because all the values but the
@@ -425,7 +427,7 @@ void Thread::search() {
                   && multiPV == 1
                   && (bestValue <= alpha || bestValue >= beta)
                   && Time.elapsed() > 3000)
-                  sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
+                  sync_cout << UCI::pv(rootPos, adjustedDepth, alpha, beta) << sync_endl;
 
               // In case of failing low/high increase aspiration window and
               // re-search, otherwise exit the loop.
@@ -433,6 +435,7 @@ void Thread::search() {
               {
                   beta = (alpha + beta) / 2;
                   alpha = std::max(bestValue - delta, -VALUE_INFINITE);
+                  failHighCnt = 0;
 
                   if (mainThread)
                   {
@@ -441,7 +444,10 @@ void Thread::search() {
                   }
               }
               else if (bestValue >= beta)
+              {
                   beta = std::min(bestValue + delta, VALUE_INFINITE);
+                  ++failHighCnt;
+              }
               else
                   break;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -404,7 +404,7 @@ void Thread::search() {
           bool failedHigh = false;
           while (true)
           {
-              Depth adjustedDepth = std::max(ONE_PLY, rootDepth - failedHigh * 2 * ONE_PLY);
+              Depth adjustedDepth = std::max(ONE_PLY, rootDepth - failedHigh * ONE_PLY);
               bestValue = ::search<PV>(rootPos, ss, alpha, beta, adjustedDepth, false);
 
               // Bring the best move to the front. It is critical that sorting

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -404,7 +404,7 @@ void Thread::search() {
           bool failedHigh = false;
           while (true)
           {
-              Depth adjustedDepth = std::max(ONE_PLY, rootDepth - failedHigh * ONE_PLY);
+              Depth adjustedDepth = std::max(ONE_PLY, rootDepth - failedHigh * 3 * ONE_PLY);
               bestValue = ::search<PV>(rootPos, ss, alpha, beta, adjustedDepth, false);
 
               // Bring the best move to the front. It is critical that sorting


### PR DESCRIPTION
STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 26142 W: 5717 L: 5460 D: 14965
http://tests.stockfishchess.org/tests/view/5b9823ab0ebc592cf275aeae

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 72395 W: 11980 L: 11574 D: 48841
http://tests.stockfishchess.org/tests/view/5b98490b0ebc592cf275b2cf

Variant of an original idea by @pb00067.  Credit and thanks to him.

@locutus2 
1) I have tried several tests that fix or limit the amount of reduction but the best I got was a green STC and yellow LTC for this http://tests.stockfishchess.org/tests/view/5b9a506b0ebc592cf275d960 version capping the reductions to 4.  Running instrumented bench to a depth of 24 revealed that the highest reduction that ever happened was by 9.  The number of reductions by amount reduced was as follows:
R1 = 596, R2 = 329, R3=158, R4=78, R5=29, R6=13, R7=6, R8=3, R9=2
Given the data I think the capped version just got a bit less lucky than this original.  We could try capping to say 3 or 5 and see what happens if you like.

2) I have an SMP test scheduled to see if setting completedDepth and lastBestMoveDepth to adjustedDepth is stronger or weaker than to rootDepth. 
http://tests.stockfishchess.org/tests/view/5b9ae8a10ebc592cf275e353
If that makes sense to you please approve the test.  Otherwise please advise.

Rebased bench: 3314347