### PR TITLE
Smoothly change playing strength with skill level.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -293,7 +293,12 @@ void Thread::search() {
   beta = VALUE_INFINITE;
 
   multiPV = Options["MultiPV"];
-  Skill skill(Options["Skill Level"]);
+  // Pick integer skill levels, but non-deterministically round up or down
+  // such that the average integer skill corresponds to the input floating point one.
+  PRNG rng(now());
+  int intLevel = int(Options["Skill Level"]) +
+        ((Options["Skill Level"] - int(Options["Skill Level"])) * 1024 > rng.rand<unsigned>() % 1024  ? 1 : 0);
+  Skill skill(intLevel);
 
   // When playing with strength handicap enable MultiPV search that we will
   // use behind the scenes to retrieve a set of possible moves.


### PR DESCRIPTION
The current skill levels (1-20) allow for adjusting playing strengths, but
do so in big steps (e.g. level 10 vs level 11 is a ~143 Elo jump at STC).
Since the 'Skill Level' input can already be a floating point number, this
patch uses the fractional part of the input to provide the user with
fine control, allowing for varying the playing strength essentially
continuously.

The implementation internally still uses integer skill levels (needed since they pick Depths),
but non-deterministically rounds up or down the used skill level such that the average integer
skill corresponds to the input floating point one. As expected, intermediate
(fractional) skill levels yield intermediate playing strenghts.

Tested at STC, playing level 10 against levels between 10 and 11 for 10000 games

level 10.25 ELO:  24.26 +-6.2
level 10.5  ELO:  67.51 +-6.3
level 10.75 ELO:  98.52 +-6.4
level 11    ELO: 143.65 +-6.7

http://tests.stockfishchess.org/tests/view/5cd9c6b40ebc5925cf056791
http://tests.stockfishchess.org/tests/view/5cd9d22b0ebc5925cf056989
http://tests.stockfishchess.org/tests/view/5cd9cf610ebc5925cf056906
http://tests.stockfishchess.org/tests/view/5cd9d2490ebc5925cf05698e

No functional change.