### PR TITLE
Turn on random access for Syzygy files in Windows

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -224,6 +224,7 @@ public:
             exit(1);
         }
 #else
+        // Note FILE_FLAG_RANDOM_ACCESS is only a hint to Windows and as such may get ignored.
         HANDLE fd = CreateFile(fname.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
                                OPEN_EXISTING, FILE_FLAG_RANDOM_ACCESS, nullptr);
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -225,7 +225,7 @@ public:
         }
 #else
         HANDLE fd = CreateFile(fname.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
-                               OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+                               OPEN_EXISTING, FILE_FLAG_RANDOM_ACCESS, nullptr);
 
         if (fd == INVALID_HANDLE_VALUE)
             return *baseAddress = nullptr, nullptr;


### PR DESCRIPTION
This is the Windows version of
https://github.com/official-stockfish/Stockfish/pull/1829
No functional change.

Some reference here:
https://stackoverflow.com/questions/1201168/what-is-fadvise-madvise-equivalent-on-windows

I have tested that the bench signature when using 6-men syzygy is the same 3088037and
that the speed is also the same(both after a fresh reboot from an SSD and subsequently).  I don't have 7-men syzygy.

bench: 3393939