### PR TITLE
Tweak of SEE pruning condition.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1041,7 +1041,7 @@ moves_loop: // When in check, search starts from here
                   continue;
 
               // Prune moves with negative SEE (~10 Elo)
-              if (!pos.see_ge(move, Value(-29 * lmrDepth * lmrDepth)))
+              if (!pos.see_ge(move, Value(-(31 - std::min(lmrDepth, 18)) * lmrDepth * lmrDepth)))
                   continue;
           }
           else if (  (!givesCheck || !extension)


### PR DESCRIPTION
passed STC 
http://tests.stockfishchess.org/tests/view/5d386bda0ebc5925cf0ef49a
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 56874 W: 12820 L: 12373 D: 31681 
passed LTC
http://tests.stockfishchess.org/tests/view/5d38873a0ebc5925cf0ef86e
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 43512 W: 7547 L: 7247 D: 28718 
Additional thx to @locutus2 , @miguel-l  and @xoto10 for fruitful discussion.
There may be some more elo there since this tweak was the first one and numbers are more or less arbitrary.
bench 3376232