### PR TITLE
Use MAX_MOVES sized quiets and captures arrays.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -528,7 +528,7 @@ namespace {
     assert(!(PvNode && cutNode));
     assert(depth / ONE_PLY * ONE_PLY == depth);
 
-    Move pv[MAX_PLY+1], capturesSearched[32], quietsSearched[64];
+    Move pv[MAX_PLY+1], capturesSearched[MAX_MOVES], quietsSearched[MAX_MOVES];
     StateInfo st;
     TTEntry* tte;
     Key posKey;
@@ -1149,10 +1149,9 @@ moves_loop: // When in check, search starts from here
 
       if (move != bestMove)
       {
-          if (captureOrPromotion && captureCount < 32)
+          if (captureOrPromotion)
               capturesSearched[captureCount++] = move;
-
-          else if (!captureOrPromotion && quietCount < 64)
+          else
               quietsSearched[quietCount++] = move;
       }
     }


### PR DESCRIPTION
remove the corresponding magic numbers and conditionals.

No change in bench at low depth.

passed STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 189759 W: 42421 L: 42636 D: 104702
http://tests.stockfishchess.org/tests/view/5ce2bbba0ebc5925cf068536

passed LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 92227 W: 15627 L: 15622 D: 60978
http://tests.stockfishchess.org/tests/view/5ce41e440ebc5925cf06b04b

Bench: 3415326