### PR TITLE
Remove Overload bonus

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -552,7 +552,7 @@ namespace {
         if (weak & attackedBy[Us][KING])
             score += ThreatByKing;
 
-        score += Hanging * popcount(weak & (~attackedBy[Them][ALL_PIECES] | (nonPawnEnemies & ~attackedBy2[Them] & attackedBy2[Us])));
+        score += Hanging * popcount(weak & (~attackedBy[Them][ALL_PIECES] | (nonPawnEnemies & attackedBy2[Us])));
     }
 
     // Bonus for restricting their piece moves

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -160,7 +160,6 @@ namespace {
   constexpr Score KnightOnQueen      = S( 20, 12);
   constexpr Score LongDiagonalBishop = S( 44,  0);
   constexpr Score MinorBehindPawn    = S( 16,  0);
-  constexpr Score Overload           = S( 12,  6);
   constexpr Score PawnlessFlank      = S( 18, 94);
   constexpr Score RestrictedPiece    = S(  7,  6);
   constexpr Score RookOnPawn         = S( 10, 28);
@@ -553,10 +552,7 @@ namespace {
         if (weak & attackedBy[Us][KING])
             score += ThreatByKing;
 
-        score += Hanging * popcount(weak & ~attackedBy[Them][ALL_PIECES]);
-
-        b = weak & nonPawnEnemies & attackedBy[Them][ALL_PIECES];
-        score += Overload * popcount(b);
+        score += Hanging * popcount(weak & (~attackedBy[Them][ALL_PIECES] | (nonPawnEnemies & ~attackedBy2[Them] & attackedBy2[Us])));
     }
 
     // Bonus for restricting their piece moves


### PR DESCRIPTION
Compensate by considering weak double attacked non pawn enemies as hanging.

STC: http://tests.stockfishchess.org/tests/view/5bfd53c40ebc5902bced9237
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 62107 W: 13664 L: 13622 D: 34821

LTC: http://tests.stockfishchess.org/tests/view/5bfd74700ebc5902bced9618
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 86406 W: 14381 L: 14365 D: 57660

A possible follow up would be to tune the hanging bonus and/or try to simplify the hanging bonus condition.

Bench: 3810849