### PR TITLE
Bug fix: always choose shortest mate in multithread mode

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -287,7 +287,11 @@ void MainThread::search() {
           votes[th->rootMoves[0].pv[0]] +=
               (th->rootMoves[0].score - minScore + 14) * int(th->completedDepth);
 
-          if (votes[th->rootMoves[0].pv[0]] > votes[bestThread->rootMoves[0].pv[0]])
+          if (   (   votes[th->rootMoves[0].pv[0]] > votes[bestThread->rootMoves[0].pv[0]]
+                  && (   bestThread->rootMoves[0].score < VALUE_MATE_IN_MAX_PLY
+                      || th->rootMoves[0].score >= bestThread->rootMoves[0].score))
+              || (   th->rootMoves[0].score >= VALUE_MATE_IN_MAX_PLY
+                  && th->rootMoves[0].score > bestThread->rootMoves[0].score))
               bestThread = th;
       }
   }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -277,7 +277,7 @@ void MainThread::search() {
       std::map<Move, int64_t> votes;
       Value minScore = this->rootMoves[0].score;
 
-      // Find out minimum score and reset votes for moves which can be voted
+      // Find out minimum score
       for (Thread* th: Threads)
           minScore = std::min(minScore, th->rootMoves[0].score);
 
@@ -287,11 +287,14 @@ void MainThread::search() {
           votes[th->rootMoves[0].pv[0]] +=
               (th->rootMoves[0].score - minScore + 14) * int(th->completedDepth);
 
-          if (   (   votes[th->rootMoves[0].pv[0]] > votes[bestThread->rootMoves[0].pv[0]]
-                  && (   bestThread->rootMoves[0].score < VALUE_MATE_IN_MAX_PLY
-                      || th->rootMoves[0].score >= bestThread->rootMoves[0].score))
-              || (   th->rootMoves[0].score >= VALUE_MATE_IN_MAX_PLY
-                  && th->rootMoves[0].score > bestThread->rootMoves[0].score))
+          if (bestThread->rootMoves[0].score >= VALUE_MATE_IN_MAX_PLY)
+          {
+              // Make sure we pick the shortest mate
+              if (th->rootMoves[0].score > bestThread->rootMoves[0].score)
+                  bestThread = th;
+          }
+          else if (   th->rootMoves[0].score >= VALUE_MATE_IN_MAX_PLY
+                   || votes[th->rootMoves[0].pv[0]] > votes[bestThread->rootMoves[0].pv[0]])
               bestThread = th;
       }
   }


### PR DESCRIPTION
With the voting scheme the best thread selection may now pick a non mate or not the shortest mate thread.  This patch fixes it.  Related past PR's: 
https://github.com/official-stockfish/Stockfish/pull/1074
https://github.com/official-stockfish/Stockfish/pull/1215

No functional change single threaded.
bench: 3720929