### PR TITLE
Remove obsolete member of Pawns::Entry

### DIFF
--- a/src/pawns.h
+++ b/src/pawns.h
@@ -61,7 +61,6 @@ struct Entry {
   Score kingSafety[COLOR_NB];
   int weakUnopposed[COLOR_NB];
   int castlingRights[COLOR_NB];
-  int pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
 };
 
 typedef HashTable<Entry, 16384> Table;


### PR DESCRIPTION
No functional change.