### PR TITLE
Fix a segfault.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -756,7 +756,7 @@ namespace {
     }
 
     // Step 7. Razoring (~2 Elo)
-    if (   !rootNode
+    if (   !rootNode // The required rootNode PV handling is not available in qsearch
         &&  depth < 2 * ONE_PLY
         &&  eval <= alpha - RazorMargin)
         return qsearch<NT>(pos, ss, alpha, beta);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -756,8 +756,9 @@ namespace {
     }
 
     // Step 7. Razoring (~2 Elo)
-    if (   depth < 2 * ONE_PLY
-        && eval <= alpha - RazorMargin)
+    if (   !rootNode
+        &&  depth < 2 * ONE_PLY
+        &&  eval <= alpha - RazorMargin)
         return qsearch<NT>(pos, ss, alpha, beta);
 
     improving =   ss->staticEval >= (ss-2)->staticEval


### PR DESCRIPTION
this patch fixes a rare but reproducible segfault observed playing a multi-threaded match, it is discussed somewhat in fishcooking.

From the core file, it could be observed that the issue was in qsearch, namely:
   ss->pv[0] = MOVE_NONE;
and the backtrace shows the it arrives there via razoring, called from the rootNode:
(gdb) bt
``` 
(gdb) bt 
#0  0x000055f6224829c2 in (anonymous namespace)::qsearch<((anonymous namespace)::NodeType)1>(Position&, Search::Stack*, Value, Value, Depth) [clone .lto_priv.868] (pos=..., ss=0x7f47062cb340, 
    alpha=-19, beta=682, depth=DEPTH_ZERO) at search.cpp:1247
#1  0x000055f6224a2ac0 in search (pos=..., ss=0x7f47062cb340, alpha=-19, beta=682, depth=ONE_PLY, cutNode=false) at search.cpp:763
#2  0x000055f62249f290 in Thread::search() (this=0x55f6242ee680) at search.cpp:409
#3  0x000055f62249dc14 in MainThread::search() (this=0x55f6242ee680) at search.cpp:223
```

Indeed, ss->pv can indeed by a nullptr at the rootNode. However, why is the segfault so rare ?

The reason is that the condition that guards razoring (depth < 2 * ONE_PLY &&  eval <= alpha - RazorMargin) is almost never true, since at the root alpha for depth < 5 is -VALUE_INFINITE. Nevertheless with the new failHigh scheme, this is not guaranteed, and rootDepth > 5, can still result in a depth < 2 search at the rootNode. If now another thread, via the hash, writes a new low eval to the rootPos qsearch can be entered. Rare but not unseen... I assume that some of the crashes in fishtest recently might be due to this.

Bench remains unchanged.

Bench: 3775064