### PR TITLE
rootDepth is local to search.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -281,7 +281,7 @@ void Thread::search() {
   Move  pv[MAX_PLY+1];
   Value bestValue, alpha, beta, delta;
   Move  lastBestMove = MOVE_NONE;
-  Depth lastBestMoveDepth = DEPTH_ZERO;
+  Depth lastBestMoveDepth = DEPTH_ZERO, rootDepth = DEPTH_ZERO;
   MainThread* mainThread = (this == Threads.main() ? Threads.main() : nullptr);
   double timeReduction = 1.0;
   Color us = rootPos.side_to_move();

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -191,7 +191,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
   for (Thread* th : *this)
   {
       th->nodes = th->tbHits = th->nmpMinPly = 0;
-      th->rootDepth = th->completedDepth = DEPTH_ZERO;
+      th->completedDepth = DEPTH_ZERO;
       th->rootMoves = rootMoves;
       th->rootPos.set(pos.fen(), pos.is_chess960(), &setupStates->back(), th);
   }

--- a/src/thread.h
+++ b/src/thread.h
@@ -67,7 +67,7 @@ public:
 
   Position rootPos;
   Search::RootMoves rootMoves;
-  Depth rootDepth, completedDepth;
+  Depth completedDepth;
   CounterMoveHistory counterMoves;
   ButterflyHistory mainHistory;
   CapturePieceToHistory captureHistory;


### PR DESCRIPTION
passed STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 61869 W: 13668 L: 13626 D: 34575
http://tests.stockfishchess.org/tests/view/5ca660eb0ebc5925cf004f0c

No functional change.