### PR TITLE
Simplify and Generalize shift

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -152,7 +152,7 @@ inline Bitboard shift(Bitboard b) {
   Bitboard b2 = ((D & 7) == 1) ? b & ~FileHBB :      //shifting EASTward
                 ((D & 7) == 7) ? b & ~FileABB : b;   //shifting WESTward
 
-  return D < 0 ? b2 >> -D : b2 << D;
+  return D < 0 ? b2 >> -D : b2 << D;  //no negative shifting
 }
 
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -145,14 +145,16 @@ inline Bitboard file_bb(Square s) {
 }
 
 
-/// shift() moves a bitboard one step along direction D
+/// shift() shifts a bitboard according to Direction (and magnitude) D
 
 template<Direction D>
-inline Bitboard shift(Bitboard b) {
-  Bitboard b2 = ((D & 7) == 1) ? b & ~FileHBB :      //shifting EASTward
-                ((D & 7) == 7) ? b & ~FileABB : b;   //shifting WESTward
+constexpr Bitboard shift(Bitboard b) {
+  static_assert(((D & 7) == 7) || ((D & 7) == 1) || ((D & 7) == 0),
+                "Shifting more than one step horizontally is not supported.");
 
-  return D < 0 ? b2 >> -D : b2 << D;  //no negative shifting
+  // Ensure we always shift using a positive value, clearing sides as needed
+  return (D < 0 ? b >> -D : b << D)
+     & ~((D & 1) * ((D & 4) ? FileHBB : FileABB));
 }
 
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -148,12 +148,11 @@ inline Bitboard file_bb(Square s) {
 /// shift() moves a bitboard one step along direction D
 
 template<Direction D>
-constexpr Bitboard shift(Bitboard b) {
-  return  D == NORTH      ?  b             << 8 : D == SOUTH      ?  b             >> 8
-        : D == EAST       ? (b & ~FileHBB) << 1 : D == WEST       ? (b & ~FileABB) >> 1
-        : D == NORTH_EAST ? (b & ~FileHBB) << 9 : D == NORTH_WEST ? (b & ~FileABB) << 7
-        : D == SOUTH_EAST ? (b & ~FileHBB) >> 7 : D == SOUTH_WEST ? (b & ~FileABB) >> 9
-        : 0;
+inline Bitboard shift(Bitboard b) {
+  Bitboard b2 = ((D & 7) == 1) ? b & ~FileHBB :      //shifting EASTward
+                ((D & 7) == 7) ? b & ~FileABB : b;   //shifting WESTward
+
+  return D < 0 ? b2 >> -D : b2 << D;
 }
 
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -716,7 +716,7 @@ namespace {
     // Find all squares which are at most three squares behind some friendly pawn
     Bitboard behind = pos.pieces(Us, PAWN);
     behind |= shift<Down>(behind);
-    behind |= shift<Down>(shift<Down>(behind));
+    behind |= shift<Down+Down>(behind);
 
     int bonus = popcount(safe) + popcount(behind & safe);
     int weight =  pos.count<ALL_PIECES>(Us)


### PR DESCRIPTION
This is a non-functional patch.

This is a generalization of shift that can concurrently handle more than the basic Directions.  Multiple shifts work fine, as well as horizontal shifts (as long as they don't go past the sides).  See the simplification in evaluate.cpp as an example.

The test verified the shift method, but the simplification in evaluate.cpp was NOT tested.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 62918 W: 13814 L: 13774 D: 35330
http://tests.stockfishchess.org/tests/view/5ca967d00ebc5925cf008e68