### PR TITLE
Two simplifications in passed pawns evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -159,7 +159,6 @@ namespace {
   constexpr Score CloseEnemies       = S(  6,  0);
   constexpr Score CorneredBishop     = S( 50, 50);
   constexpr Score Hanging            = S( 57, 32);
-  constexpr Score HinderPassedPawn   = S(  8,  0);
   constexpr Score KingProtector      = S(  6,  6);
   constexpr Score KnightOnQueen      = S( 21, 11);
   constexpr Score LongDiagonalBishop = S( 46,  0);
@@ -638,9 +637,6 @@ namespace {
 
         assert(!(pos.pieces(Them, PAWN) & forward_file_bb(Us, s + Up)));
 
-        if (forward_file_bb(Us, s) & pos.pieces(Them))
-            score -= HinderPassedPawn;
-
         int r = relative_rank(Us, s);
         int w = PassedDanger[r];
 
@@ -688,8 +684,6 @@ namespace {
 
                 bonus += make_score(k * w, k * w);
             }
-            else if (pos.pieces(Us) & blockSq)
-                bonus += make_score(w + r * 2, w + r * 2);
         } // w != 0
 
         // Scale down bonus for candidate passers which need more than one


### PR DESCRIPTION
These two simplifications appear to be affecting and/or offsetting each other.  Neither can be removed independently, but in combination they pass -3,1.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 36391 W: 7888 L: 7795 D: 20708 
http://tests.stockfishchess.org/tests/view/5b9bce410ebc592cf275f1b2

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 19513 W: 3237 L: 3114 D: 13162
http://tests.stockfishchess.org/tests/view/5b9c0edf0ebc592cf275f80e

bench 4722355