### PR TITLE
Add KNNvKP Endgame Heuristic.

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -286,6 +286,20 @@ Value Endgame<KQKR>::operator()(const Position& pos) const {
 }
 
 
+/// KNN vs KP. Simply push the opposing king to the corner.
+template<>
+Value Endgame<KNNKP>::operator()(const Position& pos) const {
+
+	assert(verify_material(pos, strongSide, 2 * KnightValueMg, 0));
+	assert(verify_material(pos, weakSide, VALUE_ZERO, 1));
+
+	Value result =  2 * KnightValueEg - PawnValueEg 
+		          + PushToEdges[pos.square<KING>(weakSide)];
+
+	return strongSide == pos.side_to_move() ? result : -result;
+}
+
+
 /// Some cases of trivial draws
 template<> Value Endgame<KNNK>::operator()(const Position&) const { return VALUE_DRAW; }
 

--- a/src/endgame.h
+++ b/src/endgame.h
@@ -37,6 +37,7 @@ enum EndgameCode {
 
   EVALUATION_FUNCTIONS,
   KNNK,  // KNN vs K
+  KNNKP, // KNN vs KP
   KXK,   // Generic "mate lone king" eval
   KBNK,  // KBN vs K
   KPK,   // KP vs K
@@ -125,6 +126,7 @@ public:
     add<KRKN>("KRKN");
     add<KQKP>("KQKP");
     add<KQKR>("KQKR");
+	add<KNNKP>("KNNKP");
 
     add<KNPK>("KNPK");
     add<KNPKB>("KNPKB");


### PR DESCRIPTION
This is a somewhat different patch. It fixes blindspots in SF's two knights vs pawn endgame.

With local testing starting from random KNNvKP positions where the pawn has not advanced beyond the 4th rank (thanks @protonspring !) at 15+0.15 (4 cores), this went +105=868-27 against master. All except two losses were won in reverse.

The heuristic is simple but effective - the strategy in these endgames is to push the opposing king to the corner, then move the knight that's blocking the pawn in for the checkmate while the pawn is free to move and prevents stalemate. This patch gives SF the little boost it needs to search the relevant king-cornering mating lines.

Bench: 3851738