### PR TITLE
Compute the double protection by pawn only once

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -274,6 +274,7 @@ namespace {
             kingRing[Us] |= shift<EAST>(kingRing[Us]);
 
         kingAttackersCount[Them] = popcount(kingRing[Us] & pe->pawn_attacks(Them));
+        kingRing[Us] &= ~double_pawn_attacks_bb<Us>(pos.pieces(Us, PAWN));
         kingAttacksCount[Them] = kingAttackersWeight[Them] = 0;
     }
   }
@@ -309,7 +310,7 @@ namespace {
         attackedBy[Us][Pt] |= b;
         attackedBy[Us][ALL_PIECES] |= b;
 
-        if (b & kingRing[Them] & ~double_pawn_attacks_bb<Them>(pos.pieces(Them, PAWN)))
+        if (b & kingRing[Them])
         {
             kingAttackersCount[Us]++;
             kingAttackersWeight[Us] += KingAttackWeights[Pt];


### PR DESCRIPTION
Non functional change.

Calculate the expression
`~double_pawn_attacks_bb<Us>(pos.pieces(Us, PAWN));`
only once in initialize, instead of once for each piece.

Passed STC
http://tests.stockfishchess.org/tests/view/5c1506380ebc5902ba11f3b4
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 9494 W: 2191 L: 2045 D: 5258

Inspired by Nick Pelling
http://tests.stockfishchess.org/tests/view/5c144d110ebc5902ba11e4af
and an older test of mine
http://tests.stockfishchess.org/tests/view/5c0402810ebc5902bcee1fc8