### PR TITLE
Calculate passedCount real-time

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -166,7 +166,6 @@ Entry* probe(const Position& pos) {
   e->key = key;
   e->scores[WHITE] = evaluate<WHITE>(pos, e);
   e->scores[BLACK] = evaluate<BLACK>(pos, e);
-  e->passedCount= popcount(e->passedPawns[WHITE] | e->passedPawns[BLACK]);
 
   return e;
 }

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -38,7 +38,7 @@ struct Entry {
   Bitboard passed_pawns(Color c) const { return passedPawns[c]; }
   Bitboard pawn_attacks_span(Color c) const { return pawnAttacksSpan[c]; }
   int weak_unopposed(Color c) const { return weakUnopposed[c]; }
-  int passed_count() const { return passedCount; }
+  int passed_count() const { return popcount(passedPawns[WHITE] | passedPawns[BLACK]); };
 
   int semiopen_file(Color c, File f) const {
     return semiopenFiles[c] & (1 << f);
@@ -71,7 +71,6 @@ struct Entry {
   int castlingRights[COLOR_NB];
   int semiopenFiles[COLOR_NB];
   int pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
-  int passedCount;
 };
 
 typedef HashTable<Entry, 16384> Table;


### PR DESCRIPTION
This is a non-functional simplification which removes the passedCount variable in pawns.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 27982 W: 6227 L: 6118 D: 15637
http://tests.stockfishchess.org/tests/view/5cb3cdd30ebc5925cf017025

Combo STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 17368 W: 3925 L: 3795 D: 9648
http://tests.stockfishchess.org/tests/view/5cb3d3510ebc5925cf01709a