### PR TITLE
Remove openFiles in pawns.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -717,7 +717,8 @@ namespace {
     behind |= (Us == WHITE ? behind >> 16 : behind << 16);
 
     int bonus = popcount(safe) + popcount(behind & safe);
-    int weight = pos.count<ALL_PIECES>(Us) - 2 * pe->open_files();
+    int weight = pos.count<ALL_PIECES>(Us) - 2 *
+                    popcount(pe->semiopenFiles[WHITE] & pe->semiopenFiles[BLACK]);
 
     Score score = make_score(bonus * weight * weight / 16, 0);
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -717,8 +717,8 @@ namespace {
     behind |= (Us == WHITE ? behind >> 16 : behind << 16);
 
     int bonus = popcount(safe) + popcount(behind & safe);
-    int weight = pos.count<ALL_PIECES>(Us) - 2 *
-                    popcount(pe->semiopenFiles[WHITE] & pe->semiopenFiles[BLACK]);
+    int weight = pos.count<ALL_PIECES>(Us)
+               - 2 * popcount(pe->semiopenFiles[WHITE] & pe->semiopenFiles[BLACK]);
 
     Score score = make_score(bonus * weight * weight / 16, 0);
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -185,7 +185,6 @@ Entry* probe(const Position& pos) {
   e->key = key;
   e->scores[WHITE] = evaluate<WHITE>(pos, e);
   e->scores[BLACK] = evaluate<BLACK>(pos, e);
-  e->openFiles = popcount(e->semiopenFiles[WHITE] & e->semiopenFiles[BLACK]);
   e->asymmetry = popcount(  (e->passedPawns[WHITE]   | e->passedPawns[BLACK])
                           | (e->semiopenFiles[WHITE] ^ e->semiopenFiles[BLACK]));
 

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -39,7 +39,6 @@ struct Entry {
   Bitboard pawn_attacks_span(Color c) const { return pawnAttacksSpan[c]; }
   int weak_unopposed(Color c) const { return weakUnopposed[c]; }
   int pawn_asymmetry() const { return asymmetry; }
-  int open_files() const { return openFiles; }
 
   int semiopen_file(Color c, File f) const {
     return semiopenFiles[c] & (1 << f);
@@ -73,7 +72,6 @@ struct Entry {
   int semiopenFiles[COLOR_NB];
   int pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
   int asymmetry;
-  int openFiles;
 };
 
 typedef HashTable<Entry, 16384> Table;


### PR DESCRIPTION
This is non-functional.

A single popcount in evaluate.cpp replaces all openFiles stuff in pawns.  It doesn't seem to affect performance at all.

I tested this 4 months ago, but never did a PR.  Do I need to test again?

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 28103 W: 6134 L: 6025 D: 15944
http://tests.stockfishchess.org/tests/view/5b7d70a20ebc5902bdbb1999