### PR TITLE
Exclude doubly protected by pawns squares when calculating attackers on king ring

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -169,7 +169,7 @@ namespace {
   constexpr Score ThreatByRank       = S( 14,  3);
   constexpr Score ThreatBySafePawn   = S(169, 99);
   constexpr Score TrappedRook        = S( 98,  5);
-  constexpr Score UselessPiece       = S( 10,  0);
+  constexpr Score UselessPiece       = S( 20,  0);
   constexpr Score WeakQueen          = S( 51, 10);
   constexpr Score WeakUnopposedPawn  = S( 14, 20);
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -486,7 +486,7 @@ namespace {
                      +  69 * kingAttacksCount[Them]
                      + 185 * popcount(kingRing[Us] & weak)
                      + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
-                     +       (tropism + 2 * nonDefender[Us]) * (tropism + 2 * nonDefender[Us]) / 4
+                     +       (tropism + 4 * nonDefender[Us]) * (tropism + 4 * nonDefender[Us]) / 4
                      - 873 * !pos.count<QUEEN>(Them)
                      -   6 * mg_value(score) / 8
                      +       mg_value(mobility[Them] - mobility[Us])

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -233,7 +233,6 @@ namespace {
     // a white knight on g5 and black's king is on g8, this white knight adds 2
     // to kingAttacksCount[WHITE].
     int kingAttacksCount[COLOR_NB];
-    int nonDefender[COLOR_NB];
   };
 
 
@@ -261,7 +260,6 @@ namespace {
     attackedBy2[Us]            = attackedBy[Us][KING] & attackedBy[Us][PAWN];
 
     kingRing[Us] = kingAttackersCount[Them] = 0;
-    nonDefender[Us] = 0;
 
     // Init our king safety tables only if we are going to use them
     if (pos.non_pawn_material(Them) >= RookValueMg + KnightValueMg)
@@ -290,10 +288,6 @@ namespace {
     constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
     constexpr Bitboard OutpostRanks = (Us == WHITE ? Rank4BB | Rank5BB | Rank6BB
                                                    : Rank5BB | Rank4BB | Rank3BB);
-    constexpr Bitboard OurCamp = (Us == WHITE ? AllSquares ^ Rank6BB ^ Rank7BB ^ Rank8BB
-                                           : AllSquares ^ Rank1BB ^ Rank2BB ^ Rank3BB);
-    constexpr Bitboard TheirCamp = (Us == BLACK ? AllSquares ^ Rank6BB ^ Rank7BB ^ Rank8BB
-                                           : AllSquares ^ Rank1BB ^ Rank2BB ^ Rank3BB);
     const Square* pl = pos.squares<Pt>(Us);
 
     Bitboard b, bb;
@@ -330,13 +324,8 @@ namespace {
 
         mobility[Us] += MobilityBonus[Pt - 2][mob];
 
-        if (!(pos.attacks_from<Pt>(s)
-             & ~attackedBy[Them][PAWN]
-             & ~pos.pieces(Us)
-             & ((kingFlankUs & OurCamp)
-             | (kingFlankThem & TheirCamp)
-             | Center
-             | pos.pieces(Them))))
+        if (!(b & mobilityArea[Us]
+             & ~pos.pieces(Us) & (kingFlankUs | kingFlankThem)))
             score -= UselessPiece;
 
         if (Pt == BISHOP || Pt == KNIGHT)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -335,7 +335,8 @@ namespace {
              & ~pos.pieces(Us)
              & ((kingFlankUs & OurCamp)
              | (kingFlankThem & TheirCamp)
-             | Center)))
+             | Center
+             | pos.pieces(Them))))
             score -= UselessPiece;
 
         if (Pt == BISHOP || Pt == KNIGHT)


### PR DESCRIPTION
STC
http://tests.stockfishchess.org/tests/view/5c0354860ebc5902bcee1106
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 70040 W: 15476 L: 15002 D: 39562 
LTC
http://tests.stockfishchess.org/tests/view/5c0385080ebc5902bcee14b5
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 16530 W: 2795 L: 2607 D: 11128 
Idea of this patch is not to count attackers if they attack only squares that are protected by 2 pawns.
This is 3rd kingsafety patch in recent times so we probably need retuning of kingsafety parameters.
Bench 3057978.
