### PR TITLE
Remove essentially unused code

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -584,8 +584,7 @@ namespace {
         if (   Threads.stop.load(std::memory_order_relaxed)
             || pos.is_draw(ss->ply)
             || ss->ply >= MAX_PLY)
-            return (ss->ply >= MAX_PLY && !inCheck) ? evaluate(pos) - 10 * ((ss-1)->statScore > 0)
-                                                    : VALUE_DRAW;
+            return (ss->ply >= MAX_PLY && !inCheck) ? evaluate(pos) : VALUE_DRAW;
 
         // Step 3. Mate distance pruning. Even if we mate at the next move our score
         // would be at best mate_in(ss->ply+1), but if alpha is already bigger because


### PR DESCRIPTION
this was added recently as part of a larger commit, but only changes eval of positions at MAX_PLY depth a little. Can be safely removed:

passed STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 7424 W: 1640 L: 1492 D: 4292
http://tests.stockfishchess.org/html/live_elo.html?5ba3bcbe0ebc592cf27677ff

passed LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 73554 W: 12028 L: 11990 D: 49536
http://tests.stockfishchess.org/html/live_elo.html?5ba397ee0ebc592cf2767556

unchanged Bench: 4248710