### PR TITLE
Bugfix of the new reduction arrays.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -76,7 +76,7 @@ namespace {
   int Reductions[2][64][64];  // [improving][depth][moveNumber]
 
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {
-    return (Reductions[i][std::min(d / ONE_PLY, 63)][std::min(mn, 63)] - PvNode) * ONE_PLY;
+    return std::max(Reductions[i][std::min(d / ONE_PLY, 63)][std::min(mn, 63)] - PvNode, 0) * ONE_PLY;
   }
 
   // History and stats update bonus, based on depth


### PR DESCRIPTION
Don't allow the reduction for PV nodes to become negative.

After commit https://github.com/official-stockfish/Stockfish/commit/22ef36803ed0f1597d8f40731c6e2d3aa01debf2 it is possible that the reduction for PV nodes will turn negative and thus act like an extension.
Although we take care this can't be possible in the LMR section of the main search function by capping the reduction, see https://github.com/official-stockfish/Stockfish/blob/master/src/search.cpp#L1069,
we don't do this in step 14 when calculating lmrDepth.
A simple `assert(lmrDepth <= newDepth / ONE_PLY);` almost fires immediately.

Better not allow negative reductions in the first place!

Bench: 3065075