### PR TITLE
Remove some calls to make_score()

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -659,7 +659,7 @@ namespace {
                 if (defendedSquares & blockSq)
                     k += 5;
 
-                bonus += make_score(k * w, k * w);
+                bonus += SCORE_ONE * k * w;
             }
         } // r > RANK_3
 

--- a/src/material.h
+++ b/src/material.h
@@ -39,7 +39,7 @@ namespace Material {
 
 struct Entry {
 
-  Score imbalance() const { return SCORE_ONE * value; }
+  Score imbalance() const { return SCORE_ONE * (int)value; }
   Phase game_phase() const { return gamePhase; }
   bool specialized_eval_exists() const { return evaluationFunction != nullptr; }
   Value evaluate(const Position& pos) const { return (*evaluationFunction)(pos); }

--- a/src/material.h
+++ b/src/material.h
@@ -39,7 +39,7 @@ namespace Material {
 
 struct Entry {
 
-  Score imbalance() const { return make_score(value, value); }
+  Score imbalance() const { return SCORE_ONE * value; }
   Phase game_phase() const { return gamePhase; }
   bool specialized_eval_exists() const { return evaluationFunction != nullptr; }
   Value evaluate(const Position& pos) const { return (*evaluationFunction)(pos); }

--- a/src/types.h
+++ b/src/types.h
@@ -259,7 +259,7 @@ enum Rank : int {
 /// The least significant 16 bits are used to store the middlegame value and the
 /// upper 16 bits are used to store the endgame value. We have to take care to
 /// avoid left-shifting a signed int to avoid undefined behavior.
-enum Score : int { SCORE_ZERO };
+enum Score : int { SCORE_ZERO, SCORE_ONE = 0x00010001 };
 
 constexpr Score make_score(int mg, int eg) {
   return Score((int)((unsigned int)eg << 16) + mg);


### PR DESCRIPTION
I hope this looks cleaner but I wish it could be done using casting.  Internally it trades a shift and an add for a multiply.  I can not measure any speed difference using bench either way.

LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 16484 W: 3729 L: 3597 D: 9158 
http://tests.stockfishchess.org/tests/view/5d156a6c0ebc5925cf0b5fca

No functional change.
bench: 3633546