### PR TITLE
Simplify passed pawns.

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -110,9 +110,8 @@ namespace {
         // full attack info to evaluate them. Include also not passed pawns
         // which could become passed after one or two pawn pushes when are
         // not attacked more times than defended.
-        if (   !(stoppers ^ lever ^ leverPush)
-            && (support || !more_than_one(lever))
-            && popcount(phalanx) >= popcount(leverPush))
+        if (   !(stoppers ^ lever) ||
+              (!(stoppers ^ leverPush) && popcount(phalanx) >= popcount(leverPush)))
             e->passedPawns[Us] |= s;
 
         else if (stoppers == square_bb(s + Up) && r >= RANK_5)


### PR DESCRIPTION
This is a functional simplification.

If all of the stoppers are levers, a simple pawn push passes.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 41768 W: 9360 L: 9278 D: 23130
http://tests.stockfishchess.org/tests/view/5ce82ed60ebc5925cf073a79

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 40463 W: 6964 L: 6875 D: 26624
http://tests.stockfishchess.org/tests/view/5ce87d0b0ebc5925cf07472b

bench 3678207