### PR TITLE
Remove the !moveCountPruning condition for check extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -925,7 +925,7 @@ moves_loop: // When in check, search starts from here
               extension = ONE_PLY;
       }
       else if (    givesCheck // Check extension (~2 Elo)
-               && !moveCountPruning
+               && !skipQuiets
                &&  pos.see_ge(move))
           extension = ONE_PLY;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -925,7 +925,6 @@ moves_loop: // When in check, search starts from here
               extension = ONE_PLY;
       }
       else if (    givesCheck // Check extension (~2 Elo)
-               && !skipQuiets
                &&  pos.see_ge(move))
           extension = ONE_PLY;
 


### PR DESCRIPTION
Condition seems not necessary.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 22238 W: 4835 L: 4715 D: 12688 
http://tests.stockfishchess.org/tests/view/5bb3241a0ebc592439f6d2ac

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 36593 W: 5898 L: 5802 D: 24893 
http://tests.stockfishchess.org/tests/view/5bb34c220ebc592439f6d5dc

Bench: 4439901