### PR TITLE
Simplify KingRing Calculations

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -259,11 +259,11 @@ namespace {
 
     // Init our king safety tables
     Square ksq = pos.square<KING>(Us);
-    kingRing[Us] = attackedBy[Us][KING]
-                 | bool(Rank1BB & ksq) * shift<NORTH>(kingRing[Us])
-                 | bool(Rank8BB & ksq) * shift<SOUTH>(kingRing[Us])
-                 | bool(FileABB & ksq) * shift< EAST>(kingRing[Us])
-                 | bool(FileHBB & ksq) * shift< WEST>(kingRing[Us]);
+    kingRing[Us] = attackedBy[Us][KING];
+    kingRing[Us] |= bool(Rank1BB & ksq) * shift<NORTH>(kingRing[Us])
+                 |  bool(Rank8BB & ksq) * shift<SOUTH>(kingRing[Us])
+                 |  bool(FileABB & ksq) * shift< EAST>(kingRing[Us])
+                 |  bool(FileHBB & ksq) * shift< WEST>(kingRing[Us]);
 
     kingAttackersCount[Them] = popcount(kingRing[Us] & pe->pawn_attacks(Them));
     kingRing[Us] &= ~double_pawn_attacks_bb<Us>(pos.pieces(Us, PAWN));

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -259,15 +259,12 @@ namespace {
     attackedBy2[Us]            = attackedBy[Us][KING] & attackedBy[Us][PAWN];
 
     // Init our king safety tables
+    Square ksq = pos.square<KING>(Us);
     kingRing[Us] = attackedBy[Us][KING];
-    if (relative_rank(Us, pos.square<KING>(Us)) == RANK_1)
-        kingRing[Us] |= shift<Up>(kingRing[Us]);
-
-    if (file_of(pos.square<KING>(Us)) == FILE_H)
-        kingRing[Us] |= shift<WEST>(kingRing[Us]);
-
-    else if (file_of(pos.square<KING>(Us)) == FILE_A)
-        kingRing[Us] |= shift<EAST>(kingRing[Us]);
+    kingRing[Us] |= bool(Rank1BB & ksq) * shift<NORTH>(kingRing[Us])
+                 |  bool(Rank8BB & ksq) * shift<SOUTH>(kingRing[Us])
+                 |  bool(FileABB & ksq) * shift< EAST>(kingRing[Us])
+                 |  bool(FileHBB & ksq) * shift< WEST>(kingRing[Us]);
 
     kingAttackersCount[Them] = popcount(kingRing[Us] & pe->pawn_attacks(Them));
     kingRing[Us] &= ~double_pawn_attacks_bb<Us>(pos.pieces(Us, PAWN));

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -260,11 +260,11 @@ namespace {
 
     // Init our king safety tables
     Square ksq = pos.square<KING>(Us);
-    kingRing[Us] = attackedBy[Us][KING];
-    kingRing[Us] |= bool(Rank1BB & ksq) * shift<NORTH>(kingRing[Us])
-                 |  bool(Rank8BB & ksq) * shift<SOUTH>(kingRing[Us])
-                 |  bool(FileABB & ksq) * shift< EAST>(kingRing[Us])
-                 |  bool(FileHBB & ksq) * shift< WEST>(kingRing[Us]);
+    kingRing[Us] = attackedBy[Us][KING]
+                 | bool(Rank1BB & ksq) * shift<NORTH>(kingRing[Us])
+                 | bool(Rank8BB & ksq) * shift<SOUTH>(kingRing[Us])
+                 | bool(FileABB & ksq) * shift< EAST>(kingRing[Us])
+                 | bool(FileHBB & ksq) * shift< WEST>(kingRing[Us]);
 
     kingAttackersCount[Them] = popcount(kingRing[Us] & pe->pawn_attacks(Them));
     kingRing[Us] &= ~double_pawn_attacks_bb<Us>(pos.pieces(Us, PAWN));

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -241,7 +241,6 @@ namespace {
   void Evaluation<T>::initialize() {
 
     constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
-    constexpr Direction Up   = (Us == WHITE ? NORTH : SOUTH);
     constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
     constexpr Bitboard LowRanks = (Us == WHITE ? Rank2BB | Rank3BB: Rank7BB | Rank6BB);
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -261,8 +261,8 @@ namespace {
     Square ksq = pos.square<KING>(Us);
     kingRing[Us] = attackedBy[Us][KING];
     kingRing[Us] |= bool(Rank1BB & ksq) * shift<NORTH>(kingRing[Us])
-                 |  bool(Rank8BB & ksq) * shift<SOUTH>(kingRing[Us])
-                 |  bool(FileABB & ksq) * shift< EAST>(kingRing[Us])
+                 |  bool(Rank8BB & ksq) * shift<SOUTH>(kingRing[Us]);
+    kingRing[Us] |= bool(FileABB & ksq) * shift< EAST>(kingRing[Us])
                  |  bool(FileHBB & ksq) * shift< WEST>(kingRing[Us]);
 
     kingAttackersCount[Them] = popcount(kingRing[Us] & pe->pawn_attacks(Them));


### PR DESCRIPTION
This is non-functional and untested.

Removes all branching and I think uses less instructions than master.

An earlier version of this (that also shifted down Rank8) passed STC , but this version uses less instructions and is non-functional.  Do I need to test?

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 83570 W: 18130 L: 18130 D: 47310
http://tests.stockfishchess.org/tests/view/5c2b048f0ebc592815d81fa8