### PR TITLE
Simplify connected

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -127,6 +127,7 @@ namespace {
         {
             int v = Connected[r] * (phalanx ? 3 : 2) / (opposed ? 2 : 1)
                   + 17 * popcount(support);
+
             score += make_score(v, v * (r - 2) / 4);
         }
         else if (!neighbours)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -36,7 +36,7 @@ namespace {
   constexpr Score Isolated = S( 5, 15);
 
   // Connected pawn bonus
-  constexpr int Connected[RANK_NB] = { 0, 13, 17, 24, 59, 96, 171 };
+  constexpr int Connected[RANK_NB] = { 0, 7, 8, 12, 29, 48, 86 };
 
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
@@ -125,8 +125,8 @@ namespace {
         // Score this pawn
         if (support | phalanx)
         {
-            int v = (phalanx ? 3 : 2) * Connected[r];
-            v = 17 * popcount(support) + (v >> (opposed + 1));
+            int v = Connected[r] * (phalanx ? 3 : 2) / (opposed ? 2 : 1)
+                  + 17 * popcount(support);
             score += make_score(v, v * (r - 2) / 4);
         }
         else if (!neighbours)


### PR DESCRIPTION
This is a functional simplification that simplifies some of the math for connected pawns.  The bench is different because I moved a /2 from opposed into the connected array.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 37954 W: 8504 L: 8415 D: 21035 
http://tests.stockfishchess.org/tests/view/5cbf599a0ebc5925cf028156

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 27780 W: 4682 L: 4572 D: 18526 
http://tests.stockfishchess.org/tests/view/5cbf6a5e0ebc5925cf0284b8

bench 3307600