### PR TITLE
 Partial revert of "Assorted trivial cleanups 5/2019"

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1713,4 +1713,10 @@ void Tablebases::rank_root_moves(Position& pos, Search::RootMoves& rootMoves) {
         if (dtz_available || rootMoves[0].tbScore <= VALUE_DRAW)
             Cardinality = 0;
     }
+    else
+    {
+        // Clean up if root_probe() and root_probe_wdl() have failed
+        for (auto& m : rootMoves)
+          m.tbRank = 0;
+    }
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1717,6 +1717,6 @@ void Tablebases::rank_root_moves(Position& pos, Search::RootMoves& rootMoves) {
     {
         // Clean up if root_probe() and root_probe_wdl() have failed
         for (auto& m : rootMoves)
-          m.tbRank = 0;
+            m.tbRank = 0;
     }
 }


### PR DESCRIPTION
Since root_probe() and root_probe_wdl() do not reset all tbRank values if they fail, it is necessary to do this in rank_root_move(). This fixes https://github.com/official-stockfish/Stockfish/issues/2196.

I have clarified the comment. Alternatively, the loop could be moved into both root_probe() and root_probe_wdl().

Non-functional change (if TBs are not used).