### PR TITLE
Add eg component to evaluate_shelter()

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -172,7 +172,7 @@ Entry* probe(const Position& pos) {
 /// penalty for a king, looking at the king file and the two closest files.
 
 template<Color Us>
-Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
+void Entry::evaluate_shelter(const Position& pos, Square ksq, Score& shelter) {
 
   constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
   constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
@@ -183,7 +183,8 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
   Bitboard ourPawns = b & pos.pieces(Us);
   Bitboard theirPawns = b & pos.pieces(Them);
 
-  Value safety = (shift<Down>(theirPawns) & BlockSquares & ksq) ? Value(374) : Value(5);
+  Value safetyMg = (shift<Down>(theirPawns) & BlockSquares & ksq) ? Value(374) : Value(5);
+  Value safetyEg = VALUE_ZERO;
 
   File center = clamp(file_of(ksq), FILE_B, FILE_G);
   for (File f = File(center - 1); f <= File(center + 1); ++f)
@@ -195,12 +196,15 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
       Rank theirRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : RANK_1;
 
       int d = std::min(f, ~f);
-      safety += ShelterStrength[d][ourRank];
-      safety -= (ourRank && (ourRank == theirRank - 1)) ? 66 * (theirRank == RANK_3)
-                                                        : UnblockedStorm[d][theirRank];
+      safetyMg += ShelterStrength[d][ourRank];
+      if (ourRank && (ourRank == theirRank - 1))
+          safetyMg -= 82 * (theirRank == RANK_3),   safetyEg -= 82 * (theirRank == RANK_3);
+      else
+          safetyMg -= UnblockedStorm[d][theirRank];
   }
 
-  return safety;
+  if (safetyMg > mg_value(shelter))
+      shelter = make_score(safetyMg, safetyEg);
 }
 
 
@@ -223,16 +227,17 @@ Score Entry::do_king_safety(const Position& pos) {
   else while (pawns)
       minPawnDist = std::min(minPawnDist, distance(ksq, pop_lsb(&pawns)));
 
-  Value bonus = evaluate_shelter<Us>(pos, ksq);
+  Score shelter = make_score(-VALUE_INFINITE, VALUE_ZERO);
+  evaluate_shelter<Us>(pos, ksq, shelter);
 
   // If we can castle use the bonus after the castling if it is bigger
   if (pos.can_castle(Us | KING_SIDE))
-      bonus = std::max(bonus, evaluate_shelter<Us>(pos, relative_square(Us, SQ_G1)));
+      evaluate_shelter<Us>(pos, relative_square(Us, SQ_G1), shelter);
 
   if (pos.can_castle(Us | QUEEN_SIDE))
-      bonus = std::max(bonus, evaluate_shelter<Us>(pos, relative_square(Us, SQ_C1)));
+      evaluate_shelter<Us>(pos, relative_square(Us, SQ_C1), shelter);
 
-  return make_score(bonus, -16 * minPawnDist);
+  return shelter - make_score(VALUE_ZERO, 16 * minPawnDist);
 }
 
 // Explicit template instantiation

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -50,7 +50,7 @@ struct Entry {
   Score do_king_safety(const Position& pos);
 
   template<Color Us>
-  Value evaluate_shelter(const Position& pos, Square ksq);
+  void evaluate_shelter(const Position& pos, Square ksq, Score& shelter);
 
   Key key;
   Score scores[COLOR_NB];


### PR DESCRIPTION
Add an endgame component to the blockedstorm penalty so that the penalty applies more uniformly through the game.

STC 10+0.1 th 1 :
LLR: -2.95 (-2.94,2.94) [0.50,4.50]
Total: 94063 W: 21426 L: 21118 D: 51519
http://tests.stockfishchess.org/tests/view/5cd4605c0ebc5925cf04bf43

LTC 60+0.6 th 1 :
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 188232 W: 32808 L: 32090 D: 123334
http://tests.stockfishchess.org/tests/view/5cd47d0a0ebc5925cf04c4fd

Refactored code with higher constant values gave a more convincing LTC result:
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 30050 W: 5330 L: 5066 D: 19654
http://tests.stockfishchess.org/tests/view/5cd6a0000ebc5925cf050653

Further work; The values used have not been carefully tuned so no doubt they can be tuned more accurately. Also, perhaps other parts of the king safety calculation could benefit from using this.

Bench 3624368
