### PR TITLE
Clear TB mappings in Search::clear()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,6 @@ int main(int argc, char* argv[]) {
   Bitbases::init();
   Search::init();
   Pawns::init();
-  Tablebases::init(Options["SyzygyPath"]); // After Bitboards are set
   Threads.set(Options["Threads"]);
   Search::clear(); // After threads are up
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -187,6 +187,7 @@ void Search::clear() {
   Time.availableNodes = 0;
   TT.clear();
   Threads.clear();
+  Tablebases::init(Options["SyzygyPath"]); // Free up mapped files
 }
 
 


### PR DESCRIPTION
This patch will make possible to free mapped TB files with "ucinewgame" command.

Also saving one LOC since Search::clear() is also called during initialization.

No functional change.