### PR TITLE
Increase pawns cache

### DIFF
--- a/src/pawns.h
+++ b/src/pawns.h
@@ -61,7 +61,7 @@ struct Entry {
   int castlingRights[COLOR_NB];
 };
 
-typedef HashTable<Entry, 65536> Table;
+typedef HashTable<Entry, 131072> Table;
 
 Entry* probe(const Position& pos);
 

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -64,7 +64,7 @@ struct Entry {
   int pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
 };
 
-typedef HashTable<Entry, 16384> Table;
+typedef HashTable<Entry, 32768> Table;
 
 Entry* probe(const Position& pos);
 

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -64,7 +64,7 @@ struct Entry {
   int pawnsOnSquares[COLOR_NB][COLOR_NB]; // [color][light/dark squares]
 };
 
-typedef HashTable<Entry, 32768> Table;
+typedef HashTable<Entry, 65536> Table;
 
 Entry* probe(const Position& pos);
 


### PR DESCRIPTION
Increase size of the pawns table by the factor 8. This decreases the number of recalculations of pawn structure information significantly (at least at LTC).

I have done  measurements for different depths and pawn cache sizes.
First are given the number of pawn entry calculations are done (in parentheses is the frequency that a call to probe triggers a pawn entry calculation). The delta% are the percentage of less done pawn entry calculations in comparison to master

```
VSTC:   bench 1 1 12
STC:    bench 8 1 16
LTC:    bench 64 1 20
VLTC:   bench 512 1 24

            VSTC       STC         LTC          VLTC
master      82218(6%)  548935(6%)  2415422(7%)  9548071(7%)
pawncache*2 79859(6%)  492943(5%)  2084794(6%)  8275206(6%)
pawncache*4 78551(6%)  458758(5%)  1827770(5%)  7112531(5%)
pawncache*8 77963(6%)  439421(4%)  1649169(5%)  6128652(4%)

delta%(p2-m)  -2.9%      -10.2%      -13.7%       -13.3%
delta%(p4-m)  -4.5%      -16.4%      -24.3%       -25.5%
delta%(p8-m)  -5.2%      -20.0%      -31.7%       -35.8%
```

STC: (non-regression test because at STC the effect is smaller than at LTC)
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 22767 W: 5160 L: 5040 D: 12567
http://tests.stockfishchess.org/tests/view/5d00f6040ebc5925cf09c3e2

LTC:
LLR: 2.94 (-2.94,2.94) [0.00,4.00]
Total: 26340 W: 4524 L: 4286 D: 17530
http://tests.stockfishchess.org/tests/view/5d00a3810ebc5925cf09ba16

No functional change.