### PR TITLE
Simplify logic for RestrictedPiece.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -559,8 +559,7 @@ namespace {
 
     // Bonus for restricting their piece moves
     restricted =   attackedBy[Them][ALL_PIECES]
-                & ~attackedBy[Them][PAWN]
-                & ~attackedBy2[Them]
+                & ~stronglyProtected
                 &  attackedBy[Us][ALL_PIECES];
     score += RestrictedPiece * popcount(restricted);
 


### PR DESCRIPTION
`~stronglyProtected` is quite similar to `~attackedBy[Them][PAWN] & ~attackedBy2[Them]`: the only difference appears to be that the former includes squares attacked twice by both sides.  The resulting logic is simpler, and the change appears to be at least Elo-neutral at both STC and LTC.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 35924 W: 7978 L: 7885 D: 20061
http://tests.stockfishchess.org/tests/view/5c14a5c00ebc5902ba11ed72

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 37078 W: 6125 L: 6030 D: 24923
http://tests.stockfishchess.org/tests/view/5c14ae880ebc5902ba11eed8

Bench: 3401337