### PR TITLE
Accessor for SquareBB

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -124,7 +124,7 @@ void Bitboards::init() {
               if (PseudoAttacks[pt][s1] & s2)
               {
                   LineBB[s1][s2] = (attacks_bb(pt, s1, 0) & attacks_bb(pt, s2, 0)) | s1 | s2;
-                  BetweenBB[s1][s2] = attacks_bb(pt, s1, SquareBB[s2]) & attacks_bb(pt, s2, SquareBB[s1]);
+                  BetweenBB[s1][s2] = attacks_bb(pt, s1, square_bb(s2)) & attacks_bb(pt, s2, square_bb(s1));
               }
   }
 }

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -106,30 +106,16 @@ extern Magic BishopMagics[SQUARE_NB];
 /// Overloads of bitwise operators between a Bitboard and a Square for testing
 /// whether a given bit is set in a bitboard, and for setting and clearing bits.
 
-inline Bitboard operator&(Bitboard b, Square s) {
+inline Bitboard square_bb(Square s) {
   assert(s >= SQ_A1 && s <= SQ_H8);
-  return b & SquareBB[s];
+  return SquareBB[s];
 }
-
-inline Bitboard operator|(Bitboard b, Square s) {
-  assert(s >= SQ_A1 && s <= SQ_H8);
-  return b | SquareBB[s];
-}
-
-inline Bitboard operator^(Bitboard b, Square s) {
-  assert(s >= SQ_A1 && s <= SQ_H8);
-  return b ^ SquareBB[s];
-}
-
-inline Bitboard& operator|=(Bitboard& b, Square s) {
-  assert(s >= SQ_A1 && s <= SQ_H8);
-  return b |= SquareBB[s];
-}
-
-inline Bitboard& operator^=(Bitboard& b, Square s) {
-  assert(s >= SQ_A1 && s <= SQ_H8);
-  return b ^= SquareBB[s];
-}
+  
+inline Bitboard  operator&( Bitboard  b, Square s) { return b &  square_bb(s); }
+inline Bitboard  operator|( Bitboard  b, Square s) { return b |  square_bb(s); }
+inline Bitboard  operator^( Bitboard  b, Square s) { return b ^  square_bb(s); }
+inline Bitboard& operator|=(Bitboard& b, Square s) { return b |= square_bb(s); }
+inline Bitboard& operator^=(Bitboard& b, Square s) { return b ^= square_bb(s); }
 
 constexpr bool more_than_one(Bitboard b) {
   return b & (b - 1);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -118,7 +118,7 @@ namespace {
             && popcount(phalanx) >= popcount(leverPush))
             e->passedPawns[Us] |= s;
 
-        else if (   stoppers == SquareBB[s + Up]
+        else if (   stoppers == square_bb(s + Up)
                  && relative_rank(Us, s) >= RANK_5)
         {
             b = shift<Up>(support) & ~theirPawns;

--- a/src/position.h
+++ b/src/position.h
@@ -413,7 +413,7 @@ inline void Position::move_piece(Piece pc, Square from, Square to) {
 
   // index[from] is not updated and becomes stale. This works as long as index[]
   // is accessed just by known occupied squares.
-  Bitboard fromTo = SquareBB[from] ^ SquareBB[to];
+  Bitboard fromTo = square_bb(from) ^ square_bb(to);
   byTypeBB[ALL_PIECES] ^= fromTo;
   byTypeBB[type_of(pc)] ^= fromTo;
   byColorBB[color_of(pc)] ^= fromTo;


### PR DESCRIPTION
This is a non-functional code style change.

If we add an accessor function for SquareBB we can consolidate all of the asserts.  This is also a bit cleaner because all SquareBB accesses go through this method making future changes easier to manage.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 63406 W: 14084 L: 14045 D: 35277
http://tests.stockfishchess.org/tests/view/5c9ea6100ebc5925cfffc9af