### PR TITLE
Make operator/(Depth d, int i) ONE_PLY invariant

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -912,9 +912,8 @@ moves_loop: // When in check, search starts from here
           &&  pos.legal(move))
       {
           Value singularBeta = ttValue - 2 * depth / ONE_PLY;
-          Depth halfDepth = depth / (2 * ONE_PLY) * ONE_PLY; // ONE_PLY invariant
           ss->excludedMove = move;
-          value = search<NonPV>(pos, ss, singularBeta - 1, singularBeta, halfDepth, cutNode);
+          value = search<NonPV>(pos, ss, singularBeta - 1, singularBeta, depth / 2, cutNode);
           ss->excludedMove = MOVE_NONE;
 
           if (value < singularBeta)


### PR DESCRIPTION
Currently operator/(Depth d, int i) is not ONE_PLY
invariant, but we can't modify it because it is
defined by a macro that is used also by other enum.

Ideally we want to overload it, adding a specialization
for Depth case. Unfortunatly we can't because it is defined
as a normal function, so we can't redefine it.

The solution is to define operators as templates, because
a function template can be overloaded by normal (non-template)
functions.

To avoid the templates to catch anything, we enable them only on
the explicitly declared enum (as is currently) by means of a SFINAE 
trick on the return value, i.e. we define the return type of the templates 
to exist only for the given enums and not in general.

This patch allows to use Depth / int in the code in a natural
way, withouth worrying for ONE_PLY value.

No functional change.