### PR TITLE
Don't update pvHit after IID

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -872,7 +872,6 @@ namespace {
         tte = TT.probe(posKey, ttHit);
         ttValue = ttHit ? value_from_tt(tte->value(), ss->ply) : VALUE_NONE;
         ttMove = ttHit ? tte->move() : MOVE_NONE;
-        pvHit = ttHit && tte->pv_hit();
     }
 
 moves_loop: // When in check, search starts from here


### PR DESCRIPTION
STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 62756 W: 13787 L: 13746 D: 35223
http://tests.stockfishchess.org/tests/view/5c446c850ebc5902bb5d4b75

LTC
LLR: 3.19 (-2.94,2.94) [-3.00,1.00]
Total: 61900 W: 10179 L: 10111 D: 41610
http://tests.stockfishchess.org/tests/view/5c45bf610ebc5902bb5d5d62

Bench testing at depth 22 shows that this line never changes the value of pvHit at NonPV nodes, while at PV nodes it often changes the value from true to false (and never the reverse). This is because the definition of pvHit at line 642 is `pvHit = (ttHit && tte->pv_hit()) || (PvNode && depth > 4 * ONE_PLY);`, while the assignment after IID omits the `(PvNode && depth > 4 * ONE_PLY)` condition.

As such, unlike the other two post-IID tte reads, this line of code does not make SF's state more consistent, but rather introduces an inconsistency in the definition of pvHit. Indeed, changing line 875 to `pvHit = (ttHit && tte->pv_hit()) || (PvNode && depth > 4 * ONE_PLY);` to match line 642 is functionally equivalent to removing it entirely as this patch does.

Bench: 3646114