### PR TITLE
Combine all TT stages in movepick

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -71,7 +71,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 /// MovePicker constructor for quiescence search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Square rs)
-           : pos(p), mainHistory(mh), captureHistory(cph), continuationHistory(ch), recaptureSquare(rs), stage(TT_STAGE), depth(d) {
+           : pos(p), mainHistory(mh), captureHistory(cph), continuationHistory(ch), stage(TT_STAGE), recaptureSquare(rs), depth(d) {
 
   assert(d <= DEPTH_ZERO);
 
@@ -86,7 +86,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 /// MovePicker constructor for ProbCut: we generate captures with SEE greater
 /// than or equal to the given threshold.
 MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePieceToHistory* cph)
-           : pos(p), captureHistory(cph), threshold(th), stage(TT_STAGE), init_stage(PROBCUT_INIT) {
+           : pos(p), captureHistory(cph), stage(TT_STAGE), init_stage(PROBCUT_INIT), threshold(th) {
 
   assert(!pos.checkers());
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -65,6 +65,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 
   stage = pos.checkers() ? EVASION_TT : MAIN_TT;
   ttMove = ttm && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE;
+  init_stage = pos.checkers() ? EVASION_INIT : CAPTURE_INIT;
   stage += (ttMove == MOVE_NONE);
 }
 
@@ -79,6 +80,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
   ttMove =   ttm
           && (depth > DEPTH_QS_RECAPTURES || to_sq(ttm) == recaptureSquare)
           && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE;
+  init_stage = pos.checkers() ? EVASION_INIT : QCAPTURE_INIT;
   stage += (ttMove == MOVE_NONE);
 }
 
@@ -94,6 +96,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePiece
           && pos.capture(ttm)
           && pos.pseudo_legal(ttm)
           && pos.see_ge(ttm, threshold) ? ttm : MOVE_NONE;
+  init_stage = PROBCUT_INIT;
   stage += (ttMove == MOVE_NONE);
 }
 
@@ -159,7 +162,8 @@ top:
   case EVASION_TT:
   case QSEARCH_TT:
   case PROBCUT_TT:
-      ++stage;
+      //++stage;
+      stage = init_stage;
       return ttMove;
 
   case CAPTURE_INIT:

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -141,7 +141,7 @@ private:
   const PieceToHistory** continuationHistory;
   Move ttMove;
   ExtMove refutations[3], *cur, *endMoves, *endBadCaptures;
-  int stage;
+  int stage, init_stage;
   Move move;
   Square recaptureSquare;
   Value threshold;


### PR DESCRIPTION
This is a non-functional simplification that combines the four TT stages into one.

I'm not sure if this qualifies as a simplification because we need to add a variable in the movepicker class to track which init stage to proceed to.  However, this removes 3 stages, is a bit faster on my machines, and is (in my opinion) conceptually cleaner.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 22862 W: 5155 L: 5036 D: 12671
http://tests.stockfishchess.org/tests/view/5c8711950ebc5925cffe906d