### PR TITLE
Consolidate some duplicated code in MovePicker

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -52,7 +52,8 @@ namespace {
 } // namespace
 
 template<GenType Type>
-void MovePicker::generate_score() {
+void MovePicker::generate_score(ExtMove* m) {
+      cur = m;
       endMoves = generate<Type>(pos, cur);
       score<Type>();
       ++stage;
@@ -173,8 +174,8 @@ top:
   case CAPTURE_INIT:
   case PROBCUT_INIT:
   case QCAPTURE_INIT:
-      cur = endBadCaptures = moves;
-      generate_score<CAPTURES>();
+      endBadCaptures = moves;
+      generate_score<CAPTURES>(moves);
       goto top;
 
   case GOOD_CAPTURE:
@@ -205,8 +206,7 @@ top:
       /* fallthrough */
 
   case QUIET_INIT:
-      cur = endBadCaptures;
-      generate_score<QUIETS>();
+      generate_score<QUIETS>(endBadCaptures);
       partial_insertion_sort(cur, endMoves, -4000 * depth / ONE_PLY);
       /* fallthrough */
 
@@ -228,8 +228,7 @@ top:
       return select<Next>(Any);
 
   case EVASION_INIT:
-      cur = moves;
-      generate_score<EVASIONS>();
+      generate_score<EVASIONS>(moves);
       /* fallthrough */
 
   case EVASION:

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -51,6 +51,12 @@ namespace {
 
 } // namespace
 
+template<GenType Type>
+void MovePicker::generate_score() {
+      endMoves = generate<Type>(pos, cur);
+      score<Type>();
+      ++stage;
+}
 
 /// Constructors of the MovePicker class. As arguments we pass information
 /// to help it to return the (presumably) good moves first, to decide which
@@ -168,10 +174,7 @@ top:
   case PROBCUT_INIT:
   case QCAPTURE_INIT:
       cur = endBadCaptures = moves;
-      endMoves = generate<CAPTURES>(pos, cur);
-
-      score<CAPTURES>();
-      ++stage;
+      generate_score<CAPTURES>();
       goto top;
 
   case GOOD_CAPTURE:
@@ -203,11 +206,8 @@ top:
 
   case QUIET_INIT:
       cur = endBadCaptures;
-      endMoves = generate<QUIETS>(pos, cur);
-
-      score<QUIETS>();
+      generate_score<QUIETS>();
       partial_insertion_sort(cur, endMoves, -4000 * depth / ONE_PLY);
-      ++stage;
       /* fallthrough */
 
   case QUIET:
@@ -229,10 +229,7 @@ top:
 
   case EVASION_INIT:
       cur = moves;
-      endMoves = generate<EVASIONS>(pos, cur);
-
-      score<EVASIONS>();
-      ++stage;
+      generate_score<EVASIONS>();
       /* fallthrough */
 
   case EVASION:

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -128,14 +128,14 @@ public:
                                            Move,
                                            Move*);
   Move next_move(bool skipQuiets = false);
+template<GenType>
+  void inline generate_score(ExtMove* m);
 
 private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }
-template<GenType>
-  void inline generate_score();
 
   const Position& pos;
   const ButterflyHistory* mainHistory;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -134,6 +134,8 @@ private:
   template<GenType> void score();
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }
+template<GenType>
+  void inline generate_score();
 
   const Position& pos;
   const ButterflyHistory* mainHistory;


### PR DESCRIPTION
This is non-functional.

Just consolidate some move generation and scoring.  The inlined function should not be any slower, but it did take longer than usual time to pass.  It also cleans up the next_move method a bit.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 97822 W: 21374 L: 21402 D: 55046 
http://tests.stockfishchess.org/tests/view/5c2ce1c80ebc596a450ba499