### PR TITLE
Exclude passed pawns from Attacked2Unsupported.

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -36,7 +36,7 @@ namespace {
   constexpr Score Doubled       = S(11, 56);
   constexpr Score Isolated      = S( 5, 15);
   constexpr Score WeakUnopposed = S( 13, 27);
-  constexpr Score Attacked2Unsupported = S( 0, 20);
+  constexpr Score Attacked2Unsupported = S( 0, 56);
 
   // Connected pawn bonus
   constexpr int Connected[RANK_NB] = { 0, 7, 8, 12, 29, 48, 86 };
@@ -83,11 +83,6 @@ namespace {
     e->passedPawns[Us] = e->pawnAttacksSpan[Us] = 0;
     e->kingSquares[Us] = SQ_NONE;
     e->pawnAttacks[Us] = pawn_attacks_bb<Us>(ourPawns);
-
-    // Unsupported enemy pawns attacked twice by us
-    score += Attacked2Unsupported * popcount(  theirPawns
-                                             & pawn_double_attacks_bb<Us>(ourPawns)
-                                             & ~pawn_attacks_bb<Them>(theirPawns));
 
     // Loop through all pawns of the current color and score each pawn
     while ((s = *pl++) != SQ_NONE)
@@ -148,6 +143,12 @@ namespace {
         if (doubled && !support)
             score -= Doubled;
     }
+
+    // Unsupported friendly pawns attacked twice by the enemy
+    score -= Attacked2Unsupported * popcount(  ourPawns
+                                             & pawn_double_attacks_bb<Them>(theirPawns)
+                                             & ~pawn_attacks_bb<Us>(ourPawns)
+                                             & ~e->passedPawns[Us]);
 
     return score;
   }


### PR DESCRIPTION
We recently added a bonus for double pawn attacks on unsupported enemy pawns, on June 27. However, it is possible that the unsupported pawn may become a passer by simply pushing forward out of the double attack. By rewarding double attacks, we may inadvertently reward the creation of enemy passers, by encouraging both of our would-be stoppers to attack the enemy pawn even if there is no opposing friendly pawn on the same file.

Here, we revise this term to exclude passed pawns. In order to simplify the code with this change included, we non-functionally rewrite Attacked2Unsupported to be a penalty for enemy attacks on friendly pawns, rather than a bonus for our attacks on enemy pawns. This allows us to exclude passed pawns with a simple `& ~e->passedPawns[Us]`, while `passedPawns[Them]` is not yet defined in this part of the code.

This dramatically reduces the proportion of positions in which Attacked2Unsupported is applied, to about a third of the original. To compensate, maintaining the same average effect across our bench positions, we nearly triple Attacked2Unsupported from S(0, 20) to S(0, 56). Although this pawn formation is rare, it is worth more than half a pawn in the endgame!

STC: (stopped automatically by fishtest after 250,000 games)
LLR: -0.87 (-2.94,2.94) [0.50,4.50]
Total: 250000 W: 56585 L: 55383 D: 138032
http://tests.stockfishchess.org/tests/view/5d25795e0ebc5925cf0cfb51

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 81038 W: 13965 L: 13558 D: 53515
http://tests.stockfishchess.org/tests/view/5d25f3920ebc5925cf0d10dd

Bench: 3765158