### PR TITLE
Send new PV also in skill mode.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -294,8 +294,8 @@ void MainThread::search() {
 
   previousScore = bestThread->rootMoves[0].score;
 
-  // Send again PV info if we have a new best thread
-  if (bestThread != this)
+  // Send again PV info if we have a new best thread or playing in skill mode
+  if (bestThread != this || Skill(Options["Skill Level"]).enabled())
       sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
 
   sync_cout << "bestmove " << UCI::move(bestThread->rootMoves[0].pv[0], rootPos.is_chess960());

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -294,7 +294,7 @@ void MainThread::search() {
 
   previousScore = bestThread->rootMoves[0].score;
 
-  // Send again PV info if we have a new best thread or playing in skill mode
+  // Send again PV info if we have a new best thread
   if (bestThread != this || Skill(Options["Skill Level"]).enabled())
       sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
 


### PR DESCRIPTION
Make sure to re-send the PV line from which we picked the best move when playing with Skill Levels,
so that the best move matches the first move of the displayed PV line.
This came up in https://github.com/official-stockfish/Stockfish/issues/2217.

No functional change.