### PR TITLE
Castling extensions: Only extend castling itself.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -948,8 +948,8 @@ moves_loop: // When in check, search starts from here
                &&  pos.see_ge(move))
           extension = ONE_PLY;
 
-      else if (   pos.can_castle(us) // Extension for king moves that change castling rights
-               && type_of(movedPiece) == KING)
+      // Extension if castling
+      else if (type_of(move) == CASTLING)
           extension = ONE_PLY;
 
       // Calculate new depth for this move


### PR DESCRIPTION
On November 16th, before the removal of the depth condition, I tried revising castling extensions to only handle castling moves, rather than moves that change castling rights generally. It appeared to be a slight Elo gain at STC but insufficient to pass [0, 4] (+0.5 Elo), but what I overlooked was that it made pos.can_castle(us) irrelevant and should have been a simplification. Recent discussion with @Chess13234 and Michael Chaly (@Vizvezdenec) inspired me to take a second look, and the simplification continues to pass when rebased on the current master.

This replaces two conditions with one, because `type_of(move) == CASTLING` implies `pos.can_castle(Us)`, allowing us to remove the latter condition.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 110948 W: 24209 L: 24263 D: 62476
http://tests.stockfishchess.org/tests/view/5bf8f65c0ebc5902bced3a63

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 88283 W: 14681 L: 14668 D: 58934
http://tests.stockfishchess.org/tests/view/5bf994a60ebc5902bced4349

Bench: 3939338