### PR TITLE
Introduce attacks on space area

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -710,6 +710,7 @@ namespace {
     int bonus = popcount(safe) + popcount(behind & safe);
     int weight = pos.count<ALL_PIECES>(Us) - 1;
     Score score = make_score(bonus * weight * weight / 16, 0);
+    score -= make_score(4, 0) * popcount(attackedBy[Them][ALL_PIECES] & behind & safe);
 
     if (T)
         Trace::add(SPACE, Us, score);


### PR DESCRIPTION
Passed STC
http://tests.stockfishchess.org/tests/view/5d10ce590ebc5925cf0af30b
LLR: 2.96 (-2.94,2.94) [0.50,4.50]
Total: 7082 W: 1648 L: 1449 D: 3985 
Passed LTC
http://tests.stockfishchess.org/tests/view/5d10d2d80ebc5925cf0af3fd
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 79494 W: 13727 L: 13324 D: 52443 
This patch introduces small malus for every square in our space mask that is attacked by enemy. 
Value is completely arbitrary and is smth we can tweak, also maybe we can gain some elo with tweaking space threshold after this addition.
bench 3516460