### PR TITLE
Combination of two promising tweaks.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -133,11 +133,11 @@ namespace {
   // which piece type attacks which one. Attacks on lesser pieces which are
   // pawn-defended are not considered.
   constexpr Score ThreatByMinor[PIECE_TYPE_NB] = {
-    S(0, 0), S(0, 31), S(39, 42), S(57, 44), S(68, 112), S(47, 120)
+    S(0, 0), S(0, 31), S(39, 42), S(57, 44), S(68, 112), S(62, 120)
   };
 
   constexpr Score ThreatByRook[PIECE_TYPE_NB] = {
-    S(0, 0), S(0, 24), S(38, 71), S(38, 61), S(0, 38), S(36, 38)
+    S(0, 0), S(0, 24), S(38, 71), S(38, 61), S(0, 38), S(51, 38)
   };
 
   // PassedRank[Rank] contains a bonus according to the rank of a passed pawn

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -757,7 +757,7 @@ namespace {
         && (ss-1)->currentMove != MOVE_NULL
         && (ss-1)->statScore < 23200
         &&  eval >= beta
-        &&  ss->staticEval >= beta - 36 * depth / ONE_PLY + 225
+        &&  pureStaticEval >= beta - 36 * depth / ONE_PLY + 225
         && !excludedMove
         &&  pos.non_pawn_material(us)
         && (ss->ply >= thisThread->nmpMinPly || us != thisThread->nmpColor))


### PR DESCRIPTION
This PR is a combination of two unrelated [0, 4] patches that appeared promising but not quite strong enough to pass on their own.  The combination initially failed STC with a positive score after a long run, and the subsequent speculative LTC test passed.

**tweak_threatOnQueen4**
Increase the middlegame components of ThreatByMinor[QUEEN] and ThreatByRook[QUEEN] by 15 each.
- Bryan's (@crossbr) analysis of CCC Bonus Game 10 inspired several tests on penalizing a queen with limited safe mobility.  While attempting to implement this idea, I noticed that when I did not include the queen's current square in the calculations, the Elo gains seemed to vanish--and only then did I have the idea to revisit ThreatByMinor[QUEEN] and ThreatByRook[QUEEN], adding a corresponding value to each.  Without Bryan's work, this test would never have been submitted.
- I would also like to recognize the efforts and contributions of @SFisGOD, who also vigorously worked on this idea.

**pss**
Use pure static eval for null move pruning.
- This idea was directly re-purposed from a promising test by Jerry Donald Watson (@jerrydonaldwatson) in August.
- It was also independently developed and tested by Stefan Geschwentner (@locutus2) previously.

Thank you all!

STC (failed yellow):
LLR: -2.96 (-2.94,2.94) [0.00,4.00]
Total: 83913 W: 17986 L: 17825 D: 48102
http://tests.stockfishchess.org/tests/view/5bbc59300ebc592439f76aa5

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 137198 W: 22351 L: 21772 D: 93075
http://tests.stockfishchess.org/tests/view/5bbce35f0ebc592439f77639

Bench: 4312846