### PR TITLE
Remove capping in reduction.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -67,10 +67,10 @@ namespace {
   }
 
   // Reductions lookup table, initialized at startup
-  int Reductions[64]; // [depth or moveNumber]
+  int Reductions[MAX_MOVES]; // [depth or moveNumber]
 
   template <bool PvNode> Depth reduction(bool i, Depth d, int mn) {
-    int r = Reductions[std::min(d / ONE_PLY, 63)] * Reductions[std::min(mn, 63)] / 1024;
+    int r = Reductions[d / ONE_PLY] * Reductions[mn] / 1024;
     return ((r + 512) / 1024 + (!i && r > 1024) - PvNode) * ONE_PLY;
   }
 
@@ -147,7 +147,7 @@ namespace {
 
 void Search::init() {
 
-  for (int i = 1; i < 64; ++i)
+  for (int i = 1; i < MAX_MOVES; ++i)
       Reductions[i] = int(1024 * std::log(i) / std::sqrt(1.95));
 }
 


### PR DESCRIPTION
saves two std::min.

Bench is unchanged to high depth, but in principle this is a functional change so tested both STC and LTC.

passed STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 78193 W: 17220 L: 17210 D: 43763
http://tests.stockfishchess.org/tests/view/5cb789540ebc5925cf01b90b

passed LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 93846 W: 15964 L: 15962 D: 61920
http://tests.stockfishchess.org/tests/view/5cb8066d0ebc5925cf01c72b

Bench: 3402947