### PR TITLE
QuietPick Speedup Bench:  3897263

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -200,11 +200,15 @@ top:
       /* fallthrough */
 
   case QUIET_INIT:
-      cur = endBadCaptures;
-      endMoves = generate<QUIETS>(pos, cur);
+      if (!skipQuiets)
+      {
+          cur = endBadCaptures;
+          endMoves = generate<QUIETS>(pos, cur);
 
-      score<QUIETS>();
-      partial_insertion_sort(cur, endMoves, -4000 * depth / ONE_PLY);
+          score<QUIETS>();
+          partial_insertion_sort(cur, endMoves, -4000 * depth / ONE_PLY);
+      }
+      
       ++stage;
       /* fallthrough */
 


### PR DESCRIPTION
Non-functional Speedup

No need to generate, score, or sort quiet moves if SkipQuiet is true.
Thanks to @mstembera for his suggestion.

STC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 27910 W: 6406 L: 6129 D: 15375
http://tests.stockfishchess.org/tests/view/5d07e0920ebc5925cf0a58a8

Bench:  3897263