### PR TITLE
[merged] Pawn and Piece Values Tuned

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -176,10 +176,10 @@ enum Value : int {
   VALUE_MATE_IN_MAX_PLY  =  VALUE_MATE - 2 * MAX_PLY,
   VALUE_MATED_IN_MAX_PLY = -VALUE_MATE + 2 * MAX_PLY,
 
-  PawnValueMg   = 142,   PawnValueEg   = 207,
-  KnightValueMg = 784,   KnightValueEg = 868,
-  BishopValueMg = 828,   BishopValueEg = 916,
-  RookValueMg   = 1286,  RookValueEg   = 1378,
+  PawnValueMg   = 136,   PawnValueEg   = 208,
+  KnightValueMg = 782,   KnightValueEg = 865,
+  BishopValueMg = 830,   BishopValueEg = 918,
+  RookValueMg   = 1289,  RookValueEg   = 1378,
   QueenValueMg  = 2529,  QueenValueEg  = 2687,
 
   MidgameLimit  = 15258, EndgameLimit  = 3915


### PR DESCRIPTION
Pawn and Piece Values Tuned at LTC

Failed STC
LLR: -2.96 (-2.94,2.94) [0.00,4.00]
Total: 27487 W: 5846 L: 5903 D: 15738
http://tests.stockfishchess.org/tests/view/5be1d3190ebc595e0ae2e5b8

Passed 1st LTC
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 38503 W: 6270 L: 5999 D: 26234
http://tests.stockfishchess.org/tests/view/5be1f5ef0ebc595e0ae2e750

Passed 2nd LTC
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 34016 W: 5584 L: 5326 D: 23106
http://tests.stockfishchess.org/tests/view/5be2a1970ebc595e0ae2f1b4

Bench: 3460731