### PR TITLE
Removing unnecesary check of killer move existance

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -658,7 +658,7 @@ namespace {
 
                 // Extra penalty for a quiet TT or main killer move in previous ply when it gets refuted
                 if (   (ss-1)->moveCount == 1
-                    || ((ss-1)->currentMove == (ss-1)->killers[0] && (ss-1)->killers[0]))
+                    || (ss-1)->currentMove == (ss-1)->killers[0])
                     if (!pos.captured_piece())
                         update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth + ONE_PLY));
             }


### PR DESCRIPTION
Removing unnecessary move existence check introduced with commit "Tweak main killer penalty "

Non functional change.

bench: 3294688