### PR TITLE
Shuffle detection

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -943,7 +943,7 @@ moves_loop: // When in check, search starts from here
               && ss->ply > 18
               && depth < 3 * ONE_PLY
               && PvNode
-              && ss->ply < 3 * thisThread->rootDepth / ONE_PLY)	// To avoid infinite loops
+              && ss->ply < 3 * thisThread->rootDepth / ONE_PLY)	           // To avoid infinite loops
           extension = ONE_PLY;
 
       // Passed pawn extension

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -608,8 +608,8 @@ namespace {
     ttPv = (ttHit && tte->is_pv()) || (PvNode && depth > 4 * ONE_PLY);
 
     // If position has been searched at higher depths and we are shuffling, return value_draw
-    if (pos.rule50_count() > 36 - 14 * (pos.count<ALL_PIECES>() > 12)
-        && ss->ply > 36 - 14 * (pos.count<ALL_PIECES>() > 12)
+    if (pos.rule50_count() > 36 - 12 * (pos.count<ALL_PIECES>() > 14)
+        && ss->ply > 36 - 12 * (pos.count<ALL_PIECES>() > 14)
         //&& depth < 3 * ONE_PLY
         && ttHit
         && tte->depth() > depth

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -946,7 +946,7 @@ moves_loop: // When in check, search starts from here
 	          && ss->ply > 14 
 	          && depth < 2 * ONE_PLY 
 			  && PvNode 
-			  && ss->ply % 2 == 1)	// To avoid infinite loops
+			  && ss->ply < 3 * thisThread->rootDepth / ONE_PLY)	// To avoid infinite loops
           extension = ONE_PLY;
 
       // Passed pawn extension

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -612,7 +612,8 @@ namespace {
         && ss->ply > 36 - 12 * (pos.count<ALL_PIECES>() > 14)
         //&& depth < 3 * ONE_PLY
         && ttHit
-        && tte->depth() > depth
+        && tte->depth() > std::max(depth, 6 * ONE_PLY)
+		&& abs(ttValue) < Value(600)
         && pos.count<PAWN>() > 0)
         {
            //sync_cout << "Shuffling : " << pos.fen() << sync_endl;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -612,8 +612,7 @@ namespace {
         && ss->ply > 36 - 12 * (pos.count<ALL_PIECES>() > 14)
         //&& depth < 3 * ONE_PLY
         && ttHit
-        && tte->depth() > std::max(depth, 6 * ONE_PLY)
-		&& abs(ttValue) < Value(600)
+        && tte->depth() > depth
         && pos.count<PAWN>() > 0)
         {
            //sync_cout << "Shuffling : " << pos.fen() << sync_endl;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -944,7 +944,7 @@ moves_loop: // When in check, search starts from here
 	  // Shuffle extension
       else if(pos.rule50_count() > 14 
 	          && ss->ply > 14 
-	          && depth < 2 * ONE_PLY 
+	          && depth < 3 * ONE_PLY 
 			  && PvNode 
 			  && ss->ply < 3 * thisThread->rootDepth / ONE_PLY)	// To avoid infinite loops
           extension = ONE_PLY;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -946,7 +946,7 @@ moves_loop: // When in check, search starts from here
 	          && ss->ply > 14 
 	          && depth < 2 * ONE_PLY 
 			  && PvNode 
-			  && ss->ply % 2 == 0)	// To avoid infinite loops
+			  && ss->ply % 2 == 1)	// To avoid infinite loops
           extension = ONE_PLY;
 
       // Passed pawn extension

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -608,8 +608,8 @@ namespace {
     ttPv = (ttHit && tte->is_pv()) || (PvNode && depth > 4 * ONE_PLY);
 
     // If position has been searched at higher depths and we are shuffling, return value_draw
-    if (pos.rule50_count() > 36 - 12 * (pos.count<ALL_PIECES>() > 14)
-        && ss->ply > 36 - 12 * (pos.count<ALL_PIECES>() > 14)
+    if (pos.rule50_count() > 36 - 6 * (pos.count<ALL_PIECES>() > 14)
+        && ss->ply > 36 - 6 * (pos.count<ALL_PIECES>() > 14)
         //&& depth < 3 * ONE_PLY
         && ttHit
         && tte->depth() > depth

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -939,8 +939,8 @@ moves_loop: // When in check, search starts from here
           extension = ONE_PLY;
 
       // Shuffle extension
-      else if(pos.rule50_count() > 14
-              && ss->ply > 14
+      else if(pos.rule50_count() > 18
+              && ss->ply > 18
               && depth < 3 * ONE_PLY
               && PvNode
               && ss->ply < 3 * thisThread->rootDepth / ONE_PLY)	// To avoid infinite loops

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -935,7 +935,7 @@ moves_loop: // When in check, search starts from here
           extension = ONE_PLY;
 
       // Shuffle extension
-      else if(pos.rule50_count() > 14 && ss->ply > 14 && depth < 3 * ONE_PLY && PvNode)
+      else if(pos.rule50_count() > 16 && ss->ply > 16 && depth < 3 * ONE_PLY && PvNode)
           extension = ONE_PLY;
 
       // Castling extension

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -608,8 +608,8 @@ namespace {
     ttPv = (ttHit && tte->is_pv()) || (PvNode && depth > 4 * ONE_PLY);
 
     // If position has been searched at higher depths and we are shuffling, return value_draw
-    if (pos.rule50_count() > 36 - 8 * (pos.count<ALL_PIECES>() > 12)
-        && ss->ply > 36 - 8 * (pos.count<ALL_PIECES>() > 12)
+    if (pos.rule50_count() > 36 - 14 * (pos.count<ALL_PIECES>() > 12)
+        && ss->ply > 36 - 14 * (pos.count<ALL_PIECES>() > 12)
         //&& depth < 3 * ONE_PLY
         && ttHit
         && tte->depth() > depth

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -610,14 +610,12 @@ namespace {
     // If position has been searched at higher depths and we are shuffling, return value_draw
     if (pos.rule50_count() > 36 - 6 * (pos.count<ALL_PIECES>() > 14)
         && ss->ply > 36 - 6 * (pos.count<ALL_PIECES>() > 14)
-        //&& depth < 3 * ONE_PLY
         && ttHit
         && tte->depth() > depth
         && pos.count<PAWN>() > 0)
         {
-           //sync_cout << "Shuffling : " << pos.fen() << sync_endl;
            return VALUE_DRAW;
-	   }
+        }
 
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode
@@ -939,13 +937,13 @@ moves_loop: // When in check, search starts from here
       // Castling extension
       else if (type_of(move) == CASTLING)
           extension = ONE_PLY;
-	  
-	  // Shuffle extension
-      else if(pos.rule50_count() > 14 
-	          && ss->ply > 14 
-	          && depth < 3 * ONE_PLY 
-			  && PvNode 
-			  && ss->ply < 3 * thisThread->rootDepth / ONE_PLY)	// To avoid infinite loops
+
+      // Shuffle extension
+      else if(pos.rule50_count() > 14
+              && ss->ply > 14
+              && depth < 3 * ONE_PLY
+              && PvNode
+              && ss->ply < 3 * thisThread->rootDepth / ONE_PLY)	// To avoid infinite loops
           extension = ONE_PLY;
 
       // Passed pawn extension

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -607,10 +607,10 @@ namespace {
             : ttHit    ? tte->move() : MOVE_NONE;
     ttPv = (ttHit && tte->is_pv()) || (PvNode && depth > 4 * ONE_PLY);
 
-    // if position has been searched at higher depths and we are shuffling, return value_draw
+    // If position has been searched at higher depths and we are shuffling, return value_draw
     if (pos.rule50_count() > 36
         && ss->ply > 36
-        && depth < 3 * ONE_PLY
+        //&& depth < 3 * ONE_PLY
         && ttHit
         && tte->depth() > depth
         && pos.count<PAWN>() > 0)
@@ -935,7 +935,7 @@ moves_loop: // When in check, search starts from here
           extension = ONE_PLY;
 
       // Shuffle extension
-      else if(pos.rule50_count() > 16 && ss->ply > 16 && depth < 3 * ONE_PLY && PvNode)
+      else if(pos.rule50_count() > 14 && ss->ply > 14 && depth < 3 * ONE_PLY && PvNode)
           extension = ONE_PLY;
 
       // Castling extension

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -608,13 +608,16 @@ namespace {
     ttPv = (ttHit && tte->is_pv()) || (PvNode && depth > 4 * ONE_PLY);
 
     // If position has been searched at higher depths and we are shuffling, return value_draw
-    if (pos.rule50_count() > 36
-        && ss->ply > 36
+    if (pos.rule50_count() > 36 - 8 * (pos.count<ALL_PIECES>() > 12)
+        && ss->ply > 36 - 8 * (pos.count<ALL_PIECES>() > 12)
         //&& depth < 3 * ONE_PLY
         && ttHit
         && tte->depth() > depth
         && pos.count<PAWN>() > 0)
-        return VALUE_DRAW;
+        {
+           //sync_cout << "Shuffling : " << pos.fen() << sync_endl;
+           return VALUE_DRAW;
+	   }
 
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -944,9 +944,9 @@ moves_loop: // When in check, search starts from here
 	  // Shuffle extension
       else if(pos.rule50_count() > 14 
 	          && ss->ply > 14 
-	          && depth < 3 * ONE_PLY 
+	          && depth < 2 * ONE_PLY 
 			  && PvNode 
-			  && ss->ply < MAX_PLY)
+			  && ss->ply % 2 == 0)	// To avoid infinite loops
           extension = ONE_PLY;
 
       // Passed pawn extension


### PR DESCRIPTION
New shuffle detection procedure : 
- tuned parameters,
- add a limit to loops to avoid infinite loops : 3x rootDepth

The new parameters are safer than older ones. With this patch SF cannot detect shuffle positions effectively at STC and LTC, but we can see positive ELO gain at VLTC

STC :
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 56493 W: 12617 L: 12565 D: 31311 
http://tests.stockfishchess.org/tests/view/5cb5b18a0ebc5925cf0199e3

LTC : 
LLR: -2.95 (-2.94,2.94) [0.00,3.50]
Total: 72809 W: 12335 L: 12305 D: 48169 
http://tests.stockfishchess.org/tests/view/5cb5cc380ebc5925cf019d4f

VLTC :
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 57835 W: 8633 L: 8316 D: 40886 
http://tests.stockfishchess.org/tests/view/5cb5cce10ebc5925cf019d6a

Bench : 3402947