### PR TITLE
Remove 0 distance limit for DistanceRing and SquareDistance.

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -113,7 +113,6 @@ void Bitboards::init() {
 
   for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
       for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2)
-          if (s1 != s2)
           {
               SquareDistance[s1][s2] = std::max(distance<File>(s1, s2), distance<Rank>(s1, s2));
               DistanceRingBB[s1][SquareDistance[s1][s2]] |= s2;


### PR DESCRIPTION
This is a non-functional simplification.

With the commit of #1741.  I believe this can go away now.



