### PR TITLE
Passed pawns: Consider rooks and queens anywhere on the file.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -649,7 +649,7 @@ namespace {
                 // in the pawn's path attacked or occupied by the enemy.
                 defendedSquares = unsafeSquares = squaresToQueen = forward_file_bb(Us, s);
 
-                bb = forward_file_bb(Them, s) & pos.pieces(ROOK, QUEEN);
+                bb = file_bb(s) & pos.pieces(ROOK, QUEEN);
 
                 if (!(pos.pieces(Us) & bb))
                     defendedSquares &= attackedBy[Us][ALL_PIECES];


### PR DESCRIPTION
This PR is a logical continuation of our most recent commit,  bf6b647, continuing to try to simplify passed pawn calculations of defended and unsafe squares.

Prior to this patch, we considered only rooks and queens (of either color) that were behind the passed pawn, not those that would block it.  To do so, we calculated a "forward file" Bitboard, containing squares that were both
- in a Bitboard of that file, and
- in a Bitboard of ranks behind the passed pawn's square.

However, this second calculation seems unnecessary--using the entire file performs at least as well at both STC and LTC.  The Elo estimate at STC was very nearly exactly 0; unexpectedly, it performed much better at LTC.  Though it is risky to infer any Elo from SPRT results too precisely, the results admit a possibility that this may be an unexpected Elo-gainer, in addition to a simplification.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 54210 W: 12009 L: 11952 D: 30249
http://tests.stockfishchess.org/tests/view/5ce0d12a0ebc5925cf064cc8

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 13308 W: 2310 L: 2177 D: 8821
http://tests.stockfishchess.org/tests/view/5ce0dedc0ebc5925cf064f95

Bench: 3231385

