### PR TITLE
Remove Rank/File constants and use arrays

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -27,7 +27,6 @@ uint8_t PopCnt16[1 << 16];
 int SquareDistance[SQUARE_NB][SQUARE_NB];
 
 Bitboard SquareBB[SQUARE_NB];
-Bitboard RankBB[RANK_NB];
 Bitboard AdjacentFilesBB[FILE_NB];
 Bitboard ForwardRanksBB[COLOR_NB][RANK_NB];
 Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
@@ -89,9 +88,6 @@ void Bitboards::init() {
 
   for (Square s = SQ_A1; s <= SQ_H8; ++s)
       SquareBB[s] = (1ULL << s);
-
-  for (Rank r = RANK_1; r <= RANK_8; ++r)
-      RankBB[r] = r > RANK_1 ? RankBB[r - 1] << 8 : Rank1BB;
 
   for (File f = FILE_A; f <= FILE_H; ++f)
       AdjacentFilesBB[f] = (f > FILE_A ? FileBB[f - 1] : 0) | (f < FILE_H ? FileBB[f + 1] : 0);
@@ -195,7 +191,7 @@ namespace {
     for (Square s = SQ_A1; s <= SQ_H8; ++s)
     {
         // Board edges are not considered in the relevant occupancies
-        edges = ((Rank1BB | Rank8BB) & ~rank_bb(s)) | ((FileBB[FILE_A] | FileBB[FILE_H]) & ~file_bb(s));
+        edges = ((RankBB[RANK_1] | RankBB[RANK_8]) & ~rank_bb(s)) | ((FileBB[FILE_A] | FileBB[FILE_H]) & ~file_bb(s));
 
         // Given a square 's', the mask is the bitboard of sliding attacks from
         // 's' computed on an empty board. The index must be big enough to contain

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -27,7 +27,6 @@ uint8_t PopCnt16[1 << 16];
 int SquareDistance[SQUARE_NB][SQUARE_NB];
 
 Bitboard SquareBB[SQUARE_NB];
-Bitboard FileBB[FILE_NB];
 Bitboard RankBB[RANK_NB];
 Bitboard AdjacentFilesBB[FILE_NB];
 Bitboard ForwardRanksBB[COLOR_NB][RANK_NB];
@@ -90,9 +89,6 @@ void Bitboards::init() {
 
   for (Square s = SQ_A1; s <= SQ_H8; ++s)
       SquareBB[s] = (1ULL << s);
-
-  for (File f = FILE_A; f <= FILE_H; ++f)
-      FileBB[f] = f > FILE_A ? FileBB[f - 1] << 1 : FileABB;
 
   for (Rank r = RANK_1; r <= RANK_8; ++r)
       RankBB[r] = r > RANK_1 ? RankBB[r - 1] << 8 : Rank1BB;
@@ -199,7 +195,7 @@ namespace {
     for (Square s = SQ_A1; s <= SQ_H8; ++s)
     {
         // Board edges are not considered in the relevant occupancies
-        edges = ((Rank1BB | Rank8BB) & ~rank_bb(s)) | ((FileABB | FileHBB) & ~file_bb(s));
+        edges = ((Rank1BB | Rank8BB) & ~rank_bb(s)) | ((FileBB[FILE_A] | FileBB[FILE_H]) & ~file_bb(s));
 
         // Given a square 's', the mask is the bitboard of sliding attacks from
         // 's' computed on an empty board. The index must be big enough to contain

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -49,10 +49,8 @@ constexpr Bitboard FileBB[FILE_NB] = {
     0x0101010101010101ULL << 6, 0x0101010101010101ULL << 7 };
 
 constexpr Bitboard RankBB[RANK_NB] = {
-    Bitboard(0xFF)           , Bitboard(0xFF) << (8 * 1),
-    Bitboard(0xFF) << (8 * 2), Bitboard(0xFF) << (8 * 3),
-    Bitboard(0xFF) << (8 * 4), Bitboard(0xFF) << (8 * 5),
-    Bitboard(0xFF) << (8 * 6), Bitboard(0xFF) << (8 * 7) };
+    0xFFULL         , 0xFFULL << (8*1), 0xFFULL << (8*2), 0xFFULL << (8*3),
+    0xFFULL << (8*4), 0xFFULL << (8*5), 0xFFULL << (8*6), 0xFFULL << (8*7) };
 
 extern int SquareDistance[SQUARE_NB][SQUARE_NB];
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -48,19 +48,15 @@ constexpr Bitboard FileBB[FILE_NB] = {
     0x0101010101010101ULL << 4, 0x0101010101010101ULL << 5,
     0x0101010101010101ULL << 6, 0x0101010101010101ULL << 7 };
 
-constexpr Bitboard Rank1BB = 0xFF;
-constexpr Bitboard Rank2BB = Rank1BB << (8 * 1);
-constexpr Bitboard Rank3BB = Rank1BB << (8 * 2);
-constexpr Bitboard Rank4BB = Rank1BB << (8 * 3);
-constexpr Bitboard Rank5BB = Rank1BB << (8 * 4);
-constexpr Bitboard Rank6BB = Rank1BB << (8 * 5);
-constexpr Bitboard Rank7BB = Rank1BB << (8 * 6);
-constexpr Bitboard Rank8BB = Rank1BB << (8 * 7);
+constexpr Bitboard RankBB[RANK_NB] = {
+    Bitboard(0xFF)           , Bitboard(0xFF) << (8 * 1),
+    Bitboard(0xFF) << (8 * 2), Bitboard(0xFF) << (8 * 3),
+    Bitboard(0xFF) << (8 * 4), Bitboard(0xFF) << (8 * 5),
+    Bitboard(0xFF) << (8 * 6), Bitboard(0xFF) << (8 * 7) };
 
 extern int SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];
-extern Bitboard RankBB[RANK_NB];
 extern Bitboard AdjacentFilesBB[FILE_NB];
 extern Bitboard ForwardRanksBB[COLOR_NB][RANK_NB];
 extern Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -42,14 +42,11 @@ const std::string pretty(Bitboard b);
 constexpr Bitboard AllSquares = ~Bitboard(0);
 constexpr Bitboard DarkSquares = 0xAA55AA55AA55AA55ULL;
 
-constexpr Bitboard FileABB = 0x0101010101010101ULL;
-constexpr Bitboard FileBBB = FileABB << 1;
-constexpr Bitboard FileCBB = FileABB << 2;
-constexpr Bitboard FileDBB = FileABB << 3;
-constexpr Bitboard FileEBB = FileABB << 4;
-constexpr Bitboard FileFBB = FileABB << 5;
-constexpr Bitboard FileGBB = FileABB << 6;
-constexpr Bitboard FileHBB = FileABB << 7;
+constexpr Bitboard FileBB[FILE_NB] = {
+    0x0101010101010101ULL     , 0x0101010101010101ULL << 1,
+    0x0101010101010101ULL << 2, 0x0101010101010101ULL << 3,
+    0x0101010101010101ULL << 4, 0x0101010101010101ULL << 5,
+    0x0101010101010101ULL << 6, 0x0101010101010101ULL << 7 };
 
 constexpr Bitboard Rank1BB = 0xFF;
 constexpr Bitboard Rank2BB = Rank1BB << (8 * 1);
@@ -63,7 +60,6 @@ constexpr Bitboard Rank8BB = Rank1BB << (8 * 7);
 extern int SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];
-extern Bitboard FileBB[FILE_NB];
 extern Bitboard RankBB[RANK_NB];
 extern Bitboard AdjacentFilesBB[FILE_NB];
 extern Bitboard ForwardRanksBB[COLOR_NB][RANK_NB];
@@ -160,9 +156,9 @@ inline Bitboard file_bb(Square s) {
 template<Direction D>
 constexpr Bitboard shift(Bitboard b) {
   return  D == NORTH      ?  b             << 8 : D == SOUTH      ?  b             >> 8
-        : D == EAST       ? (b & ~FileHBB) << 1 : D == WEST       ? (b & ~FileABB) >> 1
-        : D == NORTH_EAST ? (b & ~FileHBB) << 9 : D == NORTH_WEST ? (b & ~FileABB) << 7
-        : D == SOUTH_EAST ? (b & ~FileHBB) >> 7 : D == SOUTH_WEST ? (b & ~FileABB) >> 9
+        : D == EAST       ? (b & ~FileBB[FILE_H]) << 1 : D == WEST       ? (b & ~FileBB[FILE_A]) >> 1
+        : D == NORTH_EAST ? (b & ~FileBB[FILE_H]) << 9 : D == NORTH_WEST ? (b & ~FileBB[FILE_A]) << 7
+        : D == SOUTH_EAST ? (b & ~FileBB[FILE_H]) >> 7 : D == SOUTH_WEST ? (b & ~FileBB[FILE_A]) >> 9
         : 0;
 }
 

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -262,7 +262,7 @@ Value Endgame<KQKP>::operator()(const Position& pos) const {
 
   if (   relative_rank(weakSide, pawnSq) != RANK_7
       || distance(loserKSq, pawnSq) != 1
-      || !((FileBB[FILE_A] | FileBB[FILE_B] | FileBB[FILE_F] | FileBB[FILE_H]) & pawnSq))
+      || !((FileBB[FILE_A] | FileBB[FILE_C] | FileBB[FILE_F] | FileBB[FILE_H]) & pawnSq))
       result += QueenValueEg - PawnValueEg;
 
   return strongSide == pos.side_to_move() ? result : -result;

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -262,7 +262,7 @@ Value Endgame<KQKP>::operator()(const Position& pos) const {
 
   if (   relative_rank(weakSide, pawnSq) != RANK_7
       || distance(loserKSq, pawnSq) != 1
-      || !((FileABB | FileCBB | FileFBB | FileHBB) & pawnSq))
+      || !((FileBB[FILE_A] | FileBB[FILE_B] | FileBB[FILE_F] | FileBB[FILE_H]) & pawnSq))
       result += QueenValueEg - PawnValueEg;
 
   return strongSide == pos.side_to_move() ? result : -result;
@@ -494,7 +494,7 @@ ScaleFactor Endgame<KRPKB>::operator()(const Position& pos) const {
   assert(verify_material(pos, weakSide, BishopValueMg, 0));
 
   // Test for a rook pawn
-  if (pos.pieces(PAWN) & (FileABB | FileHBB))
+  if (pos.pieces(PAWN) & (FileBB[FILE_A] | FileBB[FILE_H]))
   {
       Square ksq = pos.square<KING>(weakSide);
       Square bsq = pos.square<BISHOP>(weakSide);
@@ -575,7 +575,7 @@ ScaleFactor Endgame<KPsK>::operator()(const Position& pos) const {
   // If all pawns are ahead of the king, on a single rook file and
   // the king is within one file of the pawns, it's a draw.
   if (   !(pawns & ~forward_ranks_bb(weakSide, ksq))
-      && !((pawns & ~FileABB) && (pawns & ~FileHBB))
+      && !((pawns & ~FileBB[FILE_A]) && (pawns & ~FileBB[FILE_H]))
       &&  distance<File>(ksq, lsb(pawns)) <= 1)
       return SCALE_FACTOR_DRAW;
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -76,7 +76,7 @@ namespace {
   constexpr Bitboard QueenSide   = FileBB[FILE_A] | FileBB[FILE_B] | FileBB[FILE_C] | FileBB[FILE_D];
   constexpr Bitboard CenterFiles = FileBB[FILE_C] | FileBB[FILE_D] | FileBB[FILE_E] | FileBB[FILE_F];
   constexpr Bitboard KingSide    = FileBB[FILE_E] | FileBB[FILE_F] | FileBB[FILE_G] | FileBB[FILE_H];
-  constexpr Bitboard Center      = (FileBB[FILE_D] | FileBB[FILE_E]) & (Rank4BB | Rank5BB);
+  constexpr Bitboard Center      = (FileBB[FILE_D] | FileBB[FILE_E]) & (RankBB[RANK_4] | RankBB[RANK_5]);
 
   constexpr Bitboard KingFlank[FILE_NB] = {
     QueenSide ^ FileBB[FILE_D], QueenSide, QueenSide,
@@ -244,7 +244,7 @@ namespace {
     constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
     constexpr Direction Up   = (Us == WHITE ? NORTH : SOUTH);
     constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
-    constexpr Bitboard LowRanks = (Us == WHITE ? Rank2BB | Rank3BB: Rank7BB | Rank6BB);
+    constexpr Bitboard LowRanks = (Us == WHITE ? RankBB[RANK_2] | RankBB[RANK_3]: RankBB[RANK_7] | RankBB[RANK_6]);
 
     // Find our pawns that are blocked or on the first two ranks
     Bitboard b = pos.pieces(Us, PAWN) & (shift<Down>(pos.pieces()) | LowRanks);
@@ -286,8 +286,8 @@ namespace {
 
     constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
     constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
-    constexpr Bitboard OutpostRanks = (Us == WHITE ? Rank4BB | Rank5BB | Rank6BB
-                                                   : Rank5BB | Rank4BB | Rank3BB);
+    constexpr Bitboard OutpostRanks = (Us == WHITE ? RankBB[RANK_4] | RankBB[RANK_5] | RankBB[RANK_6]
+                                                   : RankBB[RANK_5] | RankBB[RANK_4] | RankBB[RANK_3]);
     const Square* pl = pos.squares<Pt>(Us);
 
     Bitboard b, bb;
@@ -406,8 +406,8 @@ namespace {
   Score Evaluation<T>::king() const {
 
     constexpr Color    Them = (Us == WHITE ? BLACK : WHITE);
-    constexpr Bitboard Camp = (Us == WHITE ? AllSquares ^ Rank6BB ^ Rank7BB ^ Rank8BB
-                                           : AllSquares ^ Rank1BB ^ Rank2BB ^ Rank3BB);
+    constexpr Bitboard Camp = (Us == WHITE ? AllSquares ^ RankBB[RANK_6] ^ RankBB[RANK_7] ^ RankBB[RANK_8]
+                                           : AllSquares ^ RankBB[RANK_1] ^ RankBB[RANK_2] ^ RankBB[RANK_3]);
 
     const Square ksq = pos.square<KING>(Us);
     Bitboard kingFlank, weak, b, b1, b2, safe, unsafeChecks;
@@ -507,7 +507,7 @@ namespace {
 
     constexpr Color     Them     = (Us == WHITE ? BLACK   : WHITE);
     constexpr Direction Up       = (Us == WHITE ? NORTH   : SOUTH);
-    constexpr Bitboard  TRank3BB = (Us == WHITE ? Rank3BB : Rank6BB);
+    constexpr Bitboard  TRank3BB = (Us == WHITE ? RankBB[RANK_3] : RankBB[RANK_6]);
 
     Bitboard b, weak, defended, nonPawnEnemies, stronglyProtected, safe, restricted;
     Score score = SCORE_ZERO;
@@ -713,8 +713,8 @@ namespace {
 
     constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
     constexpr Bitboard SpaceMask =
-      Us == WHITE ? CenterFiles & (Rank2BB | Rank3BB | Rank4BB)
-                  : CenterFiles & (Rank7BB | Rank6BB | Rank5BB);
+      Us == WHITE ? CenterFiles & (RankBB[RANK_2] | RankBB[RANK_3] | RankBB[RANK_4])
+                  : CenterFiles & (RankBB[RANK_7] | RankBB[RANK_6] | RankBB[RANK_5]);
 
     // Find the available squares for our pieces inside the area defined by SpaceMask
     Bitboard safe =   SpaceMask

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -73,15 +73,15 @@ using namespace Trace;
 
 namespace {
 
-  constexpr Bitboard QueenSide   = FileABB | FileBBB | FileCBB | FileDBB;
-  constexpr Bitboard CenterFiles = FileCBB | FileDBB | FileEBB | FileFBB;
-  constexpr Bitboard KingSide    = FileEBB | FileFBB | FileGBB | FileHBB;
-  constexpr Bitboard Center      = (FileDBB | FileEBB) & (Rank4BB | Rank5BB);
+  constexpr Bitboard QueenSide   = FileBB[FILE_A] | FileBB[FILE_B] | FileBB[FILE_C] | FileBB[FILE_D];
+  constexpr Bitboard CenterFiles = FileBB[FILE_C] | FileBB[FILE_D] | FileBB[FILE_E] | FileBB[FILE_F];
+  constexpr Bitboard KingSide    = FileBB[FILE_E] | FileBB[FILE_F] | FileBB[FILE_G] | FileBB[FILE_H];
+  constexpr Bitboard Center      = (FileBB[FILE_D] | FileBB[FILE_E]) & (Rank4BB | Rank5BB);
 
   constexpr Bitboard KingFlank[FILE_NB] = {
-    QueenSide ^ FileDBB, QueenSide, QueenSide,
+    QueenSide ^ FileBB[FILE_D], QueenSide, QueenSide,
     CenterFiles, CenterFiles,
-    KingSide, KingSide, KingSide ^ FileEBB
+    KingSide, KingSide, KingSide ^ FileBB[FILE_E]
   };
 
   // Threshold for lazy and space evaluation

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -95,10 +95,10 @@ namespace {
 
     // Compute our parametrized parameters at compile time, named according to
     // the point of view of white side.
-    constexpr Color     Them     = (Us == WHITE ? BLACK      : WHITE);
-    constexpr Bitboard  TRank8BB = (Us == WHITE ? Rank8BB    : Rank1BB);
-    constexpr Bitboard  TRank7BB = (Us == WHITE ? Rank7BB    : Rank2BB);
-    constexpr Bitboard  TRank3BB = (Us == WHITE ? Rank3BB    : Rank6BB);
+    constexpr Color     Them     = (Us == WHITE ? BLACK          : WHITE);
+    constexpr Bitboard  TRank8BB = (Us == WHITE ? RankBB[RANK_8] : RankBB[RANK_1]);
+    constexpr Bitboard  TRank7BB = (Us == WHITE ? RankBB[RANK_7] : RankBB[RANK_2]);
+    constexpr Bitboard  TRank3BB = (Us == WHITE ? RankBB[RANK_3] : RankBB[RANK_6]);
     constexpr Direction Up       = (Us == WHITE ? NORTH      : SOUTH);
     constexpr Direction UpRight  = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
     constexpr Direction UpLeft   = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -207,7 +207,7 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
   Bitboard ourPawns = b & pos.pieces(Us);
   Bitboard theirPawns = b & pos.pieces(Them);
 
-  Value safety = (shift<Down>(theirPawns) & (FileABB | FileHBB) & BlockRanks & ksq) ?
+  Value safety = (shift<Down>(theirPawns) & (FileBB[FILE_A] | FileBB[FILE_H]) & BlockRanks & ksq) ?
                  Value(374) : Value(5);
 
   File center = std::max(FILE_B, std::min(FILE_G, file_of(ksq)));

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -201,7 +201,7 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
 
   constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
   constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
-  constexpr Bitboard  BlockRanks = (Us == WHITE ? Rank1BB | Rank2BB : Rank8BB | Rank7BB);
+  constexpr Bitboard  BlockRanks = (Us == WHITE ? RankBB[RANK_1] | RankBB[RANK_2] : RankBB[RANK_8] | RankBB[RANK_7]);
 
   Bitboard b = pos.pieces(PAWN) & ~forward_ranks_bb(Them, ksq);
   Bitboard ourPawns = b & pos.pieces(Us);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1265,7 +1265,7 @@ bool Position::pos_is_ok() const {
       || attackers_to(square<KING>(~sideToMove)) & pieces(sideToMove))
       assert(0 && "pos_is_ok: Kings");
 
-  if (   (pieces(PAWN) & (Rank1BB | Rank8BB))
+  if (   (pieces(PAWN) & (RankBB[RANK_1] | RankBB[RANK_8]))
       || pieceCount[W_PAWN] > 8
       || pieceCount[B_PAWN] > 8)
       assert(0 && "pos_is_ok: Pawns");


### PR DESCRIPTION
This is a non-functional simplification.

This patch removes all of the rank/file constants and always uses the FileBB and RankBB arrays essentially removing duplicated code.