### PR TITLE
Contempt 24

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -59,7 +59,7 @@ void init(OptionsMap& o) {
   constexpr int MaxHashMB = Is64Bit ? 131072 : 2048;
 
   o["Debug Log File"]        << Option("", on_logger);
-  o["Contempt"]              << Option(21, -100, 100);
+  o["Contempt"]              << Option(24, -100, 100);
   o["Analysis Contempt"]     << Option("Both var Off var White var Black var Both", "Both");
   o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);


### PR DESCRIPTION
I haven't seen any news on this so decided to make a PR...
passed non-regression STC vs c=0
http://tests.stockfishchess.org/tests/view/5bd6d7f80ebc595e0ae21e14
passed non-regression LTC vs c=0
http://tests.stockfishchess.org/tests/view/5bd6e0980ebc595e0ae21f07
Usually it's enough to set it to new (higher) value. Also because we resently decreased PawnValueMg it's logical that higher contempt values don't regress now because they are dependant on this value.