### PR TITLE
Less LMR at root

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1007,7 +1007,7 @@ moves_loop: // When in check, search starts from here
       // Step 16. Reduced depth search (LMR). If the move fails high it will be
       // re-searched at full depth.
       if (    depth >= 3 * ONE_PLY
-          &&  moveCount > 1 + PvNode
+          &&  moveCount > 1 + rootNode
           && (  !captureOrPromotion
               || moveCountPruning
               || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1007,7 +1007,7 @@ moves_loop: // When in check, search starts from here
       // Step 16. Reduced depth search (LMR). If the move fails high it will be
       // re-searched at full depth.
       if (    depth >= 3 * ONE_PLY
-          &&  moveCount > 1 + rootNode
+          &&  moveCount > 1 + 3 * rootNode
           && (  !captureOrPromotion
               || moveCountPruning
               || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1007,7 +1007,7 @@ moves_loop: // When in check, search starts from here
       // Step 16. Reduced depth search (LMR). If the move fails high it will be
       // re-searched at full depth.
       if (    depth >= 3 * ONE_PLY
-          &&  moveCount > 1
+          &&  moveCount > 1 + !bestMove
           && (  !captureOrPromotion
               || moveCountPruning
               || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1007,7 +1007,7 @@ moves_loop: // When in check, search starts from here
       // Step 16. Reduced depth search (LMR). If the move fails high it will be
       // re-searched at full depth.
       if (    depth >= 3 * ONE_PLY
-          &&  moveCount > 1 + !bestMove
+          &&  moveCount > 1 + PvNode
           && (  !captureOrPromotion
               || moveCountPruning
               || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha))


### PR DESCRIPTION
Do no LMR for the first four moves if at root node. 

STC:
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 19686 W: 4524 L: 4261 D: 10901 
http://tests.stockfishchess.org/tests/view/5cd3577b0ebc5925cf04a089

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 88335 W: 15193 L: 14766 D: 58376 
http://tests.stockfishchess.org/tests/view/5cd35e600ebc5925cf04a1c3

Bench: 3184182 