### PR TITLE
Remove DistanceRing Array

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -30,7 +30,6 @@ Bitboard SquareBB[SQUARE_NB];
 Bitboard ForwardRanksBB[COLOR_NB][RANK_NB];
 Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
 Bitboard LineBB[SQUARE_NB][SQUARE_NB];
-Bitboard DistanceRingBB[SQUARE_NB][8];
 Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 Bitboard PawnAttacks[COLOR_NB][SQUARE_NB];
 
@@ -92,10 +91,7 @@ void Bitboards::init() {
 
   for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
       for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2)
-          {
               SquareDistance[s1][s2] = std::max(distance<File>(s1, s2), distance<Rank>(s1, s2));
-              DistanceRingBB[s1][SquareDistance[s1][s2]] |= s2;
-          }
 
   int steps[][5] = { {}, { 7, 9 }, { 6, 10, 15, 17 }, {}, {}, {}, { 1, 7, 8, 9 } };
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -71,7 +71,6 @@ extern uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 extern Bitboard SquareBB[SQUARE_NB];
 extern Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
 extern Bitboard LineBB[SQUARE_NB][SQUARE_NB];
-extern Bitboard DistanceRingBB[SQUARE_NB][8];
 extern Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 extern Bitboard PawnAttacks[COLOR_NB][SQUARE_NB];
 extern Bitboard KingFlank[FILE_NB];

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -238,21 +238,21 @@ Score Entry::do_king_safety(const Position& pos) {
   Bitboard pawns = pos.pieces(Us, PAWN);
   int d, minKingPawnDistance = pawns ? 8 : 0;
   const Square* pl = pos.squares<PAWN>(Us);
-  Value bonus = evaluate_shelter<Us>(pos, ksq);
-
-  while (((s = *pl++) != SQ_NONE) && (minKingPawnDistance > 1))
-      if ((d = distance(s, ksq)) < minKingPawnDistance)
-          minKingPawnDistance = d;
-
   kingSquares[Us] = ksq;
   castlingRights[Us] = pos.castling_rights(Us);
 
-  // If we can castle use the bonus after the castling if it is bigger
+  // If we can castle, use the shelter bonus for the best king location
+  Value bonus = evaluate_shelter<Us>(pos, ksq);
   if (pos.can_castle(Us | KING_SIDE))
       bonus = std::max(bonus, evaluate_shelter<Us>(pos, relative_square(Us, SQ_G1)));
 
   if (pos.can_castle(Us | QUEEN_SIDE))
       bonus = std::max(bonus, evaluate_shelter<Us>(pos, relative_square(Us, SQ_C1)));
+
+  // Minimum distance between the king and one of our pawns
+  while (((s = *pl++) != SQ_NONE) && (minKingPawnDistance > 1))
+      if ((d = distance(s, ksq)) < minKingPawnDistance)
+          minKingPawnDistance = d;
 
   return make_score(bonus, -16 * minKingPawnDistance);
 }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -234,16 +234,18 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
 template<Color Us>
 Score Entry::do_king_safety(const Position& pos) {
 
-  Square ksq = pos.square<KING>(Us);
+  Square s, ksq = pos.square<KING>(Us);
+  Bitboard pawns = pos.pieces(Us, PAWN);
+  int d, minKingPawnDistance = pawns ? 8 : 0;
+  const Square* pl = pos.squares<PAWN>(Us);
+  Value bonus = evaluate_shelter<Us>(pos, ksq);
+
+  while (((s = *pl++) != SQ_NONE) && (minKingPawnDistance > 1))
+      if ((d = distance(s, ksq)) < minKingPawnDistance)
+          minKingPawnDistance = d;
+
   kingSquares[Us] = ksq;
   castlingRights[Us] = pos.castling_rights(Us);
-  int minKingPawnDistance = 0;
-
-  Bitboard pawns = pos.pieces(Us, PAWN);
-  if (pawns)
-      while (!(DistanceRingBB[ksq][++minKingPawnDistance] & pawns)) {}
-
-  Value bonus = evaluate_shelter<Us>(pos, ksq);
 
   // If we can castle use the bonus after the castling if it is bigger
   if (pos.can_castle(Us | KING_SIDE))

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -241,6 +241,10 @@ Score Entry::do_king_safety(const Position& pos) {
   kingSquares[Us] = ksq;
   castlingRights[Us] = pos.castling_rights(Us);
 
+  while (((s = *pl++) != SQ_NONE) && (minKingPawnDistance > 1))
+      if ((d = distance(s, ksq)) < minKingPawnDistance)
+          minKingPawnDistance = d;
+
   // If we can castle, use the shelter bonus for the best king location
   Value bonus = evaluate_shelter<Us>(pos, ksq);
   if (pos.can_castle(Us | KING_SIDE))
@@ -248,11 +252,6 @@ Score Entry::do_king_safety(const Position& pos) {
 
   if (pos.can_castle(Us | QUEEN_SIDE))
       bonus = std::max(bonus, evaluate_shelter<Us>(pos, relative_square(Us, SQ_C1)));
-
-  // Minimum distance between the king and one of our pawns
-  while (((s = *pl++) != SQ_NONE) && (minKingPawnDistance > 1))
-      if ((d = distance(s, ksq)) < minKingPawnDistance)
-          minKingPawnDistance = d;
 
   return make_score(bonus, -16 * minKingPawnDistance);
 }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -247,6 +247,7 @@ Score Entry::do_king_safety(const Position& pos) {
 
   // If we can castle, use the shelter bonus for the best king location
   Value bonus = evaluate_shelter<Us>(pos, ksq);
+
   if (pos.can_castle(Us | KING_SIDE))
       bonus = std::max(bonus, evaluate_shelter<Us>(pos, relative_square(Us, SQ_G1)));
 


### PR DESCRIPTION
This is a non-functional simplification that removes 3 lines of code and the DistanceRing array (about 4K in memory usage).

The code is not quite as clean as master, but is also slightly faster on my machine.  100 runs of bench yields:
master 1622946 +/- 20885
patch  1627417 +/- 21038
diff +4471 +/- 769

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 39159 W: 8706 L: 8619 D: 21834
http://tests.stockfishchess.org/tests/view/5c800e830ebc5925cffe23f2

No LTC because this patch is non-functional.

Bench 3380343