### PR TITLE
Remove FutilityMoveCounts array.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -910,7 +910,6 @@ moves_loop: // When in check, search starts from here
       movedPiece = pos.moved_piece(move);
       givesCheck = gives_check(pos, move);
 
-
       // Step 13. Extensions (~70 Elo)
 
       // Singular extension search (~60 Elo). If all moves but one fail low on a

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -71,12 +71,15 @@ namespace {
     return Value((175 - 50 * improving) * d / ONE_PLY);
   }
 
-  // Futility and reductions lookup tables, initialized at startup
-  int FutilityMoveCounts[2][16]; // [improving][depth]
+  // Reductions lookup table, initialized at startup
   int Reductions[2][64][64];  // [improving][depth][moveNumber]
 
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {
     return (Reductions[i][std::min(d / ONE_PLY, 63)][std::min(mn, 63)] - PvNode) * ONE_PLY;
+  }
+
+  constexpr int futility_move_count(bool improving, int depth) {
+    return (5 + depth * depth) * (1 + improving) / 2;
   }
 
   // History and stats update bonus, based on depth
@@ -168,12 +171,6 @@ void Search::init() {
               if (!imp && r > 1.0)
                 Reductions[imp][d][mc]++;
           }
-
-  for (int d = 0; d < 16; ++d)
-  {
-      FutilityMoveCounts[0][d] = int(2.4 + 0.74 * pow(d, 1.78));
-      FutilityMoveCounts[1][d] = int(5.0 + 1.00 * pow(d, 2.00));
-  }
 }
 
 
@@ -913,8 +910,7 @@ moves_loop: // When in check, search starts from here
       movedPiece = pos.moved_piece(move);
       givesCheck = gives_check(pos, move);
 
-      moveCountPruning =   depth < 16 * ONE_PLY
-                        && moveCount >= FutilityMoveCounts[improving][depth / ONE_PLY];
+      moveCountPruning = (moveCount >= futility_move_count(improving, depth / ONE_PLY));
 
       // Step 13. Extensions (~70 Elo)
 


### PR DESCRIPTION
This is a functional simplification that removes the FutilityMoveCounts array with a simple equation using only ints.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 74187 W: 16223 L: 16205 D: 41759 
http://tests.stockfishchess.org/tests/view/5c75d4c50ebc5925cffd58cd

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 69841 W: 11596 L: 11553 D: 46692 
http://tests.stockfishchess.org/tests/view/5c76308e0ebc5925cffd5d42

Bench 3210218