### PR TITLE
Cut nodes2

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -831,7 +831,7 @@ namespace {
         int probCutCount = 0;
 
         while (  (move = mp.next_move()) != MOVE_NONE
-               && probCutCount < 2 + 2 * cutNode)
+                && probCutCount < 2 + 2 * cutNode)
             if (move != excludedMove && pos.legal(move))
             {
                 probCutCount++;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -826,12 +826,12 @@ namespace {
         &&  depth >= 5 * ONE_PLY
         &&  abs(beta) < VALUE_MATE_IN_MAX_PLY)
     {
-        Value raisedBeta = std::min(beta + 216 - 48 * improving + 5 * cutNode, VALUE_INFINITE);
+        Value raisedBeta = std::min(beta + 216 - 48 * improving, VALUE_INFINITE);
         MovePicker mp(pos, ttMove, raisedBeta - ss->staticEval, &thisThread->captureHistory);
         int probCutCount = 0;
 
         while (  (move = mp.next_move()) != MOVE_NONE
-               && probCutCount < 3 + cutNode)
+               && probCutCount < 2 + 2 * cutNode)
             if (move != excludedMove && pos.legal(move))
             {
                 probCutCount++;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -831,7 +831,7 @@ namespace {
         int probCutCount = 0;
 
         while (  (move = mp.next_move()) != MOVE_NONE
-               && probCutCount < 3)
+               && probCutCount < 3 - cutNode)
             if (move != excludedMove && pos.legal(move))
             {
                 probCutCount++;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -826,12 +826,12 @@ namespace {
         &&  depth >= 5 * ONE_PLY
         &&  abs(beta) < VALUE_MATE_IN_MAX_PLY)
     {
-        Value raisedBeta = std::min(beta + 216 - 48 * improving, VALUE_INFINITE);
+        Value raisedBeta = std::min(beta + 216 - 48 * improving + 5 * cutNode, VALUE_INFINITE);
         MovePicker mp(pos, ttMove, raisedBeta - ss->staticEval, &thisThread->captureHistory);
         int probCutCount = 0;
 
         while (  (move = mp.next_move()) != MOVE_NONE
-               && probCutCount < 3 - cutNode)
+               && probCutCount < 3 + cutNode)
             if (move != excludedMove && pos.legal(move))
             {
                 probCutCount++;


### PR DESCRIPTION
ProbCutCount limit dependancy to cutNode
probcutcount < 2 + 2 * cutNode 
(instead of constant 3)

STC
LLR: -2.95 (-2.94,2.94) [0.50,4.50]
Total: 61812 W: 13599 L: 13459 D: 34754 
http://tests.stockfishchess.org/tests/view/5c6d19240ebc5925cffca07a

LTC
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 27549 W: 4614 L: 4363 D: 18572 
http://tests.stockfishchess.org/tests/view/5c6d45c10ebc5925cffca7a6

Bench: 3341275

