### PR TITLE
[RFC] Adjust rootDepth on MultiPV lines.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -372,7 +372,7 @@ void Thread::search() {
           int failedHighCnt = 0;
           while (true)
           {
-              Depth adjustedDepth = std::max(ONE_PLY, rootDepth - failedHighCnt * ONE_PLY);
+              Depth adjustedDepth = std::max(ONE_PLY, rootDepth - failedHighCnt * ONE_PLY - msb(pvIdx + 1) * ONE_PLY);
               bestValue = ::search<PV>(rootPos, ss, alpha, beta, adjustedDepth, false);
 
               // Bring the best move to the front. It is critical that sorting


### PR DESCRIPTION
This is a request for comments (especially by the experienced analysts..)

First, in multiPV analysis, the quality of the bestmove is low (compared to no multiPV), as a large fraction of the time is spent on lower quality lines. Even though a user might want to see all lines, the top move(s) appear to be the most important ones (use case http://analysis.sesse.net/).

Second, MCTS search quite naturally provides MultiPV analysis without affecting the playing strength, which is used as an argument in its favor. However, as MCTS focuses on the better lines, these lower quality lines are less searched.

Here, using an adjusted depth that is slightly smaller than rootDepth for the later multiPV lines (logarithmically growing with pvIdx), a much stronger bestmove is found, while still providing all multiPV lines. The Elo gain for the bestmove depends on the number of lines searched:

MultiPV 4 (STC)
ELO: 27.75 +-6.3 (95%) LOS: 100.0%
Total: 10000 W: 4670 L: 3873 D: 1457
http://tests.stockfishchess.org/tests/view/5cddcea50ebc5925cf05edd5

MultiPV 16 (STC)
ELO: 72.39 +-6.9 (95%) LOS: 100.0%
Total: 10000 W: 6023 L: 3969 D: 8
http://tests.stockfishchess.org/tests/view/5cddd6d40ebc5925cf05ee8f
(The strange drawrate is possibly 'effective TC' related, 10+0.1 for 16 lines is a bit little ?).

While the quality of the bestmove can easily be measured by playing games, it is not so obvious how to measure (or even define) the quality of the second best move.
This might require the experts to have a look by actually using the patch.
Forcing the engine to always play the second best line leads to some Elo loss, but I believe that's not a good way to measure the quality of the ranking (i.e. the second move will be strong if one fails to rank the best one as first, and places it second instead).
http://tests.stockfishchess.org/tests/view/5cddd1510ebc5925cf05edf4
http://tests.stockfishchess.org/tests/view/5cddd85f0ebc5925cf05eeb9

Finally, there are many possible ways to reduce the depth of later lines. The logarithmic scheme used here seems pretty simple and reasonable: 1 ply less for line 2 and 3; 2 plies less for 4, 5, 6, 7; 3 plies less for 8-15. Maybe there is a better way or another metric.

No functional change