### PR TITLE
Two castling simplifications.

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -330,7 +330,7 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
 void Position::set_castling_right(Color c, Square rfrom) {
 
   Square kfrom = square<KING>(c);
-  CastlingSide cs = kfrom < rfrom ? KING_SIDE : QUEEN_SIDE;
+  CastlingSide cs = CastlingSide(kfrom > rfrom);
   CastlingRight cr = (c | cs);
 
   st->castlingRights |= cr;

--- a/src/types.h
+++ b/src/types.h
@@ -361,7 +361,7 @@ constexpr Piece operator~(Piece pc) {
 }
 
 constexpr CastlingRight operator|(Color c, CastlingSide s) {
-  return CastlingRight(WHITE_OO << ((s == QUEEN_SIDE) + 2 * c));
+  return CastlingRight(1 << (s + 2 * c));
 }
 
 constexpr Value mate_in(int ply) {


### PR DESCRIPTION
This change is non-functional.

In position.cpp, if we change the inequality, we can just assign the result because KING_SIDE == 0, and QUEEN_SIDE == 1.

In types.h, the s == QUEEN_SIDE is not necessary.  I opted for a '1' instead of WHITE_OO because it was a bit disorienting to take a valid castling right and shift it.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 81296 W: 17751 L: 17747 D: 45798
http://tests.stockfishchess.org/tests/view/5c1aec630ebc5902ba128179


