### PR TITLE
Use average bestMoveChanges across all threads

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -295,9 +295,11 @@ void Thread::search() {
   beta = VALUE_INFINITE;
 
   if (mainThread)
+  {
       mainThread->fadeBestMoveChanges = 0;
       for (Thread* th : Threads)
           th->bestMoveChanges.store(0, std::memory_order_release);
+  }
 
   size_t multiPV = Options["MultiPV"];
   Skill skill(Options["Skill Level"]);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -295,6 +295,7 @@ void Thread::search() {
   beta = VALUE_INFINITE;
 
   if (mainThread)
+      mainThread->fadeBestMoveChanges = 0;
       for (Thread* th : Threads)
           th->bestMoveChanges.store(0, std::memory_order_release);
 


### PR DESCRIPTION
The current update only by main thread depends on the luck of whether main thread sees any/many changes to the best move or not. It then makes large, lumpy changes to the time to be used (1x, 2x, 3x, etc) depending on that sample of 1. Use the average across all threads to get a more reliable number with a smoother distribution.

STC @ 5+0.05 th 4 :
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 51899 W: 11446 L: 11029 D: 29424
http://tests.stockfishchess.org/tests/view/5ca32ff20ebc5925cf0016fb

STC @ 5+0.05 th 8 :
LLR: 2.96 (-2.94,2.94) [0.50,4.50]
Total: 13851 W: 2843 L: 2620 D: 8388
http://tests.stockfishchess.org/tests/view/5ca35ae00ebc5925cf001adb

LTC @ 20+0.2 th 8 :
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 48527 W: 7941 L: 7635 D: 32951
http://tests.stockfishchess.org/tests/view/5ca37cb70ebc5925cf001cec

Further work:
Similar changes might be possible for the fallingEval and timeReduction calculations (and elsewhere?), using either the min, average or max values across all threads.

Bench 3548313