### PR TITLE
Save complement of pawn attacks span in pawn entry

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -305,7 +305,7 @@ namespace {
         if (Pt == BISHOP || Pt == KNIGHT)
         {
             // Bonus if piece is on an outpost square or can reach one
-            bb = OutpostRanks & ~pe->pawn_attacks_span(Them);
+            bb = OutpostRanks & pe->no_pawn_attacks_span(Them);
             if (bb & s)
                 score += Outpost * (Pt == KNIGHT ? 4 : 2)
                                  * ((attackedBy[Us][PAWN] & s) ? 2 : 1);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -77,7 +77,8 @@ namespace {
     Bitboard ourPawns   = pos.pieces(  Us, PAWN);
     Bitboard theirPawns = pos.pieces(Them, PAWN);
 
-    e->passedPawns[Us] = e->pawnAttacksSpan[Us] = e->weakUnopposed[Us] = 0;
+    Bitboard pawnAttacksSpan = 0;
+    e->passedPawns[Us] = e->weakUnopposed[Us] = 0;
     e->kingSquares[Us]   = SQ_NONE;
     e->pawnAttacks[Us]   = pawn_attacks_bb<Us>(ourPawns);
 
@@ -89,7 +90,7 @@ namespace {
         File f = file_of(s);
         Rank r = relative_rank(Us, s);
 
-        e->pawnAttacksSpan[Us] |= pawn_attack_span(Us, s);
+        pawnAttacksSpan |= pawn_attack_span(Us, s);
 
         // Flag the pawn
         opposed    = theirPawns & forward_file_bb(Us, s);
@@ -139,6 +140,8 @@ namespace {
         if (doubled && !support)
             score -= Doubled;
     }
+
+    e->noPawnAttacksSpan[Us] = ~pawnAttacksSpan;
 
     return score;
   }

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -36,7 +36,7 @@ struct Entry {
   Score pawn_score(Color c) const { return scores[c]; }
   Bitboard pawn_attacks(Color c) const { return pawnAttacks[c]; }
   Bitboard passed_pawns(Color c) const { return passedPawns[c]; }
-  Bitboard pawn_attacks_span(Color c) const { return pawnAttacksSpan[c]; }
+  Bitboard no_pawn_attacks_span(Color c) const { return noPawnAttacksSpan[c]; }
   int weak_unopposed(Color c) const { return weakUnopposed[c]; }
   int passed_count() const { return popcount(passedPawns[WHITE] | passedPawns[BLACK]); }
 
@@ -56,7 +56,7 @@ struct Entry {
   Score scores[COLOR_NB];
   Bitboard passedPawns[COLOR_NB];
   Bitboard pawnAttacks[COLOR_NB];
-  Bitboard pawnAttacksSpan[COLOR_NB];
+  Bitboard noPawnAttacksSpan[COLOR_NB];
   Square kingSquares[COLOR_NB];
   Score kingSafety[COLOR_NB];
   int weakUnopposed[COLOR_NB];


### PR DESCRIPTION
Evaluation::value() always uses the complement of the pawn attacks span, not the
attacks span itself. Directly saving the complemented value in Pawns::Entry can
potentially be more efficient depending on cache and optimization.

perf N=100:
branch npas 2,189198032 seconds time elapsed +-  0,12% (0.0024)
master      2,195144913 seconds time elapsed +-  0,11% (0.0026)
delta       0.0059 (0.27%)

No functional change