### PR TITLE
Remove PvNode dimension from Reductions array.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -73,10 +73,10 @@ namespace {
 
   // Futility and reductions lookup tables, initialized at startup
   int FutilityMoveCounts[2][16]; // [improving][depth]
-  int Reductions[2][2][64][64];  // [pv][improving][depth][moveNumber]
+  int Reductions[2][64][64];  // [improving][depth][moveNumber]
 
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {
-    return Reductions[PvNode][i][std::min(d / ONE_PLY, 63)][std::min(mn, 63)] * ONE_PLY;
+    return (Reductions[i][std::min(d / ONE_PLY, 63)][std::min(mn, 63)] - PvNode) * ONE_PLY;
   }
 
   // History and stats update bonus, based on depth
@@ -162,12 +162,11 @@ void Search::init() {
           {
               double r = log(d) * log(mc) / 1.95;
 
-              Reductions[NonPV][imp][d][mc] = int(std::round(r));
-              Reductions[PV][imp][d][mc] = std::max(Reductions[NonPV][imp][d][mc] - 1, 0);
+              Reductions[imp][d][mc] = std::round(r);
 
               // Increase reduction for non-PV nodes when eval is not improving
               if (!imp && r > 1.0)
-                Reductions[NonPV][imp][d][mc]++;
+                Reductions[imp][d][mc]++;
           }
 
   for (int d = 0; d < 16; ++d)


### PR DESCRIPTION
This is a functional simplification.

If we simply subtract Reductions by 1 if PvNode is set, we can remove this dimension of the array.  I think this saves about 8K of used memory.

The version in this PR is NOT identifical to the tested version.  I moved the PvNode do I didn't have to cast it to Depth and only needed one ONE_PLY.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 10118 W: 2282 L: 2138 D: 5698 
http://tests.stockfishchess.org/tests/view/5c6332b60ebc5925cffbdfed

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 70765 W: 11617 L: 11575 D: 47573 
http://tests.stockfishchess.org/tests/view/5c63379e0ebc5925cffbe0de

Bench 3720267