### PR TITLE
Remove bonus array in shelter

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -199,12 +199,12 @@ void Entry::evaluate_shelter(const Position& pos, Square ksq, Score& shelter) {
       Rank theirRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : RANK_1;
 
       int d = std::min(f, ~f);
-      bonus += Score(ShelterStrength[d][ourRank]); //no EG value
+      bonus += make_score(ShelterStrength[d][ourRank], 0);
 
       if (ourRank && (ourRank == theirRank - 1))
           bonus -= make_score(82 * (theirRank == RANK_3), 82 * (theirRank == RANK_3));
       else
-          bonus -= Score(UnblockedStorm[d][theirRank]); //no EG value
+          bonus -= make_score(UnblockedStorm[d][theirRank], 0);
   }
 
   if (mg_value(bonus) > mg_value(shelter))

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -187,7 +187,7 @@ void Entry::evaluate_shelter(const Position& pos, Square ksq, Score& shelter) {
   Bitboard ourPawns = b & pos.pieces(Us);
   Bitboard theirPawns = b & pos.pieces(Them);
 
-  Value bonus[] = { Value(5), Value(5) };
+  Score bonus = make_score(5,5);;
 
   File center = clamp(file_of(ksq), FILE_B, FILE_G);
   for (File f = File(center - 1); f <= File(center + 1); ++f)
@@ -199,16 +199,16 @@ void Entry::evaluate_shelter(const Position& pos, Square ksq, Score& shelter) {
       Rank theirRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : RANK_1;
 
       int d = std::min(f, ~f);
-      bonus[MG] += ShelterStrength[d][ourRank];
+      bonus += Score(ShelterStrength[d][ourRank]); //no EG value
 
       if (ourRank && (ourRank == theirRank - 1))
-          bonus[MG] -= 82 * (theirRank == RANK_3), bonus[EG] -= 82 * (theirRank == RANK_3);
+          bonus -= make_score(82 * (theirRank == RANK_3), 82 * (theirRank == RANK_3));
       else
-          bonus[MG] -= UnblockedStorm[d][theirRank];
+          bonus -= Score(UnblockedStorm[d][theirRank]); //no EG value
   }
 
-  if (bonus[MG] > mg_value(shelter))
-      shelter = make_score(bonus[MG], bonus[EG]);
+  if (mg_value(bonus) > mg_value(shelter))
+      shelter = bonus;
 }
 
 


### PR DESCRIPTION
This is a non-functional simplification.  Instead of an array of values, just use a Score.

An MG value may be simply added to the score because the MG value is lower bits and does not affect EG value.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 16309 W: 3673 L: 3541 D: 9095 
http://tests.stockfishchess.org/tests/view/5d24f3b80ebc5925cf0ceb5b

Bench 3596270