### PR TITLE
Remove skipQuiets variable in search.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -914,6 +914,7 @@ moves_loop: // When in check, search starts from here
       movedPiece = pos.moved_piece(move);
       givesCheck = gives_check(pos, move);
 
+      // Skip quiet moves if movecount exceeds our FutilityMoveCount threshold
       skipQuiets = depth < 16 * ONE_PLY
                       && moveCount >= FutilityMoveCounts[improving][depth / ONE_PLY];
 


### PR DESCRIPTION
This is a functional simplification.  The moveCountPruning variable and the skipQuiets variable are similar enough in function that they can be combined.  This removes the skipQuiets variable in search.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 23278 W: 5210 L: 5091 D: 12977
http://tests.stockfishchess.org/tests/view/5c65dc490ebc5925cffc12e9

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 77107 W: 12792 L: 12761 D: 51554
http://tests.stockfishchess.org/tests/view/5c65e4360ebc5925cffc1490

bench 3640330