### PR TITLE
Apply refuted main killer penalty also on early TT cut-offs.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -655,10 +655,6 @@ namespace {
                 if (!pos.capture_or_promotion(ttMove))
                     update_quiet_stats(pos, ss, ttMove, nullptr, 0, stat_bonus(depth));
 
-                // Extra penalty for a quiet TT move in previous ply when it gets refuted
-                if ((ss-1)->moveCount == 1 && !pos.captured_piece())
-                    update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth + ONE_PLY));
-
                 // Extra penalty for a quiet TT or main killer move in previous ply when it gets refuted
                 if (   (ss-1)->moveCount == 1
                     || ((ss-1)->currentMove == (ss-1)->killers[0] && (ss-1)->killers[0]))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -658,6 +658,12 @@ namespace {
                 // Extra penalty for a quiet TT move in previous ply when it gets refuted
                 if ((ss-1)->moveCount == 1 && !pos.captured_piece())
                     update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth + ONE_PLY));
+
+                // Extra penalty for a quiet TT or main killer move in previous ply when it gets refuted
+                if (   (ss-1)->moveCount == 1
+                    || ((ss-1)->currentMove == (ss-1)->killers[0] && (ss-1)->killers[0]))
+                    if (!pos.captured_piece())
+                        update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth + ONE_PLY));
             }
             // Penalty for a quiet ttMove that fails low
             else if (!pos.capture_or_promotion(ttMove))


### PR DESCRIPTION
Makes penalty logic more consistent between early TT cut-offs and normal search.

Failed STC:
http://tests.stockfishchess.org/tests/view/5c121e730ebc5902ba11aad8
LLR: -2.95 (-2.94,2.94) [0.00,5.00]
Total: 72193 W: 15848 L: 15625 D: 40720 Elo +1.07

Passed LTC:
http://tests.stockfishchess.org/tests/view/5c17b1b10ebc5902ba123c24
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 35073 W: 5886 L: 5625 D: 23562 Elo +2.59

bench: 3393939