### PR TITLE
bool(ttm) is not needed when checking pseudo_legal(..)

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -192,8 +192,8 @@ top:
       /* fallthrough */
 
   case REFUTATION:
-      if (select<Next>([&](){ return !pos.capture(move)
-                                  &&  pos.pseudo_legal(move); }))
+      if (select<Next>([&](){ return pos.pseudo_legal(move) 
+			         && !pos.capture(move); }))
           return move;
       ++stage;
       /* fallthrough */

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -67,7 +67,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
   assert(d > DEPTH_ZERO);
 
   stage = pos.checkers() ? EVASION_TT : MAIN_TT;
-  ttMove = ttm && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE;
+  ttMove = pos.pseudo_legal(ttm) ? ttm : MOVE_NONE;
   stage += (ttMove == MOVE_NONE);
 }
 
@@ -79,8 +79,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
   assert(d <= DEPTH_ZERO);
 
   stage = pos.checkers() ? EVASION_TT : QSEARCH_TT;
-  ttMove =    ttm
-           && pos.pseudo_legal(ttm)
+  ttMove = pos.pseudo_legal(ttm)
            && (depth > DEPTH_QS_RECAPTURES || to_sq(ttm) == recaptureSquare) ? ttm : MOVE_NONE;
   stage += (ttMove == MOVE_NONE);
 }
@@ -93,8 +92,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePiece
   assert(!pos.checkers());
 
   stage = PROBCUT_TT;
-  ttMove =   ttm
-          && pos.pseudo_legal(ttm)
+  ttMove =   pos.pseudo_legal(ttm)
           && pos.capture(ttm)
           && pos.see_ge(ttm, threshold) ? ttm : MOVE_NONE;
   stage += (ttMove == MOVE_NONE);
@@ -194,9 +192,8 @@ top:
       /* fallthrough */
 
   case REFUTATION:
-      if (select<Next>([&](){ return    move != MOVE_NONE
-                                    && !pos.capture(move)
-                                    &&  pos.pseudo_legal(move); }))
+      if (select<Next>([&](){ return !pos.capture(move)
+                                  &&  pos.pseudo_legal(move); }))
           return move;
       ++stage;
       /* fallthrough */

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -579,6 +579,8 @@ bool Position::legal(Move m) const {
 /// Position::pseudo_legal() takes a random move and tests whether the move is
 /// pseudo legal. It is used to validate moves from TT that can be corrupted
 /// due to SMP concurrent access or hash position key aliasing.
+//  Determines MOVE_NONE to be not legal because we can't have a piece on A1
+//  (from square requirement) AND not have a piece on A1 (to square requirement).
 
 bool Position::pseudo_legal(const Move m) const {
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -579,8 +579,7 @@ bool Position::legal(Move m) const {
 /// Position::pseudo_legal() takes a random move and tests whether the move is
 /// pseudo legal. It is used to validate moves from TT that can be corrupted
 /// due to SMP concurrent access or hash position key aliasing.
-//  Determines MOVE_NONE to be not legal because we can't have a piece on A1
-//  (from square requirement) AND not have a piece on A1 (to square requirement).
+/// MOVE_NONE is represented as SQ_A1 to SQ_A1 which is never pseudo_legal.
 
 bool Position::pseudo_legal(const Move m) const {
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -579,7 +579,7 @@ bool Position::legal(Move m) const {
 /// Position::pseudo_legal() takes a random move and tests whether the move is
 /// pseudo legal. It is used to validate moves from TT that can be corrupted
 /// due to SMP concurrent access or hash position key aliasing.
-/// MOVE_NONE is represented as SQ_A1 to SQ_A1 which is never pseudo_legal.
+/// MOVE_NONE is not pseudo_legal.
 
 bool Position::pseudo_legal(const Move m) const {
 


### PR DESCRIPTION
This is non-functional.

I've pushed MOVE_NONE through millions of pseudo_legal(...) and they are always caught by
either
if (pc == NO_PIECE \|\| color_of(pc) != us)  which will only pass if the moving side coincidentally has a piece on SQ_A1.
OR
if (pieces(us) & to) which will only pass if the moving side coincidentally does NOT have a piece on SQ_A1.

These two test are mutually exclusive which is sufficient to test for MOVE_NONE.

Thus we do not need to test for bool(ttm) if we are also testing for pseudo_legal(..).

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 38807 W: 8363 L: 8275 D: 22169
http://tests.stockfishchess.org/tests/view/5c05f11d0ebc5902bcee4c86