### PR TITLE
Remove pvExact

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -578,7 +578,7 @@ namespace {
     Depth extension, newDepth;
     Value bestValue, value, ttValue, eval, maxValue, pureStaticEval;
     bool ttHit, pvHit, inCheck, givesCheck, improving;
-    bool captureOrPromotion, doFullDepthSearch, moveCountPruning, skipQuiets, ttCapture, pvExact;
+    bool captureOrPromotion, doFullDepthSearch, moveCountPruning, skipQuiets, ttCapture;
     Piece movedPiece;
     int moveCount, captureCount, quietCount;
 
@@ -677,7 +677,7 @@ namespace {
         return ttValue;
     }
 
-    if (   depth > 6 * ONE_PLY
+    if (   depth > 4 * ONE_PLY
         && !excludedMove
         && PvNode)
         pvHit = true;
@@ -898,7 +898,6 @@ moves_loop: // When in check, search starts from here
 
     skipQuiets = false;
     ttCapture = ttMove && pos.capture_or_promotion(ttMove);
-    pvExact = PvNode && ttHit && tte->bound() == BOUND_EXACT;
 
     // Step 12. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
@@ -1043,7 +1042,7 @@ moves_loop: // When in check, search starts from here
           Depth r = reduction<PvNode>(improving, depth, moveCount);
 
           // Decrease reduction if position is or has been on the PV
-          if (pvHit && !PvNode)
+          if (pvHit)
               r -= ONE_PLY;
 
           // Decrease reduction if opponent's move count is high (~10 Elo)
@@ -1052,10 +1051,6 @@ moves_loop: // When in check, search starts from here
 
           if (!captureOrPromotion)
           {
-              // Decrease reduction for exact PV nodes (~0 Elo)
-              if (pvExact)
-                  r -= ONE_PLY;
-
               // Increase reduction if ttMove is a capture (~0 Elo)
               if (ttCapture)
                   r += ONE_PLY;


### PR DESCRIPTION
now overlaps with the pvHit concept. Small tweaks to have pvHit trigger where pvExact previously triggered.

passed STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 20558 W: 4497 L: 4373 D: 11688
http://tests.stockfishchess.org/tests/view/5c36e9fd0ebc596a450c7885

passed LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 23482 W: 3888 L: 3772 D: 15822
http://tests.stockfishchess.org/tests/view/5c37072d0ebc596a450c7a52

Bench: 3739723