### PR TITLE
[cluster] fill sendbuffer better

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -42,7 +42,7 @@ struct MoveInfo {
 #ifdef USE_MPI
 using KeyedTTEntry = std::pair<Key, TTEntry>;
 
-constexpr std::size_t TTSendBufferSize = 16;
+constexpr std::size_t TTSendBufferSize = 32;
 template <std::size_t N> class TTSendBuffer : public std::array<KeyedTTEntry, N> {
 
   struct Compare {

--- a/src/thread.h
+++ b/src/thread.h
@@ -79,6 +79,7 @@ public:
   struct {
       Mutex mutex;
       Cluster::TTSendBuffer<Cluster::TTSendBufferSize> buffer = {};
+      size_t counter = 0;
   } ttBuffer;
 #endif
 };


### PR DESCRIPTION
use a counter to track available elements.

Some elo gain, on 4 ranks:

Score of old-r4-1t vs new-r4-1t: 422 - 508 - 1694  [0.484] 2624
Elo difference: -11.39 +/- 7.90