### PR TITLE
Early loop exit from slider_blockers()

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -373,8 +373,7 @@ namespace {
         if (Pt == QUEEN)
         {
             // Penalty if any relative pin or discovered attack against the queen
-            Bitboard queenPinners;
-            if (pos.slider_blockers(pos.pieces(Them, ROOK, BISHOP), s, queenPinners))
+            if (pos.slider_blockers(pos.pieces(Them, ROOK, BISHOP), s))
                 score -= WeakQueen;
         }
     }

--- a/src/position.h
+++ b/src/position.h
@@ -113,7 +113,7 @@ public:
   Bitboard attacks_from(PieceType pt, Square s) const;
   template<PieceType> Bitboard attacks_from(Square s) const;
   template<PieceType> Bitboard attacks_from(Square s, Color c) const;
-  Bitboard slider_blockers(Bitboard sliders, Square s, Bitboard& pinners) const;
+  Bitboard slider_blockers(Bitboard sliders, Square s, Bitboard* pinners = 0) const;
 
   // Properties of moves
   bool legal(Move m) const;


### PR DESCRIPTION
Implement early loop exit in Position::slider_blockers to speed up penalty calculation for pinned queen.

Result of  30 runs
==================
base =    1669018  +/- 2163
test =    1678540  +/- 1475
diff =      +9522  +/- 2716

speedup        = +0.0057
P(speedup > 0) =  1.0000