### PR TITLE
No tempo

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -750,7 +750,7 @@ namespace {
             ss->staticEval = eval = pureStaticEval + bonus;
         }
         else
-            ss->staticEval = eval = pureStaticEval = -(ss-1)->staticEval + 2 * Eval::Tempo;
+            ss->staticEval = eval = pureStaticEval = -(ss-1)->staticEval ;
 
         tte->save(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE, pureStaticEval);
     }
@@ -1297,7 +1297,7 @@ moves_loop: // When in check, search starts from here
         else
             ss->staticEval = bestValue =
             (ss-1)->currentMove != MOVE_NULL ? evaluate(pos)
-                                             : -(ss-1)->staticEval + 2 * Eval::Tempo;
+                                             : -(ss-1)->staticEval ;
 
         // Stand pat. Return immediately if static value is at least beta
         if (bestValue >= beta)


### PR DESCRIPTION
Removes Tempo bonus In search.cpp as simplification.
Applies to Static evaluation of NULL moves only, Tempo is not removed for normal moves in evaluate.cpp
STC passed:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 31090 W: 6866 L: 6763 D: 17461 [GREEN]
http://tests.stockfishchess.org/tests/view/5c0eb0e40ebc593602fc2b67
LTC passed:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 81816 W: 13469 L: 13445 D: 54902 [GREEN]
http://tests.stockfishchess.org/tests/view/5c0ec47a0ebc5961df240568

There are other tests currently pending that test different Tempos on the framework, so it might be wise not to merge this now, as 0,4 parameter tweaks are giving more ELO than neutral simplification. 
Bench:3445849