### PR TITLE
[cluster] Avoid TT saving our own TT entries.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -362,7 +362,7 @@ ifeq ($(CXX),$(filter $(CXX),mpicxx mpic++ mpiCC mpicxx.mpich))
 endif
 
 ifeq ($(mpi),yes)
-	CXXFLAGS += -DUSE_MPI
+	CXXFLAGS += -DUSE_MPI -Wno-cast-qual
 endif
 
 


### PR DESCRIPTION
avoid saving to TT the part of the receive buffer that actually originates from the same rank.

Now, on 1 mpi rank, we have the same bench as the non-mpi code on 1 thread.