### PR TITLE
Remove Movepick::move, and rename cur to movePtr

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -132,7 +132,7 @@ public:
 private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();
-  ExtMove* begin() { return cur; }
+  ExtMove* begin() { return movePtr; }
   ExtMove* end() { return endMoves; }
 
   const Position& pos;
@@ -140,9 +140,8 @@ private:
   const CapturePieceToHistory* captureHistory;
   const PieceToHistory** continuationHistory;
   Move ttMove;
-  ExtMove refutations[3], *cur, *endMoves, *endBadCaptures;
+  ExtMove refutations[3], *movePtr, *endMoves, *endBadCaptures;
   int stage;
-  Move move;
   Square recaptureSquare;
   Value threshold;
   Depth depth;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -132,7 +132,7 @@ public:
 private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();
-  ExtMove* begin() { return movePtr; }
+  ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }
 
   const Position& pos;
@@ -140,7 +140,7 @@ private:
   const CapturePieceToHistory* captureHistory;
   const PieceToHistory** continuationHistory;
   Move ttMove;
-  ExtMove refutations[3], *movePtr, *endMoves, *endBadCaptures;
+  ExtMove refutations[3], *cur, *endMoves, *endBadCaptures;
   int stage;
   Square recaptureSquare;
   Value threshold;


### PR DESCRIPTION
This is a non-functional simplification.

The "move" class variable is Movepick is removed (removes some abstraction) which saves a few assignment operations, and the effects of "filter" is limited to the current move (movePtr).  The resulting code is a bit more verbose, but it is also more clear what is going on.  This version is NOT tested, but is substantially similar to:

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 29191 W: 6474 L: 6367 D: 16350
http://tests.stockfishchess.org/tests/view/5ca7aab50ebc5925cf006e50