### PR TITLE
Tweak CMH pruning - Bench: 3775064

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -973,7 +973,7 @@ moves_loop: // When in check, search starts from here
               int lmrDepth = std::max(newDepth - reduction<PvNode>(improving, depth, moveCount), DEPTH_ZERO) / ONE_PLY;
 
               // Countermoves based pruning (~20 Elo)
-              if (   lmrDepth < 3 + ((ss-1)->statScore > 0)
+              if (   lmrDepth < 3 + ((ss-1)->statScore > 0 || (ss-1)->moveCount == 1)
                   && (*contHist[0])[movedPiece][to_sq(move)] < CounterMovePruneThreshold
                   && (*contHist[1])[movedPiece][to_sq(move)] < CounterMovePruneThreshold)
                   continue;


### PR DESCRIPTION
Tweak CMH pruning

STC: (yellow) 
LLR: -2.94 (-2.94,2.94) [0.00,5.00]
Total: 48919 W: 10625 L: 10517 D: 27777
http://tests.stockfishchess.org/tests/view/5c07e6a20ebc5902bcee7395

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 50360 W: 8424 L: 8102 D: 33834
http://tests.stockfishchess.org/tests/view/5c0812450ebc5902bcee76f4

Bench: 3775064
