### PR TITLE
EndgameBase::probe()

### DIFF
--- a/src/endgame.h
+++ b/src/endgame.h
@@ -140,7 +140,8 @@ public:
 
   template<typename T>
   const EndgameBase<T>* probe(Key key) {
-    return map<T>().count(key) ? map<T>()[key].get() : nullptr;
+    auto eb = map<T>().find(key);
+    return eb != map<T>().end() ? eb->second.get() : nullptr;
   }
 };
 


### PR DESCRIPTION
Reduce the number of operations by making EndgameBase::probe() search the map only once instead of twice.

No functional change.
bench: 3318033