### PR TITLE
Remove pawn attacks in pawns.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -229,17 +229,19 @@ namespace {
     const Square ksq = pos.square<KING>(Us);
 
     Bitboard dblAttackByPawn = pawn_double_attacks_bb<Us>(pos.pieces(Us, PAWN));
+    Bitboard ourPawnAttacks = pawn_attacks_bb<Us>(pos.pieces(Us, PAWN));
+    Bitboard theirPawnAttacks = pawn_attacks_bb<Them>(pos.pieces(Them, PAWN));
 
     // Find our pawns that are blocked or on the first two ranks
     Bitboard b = pos.pieces(Us, PAWN) & (shift<Down>(pos.pieces()) | LowRanks);
 
     // Squares occupied by those pawns, by our king or queen or controlled by
     // enemy pawns are excluded from the mobility area.
-    mobilityArea[Us] = ~(b | pos.pieces(Us, KING, QUEEN) | pe->pawn_attacks(Them));
+    mobilityArea[Us] = ~(b | pos.pieces(Us, KING, QUEEN) | theirPawnAttacks);
 
     // Initialize attackedBy[] for king and pawns
     attackedBy[Us][KING] = pos.attacks_from<KING>(ksq);
-    attackedBy[Us][PAWN] = pe->pawn_attacks(Us);
+    attackedBy[Us][PAWN] = ourPawnAttacks;
     attackedBy[Us][ALL_PIECES] = attackedBy[Us][KING] | attackedBy[Us][PAWN];
     attackedBy2[Us] = dblAttackByPawn | (attackedBy[Us][KING] & attackedBy[Us][PAWN]);
 
@@ -254,7 +256,7 @@ namespace {
     else if (file_of(ksq) == FILE_A)
         kingRing[Us] |= shift<EAST>(kingRing[Us]);
 
-    kingAttackersCount[Them] = popcount(kingRing[Us] & pe->pawn_attacks(Them));
+    kingAttackersCount[Them] = popcount(kingRing[Us] & theirPawnAttacks);
     kingAttacksCount[Them] = kingAttackersWeight[Them] = 0;
 
     // Remove from kingRing[] the squares defended by two pawns

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -79,7 +79,6 @@ namespace {
 
     e->passedPawns[Us] = e->pawnAttacksSpan[Us] = e->weakUnopposed[Us] = 0;
     e->kingSquares[Us]   = SQ_NONE;
-    e->pawnAttacks[Us]   = pawn_attacks_bb<Us>(ourPawns);
 
     // Loop through all pawns of the current color and score each pawn
     while ((s = *pl++) != SQ_NONE)

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -34,7 +34,6 @@ namespace Pawns {
 struct Entry {
 
   Score pawn_score(Color c) const { return scores[c]; }
-  Bitboard pawn_attacks(Color c) const { return pawnAttacks[c]; }
   Bitboard passed_pawns(Color c) const { return passedPawns[c]; }
   Bitboard pawn_attacks_span(Color c) const { return pawnAttacksSpan[c]; }
   int weak_unopposed(Color c) const { return weakUnopposed[c]; }
@@ -55,7 +54,6 @@ struct Entry {
   Key key;
   Score scores[COLOR_NB];
   Bitboard passedPawns[COLOR_NB];
-  Bitboard pawnAttacks[COLOR_NB];
   Bitboard pawnAttacksSpan[COLOR_NB];
   Square kingSquares[COLOR_NB];
   Score kingSafety[COLOR_NB];


### PR DESCRIPTION
This is a non-functional simplification that removes the PawnAttacks array from the pawns Entry.  A few previous versions of this failed, so let's be careful about this one.  Can some of you run some benchmarks?

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 55340 W: 12317 L: 12262 D: 30761
http://tests.stockfishchess.org/tests/view/5ce9fd9e0ebc5925cf0781f3