### PR TITLE
Decrease reduction in case we had singular extension.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -855,6 +855,7 @@ moves_loop: // When in check, search starts from here
     value = bestValue; // Workaround a bogus 'uninitialized' warning under gcc
     moveCountPruning = false;
     ttCapture = ttMove && pos.capture_or_promotion(ttMove);
+    int singularExtensionLMRmultiplier = 0;
 
     // Step 12. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
@@ -911,7 +912,12 @@ moves_loop: // When in check, search starts from here
           ss->excludedMove = MOVE_NONE;
 
           if (value < singularBeta)
+              {
               extension = ONE_PLY;
+              singularExtensionLMRmultiplier++;
+              if (value < singularBeta - std::min(3 * depth / ONE_PLY, 39))
+              	  singularExtensionLMRmultiplier++;
+              }
 
           // Multi-cut pruning
           // Our ttMove is assumed to fail high, and now we failed high also on a reduced
@@ -1021,6 +1027,8 @@ moves_loop: // When in check, search starts from here
           // Decrease reduction if opponent's move count is high (~10 Elo)
           if ((ss-1)->moveCount > 15)
               r -= ONE_PLY;
+          // Decrease reduction if move has been singularly extended
+          r -= singularExtensionLMRmultiplier * ONE_PLY;
 
           if (!captureOrPromotion)
           {


### PR DESCRIPTION
Passed STC http://tests.stockfishchess.org/tests/view/5cda71790ebc5925cf057a84
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 73454 W: 16482 L: 15954 D: 41018 
Passed LTC http://tests.stockfishchess.org/tests/view/5cdab17b0ebc5925cf05822f
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 56696 W: 9877 L: 9538 D: 37281 
Original idea by @locutus2
How to improve it? Well, I had a lot of different attempts on this one, 3 of them passed STC with addition of cases in which we decrease reduction by 2 plies instead of 1 if difference between value and singular beta is big enough.
Further things can be tested : 
1) decrease reduction by 3 plies if this difference is even higher;
2) tweaking around coefficients of singular beta and this new decreased sinfular beta - this is the first test after applying std::min so coefficients are somewhat random;
3) simplifying this std::min(3 * depth / ONE_PLY, 39) into constant value - it differs only from depths from 8 to 13 so not that much.
bench 3378510