### PR TITLE
Simplify pawn promotions

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -96,7 +96,6 @@ namespace {
     // Compute our parametrized parameters at compile time, named according to
     // the point of view of white side.
     constexpr Color     Them     = (Us == WHITE ? BLACK      : WHITE);
-    constexpr Bitboard  TRank8BB = (Us == WHITE ? Rank8BB    : Rank1BB);
     constexpr Bitboard  TRank7BB = (Us == WHITE ? Rank7BB    : Rank2BB);
     constexpr Bitboard  TRank3BB = (Us == WHITE ? Rank3BB    : Rank6BB);
     constexpr Direction Up       = (Us == WHITE ? NORTH      : SOUTH);

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -161,7 +161,7 @@ namespace {
     }
 
     // Promotions and underpromotions
-    if (pawnsOn7 && (Type != EVASIONS || (target & TRank8BB)))
+    if (pawnsOn7)
     {
         if (Type == CAPTURES)
             emptySquares = ~pos.pieces();


### PR DESCRIPTION
This is non-functional.

Not sure, but it seems like this can be removed.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 78020 W: 16978 L: 16967 D: 44075
http://tests.stockfishchess.org/tests/view/5c27b4fe0ebc5902ba135bb0
