### PR TITLE
FastStatReduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1049,11 +1049,16 @@ moves_loop: // When in check, search starts from here
                              - 4000;
 
               // Decrease/increase reduction by comparing opponent's stat score (~10 Elo)
-              if (ss->statScore >= 0 && (ss-1)->statScore < 0)
-                  r -= ONE_PLY;
-
-              else if ((ss-1)->statScore >= 0 && ss->statScore < 0)
-                  r += ONE_PLY;
+       /*Branchless reduction:
+The booleans are converted to 1:0
+Cases for reductions: 
+ OurScore  TheirScore
+    1           0      1-0=1  -> r-=1
+    1           1      1-1=0  -> r-=0
+    0           1      0-1=-1 -> r-=-1
+    0           0      0-0=0  -> r-=0
+*/
+r -=(int(ss->statScore >= 0)-int((ss-1)->statScore >= 0))*ONE_PLY;
 
               // Decrease/increase reduction for moves with a good/bad history (~30 Elo)
               r -= ss->statScore / 20000 * ONE_PLY;


### PR DESCRIPTION
Converts the stat reduction to branchless version 
verified STC for no regression:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 39678 W: 8409 L: 8322 D: 22947 [GREEN]
http://tests.stockfishchess.org/tests/view/5bf15f740ebc595e0ae3c094

I believe no LTC test is needed.
No functional change