### PR TITLE
Include bishop protection in king Danger evaluation.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -467,12 +467,13 @@ namespace {
                  +  69 * kingAttacksCount[Them]
                  + 185 * popcount(kingRing[Us] & weak)
                  - 100 * bool(attackedBy[Us][KNIGHT] & attackedBy[Us][KING])
+                 -  35 * bool(attackedBy[Us][BISHOP] & attackedBy[Us][KING])
                  + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
                  - 873 * !pos.count<QUEEN>(Them)
                  -   6 * mg_value(score) / 8
                  +       mg_value(mobility[Them] - mobility[Us])
                  +   5 * kingFlankAttacks * kingFlankAttacks / 16
-                 -   15;
+                 -   7;
 
     // Transform the kingDanger units into a Score, and subtract it from the evaluation
     if (kingDanger > 100)


### PR DESCRIPTION
Same idea as fisherman's knight protection.
http://tests.stockfishchess.org/tests/view/5cc3550b0ebc5925cf02dada
passed STC
http://tests.stockfishchess.org/tests/view/5cc3721d0ebc5925cf02dc90
passed LTC
bench 3429173
Looking at this 2 ideas being recent clean elo gainers I have a feeling that we can add also rook and queen protection bonuses or overall move this stuff in pieces loop in the same way as we do pieces attacking bonuses on their kingring... :) Thx fisherman for original idea.