### PR TITLE
Remove template for pos.count(Color c)

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -63,7 +63,7 @@ namespace {
 
 #ifndef NDEBUG
   bool verify_material(const Position& pos, Color c, Value npm, int pawnsCnt) {
-    return pos.non_pawn_material(c) == npm && pos.count<PAWN>(c) == pawnsCnt;
+    return pos.non_pawn_material(c) == npm && pos.count(c,PAWN) == pawnsCnt;
   }
 #endif
 
@@ -71,7 +71,7 @@ namespace {
   // is on the left half of the board.
   Square normalize(const Position& pos, Color strongSide, Square sq) {
 
-    assert(pos.count<PAWN>(strongSide) == 1);
+    assert(pos.count(strongSide, PAWN) == 1);
 
     if (file_of(pos.square<PAWN>(strongSide)) >= FILE_E)
         sq = Square(sq ^ 7); // Mirror SQ_H1 -> SQ_A1
@@ -100,13 +100,13 @@ Value Endgame<KXK>::operator()(const Position& pos) const {
   Square loserKSq = pos.square<KING>(weakSide);
 
   Value result =  pos.non_pawn_material(strongSide)
-                + pos.count<PAWN>(strongSide) * PawnValueEg
+                + pos.count(strongSide, PAWN) * PawnValueEg
                 + PushToEdges[loserKSq]
                 + PushClose[distance(winnerKSq, loserKSq)];
 
-  if (   pos.count<QUEEN>(strongSide)
-      || pos.count<ROOK>(strongSide)
-      ||(pos.count<BISHOP>(strongSide) && pos.count<KNIGHT>(strongSide))
+  if (   pos.count(strongSide, QUEEN)
+      || pos.count(strongSide, ROOK)
+      ||(pos.count(strongSide, BISHOP) && pos.count(strongSide, KNIGHT))
       || (   (pos.pieces(strongSide, BISHOP) & ~DarkSquares)
           && (pos.pieces(strongSide, BISHOP) &  DarkSquares)))
       result = std::min(result + VALUE_KNOWN_WIN, VALUE_MATE_IN_MAX_PLY - 1);
@@ -309,7 +309,7 @@ template<>
 ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
 
   assert(pos.non_pawn_material(strongSide) == BishopValueMg);
-  assert(pos.count<PAWN>(strongSide) >= 1);
+  assert(pos.count(strongSide, PAWN) >= 1);
 
   // No assertions about the material of weakSide, because we want draws to
   // be detected even when the weaker side has some pawns.
@@ -334,7 +334,7 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
   if (    (pawnsFile == FILE_B || pawnsFile == FILE_G)
       && !(pos.pieces(PAWN) & ~file_bb(pawnsFile))
       && pos.non_pawn_material(weakSide) == 0
-      && pos.count<PAWN>(weakSide) >= 1)
+      && pos.count(weakSide, PAWN) >= 1)
   {
       // Get weakSide pawn that is closest to the home rank
       Square weakPawnSq = backmost_sq(weakSide, pos.pieces(weakSide, PAWN));
@@ -347,7 +347,7 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
       // the bishop cannot attack it or they only have one pawn left
       if (   relative_rank(strongSide, weakPawnSq) == RANK_7
           && (pos.pieces(strongSide, PAWN) & (weakPawnSq + pawn_push(weakSide)))
-          && (opposite_colors(bishopSq, weakPawnSq) || pos.count<PAWN>(strongSide) == 1))
+          && (opposite_colors(bishopSq, weakPawnSq) || pos.count(strongSide, PAWN) == 1))
       {
           int strongKingDist = distance(weakPawnSq, strongKingSq);
           int weakKingDist = distance(weakPawnSq, weakKingSq);
@@ -375,8 +375,8 @@ template<>
 ScaleFactor Endgame<KQKRPs>::operator()(const Position& pos) const {
 
   assert(verify_material(pos, strongSide, QueenValueMg, 0));
-  assert(pos.count<ROOK>(weakSide) == 1);
-  assert(pos.count<PAWN>(weakSide) >= 1);
+  assert(pos.count(weakSide, ROOK) == 1);
+  assert(pos.count(weakSide, PAWN) >= 1);
 
   Square kingSq = pos.square<KING>(weakSide);
   Square rsq = pos.square<ROOK>(weakSide);
@@ -572,7 +572,7 @@ template<>
 ScaleFactor Endgame<KPsK>::operator()(const Position& pos) const {
 
   assert(pos.non_pawn_material(strongSide) == VALUE_ZERO);
-  assert(pos.count<PAWN>(strongSide) >= 2);
+  assert(pos.count(strongSide, PAWN) >= 2);
   assert(verify_material(pos, weakSide, VALUE_ZERO, 0));
 
   Square ksq = pos.square<KING>(weakSide);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -468,7 +468,7 @@ namespace {
                  + 185 * popcount(kingRing[Us] & weak)
                  - 100 * bool(attackedBy[Us][KNIGHT] & attackedBy[Us][KING])
                  + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
-                 - 873 * !pos.count<QUEEN>(Them)
+                 - 873 * !pos.count(Them, QUEEN)
                  -   6 * mg_value(score) / 8
                  +       mg_value(mobility[Them] - mobility[Us])
                  +   5 * kingFlankAttacks * kingFlankAttacks / 16
@@ -579,7 +579,7 @@ namespace {
     score += ThreatBySafePawn * popcount(b);
 
     // Bonus for threats on the next moves against enemy queen
-    if (pos.count<QUEEN>(Them) == 1)
+    if (pos.count(Them, QUEEN) == 1)
     {
         Square s = pos.square<QUEEN>(Them);
         safe = mobilityArea[Us] & ~stronglyProtected;
@@ -719,8 +719,8 @@ namespace {
     behind |= shift<Down>(shift<Down>(behind));
 
     int bonus = popcount(safe) + popcount(behind & safe);
-    int weight =  pos.count<ALL_PIECES>(Us)
-               - (16 - pos.count<PAWN>()) / 4;
+    int weight =  pos.count(Us, ALL_PIECES)
+               - (16 - pos.count(PAWN)) / 4;
 
     Score score = make_score(bonus * weight * weight / 16, 0);
 
@@ -746,7 +746,7 @@ namespace {
 
     // Compute the initiative bonus for the attacking side
     int complexity =   9 * pe->passed_count()
-                    + 11 * pos.count<PAWN>()
+                    + 11 * pos.count(PAWN)
                     +  9 * outflanking
                     + 18 * pawnsOnBothFlanks
                     + 49 * !pos.non_pawn_material()
@@ -780,7 +780,7 @@ namespace {
             && pos.non_pawn_material(BLACK) == BishopValueMg)
             sf = 16 + 4 * pe->passed_count();
         else
-            sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
+            sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count(strongSide, PAWN), sf);
 
     }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -720,7 +720,7 @@ namespace {
 
     int bonus = popcount(safe) + popcount(behind & safe);
     int weight =  pos.count(Us, ALL_PIECES)
-               - (16 - pos.count(PAWN)) / 4;
+               - (16 - pos.count<PAWN>()) / 4;
 
     Score score = make_score(bonus * weight * weight / 16, 0);
 
@@ -746,7 +746,7 @@ namespace {
 
     // Compute the initiative bonus for the attacking side
     int complexity =   9 * pe->passed_count()
-                    + 11 * pos.count(PAWN)
+                    + 11 * pos.count<PAWN>()
                     +  9 * outflanking
                     + 18 * pawnsOnBothFlanks
                     + 49 * !pos.non_pawn_material()

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -69,14 +69,14 @@ namespace {
 
   bool is_KBPsK(const Position& pos, Color us) {
     return   pos.non_pawn_material(us) == BishopValueMg
-          && pos.count<PAWN  >(us) >= 1;
+          && pos.count(us, PAWN) >= 1;
   }
 
   bool is_KQKRPs(const Position& pos, Color us) {
-    return  !pos.count<PAWN>(us)
+    return  !pos.count(us, PAWN)
           && pos.non_pawn_material(us) == QueenValueMg
-          && pos.count<ROOK>(~us) == 1
-          && pos.count<PAWN>(~us) >= 1;
+          && pos.count(~us, ROOK) == 1
+          && pos.count(~us, PAWN) >= 1;
   }
 
   /// imbalance() calculates the imbalance by comparing the piece count of each
@@ -171,19 +171,19 @@ Entry* probe(const Position& pos) {
 
   if (npm_w + npm_b == VALUE_ZERO && pos.pieces(PAWN)) // Only pawns on the board
   {
-      if (!pos.count<PAWN>(BLACK))
+      if (!pos.count(BLACK, PAWN))
       {
-          assert(pos.count<PAWN>(WHITE) >= 2);
+          assert(pos.count(WHITE, PAWN) >= 2);
 
           e->scalingFunction[WHITE] = &ScaleKPsK[WHITE];
       }
-      else if (!pos.count<PAWN>(WHITE))
+      else if (!pos.count(WHITE, PAWN))
       {
-          assert(pos.count<PAWN>(BLACK) >= 2);
+          assert(pos.count(BLACK, PAWN) >= 2);
 
           e->scalingFunction[BLACK] = &ScaleKPsK[BLACK];
       }
-      else if (pos.count<PAWN>(WHITE) == 1 && pos.count<PAWN>(BLACK) == 1)
+      else if (pos.count(WHITE, PAWN) == 1 && pos.count(BLACK, PAWN) == 1)
       {
           // This is a special case because we set scaling functions
           // for both colors instead of only one.
@@ -195,11 +195,11 @@ Entry* probe(const Position& pos) {
   // Zero or just one pawn makes it difficult to win, even with a small material
   // advantage. This catches some trivial draws like KK, KBK and KNK and gives a
   // drawish scale factor for cases such as KRKBP and KmmKm (except for KBBKN).
-  if (!pos.count<PAWN>(WHITE) && npm_w - npm_b <= BishopValueMg)
+  if (!pos.count(WHITE, PAWN) && npm_w - npm_b <= BishopValueMg)
       e->factor[WHITE] = uint8_t(npm_w <  RookValueMg   ? SCALE_FACTOR_DRAW :
                                  npm_b <= BishopValueMg ? 4 : 14);
 
-  if (!pos.count<PAWN>(BLACK) && npm_b - npm_w <= BishopValueMg)
+  if (!pos.count(BLACK, PAWN) && npm_b - npm_w <= BishopValueMg)
       e->factor[BLACK] = uint8_t(npm_b <  RookValueMg   ? SCALE_FACTOR_DRAW :
                                  npm_w <= BishopValueMg ? 4 : 14);
 
@@ -207,10 +207,10 @@ Entry* probe(const Position& pos) {
   // for the bishop pair "extended piece", which allows us to be more flexible
   // in defining bishop pair bonuses.
   const int pieceCount[COLOR_NB][PIECE_TYPE_NB] = {
-  { pos.count<BISHOP>(WHITE) > 1, pos.count<PAWN>(WHITE), pos.count<KNIGHT>(WHITE),
-    pos.count<BISHOP>(WHITE)    , pos.count<ROOK>(WHITE), pos.count<QUEEN >(WHITE) },
-  { pos.count<BISHOP>(BLACK) > 1, pos.count<PAWN>(BLACK), pos.count<KNIGHT>(BLACK),
-    pos.count<BISHOP>(BLACK)    , pos.count<ROOK>(BLACK), pos.count<QUEEN >(BLACK) } };
+  { pos.count(WHITE, BISHOP) > 1, pos.count(WHITE, PAWN), pos.count(WHITE, KNIGHT),
+    pos.count(WHITE, BISHOP)    , pos.count(WHITE, ROOK), pos.count(WHITE, QUEEN) },
+  { pos.count(BLACK, BISHOP) > 1, pos.count(BLACK, PAWN), pos.count(BLACK, KNIGHT),
+    pos.count(BLACK, BISHOP)    , pos.count(BLACK, ROOK), pos.count(BLACK, QUEEN) } };
 
   e->value = int16_t((imbalance<WHITE>(pieceCount) - imbalance<BLACK>(pieceCount)) / 16);
   return e;

--- a/src/position.h
+++ b/src/position.h
@@ -91,8 +91,8 @@ public:
   Piece piece_on(Square s) const;
   Square ep_square() const;
   bool empty(Square s) const;
-  template<PieceType Pt> int count(Color c) const;
-  template<PieceType Pt> int count() const;
+  int count(Color c, PieceType pt) const;
+  int count(PieceType pt) const;
   template<PieceType Pt> const Square* squares(Color c) const;
   template<PieceType Pt> Square square(Color c) const;
   int semiopen_file(Color c, File f) const;
@@ -241,12 +241,12 @@ inline Bitboard Position::pieces(Color c, PieceType pt1, PieceType pt2) const {
   return byColorBB[c] & (byTypeBB[pt1] | byTypeBB[pt2]);
 }
 
-template<PieceType Pt> inline int Position::count(Color c) const {
-  return pieceCount[make_piece(c, Pt)];
+inline int Position::count(Color c, PieceType pt) const {
+  return pieceCount[make_piece(c, pt)];
 }
 
-template<PieceType Pt> inline int Position::count() const {
-  return pieceCount[make_piece(WHITE, Pt)] + pieceCount[make_piece(BLACK, Pt)];
+inline int Position::count(PieceType pt) const {
+  return count(WHITE, pt) + count(BLACK, pt);
 }
 
 template<PieceType Pt> inline const Square* Position::squares(Color c) const {

--- a/src/position.h
+++ b/src/position.h
@@ -92,7 +92,7 @@ public:
   Square ep_square() const;
   bool empty(Square s) const;
   int count(Color c, PieceType pt) const;
-  int count(PieceType pt) const;
+  template<PieceType Pt> int count() const;
   template<PieceType Pt> const Square* squares(Color c) const;
   template<PieceType Pt> Square square(Color c) const;
   int semiopen_file(Color c, File f) const;
@@ -245,8 +245,8 @@ inline int Position::count(Color c, PieceType pt) const {
   return pieceCount[make_piece(c, pt)];
 }
 
-inline int Position::count(PieceType pt) const {
-  return count(WHITE, pt) + count(BLACK, pt);
+template<PieceType Pt> inline int Position::count() const {
+  return count(WHITE, Pt) + count(BLACK, Pt);
 }
 
 template<PieceType Pt> inline const Square* Position::squares(Color c) const {

--- a/src/position.h
+++ b/src/position.h
@@ -91,7 +91,7 @@ public:
   Piece piece_on(Square s) const;
   Square ep_square() const;
   bool empty(Square s) const;
-  int count(Color c, PieceType pt) const;
+  constexpr int count(Color c, PieceType pt) const;
   template<PieceType Pt> int count() const;
   template<PieceType Pt> const Square* squares(Color c) const;
   template<PieceType Pt> Square square(Color c) const;
@@ -241,7 +241,7 @@ inline Bitboard Position::pieces(Color c, PieceType pt1, PieceType pt2) const {
   return byColorBB[c] & (byTypeBB[pt1] | byTypeBB[pt2]);
 }
 
-inline int Position::count(Color c, PieceType pt) const {
+constexpr int Position::count(Color c, PieceType pt) const {
   return pieceCount[make_piece(c, pt)];
 }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -641,7 +641,7 @@ namespace {
     // Step 5. Tablebases probe
     if (!rootNode && TB::Cardinality)
     {
-        int piecesCount = pos.count<ALL_PIECES>();
+        int piecesCount = pos.count(ALL_PIECES);
 
         if (    piecesCount <= TB::Cardinality
             && (piecesCount <  TB::Cardinality || depth >= TB::ProbeDepth)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -641,7 +641,7 @@ namespace {
     // Step 5. Tablebases probe
     if (!rootNode && TB::Cardinality)
     {
-        int piecesCount = pos.count(ALL_PIECES);
+        int piecesCount = pos.count<ALL_PIECES>();
 
         if (    piecesCount <= TB::Cardinality
             && (piecesCount <  TB::Cardinality || depth >= TB::ProbeDepth)

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -363,7 +363,7 @@ TBTable<WDL>::TBTable(const std::string& code) : TBTable() {
     Position pos;
 
     key = pos.set(code, WHITE, &st).material_key();
-    pieceCount = pos.count<ALL_PIECES>();
+    pieceCount = pos.count(ALL_PIECES);
     hasPawns = pos.pieces(PAWN);
 
     hasUniquePieces = false;
@@ -374,12 +374,12 @@ TBTable<WDL>::TBTable(const std::string& code) : TBTable() {
 
     // Set the leading color. In case both sides have pawns the leading color
     // is the side with less pawns because this leads to better compression.
-    bool c =   !pos.count<PAWN>(BLACK)
-            || (   pos.count<PAWN>(WHITE)
-                && pos.count<PAWN>(BLACK) >= pos.count<PAWN>(WHITE));
+    bool c =   !pos.count(BLACK, PAWN)
+            || (   pos.count(WHITE, PAWN)
+                && pos.count(BLACK, PAWN) >= pos.count(WHITE, PAWN));
 
-    pawnCount[0] = pos.count<PAWN>(c ? WHITE : BLACK);
-    pawnCount[1] = pos.count<PAWN>(c ? BLACK : WHITE);
+    pawnCount[0] = pos.count(c ? WHITE : BLACK, PAWN);
+    pawnCount[1] = pos.count(c ? BLACK : WHITE, PAWN);
 
     key2 = pos.set(code, BLACK, &st).material_key();
 }
@@ -1158,7 +1158,7 @@ void* mapped(TBTable<Type>& e, const Position& pos) {
 template<TBType Type, typename Ret = typename TBTable<Type>::Ret>
 Ret probe_table(const Position& pos, ProbeState* result, WDLScore wdl = WDLDraw) {
 
-    if (pos.count<ALL_PIECES>() == 2) // KvK
+    if (pos.count(ALL_PIECES) == 2) // KvK
         return Ret(WDLDraw);
 
     TBTable<Type>* entry = TBTables.get<Type>(pos.material_key());

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -363,7 +363,7 @@ TBTable<WDL>::TBTable(const std::string& code) : TBTable() {
     Position pos;
 
     key = pos.set(code, WHITE, &st).material_key();
-    pieceCount = pos.count(ALL_PIECES);
+    pieceCount = pos.count<ALL_PIECES>();
     hasPawns = pos.pieces(PAWN);
 
     hasUniquePieces = false;
@@ -1158,7 +1158,7 @@ void* mapped(TBTable<Type>& e, const Position& pos) {
 template<TBType Type, typename Ret = typename TBTable<Type>::Ret>
 Ret probe_table(const Position& pos, ProbeState* result, WDLScore wdl = WDLDraw) {
 
-    if (pos.count(ALL_PIECES) == 2) // KvK
+    if (pos.count<ALL_PIECES>() == 2) // KvK
         return Ret(WDLDraw);
 
     TBTable<Type>* entry = TBTables.get<Type>(pos.material_key());


### PR DESCRIPTION
This is a non-functional simplification which removes the template for count(color c).  The only real difference is in position.h.

This template parameter is only used in conjunction with color (make_piece(...)).  Since we do NOT know the color at compile time, make_piece cannot be calculated then.  Thus, as far as I can tell, the template here provides no benefit.

The template for count() does benefit from a template, but the one for count(color c) does not.  It may be inconvenient for there to be this kind of difference between them.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 30205 W: 6746 L: 6641 D: 16818 
http://tests.stockfishchess.org/tests/view/5cbdcf7a0ebc5925cf025f74