### PR TITLE
Full bonus for LMR stats update.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1134,7 +1134,7 @@ moves_loop: // When in check, search starts from here
 
           if (doLMR && !captureOrPromotion)
           {
-              int bonus = stat_bonus(newDepth) / 2;
+              int bonus = stat_bonus(newDepth);
               if (value <= alpha)
                   bonus = -bonus;
 


### PR DESCRIPTION
Simplify by using the full bonus for LMR-triggered stats update.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 23684 W: 5255 L: 5137 D: 13292
http://tests.stockfishchess.org/tests/view/5d2826660ebc5925cf0d5180

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 16245 W: 2832 L: 2704 D: 10709
http://tests.stockfishchess.org/tests/view/5d282e9c0ebc5925cf0d529b

Bench: 3361902