### PR TITLE
Shuffle detection

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -610,6 +610,15 @@ namespace {
             : ttHit    ? tte->move() : MOVE_NONE;
     ttPv = (ttHit && tte->is_pv()) || (PvNode && depth > 4 * ONE_PLY);
 
+    // if position has been searched at higher depths and we are shuffling, return value_draw
+    if (pos.rule50_count() > 36
+        && ss->ply > 36
+        && depth < 3 * ONE_PLY
+        && ttHit
+        && tte->depth() > depth
+        && pos.count<PAWN>() > 0)
+        return VALUE_DRAW;
+
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode
         && ttHit
@@ -926,6 +935,10 @@ moves_loop: // When in check, search starts from here
       // Check extension (~2 Elo)
       else if (    givesCheck
                && (pos.blockers_for_king(~us) & from_sq(move) || pos.see_ge(move)))
+          extension = ONE_PLY;
+
+      // Shuffle extension
+      else if(pos.rule50_count() > 14 && ss->ply > 14 && depth < 3 * ONE_PLY && PvNode)
           extension = ONE_PLY;
 
       // Castling extension


### PR DESCRIPTION
Shuffle detection procedure : 

Shuffling positions are detected if 
- the last 36 moves are reversible (rule50_count() > 36), 
- the position have been already in the TT,
- there is a still a pawn on the board (to avoid special endings like KBN vs K).

The position is then judged as a draw.

An extension is realized if we already made 14 successive reversible moves in PV to accelerate the detection of the eventual draw.

To go further : we can still improve the idea. The length of the tests need a lot of ressources.
- the limit of 36 is logic but must be checked again for special zugzwang positions,
- this limit can be decreased in special positions,
- the limit of 14 moves for extension has not been tuned.

STC
LLR: -2.94 (-2.94,2.94) [0.50,4.50]
Total: 32595 W: 7273 L: 7275 D: 18047  Elo +0.43
http://tests.stockfishchess.org/tests/view/5c90aa330ebc5925cfff1768

LTC
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 51249 W: 8807 L: 8486 D: 33956  Elo +1.85
http://tests.stockfishchess.org/tests/view/5c90b2450ebc5925cfff1800

VLTC
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 137974 W: 20503 L: 19983 D: 97488 Elo +1.05
http://tests.stockfishchess.org/tests/view/5c9243a90ebc5925cfff2a93

Bench: 3548313