### PR TITLE
Simplify Distance methods and remove templates

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -111,7 +111,7 @@ void Bitboards::init() {
       for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2)
           if (s1 != s2)
           {
-              SquareDistance[s1][s2] = std::max(distance<File>(s1, s2), distance<Rank>(s1, s2));
+              SquareDistance[s1][s2] = distance(s1, s2);
               DistanceRingBB[s1][SquareDistance[s1][s2]] |= s2;
           }
 

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -111,7 +111,7 @@ void Bitboards::init() {
       for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2)
           if (s1 != s2)
           {
-              SquareDistance[s1][s2] = distance(s1, s2);
+              SquareDistance[s1][s2] = std::max(file_distance(s1,s2), rank_distance(s1,s2));
               DistanceRingBB[s1][SquareDistance[s1][s2]] |= s2;
           }
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -258,7 +258,7 @@ inline bool aligned(Square s1, Square s2, Square s3) {
 inline int distance(int x, int y) { return x < y ? y - x : x - y; }
 inline int file_distance(Square x, Square y) { return distance(file_of(x), file_of(y)); }
 inline int rank_distance(Square x, Square y) { return distance(rank_of(x), rank_of(y)); }
-inline int distance(Square x, Square y) { return std::max(file_distance(x,y), rank_distance(x,y)); }
+inline int distance(Square x, Square y) { return SquareDistance[x][y]; }
 
 
 /// attacks_bb() returns a bitboard representing all the squares attacked by a

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -255,9 +255,9 @@ inline bool aligned(Square s1, Square s2, Square s3) {
 
 /// distance() functions return the distance between x and y, defined as the
 /// number of steps for a king in x to reach y. Works with squares, ranks, files.
-inline int distance(int x, int y) { return x < y ? y - x : x - y; }
-inline int file_distance(Square x, Square y) { return distance(file_of(x), file_of(y)); }
-inline int rank_distance(Square x, Square y) { return distance(rank_of(x), rank_of(y)); }
+constexpr int distance(int x, int y) { return x < y ? y - x : x - y; }
+constexpr int file_distance(Square x, Square y) { return distance(file_of(x), file_of(y)); }
+constexpr int rank_distance(Square x, Square y) { return distance(rank_of(x), rank_of(y)); }
 inline int distance(Square x, Square y) { return SquareDistance[x][y]; }
 
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -255,13 +255,10 @@ inline bool aligned(Square s1, Square s2, Square s3) {
 
 /// distance() functions return the distance between x and y, defined as the
 /// number of steps for a king in x to reach y. Works with squares, ranks, files.
-
-template<typename T> inline int distance(T x, T y) { return x < y ? y - x : x - y; }
-template<> inline int distance<Square>(Square x, Square y) { return SquareDistance[x][y]; }
-
-template<typename T1, typename T2> inline int distance(T2 x, T2 y);
-template<> inline int distance<File>(Square x, Square y) { return distance(file_of(x), file_of(y)); }
-template<> inline int distance<Rank>(Square x, Square y) { return distance(rank_of(x), rank_of(y)); }
+inline int distance(int x, int y) { return x < y ? y - x : x - y; }
+inline int file_distance(Square x, Square y) { return distance(file_of(x), file_of(y)); }
+inline int rank_distance(Square x, Square y) { return distance(rank_of(x), rank_of(y)); }
+inline int distance(Square x, Square y) { return std::max(file_distance(x,y), rank_distance(x,y)); }
 
 
 /// attacks_bb() returns a bitboard representing all the squares attacked by a

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -419,7 +419,7 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
   if (   r == RANK_6
       && distance(bksq, queeningSq) <= 1
       && rank_of(wksq) + tempo <= RANK_6
-      && (rank_of(brsq) == RANK_1 || (!tempo && distance<File>(brsq, wpsq) >= 3)))
+      && (rank_of(brsq) == RANK_1 || (!tempo && file_distance(brsq, wpsq) >= 3)))
       return SCALE_FACTOR_DRAW;
 
   if (   r >= RANK_6
@@ -475,7 +475,7 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
   {
       if (file_of(bksq) == file_of(wpsq))
           return ScaleFactor(10);
-      if (   distance<File>(bksq, wpsq) == 1
+      if (   file_distance(bksq, wpsq) == 1
           && distance(wksq, bksq) > 2)
           return ScaleFactor(24 - 2 * distance(wksq, bksq));
   }
@@ -519,7 +519,7 @@ ScaleFactor Endgame<KRPKB>::operator()(const Position& pos) const {
       if (   rk == RANK_6
           && distance(psq + 2 * push, ksq) <= 1
           && (PseudoAttacks[BISHOP][bsq] & (psq + push))
-          && distance<File>(bsq, psq) >= 2)
+          && file_distance(bsq, psq) >= 2)
           return ScaleFactor(8);
   }
 
@@ -544,8 +544,8 @@ ScaleFactor Endgame<KRPPKRP>::operator()(const Position& pos) const {
 
   Rank r = std::max(relative_rank(strongSide, wpsq1), relative_rank(strongSide, wpsq2));
 
-  if (   distance<File>(bksq, wpsq1) <= 1
-      && distance<File>(bksq, wpsq2) <= 1
+  if (   file_distance(bksq, wpsq1) <= 1
+      && file_distance(bksq, wpsq2) <= 1
       && relative_rank(strongSide, bksq) > r)
   {
       assert(r > RANK_1 && r < RANK_7);
@@ -571,7 +571,7 @@ ScaleFactor Endgame<KPsK>::operator()(const Position& pos) const {
   // the king is within one file of the pawns, it's a draw.
   if (   !(pawns & ~forward_ranks_bb(weakSide, ksq))
       && !((pawns & ~FileABB) && (pawns & ~FileHBB))
-      &&  distance<File>(ksq, lsb(pawns)) <= 1)
+      &&  file_distance(ksq, lsb(pawns)) <= 1)
       return SCALE_FACTOR_DRAW;
 
   return SCALE_FACTOR_NONE;
@@ -639,7 +639,7 @@ ScaleFactor Endgame<KBPPKB>::operator()(const Position& pos) const {
       blockSq2 = make_square(file_of(psq1), rank_of(psq2));
   }
 
-  switch (distance<File>(psq1, psq2))
+  switch (file_distance(psq1, psq2))
   {
   case 0:
     // Both pawns are on the same file. It's an easy draw if the defender firmly

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -737,8 +737,8 @@ namespace {
   template<Tracing T>
   Score Evaluation<T>::initiative(Value eg) const {
 
-    int outflanking =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
-                     - distance<Rank>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
+    int outflanking =  file_distance(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
+                     - rank_distance(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
 
     bool pawnsOnBothFlanks =   (pos.pieces(PAWN) & QueenSide)
                             && (pos.pieces(PAWN) & KingSide);


### PR DESCRIPTION
This is a non-functional style change.

I hope I don't offend someone.  I think these templates are elegant and well-done.  I just think they are unnecessarily complex.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 27135 W: 5962 L: 5851 D: 15322
http://tests.stockfishchess.org/tests/view/5c4cda5a0ebc593af5d4a94f
