### PR TITLE
Reduce stack usage.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -21,6 +21,7 @@
 #include <cassert>
 
 #include "movepick.h"
+#include "thread.h"
 
 namespace {
 
@@ -53,7 +54,17 @@ namespace {
 /// to help it to return the (presumably) good moves first, to decide which
 /// moves to return (in the quiescence search, for instance, we only want to
 /// search captures, promotions, and some checks) and how important good move
-/// ordering is at the current node.
+/// ordering is at the current node. The MovePicker uses preallocated memory,
+/// accessible via pos.this_thread() to store generated moves, to avoid exhausting
+/// stack space in deep searches, while keeping low overhead.
+
+/// Destructor makes the space on the movesStack available,
+/// and asserts that the order of construction and destruction is consistent.
+MovePicker::~MovePicker() {
+
+  pos.this_thread()->movesStack -= MAX_MOVES;
+  assert(pos.this_thread()->movesStack == moves);
+}
 
 /// MovePicker constructor for the main search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
@@ -62,6 +73,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
              refutations{{killers[0], 0}, {killers[1], 0}, {cm, 0}}, depth(d) {
 
   assert(d > DEPTH_ZERO);
+  moves = pos.this_thread()->movesStack;
+  pos.this_thread()->movesStack += MAX_MOVES;
 
   stage = pos.checkers() ? EVASION_TT : MAIN_TT;
   ttMove = ttm && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE;
@@ -74,6 +87,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
            : pos(p), mainHistory(mh), captureHistory(cph), continuationHistory(ch), recaptureSquare(rs), depth(d) {
 
   assert(d <= DEPTH_ZERO);
+  moves = pos.this_thread()->movesStack;
+  pos.this_thread()->movesStack += MAX_MOVES;
 
   stage = pos.checkers() ? EVASION_TT : QSEARCH_TT;
   ttMove =   ttm
@@ -88,6 +103,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePiece
            : pos(p), captureHistory(cph), threshold(th) {
 
   assert(!pos.checkers());
+  moves = pos.this_thread()->movesStack;
+  pos.this_thread()->movesStack += MAX_MOVES;
 
   stage = PROBCUT_TT;
   ttMove =   ttm

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -117,6 +117,7 @@ class MovePicker {
 public:
   MovePicker(const MovePicker&) = delete;
   MovePicker& operator=(const MovePicker&) = delete;
+ ~MovePicker();
   MovePicker(const Position&, Move, Value, const CapturePieceToHistory*);
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*,
                                            const CapturePieceToHistory*,
@@ -146,7 +147,7 @@ private:
   Square recaptureSquare;
   Value threshold;
   Depth depth;
-  ExtMove moves[MAX_MOVES];
+  ExtMove* moves;
 };
 
 #endif // #ifndef MOVEPICK_H_INCLUDED

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -36,6 +36,10 @@ ThreadPool Threads; // Global object
 
 Thread::Thread(size_t n) : idx(n), stdThread(&Thread::idle_loop, this) {
 
+  // Allow for the creation of MAX_PLY MovePicker objects
+  size_t movesSpace = MAX_PLY * MAX_MOVES * sizeof(ExtMove);
+  movesStack = (ExtMove*) malloc(movesSpace);
+
   wait_for_search_finished();
 }
 
@@ -49,6 +53,7 @@ Thread::~Thread() {
 
   exit = true;
   start_searching();
+  free(movesStack);
   stdThread.join();
 }
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -73,6 +73,8 @@ public:
   CapturePieceToHistory captureHistory;
   ContinuationHistory continuationHistory;
   Score contempt;
+
+  ExtMove* movesStack; // a stack of moves needed for MovePicker objects.
 };
 
 


### PR DESCRIPTION
in #2027 a crash was tracked down (using -fsanitize=address) to a stack overflow on macOS. It appears that on macOS threads are created with a 512Kb stack size, and the code is close to exceeding this when search reaches MAX_PLY search depth. The precise stack needed will vary in the future, and depends on details such as compiler optimization. To address this issue, one can either use OS specific code to try and create threads with a larger stack, or reduce the stack usage. This patch implements (one option for) the latter.

The largest stack usage comes from the movepicker, in particular the storage that is reserved for the generated moves (MAX_MOVES * 8 bytes = 2048 bytes), in search MAX_PLY MovePicker objects are needed, so 256 KB of stack, a significant fraction of total. This patch preallocates this storage, and manages its use by hand. Since it is memory local to each thread, the preallocated memory is part of the Thread structure.

As reported https://github.com/vondele/Stockfish/commit/559d0de5a2b6896f871b8d74245350e4603a0d43#commitcomment-32604063 this fixes the macOS problem. It can also be tested by manually limiting the stack (e.g. ulimit -s 128) and running with the sanitizer. With 128 KB, master reaches depth 26, while this branch reaches 73. (Fen: 8/2p1p1p1/2P1P1Pp/P4K2/P7/p2p4/rppP3P/qkn4R w - -  anybody has a fen where seldepth reaches MAX_PLY more quickly?)

The patch tested fine for no regression at STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 58497 W: 12908 L: 12859 D: 32730
http://tests.stockfishchess.org/tests/view/5c7ec1980ebc5925cffe0769

There are obvious cons to this approach, namely that it is less flexible 1) the lifetime of the MovePicker objects can not be arbitrary (i.e. the underlying stack must be respected), and 2) the maximum number of objects is fixed (MAX_PLY currently). There is an assert in place to check 1), and for 2) it possibly is a good idea to be conservative and oversize the allocation a bit more than what is done in this patch.

closes #2027

No functional change.