### PR TITLE
No influence on unsafeSquares of passers by pieces

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -642,7 +642,7 @@ namespace {
                 bb = forward_file_bb(Them, s) & pos.pieces(ROOK, QUEEN);
 
                 if (!(pos.pieces(Them) & bb))
-                    unsafeSquares &= attackedBy[Them][ALL_PIECES] | pos.pieces(Them);
+                    unsafeSquares &= attackedBy[Them][ALL_PIECES];
 
                 // If there are no enemy attacks on passed pawn span, assign a big bonus.
                 // Otherwise assign a smaller bonus if the path to queen is not attacked


### PR DESCRIPTION
Remove their pieces from influencing 'unsafeSquares' in passer
evaluation.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 36421 W: 8170 L: 8078 D: 20173
http://tests.stockfishchess.org/tests/view/5d22fc8e0ebc5925cf0cb26e

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 18927 W: 3253 L: 3129 D: 12545
http://tests.stockfishchess.org/tests/view/5d26e2b20ebc5925cf0d3218

Bench: 3748938