### PR TITLE
More bonus for free passed pawn

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -605,6 +605,7 @@ namespace {
     };
 
     Bitboard b, bb, squaresToQueen, defendedSquares, unsafeSquares;
+    Bitboard wideUnsafeSquares;
     Score score = SCORE_ZERO;
 
     b = pe->passed_pawns(Us);
@@ -639,6 +640,7 @@ namespace {
                 // consider all the squaresToQueen. Otherwise consider only the squares
                 // in the pawn's path attacked or occupied by the enemy.
                 defendedSquares = unsafeSquares = squaresToQueen = forward_file_bb(Us, s);
+                wideUnsafeSquares = AllSquares;
 
                 bb = forward_file_bb(Them, s) & pos.pieces(ROOK, QUEEN);
 
@@ -647,10 +649,14 @@ namespace {
 
                 if (!(pos.pieces(Them) & bb))
                     unsafeSquares &= attackedBy[Them][ALL_PIECES] | pos.pieces(Them);
+                      
+                if (!unsafeSquares)
+                    wideUnsafeSquares = (attackedBy[Them][ALL_PIECES] | pos.pieces(Them)) 
+                                       & (shift<WEST>(squaresToQueen) | shift<EAST>(squaresToQueen));
 
                 // If there aren't any enemy attacks, assign a big bonus. Otherwise
                 // assign a smaller bonus if the block square isn't attacked.
-                int k = !unsafeSquares ? 20 : !(unsafeSquares & blockSq) ? 9 : 0;
+                int k = !wideUnsafeSquares ? 35 : !unsafeSquares ? 20 : !(unsafeSquares & blockSq) ? 9 : 0;
 
                 // Assign a larger bonus if the block square is defended.
                 if (defendedSquares & blockSq)


### PR DESCRIPTION
Give even more bonus to passed pawn if adjacent squares to it path are not attacked

passed STC
http://tests.stockfishchess.org/tests/view/5d08c9b10ebc5925cf0a6630
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 175197 W: 39859 L: 38816 D: 96522 
passed LTC
http://tests.stockfishchess.org/tests/view/5d0ab8240ebc5925cf0a8fe4
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 92928 W: 16124 L: 15682 D: 61122 
bench 3539707