### PR TITLE
Fix output of truncated pv lines

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1124,12 +1124,16 @@ moves_loop: // When in check, search starts from here
       {
           bestValue = value;
 
+          // We have a new best move. At PV nodes and if the move
+          // is above alpha or we are still without a 'bestMove'
+          // because all the moves we tried so far failed low, 
+          // we must save this move as PV move.
+          if (PvNode && !rootNode && (value > alpha || !bestMove))
+              update_pv(ss->pv, move, (ss+1)->pv);
+
           if (value > alpha)
           {
               bestMove = move;
-
-              if (PvNode && !rootNode) // Update pv even in fail-high case
-                  update_pv(ss->pv, move, (ss+1)->pv);
 
               if (PvNode && value < beta) // Update alpha! Always alpha < beta
                   alpha = value;
@@ -1140,11 +1144,6 @@ moves_loop: // When in check, search starts from here
                   break;
               }
           }
-          // A new move which raises bestValue yet doesn't raise alpha.
-          // At a pv node with no best move we must save this move as
-          // pv move to avoid being left without a pv move at all.
-          else if (PvNode && !rootNode && !bestMove)
-              update_pv(ss->pv, move, (ss+1)->pv);
       }
 
       if (move != bestMove)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1140,8 +1140,9 @@ moves_loop: // When in check, search starts from here
                   break;
               }
           }
-          // We have a better move though it doesn't raise alpha. At a pv node
-          // and without a best move we must store this move as pv move.
+          // A new move which raises bestValue yet doesn't raise alpha.
+          // At a pv node with no best move we must save this move as
+          // pv move to avoid being left without a pv move at all.
           else if (PvNode && !rootNode && !bestMove)
               update_pv(ss->pv, move, (ss+1)->pv);
       }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1140,6 +1140,10 @@ moves_loop: // When in check, search starts from here
                   break;
               }
           }
+          // We have a better move though it doesn't raise alpha. At a pv node
+          // and without a best move we must store this move as pv move.
+          else if (PvNode && !rootNode && !bestMove)
+              update_pv(ss->pv, move, (ss+1)->pv);
       }
 
       if (move != bestMove)


### PR DESCRIPTION
At PV nodes we only update the pv if a move raises alpha. If all moves we try fail-low with value <= alpha, we could be left with no pv move which leads to a truncated pv line.
This patch fixes this by also updating the pv if a move is a new best move (value > bestValue) yet still failing low (value <= alpha). This must only be done and only as long as there is no other move above alpha, of course!
This is guaranteed by the !bestMove condition.

Example:
stockfish
uci
go depth 24

**master**
info depth 24 seldepth 30 multipv 1 score cp 60 upperbound nodes 11895367 nps 1090018 hashfull 999 tbhits 0 time 10913 pv e2e4 e7e5
info depth 24 currmove e2e4 currmovenumber 1
info depth 24 seldepth 32 multipv 1 score cp 69 lowerbound nodes 13908134 nps 1086488 hashfull 999 tbhits 0 time 12801 pv e2e4

**patch**
info depth 24 seldepth 30 multipv 1 score cp 60 upperbound nodes 11895367 nps 1092019 hashfull 999 tbhits 0 time 10893 pv e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 e4d6 b5c6 d7c6 d4e5 d6f5 d1e2 f5d4 f3d4 d8d4 b1c3
info depth 24 currmove e2e4 currmovenumber 1
info depth 24 seldepth 32 multipv 1 score cp 69 lowerbound nodes 13908134 nps 1088699 hashfull 999 tbhits 0 time 12775 pv e2e4 e7e5 g1f3 b8c6 f1c4 g8f6 d2d3 f8c5 e1g1 h7h6 c2c3 c5b6

This patch is heavily inspired by Günther's (pb00068) try to fix this, so also kudos to him.

No functional change.