### PR TITLE
Remove BlockedStorm array

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -58,10 +58,6 @@ namespace {
     { V(-10), V(-14), V( 90), V(15), V( 2), V( -7), V(-16) }
   };
 
-  // Danger of blocked enemy pawns storming our king, by rank
-  constexpr Value BlockedStorm[RANK_NB] =
-    { V(0), V(0), V(66), V(6), V(5), V(1), V(15) };
-
   #undef S
   #undef V
 
@@ -225,8 +221,8 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
 
       int d = std::min(f, ~f);
       safety += ShelterStrength[d][ourRank];
-      safety -= (ourRank && (ourRank == theirRank - 1)) ? BlockedStorm[theirRank]
-                                                        : UnblockedStorm[d][theirRank];
+      safety -= (ourRank && (ourRank == theirRank - 1)) ?
+          ((theirRank == RANK_3) ? 66 : 0) : UnblockedStorm[d][theirRank];
   }
 
   return safety;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -222,7 +222,7 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
       int d = std::min(f, ~f);
       safety += ShelterStrength[d][ourRank];
       safety -= (ourRank && (ourRank == theirRank - 1)) ?
-          ((theirRank == RANK_3) ? 66 : 0) : UnblockedStorm[d][theirRank];
+          66 * (theirRank == RANK_3) : UnblockedStorm[d][theirRank];
   }
 
   return safety;


### PR DESCRIPTION
Apparently, only RANK_3 is relevant.  This removes a look-up and the BlockedStorm array, but adds another conditional.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 84340 W: 18054 L: 18054 D: 48232 
http://tests.stockfishchess.org/tests/view/5bea10f40ebc595e0ae3457b

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 31874 W: 5135 L: 5032 D: 21707 
http://tests.stockfishchess.org/tests/view/5beadb6a0ebc595e0ae35542