### PR TITLE
tablebase file checks (#1911)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -86,7 +86,9 @@ Currently, Stockfish has the following UCI options:
     Example: `C:\tablebases\wdl345;C:\tablebases\wdl6;D:\tablebases\dtz345;D:\tablebases\dtz6`
     
     It is recommended to store .rtbw files on an SSD. There is no loss in storing 
-    the .rtbz files on a regular HD.
+    the .rtbz files on a regular HD. It is recommended to verify all md5 checksums of the
+    downloaded tablebase files (`md5sum -c checksum.md5`) as corruption will lead to
+    engine crashes.
 
   * #### SyzygyProbeDepth
     Minimum remaining search depth for which a position is probed. Set this option

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -215,6 +215,11 @@ public:
 
         fstat(fd, &statbuf);
         *mapping = statbuf.st_size;
+        if (statbuf.st_size % 64 != 16)
+        {
+            std::cerr << "Corrupt tablebase file " << fname << std::endl;
+            exit(1);
+        }
         *baseAddress = mmap(nullptr, statbuf.st_size, PROT_READ, MAP_SHARED, fd, 0);
         madvise(*baseAddress, statbuf.st_size, MADV_RANDOM);
         ::close(fd);
@@ -233,6 +238,11 @@ public:
 
         DWORD size_high;
         DWORD size_low = GetFileSize(fd, &size_high);
+        if (size_low % 64 != 16)
+        {
+            std::cerr << "Corrupt tablebase file " << fname << std::endl;
+            exit(1);
+        }
         HANDLE mmap = CreateFileMapping(fd, nullptr, PAGE_READONLY, size_high, size_low, nullptr);
         CloseHandle(fd);
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -214,12 +214,12 @@ public:
             return *baseAddress = nullptr, nullptr;
 
         fstat(fd, &statbuf);
-        *mapping = statbuf.st_size;
         if (statbuf.st_size % 64 != 16)
         {
             std::cerr << "Corrupt tablebase file " << fname << std::endl;
             exit(1);
         }
+        *mapping = statbuf.st_size;
         *baseAddress = mmap(nullptr, statbuf.st_size, PROT_READ, MAP_SHARED, fd, 0);
         madvise(*baseAddress, statbuf.st_size, MADV_RANDOM);
         ::close(fd);


### PR DESCRIPTION
this addresses partially issue #1911 in that it documents the command for verifying the md5sum of downloaded tablebase files.

Additionally, a quick check of the file size (the size of each tb file modulo 64 is 16 as pointed out by @syzygy1) has been implemented.

No functional change.