### PR TITLE
Simplify Killer Move Penalty-Bench: 3267773

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1187,15 +1187,9 @@ moves_loop: // When in check, search starts from here
 
         update_capture_stats(pos, bestMove, capturesSearched, captureCount, stat_bonus(depth + ONE_PLY));
 
-        // Extra penalty for a quiet TT move in previous ply when it gets refuted
-        if ((ss-1)->moveCount == 1 && !pos.captured_piece())
+        // Extra penalty for a quiet TT or main killer move in previous ply when it gets refuted
+		if (((ss - 1)->moveCount == 1 || ((ss-1)->currentMove == (ss-1)->killers[0] && (ss-1)->killers[0])) && !pos.captured_piece())
             update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth + ONE_PLY));
-
-        // Extra penalty for killer move in previous ply when it gets refuted
-        else if (  (ss-1)->killers[0]
-                && (ss-1)->currentMove == (ss-1)->killers[0]
-                && !pos.captured_piece())
-            update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth));
     }
     // Bonus for prior countermove that caused the fail low
     else if (   (depth >= 3 * ONE_PLY || PvNode)


### PR DESCRIPTION
Simplify Killer Move Penalty

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 20816 W: 4525 L: 4402 D: 11889
http://tests.stockfishchess.org/tests/view/5c017cb90ebc5902bcede5b4

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 39287 W: 6401 L: 6309 D: 26577
http://tests.stockfishchess.org/tests/view/5c01825e0ebc5902bcede686

Bench:  3267773