### PR TITLE
Introduce non-singular cut node pruning.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -951,11 +951,11 @@ moves_loop: // When in check, search starts from here
           if (value < singularBeta)
               extension = ONE_PLY;
 
-          // Non-singular cut node pruning
-          // If we can fail high on lower depth searches for more than one move,
-          // we can prune on a cut node. In this case, our ttMove fails high and
-          // even if we exclude it, we have proven that we can still fail high
-          // on another move based on our lower depth search.
+          // Multi-cut pruning
+          // Our ttMove is assumed to fail high, and now we failed high also on a reduced
+          // search without the ttMove. So we assume this expected Cut-node is not singular,
+          // that is multiple moves fail high, and we can prune the whole subtree by returning
+          // the hard beta bound.
           else if (cutNode && singularBeta > beta)
               return beta;
       }


### PR DESCRIPTION
This was inspired after reading about [Multi-Cut](https://www.chessprogramming.org/Multi-Cut).

The idea is to prune when we have a "backup plan" in case our expected
fail high node does not fail high on the ttMove.

For singular extensions, we do a search on all other moves but the
ttMove. If this fails high on our original beta, this means that both
the ttMove, as well as at least one other move was proven to fail high
on a lower depth search. We then assume that one of these moves will
work on a higher depth and prune.

STC:
LLR: 2.96 (-2.94,2.94) [0.50,4.50]
Total: 72952 W: 16104 L: 15583 D: 41265
http://tests.stockfishchess.org/tests/view/5c3119640ebc596a450c0be5

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 27103 W: 4564 L: 4314 D: 18225
http://tests.stockfishchess.org/tests/view/5c3184c00ebc596a450c1662

Bench: 3145487