### PR TITLE
[cluster] keep track of node counts cluster-wide.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -359,7 +359,7 @@ endif
 ### 3.10 MPI
 ifneq (,$(findstring mpi, $(CXX)))
 	mpi = yes
-	CXXFLAGS += -DUSE_MPI -Wno-cast-qual
+	CXXFLAGS += -DUSE_MPI -Wno-cast-qual -fexceptions
         DEPENDFLAGS += -DUSE_MPI
 endif
 

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -124,7 +124,7 @@ bool getline(std::istream& input, std::string& str) {
       size = vec.size();
   }
 
-  // Some MPI implementations use busy-wait pooling, while we need yielding
+  // Some MPI implementations use busy-wait polling, while we need yielding
   static MPI_Request reqInput = MPI_REQUEST_NULL;
   MPI_Ibcast(&size, 1, MPI_INT, 0, InputComm, &reqInput);
   if (is_root())

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -74,9 +74,10 @@ int rank();
 inline bool is_root() { return rank() == 0; }
 void save(Thread* thread, TTEntry* tte, Key k, Value v, Bound b, Depth d, Move m, Value ev);
 void pick_moves(MoveInfo& mi);
-void sum(uint64_t& val);
-void sync_start();
-void sync_stop();
+uint64_t nodes_searched();
+void signals_init();
+void signals_poll();
+void signals_sync();
 
 #else
 
@@ -88,9 +89,10 @@ constexpr int rank() { return 0; }
 constexpr bool is_root() { return true; }
 inline void save(Thread*, TTEntry* tte, Key k, Value v, Bound b, Depth d, Move m, Value ev) { tte->save(k, v, b, d, m, ev); }
 inline void pick_moves(MoveInfo&) { }
-inline void sum(uint64_t& ) { }
-inline void sync_start() { }
-inline void sync_stop() { }
+uint64_t nodes_searched();
+inline void signals_init() { }
+inline void signals_poll() { }
+inline void signals_sync() { }
 
 #endif /* USE_MPI */
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -75,6 +75,7 @@ inline bool is_root() { return rank() == 0; }
 void save(Thread* thread, TTEntry* tte, Key k, Value v, Bound b, Depth d, Move m, Value ev);
 void pick_moves(MoveInfo& mi);
 uint64_t nodes_searched();
+uint64_t tb_hits();
 void signals_init();
 void signals_poll();
 void signals_sync();
@@ -90,6 +91,7 @@ constexpr bool is_root() { return true; }
 inline void save(Thread*, TTEntry* tte, Key k, Value v, Bound b, Depth d, Move m, Value ev) { tte->save(k, v, b, d, m, ev); }
 inline void pick_moves(MoveInfo&) { }
 uint64_t nodes_searched();
