### PR TITLE
Simplify SEE Pruning - Bench:  3897263

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -980,7 +980,7 @@ moves_loop: // When in check, search starts from here
               if (!pos.see_ge(move, Value(-29 * lmrDepth * lmrDepth)))
                   continue;
           }
-          else if ((!givesCheck || !(pos.blockers_for_king(~us) & from_sq(move)))
+          else if ((!givesCheck || !extension)
                   && !pos.see_ge(move, -PawnValueEg * (depth / ONE_PLY))) // (~20 Elo)
                   continue;
       }


### PR DESCRIPTION
Simplify SEE Pruning
Note this should also be a speedup...
If givesCheck is extended we know (except for DC) that it will have a positive SEE.  So this new logic will be triggered before doing another expensive SEE function.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 24429 W: 5484 L: 5368 D: 13577
http://tests.stockfishchess.org/tests/view/5cffbccd0ebc5925cf09a154


LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 28428 W: 4873 L: 4765 D: 18790
http://tests.stockfishchess.org/tests/view/5d0015f60ebc5925cf09acb1

Bench:  3897263