### PR TITLE
Pawn clean up

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -111,17 +111,17 @@ namespace {
         backward =  !(neighbours & forward_ranks_bb(Them, s))
                   && (stoppers & (leverPush | (s + Up)));
 
-        // Passed pawns will be properly scored in evaluation because we need
-        // full attack info to evaluate them.
-        // A pawn is passed if no stoppers apart some levers,
+        // A pawn is passed if there is no stoppers except some levers,
         // or the only stoppers are the leverPush, but we outnumber them,
-        // or there is only one front stopper which can be safely levered.
+        // or there is only one front stopper which can be levered.
         passed =   !(stoppers ^ lever)
                 || (   !(stoppers ^ leverPush)
                     && popcount(phalanx) >= popcount(leverPush))
                 || (   stoppers == square_bb(s + Up) && r >= RANK_5
                     && (shift<Up>(support) & ~(theirPawns | dblAttackThem)));
 
+        // Passed pawns will be properly scored later in evaluation when we have
+        // full attack info.
         if (passed)
             e->passedPawns[Us] |= s;
 
@@ -144,8 +144,8 @@ namespace {
             score -= Doubled;
     }
 
-    // Penalize unsupported and non passed pawns attacked twice by the enemy
-    b =  ourPawns & ~(e->pawnAttacks[Us] | e->passedPawns[Us]) & dblAttackThem;
+    // Penalize the unsupported and non passed pawns attacked twice by the enemy
+    b = ourPawns & ~(e->pawnAttacks[Us] | e->passedPawns[Us]) & dblAttackThem;
     score -= BadLever * popcount(b);
 
     return score;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -35,8 +35,8 @@ namespace {
   constexpr Score Backward      = S( 9, 24);
   constexpr Score Doubled       = S(11, 56);
   constexpr Score Isolated      = S( 5, 15);
+  constexpr Score WeakLever     = S( 0, 56);
   constexpr Score WeakUnopposed = S(13, 27);
-  constexpr Score BadLever      = S( 0, 56);
 
   // Connected pawn bonus
   constexpr int Connected[RANK_NB] = { 0, 7, 8, 12, 29, 48, 86 };
@@ -145,8 +145,10 @@ namespace {
     }
 
     // Penalize the unsupported and non passed pawns attacked twice by the enemy
-    b = ourPawns & ~(e->pawnAttacks[Us] | e->passedPawns[Us]) & dblAttackThem;
-    score -= BadLever * popcount(b);
+    b =   ourPawns
+        & dblAttackThem
+        & ~(e->pawnAttacks[Us] | e->passedPawns[Us]);
+    score -= WeakLever * popcount(b);
 
     return score;
   }


### PR DESCRIPTION
Non functional simplification when we find the passed pawns in pawn.cpp and some code clean up

http://tests.stockfishchess.org/tests/view/5d3325bb0ebc5925cf0e6e91
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 124666 W: 27586 L: 27669 D: 69411

bench: 3357457