### PR TITLE
Simplify Opposite Colors Determination

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -135,6 +135,10 @@ constexpr bool more_than_one(Bitboard b) {
   return b & (b - 1);
 }
 
+inline bool opposite_colors(Square s1, Square s2) {
+  return bool(DarkSquares & s1) != bool(DarkSquares & s2);
+}
+
 /// rank_bb() and file_bb() return a bitboard representing all the squares on
 /// the given file or rank.
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -136,7 +136,7 @@ constexpr bool more_than_one(Bitboard b) {
 }
 
 inline bool opposite_colors(Square s1, Square s2) {
-  return bool(DarkSquares & s1) != bool(DarkSquares & s2);
+  return (bool(DarkSquares & s1) != bool(DarkSquares & s2));
 }
 
 /// rank_bb() and file_bb() return a bitboard representing all the squares on

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -136,7 +136,8 @@ constexpr bool more_than_one(Bitboard b) {
 }
 
 inline bool opposite_colors(Square s1, Square s2) {
-  return (bool(DarkSquares & s1) != bool(DarkSquares & s2));
+
+  return bool(DarkSquares & s1) != bool(DarkSquares & s2);
 }
 
 /// rank_bb() and file_bb() return a bitboard representing all the squares on

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -136,7 +136,6 @@ constexpr bool more_than_one(Bitboard b) {
 }
 
 inline bool opposite_colors(Square s1, Square s2) {
-
   return bool(DarkSquares & s1) != bool(DarkSquares & s2);
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -413,11 +413,6 @@ constexpr Rank relative_rank(Color c, Square s) {
   return relative_rank(c, rank_of(s));
 }
 
-inline bool opposite_colors(Square s1, Square s2) {
-  int s = int(s1) ^ int(s2);
-  return ((s >> 3) ^ s) & 1;
-}
-
 constexpr Direction pawn_push(Color c) {
   return c == WHITE ? NORTH : SOUTH;
 }


### PR DESCRIPTION
This is a non-functional simplification.

The code is master is a bit cryptic.  This is much easier to read/understand and I was not able to determine any appreciable performance difference.  Could someone do a performance test other than the framework test I ran?

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 36200 W: 7917 L: 7824 D: 20459
http://tests.stockfishchess.org/tests/view/5c0c09050ebc5902bceecf59