### PR TITLE
Force time check on TB probe in search.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -675,6 +675,10 @@ namespace {
             TB::ProbeState err;
             TB::WDLScore wdl = Tablebases::probe_wdl(pos, &err);
 
+            // Force check of time on the next occasion
+            if (thisThread == Threads.main())
+                static_cast<MainThread*>(thisThread)->callsCnt = 0;
+
             if (err != TB::ProbeState::FAIL)
             {
                 thisThread->tbHits.fetch_add(1, std::memory_order_relaxed);


### PR DESCRIPTION
this is the minimally invasive part of #1623 , for easy merging, see there for full discussion.

No functional change.