### PR TITLE
Revert "Smoothly change playing strength with skill level. (#2142)" and increase levels of play to 41. 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -94,7 +94,7 @@ namespace {
   // Skill structure is used to implement strength limit
   struct Skill {
     explicit Skill(int l) : level(l) {}
-    bool enabled() const { return level < 20; }
+    bool enabled() const { return level < 40; }
     bool time_to_pick(Depth depth) const { return depth / ONE_PLY == 1 + level; }
     Move pick_best(size_t multiPV);
 
@@ -335,12 +335,7 @@ void Thread::search() {
   beta = VALUE_INFINITE;
 
   multiPV = Options["MultiPV"];
-  // Pick integer skill levels, but non-deterministically round up or down
-  // such that the average integer skill corresponds to the input floating point one.
-  PRNG rng(now());
-  int intLevel = int(Options["Skill Level"]) +
-        ((Options["Skill Level"] - int(Options["Skill Level"])) * 1024 > rng.rand<unsigned>() % 1024  ? 1 : 0);
-  Skill skill(intLevel);
+  Skill skill(Options["Skill Level"]);
 
   // When playing with strength handicap enable MultiPV search that we will
   // use behind the scenes to retrieve a set of possible moves.
@@ -1593,7 +1588,7 @@ moves_loop: // When in check, search starts from here
     // RootMoves are already sorted by score in descending order
     Value topScore = rootMoves[0].score;
     int delta = std::min(topScore - rootMoves[multiPV - 1].score, PawnValueMg);
-    int weakness = 120 - 2 * level;
+    int weakness = 120 - level;
     int maxScore = -VALUE_INFINITE;
 
     // Choose best move. For each move score we add two terms, both dependent on

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -67,7 +67,7 @@ void init(OptionsMap& o) {
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);
-  o["Skill Level"]           << Option(20, 0, 20);
+  o["Skill Level"]           << Option(40, 0, 20);
   o["Move Overhead"]         << Option(30, 0, 5000);
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
   o["Slow Mover"]            << Option(84, 10, 1000);


### PR DESCRIPTION
This reverts commit ca51d1ee63f376e0eb6efb6f3d5d901e4b2a5bb0.

Increase skill levels to 41 for moderate jumps in playing level (#2216)
This patch will reverse commit ca51d1ee63 'Smoothly change playing strength with skill level. (#2142)' and replace it with the prior formula with the exception that skill levels will expand from 21 (0-20) to 41 (0-40). This will have the desire affect of commit ca51d1ee63 of introducing smoother playing strength levels but with the additional aspect that it will work in all current GUIs without any further programming changes to the GUIs.  
The current implementation introduced with commit ca51d1ee63 had no practical impact since there are no GUIs that could process the floating point input to the integer base UCI 'spin' specification.