### PR TITLE
Use constructor for stack.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -20,7 +20,6 @@
 
 #include <cassert>
 #include <cmath>
-#include <cstring>   // For std::memset
 #include <iostream>
 #include <sstream>
 
@@ -289,7 +288,6 @@ void Thread::search() {
   double timeReduction = 1, totBestMoveChanges = 0;
   Color us = rootPos.side_to_move();
 
-  std::memset(ss-7, 0, 10 * sizeof(Stack));
   for (int i = 7; i > 0; i--)
      (ss-i)->continuationHistory = &this->continuationHistory[NO_PIECE][0]; // Use as sentinel
   ss->pv = pv;

--- a/src/search.h
+++ b/src/search.h
@@ -53,7 +53,7 @@ struct Stack {
   Stack(): pv(NULL), continuationHistory(NULL), currentMove(MOVE_NONE),
                      excludedMove(MOVE_NONE),   killers{MOVE_NONE, MOVE_NONE}
   {
-      ply = statScore = moveCount = 0;
+      ply = statScore = moveCount = staticEval = Value(0);
   };
 };
 

--- a/src/search.h
+++ b/src/search.h
@@ -49,6 +49,12 @@ struct Stack {
   Value staticEval;
   int statScore;
   int moveCount;
+
+  Stack(): pv(NULL), continuationHistory(NULL), currentMove(MOVE_NONE),
+                     excludedMove(MOVE_NONE),   killers{MOVE_NONE, MOVE_NONE}
+  {
+      ply = statScore = moveCount = 0;
+  };
 };
 
 


### PR DESCRIPTION
This is a non-functional code style change.

An actual constructor for the Stack struct is much better c++ form and allows removal of the memset.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 30893 W: 6902 L: 6799 D: 17192
http://tests.stockfishchess.org/tests/view/5cbbec200ebc5925cf023600