### PR TITLE
Use vectors to build the PV.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -293,7 +293,16 @@ void Thread::search() {
   double timeReduction = 1.0;
   Color us = rootPos.side_to_move();
 
-  std::memset(ss-7, 0, 10 * sizeof(Stack));
+  // Zero-initialize the first stack levels
+  for (int i = -7; i < 3; i++)
+  {
+      (ss+i)->ply = 0;
+      (ss+i)->currentMove = (ss+i)->excludedMove = MOVE_NONE;
+      (ss+i)->killers[0] = (ss+i)->killers[1] = MOVE_NONE;
+      (ss+i)->staticEval = VALUE_ZERO;
+      (ss+i)->statScore = (ss+i)->moveCount = 0;
+  }
+
   for (int i = 7; i > 0; i--)
      (ss-i)->continuationHistory = &this->continuationHistory[NO_PIECE][0]; // Use as sentinel
 

--- a/src/search.h
+++ b/src/search.h
@@ -40,7 +40,7 @@ constexpr int CounterMovePruneThreshold = 0;
 /// its own array of Stack objects, indexed by the current ply.
 
 struct Stack {
-  Move* pv;
+  std::vector<Move> pv;
   PieceToHistory* continuationHistory;
   int ply;
   Move currentMove;


### PR DESCRIPTION
This patch replaces the pv arrays per stack level and their pointers with vectors.
This not only seems to be a bit easier to follow, but also uses less memory on the stack.

A functionally almost identical version has been tested for no regression:
http://tests.stockfishchess.org/tests/view/5c91590a0ebc5925cfff207b
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 38117 W: 8500 L: 8411 D: 21206 

Also changed the assert in qsearch to `1 <= ss->ply` to guard against dropping into qsearch while still at root level. This makes https://github.com/official-stockfish/Stockfish/pull/2043 obsolete.

No functional change.