### PR TITLE
Scale lazy threshold according to non_pawn_material()

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -74,7 +74,7 @@ using namespace Trace;
 namespace {
 
   // Threshold for lazy and space evaluation
-  constexpr Value LazyThreshold  = Value(1500);
+  constexpr Value LazyThreshold  = Value(1400);
   constexpr Value SpaceThreshold = Value(12222);
 
   // KingAttackWeights[PieceType] contains king attack weights by piece type
@@ -813,7 +813,7 @@ namespace {
 
     // Early exit if score is high
     Value v = (mg_value(score) + eg_value(score)) / 2;
-    if (abs(v) > LazyThreshold)
+    if (abs(v) > (LazyThreshold + pos.non_pawn_material() / 64))
        return pos.side_to_move() == WHITE ? v : -v;
 
     // Main evaluation begins here


### PR DESCRIPTION
STC
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 58543 W: 13238 L: 12782 D: 32523 
http://tests.stockfishchess.org/tests/view/5cef3efa0ebc5925cf081f07

LTC
LLR: 3.70 (-2.94,2.94) [0.00,3.50]
Total: 82232 W: 14281 L: 13825 D: 54126 
http://tests.stockfishchess.org/tests/view/5cef595d0ebc5925cf082441

bench 3807737