### PR TITLE
Simplify StatScore Reset - Bench:  3542999

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -277,7 +277,7 @@ void MainThread::search() {
 
 void Thread::search() {
 
-  // To allow access to (ss-7) up to (ss+2), the stack must be oversized.
+  // To allow access to (ss-7) up to (ss+4), the stack must be oversized.
   // The former is needed to allow update_continuation_histories(ss-1, ...),
   // which accesses its argument at ss-6, also near the root.
   // The latter is needed for statScores and killer initialization.
@@ -290,7 +290,7 @@ void Thread::search() {
   double timeReduction = 1, totBestMoveChanges = 0;
   Color us = rootPos.side_to_move();
 
-  std::memset(ss-7, 0, 10 * sizeof(Stack));
+  std::memset(ss-7, 0, 12 * sizeof(Stack));
   for (int i = 7; i > 0; i--)
      (ss-i)->continuationHistory = &this->continuationHistory[NO_PIECE][0]; // Use as sentinel
   ss->pv = pv;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -281,7 +281,7 @@ void Thread::search() {
   // The former is needed to allow update_continuation_histories(ss-1, ...),
   // which accesses its argument at ss-6, also near the root.
   // The latter is needed for statScores and killer initialization.
-  Stack stack[MAX_PLY+10], *ss = stack+7;
+  Stack stack[MAX_PLY+12], *ss = stack+7;
   Move  pv[MAX_PLY+1];
   Value bestValue, alpha, beta, delta;
   Move  lastBestMove = MOVE_NONE;
@@ -594,10 +594,7 @@ namespace {
     // starts with statScore = 0. Later grandchildren start with the last calculated
     // statScore of the previous grandchild. This influences the reduction rules in
     // LMR which are based on the statScore of parent position.
-	if (rootNode)
-		(ss + 4)->statScore = 0;
-	else
-		(ss + 2)->statScore = 0;
+	(ss + 4)->statScore = 0;
 
     // Step 4. Transposition table lookup. We don't want the score of a partial
     // search to overwrite a previous full search TT value, so we use a different


### PR DESCRIPTION
Simplify Stat Score Reset

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 14926 W: 3353 L: 3218 D: 8355
http://tests.stockfishchess.org/tests/view/5ccc567a0ebc5925cf03cf10

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 49153 W: 8471 L: 8397 D: 32285
http://tests.stockfishchess.org/tests/view/5ccc5aed0ebc5925cf03d076

Bench:  3542999