### PR TITLE
Remove levers

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -69,7 +69,7 @@ namespace {
     constexpr Direction Up   = (Us == WHITE ? NORTH : SOUTH);
 
     Bitboard b, neighbours, stoppers, doubled, support, phalanx;
-    Bitboard lever, leverPush;
+    Bitboard leverPush;
     Square s;
     bool opposed, backward;
     Score score = SCORE_ZERO;
@@ -94,7 +94,6 @@ namespace {
         // Flag the pawn
         opposed    = theirPawns & forward_file_bb(Us, s);
         stoppers   = theirPawns & passed_pawn_span(Us, s);
-        lever      = theirPawns & PawnAttacks[Us][s];
         leverPush  = theirPawns & PawnAttacks[Us][s + Up];
         doubled    = ourPawns   & (s - Up);
         neighbours = ourPawns   & adjacent_files_bb(s);
@@ -110,7 +109,7 @@ namespace {
         // full attack info to evaluate them. Include also not passed pawns
         // which could become passed after one or two pawn pushes when are
         // not attacked more times than defended.
-        if (   !(stoppers ^ lever) ||
+        if (   !(stoppers & ~PawnAttacks[Us][s]) ||   //if ONLY levers
               (!(stoppers ^ leverPush) && popcount(phalanx) >= popcount(leverPush)))
             e->passedPawns[Us] |= s;
 


### PR DESCRIPTION
This is a non-functional simplification.  The levers variable is only used once and its calculation can be replaced with PawnAttacks.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 16117 W: 3642 L: 3509 D: 8966 
http://tests.stockfishchess.org/tests/view/5d113f1a0ebc5925cf0afcc6