### PR TITLE
Late Move reduction and continuation history

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -578,7 +578,7 @@ namespace {
     Move ttMove, move, excludedMove, bestMove;
     Depth extension, newDepth;
     Value bestValue, value, ttValue, eval, maxValue;
-    bool ttHit, ttPv, inCheck, givesCheck, improving;
+    bool ttHit, ttPv, inCheck, givesCheck, improving, doLMR;
     bool captureOrPromotion, doFullDepthSearch, moveCountPruning, ttCapture;
     Piece movedPiece;
     int moveCount, captureCount, quietCount, singularLMR;
@@ -1122,14 +1122,25 @@ moves_loop: // When in check, search starts from here
 
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, d, true);
 
-          doFullDepthSearch = (value > alpha && d != newDepth);
+          doFullDepthSearch = (value > alpha && d != newDepth), doLMR = true;
       }
       else
-          doFullDepthSearch = !PvNode || moveCount > 1;
+          doFullDepthSearch = !PvNode || moveCount > 1, doLMR = false;
 
       // Step 17. Full depth search when LMR is skipped or fails high
       if (doFullDepthSearch)
+      {
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, newDepth, !cutNode);
+
+          if (doLMR && !captureOrPromotion)
+          {
+              int bonus = stat_bonus(newDepth) / 2;
+              if (value > alpha)
+                  update_continuation_histories(ss, movedPiece, to_sq(move), bonus);
+              else
+                  update_continuation_histories(ss, movedPiece, to_sq(move), -bonus);
+          }
+      }
 
       // For PV nodes only, do a full PV search on the first move or after a fail
       // high (in the latter case search only if value < beta), otherwise let the


### PR DESCRIPTION
Update continuation history after LMR-triggered full depth research. Directly after a LMR-triggered full depth research update for quiet moves the continuation history with only half stat bonus.

STC:
LLR: 2.96 (-2.94,2.94) [0.50,4.50]
Total: 39657 W: 8966 L: 8604 D: 22087
http://tests.stockfishchess.org/tests/view/5d279fa40ebc5925cf0d4566

LTC:
LLR: 2.96 (-2.94,2.94) [0.50,3.50]
Total: 32582 W: 5740 L: 5427 D: 21415
http://tests.stockfishchess.org/tests/view/5d27dbf90ebc5925cf0d4b7e

Bench: 3239357