### PR TITLE
Simplify Passed Pawns

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -114,7 +114,7 @@ namespace {
         // which could become passed after one or two pawn pushes when are
         // not attacked more times than defended.
         if (   !(stoppers ^ lever ^ leverPush)
-            && (!more_than_one(lever) || support)
+            && (support || !more_than_one(lever))
             && popcount(phalanx) >= popcount(leverPush))
             e->passedPawns[Us] |= s;
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -114,7 +114,7 @@ namespace {
         // which could become passed after one or two pawn pushes when are
         // not attacked more times than defended.
         if (   !(stoppers ^ lever ^ leverPush)
-            && popcount(support) >= popcount(lever) - 1
+            && (!more_than_one(lever) || support)
             && popcount(phalanx) >= popcount(leverPush))
             e->passedPawns[Us] |= s;
 


### PR DESCRIPTION
This is a non-functional simplification/speedup.

The truth-table for popcount(support) >= popcount(lever) - 1 is:
------------------lever
------------------0-------1---------2
support--0------X-------X---------0
-----------1------X-------X---------X
-----------2------X-------X---------X

Thus, it is functionally equivalent to just do:  support || !more_than_one(lever) which removes the expensive popcounts and the -1.

Result of  20 runs:
base (...h_master.exe) =    1451680  +/- 8202
test (./stockfish    ) =    1454781  +/- 8604
diff                   =      +3101  +/- 931

STC
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 35424 W: 7768 L: 7674 D: 19982
Http://tests.stockfishchess.org/tests/view/5c970f170ebc5925cfff5e28

bench 3188688
