### PR TITLE
pseudo_legal() promotion check

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -611,10 +611,6 @@ bool Position::pseudo_legal(const Move m) const {
   if (type_of(m) != NORMAL)
       return MoveList<LEGAL>(*this).contains(m);
 
-  // Is not a promotion, so promotion piece must be empty
-  if (promotion_type(m) - KNIGHT != NO_PIECE_TYPE)
-      return false;
-
   // If the 'from' square is not occupied by a piece belonging to the side to
   // move, the move is obviously not legal.
   if (pc == NO_PIECE || color_of(pc) != us)


### PR DESCRIPTION
Remove check for a condition that never happens.  A TT move can only be inconsistent relative to the position but is always self consistent.
No functional change.
bench: 3318033