### PR TITLE
Remove one division.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -71,7 +71,7 @@ namespace {
   int Reductions[MAX_MOVES]; // [depth or moveNumber]
 
   Depth reduction(bool i, Depth d, int mn) {
-    int r = Reductions[d / ONE_PLY] * Reductions[mn] / 1024;
+    int r = Reductions[d / ONE_PLY] * Reductions[mn];
     return ((r + 512) / 1024 + (!i && r > 1024)) * ONE_PLY;
   }
 
@@ -149,7 +149,7 @@ namespace {
 void Search::init() {
 
   for (int i = 1; i < MAX_MOVES; ++i)
-     Reductions[i] = int(733.3 * std::log(i));
+     Reductions[i] = int(22.9 * std::log(i));
 }
 
 


### PR DESCRIPTION
can be included in the earlier calculation, with a small rounding difference.

passed STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 17912 W: 4044 L: 3915 D: 9953
http://tests.stockfishchess.org/tests/view/5ce711f90ebc5925cf070d0e

passed LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 56061 W: 9579 L: 9516 D: 36966
http://tests.stockfishchess.org/tests/view/5ce716820ebc5925cf070e37

Bench: 3817662