### PR TITLE
Use multiple threads to update bestMoveChanges

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -467,7 +467,7 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (298 + 9 * (mainThread->previousScore - bestValue)) / 581.0;
+          double fallingEval = (314 + 9 * (mainThread->previousScore - bestValue)) / 581.0;
           fallingEval        = std::max(0.5, std::min(1.5, fallingEval));
 
           // If the bestMove is stable over several iterations, reduce time accordingly
@@ -1097,7 +1097,7 @@ moves_loop: // When in check, search starts from here
               // We record how often the best move has been changed in each
               // iteration. This information is used for time management: When
               // the best move changes frequently, we allocate some more time.
-              if (moveCount > 1 && thisThread->get_idx() < 4)
+              if (moveCount > 1 && thisThread->get_idx() < Threads.bmcUpdateLimit)
                   thisThread->inc_bestMoveChanges();
           }
           else

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -467,7 +467,7 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (314 + 9 * (mainThread->previousScore - bestValue)) / 581.0;
+          double fallingEval = (298 + 9 * (mainThread->previousScore - bestValue)) / 581.0;
           fallingEval        = std::max(0.5, std::min(1.5, fallingEval));
 
           // If the bestMove is stable over several iterations, reduce time accordingly

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -467,7 +467,7 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (306 + 9 * (mainThread->previousScore - bestValue)) / 581.0;
+          double fallingEval = (314 + 9 * (mainThread->previousScore - bestValue)) / 581.0;
           fallingEval        = std::max(0.5, std::min(1.5, fallingEval));
 
           // If the bestMove is stable over several iterations, reduce time accordingly

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1097,8 +1097,8 @@ moves_loop: // When in check, search starts from here
               // We record how often the best move has been changed in each
               // iteration. This information is used for time management: When
               // the best move changes frequently, we allocate some more time.
-              if (moveCount > 1 && thisThread == Threads.main())
-                  ++static_cast<MainThread*>(thisThread)->bestMoveChanges;
+              if (moveCount > 1 && thisThread->get_idx() < 4)
+                  thisThread->inc_bestMoveChanges();
           }
           else
               // All other moves but the PV are set to the lowest value: this

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -87,6 +87,14 @@ void Thread::wait_for_search_finished() {
   cv.wait(lk, [&]{ return !searching; });
 }
 
+/// Thread::inc_bestMoveChanges() adds changeInc to bestMoveChanges
+
+void Thread::inc_bestMoveChanges() {
+  MainThread* mt = Threads.main();
+
+  std::lock_guard<Mutex> lk(mutex);
+  mt->bestMoveChanges += mt->changeInc;
+}
 
 /// Thread::idle_loop() is where the thread is parked, blocked on the
 /// condition variable, when it has no work to do.
@@ -152,6 +160,7 @@ void ThreadPool::clear() {
   main()->callsCnt = 0;
   main()->previousScore = VALUE_INFINITE;
   main()->previousTimeReduction = 1.0;
+  main()->changeInc = 1.0 / std::min(4, int(Threads.size()));
 }
 
 /// ThreadPool::start_thinking() wakes up main thread waiting in idle_loop() and

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -160,7 +160,7 @@ void ThreadPool::clear() {
   main()->callsCnt = 0;
   main()->previousScore = VALUE_INFINITE;
   main()->previousTimeReduction = 1.0;
-  main()->changeInc = 1.0 / std::min(4, int(Threads.size()));
+  main()->changeInc = 1.0 / std::min(Threads.bmcUpdateLimit, Threads.size());
 }
 
 /// ThreadPool::start_thinking() wakes up main thread waiting in idle_loop() and

--- a/src/thread.h
+++ b/src/thread.h
@@ -110,6 +110,7 @@ struct ThreadPool : public std::vector<Thread*> {
   uint64_t tb_hits()        const { return accumulate(&Thread::tbHits); }
 
   std::atomic_bool stop;
+  const size_t bmcUpdateLimit = 8;
 
 private:
   StateListPtr setupStates;

--- a/src/thread.h
+++ b/src/thread.h
@@ -56,6 +56,8 @@ public:
   void idle_loop();
   void start_searching();
   void wait_for_search_finished();
+  void inc_bestMoveChanges();
+  size_t get_idx() { return(idx); }
 
   Pawns::Table pawnsTable;
   Material::Table materialTable;
@@ -85,7 +87,7 @@ struct MainThread : public Thread {
   void search() override;
   void check_time();
 
-  double bestMoveChanges, previousTimeReduction;
+  double bestMoveChanges, changeInc, previousTimeReduction;
   Value previousScore;
   int callsCnt;
   bool stopOnPonderhit;


### PR DESCRIPTION
The current update only by main thread depends on the luck of whether main thread sees changes to the best move or not. Make smaller updates from up to the first N threads to get a more reliable number with a smoother distribution.

STC @ 5+0.05 th 8:
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 37574 W: 7586 L: 7255 D: 22733
http://tests.stockfishchess.org/tests/view/5c9d8c800ebc5925cfffb921

LTC
?

The change includes a small increase in the base constant for fallingEval, so a test for non-regression in the case of 1 thread was done:

STC @ 10+0.1 th 1:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 114303 W: 25320 L: 25382 D: 63601
http://tests.stockfishchess.org/tests/view/5c9c91290ebc5925cfffa850


Bench: 3575627
