### PR TITLE
Passed file cleanup

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -123,13 +123,7 @@ namespace {
 
   // PassedRank[Rank] contains a bonus according to the rank of a passed pawn
   constexpr Score PassedRank[RANK_NB] = {
-    S(0, 0), S(5, 18), S(12, 23), S(10, 31), S(57, 62), S(163, 167), S(271, 250)
-  };
-
-  // PassedFile[File] contains a bonus according to the file of a passed pawn
-  constexpr Score PassedFile[FILE_NB] = {
-    S( -1,  7), S( 0,  9), S(-9, -8), S(-30,-14),
-    S(-30,-14), S(-9, -8), S( 0,  9), S( -1,  7)
+    S(0, 0), S(10, 28), S(17, 33), S(15, 41), S(62, 72), S(168, 177), S(276, 260)
   };
 
   // Assorted bonuses and penalties
@@ -143,6 +137,7 @@ namespace {
   constexpr Score LongDiagonalBishop = S( 45,  0);
   constexpr Score MinorBehindPawn    = S( 18,  3);
   constexpr Score Outpost            = S( 18,  6);
+  constexpr Score PassedFile         = S( 11,  8);
   constexpr Score PawnlessFlank      = S( 17, 95);
   constexpr Score RestrictedPiece    = S(  7,  7);
   constexpr Score RookOnPawn         = S( 10, 32);
@@ -617,6 +612,7 @@ namespace {
         assert(!(pos.pieces(Them, PAWN) & forward_file_bb(Us, s + Up)));
 
         int r = relative_rank(Us, s);
+        int f = file_of(s);
 
         Score bonus = PassedRank[r];
 
@@ -666,7 +662,7 @@ namespace {
             || (pos.pieces(PAWN) & (s + Up)))
             bonus = bonus / 2;
 
-        score += bonus + PassedFile[file_of(s)];
+        score += bonus - PassedFile * std::min(f, ~f);
     }
 
     if (T)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -612,7 +612,7 @@ namespace {
         assert(!(pos.pieces(Them, PAWN) & forward_file_bb(Us, s + Up)));
 
         int r = relative_rank(Us, s);
-        int f = file_of(s);
+        File f = file_of(s);
 
         Score bonus = PassedRank[r];
 


### PR DESCRIPTION
Merge the additive term S(5, 10) of #2250 into the PassedRank array.

This harmless change have a different bench because, the candidate passer evaluation
(those for which we apply bonus = bonus /2;)
will always get S(5, 10)/2 less compared to # 2250

Tested as a non-regression against #2250 

Passed STC 
http://tests.stockfishchess.org/tests/view/5d33427e0ebc5925cf0e6fa2
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 81459 W: 18174 L: 18171 D: 45114

Passed LTC
http://tests.stockfishchess.org/tests/view/5d335c8d0ebc5925cf0e731e
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 18525 W: 3176 L: 3052 D: 12297
