### PR TITLE
Use pruning heuristics for advanced pawn pushes if enemy material is high enough.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -958,7 +958,7 @@ moves_loop: // When in check, search starts from here
 
           if (   !captureOrPromotion
               && !givesCheck
-              && !pos.advanced_pawn_push(move))
+              && (!pos.advanced_pawn_push(move) || pos.non_pawn_material(~us) > BishopValueMg))
           {
               // Move count based pruning (~30 Elo)
               if (moveCountPruning)


### PR DESCRIPTION
passed STC
http://tests.stockfishchess.org/tests/view/5cf586ee0ebc5925cf08c0ed
LLR: 2.96 (-2.94,2.94) [0.50,4.50]
Total: 29496 W: 6718 L: 6406 D: 16372 
passed LTC
http://tests.stockfishchess.org/tests/view/5cf59b630ebc5925cf08c343
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 40778 W: 7057 L: 6765 D: 26956 
bench 3584443
original idea from early 2018 by @jerrydonaldwatson
Code slightly rewritten to be shorter and more logical, no functinal changes compared to passed patch.