### PR TITLE
Remove SkipSize and SkipPhase arrays

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -347,9 +347,9 @@ void Thread::search() {
          && !(Limits.depth && mainThread && rootDepth / ONE_PLY > Limits.depth))
   {
       // Distribute search depths across the helper threads
-      if (idx % 20 > 0)
+      if (idx % 21 > 0)
       {
-          int skipSize = sqrt(idx % 20) + 0.5;
+          int skipSize = sqrt(idx % 21) + 0.5;
           if (((rootDepth / ONE_PLY + idx) / skipSize) % 2)
              continue; //retry with incremented rootDepth
       }


### PR DESCRIPTION
This simplification is identical to master except offsets after more than 20 threads.  Threads 21, 42, 63, . . . duplicate thread 0 and do every depth shifting correspondingly.  Threads between 21-41, 42-62, etc. . have the same coverage as threads 0-20.

The SkipSize array is replaced with: sqrt(idx % 20) + 0.5;
The SkipPhase array is replaced with simply the thread number (idx).

See #1835 for discussion regarding removal of the SkipPhase array.

I didn't see the need to test, but I can submit one if requested.