### PR TITLE
Remove reductions array

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -73,10 +73,10 @@ namespace {
 
   // Futility and reductions lookup tables, initialized at startup
   int FutilityMoveCounts[2][16]; // [improving][depth]
-  double rFactor[MAX_MOVES];
+  float rFactor[MAX_MOVES];
 
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {
-    double r = 0.5 + rFactor[d] * rFactor[mn];
+    float r = 0.5 + rFactor[d] * rFactor[mn];
     return Depth(int(r) + (!i && r > 1.5) - PvNode);
   }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -73,11 +73,11 @@ namespace {
 
   // Futility and reductions lookup tables, initialized at startup
   int FutilityMoveCounts[2][16]; // [improving][depth]
-  float rFactor[MAX_MOVES];
+  float Reductions[256]; // [depth or moveNumber]
 
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {
-    float r = 0.5 + rFactor[d] * rFactor[mn];
-    return Depth(int(r) + (!i && r > 1.5) - PvNode);
+    float r = Reductions[d] * Reductions[mn] / 1024;
+    return Depth(int(r + 512)/1024 + (!i && r > 1024) - PvNode);
   }
 
   // History and stats update bonus, based on depth
@@ -157,8 +157,8 @@ namespace {
 
 void Search::init() {
 
-  for (int d = 1; d < MAX_MOVES ; d++)
-      rFactor[d] = std::log(d) / std::sqrt(1.95);
+  for (int d = 1; d < 256; ++d)
+      Reductions[d] = 1024 * std::log(d) / std::sqrt(1.95);
 
   for (int d = 0; d < 16; ++d)
   {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -76,8 +76,8 @@ namespace {
   float Reductions[256]; // [depth or moveNumber]
 
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {
-    float r = Reductions[d] * Reductions[mn] / 1024;
-    return Depth(int(r + 512)/1024 + (!i && r > 1024) - PvNode);
+    int r = Reductions[d] * Reductions[mn] / 1024;
+    return Depth((r + 512)/1024 + (!i && r > 1024) - PvNode);
   }
 
   // History and stats update bonus, based on depth

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -73,7 +73,7 @@ namespace {
 
   // Futility and reductions lookup tables, initialized at startup
   int FutilityMoveCounts[2][16]; // [improving][depth]
-  float Reductions[256]; // [depth or moveNumber]
+  int Reductions[256]; // [depth or moveNumber]
 
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {
     int r = Reductions[d] * Reductions[mn] / 1024;


### PR DESCRIPTION
This is a non-functional patch which removes the reductions array.  This saves about 8Kb of memory.

The only slow part of master's reductions array is the calculation of the log values, so using a separate array for those values and calculating the rest real-time appears to be just as fast as master.  This version is syntactically different from the passing version.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 63245 W: 13906 L: 13866 D: 35473
http://tests.stockfishchess.org/tests/view/5c7b571f0ebc5925cffdc104

No LTC because this is a non-functional patch.

Bench 3292342