### PR TITLE
Move storm special condition to UnblockedStorm array

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -54,10 +54,10 @@ namespace {
   // RANK_1 = 0 is used for files where the enemy has no pawn, or their pawn
   // is behind our king.
   constexpr Value UnblockedStorm[int(FILE_NB) / 2][RANK_NB] = {
-    { V( 89), V(107), V(123), V(93), V(57), V( 45), V( 51) },
-    { V( 44), V(-18), V(123), V(46), V(39), V( -7), V( 23) },
-    { V(  4), V( 52), V(162), V(37), V( 7), V(-14), V( -2) },
-    { V(-10), V(-14), V( 90), V(15), V( 2), V( -7), V(-16) }
+    { V( 89), V(-285), V(-185), V(93), V(57), V( 45), V( 51) },
+    { V( 44), V( -18), V( 123), V(46), V(39), V( -7), V( 23) },
+    { V(  4), V(  52), V( 162), V(37), V( 7), V(-14), V( -2) },
+    { V(-10), V( -14), V(  90), V(15), V( 2), V( -7), V(-16) }
   };
 
   #undef S
@@ -181,16 +181,12 @@ template<Color Us>
 void Entry::evaluate_shelter(const Position& pos, Square ksq, Score& shelter) {
 
   constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
-  constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
-  constexpr Bitboard BlockSquares =  (Rank1BB | Rank2BB | Rank7BB | Rank8BB)
-                                   & (FileABB | FileHBB);
 
   Bitboard b = pos.pieces(PAWN) & ~forward_ranks_bb(Them, ksq);
   Bitboard ourPawns = b & pos.pieces(Us);
   Bitboard theirPawns = b & pos.pieces(Them);
 
-  Value bonus[] = { (shift<Down>(theirPawns) & BlockSquares & ksq) ? Value(374) : Value(5),
-                    VALUE_ZERO };
+  Value bonus[] = { Value(5), Value(5) };
 
   File center = clamp(file_of(ksq), FILE_B, FILE_G);
   for (File f = File(center - 1); f <= File(center + 1); ++f)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -53,6 +53,7 @@ namespace {
   // Danger of enemy pawns moving toward our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where the enemy has no pawn, or their pawn
   // is behind our king.
+  // [0][1-2] accommodate opponent pawn on edge (likely blocked by our king)
   constexpr Value UnblockedStorm[int(FILE_NB) / 2][RANK_NB] = {
     { V( 89), V(-285), V(-185), V(93), V(57), V( 45), V( 51) },
     { V( 44), V( -18), V( 123), V(46), V(39), V( -7), V( 23) },


### PR DESCRIPTION
This is a functional simplification.

Looks like we can accommodate the special initialization of Value in evaluate_shelter in the UnblockedStorm array.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 32483 W: 7422 L: 7322 D: 17739
http://tests.stockfishchess.org/tests/view/5d14c5f80ebc5925cf0b48da

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 35361 W: 6139 L: 6042 D: 23180
http://tests.stockfishchess.org/tests/view/5d14d69c0ebc5925cf0b4bd0

Bench 3596270
