### PR TITLE
Use a bit less code to calculate hashfull()

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -85,7 +85,7 @@ void TranspositionTable::clear() {
 
   std::vector<std::thread> threads;
 
-  for (size_t idx = 0; idx < Options["Threads"]; idx++)
+  for (size_t idx = 0; idx < Options["Threads"]; ++idx)
   {
       threads.emplace_back([this, idx]() {
 
@@ -148,12 +148,9 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 int TranspositionTable::hashfull() const {
 
   int cnt = 0;
-  for (int i = 0; i < 1000 / ClusterSize; i++)
-  {
-      const TTEntry* tte = &table[i].entry[0];
-      for (int j = 0; j < ClusterSize; j++)
-          if ((tte[j].genBound8 & 0xFC) == generation8)
-              cnt++;
-  }
-  return cnt;
+  for (int i = 0; i < 1000 / ClusterSize; ++i)
+      for (int j = 0; j < ClusterSize; ++j)
+          cnt += (table[i].entry[j].genBound8 & 0xFC) == generation8;
+
+  return cnt * 1000 / 999;
 }

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -152,5 +152,5 @@ int TranspositionTable::hashfull() const {
       for (int j = 0; j < ClusterSize; ++j)
           cnt += (table[i].entry[j].genBound8 & 0xFC) == generation8;
 
-  return cnt * 1000 / 999;
+  return cnt * 1000 / (ClusterSize * (1000 / ClusterSize));
 }


### PR DESCRIPTION
Use a bit less code to calculate hashfull().
Also change post increment to pre increment as is more standard in the rest of Stockfish.

No functional change.
bench: 4041387

If it's ok with the maintainers I would also like to change the return to
```C++
return cnt * 1000 / 999;
```
so that when the hash is 100% full we actually report 100 instead of 99.9.  Currently Stockfish never reports 100% full which is inaccurate.  Please advise.