### PR TITLE
Simplify space bonus

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -133,7 +133,6 @@ namespace {
   };
 
   // Assorted bonuses and penalties
-  constexpr Score AttacksOnSpaceArea = S(  4,  0);
   constexpr Score BishopPawns        = S(  3,  7);
   constexpr Score CorneredBishop     = S( 50, 50);
   constexpr Score FlankAttacks       = S(  8,  0);
@@ -705,11 +704,9 @@ namespace {
     behind |= shift<Down>(behind);
     behind |= shift<Down+Down>(behind);
 
-    int bonus = popcount(safe) + popcount(behind & safe);
+    int bonus = popcount(safe) + popcount(behind & safe & ~attackedBy[Them][ALL_PIECES]);
     int weight = pos.count<ALL_PIECES>(Us) - 1;
     Score score = make_score(bonus * weight * weight / 16, 0);
-
-    score -= AttacksOnSpaceArea * popcount(attackedBy[Them][ALL_PIECES] & behind & safe);
 
     if (T)
         Trace::add(SPACE, Us, score);


### PR DESCRIPTION
STC http://tests.stockfishchess.org/tests/view/5d2b62c90ebc5925cf0da2a4
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 51299 W: 11320 L: 11257 D: 28722

LTC http://tests.stockfishchess.org/tests/view/5d2bac270ebc5925cf0db215
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 49761 W: 8409 L: 8335 D: 33017

bench: 3395999