### PR TITLE
Simplify generate_castling

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -25,8 +25,8 @@
 
 namespace {
 
-  template<Color Us, CastlingSide Cs, bool Checks, bool Chess960>
-  ExtMove* generate_castling(const Position& pos, ExtMove* moveList) {
+  template<Color Us, CastlingSide Cs, bool Checks>
+  ExtMove* generate_castling(const Position& pos, ExtMove* moveList, bool Chess960) {
 
     constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
     constexpr CastlingRight Cr = Us | Cs;
@@ -279,16 +279,8 @@ namespace {
 
     if (Type != CAPTURES && Type != EVASIONS && pos.castling_rights(Us))
     {
-        if (pos.is_chess960())
-        {
-            moveList = generate_castling<Us, KING_SIDE, Checks, true>(pos, moveList);
-            moveList = generate_castling<Us, QUEEN_SIDE, Checks, true>(pos, moveList);
-        }
-        else
-        {
-            moveList = generate_castling<Us, KING_SIDE, Checks, false>(pos, moveList);
-            moveList = generate_castling<Us, QUEEN_SIDE, Checks, false>(pos, moveList);
-        }
+        moveList = generate_castling<Us, KING_SIDE, Checks>(pos, moveList, pos.is_chess960());
+        moveList = generate_castling<Us, QUEEN_SIDE, Checks>(pos, moveList, pos.is_chess960());
     }
 
     return moveList;


### PR DESCRIPTION
This is non-functional.

My intuition says this should be slower, but it's about 1% faster on my machines and removes 8 lines of code.  STC tests seems to indicate similar performance.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 11738 W: 2637 L: 2496 D: 6605
http://tests.stockfishchess.org/tests/view/5c2be4000ebc596a450b9318