### PR TITLE
Remove backmost_sq

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -376,10 +376,7 @@ inline Square pop_lsb(Bitboard* b) {
 }
 
 
-/// frontmost_sq() and backmost_sq() return the most/least advanced square in
-/// the given bitboard relative to the given color.
-
+/// frontmost_sq() returns the most advanced square for the given color
 inline Square frontmost_sq(Color c, Bitboard b) { return c == WHITE ? msb(b) : lsb(b); }
-inline Square  backmost_sq(Color c, Bitboard b) { return c == WHITE ? lsb(b) : msb(b); }
 
 #endif // #ifndef BITBOARD_H_INCLUDED

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -365,7 +365,7 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
       && pos.count<PAWN>(weakSide) >= 1)
   {
       // Get weakSide pawn that is closest to the home rank
-      Square weakPawnSq = backmost_sq(weakSide, pos.pieces(weakSide, PAWN));
+      Square weakPawnSq = frontmost_sq(strongSide, pos.pieces(weakSide, PAWN));
 
       Square strongKingSq = pos.square<KING>(strongSide);
       Square weakKingSq = pos.square<KING>(weakSide);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -190,7 +190,7 @@ void Entry::evaluate_shelter(const Position& pos, Square ksq, Score& shelter) {
   for (File f = File(center - 1); f <= File(center + 1); ++f)
   {
       b = ourPawns & file_bb(f);
-      Rank ourRank = b ? relative_rank(Us, backmost_sq(Us, b)) : RANK_1;
+      Rank ourRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : RANK_1;
 
       b = theirPawns & file_bb(f);
       Rank theirRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : RANK_1;


### PR DESCRIPTION
This is a non-functional simplification.

backmost_sq and frontmost_sq are redundant.  It seems quite clear to always use frontmost_sq and use the correct color.

Not tested.