### PR TITLE
Try to get a more precise bench time

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -139,9 +139,9 @@ vector<string> setup_bench(const Position& current, istream& is) {
       file.close();
   }
 
-  list.emplace_back("ucinewgame");
   list.emplace_back("setoption name Threads value " + threads);
   list.emplace_back("setoption name Hash value " + ttSize);
+  list.emplace_back("ucinewgame");
 
   for (const string& fen : fens)
       if (fen.find("setoption") != string::npos)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -164,7 +164,7 @@ namespace {
         }
         else if (token == "setoption")  setoption(is);
         else if (token == "position")   position(pos, is, states);
-        else if (token == "ucinewgame") Search::clear();
+        else if (token == "ucinewgame") { Search::clear(); elapsed = now(); } // Search::clear() may take some while
     }
 
     elapsed = now() - elapsed + 1; // Ensure positivity to avoid a 'divide by zero'


### PR DESCRIPTION
Initialization of larger hash sizes can take some time.
Don't include this time in the bench by resetting the timer after Search::clear().
Also move 'ucinewgame' command down in the list, so that it is processed
after the configuration of Threads and Hash size.

No functional change.