### PR TITLE
Progressive decrease of failedHighCnt

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -408,7 +408,7 @@ void Thread::search() {
 
                   if (mainThread)
                   {
-                      failedHighCnt = 0;
+                      failedHighCnt = std::max(0, failedHighCnt - 1);
                       mainThread->stopOnPonderhit = false;
                   }
               }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -400,7 +400,7 @@ void Thread::search() {
                   sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
 
               // In case of failing low/high increase aspiration window and
-              // re-search, otherwise exit the loop.
+              // re-search, otherwise exit the loop. 
               if (bestValue <= alpha)
               {
                   beta = (alpha + beta) / 2;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -408,7 +408,7 @@ void Thread::search() {
 
                   if (mainThread)
                   {
-                      failedHighCnt = std::max(0, failedHighCnt - 1);
+                      failedHighCnt /= 2;
                       mainThread->stopOnPonderhit = false;
                   }
               }


### PR DESCRIPTION
This change resolves the problem of some hanging positions due to multiple fail high / low iterations. An example is given in issue #2126 

Decreasing progressively the counter needs some more iterations but don't lead to a signification regression at STC and LTC.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 159582 W: 35368 L: 35521 D: 88693 
http://tests.stockfishchess.org/tests/view/5ccdaf7b0ebc5925cf03efa3

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 83698 W: 14095 L: 14076 D: 55527 
http://tests.stockfishchess.org/tests/view/5ccddcc70ebc5925cf03f5a9

Bench : 3394164