### PR TITLE
[cluster] keep track of node counts cluster-wide.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -359,7 +359,7 @@ endif
 ### 3.10 MPI
 ifneq (,$(findstring mpi, $(CXX)))
 	mpi = yes
-	CXXFLAGS += -DUSE_MPI -Wno-cast-qual
+	CXXFLAGS += -DUSE_MPI -Wno-cast-qual -fexceptions
         DEPENDFLAGS += -DUSE_MPI
 endif
 

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -144,7 +144,7 @@ void sync_start() {
 void sync_stop() {
 
   // update the nodeCount, non-blocking collective,
-  // we don't quite now how many of those we issue on each rank, there might be pending a pending one on some ranks
+  // we don't quite know how many of those we issue on each rank, there might be pending a pending one on some ranks
   int flag;
   MPI_Test(&reqNodesSearched, &flag, MPI_STATUS_IGNORE);
   if (flag)

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -74,7 +74,7 @@ int rank();
 inline bool is_root() { return rank() == 0; }
 void save(Thread* thread, TTEntry* tte, Key k, Value v, Bound b, Depth d, Move m, Value ev);
 void pick_moves(MoveInfo& mi);
-void sum(uint64_t& val);
+uint64_t nodes_searched();
 void sync_start();
 void sync_stop();
 
@@ -88,7 +88,7 @@ constexpr int rank() { return 0; }
 constexpr bool is_root() { return true; }
 inline void save(Thread*, TTEntry* tte, Key k, Value v, Bound b, Depth d, Move m, Value ev) { tte->save(k, v, b, d, m, ev); }
 inline void pick_moves(MoveInfo&) { }
-inline void sum(uint64_t& ) { }
+uint64_t nodes_searched();
 inline void sync_start() { }
 inline void sync_stop() { }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1658,9 +1658,8 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
       if (!tb && i == pvIdx)
           ss << (v >= beta ? " lowerbound" : v <= alpha ? " upperbound" : "");
 
-      // TODO fix approximate node calculation.
-      ss << " nodes "    << nodesSearched * Cluster::size()
-         << " nps "      << nodesSearched * Cluster::size() * 1000 / elapsed;
+      ss << " nodes "    << nodesSearched
+         << " nps "      << nodesSearched * 1000 / elapsed;
 
       if (elapsed > 1000) // Earlier makes little sense
           ss << " hashfull " << TT.hashfull();

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -163,7 +163,6 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
   main()->wait_for_search_finished();
 
   stopOnPonderhit = stop = false;
-  Cluster::sync_start();
 
   ponder = ponderMode;
   Search::Limits = limits;
@@ -200,6 +199,8 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
   }
 
   setupStates->back() = tmp;
+
+  Cluster::sync_start();
 
   main()->start_searching();
 }

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -23,7 +23,7 @@
 
 #include "misc.h"
 #include "search.h"
-#include "thread.h"
+#include "cluster.h"
 
 /// The TimeManagement class computes the optimal time to think depending on
 /// the maximum available time, the game move number and other parameters.
@@ -34,7 +34,7 @@ public:
   TimePoint optimum() const { return optimumTime; }
   TimePoint maximum() const { return maximumTime; }
   TimePoint elapsed() const { return Search::Limits.npmsec ?
-                                     TimePoint(Threads.nodes_searched()) : now() - startTime; }
+                                     TimePoint(Cluster::nodes_searched()) : now() - startTime; }
 
   int64_t availableNodes; // When in 'nodes as time' mode
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -162,7 +162,7 @@ namespace {
                 cerr << "\nPosition: " << cnt++ << '/' << num << endl;
             go(pos, is, states);
             Threads.main()->wait_for_search_finished();
-            nodes += Threads.nodes_searched();
+            nodes += Cluster::nodes_searched();
         }
         else if (token == "setoption")  setoption(is);
         else if (token == "position")   position(pos, is, states);
@@ -173,7 +173,6 @@ namespace {
 
     dbg_print(); // Just before exiting
 
-    Cluster::sum(nodes);
     if (Cluster::is_root())
         cerr << "\n==========================="
              << "\nTotal time (ms) : " << elapsed


### PR DESCRIPTION
using a non-blocking all-reduce keep lazily track of the node counts across the cluster.

More or less performance neutral on 4 ranks:
Score of new-r4-1t vs old-r4-1t: 1216 - 1225 - 4732  [0.499] 7173
Elo difference: -0.44 +/- 4.68