### PR TITLE
Use all PV nodes for ttPv.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -603,7 +603,7 @@ namespace {
     ttValue = ttHit ? value_from_tt(tte->value(), ss->ply) : VALUE_NONE;
     ttMove =  rootNode ? thisThread->rootMoves[thisThread->pvIdx].pv[0]
             : ttHit    ? tte->move() : MOVE_NONE;
-    ttPv = (ttHit && tte->is_pv()) || (PvNode && depth > 4 * ONE_PLY);
+    ttPv = PvNode || (ttHit && tte->is_pv());
 
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode


### PR DESCRIPTION
Currently PV nodes with a depth <= 4 were ignored for ttPv. Now remove this constraint and use all PV nodes.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 52209 W: 11755 L: 11694 D: 28760
http://tests.stockfishchess.org/tests/view/5cebc2d30ebc5925cf07b93a

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 20874 W: 3689 L: 3568 D: 13617
http://tests.stockfishchess.org/tests/view/5cec01fc0ebc5925cf07c62d

Bench: 4136732