### PR TITLE
[Cluster] Improve message passing part.

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -42,8 +42,8 @@ struct MoveInfo {
 #ifdef USE_MPI
 using KeyedTTEntry = std::pair<Key, TTEntry>;
 
-constexpr std::size_t TTSendBufferSize = 32;
-template <std::size_t N> class TTSendBuffer : public std::array<KeyedTTEntry, N> {
+constexpr std::size_t TTCacheSize = 32;
+template <std::size_t N> class TTCache : public std::array<KeyedTTEntry, N> {
 
   struct Compare {
       inline bool operator()(const KeyedTTEntry& lhs, const KeyedTTEntry& rhs) {
@@ -74,6 +74,7 @@ int rank();
 inline bool is_root() { return rank() == 0; }
 void save(Thread* thread, TTEntry* tte, Key k, Value v, Bound b, Depth d, Move m, Value ev);
 void pick_moves(MoveInfo& mi);
+void ttRecvBuff_resize(size_t nThreads);
 uint64_t nodes_searched();
 uint64_t tb_hits();
 void signals_init();
@@ -90,6 +91,7 @@ constexpr int rank() { return 0; }
 constexpr bool is_root() { return true; }
 inline void save(Thread*, TTEntry* tte, Key k, Value v, Bound b, Depth d, Move m, Value ev) { tte->save(k, v, b, d, m, ev); }
 inline void pick_moves(MoveInfo&) { }
+inline void ttRecvBuff_resize(size_t) { }
 uint64_t nodes_searched();
 uint64_t tb_hits();
 inline void signals_init() { }

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -139,6 +139,9 @@ void ThreadPool::set(size_t requested) {
 
       // Reallocate the hash with the new threadpool size
       TT.resize(Options["Hash"]);
+
+      // Adjust cluster buffers
+      Cluster::ttRecvBuff_resize(requested);
   }
 }
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -78,9 +78,8 @@ public:
 #ifdef USE_MPI
   struct {
       Mutex mutex;
-      Cluster::TTSendBuffer<Cluster::TTSendBufferSize> buffer = {};
-      size_t counter = 0;
-  } ttBuffer;
+      Cluster::TTCache<Cluster::TTCacheSize> buffer = {};
+  } ttCache;
 #endif
 };
 


### PR DESCRIPTION
This rewrites in part the message passing part, using in place gather, and collecting, rather than merging, the data of all threads.

neutral with a single thread per rank:
Score of new-2mpi-1t vs old-2mpi-1t: 789 - 787 - 2615  [0.500] 4191
Elo difference: 0.17 +/- 6.44

likely progress with multiple threads per rank:
Score of new-2mpi-36t vs old-2mpi-36t: 76 - 53 - 471  [0.519] 600
Elo difference: 13.32 +/- 12.85