### PR TITLE
Remove inconsistent comparison

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -589,10 +589,10 @@ namespace {
     // starts with statScore = 0. Later grandchildren start with the last calculated
     // statScore of the previous grandchild. This influences the reduction rules in
     // LMR which are based on the statScore of parent position.
-	if (rootNode)
-		(ss + 4)->statScore = 0;
-	else
-		(ss + 2)->statScore = 0;
+    if (rootNode)
+        (ss + 4)->statScore = 0;
+    else
+        (ss + 2)->statScore = 0;
 
     // Step 4. Transposition table lookup. We don't want the score of a partial
     // search to overwrite a previous full search TT value, so we use a different
@@ -910,8 +910,6 @@ moves_loop: // When in check, search starts from here
               {
               extension = ONE_PLY;
               singularExtensionLMRmultiplier++;
-              if (value < singularBeta - std::min(3 * depth / ONE_PLY, 39))
-              	  singularExtensionLMRmultiplier++;
               }
 
           // Multi-cut pruning


### PR DESCRIPTION
It is wrong to compare a value returned by an
alpha / beta search ourside of its search window.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 19899 W: 4504 L: 4379 D: 11016

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 73465 W: 12568 L: 12533 D: 48364 

Bench: 3387586