### PR TITLE
Clean-up some shifting in space calculation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -714,8 +714,8 @@ namespace {
 
     // Find all squares which are at most three squares behind some friendly pawn
     Bitboard behind = pos.pieces(Us, PAWN);
-    for (int s = 0; s < 3; ++s)
-        behind |= shift<Down>(behind);
+    behind |= shift<Down>(behind);
+    behind |= shift<Down>(shift<Down>(behind));
 
     int bonus = popcount(safe) + popcount(behind & safe);
     int weight =  pos.count<ALL_PIECES>(Us)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -701,7 +701,8 @@ namespace {
     if (pos.non_pawn_material() < SpaceThreshold)
         return SCORE_ZERO;
 
-    constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
+    constexpr Color Them     = (Us == WHITE ? BLACK : WHITE);
+    constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
     constexpr Bitboard SpaceMask =
       Us == WHITE ? CenterFiles & (Rank2BB | Rank3BB | Rank4BB)
                   : CenterFiles & (Rank7BB | Rank6BB | Rank5BB);
@@ -713,8 +714,8 @@ namespace {
 
     // Find all squares which are at most three squares behind some friendly pawn
     Bitboard behind = pos.pieces(Us, PAWN);
-    behind |= (Us == WHITE ? behind >>  8 : behind <<  8);
-    behind |= (Us == WHITE ? behind >> 16 : behind << 16);
+    for (int s = 0; s < 3; ++s)
+        behind |= shift<Down>(behind);
 
     int bonus = popcount(safe) + popcount(behind & safe);
     int weight =  pos.count<ALL_PIECES>(Us)


### PR DESCRIPTION
This is non-functional code style change.  The code in master is a bit hoky here (to me).

I believe this patch is more readable and more consistent with how we shift bitboards in other places.  I wouldn't expect any performance difference, but the STC passed rather quickly.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 13588 W: 3033 L: 2896 D: 7659
http://tests.stockfishchess.org/tests/view/5c4010370ebc5902bb5cf1b5