### PR TITLE
Slight improvement of bishop evaluation.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -144,6 +144,7 @@ namespace {
   constexpr Score PawnlessFlank      = S( 17, 95);
   constexpr Score RestrictedPiece    = S(  7,  7);
   constexpr Score RookOnPawn         = S( 10, 32);
+  constexpr Score SideAttackBishop   = S( 20, 20);
   constexpr Score SliderOnQueen      = S( 59, 18);
   constexpr Score ThreatByKing       = S( 24, 89);
   constexpr Score ThreatByPawnPush   = S( 48, 39);
@@ -334,6 +335,15 @@ namespace {
                 // Bonus for bishop on a long diagonal which can "see" both center squares
                 if (more_than_one(attacks_bb<BISHOP>(s, pos.pieces(PAWN)) & Center))
                     score += LongDiagonalBishop;
+                else 
+                {
+                    constexpr Bitboard boardSide (Us == WHITE? Rank1BB | FileABB | FileHBB : 
+                                                           Rank8BB | FileABB | FileHBB);
+                    // Penalty for bishop that doesn't attack anyhing apart from the sides of the board
+                    // in our mobility area
+                    if (!(b & mobilityArea[Us] & ~boardSide))
+		    	score -= SideAttackBishop;
+                }
             }
 
             // An important Chess960 pattern: A cornered bishop blocked by a friendly


### PR DESCRIPTION
Was yellow at STC
http://tests.stockfishchess.org/tests/view/5cb4da2b0ebc5925cf0187e6
LLR: -2.96 (-2.94,2.94) [0.50,4.50]
Total: 98274 W: 21959 L: 21636 D: 54679 
green at LTC
http://tests.stockfishchess.org/tests/view/5cb5763b0ebc5925cf01951a
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 234796 W: 40052 L: 39212 D: 155532 
bench 3138268
There can be further attempts on either improving this eval term or simplifying it away with mobility/psqt compensation. Effectively this term increases penalty for 0 mobility bishop by (20,20), for example, so this should be the first thing tried in case of attempted simplifications :)
This patch should further prohibit SF from getting trapped bishops that have no squares to move - sometimes SF still underestimates how bad this bishops are.
Slight code optimization compared to base patch and rebased on the newest master.