### PR TITLE
Simplify Scores

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -257,25 +257,21 @@ enum Rank : int {
 
 /// Score enum stores a middlegame and an endgame value in a single integer (enum).
 /// The least significant 16 bits are used to store the middlegame value and the
-/// upper 16 bits are used to store the endgame value. We have to take care to
-/// avoid left-shifting a signed int to avoid undefined behavior.
-enum Score : int { SCORE_ZERO };
+/// upper 16 bits are used to store the endgame value.  We have to be careful
+/// not to lose the signs of the separate values.
+enum Score : int32_t { SCORE_ZERO };
 
 constexpr Score make_score(int mg, int eg) {
-  return Score((int)((unsigned int)eg << 16) + mg);
+  return Score(eg * 65536 + mg);
 }
 
-/// Extracting the signed lower and upper 16 bits is not so trivial because
-/// according to the standard a simple cast to short is implementation defined
-/// and so is a right shift of a signed integer.
+/// Extracting the signed lower and upper 16 bits is not so trivial.
 inline Value eg_value(Score s) {
-  union { uint16_t u; int16_t s; } eg = { uint16_t(unsigned(s + 0x8000) >> 16) };
-  return Value(eg.s);
+  return Value(int16_t(unsigned(s + 0x8000) / 65536));
 }
 
 inline Value mg_value(Score s) {
-  union { uint16_t u; int16_t s; } mg = { uint16_t(unsigned(s)) };
-  return Value(mg.s);
+  return Value(int16_t(s & 0xFFFF));
 }
 
 #define ENABLE_BASE_OPERATORS_ON(T)                                \

--- a/src/types.h
+++ b/src/types.h
@@ -266,11 +266,11 @@ constexpr Score make_score(int mg, int eg) {
 }
 
 /// Extracting the signed lower and upper 16 bits is not so trivial.
-inline Value eg_value(Score s) {
+constexpr Value eg_value(Score s) {
   return Value(int16_t(unsigned(s + 0x8000) / 65536));
 }
 
-inline Value mg_value(Score s) {
+constexpr Value mg_value(Score s) {
   return Value(int16_t(s & 0xFFFF));
 }
 


### PR DESCRIPTION
This is a non-functional simplification.  On my machine it generates exactly the same assembly as master, but I'm not sure if that necessarily the case across the board.

I'm also a bit leery because I don't understand a few things:
1) I would expect adding a negative signed mg value would alter eg, but that doesn't appear to happen.
2) I don't understand the addition of 0x8000 in eg_value.
   (NOTE: The 0x8000 adds 1 to the eg value if it is negative to preserve correct values).

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 100158 W: 22206 L: 22240 D: 55712 
http://tests.stockfishchess.org/tests/view/5d2c27ef0ebc5925cf0dc572