### PR TITLE
Make the debug counters thread safe.

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -145,7 +145,7 @@ const string engine_info(bool to_uci) {
 
 
 /// Debug functions used mainly to collect run-time statistics
-static int64_t hits[2], means[2];
+static std::atomic<int64_t> hits[2], means[2];
 
 void dbg_hit_on(bool b) { ++hits[0]; if (b) ++hits[1]; }
 void dbg_hit_on(bool c, bool b) { if (c) dbg_hit_on(b); }


### PR DESCRIPTION
needed to use them in a threaded run.

No functional change.