### PR TITLE
Simplify k-value for passers.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -661,13 +661,9 @@ namespace {
                 // assign a smaller bonus if the block square isn't attacked.
                 int k = !unsafeSquares ? 20 : !(unsafeSquares & blockSq) ? 9 : 0;
 
-                // If the path to the queen is fully defended, assign a big bonus.
-                // Otherwise assign a smaller bonus if the block square is defended.
-                if (defendedSquares == squaresToQueen)
-                    k += 6;
-
-                else if (defendedSquares & blockSq)
-                    k += 4;
+                // Assign a larger bonus if the block square is defended.
+                if (defendedSquares & blockSq)
+                    k += 5;
 
                 bonus += make_score(k * w, k * w);
             }


### PR DESCRIPTION
Stockfish evaluates passed pawns in part based on a variable k, which shapes the passed pawn bonus based on the number of squares between the current square and promotion square that are attacked by enemy pieces, and the number defended by friendly ones.  Prior to this commit, we gave a large bonus when all squares between the pawn and the promotion square were defended, and if they were not, a somewhat smaller bonus if at least the pawn's next square was.  However, this distinction does not appear to provide any Elo at STC or LTC.

Where do we go from here?  Many promising Elo-gaining patches were attempted in the past few months to refine passed pawn calculation, by altering the definitions of unsafe and defended squares.  Stockfish uses these definitions to choose the value of k, so those tests interact with this PR.  Therefore, it may be worthwhile to retest previously promising but not-quite-passing tests in the vicinity of this patch.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 42344 W: 9455 L: 9374 D: 23515
http://tests.stockfishchess.org/tests/view/5cf83ede0ebc5925cf0904fb

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 69548 W: 11855 L: 11813 D: 45880
http://tests.stockfishchess.org/tests/view/5cf8698f0ebc5925cf0908c8

Bench: 3854907