### PR TITLE
Remove uiThread (closes #1990)

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -191,9 +191,8 @@ void UCI::loop(int argc, char* argv[]) {
   Position pos;
   string token, cmd;
   StateListPtr states(new std::deque<StateInfo>(1));
-  auto uiThread = std::make_shared<Thread>(0);
 
-  pos.set(StartFEN, false, &states->back(), uiThread.get());
+  pos.set(StartFEN, false, &states->back(), Threads.main());
 
   for (int i = 1; i < argc; ++i)
       cmd += std::string(argv[i]) + " ";


### PR DESCRIPTION
Use Thread.main() instead of spawning an idle dummy thread.
position() already does this.

No functional change.