### PR TITLE
Change Default Contempt from C=24 to C=20

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -59,7 +59,7 @@ void init(OptionsMap& o) {
   constexpr int MaxHashMB = Is64Bit ? 131072 : 2048;
 
   o["Debug Log File"]        << Option("", on_logger);
-  o["Contempt"]              << Option(24, -100, 100);
+  o["Contempt"]              << Option(20, -100, 100);
   o["Analysis Contempt"]     << Option("Both var Off var White var Black var Both", "Both");
   o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);


### PR DESCRIPTION
Stockfish contempt is set to the highest non-regressive value against master with contempt=0. Since PawnValueEg increased, the non-regressive contempt might have changed because of the following dependency in line 310 of search.cpp :

````
int ct = int(Options["Contempt"]) * PawnValueEg / 100; // From centipawns
````

The default contempt 24 passed STC non-regression but it failed LTC non-regression. So, a proposed new contempt is C=20 which passed both STC and LTC non-regressions.

Contempt 24
Passed STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 30255 W: 6038 L: 5933 D: 18284
http://tests.stockfishchess.org/tests/view/5ca104260ebc5925cfffec6b

Failed LTC
LLR: -2.95 (-2.94,2.94) [-3.00,1.00]
Total: 71069 W: 10037 L: 10287 D: 50745
http://tests.stockfishchess.org/tests/view/5ca1e1050ebc5925cf000493

Contempt 20
Passed STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 65905 W: 12642 L: 12601 D: 40662
http://tests.stockfishchess.org/tests/view/5ca472480ebc5925cf002a24

Passed LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 12668 W: 1847 L: 1715 D: 9106
http://tests.stockfishchess.org/tests/view/5ca4bf250ebc5925cf002fab

Against Stockfish 10, C=20 is about equal to C=24.

Contempt 20 Master vs Stockfish 10
ELO: 17.19 +-1.8 (95%) LOS: 100.0%
Total: 40000 W: 6424 L: 4446 D: 29130
http://tests.stockfishchess.org/tests/view/5ca4b62c0ebc5925cf002f7e

Contempt 24 Master vs Stockfish 10
ELO: 16.58 +-1.8 (95%) LOS: 100.0%
Total: 40000 W: 6649 L: 4742 D: 28609
http://tests.stockfishchess.org/tests/view/5ca294f90ebc5925cf000e4d

Bench: 3490352