### PR TITLE
Simplify pawn asymmetry (remove use of semiopen files).

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -748,7 +748,7 @@ namespace {
                     +  9 * outflanking
                     + 18 * pawnsOnBothFlanks
                     + 49 * !pos.non_pawn_material()
-                    -121 ;
+                    -103 ;
 
     // Now apply the bonus: note that we find the attacking side by extracting
     // the sign of the endgame value, and that we carefully cap the bonus so
@@ -776,7 +776,7 @@ namespace {
         if (   pos.opposite_bishops()
             && pos.non_pawn_material(WHITE) == BishopValueMg
             && pos.non_pawn_material(BLACK) == BishopValueMg)
-            sf = 8 + 4 * pe->passed_count();
+            sf = 16 + 4 * pe->passed_count();
         else
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -743,7 +743,7 @@ namespace {
                             && (pos.pieces(PAWN) & KingSide);
 
     // Compute the initiative bonus for the attacking side
-    int complexity =   9 * pe->pawn_asymmetry()
+    int complexity =   9 * pe->passed_count()
                     + 11 * pos.count<PAWN>()
                     +  9 * outflanking
                     + 18 * pawnsOnBothFlanks
@@ -776,7 +776,7 @@ namespace {
         if (   pos.opposite_bishops()
             && pos.non_pawn_material(WHITE) == BishopValueMg
             && pos.non_pawn_material(BLACK) == BishopValueMg)
-            sf = 8 + 4 * pe->pawn_asymmetry();
+            sf = 8 + 4 * pe->passed_count();
         else
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -185,8 +185,7 @@ Entry* probe(const Position& pos) {
   e->key = key;
   e->scores[WHITE] = evaluate<WHITE>(pos, e);
   e->scores[BLACK] = evaluate<BLACK>(pos, e);
-  e->asymmetry = popcount(  (e->passedPawns[WHITE]   | e->passedPawns[BLACK])
-                          | (e->semiopenFiles[WHITE] ^ e->semiopenFiles[BLACK]));
+  e->asymmetry = 2 + popcount(e->passedPawns[WHITE] | e->passedPawns[BLACK]);
 
   return e;
 }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -185,7 +185,7 @@ Entry* probe(const Position& pos) {
   e->key = key;
   e->scores[WHITE] = evaluate<WHITE>(pos, e);
   e->scores[BLACK] = evaluate<BLACK>(pos, e);
-  e->asymmetry = 2 + popcount(e->passedPawns[WHITE] | e->passedPawns[BLACK]);
+  e->passedCount= 2 + popcount(e->passedPawns[WHITE] | e->passedPawns[BLACK]);
 
   return e;
 }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -185,7 +185,7 @@ Entry* probe(const Position& pos) {
   e->key = key;
   e->scores[WHITE] = evaluate<WHITE>(pos, e);
   e->scores[BLACK] = evaluate<BLACK>(pos, e);
-  e->passedCount= 2 + popcount(e->passedPawns[WHITE] | e->passedPawns[BLACK]);
+  e->passedCount= popcount(e->passedPawns[WHITE] | e->passedPawns[BLACK]);
 
   return e;
 }

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -38,7 +38,7 @@ struct Entry {
   Bitboard passed_pawns(Color c) const { return passedPawns[c]; }
   Bitboard pawn_attacks_span(Color c) const { return pawnAttacksSpan[c]; }
   int weak_unopposed(Color c) const { return weakUnopposed[c]; }
-  int pawn_asymmetry() const { return asymmetry; }
+  int passed_count() const { return passedCount; }
 
   int semiopen_file(Color c, File f) const {
     return semiopenFiles[c] & (1 << f);
@@ -71,7 +71,7 @@ struct Entry {
   int castlingRights[COLOR_NB];
   int semiopenFiles[COLOR_NB];
   int pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
-  int asymmetry;
+  int passedCount;
 };
 
 typedef HashTable<Entry, 16384> Table;


### PR DESCRIPTION
This is a functional simplification.

To me, the exclusive OR of semiopenFiles here is quite convoluted.  Looks like it can be removed.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 43885 W: 9731 L: 9653 D: 24501 
http://tests.stockfishchess.org/tests/view/5c9041680ebc5925cfff10ea

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 68437 W: 11577 L: 11533 D: 45327 
http://tests.stockfishchess.org/tests/view/5c9101740ebc5925cfff1cbf

bench 3575627