### PR TITLE
Simplify PassedFile (remove array)

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -126,12 +126,6 @@ namespace {
     S(0, 0), S(5, 18), S(12, 23), S(10, 31), S(57, 62), S(163, 167), S(271, 250)
   };
 
-  // PassedFile[File] contains a bonus according to the file of a passed pawn
-  constexpr Score PassedFile[FILE_NB] = {
-    S( -1,  7), S( 0,  9), S(-9, -8), S(-30,-14),
-    S(-30,-14), S(-9, -8), S( 0,  9), S( -1,  7)
-  };
-
   // Assorted bonuses and penalties
   constexpr Score AttacksOnSpaceArea = S(  4,  0);
   constexpr Score BishopPawns        = S(  3,  7);
@@ -616,7 +610,8 @@ namespace {
 
         assert(!(pos.pieces(Them, PAWN) & forward_file_bb(Us, s + Up)));
 
-        int r = relative_rank(Us, s);
+        Rank r = relative_rank(Us, s);
+        File f = file_of(s);
 
         Score bonus = PassedRank[r];
 
@@ -666,7 +661,8 @@ namespace {
             || (pos.pieces(PAWN) & (s + Up)))
             bonus = bonus / 2;
 
-        score += bonus + PassedFile[file_of(s)];
+        int d = std::min(f, ~f);  //File based bonus/penalty
+        score += bonus + make_score(5 - 11 * d, 10 - 8 * d);
     }
 
     if (T)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -662,7 +662,7 @@ namespace {
             bonus = bonus / 2;
 
         int d = std::min(f, ~f);  //File based bonus/penalty
-        score += bonus + make_score(5 - 11 * d, 10 - 8 * d);
+        score += bonus + make_score(5, 10) - make_score(11,8) * d;
     }
 
     if (T)


### PR DESCRIPTION
This is a functional simplification that removes the PassedFile array using a simple linear equation.

Thanks to @Sopel97 for the godbolt help.  This version is NOT exactly what was tested, but godbolt says it is faster ( https://godbolt.org/z/38faPJ ).

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 23331 W: 5233 L: 5115 D: 12983
http://tests.stockfishchess.org/tests/view/5d323b600ebc5925cf0e5f83

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 10590 W: 1805 L: 1668 D: 7117
http://tests.stockfishchess.org/tests/view/5d324ba20ebc5925cf0e6076

bench 3209131