### PR TITLE
Start a TT resize only after search finished.

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -24,6 +24,7 @@
 
 #include "bitboard.h"
 #include "misc.h"
+#include "thread.h"
 #include "tt.h"
 #include "uci.h"
 
@@ -57,6 +58,8 @@ void TTEntry::save(Key k, Value v, Bound b, Depth d, Move m, Value ev) {
 /// of clusters and each cluster consists of ClusterSize number of TTEntry.
 
 void TranspositionTable::resize(size_t mbSize) {
+
+  Threads.main()->wait_for_search_finished();
 
   clusterCount = mbSize * 1024 * 1024 / sizeof(Cluster);
 


### PR DESCRIPTION
As noticed in the forum, a crash in extract_ponder_from_tt could result if hash size is set before the ponder move is printed.
While it is arguably a GUI issue (but it got me on the cli), it is easy to avoid this issue.

No functional change.