### PR TITLE
Remove DistanceRing

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -28,7 +28,6 @@ uint8_t PopCnt16[1 << 16];
 uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 Bitboard LineBB[SQUARE_NB][SQUARE_NB];
-Bitboard DistanceRingBB[SQUARE_NB][8];
 Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 Bitboard PawnAttacks[COLOR_NB][SQUARE_NB];
 Bitboard SquareBB[SQUARE_NB];
@@ -83,10 +82,7 @@ void Bitboards::init() {
 
   for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
       for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2)
-          {
               SquareDistance[s1][s2] = std::max(distance<File>(s1, s2), distance<Rank>(s1, s2));
-              DistanceRingBB[s1][SquareDistance[s1][s2]] |= s2;
-          }
 
   int steps[][5] = { {}, { 7, 9 }, { 6, 10, 15, 17 }, {}, {}, {}, { 1, 7, 8, 9 } };
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -69,7 +69,6 @@ extern uint8_t PopCnt16[1 << 16];
 extern uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard LineBB[SQUARE_NB][SQUARE_NB];
-extern Bitboard DistanceRingBB[SQUARE_NB][8];
 extern Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 extern Bitboard PawnAttacks[COLOR_NB][SQUARE_NB];
 extern Bitboard KingFlank[FILE_NB];

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -212,11 +212,12 @@ Score Entry::do_king_safety(const Position& pos) {
   Square ksq = pos.square<KING>(Us);
   kingSquares[Us] = ksq;
   castlingRights[Us] = pos.castling_rights(Us);
-  int minKingPawnDistance = 0;
 
   Bitboard pawns = pos.pieces(Us, PAWN);
-  if (pawns)
-      while (!(DistanceRingBB[ksq][++minKingPawnDistance] & pawns)) {}
+  int d, minKingPawnDistance = pawns ? 8 : 0;
+  while(pawns)
+      if ((d = distance(pop_lsb(&pawns), ksq)) < minKingPawnDistance)
+          minKingPawnDistance = d;
 
   Value bonus = evaluate_shelter<Us>(pos, ksq);
 


### PR DESCRIPTION
This is a non-functional simplification that removes the DistanceRing array.  This reduces the memory footprint by about 4kb.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 15918 W: 3568 L: 3435 D: 8915 
http://tests.stockfishchess.org/tests/view/5cb64eed0ebc5925cf01a7c6

LTC (low tp, prio: -1 to verify)
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 35470 W: 6015 L: 5918 D: 23537 
http://tests.stockfishchess.org/tests/view/5cb65a000ebc5925cf01a85e