### PR TITLE
Simplify Stat Score Reset - Bench:  3251357

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -594,10 +594,7 @@ namespace {
     // starts with statScore = 0. Later grandchildren start with the last calculated
     // statScore of the previous grandchild. This influences the reduction rules in
     // LMR which are based on the statScore of parent position.
-	if (rootNode)
-		(ss + 4)->statScore = 0;
-	else
-		(ss + 2)->statScore = 0;
+    (ss + 4)->statScore = 0;
 
     // Step 4. Transposition table lookup. We don't want the score of a partial
     // search to overwrite a previous full search TT value, so we use a different


### PR DESCRIPTION
Simplify Stat Score Reset

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 14926 W: 3353 L: 3218 D: 8355
http://tests.stockfishchess.org/tests/view/5ccc567a0ebc5925cf03cf10

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 49153 W: 8471 L: 8397 D: 32285
http://tests.stockfishchess.org/tests/view/5ccc5aed0ebc5925cf03d076

Bench:  3251357