### PR TITLE
Simplify reduction3

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -163,7 +163,6 @@ void Search::init() {
               double r = log(d) * log(mc) / 1.95;
 
               Reductions[NonPV][imp][d][mc] = imp ? int(std::round(r)) : int(std::round(r * 1.22));
-
               Reductions[PV][imp][d][mc] = std::max(Reductions[NonPV][imp][d][mc] - 1, 0);
           }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -162,12 +162,9 @@ void Search::init() {
           {
               double r = log(d) * log(mc) / 1.95;
 
-              Reductions[NonPV][imp][d][mc] = int(std::round(r));
-              Reductions[PV][imp][d][mc] = std::max(Reductions[NonPV][imp][d][mc] - 1, 0);
+              Reductions[NonPV][imp][d][mc] = imp ? int(std::round(r)) : int(std::round(r * 1.2));
 
-              // Increase reduction for non-PV nodes when eval is not improving
-              if (!imp && r > 1.0)
-                Reductions[NonPV][imp][d][mc]++;
+              Reductions[PV][imp][d][mc] = std::max(Reductions[NonPV][imp][d][mc] - 1, 0);
           }
 
   for (int d = 0; d < 16; ++d)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -162,7 +162,7 @@ void Search::init() {
           {
               double r = log(d) * log(mc) / 1.95;
 
-              Reductions[NonPV][imp][d][mc] = imp ? int(std::round(r)) : int(std::round(r * 1.2));
+              Reductions[NonPV][imp][d][mc] = imp ? int(std::round(r)) : int(std::round(r * 1.22));
 
               Reductions[PV][imp][d][mc] = std::max(Reductions[NonPV][imp][d][mc] - 1, 0);
           }


### PR DESCRIPTION
Small simplification to the reduction formula.
Add +22% if not improving instead of increasing by 1 if r>1 && nonPV.

STC : 
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 37725 W: 8263 L: 8173 D: 21289 
http://tests.stockfishchess.org/tests/view/5c5b4c720ebc5925cffb3ee4

LTC : 
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 52989 W: 8735 L: 8665 D: 35589 
http://tests.stockfishchess.org/tests/view/5c5b75c40ebc5925cffb42c1

Bench: 3596663