### PR TITLE
Defensive Knight

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -482,12 +482,13 @@ namespace {
     kingDanger +=        kingAttackersCount[Them] * kingAttackersWeight[Them]
                  +  69 * kingAttacksCount[Them]
                  + 185 * popcount(kingRing[Us] & weak)
+                 - 100 * bool(attackedBy[Us][KNIGHT] & attackedBy[Us][KING])
                  + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
                  +   5 * tropism * tropism / 16
                  - 873 * !pos.count<QUEEN>(Them)
                  -   6 * mg_value(score) / 8
                  +       mg_value(mobility[Them] - mobility[Us])
-                 -   30;
+                 -   25;
 
     // Transform the kingDanger units into a Score, and subtract it from the evaluation
     if (kingDanger > 0)


### PR DESCRIPTION
Less king danger if we have a knight near by to defend it.

STC: LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 113106 W: 25087 L: 24367 D: 63652 
http://tests.stockfishchess.org/tests/view/5c5517540ebc592fc7bb0eb4

LTC: LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 96669 W: 16318 L: 15872 D: 64479 
http://tests.stockfishchess.org/tests/view/5c55352b0ebc592fc7bb11c8

bench: 3653942