### PR TITLE
Simplify  fallingEval

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -479,8 +479,8 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (306 + 9 * (mainThread->previousScore - bestValue)) / 581.0;
-          fallingEval        = std::max(0.5, std::min(1.5, fallingEval));
+          int diff = mainThread->previousScore - bestValue;
+          double fallingEval = diff < -1 ? 0.5 : diff < 62 ? 0.527 + 0.0155 * diff : 1.5;
 
           // If the bestMove is stable over several iterations, reduce time accordingly
           timeReduction = lastBestMoveDepth + 10 * ONE_PLY < completedDepth ? 1.95 : 1.0;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -480,7 +480,9 @@ void Thread::search() {
           && !mainThread->stopOnPonderhit)
       {
           int diff = mainThread->previousScore - bestValue;
-          double fallingEval = diff < -1 ? 0.5 : diff < 62 ? 0.527 + 0.0155 * diff : 1.5;
+          double fallingEval = diff < -1 ? 0.5
+                             : diff < 62 ? 0.527 + 0.0155 * diff
+                             :             1.5;
 
           // If the bestMove is stable over several iterations, reduce time accordingly
           timeReduction = lastBestMoveDepth + 10 * ONE_PLY < completedDepth ? 1.95 : 1.0;


### PR DESCRIPTION
This is a non-functional simplification.

1) Instead of std::max/min (always doing both compares), here, in many cases, only one compare is done.
2) Master always calculates the full equation.  Here, in some cases, we don't even calculate the value.
3) Even if we eventually calculate the equation, in this patch is one less operation than master.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 11506 W: 2636 L: 2494 D: 6376
http://tests.stockfishchess.org/tests/view/5c85739e0ebc5925cffe76db

I did not test LTC because the bench doesn't change, but maybe we should because it messes with time?

bench 3318033