### PR TITLE
Bonus for double attacks on an unsupported pawn.

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -36,6 +36,7 @@ namespace {
   constexpr Score Doubled  = S(11, 56);
   constexpr Score Isolated = S( 5, 15);
   constexpr Score WeakUnopposed = S( 13, 27);
+  constexpr Score Attacked2Unsupported = S( 0, 20);
 
   // Connected pawn bonus
   constexpr int Connected[RANK_NB] = { 0, 7, 8, 12, 29, 48, 86 };
@@ -75,12 +76,17 @@ namespace {
     Score score = SCORE_ZERO;
     const Square* pl = pos.squares<PAWN>(Us);
 
-    Bitboard ourPawns   = pos.pieces(  Us, PAWN);
-    Bitboard theirPawns = pos.pieces(Them, PAWN);
+    Bitboard ourPawns     = pos.pieces(  Us, PAWN);
+    Bitboard ourDoubles   = pawn_double_attacks_bb<Us>(ourPawns);
+    Bitboard theirPawns   = pos.pieces(Them, PAWN);
+    Bitboard theirAttacks = pawn_attacks_bb<Them>(theirPawns);
 
     e->passedPawns[Us] = e->pawnAttacksSpan[Us] = 0;
-    e->kingSquares[Us]   = SQ_NONE;
-    e->pawnAttacks[Us]   = pawn_attacks_bb<Us>(ourPawns);
+    e->kingSquares[Us] = SQ_NONE;
+    e->pawnAttacks[Us] = pawn_attacks_bb<Us>(ourPawns);
+
+    //Unsupported pawns attacked twice
+    score += Attacked2Unsupported * popcount(ourDoubles & theirPawns & ~theirAttacks);
 
     // Loop through all pawns of the current color and score each pawn
     while ((s = *pl++) != SQ_NONE)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -85,7 +85,7 @@ namespace {
     e->kingSquares[Us] = SQ_NONE;
     e->pawnAttacks[Us] = pawn_attacks_bb<Us>(ourPawns);
 
-    //Unsupported pawns attacked twice
+    //Unsupported enemy pawns attacked twice by us
     score += Attacked2Unsupported * popcount(ourDoubles & theirPawns & ~theirAttacks);
 
     // Loop through all pawns of the current color and score each pawn


### PR DESCRIPTION
This is a functional change that rewards double attacks on an unsupported pawn.

STC (non-functional difference)
LLR: 2.96 (-2.94,2.94) [0.50,4.50]
Total: 83276 W: 18981 L: 18398 D: 45897 
http://tests.stockfishchess.org/tests/view/5d0970500ebc5925cf0a77d4

LTC (incomplete looping version)
LLR: 0.50 (-2.94,2.94) [0.00,3.50]
Total: 82999 W: 14244 L: 13978 D: 54777 
http://tests.stockfishchess.org/tests/view/5d0a8d480ebc5925cf0a8d58

LTC (completed non-looping version).
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 223381 W: 38323 L: 37512 D: 147546 
http://tests.stockfishchess.org/tests/view/5d0e80510ebc5925cf0ad320

Bench 3809056