### PR TITLE
Make helper threads handle failedHighCnt the same way as main thread

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -405,17 +405,14 @@ void Thread::search() {
                   beta = (alpha + beta) / 2;
                   alpha = std::max(bestValue - delta, -VALUE_INFINITE);
 
+                  failedHighCnt = 0;
                   if (mainThread)
-                  {
-                      failedHighCnt = 0;
                       mainThread->stopOnPonderhit = false;
-                  }
               }
               else if (bestValue >= beta)
               {
                   beta = std::min(bestValue + delta, VALUE_INFINITE);
-                  if (mainThread)
-                      ++failedHighCnt;
+                  ++failedHighCnt;
               }
               else
                   break;


### PR DESCRIPTION
Treat all threads the same as main thread and increment failedHighCnt on fail highs. This makes the search try again at lower depth.

@vondele suggested also changing the reset of failedHighCnt when there is a fail low. Tests including this passed so the branch has been updated to include both changes. failedHighCnt is now handled exactly the same in helper threads and the main thread. Thanks vondele :-)

STC @ 5+0.05 th 4 :
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 7769 W: 1704 L: 1557 D: 4508
http://tests.stockfishchess.org/tests/view/5c9f19520ebc5925cfffd2a1

LTC @ 20+0.2 th 8 :
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 37888 W: 5983 L: 5889 D: 26016
http://tests.stockfishchess.org/tests/view/5c9f57d10ebc5925cfffd696

Further work:
I am currently looking at bestMoveChanges, and perhaps there are other places where the main and helper threads can usefully be brought more into line.

Bench: 3548313
