### PR TITLE
Remove endgame KQvKP

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -244,6 +244,7 @@ Value Endgame<KRKN>::operator()(const Position& pos) const {
 }
 
 
+/*
 /// KQ vs KP. In general, this is a win for the stronger side, but there are a
 /// few important exceptions. A pawn on 7th rank and on the A,C,F or H files
 /// with a king positioned next to it can be a draw, so in that case, we only
@@ -267,6 +268,7 @@ Value Endgame<KQKP>::operator()(const Position& pos) const {
 
   return strongSide == pos.side_to_move() ? result : -result;
 }
+*/
 
 
 /// KQ vs KR.  This is almost identical to KX vs K:  We give the attacking

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -244,33 +244,6 @@ Value Endgame<KRKN>::operator()(const Position& pos) const {
 }
 
 
-/*
-/// KQ vs KP. In general, this is a win for the stronger side, but there are a
-/// few important exceptions. A pawn on 7th rank and on the A,C,F or H files
-/// with a king positioned next to it can be a draw, so in that case, we only
-/// use the distance between the kings.
-template<>
-Value Endgame<KQKP>::operator()(const Position& pos) const {
-
-  assert(verify_material(pos, strongSide, QueenValueMg, 0));
-  assert(verify_material(pos, weakSide, VALUE_ZERO, 1));
-
-  Square winnerKSq = pos.square<KING>(strongSide);
-  Square loserKSq = pos.square<KING>(weakSide);
-  Square pawnSq = pos.square<PAWN>(weakSide);
-
-  Value result = Value(PushClose[distance(winnerKSq, loserKSq)]);
-
-  if (   relative_rank(weakSide, pawnSq) != RANK_7
-      || distance(loserKSq, pawnSq) != 1
-      || !((FileABB | FileCBB | FileFBB | FileHBB) & pawnSq))
-      result += QueenValueEg - PawnValueEg;
-
-  return strongSide == pos.side_to_move() ? result : -result;
-}
-*/
-
-
 /// KQ vs KR.  This is almost identical to KX vs K:  We give the attacking
 /// king a bonus for having the kings close together, and for forcing the
 /// defending king towards the edge. If we also take care to avoid null move for

--- a/src/endgame.h
+++ b/src/endgame.h
@@ -43,7 +43,6 @@ enum EndgameCode {
   KRKP,  // KR vs KP
   KRKB,  // KR vs KB
   KRKN,  // KR vs KN
-  //KQKP,  // KQ vs KP
   KQKR,  // KQ vs KR
 
   SCALING_FUNCTIONS,
@@ -123,7 +122,6 @@ public:
     add<KRKP>("KRKP");
     add<KRKB>("KRKB");
     add<KRKN>("KRKN");
-    //add<KQKP>("KQKP");
     add<KQKR>("KQKR");
 
     add<KNPK>("KNPK");

--- a/src/endgame.h
+++ b/src/endgame.h
@@ -43,7 +43,7 @@ enum EndgameCode {
   KRKP,  // KR vs KP
   KRKB,  // KR vs KB
   KRKN,  // KR vs KN
-  KQKP,  // KQ vs KP
+  //KQKP,  // KQ vs KP
   KQKR,  // KQ vs KR
 
   SCALING_FUNCTIONS,
@@ -123,7 +123,7 @@ public:
     add<KRKP>("KRKP");
     add<KRKB>("KRKB");
     add<KRKN>("KRKN");
-    add<KQKP>("KQKP");
+    //add<KQKP>("KQKP");
     add<KQKR>("KQKR");
 
     add<KNPK>("KNPK");


### PR DESCRIPTION
This endgame can be removed.  It is a trivial solution and my tests indicate that it does not contribute anything to playing strength.

After 40k games (tc = 5+0.1), this patch is dead even with master running strictly on KQvKP positions.

This can be validated by downloading my KQvKP fen file and use it as an opening book with cutechess. Set to random and depth to 1.
https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/ZXzi8K0CcxU

bench 3729967