### PR TITLE
Tweak LMR and killers

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1144,6 +1144,9 @@ moves_loop: // When in check, search starts from here
               int bonus = value > alpha ?  stat_bonus(newDepth)
                                         : -stat_bonus(newDepth);
 
+              if (move == ss->killers[0])
+              	  bonus += bonus / 4;
+
               update_continuation_histories(ss, movedPiece, to_sq(move), bonus);
           }
       }


### PR DESCRIPTION
passed STC
http://tests.stockfishchess.org/tests/view/5d2c8e760ebc5925cf0dcf23
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 67188 W: 15030 L: 14534 D: 37624 
passed LTC
http://tests.stockfishchess.org/tests/view/5d2d0ce40ebc5925cf0de115
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 144355 W: 24739 L: 24153 D: 95463 
bench 3531098