### PR TITLE
Simplify king ring determination

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -265,7 +265,7 @@ namespace {
     if (pos.non_pawn_material(Them) >= RookValueMg + KnightValueMg)
     {
         kingRing[Us] = attackedBy[Us][KING];
-        if ((Rank1BB | Rank8BB) & pos.square<KING>(Us))
+        if (relative_rank(Us, pos.square<KING>(Us)) == RANK_1)
             kingRing[Us] |= shift<Up>(kingRing[Us]);
 
         if (FileHBB & pos.square<KING>(Us))

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -265,13 +265,13 @@ namespace {
     if (pos.non_pawn_material(Them) >= RookValueMg + KnightValueMg)
     {
         kingRing[Us] = attackedBy[Us][KING];
-        if (relative_rank(Us, pos.square<KING>(Us)) == RANK_1)
+        if ((Rank1BB | Rank8BB) & pos.square<KING>(Us))
             kingRing[Us] |= shift<Up>(kingRing[Us]);
 
-        if (file_of(pos.square<KING>(Us)) == FILE_H)
+        if (FileHBB & pos.square<KING>(Us))
             kingRing[Us] |= shift<WEST>(kingRing[Us]);
 
-        else if (file_of(pos.square<KING>(Us)) == FILE_A)
+        else if (FileABB & pos.square<KING>(Us))
             kingRing[Us] |= shift<EAST>(kingRing[Us]);
 
         kingAttackersCount[Them] = popcount(kingRing[Us] & pe->pawn_attacks(Them));


### PR DESCRIPTION
Replaces a file_of and a compare with a single AND.  This is a non-functional simplification.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 13530 W: 2972 L: 2835 D: 7723
http://tests.stockfishchess.org/tests/view/5be0dd590ebc595e0ae2d6b5