### PR TITLE
Compute the doubly supported pawn squares only once

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -273,8 +273,9 @@ namespace {
         else if (file_of(pos.square<KING>(Us)) == FILE_A)
             kingRing[Us] |= shift<EAST>(kingRing[Us]);
 
-        kingAttackersCount[Them] = popcount(kingRing[Us] & pe->pawn_attacks(Them));
         kingRing[Us] &= ~double_pawn_attacks_bb<Us>(pos.pieces(Us, PAWN));
+
+        kingAttackersCount[Them] = popcount(kingRing[Us] & pe->pawn_attacks(Them));
         kingAttacksCount[Them] = kingAttackersWeight[Them] = 0;
     }
   }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -274,6 +274,7 @@ namespace {
             kingRing[Us] |= shift<EAST>(kingRing[Us]);
 
         kingAttackersCount[Them] = popcount(kingRing[Us] & pe->pawn_attacks(Them));
+        kingRing[Us] &= ~double_pawn_attacks_bb<Them>(pos.pieces(Them, PAWN))
         kingAttacksCount[Them] = kingAttackersWeight[Them] = 0;
     }
   }
@@ -309,7 +310,7 @@ namespace {
         attackedBy[Us][Pt] |= b;
         attackedBy[Us][ALL_PIECES] |= b;
 
-        if (b & kingRing[Them] & ~double_pawn_attacks_bb<Them>(pos.pieces(Them, PAWN)))
+        if (b & kingRing[Them])
         {
             kingAttackersCount[Us]++;
             kingAttackersWeight[Us] += KingAttackWeights[Pt];

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -274,7 +274,7 @@ namespace {
             kingRing[Us] |= shift<EAST>(kingRing[Us]);
 
         kingAttackersCount[Them] = popcount(kingRing[Us] & pe->pawn_attacks(Them));
-        kingRing[Us] &= ~double_pawn_attacks_bb<Them>(pos.pieces(Them, PAWN))
+        kingRing[Us] &= ~double_pawn_attacks_bb<Us>(pos.pieces(Us, PAWN));
         kingAttacksCount[Them] = kingAttackersWeight[Them] = 0;
     }
   }


### PR DESCRIPTION
Non functional change.

Calculate the expression
`~double_pawn_attacks_bb<Us>(pos.pieces(Us, PAWN));`
only once in initialize, instead of once for each piece.

Passed STC
http://tests.stockfishchess.org/tests/view/5c1506380ebc5902ba11f3b4
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 9494 W: 2191 L: 2045 D: 5258
