### PR TITLE
Simplify generate_castling

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -29,7 +29,7 @@ namespace {
   ExtMove* generate_castling(const Position& pos, ExtMove* moveList) {
 
     constexpr CastlingRight Cr = Us | Cs;
-    constexpr bool QueenSide = Cs;
+    constexpr bool KingSide = (Cs == KING_SIDE);
 
     if (pos.castling_impeded(Cr) || !pos.can_castle(Cr))
         return moveList;
@@ -38,13 +38,13 @@ namespace {
     // as they would be in standard chess.
     Square kfrom = pos.square<KING>(Us);
     Square rfrom = pos.castling_rook_square(Cr);
-    Square kto = relative_square(Us, QueenSide ? SQ_C1 : SQ_G1);
+    Square kto = relative_square(Us, KingSide ? SQ_G1 : SQ_C1);
     Bitboard enemies = pos.pieces(~Us);
 
     assert(!pos.checkers());
 
     const Direction step = Chess960 ? kto > kfrom ? WEST : EAST
-                                    : QueenSide   ? EAST : WEST;
+                                    : KingSide    ? WEST : EAST;
 
     for (Square s = kto; s != kfrom; s += step)
         if (pos.attackers_to(s) & enemies)

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -29,7 +29,7 @@ namespace {
   ExtMove* generate_castling(const Position& pos, ExtMove* moveList) {
 
     constexpr CastlingRight Cr = Us | Cs;
-    constexpr bool KingSide = (Cr == WHITE_OO || Cr == BLACK_OO);
+    constexpr bool QueenSide = Cs;
 
     if (pos.castling_impeded(Cr) || !pos.can_castle(Cr))
         return moveList;
@@ -38,13 +38,13 @@ namespace {
     // as they would be in standard chess.
     Square kfrom = pos.square<KING>(Us);
     Square rfrom = pos.castling_rook_square(Cr);
-    Square kto = relative_square(Us, KingSide ? SQ_G1 : SQ_C1);
+    Square kto = relative_square(Us, QueenSide ? SQ_C1 : SQ_G1);
     Bitboard enemies = pos.pieces(~Us);
 
     assert(!pos.checkers());
 
     const Direction step = Chess960 ? kto > kfrom ? WEST : EAST
-                                    : KingSide    ? WEST : EAST;
+                                    : QueenSide   ? EAST : WEST;
 
     for (Square s = kto; s != kfrom; s += step)
         if (pos.attackers_to(s) & enemies)


### PR DESCRIPTION
This is non-functional and NOT tested.

Although this is a compile-time constant, we stick the castlingSide into a CastlingRight, then pull it out again.  This seems unecessarily complex.

Alternatively, we could keep KingSide and do:  constexpr bool KingSide = !Cs;