### PR TITLE
Reintroduce tropism to kingdanger

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -478,7 +478,7 @@ namespace {
                      + 185 * popcount(kingRing[Us] & weak)
                      + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
                      - 873 * !pos.count<QUEEN>(Them)
-                     - 100 * notAttackingQueen
+                     - 200 * notAttackingQueen
                      -   6 * mg_value(score) / 8
                      +       mg_value(mobility[Them] - mobility[Us])
                      -   30;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -466,8 +466,8 @@ namespace {
             kingDanger += KnightSafeCheck;
         else
             unsafeChecks |= b;
-        
-        bool notAttackingQueen = !((attackedBy[Them][QUEEN] | attackedBy[Them][ROOK]) & kingFlank & Camp);
+        Bitboard MajorAttacks = (attackedBy[Them][QUEEN] | attackedBy[Them][ROOK]) & kingFlank & Camp;
+        int notAttackingMajors = 2 - more_than_one(MajorAttacks) - bool (MajorAttacks);
 
         // Unsafe or occupied checking squares will also be considered, as long as
         // the square is in the attacker's mobility area.
@@ -478,7 +478,7 @@ namespace {
                      + 185 * popcount(kingRing[Us] & weak)
                      + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
                      - 873 * !pos.count<QUEEN>(Them)
-                     - 100 * notAttackingQueen
+                     - 100 * notAttackingMajors
                      -   6 * mg_value(score) / 8
                      +       mg_value(mobility[Them] - mobility[Us])
                      -   30;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -467,7 +467,7 @@ namespace {
         else
             unsafeChecks |= b;
         
-        bool notAttackingQueen = pos.pieces(Them, QUEEN) & ~(attackedBy[Them][QUEEN] & kingFlank & Camp);
+        bool notAttackingQueen = pos.pieces(Them, QUEEN) && !(attackedBy[Them][QUEEN] & kingFlank & Camp);
 
         // Unsafe or occupied checking squares will also be considered, as long as
         // the square is in the attacker's mobility area.

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -466,7 +466,7 @@ namespace {
             kingDanger += KnightSafeCheck;
         else
             unsafeChecks |= b;
-        bool noQueenAttacks = pos.pieces(Them,QUEEN) && !(attackedBy[Them][QUEEN] & kingFlank);
+        bool noTropism = (tropism == 0);
 
         // Unsafe or occupied checking squares will also be considered, as long as
         // the square is in the attacker's mobility area.
@@ -477,7 +477,7 @@ namespace {
                      + 185 * popcount(kingRing[Us] & weak)
                      + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
                      - 873 * !pos.count<QUEEN>(Them)
-                     - 200 * noQueenAttacks
+                     - 200 * noTropism
                      -   6 * mg_value(score) / 8
                      +       mg_value(mobility[Them] - mobility[Us])
                      -   30;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -476,7 +476,7 @@ namespace {
                      + 185 * popcount(kingRing[Us] & weak)
                      + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
                      - 873 * !pos.count<QUEEN>(Them)
-                     +       tropism * tropism / 2
+                     +   8 * tropism
                      -   6 * mg_value(score) / 8
                      +       mg_value(mobility[Them] - mobility[Us])
                      -   30;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -466,7 +466,6 @@ namespace {
             kingDanger += KnightSafeCheck;
         else
             unsafeChecks |= b;
-        bool noTropism = (tropism == 0);
 
         // Unsafe or occupied checking squares will also be considered, as long as
         // the square is in the attacker's mobility area.
@@ -477,7 +476,7 @@ namespace {
                      + 185 * popcount(kingRing[Us] & weak)
                      + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
                      - 873 * !pos.count<QUEEN>(Them)
-                     - 200 * noTropism
+                     +       tropism * tropism
                      -   6 * mg_value(score) / 8
                      +       mg_value(mobility[Them] - mobility[Us])
                      -   30;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -476,7 +476,7 @@ namespace {
                      + 185 * popcount(kingRing[Us] & weak)
                      + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
                      - 873 * !pos.count<QUEEN>(Them)
-                     +   8 * tropism
+                     +       tropism * tropism / 4
                      -   6 * mg_value(score) / 8
                      +       mg_value(mobility[Them] - mobility[Us])
                      -   30;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -478,7 +478,7 @@ namespace {
                      + 185 * popcount(kingRing[Us] & weak)
                      + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
                      - 873 * !pos.count<QUEEN>(Them)
-                     - 200 * notAttackingQueen
+                     - 100 * notAttackingQueen
                      -   6 * mg_value(score) / 8
                      +       mg_value(mobility[Them] - mobility[Us])
                      -   30;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -478,7 +478,7 @@ namespace {
                      + 185 * popcount(kingRing[Us] & weak)
                      + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
                      - 873 * !pos.count<QUEEN>(Them)
-                     - 100 * notAttackingMajors
+                     - 200 * notAttackingMajors
                      -   6 * mg_value(score) / 8
                      +       mg_value(mobility[Them] - mobility[Us])
                      -   30;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -467,7 +467,7 @@ namespace {
         else
             unsafeChecks |= b;
         
-        bool notAttackingQueen = pos.pieces(Them, QUEEN) && !(attackedBy[Them][QUEEN] & kingFlank & Camp);
+        bool notAttackingQueen = !((attackedBy[Them][QUEEN] | attackedBy[Them][ROOK]) & kingFlank & Camp);
 
         // Unsafe or occupied checking squares will also be considered, as long as
         // the square is in the attacker's mobility area.

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -476,7 +476,7 @@ namespace {
                      + 185 * popcount(kingRing[Us] & weak)
                      + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
                      - 873 * !pos.count<QUEEN>(Them)
-                     +       tropism * tropism
+                     +       tropism * tropism / 2
                      -   6 * mg_value(score) / 8
                      +       mg_value(mobility[Them] - mobility[Us])
                      -   30;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -466,6 +466,8 @@ namespace {
             kingDanger += KnightSafeCheck;
         else
             unsafeChecks |= b;
+        
+        bool notAttackingQueen = pos.pieces(Them, QUEEN) & ~(attackedBy[Them][QUEEN] & kingFlank & Camp);
 
         // Unsafe or occupied checking squares will also be considered, as long as
         // the square is in the attacker's mobility area.
@@ -475,8 +477,8 @@ namespace {
                      +  69 * kingAttacksCount[Them]
                      + 185 * popcount(kingRing[Us] & weak)
                      + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
-                     +   4 * tropism
                      - 873 * !pos.count<QUEEN>(Them)
+                     - 100 * notAttackingQueen
                      -   6 * mg_value(score) / 8
                      +       mg_value(mobility[Them] - mobility[Us])
                      -   30;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -466,8 +466,7 @@ namespace {
             kingDanger += KnightSafeCheck;
         else
             unsafeChecks |= b;
-        Bitboard MajorAttacks = (attackedBy[Them][QUEEN] | attackedBy[Them][ROOK]) & kingFlank & Camp;
-        int notAttackingMajors = 2 - more_than_one(MajorAttacks) - bool (MajorAttacks);
+        bool noQueenAttacks = pos.pieces(Them,QUEEN) && !(attackedBy[Them][QUEEN] & kingFlank);
 
         // Unsafe or occupied checking squares will also be considered, as long as
         // the square is in the attacker's mobility area.
@@ -478,7 +477,7 @@ namespace {
                      + 185 * popcount(kingRing[Us] & weak)
                      + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
                      - 873 * !pos.count<QUEEN>(Them)
-                     - 200 * notAttackingMajors
+                     - 200 * noQueenAttacks
                      -   6 * mg_value(score) / 8
                      +       mg_value(mobility[Them] - mobility[Us])
                      -   30;


### PR DESCRIPTION
Tropism in kingdanger was simplified away in this PR https://github.com/official-stockfish/Stockfish/pull/1821 (yet to be merged but probably should be).
This PR reintroduces tropism in kingdanger with using quadratic scaling.
Passed STC http://tests.stockfishchess.org/tests/view/5bf7c1b10ebc5902bced1f8f
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 52803 W: 11835 L: 11442 D: 29526 
Passed LTC http://tests.stockfishchess.org/tests/view/5bf816e90ebc5902bced24f1
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 17204 W: 2988 L: 2795 D: 11421 
How do we work from there? 
I've recently tried to introduce tropism difference term in kingdanger which passed STC 6 times but failed LTC all the time. Maybe using quadratic scaling for it will also be helpful.
Bench 4041387