### PR TITLE
Use int8_t instead of int for SquareDistance[]

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -24,7 +24,7 @@
 #include "misc.h"
 
 uint8_t PopCnt16[1 << 16];
-int SquareDistance[SQUARE_NB][SQUARE_NB];
+int8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 Bitboard SquareBB[SQUARE_NB];
 Bitboard FileBB[FILE_NB];

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -60,7 +60,7 @@ constexpr Bitboard Rank6BB = Rank1BB << (8 * 5);
 constexpr Bitboard Rank7BB = Rank1BB << (8 * 6);
 constexpr Bitboard Rank8BB = Rank1BB << (8 * 7);
 
-extern int SquareDistance[SQUARE_NB][SQUARE_NB];
+extern int8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];
 extern Bitboard FileBB[FILE_NB];


### PR DESCRIPTION
Saves (4-1) * 64 * 64 = 12KiB of cache.

STC
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 176120 W: 38944 L: 38087 D: 99089
http://tests.stockfishchess.org/tests/view/5c4c9f840ebc593af5d4a7ce

TC	10+0.1
SPRT	elo0: 0.00  alpha: 0.05  elo1: 4.00  beta: 0.05
LLR	2.95 [-2.94,2.94] (accepted)
Elo	1.40 [-0.33,3.08] (95%)
LOS	95.0%
Games	176120 [w:22.1%, l:21.6%, d:56.3%]

LTC
As a pure speed up, I've been informed it should not require LTC.

No functional change