### PR TITLE
Add countermove to killers array.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -60,9 +60,9 @@ namespace {
 
 /// MovePicker constructor for the main search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
-                       const CapturePieceToHistory* cph, const PieceToHistory** ch, Move* killers)
+                       const CapturePieceToHistory* cph, const PieceToHistory** ch, ExtMove* killers)
            : pos(p), mainHistory(mh), captureHistory(cph), continuationHistory(ch),
-             refutations{{killers[0], 0}, {killers[1], 0}, {killers[2], 0}}, depth(d) {
+             refutations{ killers[0], killers[1], killers[2]}, depth(d) {
 
   assert(d > DEPTH_ZERO);
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -60,9 +60,9 @@ namespace {
 
 /// MovePicker constructor for the main search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
-                       const CapturePieceToHistory* cph, const PieceToHistory** ch, ExtMove* killers)
+                       const CapturePieceToHistory* cph, const PieceToHistory** ch, Move* killers)
            : pos(p), mainHistory(mh), captureHistory(cph), continuationHistory(ch),
-             refutations{ killers[0], killers[1], killers[2]}, depth(d) {
+             refutations{{killers[0], 0}, {killers[1], 0}, {killers[2], 0}}, depth(d) {
 
   assert(d > DEPTH_ZERO);
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -60,9 +60,9 @@ namespace {
 
 /// MovePicker constructor for the main search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
-                       const CapturePieceToHistory* cph, const PieceToHistory** ch, Move cm, Move* killers)
+                       const CapturePieceToHistory* cph, const PieceToHistory** ch, Move* killers)
            : pos(p), mainHistory(mh), captureHistory(cph), continuationHistory(ch),
-             refutations{{killers[0], 0}, {killers[1], 0}, {cm, 0}}, depth(d) {
+             refutations{{killers[0], 0}, {killers[1], 0}, {killers[2], 0}}, depth(d) {
 
   assert(d > DEPTH_ZERO);
 
@@ -185,7 +185,7 @@ top:
       cur = std::begin(refutations);
       endMoves = std::end(refutations);
 
-      // If the countermove is the same as a killer, skip it
+      // If the countermove(2) is the same as a killer(0-1), skip it
       if (   refutations[0].move == refutations[2].move
           || refutations[1].move == refutations[2].move)
           --endMoves;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -125,7 +125,6 @@ public:
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*,
                                            const CapturePieceToHistory*,
                                            const PieceToHistory**,
-                                           Move,
                                            Move*);
   Move next_move(bool skipQuiets = false);
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -125,7 +125,7 @@ public:
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*,
                                            const CapturePieceToHistory*,
                                            const PieceToHistory**,
-                                           ExtMove*);
+                                           Move*);
   Move next_move(bool skipQuiets = false);
 
 private:

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -125,7 +125,7 @@ public:
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*,
                                            const CapturePieceToHistory*,
                                            const PieceToHistory**,
-                                           Move*);
+                                           ExtMove*);
   Move next_move(bool skipQuiets = false);
 
 private:

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -619,7 +619,7 @@ namespace {
     (ss+1)->ply = ss->ply + 1;
     ss->currentMove = (ss+1)->excludedMove = bestMove = MOVE_NONE;
     ss->continuationHistory = &thisThread->continuationHistory[NO_PIECE][0];
-    (ss+2)->killers[0] = (ss+2)->killers[1] = MOVE_NONE;
+    (ss+2)->killers[0].move = (ss+2)->killers[1].move = MOVE_NONE;
     Square prevSq = to_sq((ss-1)->currentMove);
 
     // Initialize statScore to zero for the grandchildren of the current position.
@@ -1191,8 +1191,8 @@ moves_loop: // When in check, search starts from here
             update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth + ONE_PLY));
 
         // Extra penalty for killer move in previous ply when it gets refuted
-        else if (  (ss-1)->killers[0]
-                && (ss-1)->currentMove == (ss-1)->killers[0]
+        else if (  (ss-1)->killers[0].move
+                && ((ss-1)->currentMove == (ss-1)->killers[0].move)
                 && !pos.captured_piece())
             update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth));
     }
