### PR TITLE
Skip skipping thread scheme

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -61,10 +61,6 @@ namespace {
   // Different node types, used as a template parameter
   enum NodeType { NonPV, PV };
 
-  // Sizes and phases of the skip-blocks, used for distributing search depths across the threads
-  constexpr int SkipSize[]  = { 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4 };
-  constexpr int SkipPhase[] = { 0, 1, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7 };
-
   // Razor and futility margins
   constexpr int RazorMargin = 600;
   Value futility_margin(Depth d, bool improving) {
@@ -356,14 +352,6 @@ void Thread::search() {
          && !Threads.stop
          && !(Limits.depth && mainThread && rootDepth / ONE_PLY > Limits.depth))
   {
-      // Distribute search depths across the helper threads
-      if (idx > 0)
-      {
-          int i = (idx - 1) % 20;
-          if (((rootDepth / ONE_PLY + SkipPhase[i]) / SkipSize[i]) % 2)
-              continue;  // Retry with an incremented rootDepth
-      }
-
       // Age out PV variability metric
       if (mainThread)
           mainThread->bestMoveChanges *= 0.517, failedLow = false;


### PR DESCRIPTION
Several simplification tests (all with the bounds [-3,1]) were run:
5+0.05 8 threads, failed very quickly:
http://tests.stockfishchess.org/tests/view/5c439a020ebc5902bb5d3970
20+0.2 8 threads, also failed, but needed a lot more games:
http://tests.stockfishchess.org/tests/view/5c44b1b70ebc5902bb5d4e34
60+0.6 8 threads passed:
http://tests.stockfishchess.org/tests/view/5c48bfe40ebc5902bca15325
60+0.6 4 threads passed:
http://tests.stockfishchess.org/tests/view/5c4b71a00ebc593af5d49904

I think removing the feature is better, than running simplification tests against the skipping scheme of current master.