### PR TITLE
Use linear formula for passer w.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -622,7 +622,7 @@ namespace {
 
         if (r > RANK_3)
         {
-            int w = (r-2) * (r-2) + 2;
+            int w = 5 * r - 13;
             Square blockSq = s + Up;
 
             // Adjust bonus based on the king's proximity


### PR DESCRIPTION
In Stockfish, both the middlegame and endgame bonus for a passed pawn are calculated as a product of two factors.  The first is k, chosen based on the presence of defended and unsafe squares.  The second is w, a quadratic function of the pawn's rank.  Both are only applied if the pawn's relative rank is at least RANK_4.

It does not appear that the complexity of a quadratic function is necessary for w.  Here, we replace it with a simpler linear one, which performs equally at both STC and LTC.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 46814 W: 10386 L: 10314 D: 26114
http://tests.stockfishchess.org/tests/view/5d29686e0ebc5925cf0d76a1

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 82372 W: 13845 L: 13823 D: 54704
http://tests.stockfishchess.org/tests/view/5d2980650ebc5925cf0d7bfd

Bench: 3328507