### PR TITLE
Add cast overload for option in various types.

### DIFF
--- a/src/uci.h
+++ b/src/uci.h
@@ -25,6 +25,8 @@
 #include <string>
 
 #include "types.h"
+#include "misc.h"
+
 
 class Position;
 
@@ -49,12 +51,16 @@ public:
   Option(OnChange = nullptr);
   Option(bool v, OnChange = nullptr);
   Option(const char* v, OnChange = nullptr);
-  Option(double v, int minv, int maxv, OnChange = nullptr);
+  Option(int v, int minv, int maxv, OnChange = nullptr);
   Option(const char* v, const char* cur, OnChange = nullptr);
 
   Option& operator=(const std::string&);
   void operator<<(const Option&);
-  operator double() const;
+  
+  operator bool() const;
+  operator int() const;
+  operator size_t() const;
+  operator TimePoint() const;
   operator std::string() const;
   bool operator==(const char*) const;
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -121,15 +121,32 @@ Option::Option(bool v, OnChange f) : type("check"), min(0), max(0), on_change(f)
 Option::Option(OnChange f) : type("button"), min(0), max(0), on_change(f)
 {}
 
-Option::Option(double v, int minv, int maxv, OnChange f) : type("spin"), min(minv), max(maxv), on_change(f)
+Option::Option(int v, int minv, int maxv, OnChange f) : type("spin"), min(minv), max(maxv), on_change(f)
 { defaultValue = currentValue = std::to_string(v); }
 
 Option::Option(const char* v, const char* cur, OnChange f) : type("combo"), min(0), max(0), on_change(f)
 { defaultValue = v; currentValue = cur; }
 
-Option::operator double() const {
-  assert(type == "check" || type == "spin");
-  return (type == "spin" ? stof(currentValue) : currentValue == "true");
+
+Option::operator int() const {
+  assert(type == "spin");
+  return stoi(currentValue);
+}
+
+Option::operator size_t() const
+{
+  assert(type == "spin");
+  return stoull(currentValue);
+}
+
+Option::operator TimePoint() const {
+  assert(type == "spin");
+  return stoll(currentValue);
+}
+
+Option::operator bool() const {
+  assert(type == "check");
+  return currentValue == "true";
 }
 
 Option::operator std::string() const {


### PR DESCRIPTION
Clearer code to read option in the code. 

The double cast operator was made to support bool or integer in one cast which is a bit awkward. Code is now more clearer in regards to which UCI option type is associated which a C++ type.

"spin" => integer
"check" => bool
"string" => std::string

Tests has been made manually and codes changes keep to a bare minimum.