### PR TITLE
Remove two useless assignments

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1240,8 +1240,7 @@ moves_loop: // When in check, search starts from here
 
     Thread* thisThread = pos.this_thread();
     (ss+1)->ply = ss->ply + 1;
-    ss->currentMove = bestMove = MOVE_NONE;
-    ss->continuationHistory = &thisThread->continuationHistory[NO_PIECE][0];
+    bestMove = MOVE_NONE;
     inCheck = pos.checkers();
     moveCount = 0;
 


### PR DESCRIPTION
these variables are initialized before their use in the movepicker loop.

passed STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 138732 W: 30727 L: 30838 D: 77167
http://tests.stockfishchess.org/tests/view/5cb07af40ebc5925cf012c32

No functional change.