### PR TITLE
Simplify thread skipping scheme.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -61,10 +61,6 @@ namespace {
   // Different node types, used as a template parameter
   enum NodeType { NonPV, PV };
 
-  // Sizes and phases of the skip-blocks, used for distributing search depths across the threads
-  constexpr int SkipSize[]  = { 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4 };
-  constexpr int SkipPhase[] = { 0, 1, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7 };
-
   // Razor and futility margins
   constexpr int RazorMargin = 600;
   Value futility_margin(Depth d, bool improving) {
@@ -357,12 +353,10 @@ void Thread::search() {
          && !(Limits.depth && mainThread && rootDepth / ONE_PLY > Limits.depth))
   {
       // Distribute search depths across the helper threads
-      if (idx > 0)
-      {
-          int i = (idx - 1) % 20;
-          if (((rootDepth / ONE_PLY + SkipPhase[i]) / SkipSize[i]) % 2)
-              continue;  // Retry with an incremented rootDepth
-      }
+      // (approx. 6 Elo on 8 threads, with short TC)
+      int skipSize = int(std::log(idx + 2) / std::log(2.26));
+      if (skipSize && (rootDepth / ONE_PLY + idx + 1) / skipSize % 2)
+          continue;  // Retry with an incremented rootDepth
 
       // Age out PV variability metric
       if (mainThread)


### PR DESCRIPTION
replaces the current scheme of distributing threads with a simplified form. This form doesn't depend on two parameter arrays, which are quite arbitrarily set to length 20. Quite a number of tests have been performed to quantify the performance of this and related schemes, which summarized below

The precise form of this patch was tested

[-3, 1] @ 5+0.05 th 4
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 11879 W: 2569 L: 2429 D: 6881
http://tests.stockfishchess.org/tests/view/5c4566f80ebc5902bb5d5696

[-3, 1] @ 5+0.05 th 8
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 14558 W: 2859 L: 2726 D: 8973
http://tests.stockfishchess.org/tests/view/5c4574d60ebc5902bb5d577f

both suggesting a moderate Elo gain relative to master.

The current master Elo gain due to skipping was measured by disabling this feature:
20000 @ 5+0.05 th 8
ELO: -4.93 +-3.0 (95%) LOS: 0.1%
Total: 20000 W: 3758 L: 4042 D: 12200
http://tests.stockfishchess.org/tests/view/5c4069350ebc5902bb5cfd9b

and confirmed by a sprt run removing the feature that failed quickly:
LLR: -2.95 (-2.94,2.94) [-3.00,1.00]  @ 5+0.05 th 8
Total: 5042 W: 880 L: 1047 D: 3115
http://tests.stockfishchess.org/tests/view/5c439a020ebc5902bb5d3970

however, this might be TC dependent, and at longer TC the feature seems worth much less Elo.
A running test (removal of skipping) indicates it might be Elo neutral at longer TC:
LLR: 0.07 (-2.94,2.94) [-3.00,1.00] @ 20+0.2 th 8
Total: 16000 W: 2535 L: 2556 D: 10909
http://tests.stockfishchess.org/tests/view/5c44b1b70ebc5902bb5d4e34

It was suggested in the comments that now, with thread-local histories, the feature might be worth less
than at its introduction.

A very similar earlier version of the patch (different skipSize for 1 thread, otherwise the same, but testing as weaker with few threads),
passed testing with 31 threads. Given this patch is strong on 4 and 8 threads, it provides good enough evidence
for many thread performance (taking into account both the cost of testing, and the importance of this feature at long TC):

LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 48654 W: 8169 L: 8093 D: 32392
http://tests.stockfishchess.org/tests/view/5c4574d60ebc5902bb5d577f

Finally, just SkipPhase removal was tested by protonspring (#1835):

STC (+1 offset) (3 threads)
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 28428 W: 6278 L: 6170 D: 15980
http://tests.stockfishchess.org/tests/view/5bfe01c20ebc5902bceda021

STC (+1 offset) (8 threads)
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 26002 W: 5082 L: 4970 D: 15950
http://tests.stockfishchess.org/tests/view/5bfe132c0ebc5902bceda12f

and the skipSize replacement further extends this idea.

On 1 thread this patch is

No functional change