### PR TITLE
Remove templates for pos.square(s)

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -73,7 +73,7 @@ namespace {
 
     assert(pos.count<PAWN>(strongSide) == 1);
 
-    if (file_of(pos.square<PAWN>(strongSide)) >= FILE_E)
+    if (file_of(pos.square(strongSide, PAWN)) >= FILE_E)
         sq = Square(sq ^ 7); // Mirror SQ_H1 -> SQ_A1
 
     return strongSide == WHITE ? sq : ~sq;
@@ -96,8 +96,8 @@ Value Endgame<KXK>::operator()(const Position& pos) const {
   if (pos.side_to_move() == weakSide && !MoveList<LEGAL>(pos).size())
       return VALUE_DRAW;
 
-  Square winnerKSq = pos.square<KING>(strongSide);
-  Square loserKSq = pos.square<KING>(weakSide);
+  Square winnerKSq = pos.square(strongSide, KING);
+  Square loserKSq = pos.square(weakSide, KING);
 
   Value result =  pos.non_pawn_material(strongSide)
                 + pos.count<PAWN>(strongSide) * PawnValueEg
@@ -123,9 +123,9 @@ Value Endgame<KBNK>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, KnightValueMg + BishopValueMg, 0));
   assert(verify_material(pos, weakSide, VALUE_ZERO, 0));
 
-  Square winnerKSq = pos.square<KING>(strongSide);
-  Square loserKSq = pos.square<KING>(weakSide);
-  Square bishopSq = pos.square<BISHOP>(strongSide);
+  Square winnerKSq = pos.square(strongSide, KING);
+  Square loserKSq = pos.square(weakSide, KING);
+  Square bishopSq = pos.square(strongSide, BISHOP);
 
   // If our Bishop does not attack A1/H8, we flip the enemy king square
   // to drive to opposite corners (A8/H1).
@@ -147,9 +147,9 @@ Value Endgame<KPK>::operator()(const Position& pos) const {
   assert(verify_material(pos, weakSide, VALUE_ZERO, 0));
 
   // Assume strongSide is white and the pawn is on files A-D
-  Square wksq = normalize(pos, strongSide, pos.square<KING>(strongSide));
-  Square bksq = normalize(pos, strongSide, pos.square<KING>(weakSide));
-  Square psq  = normalize(pos, strongSide, pos.square<PAWN>(strongSide));
+  Square wksq = normalize(pos, strongSide, pos.square(strongSide, KING));
+  Square bksq = normalize(pos, strongSide, pos.square(weakSide, KING));
+  Square psq  = normalize(pos, strongSide, pos.square(strongSide, PAWN));
 
   Color us = strongSide == pos.side_to_move() ? WHITE : BLACK;
 
@@ -172,10 +172,10 @@ Value Endgame<KRKP>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, RookValueMg, 0));
   assert(verify_material(pos, weakSide, VALUE_ZERO, 1));
 
-  Square wksq = relative_square(strongSide, pos.square<KING>(strongSide));
-  Square bksq = relative_square(strongSide, pos.square<KING>(weakSide));
-  Square rsq  = relative_square(strongSide, pos.square<ROOK>(strongSide));
-  Square psq  = relative_square(strongSide, pos.square<PAWN>(weakSide));
+  Square wksq = relative_square(strongSide, pos.square(strongSide, KING));
+  Square bksq = relative_square(strongSide, pos.square(weakSide, KING));
+  Square rsq  = relative_square(strongSide, pos.square(strongSide, ROOK));
+  Square psq  = relative_square(strongSide, pos.square(weakSide, PAWN));
 
   Square queeningSq = make_square(file_of(psq), RANK_1);
   Value result;
@@ -215,7 +215,7 @@ Value Endgame<KRKB>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, RookValueMg, 0));
   assert(verify_material(pos, weakSide, BishopValueMg, 0));
 
-  Value result = Value(PushToEdges[pos.square<KING>(weakSide)]);
+  Value result = Value(PushToEdges[pos.square(weakSide, KING)]);
   return strongSide == pos.side_to_move() ? result : -result;
 }
 
