### PR TITLE
Penalty if our king is attacked by our minors.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -156,6 +156,7 @@ namespace {
   constexpr Score CloseEnemies       = S(  8,  0);
   constexpr Score CorneredBishop     = S( 50, 50);
   constexpr Score Hanging            = S( 69, 36);
+  constexpr Score HinderMinor        = S( 10, 15);
   constexpr Score KingProtector      = S(  7,  8);
   constexpr Score KnightOnQueen      = S( 16, 12);
   constexpr Score LongDiagonalBishop = S( 45,  0);
@@ -477,6 +478,9 @@ namespace {
     // Transform the kingDanger units into a Score, and subtract it from the evaluation
     if (kingDanger > 0)
         score -= make_score(kingDanger * kingDanger / 4096, kingDanger / 16);
+    // Penalty if our king hinders the mobility of a minor.
+    else if ((attackedBy[Us][BISHOP] | attackedBy[Us][KNIGHT]) & ksq)
+        score -= HinderMinor;
 
     // Penalty when our king is on a pawnless flank
     if (!(pos.pieces(PAWN) & kingFlank))

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -478,6 +478,9 @@ namespace {
     // Transform the kingDanger units into a Score, and subtract it from the evaluation
     if (kingDanger > 0)
         score -= make_score(kingDanger * kingDanger / 4096, kingDanger / 16);
+
+    // The king is not in danger, so try some heuristics to improve gameplay
+    // that make sense only if the king is already safe.
     // Penalty if our king hinders the mobility of a minor.
     else if ((attackedBy[Us][BISHOP] | attackedBy[Us][KNIGHT]) & ksq)
         score -= HinderMinor;


### PR DESCRIPTION
On https://github.com/ElbertoOne/Stockfish/compare/f69106f...d370c47 @ElbertoOne indicated that "I don't have time and access to open a PR. I have time on Monday. If someone else would open a PR I'm fine with that."  With the conclusion of Division P of TCEC estimated to be only about three days away, and with Stockfish currently very likely to participate in the Superfinal, I have opened this PR to facilitate the commit of this Elo-gainer before the engine submission deadline.  Full authorship credit for this patch belongs to @ElbertoOne.  I also thank @mcostalba for the insightful discussion and improved comment in this patch.

This patch was motivated by the following position:
`3r4/rp2qpk1/1Np1pb2/Pn4p1/3P2Pp/3RP2P/4QP2/3RB1K1 b - - 5 47`
The best move is Kh6, giving the bishop greater mobility.

We introduce a simple S(10, 15) penalty if our minors attack our king.  Notably, we only do so if we are not currently under significant kingDanger, because this patch motivates the king to move away from a bishop or knight that is defending it, which would be reckless during an enemy attack.  There is some evidence that consideration of kingDanger is important for this penalty, that is, applying it regardless of kingDanger is worse than this PR:
http://tests.stockfishchess.org/tests/view/5c3991ca0ebc596a450ca80f
To describe this patch simply: "If it is safe to do so, make sure our king gives our bishops and knights some space to be mobile."

Where can we go from here? @ElbertoOne proposed:

- The penalty values are currently guesswork and may benefit from tuning.
- We may want to refine the logic of this penalty, especially for bishops. For instance, a bishop on g2 and a king on h1 gets the penalty, but perhaps should not. Ideally, the penalty should be given if the mobility of the piece is low.
- Maybe this also works for other pieces like rooks and queens.

STC:
LLR: 2.96 (-2.94,2.94) [0.50,4.50]
Total: 34206 W: 7614 L: 7282 D: 19310
http://tests.stockfishchess.org/tests/view/5c35bd500ebc596a450c6406

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 186368 W: 31243 L: 30548 D: 124577
http://tests.stockfishchess.org/tests/view/5c35f4bb0ebc596a450c682d

Bench: 4024176