### PR TITLE
Move WeakUnopposed to pawns

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -557,10 +557,6 @@ namespace {
 
     score += RestrictedPiece * popcount(b);
 
-    // Bonus for enemy unopposed weak pawns
-    if (pos.pieces(Us, ROOK, QUEEN))
-        score += WeakUnopposedPawn * pe->weak_unopposed(Them);
-
     // Find squares where our pawns can push on the next move
     b  = shift<Up>(pos.pieces(Us, PAWN)) & ~pos.pieces();
     b |= shift<Up>(b & TRank3BB) & ~pos.pieces();

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -152,7 +152,6 @@ namespace {
   constexpr Score ThreatBySafePawn   = S(173, 94);
   constexpr Score TrappedRook        = S( 47,  4);
   constexpr Score WeakQueen          = S( 49, 15);
-  constexpr Score WeakUnopposedPawn  = S( 12, 23);
 
 #undef S
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -35,7 +35,7 @@ namespace {
   constexpr Score Backward = S( 9, 24);
   constexpr Score Doubled  = S(11, 56);
   constexpr Score Isolated = S( 5, 15);
-  constexpr Score WeakUnopposed = S( 11, 22);
+  constexpr Score WeakUnopposed = S( 7*11/8, 7*22/8);
 
   // Connected pawn bonus
   constexpr int Connected[RANK_NB] = { 0, 7, 8, 12, 29, 48, 86 };

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -35,7 +35,7 @@ namespace {
   constexpr Score Backward = S( 9, 24);
   constexpr Score Doubled  = S(11, 56);
   constexpr Score Isolated = S( 5, 15);
-  constexpr Score WeakUnopposed = S( 10*11/8, 10*22/8);
+  constexpr Score WeakUnopposed = S( 13, 27);
 
   // Connected pawn bonus
   constexpr int Connected[RANK_NB] = { 0, 7, 8, 12, 29, 48, 86 };

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -35,7 +35,7 @@ namespace {
   constexpr Score Backward = S( 9, 24);
   constexpr Score Doubled  = S(11, 56);
   constexpr Score Isolated = S( 5, 15);
-  constexpr Score WeakUnopposed = S( 7*11/8, 7*22/8);
+  constexpr Score WeakUnopposed = S( 9*11/8, 9*22/8);
 
   // Connected pawn bonus
   constexpr int Connected[RANK_NB] = { 0, 7, 8, 12, 29, 48, 86 };

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -35,7 +35,7 @@ namespace {
   constexpr Score Backward = S( 9, 24);
   constexpr Score Doubled  = S(11, 56);
   constexpr Score Isolated = S( 5, 15);
-  constexpr Score WeakUnopposed = S( 9*11/8, 9*22/8);
+  constexpr Score WeakUnopposed = S( 10*11/8, 10*22/8);
 
   // Connected pawn bonus
   constexpr int Connected[RANK_NB] = { 0, 7, 8, 12, 29, 48, 86 };

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -133,10 +133,10 @@ namespace {
             score += make_score(v, v * (r - 2) / 4);
         }
         else if (!neighbours)
-            score -= Isolated + WeakUnopposed * !opposed;
+            score -= Isolated + WeakUnopposed * int(!opposed);
 
         else if (backward)
-            score -= Backward + WeakUnopposed * !opposed;
+            score -= Backward + WeakUnopposed * int(!opposed);
 
         if (doubled && !support)
             score -= Doubled;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -35,6 +35,7 @@ namespace {
   constexpr Score Backward = S( 9, 24);
   constexpr Score Doubled  = S(11, 56);
   constexpr Score Isolated = S( 5, 15);
+  constexpr Score WeakUnopposed = S( 11, 22);
 
   // Connected pawn bonus
   constexpr int Connected[RANK_NB] = { 0, 7, 8, 12, 29, 48, 86 };
@@ -77,7 +78,7 @@ namespace {
     Bitboard ourPawns   = pos.pieces(  Us, PAWN);
     Bitboard theirPawns = pos.pieces(Them, PAWN);
 
-    e->passedPawns[Us] = e->pawnAttacksSpan[Us] = e->weakUnopposed[Us] = 0;
+    e->passedPawns[Us] = e->pawnAttacksSpan[Us] = 0;
     e->kingSquares[Us]   = SQ_NONE;
     e->pawnAttacks[Us]   = pawn_attacks_bb<Us>(ourPawns);
 
@@ -132,10 +133,10 @@ namespace {
             score += make_score(v, v * (r - 2) / 4);
         }
         else if (!neighbours)
-            score -= Isolated, e->weakUnopposed[Us] += !opposed;
+            score -= Isolated + WeakUnopposed * !opposed;
 
         else if (backward)
-            score -= Backward, e->weakUnopposed[Us] += !opposed;
+            score -= Backward + WeakUnopposed * !opposed;
 
         if (doubled && !support)
             score -= Doubled;

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -37,7 +37,6 @@ struct Entry {
   Bitboard pawn_attacks(Color c) const { return pawnAttacks[c]; }
   Bitboard passed_pawns(Color c) const { return passedPawns[c]; }
   Bitboard pawn_attacks_span(Color c) const { return pawnAttacksSpan[c]; }
-  int weak_unopposed(Color c) const { return weakUnopposed[c]; }
   int passed_count() const { return popcount(passedPawns[WHITE] | passedPawns[BLACK]); }
 
   template<Color Us>
@@ -59,7 +58,6 @@ struct Entry {
   Bitboard pawnAttacksSpan[COLOR_NB];
   Square kingSquares[COLOR_NB];
   Score kingSafety[COLOR_NB];
-  int weakUnopposed[COLOR_NB];
   int castlingRights[COLOR_NB];
   int pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
 };


### PR DESCRIPTION
This is a functional simplification.

Disconnects WeakUnopposedPawns from any non-pawn piece type.
Moves WeakUnopposedPawn to pawns.cpp.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 8699 W: 2000 L: 1853 D: 4846 
http://tests.stockfishchess.org/tests/view/5cf7721b0ebc5925cf08ee79

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 46605 W: 7969 L: 7890 D: 30746
http://tests.stockfishchess.org/tests/view/5cf7d5f70ebc5925cf08fa96

bench 3542786