@@ -1502,10 +1502,10 @@ moves_loop: // When in check, search starts from here
   void update_quiet_stats(const Position& pos, Stack* ss, Move move,
                           Move* quiets, int quietsCnt, int bonus) {
 
-    if (ss->killers[0] != move)
+    if (ss->killers[0].move != move)
     {
-        ss->killers[1] = ss->killers[0];
-        ss->killers[0] = move;
+        ss->killers[1].move = ss->killers[0].move;
+        ss->killers[0].move = move;
     }
 
     Color us = pos.side_to_move();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -873,12 +873,11 @@ namespace {
 moves_loop: // When in check, search starts from here
 
     const PieceToHistory* contHist[] = { (ss-1)->continuationHistory, (ss-2)->continuationHistory, nullptr, (ss-4)->continuationHistory };
-    Move countermove = thisThread->counterMoves[pos.piece_on(prevSq)][prevSq];
+    ss->killers[2] = thisThread->counterMoves[pos.piece_on(prevSq)][prevSq]; //countermove
 
     MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory,
                                       &thisThread->captureHistory,
                                       contHist,
-                                      countermove,
                                       ss->killers);
     value = bestValue; // Workaround a bogus 'uninitialized' warning under gcc
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -619,7 +619,7 @@ namespace {
     (ss+1)->ply = ss->ply + 1;
     ss->currentMove = (ss+1)->excludedMove = bestMove = MOVE_NONE;
     ss->continuationHistory = &thisThread->continuationHistory[NO_PIECE][0];
-    (ss+2)->killers[0].move = (ss+2)->killers[1].move = MOVE_NONE;
+    (ss+2)->killers[0] = (ss+2)->killers[1] = MOVE_NONE;
     Square prevSq = to_sq((ss-1)->currentMove);
 
     // Initialize statScore to zero for the grandchildren of the current position.
@@ -1191,8 +1191,8 @@ moves_loop: // When in check, search starts from here
             update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth + ONE_PLY));
 
         // Extra penalty for killer move in previous ply when it gets refuted
-        else if (  (ss-1)->killers[0].move
-                && ((ss-1)->currentMove == (ss-1)->killers[0].move)
+        else if (  (ss-1)->killers[0]
+                && (ss-1)->currentMove == (ss-1)->killers[0]
                 && !pos.captured_piece())
             update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth));
     }
@@ -1502,10 +1502,10 @@ moves_loop: // When in check, search starts from here
   void update_quiet_stats(const Position& pos, Stack* ss, Move move,
                           Move* quiets, int quietsCnt, int bonus) {
 
-    if (ss->killers[0].move != move)
+    if (ss->killers[0] != move)
     {
-        ss->killers[1].move = ss->killers[0].move;
-        ss->killers[0].move = move;
+        ss->killers[1] = ss->killers[0];
+        ss->killers[0] = move;
     }
 
     Color us = pos.side_to_move();

--- a/src/search.h
+++ b/src/search.h
@@ -45,7 +45,7 @@ struct Stack {
   int ply;
   Move currentMove;
   Move excludedMove;
-  Move killers[2];
+  Move killers[3];
   Value staticEval;
   int statScore;
   int moveCount;

--- a/src/search.h
+++ b/src/search.h
@@ -45,7 +45,7 @@ struct Stack {
   int ply;
   Move currentMove;
   Move excludedMove;
-  ExtMove killers[3];
+  Move killers[3];
   Value staticEval;
   int statScore;
   int moveCount;

--- a/src/search.h
+++ b/src/search.h
@@ -45,7 +45,7 @@ struct Stack {
   int ply;
   Move currentMove;
   Move excludedMove;
-  Move killers[3];
+  ExtMove killers[3];
   Value staticEval;
   int statScore;
   int moveCount;


### PR DESCRIPTION
Non-functional.  Adds a 3rd killer move to the killers array for storing the countermove, just as we do in movepick.cpp.

Removes a parameter for the MovePicker constructor.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 79542 W: 17229 L: 17221 D: 45092
http://tests.stockfishchess.org/tests/view/5c03018a0ebc5902bcee090e