### PR TITLE
Remove ForwardRanksBB

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -27,7 +27,6 @@ uint8_t PopCnt16[1 << 16];
 int8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 Bitboard SquareBB[SQUARE_NB];
-Bitboard ForwardRanksBB[COLOR_NB][RANK_NB];
 Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
 Bitboard LineBB[SQUARE_NB][SQUARE_NB];
 Bitboard DistanceRingBB[SQUARE_NB][8];
@@ -84,9 +83,6 @@ void Bitboards::init() {
 
   for (Square s = SQ_A1; s <= SQ_H8; ++s)
       SquareBB[s] = (1ULL << s);
-
-  for (Rank r = RANK_1; r < RANK_8; ++r)
-      ForwardRanksBB[WHITE][r] = ~(ForwardRanksBB[BLACK][r + 1] = ForwardRanksBB[BLACK][r] | rank_bb(r));
 
   for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
       for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2)

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -60,9 +60,6 @@ constexpr Bitboard Rank6BB = Rank1BB << (8 * 5);
 constexpr Bitboard Rank7BB = Rank1BB << (8 * 6);
 constexpr Bitboard Rank8BB = Rank1BB << (8 * 7);
 
-constexpr Bitboard AllButRank1 = AllSquares ^ Rank1BB;
-constexpr Bitboard AllButRank8 = AllSquares ^ Rank8BB;
-
 extern int8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];
@@ -209,8 +206,8 @@ inline Bitboard between_bb(Square s1, Square s2) {
 /// forward_ranks_bb(BLACK, SQ_D3) will return the 16 squares on ranks 1 and 2.
 
 inline Bitboard forward_ranks_bb(Color c, Square s) {
-  return (c == WHITE) ? AllButRank1 << 8 * rank_of(s)
-                      : AllButRank8 >> 8 * (7 - rank_of(s));
+  return (c == WHITE) ? shift<NORTH>(AllSquares) << 8 * rank_of(s)
+                      : shift<SOUTH>(AllSquares) >> 8 * (7 - rank_of(s));
 }
 
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -206,8 +206,8 @@ inline Bitboard between_bb(Square s1, Square s2) {
 /// forward_ranks_bb(BLACK, SQ_D3) will return the 16 squares on ranks 1 and 2.
 
 inline Bitboard forward_ranks_bb(Color c, Square s) {
-  return (c == WHITE) ? shift<NORTH>(AllSquares) << 8 * rank_of(s)
-                      : shift<SOUTH>(AllSquares) >> 8 * (7 - rank_of(s));
+  return (c == WHITE) ? (AllSquares ^ Rank1BB) << 8 * rank_of(s)
+                      : (AllSquares ^ Rank8BB) >> 8 * (7 - rank_of(s));
 }
 
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -60,10 +60,12 @@ constexpr Bitboard Rank6BB = Rank1BB << (8 * 5);
 constexpr Bitboard Rank7BB = Rank1BB << (8 * 6);
 constexpr Bitboard Rank8BB = Rank1BB << (8 * 7);
 
+constexpr Bitboard AllButRank1 = AllSquares ^ Rank1BB;
+constexpr Bitboard AllButRank8 = AllSquares ^ Rank8BB;
+
 extern int8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];
-extern Bitboard ForwardRanksBB[COLOR_NB][RANK_NB];
 extern Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
 extern Bitboard LineBB[SQUARE_NB][SQUARE_NB];
 extern Bitboard DistanceRingBB[SQUARE_NB][8];
@@ -207,7 +209,8 @@ inline Bitboard between_bb(Square s1, Square s2) {
 /// forward_ranks_bb(BLACK, SQ_D3) will return the 16 squares on ranks 1 and 2.
 
 inline Bitboard forward_ranks_bb(Color c, Square s) {
-  return ForwardRanksBB[c][rank_of(s)];
+  return (c == WHITE) ? AllButRank1 << 8 * rank_of(s)
+                      : AllButRank8 >> 8 * (7 - rank_of(s));
 }
 
 
@@ -216,7 +219,7 @@ inline Bitboard forward_ranks_bb(Color c, Square s) {
 ///      ForwardFileBB[c][s] = forward_ranks_bb(c, s) & file_bb(s)
 
 inline Bitboard forward_file_bb(Color c, Square s) {
-  return ForwardRanksBB[c][rank_of(s)] & file_bb(s);
+  return forward_ranks_bb(c, s) & file_bb(s);
 }
 
 


### PR DESCRIPTION
This is a non-functional simplification.  The ForwardRanksBB is removed.  Local testing suggests a 0.3% speedup and also reduces the memory footprint.

The version in this PR is more simplified than the tested version, but functionally equivalent.

STC
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 82787 W: 18061 L: 18060 D: 46666 
http://tests.stockfishchess.org/tests/view/5c60e6340ebc5925cffbaf91