### PR TITLE
Raise kingDanger threshold and adjust constant term.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -472,10 +472,10 @@ namespace {
                  -   6 * mg_value(score) / 8
                  +       mg_value(mobility[Them] - mobility[Us])
                  +   5 * kingFlankAttacks * kingFlankAttacks / 16
-                 -   25;
+                 -   15;
 
     // Transform the kingDanger units into a Score, and subtract it from the evaluation
-    if (kingDanger > 0)
+    if (kingDanger > 100)
         score -= make_score(kingDanger * kingDanger / 4096, kingDanger / 16);
 
     // Penalty when our king is on a pawnless flank


### PR DESCRIPTION
The kingDanger term is intended to give a penalty which increases rapidly in the middlegame but less so in the endgame.  To this end, the middlegame component is quadratic, and the endgame component is linear.  However, this produces unintended consequences for relatively small values of kingDanger: the endgame penalty will exceed the middlegame penalty.  This remains true up to kingDanger = 256 (a S(16, 16) penalty), so some of these inaccurate penalties are actually rather large.

In this patch, we increase the threshold for applying the kingDanger penalty to eliminate some of this unintended behavior.  This was very nearly, but not quite, sufficient to pass on its own.  The patch was finally successful by integrating a second kingDanger tweak by @Vizvezdenec, increasing the kingDanger constant term slightly and improving both STC and LTC performance.

Where do we go from here?  I propose that in the future, any attempts to tune kingDanger coefficients should also consider tuning the kingDanger threshold.  The evidence shows clearly that it should not be automatically taken to be zero.

Special thanks to @Vizvezdenec for the kingDanger constant tweak.  Thanks also to all the approvers and CPU donors who made this possible!

STC:
LLR: -2.96 (-2.94,2.94) [0.00,4.00]
Total: 141225 W: 31239 L: 30846 D: 79140
http://tests.stockfishchess.org/tests/view/5cabbdb20ebc5925cf00b86c

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 30708 W: 5296 L: 5043 D: 20369
http://tests.stockfishchess.org/tests/view/5cabff760ebc5925cf00c22d

Bench: 3445945