### PR TITLE
Simplify Stat Score bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -747,10 +747,7 @@ namespace {
     {
         if ((ss-1)->currentMove != MOVE_NULL)
         {
-            int p = (ss-1)->statScore;
-            int bonus = p > 0 ? (-p - 2500) / 512 :
-                        p < 0 ? (-p + 2500) / 512 : 0;
-
+            int bonus = -(ss-1)->statScore / 512;
             pureStaticEval = evaluate(pos);
             ss->staticEval = eval = pureStaticEval + bonus;
         }


### PR DESCRIPTION
This is a functional simplification of this statScore bonus.  It seems like I am annoying people with too many simplifications, so I'll scale it back a bit.  There seems to be little risk of regression with this one.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 26829 W: 5892 L: 5781 D: 15156 
http://tests.stockfishchess.org/tests/view/5c5086bb0ebc593af5d4db75

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 28232 W: 4684 L: 4575 D: 18973 
http://tests.stockfishchess.org/tests/view/5c50d7690ebc593af5d4dec9

bench 4001014