### PR TITLE
Increase thread stack for OS X

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -32,7 +32,7 @@
 #include "../movegen.h"
 #include "../position.h"
 #include "../search.h"
-#include "../thread_win32.h"
+#include "../thread_win32_osx.h"
 #include "../types.h"
 #include "../uci.h"
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -46,7 +46,7 @@ class Thread {
   ConditionVariable cv;
   size_t idx;
   bool exit = false, searching = true; // Set before starting std::thread
-  std::thread stdThread;
+  NativeThread stdThread;
 
 public:
   explicit Thread(size_t);

--- a/src/thread.h
+++ b/src/thread.h
@@ -32,7 +32,7 @@
 #include "pawns.h"
 #include "position.h"
 #include "search.h"
-#include "thread_win32.h"
+#include "thread_win32_osx.h"
 
 
 /// Thread class keeps together all the thread-related stuff. We use

--- a/src/thread_win32.h
+++ b/src/thread_win32.h
@@ -78,7 +78,7 @@ typedef std::condition_variable ConditionVariable;
 
 static const size_t TH_STACK_SIZE = 2 * 1024 * 1024;
 
-template <class Fun, class This, class P = std::pair<Fun, This>>
+template <class Fun, class Obj, class P = std::pair<Fun, Obj*>>
 void* start_routine(void* ptr)
 {
    P* p = reinterpret_cast<P*>(ptr);
@@ -92,13 +92,13 @@ class NativeThread {
    pthread_t thread;
 
 public:
-  template<class Fun, class This>
-  explicit NativeThread(Fun fun, This obj) {
-    auto ptr = new std::pair<Fun, This>(fun, obj); // Should survive to us
+  template<class Fun, class Obj>
+  explicit NativeThread(Fun fun, Obj* obj) {
+    auto ptr = new std::pair<Fun, Obj*>(fun, obj); // Should survive to us
     pthread_attr_t attr_storage, *attr = &attr_storage;
     pthread_attr_init(attr);
     pthread_attr_setstacksize(attr, TH_STACK_SIZE);
-    pthread_create(&thread, attr, start_routine<Fun, This>, (void*)ptr);
+    pthread_create(&thread, attr, start_routine<Fun, Obj>, (void*)ptr);
   }
   void join() { pthread_join(thread, NULL); }
 };

--- a/src/thread_win32.h
+++ b/src/thread_win32.h
@@ -83,6 +83,7 @@ void* start_routine(void* ptr)
 {
    P* p = reinterpret_cast<P*>(ptr);
    (p->second->*(p->first))(); // Call member function pointer
+   delete p;
    return NULL;
 }
 
@@ -93,11 +94,11 @@ class NativeThread {
 public:
   template<class Fun, class This>
   explicit NativeThread(Fun fun, This obj) {
-    auto ptr = std::make_pair(fun, obj);
+    auto ptr = new std::pair<Fun, This>(fun, obj); // Should survive to us
     pthread_attr_t attr_storage, *attr = &attr_storage;
     pthread_attr_init(attr);
     pthread_attr_setstacksize(attr, TH_STACK_SIZE);
-    pthread_create(&thread, attr, start_routine<Fun, This>, (void*)&ptr);
+    pthread_create(&thread, attr, start_routine<Fun, This>, (void*)ptr);
   }
   void join() { pthread_join(thread, NULL); }
 };


### PR DESCRIPTION
 On OSX threads other than the main thread are created with a reduced stack
size of 512KB by default, this is dangerously low for deep searches, so
adjust it to TH_STACK_SIZE. The implementation calls pthread_create() with
proper stack size parameter.

Verified for no regression at STC enabling the patch on all platforms where 
pthread is supported.

LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 50873 W: 9768 L: 9700 D: 31405

No functional change.