### PR TITLE
Remove Pawns Connected Array

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -38,9 +38,6 @@ namespace {
   constexpr Score WeakLever     = S( 0, 56);
   constexpr Score WeakUnopposed = S(13, 27);
 
-  // Connected pawn bonus
-  constexpr int Connected[RANK_NB] = { 0, 7, 8, 12, 29, 48, 86 };
-
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
@@ -129,7 +126,7 @@ namespace {
         // Score this pawn
         if (support | phalanx)
         {
-            int v =  Connected[r] * (phalanx ? 3 : 2) / (opposed ? 2 : 1)
+            int v = (7 + r * r * r * r / 16) * (phalanx ? 3 : 2) / (opposed ? 2 : 1)
                    + 17 * popcount(support);
 
             score += make_score(v, v * (r - 2) / 4);


### PR DESCRIPTION
This is a functional simplification.  The resulting values are substantially close to master, but no lookup is required, so this is presumably faster.

STC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 17785 W: 4020 L: 3890 D: 9875
http://tests.stockfishchess.org/tests/view/5d39c2160ebc5925cf0f0e03

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 28867 W: 4939 L: 4831 D: 19097
http://tests.stockfishchess.org/tests/view/5d3a04430ebc5925cf0f12e9

bench 3533582