### PR TITLE
[cluster] Do time managment on root only.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -495,7 +495,7 @@ void Thread::search() {
           && VALUE_MATE - bestValue <= 2 * Limits.mate)
           Threads.stop = true;
 
-      if (!mainThread)
+      if (!(Cluster::is_root() && mainThread))
           continue;
 
       // If skill level is enabled and time is up, pick a sub-optimal best move


### PR DESCRIPTION
for consistency with the threaded case. Similar performance:
Score of new-4r-1t vs old-4r-1t: 8245 - 8124 - 24618  [0.501] 40987
Elo difference: 1.03 +/- 2.12