### PR TITLE
Breakout PROBCUT from MovePicker::next_move()

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -97,7 +97,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePiece
           && pos.capture(ttm)
           && pos.see_ge(ttm, threshold) ? ttm : MOVE_NONE;
 
-  stage += PROBCUT_TT + (ttMove == MOVE_NONE);
+  stage = PROBCUT_TT + (ttMove == MOVE_NONE);
 }
 
 /// MovePicker::score() assigns a numerical value to each move in a list, used

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -92,12 +92,12 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePiece
 
   assert(!pos.checkers());
 
-  stage = PROBCUT_TT;
   ttMove =   ttm
           && pos.pseudo_legal(ttm)
           && pos.capture(ttm)
           && pos.see_ge(ttm, threshold) ? ttm : MOVE_NONE;
-  stage += (ttMove == MOVE_NONE);
+
+  stage += PROBCUT_TT + (ttMove == MOVE_NONE);
 }
 
 /// MovePicker::score() assigns a numerical value to each move in a list, used
@@ -149,6 +149,8 @@ Move MovePicker::select(Pred filter) {
   return move = MOVE_NONE;
 }
 
+/// MovePicker::next_move_pc() returns a highest scored pseudo legal moves every time it is
+/// called until there are no more moves (then returns MOVE_NONE).
 Move MovePicker::next_move_pc() {
 
   if (stage == PROBCUT_TT) {
@@ -157,7 +159,7 @@ Move MovePicker::next_move_pc() {
   }
 
   if (stage == PROBCUT_INIT) {
-      cur = endBadCaptures = moves;
+      cur = moves;
       endMoves = generate<CAPTURES>(pos, cur);
 
       score<CAPTURES>();
@@ -165,9 +167,6 @@ Move MovePicker::next_move_pc() {
   }
 
   return select<Best>([&](){ return pos.see_ge(move, threshold); });
-
-  assert(false);
-  return MOVE_NONE; // Silence warning
 }
 
 /// MovePicker::next_move() is the most important method of the MovePicker class. It

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -128,6 +128,7 @@ public:
                                            Move,
                                            Move*);
   Move next_move(bool skipQuiets = false);
+  Move next_move_pc();
 
 private:
   template<PickType T, typename Pred> Move select(Pred);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -839,7 +839,7 @@ namespace {
         MovePicker mp(pos, ttMove, raisedBeta - ss->staticEval, &thisThread->captureHistory);
         int probCutCount = 0;
 
-        while (  (move = mp.next_move()) != MOVE_NONE
+        while (  (move = mp.next_move_pc()) != MOVE_NONE
                && probCutCount < 3)
             if (move != excludedMove && pos.legal(move))
             {


### PR DESCRIPTION
This is non-functional and is faster on my machines.  Opening a PR so others can verify the speed.

We spend about 17% of our total execution time in next_move and it looks like our LARGE switch statement may not be that fast.

./stockfish_master bench 128 1 7 current perft -----------> AVE: 19420ms
./stockfish_patch bench 128 1 7 current perft ------------> AVE: 19140ms

Perhaps more speed could be gained by breaking out others into main, evasion, and qsearch?
