### PR TITLE
small ttCapture simplification.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -863,7 +863,7 @@ moves_loop: // When in check, search starts from here
     value = bestValue; // Workaround a bogus 'uninitialized' warning under gcc
 
     skipQuiets = false;
-    ttCapture = false;
+    ttCapture = ttMove && pos.capture_or_promotion(ttMove);
     pvExact = PvNode && ttHit && tte->bound() == BOUND_EXACT;
 
     // Step 12. Loop through all pseudo-legal moves until no moves remain
@@ -981,9 +981,6 @@ moves_loop: // When in check, search starts from here
           ss->moveCount = --moveCount;
           continue;
       }
-
-      if (move == ttMove && captureOrPromotion)
-          ttCapture = true;
 
       // Update the current move (this must be done after singular extension search)
       ss->currentMove = move;


### PR DESCRIPTION
ttCapture can be assigned to only once outside of the main loop. The patch seems functional at higher depths (seems possible in the case of non-legal TTmoves that are captures).

passed STC
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 23189 W: 5098 L: 4980 D: 13111
http://tests.stockfishchess.org/tests/view/5bb3822c0ebc592439f6d966

passed LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 10336 W: 1665 L: 1529 D: 7142
http://tests.stockfishchess.org/tests/view/5bb39a190ebc592439f6db8a

unchanged bench: 4059356