### PR TITLE
Use a sigmoid for move_importance (sqrt version)

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -37,18 +37,12 @@ namespace {
   constexpr double StealRatio = 0.34; // However we must not steal time from remaining moves over this ratio
 
 
-  // move_importance() is a skew-logistic function based on naive statistical
-  // analysis of "how many games are still undecided after n half-moves". Game
-  // is considered "undecided" as long as neither side has >275cp advantage.
-  // Data was extracted from the CCRL game database with some simple filtering criteria.
-
+  // move_importance() is a sigmoid for adjusting time allocation for a move.
+  // The aim is to allocate more time for earlier moves.
   double move_importance(int ply) {
 
-    constexpr double XScale = 6.85;
-    constexpr double XShift = 64.5;
-    constexpr double Skew   = 0.171;
-
-    return pow((1 + exp((ply - XShift) / XScale)), -Skew) + DBL_MIN; // Ensure non-zero
+    int p = ply - 88;
+    return 0.6 - 0.6 * p / std::sqrt(p * p + 1936);
   }
 
   template<TimeType T>


### PR DESCRIPTION
This is similar to #2145 and uses a sqrt sigmoid for move_importance.  This version is much closer to master and uses a single sqrt instead of hypot.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 64093 W: 14390 L: 14353 D: 35350
http://tests.stockfishchess.org/tests/view/5d1f6e110ebc5925cf0c5133

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 40812 W: 7028 L: 6940 D: 26844
http://tests.stockfishchess.org/tests/view/5d20179f0ebc5925cf0c6a9d

![image](https://user-images.githubusercontent.com/29714248/60757295-f045f100-9fc5-11e9-9fc6-d0f34eb45aa1.png)

