### PR TITLE
Remove Seed array

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -154,15 +154,13 @@ namespace Pawns {
 
 void init() {
 
-  static constexpr int Seed[RANK_NB] = { 0, 13, 24, 18, 65, 100, 175, 330 };
-
   for (int opposed = 0; opposed <= 1; ++opposed)
       for (int phalanx = 0; phalanx <= 1; ++phalanx)
           for (int support = 0; support <= 2; ++support)
               for (Rank r = RANK_2; r < RANK_8; ++r)
   {
       int v = 17 * support;
-      v += (Seed[r] + (phalanx ? (Seed[r + 1] - Seed[r]) / 2 : 0)) >> opposed;
+      v += ((10 * r * r - 40 * r + 55) + (phalanx * (10 * r - 15))) >> opposed;
 
       Connected[opposed][phalanx][support][r] = make_score(v, v * (r - 2) / 4);
   }


### PR DESCRIPTION
This PR is a functional simplification of master that removes the Seed array, but is a non-tested non-functional simplification of these passing tests (mathematical equivalent).

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 114563 W: 25131 L: 25193 D: 64239 
http://tests.stockfishchess.org/tests/view/5c76ecca0ebc5925cffd6576

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 34446 W: 5767 L: 5668 D: 23011 
http://tests.stockfishchess.org/tests/view/5c7730380ebc5925cffd6b80

bench 3224966