### PR TITLE
[Cluster] Use a sendrecv ring instead of allgather

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -91,7 +91,7 @@ int rank();
 inline bool is_root() { return rank() == 0; }
 void save(Thread* thread, TTEntry* tte, Key k, Value v, bool PvHit, Bound b, Depth d, Move m, Value ev);
 void pick_moves(MoveInfo& mi, std::string& PVLine);
-void ttRecvBuff_resize(size_t nThreads);
+void ttSendRecvBuff_resize(size_t nThreads);
 uint64_t nodes_searched();
 uint64_t tb_hits();
 uint64_t TT_saves();
@@ -110,7 +110,7 @@ constexpr int rank() { return 0; }
 constexpr bool is_root() { return true; }
 inline void save(Thread*, TTEntry* tte, Key k, Value v, bool PvHit, Bound b, Depth d, Move m, Value ev) { tte->save(k, v, PvHit, b, d, m, ev); }
 inline void pick_moves(MoveInfo&, std::string&) { }
-inline void ttRecvBuff_resize(size_t) { }
+inline void ttSendRecvBuff_resize(size_t) { }
 uint64_t nodes_searched();
 uint64_t tb_hits();
 uint64_t TT_saves();

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -141,7 +141,7 @@ void ThreadPool::set(size_t requested) {
       TT.resize(Options["Hash"]);
 
       // Adjust cluster buffers
-      Cluster::ttRecvBuff_resize(requested);
+      Cluster::ttSendRecvBuff_resize(requested);
   }
 }
 


### PR DESCRIPTION
Using point to point instead of a collective improves performance, and might be more flexible for future improvements.
Also corrects the condition for the number elements required to fill the send buffer.

The actual Elo gains depends a bit on the setup used for testing.

8mpi x 32t yields 141 - 102 - 957 ~ 11 Elo
8mpi x 1t yields 70 +- 9 Elo.