### PR TITLE
Simplify semiopen_file

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -357,8 +357,8 @@ namespace {
                 score += RookOnPawn * popcount(pos.pieces(Them, PAWN) & PseudoAttacks[ROOK][s]);
 
             // Bonus for rook on an open or semi-open file
-            if (pos.is_semiopen_file(Us, s))
-                score += RookOnFile[bool(pos.is_semiopen_file(Them, s))];
+            if (pos.is_on_semiopen_file(Us, s))
+                score += RookOnFile[bool(pos.is_on_semiopen_file(Them, s))];
 
             // Penalty when trapped by the king, even more if the king cannot castle
             else if (mob <= 3)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -357,8 +357,8 @@ namespace {
                 score += RookOnPawn * popcount(pos.pieces(Them, PAWN) & PseudoAttacks[ROOK][s]);
 
             // Bonus for rook on an open or semi-open file
-            if (pos.is_semiopen_file(Us, file_of(s)))
-                score += RookOnFile[bool(pos.is_semiopen_file(Them, file_of(s)))];
+            if (pos.is_semiopen_file(Us, s))
+                score += RookOnFile[bool(pos.is_semiopen_file(Them, s))];
 
             // Penalty when trapped by the king, even more if the king cannot castle
             else if (mob <= 3)

--- a/src/position.h
+++ b/src/position.h
@@ -96,7 +96,7 @@ public:
   template<PieceType Pt> int count() const;
   template<PieceType Pt> const Square* squares(Color c) const;
   template<PieceType Pt> Square square(Color c) const;
-  bool is_semiopen_file(Color c, File f) const;
+  bool is_semiopen_file(Color c, Square s) const;
 
   // Castling
   int castling_rights(Color c) const;
@@ -263,8 +263,8 @@ inline Square Position::ep_square() const {
   return st->epSquare;
 }
 
-inline bool Position::is_semiopen_file(Color c, File f) const {
-  return !(pieces(c, PAWN) & file_bb(f));
+inline bool Position::is_semiopen_file(Color c, Square s) const {
+  return !(pieces(c, PAWN) & file_bb(s));
 }
 
 inline bool Position::can_castle(CastlingRight cr) const {

--- a/src/position.h
+++ b/src/position.h
@@ -96,7 +96,7 @@ public:
   template<PieceType Pt> int count() const;
   template<PieceType Pt> const Square* squares(Color c) const;
   template<PieceType Pt> Square square(Color c) const;
-  bool is_semiopen_file(Color c, Square s) const;
+  bool is_on_semiopen_file(Color c, Square s) const;
 
   // Castling
   int castling_rights(Color c) const;
@@ -263,7 +263,7 @@ inline Square Position::ep_square() const {
   return st->epSquare;
 }
 
-inline bool Position::is_semiopen_file(Color c, Square s) const {
+inline bool Position::is_on_semiopen_file(Color c, Square s) const {
   return !(pieces(c, PAWN) & file_bb(s));
 }
 


### PR DESCRIPTION
This is a non-functional simplification.  Since our file_bb handles either Files or Squares, using Square here removes some code.  Not likely any performance difference despite the test.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 6081 W: 1444 L: 1291 D: 3346
http://tests.stockfishchess.org/tests/view/5ceb3e2e0ebc5925cf07ab03