### PR TITLE
No influence on unsafeSquares of passers by pieces

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -642,7 +642,7 @@ namespace {
                 bb = forward_file_bb(Them, s) & pos.pieces(ROOK, QUEEN);
 
                 if (!(pos.pieces(Them) & bb))
-                    unsafeSquares &= attackedBy[Them][ALL_PIECES] | pos.pieces(Them);
+                    unsafeSquares &= attackedBy[Them][ALL_PIECES];
 
                 // If there are no enemy attacks on passed pawn span, assign a big bonus.
                 // Otherwise assign a smaller bonus if the path to queen is not attacked


### PR DESCRIPTION
Remove their pieces from influencing 'unsafeSquares' in passer
evaluation.

In most cases, blocking pieces attack squares in 'unsafeSquares' which
does influence the computation. Now, pieces blocking a pawn will have a
reduced impact in the passer's score. Lone knights in particular do not
reduce the score if the pawn is on rank 6 or higher.

These changes are beneficial: (Lone) queens are in constant danger of
being attacked and the passer freed, (lone) knights are restricted
severely in their movement due to knights' range restriction.

Maybe some improvements can be made by distinguishing between diagonal
and straight sliders; bishops especially might be considered most useful
to block pawns, lacking straight moves to be blocked by the passer in
return.
(Lone) bishops blocking a passer on rank 7 don't attack the
passed-pawn-span and are penaltized compared to master. This might or
might not be beneficial.

STC LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
    Total: 36421 W: 8170 L: 8078 D: 20173
    http://tests.stockfishchess.org/tests/view/5d22fc8e0ebc5925cf0cb26e
LTC LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
    Total: 18927 W: 3253 L: 3129 D: 12545
    http://tests.stockfishchess.org/tests/view/5d26e2b20ebc5925cf0d3218

Bench: 3748938