### PR TITLE
Only use blocking square for determining candidate passers.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -666,7 +666,7 @@ namespace {
         // Scale down bonus for candidate passers which need more than one
         // pawn push to become passed, or have a pawn in front of them.
         if (   !pos.pawn_passed(Us, s + Up)
-            || (pos.pieces(PAWN) & forward_file_bb(Us, s)))
+            || (pos.pieces(PAWN) & (s + Up)))
             bonus = bonus / 2;
 
         score += bonus + PassedFile[file_of(s)];


### PR DESCRIPTION
This is another functional simplification to Stockfish passed pawn evaluation.

Stockfish evaluates some pawns which are not yet passed as "candidate" passed pawns, which are given half the bonus of fully passed ones.  Prior to this commit, Stockfish considered a passed pawn to be a "candidate" if (a) it would not be a passed pawn if moved one square forward (the blocking square), or (b) there were other pawns (of either color) in front of it on the file.  This latter condition used a fairly complicated method, `forward_file_bb`; here, rather than inspect the entire forward file, we simply re-use the blocking square.  As a result, some pawns previously considered "candidates", but which are able to push forward, no longer have their bonus halved.

Simplification tests passed quickly at both STC and LTC.  The results from both tests imply that this simplification is, most likely, additionally a small Elo gain, with a LTC likelihood of superiority of 87 percent.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 12908 W: 2909 L: 2770 D: 7229
http://tests.stockfishchess.org/tests/view/5d2a1c880ebc5925cf0d9006

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 20723 W: 3591 L: 3470 D: 13662
http://tests.stockfishchess.org/tests/view/5d2a21fd0ebc5925cf0d9118

Bench: 3377831