### PR TITLE
Use same scoring.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -105,24 +105,17 @@ void MovePicker::score() {
 
   static_assert(Type == CAPTURES || Type == QUIETS || Type == EVASIONS, "Wrong type");
 
-  auto captScore = [&](ExtMove m){return PieceValue[MG][pos.piece_on(to_sq(m))]
-                       + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))] / 8;};
-
-  auto quietScore = [&](ExtMove m){return (*mainHistory)[pos.side_to_move()][from_to(m)]
-                        + (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
-                        + (*continuationHistory[1])[pos.moved_piece(m)][to_sq(m)]
-                        + (*continuationHistory[3])[pos.moved_piece(m)][to_sq(m)]
-                        + (*continuationHistory[5])[pos.moved_piece(m)][to_sq(m)] / 2;};
-
   for (auto& m : *this)
-      if (Type == CAPTURES)
-          m.value = captScore(m);
-      else if (Type == QUIETS)
-          m.value = quietScore(m);
-      else if (pos.capture(m))   // Type == EVASIONS
-          m.value = captScore(m);
+      if (Type == CAPTURES || (Type == EVASIONS && pos.capture(m)))
+          m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
+                   + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))] / 8;
       else
-          m.value = quietScore(m) - (1 << 28);
+          m.value =  (*mainHistory)[pos.side_to_move()][from_to(m)]
+                   + (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
+                   + (*continuationHistory[1])[pos.moved_piece(m)][to_sq(m)]
+                   + (*continuationHistory[3])[pos.moved_piece(m)][to_sq(m)]
+                   + (*continuationHistory[5])[pos.moved_piece(m)][to_sq(m)] / 2
+                   - (Type == EVASIONS ? 1 << 28 : 0);
 }
 
 /// MovePicker::select() returns the next move satisfying a predicate function.

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -105,28 +105,24 @@ void MovePicker::score() {
 
   static_assert(Type == CAPTURES || Type == QUIETS || Type == EVASIONS, "Wrong type");
 
+  auto captScore = [&](ExtMove m){return PieceValue[MG][pos.piece_on(to_sq(m))]
+                       + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))] / 8;};
+
+  auto quietScore = [&](ExtMove m){return (*mainHistory)[pos.side_to_move()][from_to(m)]
+                        + (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
+                        + (*continuationHistory[1])[pos.moved_piece(m)][to_sq(m)]
+                        + (*continuationHistory[3])[pos.moved_piece(m)][to_sq(m)]
+                        + (*continuationHistory[5])[pos.moved_piece(m)][to_sq(m)] / 2;};
+
   for (auto& m : *this)
       if (Type == CAPTURES)
-          m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
-                   + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))] / 8;
-
+          m.value = captScore(m);
       else if (Type == QUIETS)
-          m.value =  (*mainHistory)[pos.side_to_move()][from_to(m)]
-                   + (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
-                   + (*continuationHistory[1])[pos.moved_piece(m)][to_sq(m)]
-                   + (*continuationHistory[3])[pos.moved_piece(m)][to_sq(m)]
-                   + (*continuationHistory[5])[pos.moved_piece(m)][to_sq(m)] / 2;
-
-      else // Type == EVASIONS
-      {
-          if (pos.capture(m))
-              m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
-                       - Value(type_of(pos.moved_piece(m)));
-          else
-              m.value =  (*mainHistory)[pos.side_to_move()][from_to(m)]
-                       + (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
-                       - (1 << 28);
-      }
+          m.value = quietScore(m);
+      else if (pos.capture(m))   // Type == EVASIONS
+          m.value = captScore(m);
+      else
+          m.value = quietScore(m) - (1 << 28);
 }
 
 /// MovePicker::select() returns the next move satisfying a predicate function.


### PR DESCRIPTION
score quiets and captures using the same expressions, also when generated as evasions.

passed STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 95244 W: 21066 L: 21090 D: 53088
http://tests.stockfishchess.org/tests/view/5c8a7e3f0ebc5925cffec201

passed LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 157509 W: 26570 L: 26670 D: 104269
http://tests.stockfishchess.org/tests/view/5c8b387a0ebc5925cffecf08

Bench: 3393182