### PR TITLE
Improve multiPV mode.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -296,7 +296,7 @@ void Thread::search() {
   bestValue = delta = alpha = -VALUE_INFINITE;
   beta = VALUE_INFINITE;
 
-  size_t multiPV = Options["MultiPV"];
+  multiPV = Options["MultiPV"];
   Skill skill(Options["Skill Level"]);
 
   // When playing with strength handicap enable MultiPV search that we will
@@ -875,6 +875,12 @@ moves_loop: // When in check, search starts from here
           sync_cout << "info depth " << depth / ONE_PLY
                     << " currmove " << UCI::move(move, pos.is_chess960())
                     << " currmovenumber " << moveCount + thisThread->pvIdx << sync_endl;
+
+      // In MultiPV mode also skip moves which will be searched later as PV moves
+      if (rootNode && std::count(thisThread->rootMoves.begin() + thisThread->pvIdx + 1,
+                                 thisThread->rootMoves.begin() + thisThread->multiPV, move))
+          continue;
+
       if (PvNode)
           (ss+1)->pv = nullptr;
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -59,7 +59,7 @@ public:
 
   Pawns::Table pawnsTable;
   Material::Table materialTable;
-  size_t pvIdx, pvLast;
+  size_t pvIdx, multiPV, pvLast;
   int selDepth, nmpMinPly;
   Color nmpColor;
   std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;


### PR DESCRIPTION
Skip all moves during the Non-PV (zero-window) search which will be searched
as PV moves later anyways.
Make sure the moves will be reported to the GUI despite they're not being searched.
Some GUIs may get confused otherwise, and it would unnecessarily complicate the code.

**Tested with MultiPV=4**
STC
http://tests.stockfishchess.org/tests/view/5ce7137c0ebc5925cf070d69
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 8233 W: 3708 L: 3424 D: 1101

LTC
http://tests.stockfishchess.org/tests/view/5ce798d60ebc5925cf071d17
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 7369 W: 3197 L: 2911 D: 1261

No functional change. (in single PV mode)