@@ -228,8 +228,8 @@ Value Endgame<KRKN>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, RookValueMg, 0));
   assert(verify_material(pos, weakSide, KnightValueMg, 0));
 
-  Square bksq = pos.square<KING>(weakSide);
-  Square bnsq = pos.square<KNIGHT>(weakSide);
+  Square bksq = pos.square(weakSide, KING);
+  Square bnsq = pos.square(weakSide, KNIGHT);
   Value result = Value(PushToEdges[bksq] + PushAway[distance(bksq, bnsq)]);
   return strongSide == pos.side_to_move() ? result : -result;
 }
@@ -245,9 +245,9 @@ Value Endgame<KQKP>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, QueenValueMg, 0));
   assert(verify_material(pos, weakSide, VALUE_ZERO, 1));
 
-  Square winnerKSq = pos.square<KING>(strongSide);
-  Square loserKSq = pos.square<KING>(weakSide);
-  Square pawnSq = pos.square<PAWN>(weakSide);
+  Square winnerKSq = pos.square(strongSide, KING);
+  Square loserKSq = pos.square(weakSide, KING);
+  Square pawnSq = pos.square(weakSide, PAWN);
 
   Value result = Value(PushClose[distance(winnerKSq, loserKSq)]);
 
@@ -270,8 +270,8 @@ Value Endgame<KQKR>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, QueenValueMg, 0));
   assert(verify_material(pos, weakSide, RookValueMg, 0));
 
-  Square winnerKSq = pos.square<KING>(strongSide);
-  Square loserKSq = pos.square<KING>(weakSide);
+  Square winnerKSq = pos.square(strongSide, KING);
+  Square loserKSq = pos.square(weakSide, KING);
 
   Value result =  QueenValueEg
                 - RookValueEg
@@ -291,7 +291,7 @@ Value Endgame<KNNKP>::operator()(const Position& pos) const {
 
   Value result =  2 * KnightValueEg
                 - PawnValueEg
-                + PushToEdges[pos.square<KING>(weakSide)];
+                + PushToEdges[pos.square(weakSide, KING)];
 
   return strongSide == pos.side_to_move() ? result : -result;
 }
