### PR TITLE
Use a sigmoid for MoveImportance

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -38,7 +38,7 @@ namespace {
 
 
   // move_importance() is a sigmoid for scaling time usage according to ply.
-  constexpr double move_importance(int ply) {
+  double move_importance(int ply) {
     return 1 - (ply - 88) / std::hypot(44, ply - 88);
   }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -37,18 +37,12 @@ namespace {
   constexpr double StealRatio = 0.34; // However we must not steal time from remaining moves over this ratio
 
 
-  // move_importance() is a skew-logistic function based on naive statistical
-  // analysis of "how many games are still undecided after n half-moves". Game
-  // is considered "undecided" as long as neither side has >275cp advantage.
-  // Data was extracted from the CCRL game database with some simple filtering criteria.
-
+  // move_importance() is a ply-based skew-logistic function suggesting an
+  // amount of time to allocate to this particular move
   double move_importance(int ply) {
 
-    constexpr double XScale = 6.85;
-    constexpr double XShift = 64.5;
-    constexpr double Skew   = 0.171;
-
-    return pow((1 + exp((ply - XShift) / XScale)), -Skew) + DBL_MIN; // Ensure non-zero
+    int x = 88;
+    return 1 - (ply - x) / std::hypot(x / 2, ply - x);
   }
 
   template<TimeType T>

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -37,12 +37,9 @@ namespace {
   constexpr double StealRatio = 0.34; // However we must not steal time from remaining moves over this ratio
 
 
-  // move_importance() is a ply-based skew-logistic function suggesting an
-  // amount of time to allocate to this particular move
-  double move_importance(int ply) {
-
-    int x = 88;
-    return 1 - (ply - x) / std::hypot(x / 2, ply - x);
+  // move_importance() is a sigmoid for scaling time usage according to ply.
+  constexpr double move_importance(int ply) {
+    return 1 - (ply - 88) / std::hypot(44, ply - 88);
   }
 
   template<TimeType T>


### PR DESCRIPTION
This is a functional simplification using a simple sigmoid.  Low ply values are significantly higher, but scales close to master for higher values.  Seems like there was a reason (I don't remember) why we didn't want this value to be > 1.0, but it does seem to be a little better.  The version in this PR is NOT the tested version, but should be identical.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 14958 W: 3460 L: 3324 D: 8174
http://tests.stockfishchess.org/tests/view/5cdaed960ebc5925cf05894e

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 21494 W: 3750 L: 3630 D: 14114
http://tests.stockfishchess.org/tests/view/5cdaf5460ebc5925cf058aa2

![image](https://user-images.githubusercontent.com/29714248/57728168-7726bf00-7650-11e9-863e-5118bfe2c1ba.png)

