### PR TITLE
Extend discovered checks regardless of SEE

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -953,8 +953,9 @@ moves_loop: // When in check, search starts from here
           else if (cutNode && singularBeta > beta)
               return beta;
       }
-      else if (    givesCheck // Check extension (~2 Elo)
-               &&  pos.see_ge(move))
+      // Check extension (~2 Elo)
+      else if (    givesCheck
+               && (pos.see_ge(move) || pos.blockers_for_king(~us) & from_sq(move)))
           extension = ONE_PLY;
 
       // Extension if castling

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -955,7 +955,7 @@ moves_loop: // When in check, search starts from here
       }
       // Check extension (~2 Elo)
       else if (    givesCheck
-               && (pos.see_ge(move) || pos.blockers_for_king(~us) & from_sq(move)))
+               && (pos.blockers_for_king(~us) & from_sq(move) || pos.see_ge(move)))
           extension = ONE_PLY;
 
       // Extension if castling


### PR DESCRIPTION
A simple idea, but it makes sense.
Search is extended for checks that are considered somewhat safe.
For this the static exchange evaluation is used, but that only considers
the `to_sq` of a move. This is not reliable for discovered checks, where
another piece is giving the check and is arguably a more dangerous type
of check. Thus, if it is a discovered check, the result of SEE is not
relevant and can be ignored.

STC:
LLR: 2.96 (-2.94,2.94) [0.50,4.50]
Total: 29370 W: 6583 L: 6274 D: 16513
http://tests.stockfishchess.org/tests/view/5c5062950ebc593af5d4d9b5

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 227341 W: 37972 L: 37165 D: 152204
http://tests.stockfishchess.org/tests/view/5c5094fb0ebc593af5d4dc2c

Bench: 3951853