### PR TITLE
Optimisations for ppc-64

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -137,6 +137,7 @@ ifeq ($(ARCH),ppc-64)
 	arch = ppc64
 	bits = 64
 	popcnt = yes
+	prefetch = yes
 endif
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -136,6 +136,7 @@ endif
 ifeq ($(ARCH),ppc-64)
 	arch = ppc64
 	bits = 64
+	popcnt = yes
 endif
 
 
@@ -313,7 +314,9 @@ endif
 
 ### 3.6 popcnt
 ifeq ($(popcnt),yes)
-	ifeq ($(comp),icc)
+	ifeq ($(arch),ppc64)
+		CXXFLAGS += -DUSE_POPCNT
+	else ifeq ($(comp),icc)
 		CXXFLAGS += -msse3 -DUSE_POPCNT
 	else
 		CXXFLAGS += -msse3 -mpopcnt -DUSE_POPCNT


### PR DESCRIPTION
These two patches enable popcount and prefetch on PowerPC, both of which have been supported in hardware for a long time.

They lead to a cumulative 9.5% performance bump on my POWER8 VM.