### PR TITLE
Revert "Improve multiPV mode"

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -341,7 +341,7 @@ void Thread::search() {
   bestValue = delta = alpha = -VALUE_INFINITE;
   beta = VALUE_INFINITE;
 
-  multiPV = Options["MultiPV"];
+  size_t multiPV = Options["MultiPV"];
 
   // Pick integer skill levels, but non-deterministically round up or down
   // such that the average integer skill corresponds to the input floating point one.
@@ -934,12 +934,6 @@ moves_loop: // When in check, search starts from here
           sync_cout << "info depth " << depth / ONE_PLY
                     << " currmove " << UCI::move(move, pos.is_chess960())
                     << " currmovenumber " << moveCount + thisThread->pvIdx << sync_endl;
-
-      // In MultiPV mode also skip moves which will be searched later as PV moves
-      if (rootNode && std::count(thisThread->rootMoves.begin() + thisThread->pvIdx + 1,
-                                 thisThread->rootMoves.begin() + thisThread->multiPV, move))
-          continue;
-
       if (PvNode)
           (ss+1)->pv = nullptr;
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -59,7 +59,7 @@ public:
 
   Pawns::Table pawnsTable;
   Material::Table materialTable;
-  size_t pvIdx, multiPV, pvLast, shuffleExts;
+  size_t pvIdx, pvLast, shuffleExts;
   int selDepth, nmpMinPly;
   Color nmpColor;
   std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;


### PR DESCRIPTION
This reverts commit a8de07cc26999e2fef7298a63bfe349aaa4650fa.

Even though the STC and LTC tests showed some significant gain, this is not the typical use case of a MultiPV search. Usually, MultiPV searches are used in Analyse mode, or up to a fixed depth or movetime.

Testing with fixed depth or movetime against a version without this 'improvement' are raising some serious doubts about this patch. So better be on the safe side and revert it!

_Test with fixed movetime=400 ms, MultiPV=4:_
Finished game 1000 (SF2-MultiPV4 vs SF-MultiPV4): 1-0 {White wins by adjudication}
Score of SF-MultiPV4 vs SF2-MultiPV4: 258 - 305 - 437  [0.476] 1000
**Elo difference: -16.34 +/- 16.15**
Finished match

_Test with fixed depth=8, MultiPV=4:_
Finished game 1999 (SF-MultiPV4 vs SF2-MultiPV4): 1/2-1/2 {Draw by fifty moves rule}
Score of SF-MultiPV4 vs SF2-MultiPV4: 689 - 1043 - 268  [0.411] 2000
**Elo difference: -62.15 +/- 14.35**
Finished match

No functional change (in SinglePV mode).
Bench: 3596270