### PR TITLE
Try LMR for insufficient captures/promotions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1008,7 +1008,9 @@ moves_loop: // When in check, search starts from here
       // re-searched at full depth.
       if (    depth >= 3 * ONE_PLY
           &&  moveCount > 1
-          && (!captureOrPromotion || moveCountPruning))
+          && (  !captureOrPromotion
+              || moveCountPruning
+              || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha))
       {
           Depth r = reduction<PvNode>(improving, depth, moveCount);
 


### PR DESCRIPTION
Enable LMR for a capture/promotion move which doesn't seem to have a good chance to fail high according to static eval and value of captured piece.

STC:
LLR: 2.96 (-2.94,2.94) [0.50,4.50]
Total: 40477 W: 9158 L: 8792 D: 22527
http://tests.stockfishchess.org/tests/view/5cceedc60ebc5925cf04174f

LTC:
LLR: 2.94 (-2.94,2.94) [0.00,3.50]
Total: 21926 W: 3873 L: 3634 D: 14419 
http://tests.stockfishchess.org/tests/view/5ccf04310ebc5925cf041ab0

Bench: 3644175