### PR TITLE
Remove semiopenFiles in pawns and simplify space

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -358,8 +358,8 @@ namespace {
                 score += RookOnPawn * popcount(pos.pieces(Them, PAWN) & PseudoAttacks[ROOK][s]);
 
             // Bonus for rook on an open or semi-open file
-            if (pe->semiopen_file(Us, file_of(s)))
-                score += RookOnFile[bool(pe->semiopen_file(Them, file_of(s)))];
+            if (pos.semiopen_file(Us, file_of(s)))
+                score += RookOnFile[bool(pos.semiopen_file(Them, file_of(s)))];
 
             // Penalty when trapped by the king, even more if the king cannot castle
             else if (mob <= 3)
@@ -720,7 +720,7 @@ namespace {
 
     int bonus = popcount(safe) + popcount(behind & safe);
     int weight =  pos.count<ALL_PIECES>(Us)
-                - 2 * popcount(pe->semiopenFiles[WHITE] & pe->semiopenFiles[BLACK]);
+               - (16 - pos.count<PAWN>()) / 4;
 
     Score score = make_score(bonus * weight * weight / 16, 0);
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -77,7 +77,6 @@ namespace {
     Bitboard theirPawns = pos.pieces(Them, PAWN);
 
     e->passedPawns[Us] = e->pawnAttacksSpan[Us] = e->weakUnopposed[Us] = 0;
-    e->semiopenFiles[Us] = 0xFF;
     e->kingSquares[Us]   = SQ_NONE;
     e->pawnAttacks[Us]   = pawn_attacks_bb<Us>(ourPawns);
     e->pawnsOnSquares[Us][BLACK] = popcount(ourPawns & DarkSquares);
@@ -91,7 +90,6 @@ namespace {
         File f = file_of(s);
         Rank r = relative_rank(Us, s);
 
-        e->semiopenFiles[Us]   &= ~(1 << f);
         e->pawnAttacksSpan[Us] |= pawn_attack_span(Us, s);
 
         // Flag the pawn

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -40,10 +40,6 @@ struct Entry {
   int weak_unopposed(Color c) const { return weakUnopposed[c]; }
   int passed_count() const { return passedCount; }
 
-  int semiopen_file(Color c, File f) const {
-    return semiopenFiles[c] & (1 << f);
-  }
-
   int pawns_on_same_color_squares(Color c, Square s) const {
     return pawnsOnSquares[c][bool(DarkSquares & s)];
   }
@@ -69,7 +65,6 @@ struct Entry {
   Score kingSafety[COLOR_NB];
   int weakUnopposed[COLOR_NB];
   int castlingRights[COLOR_NB];
-  int semiopenFiles[COLOR_NB];
   int pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
   int passedCount;
 };

--- a/src/position.h
+++ b/src/position.h
@@ -95,6 +95,7 @@ public:
   template<PieceType Pt> int count() const;
   template<PieceType Pt> const Square* squares(Color c) const;
   template<PieceType Pt> Square square(Color c) const;
+  int semiopen_file(Color c, File f) const;
 
   // Castling
   int castling_rights(Color c) const;
@@ -258,6 +259,10 @@ template<PieceType Pt> inline Square Position::square(Color c) const {
 
 inline Square Position::ep_square() const {
   return st->epSquare;
+}
+
+inline int Position::semiopen_file(Color c, File f) const {
+  return !(pieces(c, PAWN) & file_bb(f));
 }
 
 inline bool Position::can_castle(CastlingRight cr) const {


### PR DESCRIPTION
This is a functional simplification.

1) semiopenFiles is removed in pawns and uses the piece arrays in position instead.

2) popcount is removed in space calculations and uses pawn piece count instead.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 33327 W: 7423 L: 7324 D: 18580
http://tests.stockfishchess.org/tests/view/5cb4be090ebc5925cf018511

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 10173 W: 1774 L: 1636 D: 6763 
http://tests.stockfishchess.org/tests/view/5cb4c5920ebc5925cf018696

bench 3402947