### PR TITLE
Remove popcount16()

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -19,6 +19,7 @@
 */
 
 #include <algorithm>
+#include <bitset>
 
 #include "bitboard.h"
 #include "misc.h"
@@ -49,14 +50,6 @@ namespace {
   Bitboard BishopTable[0x1480]; // To store bishop attacks
 
   void init_magics(Bitboard table[], Magic magics[], Direction directions[]);
-
-  // popcount16() counts the non-zero bits using SWAR-Popcount algorithm
-  unsigned popcount16(unsigned u) {
-    u -= (u >> 1) & 0x5555U;
-    u = ((u >> 2) & 0x3333U) + (u & 0x3333U);
-    u = ((u >> 4) + u) & 0x0F0FU;
-    return (u * 0x0101U) >> 8;
-  }
 }
 
 
@@ -85,7 +78,7 @@ const std::string Bitboards::pretty(Bitboard b) {
 void Bitboards::init() {
 
   for (unsigned i = 0; i < (1 << 16); ++i)
-      PopCnt16[i] = (uint8_t)popcount16(i);
+      PopCnt16[i] = std::bitset<16>(i).count();
 
   for (Square s = SQ_A1; s <= SQ_H8; ++s)
       SquareBB[s] = (1ULL << s);

--- a/src/types.h
+++ b/src/types.h
@@ -115,7 +115,7 @@ constexpr int MAX_PLY   = 128;
 /// any normal move destination square is always different from origin square
 /// while MOVE_NONE and MOVE_NULL have the same origin and destination square.
 
-enum Move : uint16_t {
+enum Move : int {
   MOVE_NONE,
   MOVE_NULL = 65
 };

--- a/src/types.h
+++ b/src/types.h
@@ -115,7 +115,7 @@ constexpr int MAX_PLY   = 128;
 /// any normal move destination square is always different from origin square
 /// while MOVE_NONE and MOVE_NULL have the same origin and destination square.
 
-enum Move : int {
+enum Move : uint16_t {
   MOVE_NONE,
   MOVE_NULL = 65
 };


### PR DESCRIPTION
This is a non-functional simplification / code-style change.

This popcount16 method does nothing but initialize the PopCnt16 arrays.

This can be done in a single bitset line, which is less lines and more clear.  Performance for this code is moot.