@@ -321,9 +321,9 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
   if (    (pawnsFile == FILE_A || pawnsFile == FILE_H)
       && !(pawns & ~file_bb(pawnsFile)))
   {
-      Square bishopSq = pos.square<BISHOP>(strongSide);
+      Square bishopSq = pos.square(strongSide, BISHOP);
       Square queeningSq = relative_square(strongSide, make_square(pawnsFile, RANK_8));
-      Square kingSq = pos.square<KING>(weakSide);
+      Square kingSq = pos.square(weakSide, KING);
 
       if (   opposite_colors(queeningSq, bishopSq)
           && distance(queeningSq, kingSq) <= 1)
@@ -339,9 +339,9 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
       // Get weakSide pawn that is closest to the home rank
       Square weakPawnSq = backmost_sq(weakSide, pos.pieces(weakSide, PAWN));
 
-      Square strongKingSq = pos.square<KING>(strongSide);
-      Square weakKingSq = pos.square<KING>(weakSide);
-      Square bishopSq = pos.square<BISHOP>(strongSide);
+      Square strongKingSq = pos.square(strongSide, KING);
+      Square weakKingSq = pos.square(weakSide, KING);
+      Square bishopSq = pos.square(strongSide, BISHOP);
 
       // There's potential for a draw if our pawn is blocked on the 7th rank,
       // the bishop cannot attack it or they only have one pawn left
@@ -378,11 +378,11 @@ ScaleFactor Endgame<KQKRPs>::operator()(const Position& pos) const {
   assert(pos.count<ROOK>(weakSide) == 1);
   assert(pos.count<PAWN>(weakSide) >= 1);
 
-  Square kingSq = pos.square<KING>(weakSide);
-  Square rsq = pos.square<ROOK>(weakSide);
+  Square kingSq = pos.square(weakSide, KING);
+  Square rsq = pos.square(weakSide, ROOK);
 
   if (    relative_rank(weakSide, kingSq) <= RANK_2
-      &&  relative_rank(weakSide, pos.square<KING>(strongSide)) >= RANK_4
+      &&  relative_rank(weakSide, pos.square(strongSide, KING)) >= RANK_4
       &&  relative_rank(weakSide, rsq) == RANK_3
       && (  pos.pieces(weakSide, PAWN)
           & pos.attacks_from<KING>(kingSq)
@@ -406,11 +406,11 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
   assert(verify_material(pos, weakSide,   RookValueMg, 0));
 
   // Assume strongSide is white and the pawn is on files A-D
-  Square wksq = normalize(pos, strongSide, pos.square<KING>(strongSide));
-  Square bksq = normalize(pos, strongSide, pos.square<KING>(weakSide));
-  Square wrsq = normalize(pos, strongSide, pos.square<ROOK>(strongSide));
-  Square wpsq = normalize(pos, strongSide, pos.square<PAWN>(strongSide));
-  Square brsq = normalize(pos, strongSide, pos.square<ROOK>(weakSide));
+  Square wksq = normalize(pos, strongSide, pos.square(strongSide, KING));
+  Square bksq = normalize(pos, strongSide, pos.square(weakSide, KING));
+  Square wrsq = normalize(pos, strongSide, pos.square(strongSide, ROOK));
+  Square wpsq = normalize(pos, strongSide, pos.square(strongSide, PAWN));
+  Square brsq = normalize(pos, strongSide, pos.square(weakSide, ROOK));
 
   File f = file_of(wpsq);
   Rank r = rank_of(wpsq);
@@ -502,9 +502,9 @@ ScaleFactor Endgame<KRPKB>::operator()(const Position& pos) const {
   // Test for a rook pawn
   if (pos.pieces(PAWN) & (FileABB | FileHBB))
   {
-      Square ksq = pos.square<KING>(weakSide);
-      Square bsq = pos.square<BISHOP>(weakSide);
-      Square psq = pos.square<PAWN>(strongSide);
+      Square ksq = pos.square(weakSide, KING);
+      Square bsq = pos.square(weakSide, BISHOP);
+      Square psq = pos.square(strongSide, PAWN);
       Rank rk = relative_rank(strongSide, psq);
       Direction push = pawn_push(strongSide);
 
@@ -517,7 +517,7 @@ ScaleFactor Endgame<KRPKB>::operator()(const Position& pos) const {
       {
           int d = distance(psq + 3 * push, ksq);
 
-          if (d <= 2 && !(d == 0 && ksq == pos.square<KING>(strongSide) + 2 * push))
+          if (d <= 2 && !(d == 0 && ksq == pos.square(strongSide, KING) + 2 * push))
               return ScaleFactor(24);
           else
               return ScaleFactor(48);
@@ -545,9 +545,9 @@ ScaleFactor Endgame<KRPPKRP>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, RookValueMg, 2));
   assert(verify_material(pos, weakSide,   RookValueMg, 1));
 
-  Square wpsq1 = pos.squares<PAWN>(strongSide)[0];
-  Square wpsq2 = pos.squares<PAWN>(strongSide)[1];
-  Square bksq = pos.square<KING>(weakSide);
+  Square wpsq1 = pos.squares(strongSide, PAWN)[0];
+  Square wpsq2 = pos.squares(strongSide, PAWN)[1];
+  Square bksq = pos.square(weakSide, KING);
 
   // Does the stronger side have a passed pawn?
   if (pos.pawn_passed(strongSide, wpsq1) || pos.pawn_passed(strongSide, wpsq2))
@@ -575,7 +575,7 @@ ScaleFactor Endgame<KPsK>::operator()(const Position& pos) const {
   assert(pos.count<PAWN>(strongSide) >= 2);
   assert(verify_material(pos, weakSide, VALUE_ZERO, 0));
 
-  Square ksq = pos.square<KING>(weakSide);
+  Square ksq = pos.square(weakSide, KING);
   Bitboard pawns = pos.pieces(strongSide, PAWN);
 
   // If all pawns are ahead of the king, on a single rook file and
@@ -599,10 +599,10 @@ ScaleFactor Endgame<KBPKB>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, BishopValueMg, 1));
   assert(verify_material(pos, weakSide,   BishopValueMg, 0));
 
-  Square pawnSq = pos.square<PAWN>(strongSide);
-  Square strongBishopSq = pos.square<BISHOP>(strongSide);
-  Square weakBishopSq = pos.square<BISHOP>(weakSide);
-  Square weakKingSq = pos.square<KING>(weakSide);
+  Square pawnSq = pos.square(strongSide, PAWN);
+  Square strongBishopSq = pos.square(strongSide, BISHOP);
+  Square weakBishopSq = pos.square(weakSide, BISHOP);
+  Square weakKingSq = pos.square(weakSide, KING);
 
   // Case 1: Defending king blocks the pawn, and cannot be driven away
   if (   file_of(weakKingSq) == file_of(pawnSq)
@@ -626,15 +626,15 @@ ScaleFactor Endgame<KBPPKB>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, BishopValueMg, 2));
   assert(verify_material(pos, weakSide,   BishopValueMg, 0));
 
-  Square wbsq = pos.square<BISHOP>(strongSide);
-  Square bbsq = pos.square<BISHOP>(weakSide);
+  Square wbsq = pos.square(strongSide, BISHOP);
+  Square bbsq = pos.square(weakSide, BISHOP);
 
   if (!opposite_colors(wbsq, bbsq))
       return SCALE_FACTOR_NONE;
 
-  Square ksq = pos.square<KING>(weakSide);
-  Square psq1 = pos.squares<PAWN>(strongSide)[0];
-  Square psq2 = pos.squares<PAWN>(strongSide)[1];
+  Square ksq = pos.square(weakSide, KING);
+  Square psq1 = pos.squares(strongSide, PAWN)[0];
+  Square psq2 = pos.squares(strongSide, PAWN)[1];
   Square blockSq1, blockSq2;
 
   if (relative_rank(strongSide, psq1) > relative_rank(strongSide, psq2))
@@ -695,9 +695,9 @@ ScaleFactor Endgame<KBPKN>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, BishopValueMg, 1));
   assert(verify_material(pos, weakSide, KnightValueMg, 0));
 
-  Square pawnSq = pos.square<PAWN>(strongSide);
-  Square strongBishopSq = pos.square<BISHOP>(strongSide);
-  Square weakKingSq = pos.square<KING>(weakSide);
+  Square pawnSq = pos.square(strongSide, PAWN);
+  Square strongBishopSq = pos.square(strongSide, BISHOP);
+  Square weakKingSq = pos.square(weakSide, KING);
 
   if (   file_of(weakKingSq) == file_of(pawnSq)
       && relative_rank(strongSide, pawnSq) < relative_rank(strongSide, weakKingSq)
@@ -718,8 +718,8 @@ ScaleFactor Endgame<KNPK>::operator()(const Position& pos) const {
   assert(verify_material(pos, weakSide, VALUE_ZERO, 0));
 
   // Assume strongSide is white and the pawn is on files A-D
-  Square pawnSq     = normalize(pos, strongSide, pos.square<PAWN>(strongSide));
-  Square weakKingSq = normalize(pos, strongSide, pos.square<KING>(weakSide));
+  Square pawnSq     = normalize(pos, strongSide, pos.square(strongSide, PAWN));
+  Square weakKingSq = normalize(pos, strongSide, pos.square(weakSide, KING));
 
   if (pawnSq == SQ_A7 && distance(SQ_A8, weakKingSq) <= 1)
       return SCALE_FACTOR_DRAW;
@@ -736,9 +736,9 @@ ScaleFactor Endgame<KNPKB>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, KnightValueMg, 1));
   assert(verify_material(pos, weakSide, BishopValueMg, 0));
 
-  Square pawnSq = pos.square<PAWN>(strongSide);
-  Square bishopSq = pos.square<BISHOP>(weakSide);
-  Square weakKingSq = pos.square<KING>(weakSide);
+  Square pawnSq = pos.square(strongSide, PAWN);
+  Square bishopSq = pos.square(weakSide, BISHOP);
+  Square weakKingSq = pos.square(weakSide, KING);
 
   // King needs to get close to promoting pawn to prevent knight from blocking.
   // Rules for this are very tricky, so just approximate.
@@ -761,9 +761,9 @@ ScaleFactor Endgame<KPKP>::operator()(const Position& pos) const {
   assert(verify_material(pos, weakSide,   VALUE_ZERO, 1));
 
   // Assume strongSide is white and the pawn is on files A-D
-  Square wksq = normalize(pos, strongSide, pos.square<KING>(strongSide));
-  Square bksq = normalize(pos, strongSide, pos.square<KING>(weakSide));
-  Square psq  = normalize(pos, strongSide, pos.square<PAWN>(strongSide));
+  Square wksq = normalize(pos, strongSide, pos.square(strongSide, KING));
+  Square bksq = normalize(pos, strongSide, pos.square(weakSide, KING));
+  Square psq  = normalize(pos, strongSide, pos.square(strongSide, PAWN));
 
   Color us = strongSide == pos.side_to_move() ? WHITE : BLACK;
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -226,7 +226,7 @@ namespace {
     constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
     constexpr Bitboard LowRanks = (Us == WHITE ? Rank2BB | Rank3BB: Rank7BB | Rank6BB);
 
-    const Square ksq = pos.square<KING>(Us);
+    const Square ksq = pos.square(Us, KING);
 
     Bitboard dblAttackByPawn = pawn_double_attacks_bb<Us>(pos.pieces(Us, PAWN));
 
@@ -271,7 +271,7 @@ namespace {
     constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
     constexpr Bitboard OutpostRanks = (Us == WHITE ? Rank4BB | Rank5BB | Rank6BB
                                                    : Rank5BB | Rank4BB | Rank3BB);
-    const Square* pl = pos.squares<Pt>(Us);
+    const Square* pl = pos.squares(Us, Pt);
 
     Bitboard b, bb;
     Score score = SCORE_ZERO;
@@ -286,7 +286,7 @@ namespace {
                          : pos.attacks_from<Pt>(s);
 
         if (pos.blockers_for_king(Us) & s)
-            b &= LineBB[pos.square<KING>(Us)][s];
+            b &= LineBB[pos.square(Us, KING)][s];
 
         attackedBy2[Us] |= attackedBy[Us][ALL_PIECES] & b;
         attackedBy[Us][Pt] |= b;
@@ -320,7 +320,7 @@ namespace {
                 score += MinorBehindPawn;
 
             // Penalty if the piece is far from the king
-            score -= KingProtector * distance(s, pos.square<KING>(Us));
+            score -= KingProtector * distance(s, pos.square(Us, KING));
 
             if (Pt == BISHOP)
             {
@@ -364,7 +364,7 @@ namespace {
             // Penalty when trapped by the king, even more if the king cannot castle
             else if (mob <= 3)
             {
-                File kf = file_of(pos.square<KING>(Us));
+                File kf = file_of(pos.square(Us, KING));
                 if ((kf < FILE_E) == (file_of(s) < kf))
                     score -= TrappedRook * (1 + !pos.castling_rights(Us));
             }
@@ -396,7 +396,7 @@ namespace {
     Bitboard weak, b1, b2, safe, unsafeChecks = 0;
     Bitboard rookChecks, queenChecks, bishopChecks, knightChecks;
     int kingDanger = 0;
-    const Square ksq = pos.square<KING>(Us);
+    const Square ksq = pos.square(Us, KING);
 
     // Init the score with king shelter and enemy pawns storm
     Score score = pe->king_safety<Us>(pos);
@@ -581,7 +581,7 @@ namespace {
     // Bonus for threats on the next moves against enemy queen
     if (pos.count<QUEEN>(Them) == 1)
     {
-        Square s = pos.square<QUEEN>(Them);
+        Square s = pos.square(Them, QUEEN);
         safe = mobilityArea[Us] & ~stronglyProtected;
 
         b = attackedBy[Us][KNIGHT] & pos.attacks_from<KNIGHT>(s);
@@ -610,7 +610,7 @@ namespace {
     constexpr Direction Up   = (Us == WHITE ? NORTH : SOUTH);
 
     auto king_proximity = [&](Color c, Square s) {
-      return std::min(distance(pos.square<KING>(c), s), 5);
+      return std::min(distance(pos.square(c, KING), s), 5);
     };
 
     Bitboard b, bb, squaresToQueen, defendedSquares, unsafeSquares;
@@ -738,8 +738,8 @@ namespace {
   template<Tracing T>
   Score Evaluation<T>::initiative(Value eg) const {
 
-    int outflanking =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
-                     - distance<Rank>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
+    int outflanking =  distance<File>(pos.square(WHITE, KING), pos.square(BLACK, KING))
+                     - distance<Rank>(pos.square(WHITE, KING), pos.square(BLACK, KING));
 
     bool pawnsOnBothFlanks =   (pos.pieces(PAWN) & QueenSide)
                             && (pos.pieces(PAWN) & KingSide);

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -84,7 +84,7 @@ namespace {
 
         if (Type == QUIET_CHECKS)
         {
-            Square ksq = pos.square<KING>(Them);
+            Square ksq = pos.square(Them, KING);
 
             b1 &= pos.attacks_from<PAWN>(ksq, Them);
             b2 &= pos.attacks_from<PAWN>(ksq, Them);
@@ -130,7 +130,7 @@ namespace {
         Bitboard b2 = shift<UpLeft >(pawnsOn7) & enemies;
         Bitboard b3 = shift<Up     >(pawnsOn7) & emptySquares;
 
-        Square ksq = pos.square<KING>(Them);
+        Square ksq = pos.square(Them, KING);
 
         while (b1)
             moveList = make_promotions<Type, UpRight>(moveList, pop_lsb(&b1), ksq);
@@ -189,7 +189,7 @@ namespace {
 
     assert(Pt != KING && Pt != PAWN);
 
-    const Square* pl = pos.squares<Pt>(us);
+    const Square* pl = pos.squares(us, Pt);
 
     for (Square from = *pl; from != SQ_NONE; from = *++pl)
     {
@@ -231,7 +231,7 @@ namespace {
 
     if (Type != QUIET_CHECKS && Type != EVASIONS)
     {
-        Square ksq = pos.square<KING>(Us);
+        Square ksq = pos.square(Us, KING);
         Bitboard b = pos.attacks_from<KING>(ksq) & target;
         while (b)
             *moveList++ = make_move(ksq, pop_lsb(&b));
@@ -301,7 +301,7 @@ ExtMove* generate<QUIET_CHECKS>(const Position& pos, ExtMove* moveList) {
      Bitboard b = pos.attacks_from(pt, from) & ~pos.pieces();
 
      if (pt == KING)
-         b &= ~PseudoAttacks[QUEEN][pos.square<KING>(~us)];
+         b &= ~PseudoAttacks[QUEEN][pos.square(~us, KING)];
 
      while (b)
          *moveList++ = make_move(from, pop_lsb(&b));
@@ -320,7 +320,7 @@ ExtMove* generate<EVASIONS>(const Position& pos, ExtMove* moveList) {
   assert(pos.checkers());
 
   Color us = pos.side_to_move();
-  Square ksq = pos.square<KING>(us);
+  Square ksq = pos.square(us, KING);
   Bitboard sliderAttacks = 0;
   Bitboard sliders = pos.checkers() & ~pos.pieces(KNIGHT, PAWN);
 
@@ -357,7 +357,7 @@ ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
 
   Color us = pos.side_to_move();
   Bitboard pinned = pos.blockers_for_king(us) & pos.pieces(us);
-  Square ksq = pos.square<KING>(us);
+  Square ksq = pos.square(us, KING);
   ExtMove* cur = moveList;
 
   moveList = pos.checkers() ? generate<EVASIONS    >(pos, moveList)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -71,7 +71,7 @@ namespace {
     Square s;
     bool opposed, backward;
     Score score = SCORE_ZERO;
-    const Square* pl = pos.squares<PAWN>(Us);
+    const Square* pl = pos.squares(Us, PAWN);
 
     Bitboard ourPawns   = pos.pieces(  Us, PAWN);
     Bitboard theirPawns = pos.pieces(Them, PAWN);
@@ -209,7 +209,7 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
 template<Color Us>
 Score Entry::do_king_safety(const Position& pos) {
 
-  Square ksq = pos.square<KING>(Us);
+  Square ksq = pos.square(Us, KING);
   kingSquares[Us] = ksq;
   castlingRights[Us] = pos.castling_rights(Us);
 

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -42,7 +42,7 @@ struct Entry {
 
   template<Color Us>
   Score king_safety(const Position& pos) {
-    return  kingSquares[Us] == pos.square<KING>(Us) && castlingRights[Us] == pos.castling_rights(Us)
+    return  kingSquares[Us] == pos.square(Us, KING) && castlingRights[Us] == pos.castling_rights(Us)
           ? kingSafety[Us] : (kingSafety[Us] = do_king_safety<Us>(pos));
   }
 

--- a/src/position.h
+++ b/src/position.h
@@ -93,8 +93,8 @@ public:
   bool empty(Square s) const;
   template<PieceType Pt> int count(Color c) const;
   template<PieceType Pt> int count() const;
-  template<PieceType Pt> const Square* squares(Color c) const;
-  template<PieceType Pt> Square square(Color c) const;
+  const Square* squares(Color c, PieceType pt) const;
+  Square square(Color c, PieceType) const;
   int semiopen_file(Color c, File f) const;
 
   // Castling
@@ -249,13 +249,13 @@ template<PieceType Pt> inline int Position::count() const {
   return pieceCount[make_piece(WHITE, Pt)] + pieceCount[make_piece(BLACK, Pt)];
 }
 
-template<PieceType Pt> inline const Square* Position::squares(Color c) const {
-  return pieceList[make_piece(c, Pt)];
+inline const Square* Position::squares(Color c, PieceType pt) const {
+    return pieceList[make_piece(c, pt)];
 }
 
-template<PieceType Pt> inline Square Position::square(Color c) const {
-  assert(pieceCount[make_piece(c, Pt)] == 1);
-  return pieceList[make_piece(c, Pt)][0];
+inline Square Position::square(Color c, PieceType pt) const {
+  assert(pieceCount[make_piece(c, pt)] == 1);
+  return pieceList[make_piece(c, pt)][0];
 }
 
 inline Square Position::ep_square() const {
@@ -363,7 +363,7 @@ inline int Position::rule50_count() const {
 inline bool Position::opposite_bishops() const {
   return   pieceCount[W_BISHOP] == 1
         && pieceCount[B_BISHOP] == 1
-        && opposite_colors(square<BISHOP>(WHITE), square<BISHOP>(BLACK));
+        && opposite_colors(square(WHITE, BISHOP), square(BLACK, BISHOP));
 }
 
 inline bool Position::is_chess960() const {


### PR DESCRIPTION
This is non-functional.  The only real change is in position.h.

If it is demonstrable (not just by testing) that the template does not provide any benefit, I believe it should be removed.

Here, the template parameter PieceType is used in make_piece.  Because make_piece depends on Color (which is NOT a template parameter), the compiler cannot perform any reduction.  Thus, the 12 templates for square and the 12 for squares are most likely identical.  Both pos.square() and pos.squares() are similarly simplified so they are still consistent with each other.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 18415 W: 4165 L: 4037 D: 10213
http://tests.stockfishchess.org/tests/view/5cbe1d6c0ebc5925cf02653d

