### PR TITLE
Remove pawn count in space() calculation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -719,7 +719,7 @@ namespace {
     behind |= shift<Down+Down>(behind);
 
     int bonus = popcount(safe) + popcount(behind & safe);
-    int weight =  pos.count<ALL_PIECES>(Us) - 4;
+    int weight =  pos.count<ALL_PIECES>(Us) - 1;
     Score score = make_score(bonus * weight * weight / 16, 0);
 
     if (T)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -719,9 +719,7 @@ namespace {
     behind |= shift<Down+Down>(behind);
 
     int bonus = popcount(safe) + popcount(behind & safe);
-    int weight =  pos.count<ALL_PIECES>(Us)
-               - (16 - pos.count<PAWN>()) / 4;
-
+    int weight =  pos.count<ALL_PIECES>(Us) - 4;
     Score score = make_score(bonus * weight * weight / 16, 0);
 
     if (T)


### PR DESCRIPTION
Simplification. Various attempts to optimise the pawn count bonus showed little effect, so remove pawn count altogether and compensate by subtracting 1 instead of 4.

STC 10+0.1 th 1:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 152244 W: 33709 L: 33847 D: 84688
http://tests.stockfishchess.org/tests/view/5cceed330ebc5925cf04170e

LTC 60+0.6 th 1:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 24100 W: 4079 L: 3964 D: 16057
http://tests.stockfishchess.org/tests/view/5cd5b6b80ebc5925cf04e889

Bench: 2849754