+uint64_t tb_hits();
 inline void signals_init() { }
 inline void signals_poll() { }
 inline void signals_sync() { }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -234,14 +234,14 @@ void MainThread::search() {
   Threads.stopOnPonderhit = true;
 
   while (!Threads.stop && (Threads.ponder || Limits.infinite))
-  { } // Busy wait for a stop or a ponder reset
+  { Cluster::signals_poll(); } // Busy wait for a stop or a ponder reset
 
   // Stop the threads if not already stopped (also raise the stop if
   // "ponderhit" just reset Threads.ponder).
   Threads.stop = true;
 
-  // Finish any outstanding barriers.
-  Cluster::sync_stop();
+  // Signal and synchronize all other ranks
+  Cluster::signals_sync();
 
   // Wait until all threads have finished
   for (Thread* th : Threads)
@@ -251,7 +251,7 @@ void MainThread::search() {
   // When playing in 'nodes as time' mode, subtract the searched nodes from
   // the available ones before exiting.
   if (Limits.npmsec)
-      Time.availableNodes += Limits.inc[us] - Threads.nodes_searched();
+      Time.availableNodes += Limits.inc[us] - Cluster::nodes_searched();
 
   // Check if there are threads with a better score than main thread
   Thread* bestThread = this;
@@ -363,7 +363,7 @@ void Thread::search() {
   // Iterative deepening loop until requested to stop or the target depth is reached
   while (   (rootDepth += ONE_PLY) < DEPTH_MAX
          && !Threads.stop
-         && !(Limits.depth && mainThread && rootDepth / ONE_PLY > Limits.depth))
+         && !(Limits.depth && mainThread && Cluster::is_root() && rootDepth / ONE_PLY > Limits.depth))
   {
       // Distribute search depths across the helper threads
       if (idx + Cluster::rank() > 0)
@@ -376,6 +376,7 @@ void Thread::search() {
       // Age out PV variability metric
       if (mainThread)
           mainThread->bestMoveChanges *= 0.517, failedLow = false;
+
 
       // Save the last iteration's scores before first PV line is searched and
       // all the move scores except the (new) PV are set to -VALUE_INFINITE.
@@ -1601,16 +1602,16 @@ void MainThread::check_time() {
       dbg_print();
   }
 
+  // poll on MPI signals
+  Cluster::signals_poll();
+
   // We should not stop pondering until told so by the GUI
   if (Threads.ponder)
       return;
 
-  // Check if root has reached a stop barrier
-  Cluster::sync_stop();
-
   if (   (Limits.use_time_management() && elapsed > Time.maximum() - 10)
       || (Limits.movetime && elapsed >= Limits.movetime)
-      || (Limits.nodes && Threads.nodes_searched() >= (uint64_t)Limits.nodes))
+      || (Limits.nodes && Cluster::nodes_searched() >= (uint64_t)Limits.nodes))
       Threads.stop = true;
 }
 
@@ -1625,7 +1626,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
   const RootMoves& rootMoves = pos.this_thread()->rootMoves;
   size_t pvIdx = pos.this_thread()->pvIdx;
   size_t multiPV = std::min((size_t)Options["MultiPV"], rootMoves.size());
-  uint64_t nodesSearched = Threads.nodes_searched();
+  uint64_t nodesSearched = Cluster::nodes_searched();
   uint64_t tbHits = Threads.tb_hits() + (TB::RootInTB ? rootMoves.size() : 0);
 
   for (size_t i = 0; i < multiPV; ++i)
@@ -1653,9 +1654,8 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
       if (!tb && i == pvIdx)
           ss << (v >= beta ? " lowerbound" : v <= alpha ? " upperbound" : "");
 
-      // TODO fix approximate node calculation.
-      ss << " nodes "    << nodesSearched * Cluster::size()
-         << " nps "      << nodesSearched * Cluster::size() * 1000 / elapsed;
+      ss << " nodes "    << nodesSearched
+         << " nps "      << nodesSearched * 1000 / elapsed;
 
       if (elapsed > 1000) // Earlier makes little sense
           ss << " hashfull " << TT.hashfull();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1627,7 +1627,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
   size_t pvIdx = pos.this_thread()->pvIdx;
   size_t multiPV = std::min((size_t)Options["MultiPV"], rootMoves.size());
   uint64_t nodesSearched = Cluster::nodes_searched();
-  uint64_t tbHits = Threads.tb_hits() + (TB::RootInTB ? rootMoves.size() : 0);
+  uint64_t tbHits = Cluster::tb_hits() + (TB::RootInTB ? rootMoves.size() : 0);
 
   for (size_t i = 0; i < multiPV; ++i)
   {

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -163,7 +163,6 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
   main()->wait_for_search_finished();
 
   stopOnPonderhit = stop = false;
-  Cluster::sync_start();
 
   ponder = ponderMode;
   Search::Limits = limits;
@@ -200,6 +199,8 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
   }
 
   setupStates->back() = tmp;
+
+  Cluster::signals_init();
 
   main()->start_searching();
 }

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -23,7 +23,7 @@
 
 #include "misc.h"
 #include "search.h"
-#include "thread.h"
+#include "cluster.h"
 
 /// The TimeManagement class computes the optimal time to think depending on
 /// the maximum available time, the game move number and other parameters.
@@ -34,7 +34,7 @@ public:
   TimePoint optimum() const { return optimumTime; }
   TimePoint maximum() const { return maximumTime; }
   TimePoint elapsed() const { return Search::Limits.npmsec ?
-                                     TimePoint(Threads.nodes_searched()) : now() - startTime; }
+                                     TimePoint(Cluster::nodes_searched()) : now() - startTime; }
 
   int64_t availableNodes; // When in 'nodes as time' mode
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -162,7 +162,7 @@ namespace {
                 cerr << "\nPosition: " << cnt++ << '/' << num << endl;
             go(pos, is, states);
             Threads.main()->wait_for_search_finished();
-            nodes += Threads.nodes_searched();
+            nodes += Cluster::nodes_searched();
         }
         else if (token == "setoption")  setoption(is);
         else if (token == "position")   position(pos, is, states);
@@ -173,7 +173,6 @@ namespace {
 
     dbg_print(); // Just before exiting
 
-    Cluster::sum(nodes);
     if (Cluster::is_root())
         cerr << "\n==========================="
              << "\nTotal time (ms) : " << elapsed


### PR DESCRIPTION
This generalizes exchange of signals between the ranks using a non-blocking all-reduce. It is now used for the stop signal and the node count, but should be easily generalizable (TB hits, and ponder still missing). It avoids having long-lived outstanding non-blocking collectives (removes an early posted Ibarrier). A bit too short a test, but not worse than before:

Score of new-r4-1t vs old-r4-1t: 459 - 401 - 1505  [0.512] 2365
Elo difference: 8.52 +/- 8.43