### PR TITLE
Simplify weak lever.

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -148,7 +148,7 @@ namespace {
     // Penalize the unsupported and non passed pawns attacked twice by the enemy
     b =   ourPawns
         & doubleAttackThem
-        & ~(e->pawnAttacks[Us] | e->passedPawns[Us]);
+        & ~e->pawnAttacks[Us];
     score -= WeakLever * popcount(b);
 
     return score;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -70,7 +70,7 @@ namespace {
     constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
     constexpr Direction Up   = (Us == WHITE ? NORTH : SOUTH);
 
-    Bitboard b, neighbours, stoppers, doubled, support, phalanx;
+    Bitboard neighbours, stoppers, doubled, support, phalanx;
     Bitboard lever, leverPush;
     Square s;
     bool opposed, backward, passed;
@@ -145,11 +145,8 @@ namespace {
             score -= Doubled;
     }
 
-    // Penalize the unsupported and non passed pawns attacked twice by the enemy
-    b =   ourPawns
-        & doubleAttackThem
-        & ~e->pawnAttacks[Us];
-    score -= WeakLever * popcount(b);
+    // Penalize the unsupported pawns attacked twice by the enemy
+    score -= WeakLever * popcount(ourPawns & doubleAttackThem & ~e->pawnAttacks[Us]);
 
     return score;
   }


### PR DESCRIPTION
This is a functional simplification that previously failed STC (see comments).

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 14844 W: 3347 L: 3212 D: 8285 
http://tests.stockfishchess.org/tests/view/5d3a2d7b0ebc5925cf0f1632

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 55261 W: 9374 L: 9309 D: 36578 
http://tests.stockfishchess.org/tests/view/5d3a3d9e0ebc5925cf0f1786

bench 3484124