### PR TITLE
More precise checks evaluation in king danger

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -453,6 +453,8 @@ namespace {
 
     // Enemy bishops checks
 
+    b2 &= attackedBy[Them][BISHOP];
+
     if (b2 & safe & ~QueenSafeCheckBB)
         kingDanger += BishopSafeCheck;
     else


### PR DESCRIPTION
More precise checks evaluation in king danger

Remove overlapping safe checks from kingdanger:
- rook and queen checks from the same square: rook check is preferred
- bishop and queen checks form the same square: queen check is preferred

Increase bishop and rook check values as a compensation.

STC
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 27480 W: 6111 L: 5813 D: 15556
http://tests.stockfishchess.org/tests/view/5c521d050ebc593af5d4e66a

LTC
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 78500 W: 13145 L: 12752 D: 52603
http://tests.stockfishchess.org/tests/view/5c52b9460ebc592fc7baecc5

Closes https://github.com/official-stockfish/Stockfish/pull/1983

------------------------------------------

I have quite a few ideas of how to improve this patch.

- actually rethinking it now it will maybe be useful to discount
  queen/bishop checks if there is only one square that they can
  give check from and it's "occupied" by more valuable check. Right
  now count of this squares does not really matter.

- maybe some small extra bonus can be given for overlapping checks.

- some ideas about using popcount() on safechecks can be retried.

- tune this safecheck values since they were more or less randomly handcrafted in this patch.

Bench: 3216489