### PR TITLE
SMP: Return to previous thread selection mechanism

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -231,7 +231,7 @@ void MainThread::search() {
       && !Skill(Options["Skill Level"]).enabled()
       &&  rootMoves[0].pv[0] != MOVE_NONE)
   {
-      std::map<Move, int64_t> votes;
+      std::map<Move, int> votes;
       Value minScore = this->rootMoves[0].score;
 
       // Find out minimum score and reset votes for moves which can be voted
@@ -240,13 +240,11 @@ void MainThread::search() {
 
       // Vote according to score and depth
       for (Thread* th : Threads)
-      {
-          int64_t s = th->rootMoves[0].score - minScore + 1;
-          votes[th->rootMoves[0].pv[0]] += 200 + s * s * int(th->completedDepth);
-      }
+          votes[th->rootMoves[0].pv[0]] +=  int(th->rootMoves[0].score - minScore)
+                                          + int(th->completedDepth);
 
       // Select best thread
-      auto bestVote = votes[this->rootMoves[0].pv[0]];
+      int bestVote = votes[this->rootMoves[0].pv[0]];
       for (Thread* th : Threads)
           if (votes[th->rootMoves[0].pv[0]] > bestVote)
           {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -231,26 +231,16 @@ void MainThread::search() {
       && !Skill(Options["Skill Level"]).enabled()
       &&  rootMoves[0].pv[0] != MOVE_NONE)
   {
-      std::map<Move, int> votes;
-      Value minScore = this->rootMoves[0].score;
-
-      // Find out minimum score and reset votes for moves which can be voted
-      for (Thread* th: Threads)
-          minScore = std::min(minScore, th->rootMoves[0].score);
-
-      // Vote according to score and depth
       for (Thread* th : Threads)
-          votes[th->rootMoves[0].pv[0]] +=  int(th->rootMoves[0].score - minScore)
-                                          + int(th->completedDepth);
+      {
+          Depth depthDiff = th->completedDepth - bestThread->completedDepth;
+          Value scoreDiff = th->rootMoves[0].score - bestThread->rootMoves[0].score;
 
-      // Select best thread
-      int bestVote = votes[this->rootMoves[0].pv[0]];
-      for (Thread* th : Threads)
-          if (votes[th->rootMoves[0].pv[0]] > bestVote)
-          {
-              bestVote = votes[th->rootMoves[0].pv[0]];
+          // Select the thread with the best score, always if it is a mate
+          if (    scoreDiff > 0
+              && (depthDiff >= 0 || th->rootMoves[0].score >= VALUE_MATE_IN_MAX_PLY))
               bestThread = th;
-          }
+      }
   }
 
   previousScore = bestThread->rootMoves[0].score;


### PR DESCRIPTION
I suggest to revert 2 Elo gaining patches from the past about thread voting.
The pull request is NO funtional change on 1 thread of course, signature is unchanged

The following tests were run:
4 threads STC 10+0.1: failed
LLR: -2.95 (-2.94,2.94) [-3.00,1.00] 
Total: 44740 W: 8529 L: 8768 D: 27443
Elo: -1.45 [-3.56,0.79] (95%)
http://tests.stockfishchess.org/tests/view/5c993a630ebc5925cfff7b61

4 threads LTC 60+0.6: passed
LLR: 2.94 (-2.94,2.94) [-3.00,1.00] 
Total: 12549 W: 1942 L: 1810 D: 8797
Elo: 3.31 [-0.10,6.69] (95%)
http://tests.stockfishchess.org/tests/view/5c996f220ebc5925cfff7fa9

8 threads STC 10+0.1: failed
LLR: -2.95 (-2.94,2.94) [-3.00,1.00] 
Total: 10964 W: 1856 L: 2030 D: 7078
Elo: -5.12 [-9.05,-1.15] (95%)
http://tests.stockfishchess.org/tests/view/5cb3af210ebc5925cf016db0

8 threads LTC 60+0.6: RUN1 stopped
LLR: 0.33 (-2.94,2.94) [-3.00,1.00] 
Total: 157875 W: 20295 L: 20483 D: 117097
Elo: -0.44 [-1.58,0.69] (95%)
http://tests.stockfishchess.org/tests/view/5c50df5c0ebc593af5d4df01

8 threads LTC 60+0.6: RUN2 failed
LLR: -2.96 (-2.94,2.94) [-3.00,1.00] 
Total: 117824 W: 15660 L: 15966 D: 86198
Elo: -0.63 [-1.82,0.68] (95%)
http://tests.stockfishchess.org/tests/view/5c99c6080ebc5925cfff81f8

Rationale behind this pull-request (even though from the 5 tests only one passed, 3 failed and one was stopped):
Scaling with time of the thread voting scheme is bad. The tests show, that there is a huge difference between 10+0.1 and 60+0.6. At 10+0.1 for both 4 and 8 threads there is a nice Elo gain, for 60+0.6 not:
At 4 threads the thread voting scheme is even a regression, at 8 threads it's still has a positive effect, but value (in Elo) seems to be very low ~0.44 / ~0.63 according to the 2 tests.

So better remove the feature completely and we should make tests later on at 60+0.6 when we try to re-introduce the feauture (in an improved way). It shall be in NO WAY an Elo loss on 4 threads at 60+0.6

Additional Remark:
I would really appreciate to have official (in written form) testing standards (1. number of threads: 2. time for STC, 3. TT size for STC test; 4. time for LTC, 5. TT size for LTC test)




