### PR TITLE
Penalize refuted killers in continuation history

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1190,6 +1190,12 @@ moves_loop: // When in check, search starts from here
         // Extra penalty for a quiet TT move in previous ply when it gets refuted
         if ((ss-1)->moveCount == 1 && !pos.captured_piece())
             update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth + ONE_PLY));
+
+        // Extra penalty for killer move in previous ply when it gets refuted
+        else if (  (ss-1)->killers[0]
+                && (ss-1)->currentMove == (ss-1)->killers[0]
+                && !pos.captured_piece())
+            update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth));
     }
     // Bonus for prior countermove that caused the fail low
     else if (   (depth >= 3 * ONE_PLY || PvNode)


### PR DESCRIPTION
Currently we apply a penalty in continuation history for refuted TT moves.
We can use the same idea to also penalize refuted killer moves in continuation
history.

STC:
http://tests.stockfishchess.org/tests/view/5c00ccbd0ebc5902bcedd768
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 54366 W: 12086 L: 11687 D: 30593

LTC:
http://tests.stockfishchess.org/tests/view/5c0107880ebc5902bceddc9c
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 25457 W: 4302 L: 4078 D: 17077

Bench: 3372057