### PR TITLE
Simplify castlingPath

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -340,13 +340,8 @@ void Position::set_castling_right(Color c, Square rfrom) {
   Square kto = relative_square(c, cs == KING_SIDE ? SQ_G1 : SQ_C1);
   Square rto = relative_square(c, cs == KING_SIDE ? SQ_F1 : SQ_D1);
 
-  for (Square s = std::min(rfrom, rto); s <= std::max(rfrom, rto); ++s)
-      if (s != kfrom && s != rfrom)
-          castlingPath[cr] |= s;
-
-  for (Square s = std::min(kfrom, kto); s <= std::max(kfrom, kto); ++s)
-      if (s != kfrom && s != rfrom)
-          castlingPath[cr] |= s;
+  castlingPath[cr] = (between_bb(rfrom, rto) | between_bb(kfrom, kto) | rto | kto)
+                   & ~(square_bb(kfrom) | rfrom);
 }
 
 


### PR DESCRIPTION
This is a non-functional simplification.

Instead of looping through kfrom,kto, rfrom, rto, we can use BetweenBB.  This is less lines of code and it is more clear what castlingPath actually is.  Personal benchmarks are all over the place.  However, this code is only executed when loading a position, so performance doesn't seem that relevant.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 74849 W: 16520 L: 16504 D: 41825
http://tests.stockfishchess.org/tests/view/5caca9bc0ebc5925cf00ce44
