### PR TITLE
Capture Scoring Tweak - Bench:  3882919

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -107,8 +107,8 @@ void MovePicker::score() {
 
   for (auto& m : *this)
       if (Type == CAPTURES)
-          m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
-                   + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))] / 8;
+          m.value =  int(PieceValue[MG][pos.piece_on(to_sq(m))]) * 6
+                   + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))];
 
       else if (Type == QUIETS)
           m.value =  (*mainHistory)[pos.side_to_move()][from_to(m)]


### PR DESCRIPTION
Tweak capture scoring formula

STC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 20556 W: 4685 L: 4438 D: 11433
http://tests.stockfishchess.org/tests/view/5d25d26e0ebc5925cf0d0b4a

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 14856 W: 2649 L: 2446 D: 9761
http://tests.stockfishchess.org/tests/view/5d25d8b20ebc5925cf0d0c6d

Bench:  3882919