### PR TITLE
Remove SkipPhase Array

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -353,7 +353,7 @@ void Thread::search() {
           constexpr int skips[]  = { 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4 };
 
           int i = (idx-1) % 20;
-          if (((rootDepth + idx) / skips[i]) % 2)
+          if (((rootDepth / ONE_PLY + idx) / skips[i]) % 2)
              continue;
       }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -61,6 +61,9 @@ namespace {
   // Different node types, used as a template parameter
   enum NodeType { NonPV, PV };
 
+  // Defines the skip-blocks, used for distributing search depths across the threads
+  constexpr int skips[]  = { 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4 };
+
   // Razor and futility margins
   constexpr int RazorMargin = 600;
   Value futility_margin(Depth d, bool improving) {
@@ -349,12 +352,9 @@ void Thread::search() {
       // Distribute search depths across the helper threads
       if (idx > 0)
       {
-          //Helper threads skip some depths according to this skip pattern
-          constexpr int skips[]  = { 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4 };
-
-          int i = (idx-1) % 20;
+          int i = (idx - 1) % 20;
           if (((rootDepth / ONE_PLY + idx) / skips[i]) % 2)
-             continue;
+             continue; //retry with incremented rootDepth
       }
 
       // Age out PV variability metric


### PR DESCRIPTION
This patch removes the SkipPhase array entirely.

Because we are ultimately % 2, and SkipPhase alternates between odd/even, any simple counter would provide the same effect.  Thus adding idx instead of SkipPhase is substantially equivalent to master.  The only different is the offset of the skips.  This patch provides the same coverage as master.  See the comments.

My other branch ps_threads20 provides a +1 offset which. . strangely enough. . . seems to perform a bit better, but I'm not sure that it makes any real difference.

STC (no offset) (3 threads)
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 64301 W: 14247 L: 14210 D: 35844
http://tests.stockfishchess.org/tests/view/5bfd9a280ebc5902bced98c6

STC (no offset) (8 threads)
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 87210 W: 16970 L: 16968 D: 53272 
http://tests.stockfishchess.org/tests/view/5bfe22d70ebc5902bceda2d7

STC (+1 offset) (3 threads)
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 28428 W: 6278 L: 6170 D: 15980
http://tests.stockfishchess.org/tests/view/5bfe01c20ebc5902bceda021

STC (+1 offset) (8 threads)
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 26002 W: 5082 L: 4970 D: 15950 
http://tests.stockfishchess.org/tests/view/5bfe132c0ebc5902bceda12f

