### PR TITLE
Simpify new voting formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -267,8 +267,8 @@ void MainThread::search() {
       // Vote according to score and depth
       auto square = [](int64_t x) { return x * x; };
       for (Thread* th : Threads)
-          votes[th->rootMoves[0].pv[0]] += 200 + (square(th->rootMoves[0].score - minScore + 1)
-                                                  * int64_t(th->completedDepth));
+          votes[th->rootMoves[0].pv[0]] += (square(th->rootMoves[0].score - minScore + 1)
+                                            * int64_t(th->completedDepth));
 
       // Select best thread
       int64_t bestVote = votes[this->rootMoves[0].pv[0]];


### PR DESCRIPTION
[ Note: I created this to ask about a large thread count test in the next comment, and to get any other feedback of course. I have also started a test [here](http://tests.stockfishchess.org/tests/view/5c1e8cd20ebc5902ba12a02a) that makes a different, conflicting change to the voting calc, so we should wait to see how that goes before deciding this is ok. ]

Simplify the recent change to thread voting by removing the constant 200.

STC:  5+0.05 th 8
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 36137 W: 7093 L: 6999 D: 22045

LTC: 20+0.2 th 8
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 53696 W: 8433 L: 8362 D: 36901

Large thread count test:
TBA

No functional change on one thread.