### PR TITLE
Stop Depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -323,10 +323,11 @@ void Thread::search() {
                           : -make_score(ct, ct / 2));
 
   // Iterative deepening loop until requested to stop or the target depth is reached
-  while (rootDepth = std::min(rootDepth + ONE_PLY, DEPTH_MAX - ONE_PLY),
-            !Threads.stop
-         && !(Limits.depth && mainThread && rootDepth / ONE_PLY > Limits.depth))
+  while (   !Threads.stop
+         && !(Limits.depth && mainThread && rootDepth / ONE_PLY >= Limits.depth))
   {
+      rootDepth = std::min(rootDepth + ONE_PLY, DEPTH_MAX - ONE_PLY);
+
       // Age out PV variability metric
       if (mainThread)
           totBestMoveChanges /= 2;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -323,8 +323,8 @@ void Thread::search() {
                           : -make_score(ct, ct / 2));
 
   // Iterative deepening loop until requested to stop or the target depth is reached
-  while (   (rootDepth += ONE_PLY) < DEPTH_MAX
-         && !Threads.stop
+  while (rootDepth = std::min(rootDepth + ONE_PLY, DEPTH_MAX - ONE_PLY),
+            !Threads.stop
          && !(Limits.depth && mainThread && rootDepth / ONE_PLY > Limits.depth))
   {
       // Age out PV variability metric

--- a/src/types.h
+++ b/src/types.h
@@ -214,7 +214,7 @@ enum Depth : int {
   DEPTH_QS_RECAPTURES = -5 * ONE_PLY,
 
   DEPTH_NONE = -6 * ONE_PLY,
-  DEPTH_MAX  = 15 * ONE_PLY
+  DEPTH_MAX  = MAX_PLY * ONE_PLY
 };
 
 static_assert(!(ONE_PLY & (ONE_PLY - 1)), "ONE_PLY is not a power of 2");

--- a/src/types.h
+++ b/src/types.h
@@ -214,7 +214,7 @@ enum Depth : int {
   DEPTH_QS_RECAPTURES = -5 * ONE_PLY,
 
   DEPTH_NONE = -6 * ONE_PLY,
-  DEPTH_MAX  = MAX_PLY * ONE_PLY
+  DEPTH_MAX  = 15 * ONE_PLY
 };
 
 static_assert(!(ONE_PLY & (ONE_PLY - 1)), "ONE_PLY is not a power of 2");


### PR DESCRIPTION
When we have time left on the clock and we reach DEPTH_MAX it's significantly better to keep searching DEPTH_MAX than stopping. 

STC: http://tests.stockfishchess.org/tests/view/5cd8aea60ebc5925cf054474
LLR: 2.96 (-2.94,2.94) [0.50,4.50]
Total: 363 W: 190 L: 24 D: 149 

LTC: http://tests.stockfishchess.org/tests/view/5cd8b25b0ebc5925cf054561
LLR: 2.96 (-2.94,2.94) [0.50,4.50]
Total: 241 W: 171 L: 7 D: 63 

This was tested by setting DEPTH_MAX to 15 so it could be reached at STC on fishtest.
