### PR TITLE
Score and Select Best Thread in same loop

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -238,21 +238,18 @@ void MainThread::search() {
       for (Thread* th: Threads)
           minScore = std::min(minScore, th->rootMoves[0].score);
 
-      // Vote according to score and depth
+      // Vote according to score and depth, and select the best thread
+      auto bestVote = 0; //votes[this->rootMoves[0].pv[0]];
       for (Thread* th : Threads)
       {
           int64_t s = th->rootMoves[0].score - minScore + 1;
           votes[th->rootMoves[0].pv[0]] += 200 + s * s * int(th->completedDepth);
-      }
-
-      // Select best thread
-      auto bestVote = votes[this->rootMoves[0].pv[0]];
-      for (Thread* th : Threads)
           if (votes[th->rootMoves[0].pv[0]] > bestVote)
           {
               bestVote = votes[th->rootMoves[0].pv[0]];
               bestThread = th;
           }
+      }
   }
 
   previousScore = bestThread->rootMoves[0].score;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -239,7 +239,7 @@ void MainThread::search() {
           minScore = std::min(minScore, th->rootMoves[0].score);
 
       // Vote according to score and depth, and select the best thread
-      auto bestVote = 0;
+      int64_t bestVote = 0;
       for (Thread* th : Threads)
       {
           int64_t s = th->rootMoves[0].score - minScore + 1;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -239,7 +239,7 @@ void MainThread::search() {
           minScore = std::min(minScore, th->rootMoves[0].score);
 
       // Vote according to score and depth, and select the best thread
-      auto bestVote = 0; //votes[this->rootMoves[0].pv[0]];
+      auto bestVote = 0;
       for (Thread* th : Threads)
       {
           int64_t s = th->rootMoves[0].score - minScore + 1;


### PR DESCRIPTION
This is a non-functional simplification that combines vote counting and thread selecting in the same loop.

It is possible that the best thread would be updated more frequently than master, but I'm not sure it matters here.  Perhaps "mostVotes" is a better name than "bestVote?"

STC (stopped early).
LLR: 0.70 (-2.94,2.94) [-3.00,1.00]
Total: 10714 W: 2329 L: 2311 D: 6074 
http://tests.stockfishchess.org/tests/view/5ccc71470ebc5925cf03d244