### PR TITLE
Dbg_pring_formatting

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -154,11 +154,11 @@ void dbg_mean_of(int v) { ++means[0]; means[1] += v; }
 void dbg_print() {
 
   if (hits[0])
-      cerr << "Total " << hits[0] << " Hits " << hits[1]
-           << " hit rate (%) " << 100 * hits[1] / hits[0] << endl;
+      cerr << "Total:" << hits[0] << " Hits:" << hits[1]
+           << " Hit rate:" << 100 * double(hits[1]) / hits[0] <<"% " << endl;
 
   if (means[0])
-      cerr << "Total " << means[0] << " Mean "
+      cerr << "Total:" << means[0] << " Mean:"
            << (double)means[1] / means[0] << endl;
 }
 


### PR DESCRIPTION
Change dbg_print to use a  better format and floating point percents.
Example New:
Total:6934970 Hits:226545 Hit rate:3.2667% 
Total:6934970 Mean:50.2187
Example master:
Total 6807287 Hits 220536 hit rate (%) 3
Total 6807287 Mean 52.6394

No functional change.