### PR TITLE
Simplify Thread Voting Scheme

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -240,10 +240,8 @@ void MainThread::search() {
 
       // Vote according to score and depth
       for (Thread* th : Threads)
-      {
-          int64_t s = th->rootMoves[0].score - minScore + 1;
-          votes[th->rootMoves[0].pv[0]] += 200 + s * s * int(th->completedDepth);
-      }
+          votes[th->rootMoves[0].pv[0]] +=
+               (th->rootMoves[0].score - minScore + 14) * int(th->completedDepth);
 
       // Select best thread
       auto bestVote = votes[this->rootMoves[0].pv[0]];


### PR DESCRIPTION
This is a functional simplification of the math in the voting scheme.

It took a bit longer to pass LTC 8 threads, so perhaps more testing is needed at longer times and/or more threads.

STC 4 threads
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 22315 W: 4852 L: 4732 D: 12731
http://tests.stockfishchess.org/tests/view/5ccc86280ebc5925cf03d439

STC 8 threads
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 42427 W: 8451 L: 8369 D: 25607
http://tests.stockfishchess.org/tests/view/5cccb67c0ebc5925cf03da90

LTC 4 Threads
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 23513 W: 4208 L: 4092 D: 15213
http://tests.stockfishchess.org/tests/view/5ccce94d0ebc5925cf03e1ec

LTC 8 Threads
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 70098 W: 11442 L: 11399 D: 47257
http://tests.stockfishchess.org/tests/view/5ccd22aa0ebc5925cf03e463