### PR TITLE
Use a simple sigmoid for move_importance

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -37,10 +37,7 @@ namespace {
   constexpr double StealRatio = 0.34; // However we must not steal time from remaining moves over this ratio
 
 
-  // move_importance() is a skew-logistic function based on naive statistical
-  // analysis of "how many games are still undecided after n half-moves". Game
-  // is considered "undecided" as long as neither side has >275cp advantage.
-  // Data was extracted from the CCRL game database with some simple filtering criteria.
+  // A sigmoid function indicating how "important" a move is based on ply.
 
   double move_importance(int ply) {
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -44,11 +44,8 @@ namespace {
 
   double move_importance(int ply) {
 
-    constexpr double XScale = 6.85;
-    constexpr double XShift = 64.5;
-    constexpr double Skew   = 0.171;
-
-    return pow((1 + exp((ply - XShift) / XScale)), -Skew) + DBL_MIN; // Ensure non-zero
+    double mid = (ply - 97.0) / 45.0;
+    return 0.5 - (mid / std::sqrt(1.0 + mid * mid)) / 2.0;
   }
 
   template<TimeType T>


### PR DESCRIPTION
This is a non-functional simplification.  This simple sigmoid equation does as well as master, but it is mathematically more simple.

I few early version passed STC quickly, but failed LTC.  This version was tuned at LTC and tested at LTC.

LTC
LLR: 2.97 (-2.94,2.94) [-3.00,1.00]
Total: 33286 W: 5504 L: 5402 D: 22380
http://tests.stockfishchess.org/tests/view/5c4a9e460ebc593af5d48c31