### PR TITLE
Simplify generate castling step direction

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -43,8 +43,7 @@ namespace {
 
     assert(!pos.checkers());
 
-    const Direction step = Chess960 ? kto > kfrom ? WEST : EAST
-                                    : KingSide    ? WEST : EAST;
+    const Direction step = KingSide ? WEST : EAST;
 
     for (Square s = kto; s != kfrom; s += step)
         if (pos.attackers_to(s) & enemies)


### PR DESCRIPTION
This is non-functional and untested.

The only time (as far as I can tell) bool(KingSide) is not equal to bool(kto > kfrom) is when kto == kfrom.  In that case, the direction does not matter since we won't be stepping at all.

Thus, this change is equivalent and more simple.