### PR TITLE
Remove per thread instances of Endgames

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -82,6 +82,33 @@ namespace {
 } // namespace
 
 
+namespace Endgames {
+
+  std::pair<Map<Value>, Map<ScaleFactor>> maps;
+
+  void init() {
+
+      add<KPK>("KPK");
+      add<KNNK>("KNNK");
+      add<KBNK>("KBNK");
+      add<KRKP>("KRKP");
+      add<KRKB>("KRKB");
+      add<KRKN>("KRKN");
+      add<KQKP>("KQKP");
+      add<KQKR>("KQKR");
+      add<KNNKP>("KNNKP");
+
+      add<KNPK>("KNPK");
+      add<KNPKB>("KNPKB");
+      add<KRPKR>("KRPKR");
+      add<KRPKB>("KRPKB");
+      add<KBPKB>("KBPKB");
+      add<KBPKN>("KBPKN");
+      add<KBPPKB>("KBPPKB");
+      add<KRPPKRP>("KRPPKRP");
+  }
+}
+
 /// Mate with KX vs K. This function is used to evaluate positions with
 /// king and plenty of material vs a lone king. It simply gives the
 /// attacking side a bonus for driving the defending king towards the edge

--- a/src/endgame.h
+++ b/src/endgame.h
@@ -95,10 +95,12 @@ struct Endgame : public EndgameBase<T> {
 /// base objects in two std::map. We use polymorphism to invoke the actual
 /// endgame function by calling its virtual operator().
 
-class Endgames {
+namespace Endgames {
 
   template<typename T> using Ptr = std::unique_ptr<EndgameBase<T>>;
   template<typename T> using Map = std::map<Key, Ptr<T>>;
+  
+  extern std::pair<Map<Value>, Map<ScaleFactor>> maps;
 
   template<typename T>
   Map<T>& map() {
@@ -113,35 +115,12 @@ class Endgames {
     map<T>()[Position().set(code, BLACK, &st).material_key()] = Ptr<T>(new Endgame<E>(BLACK));
   }
 
-  std::pair<Map<Value>, Map<ScaleFactor>> maps;
-
-public:
-  Endgames() {
-
-    add<KPK>("KPK");
-    add<KNNK>("KNNK");
-    add<KBNK>("KBNK");
-    add<KRKP>("KRKP");
-    add<KRKB>("KRKB");
-    add<KRKN>("KRKN");
-    add<KQKP>("KQKP");
-    add<KQKR>("KQKR");
-    add<KNNKP>("KNNKP");
-
-    add<KNPK>("KNPK");
-    add<KNPKB>("KNPKB");
-    add<KRPKR>("KRPKR");
-    add<KRPKB>("KRPKB");
-    add<KBPKB>("KBPKB");
-    add<KBPKN>("KBPKN");
-    add<KBPPKB>("KBPPKB");
-    add<KRPPKRP>("KRPPKRP");
-  }
-
   template<typename T>
   const EndgameBase<T>* probe(Key key) {
     return map<T>().count(key) ? map<T>()[key].get() : nullptr;
   }
-};
+
+  void init();
+}
 
 #endif // #ifndef ENDGAME_H_INCLUDED

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@
 #include "thread.h"
 #include "tt.h"
 #include "uci.h"
+#include "endgame.h"
 #include "syzygy/tbprobe.h"
 
 namespace PSQT {
@@ -42,6 +43,7 @@ int main(int argc, char* argv[]) {
   Position::init();
   Bitbases::init();
   Search::init();
+  Endgames::init();
   Threads.set(Options["Threads"]);
   Search::clear(); // After threads are up
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -137,7 +137,7 @@ Entry* probe(const Position& pos) {
   // Let's look if we have a specialized evaluation function for this particular
   // material configuration. Firstly we look for a fixed configuration one, then
   // for a generic one if the previous search failed.
-  if ((e->evaluationFunction = pos.this_thread()->endgames.probe<Value>(key)) != nullptr)
+  if ((e->evaluationFunction = Endgames::probe<Value>(key)) != nullptr)
       return e;
 
   for (Color c = WHITE; c <= BLACK; ++c)
@@ -149,7 +149,7 @@ Entry* probe(const Position& pos) {
 
   // OK, we didn't find any special evaluation function for the current material
   // configuration. Is there a suitable specialized scaling function?
-  const auto* sf = pos.this_thread()->endgames.probe<ScaleFactor>(key);
+  const auto* sf = Endgames::probe<ScaleFactor>(key);
 
   if (sf)
   {

--- a/src/thread.h
+++ b/src/thread.h
@@ -59,7 +59,6 @@ public:
 
   Pawns::Table pawnsTable;
   Material::Table materialTable;
-  Endgames endgames;
   size_t pvIdx, pvLast;
   int selDepth, nmpMinPly;
   Color nmpColor;


### PR DESCRIPTION
Similar to PSQT we only need one instance of the Endgames resource.  The current per thread copies are identical and read only(after initialization) so from a design point of view it doesn't make sense to have them.

No functional change.
Tested for no slowdown.
http://tests.stockfishchess.org/tests/view/5c94377a0ebc5925cfff43ca
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 17320 W: 3487 L: 3359 D: 10474 

bench: 3188688