### PR TITLE
Use constexpr to replace rank/files.

### DIFF
--- a/src/bitbase.cpp
+++ b/src/bitbase.cpp
@@ -44,7 +44,7 @@ namespace {
   // bit 13-14: white pawn file (from FILE_A to FILE_D)
   // bit 15-17: white pawn RANK_7 - rank (from RANK_7 - RANK_7 to RANK_7 - RANK_2)
   unsigned index(Color us, Square bksq, Square wksq, Square psq) {
-    return wksq | (bksq << 6) | (us << 12) | (file_of(psq) << 13) | ((RANK_7 - rank_of(psq)) << 15);
+    return wksq | (bksq << 6) | (us << 12) | (file_of(psq) << 13) | ((Rank(R7) - rank_of(psq)) << 15);
   }
 
   enum Result {
@@ -111,7 +111,7 @@ namespace {
     ksq[WHITE] = Square((idx >>  0) & 0x3F);
     ksq[BLACK] = Square((idx >>  6) & 0x3F);
     us         = Color ((idx >> 12) & 0x01);
-    psq        = make_square(File((idx >> 13) & 0x3), Rank(RANK_7 - ((idx >> 15) & 0x7)));
+    psq        = make_square(File((idx >> 13) & 0x3), Rank(Rank(R7) - ((idx >> 15) & 0x7)));
 
     // Check if two pieces are on the same square or if a king can be captured
     if (   distance(ksq[WHITE], ksq[BLACK]) <= 1
@@ -122,7 +122,7 @@ namespace {
 
     // Immediate win if a pawn can be promoted without getting captured
     else if (   us == WHITE
-             && rank_of(psq) == RANK_7
+             && rank_of(psq) == Rank(R7)
              && ksq[us] != psq + NORTH
              && (    distance(ksq[~us], psq + NORTH) > 1
                  || (PseudoAttacks[KING][ksq[us]] & (psq + NORTH))))
@@ -165,10 +165,10 @@ namespace {
 
     if (Us == WHITE)
     {
-        if (rank_of(psq) < RANK_7)      // Single push
+        if (rank_of(psq) < Rank(R7))      // Single push
             r |= db[index(Them, ksq[Them], ksq[Us], psq + NORTH)];
 
-        if (   rank_of(psq) == RANK_2   // Double push
+        if (   rank_of(psq) == Rank(R2)   // Double push
             && psq + NORTH != ksq[Us]
             && psq + NORTH != ksq[Them])
             r |= db[index(Them, ksq[Them], ksq[Us], psq + NORTH + NORTH)];

--- a/src/bitbase.cpp
+++ b/src/bitbase.cpp
@@ -41,8 +41,8 @@ namespace {
   // bit  0- 5: white king square (from SQ_A1 to SQ_H8)
   // bit  6-11: black king square (from SQ_A1 to SQ_H8)
   // bit    12: side to move (WHITE or BLACK)
-  // bit 13-14: white pawn file (from FILE_A to FILE_D)
-  // bit 15-17: white pawn RANK_7 - rank (from RANK_7 - RANK_7 to RANK_7 - RANK_2)
+  // bit 13-14: white pawn file (from File(A) to File(D))
+  // bit 15-17: white pawn Rank(R7) - rank (from Rank(7) - Rank(R7) to Rank(R7) - Rank(R2))
   unsigned index(Color us, Square bksq, Square wksq, Square psq) {
     return wksq | (bksq << 6) | (us << 12) | (file_of(psq) << 13) | ((Rank(R7) - rank_of(psq)) << 15);
   }
@@ -75,7 +75,7 @@ namespace {
 
 bool Bitbases::probe(Square wksq, Square wpsq, Square bksq, Color us) {
 
-  assert(file_of(wpsq) <= FILE_D);
+  assert(file_of(wpsq) <= File(D));
 
   unsigned idx = index(us, bksq, wksq, wpsq);
   return KPKBitbase[idx / 32] & (1 << (idx & 0x1F));

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -51,9 +51,9 @@ const std::string Bitboards::pretty(Bitboard b) {
 
   std::string s = "+---+---+---+---+---+---+---+---+\n";
 
-  for (Rank r = RANK_8; r >= RANK_1; --r)
+  for (Rank r = Rank(R8); r >= Rank(R1); --r)
   {
-      for (File f = FILE_A; f <= FILE_H; ++f)
+      for (File f = File(A); f <= File(H); ++f)
           s += b & make_square(f, r) ? "| X " : "|   ";
 
       s += "|\n+---+---+---+---+---+---+---+---+\n";
@@ -153,7 +153,7 @@ namespace {
     for (Square s = SQ_A1; s <= SQ_H8; ++s)
     {
         // Board edges are not considered in the relevant occupancies
-        edges = ((Rank1BB | Rank8BB) & ~rank_bb(s)) | ((FileABB | FileHBB) & ~file_bb(s));
+        edges = ((RankBB(R1) | RankBB(R8)) & ~RankBB(s)) | ((FileBB(A) | FileBB(H)) & ~FileBB(s));
 
         // Given a square 's', the mask is the bitboard of sliding attacks from
         // 's' computed on an empty board. The index must be big enough to contain

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -73,7 +73,7 @@ namespace {
 
     assert(pos.count<PAWN>(strongSide) == 1);
 
-    if (file_of(pos.square<PAWN>(strongSide)) >= FILE_E)
+    if (file_of(pos.square<PAWN>(strongSide)) >= File(E))
         sq = Square(sq ^ 7); // Mirror SQ_H1 -> SQ_A1
 
     return strongSide == WHITE ? sq : ~sq;
@@ -205,7 +205,7 @@ Value Endgame<KRKP>::operator()(const Position& pos) const {
   Square rsq  = relative_square(strongSide, pos.square<ROOK>(strongSide));
   Square psq  = relative_square(strongSide, pos.square<PAWN>(weakSide));
 
-  Square queeningSq = make_square(file_of(psq), RANK_1);
+  Square queeningSq = make_square(file_of(psq), Rank(R1));
   Value result;
 
   // If the stronger side's king is in front of the pawn, it's a win
@@ -220,9 +220,9 @@ Value Endgame<KRKP>::operator()(const Position& pos) const {
 
   // If the pawn is far advanced and supported by the defending king,
   // the position is drawish
-  else if (   rank_of(bksq) <= RANK_3
+  else if (   rank_of(bksq) <= Rank(R3)
            && distance(bksq, psq) == 1
-           && rank_of(wksq) >= RANK_4
+           && rank_of(wksq) >= Rank(R4)
            && distance(wksq, psq) > 2 + (pos.side_to_move() == strongSide))
       result = Value(80) - 8 * distance(wksq, psq);
 
@@ -279,9 +279,9 @@ Value Endgame<KQKP>::operator()(const Position& pos) const {
 
   Value result = Value(PushClose[distance(winnerKSq, loserKSq)]);
 
-  if (   relative_rank(weakSide, pawnSq) != RANK_7
+  if (   relative_rank(weakSide, pawnSq) != Rank(R7)
       || distance(loserKSq, pawnSq) != 1
-      || !((FileABB | FileCBB | FileFBB | FileHBB) & pawnSq))
+      || !((FileBB(A) | FileBB(C) | FileBB(F) | FileBB(H)) & pawnSq))
       result += QueenValueEg - PawnValueEg;
 
   return strongSide == pos.side_to_move() ? result : -result;
@@ -346,11 +346,11 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
   File pawnsFile = file_of(lsb(pawns));
 
   // All pawns are on a single rook file?
-  if (    (pawnsFile == FILE_A || pawnsFile == FILE_H)
-      && !(pawns & ~file_bb(pawnsFile)))
+  if (    (pawnsFile == File(A) || pawnsFile == File(H))
+      && !(pawns & ~FileBB(pawnsFile)))
   {
       Square bishopSq = pos.square<BISHOP>(strongSide);
-      Square queeningSq = relative_square(strongSide, make_square(pawnsFile, RANK_8));
+      Square queeningSq = relative_square(strongSide, make_square(pawnsFile, Rank(R8)));
       Square kingSq = pos.square<KING>(weakSide);
 
       if (   opposite_colors(queeningSq, bishopSq)
@@ -359,8 +359,8 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
   }
 
   // If all the pawns are on the same B or G file, then it's potentially a draw
-  if (    (pawnsFile == FILE_B || pawnsFile == FILE_G)
-      && !(pos.pieces(PAWN) & ~file_bb(pawnsFile))
+  if (    (pawnsFile == File(B) || pawnsFile == File(G))
+      && !(pos.pieces(PAWN) & ~FileBB(pawnsFile))
       && pos.non_pawn_material(weakSide) == 0
       && pos.count<PAWN>(weakSide) >= 1)
   {
@@ -373,7 +373,7 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
 
       // There's potential for a draw if our pawn is blocked on the 7th rank,
       // the bishop cannot attack it or they only have one pawn left
-      if (   relative_rank(strongSide, weakPawnSq) == RANK_7
+      if (   relative_rank(strongSide, weakPawnSq) == Rank(R7)
           && (pos.pieces(strongSide, PAWN) & (weakPawnSq + pawn_push(weakSide)))
           && (opposite_colors(bishopSq, weakPawnSq) || pos.count<PAWN>(strongSide) == 1))
       {
@@ -386,7 +386,7 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
           // unreachable positions such as 5k1K/6p1/6P1/8/8/3B4/8/8 w
           // and positions where qsearch will immediately correct the
           // problem such as 8/4k1p1/6P1/1K6/3B4/8/8/8 w)
-          if (   relative_rank(strongSide, weakKingSq) >= RANK_7
+          if (   relative_rank(strongSide, weakKingSq) >= Rank(R7)
               && weakKingDist <= 2
               && weakKingDist <= strongKingDist)
               return SCALE_FACTOR_DRAW;
@@ -409,9 +409,9 @@ ScaleFactor Endgame<KQKRPs>::operator()(const Position& pos) const {
   Square kingSq = pos.square<KING>(weakSide);
   Square rsq = pos.square<ROOK>(weakSide);
 
-  if (    relative_rank(weakSide, kingSq) <= RANK_2
-      &&  relative_rank(weakSide, pos.square<KING>(strongSide)) >= RANK_4
-      &&  relative_rank(weakSide, rsq) == RANK_3
+  if (    relative_rank(weakSide, kingSq) <= Rank(R2)
+      &&  relative_rank(weakSide, pos.square<KING>(strongSide)) >= Rank(R4)
+      &&  relative_rank(weakSide, rsq) == Rank(R3)
       && (  pos.pieces(weakSide, PAWN)
           & pos.attacks_from<KING>(kingSq)
           & pos.attacks_from<PAWN>(rsq, strongSide)))
@@ -442,28 +442,28 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
 
   File f = file_of(wpsq);
   Rank r = rank_of(wpsq);
-  Square queeningSq = make_square(f, RANK_8);
+  Square queeningSq = make_square(f, Rank(R8));
   int tempo = (pos.side_to_move() == strongSide);
 
   // If the pawn is not too far advanced and the defending king defends the
   // queening square, use the third-rank defence.
-  if (   r <= RANK_5
+  if (   r <= Rank(R5)
       && distance(bksq, queeningSq) <= 1
       && wksq <= SQ_H5
-      && (rank_of(brsq) == RANK_6 || (r <= RANK_3 && rank_of(wrsq) != RANK_6)))
+      && (rank_of(brsq) == Rank(R6) || (r <= Rank(R3) && rank_of(wrsq) != Rank(R6))))
       return SCALE_FACTOR_DRAW;
 
   // The defending side saves a draw by checking from behind in case the pawn
   // has advanced to the 6th rank with the king behind.
-  if (   r == RANK_6
+  if (   r == Rank(R6)
       && distance(bksq, queeningSq) <= 1
-      && rank_of(wksq) + tempo <= RANK_6
-      && (rank_of(brsq) == RANK_1 || (!tempo && distance<File>(brsq, wpsq) >= 3)))
+      && rank_of(wksq) + tempo <= Rank(R6)
+      && (rank_of(brsq) == Rank(R1) || (!tempo && distance<File>(brsq, wpsq) >= 3)))
       return SCALE_FACTOR_DRAW;
 
-  if (   r >= RANK_6
+  if (   r >= Rank(R6)
       && bksq == queeningSq
-      && rank_of(brsq) == RANK_1
+      && rank_of(brsq) == Rank(R1)
       && (!tempo || distance(wksq, wpsq) >= 2))
       return SCALE_FACTOR_DRAW;
 
@@ -472,13 +472,13 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
   if (   wpsq == SQ_A7
       && wrsq == SQ_A8
       && (bksq == SQ_H7 || bksq == SQ_G7)
-      && file_of(brsq) == FILE_A
-      && (rank_of(brsq) <= RANK_3 || file_of(wksq) >= FILE_D || rank_of(wksq) <= RANK_5))
+      && file_of(brsq) == File(A)
+      && (rank_of(brsq) <= Rank(R3) || file_of(wksq) >= File(D) || rank_of(wksq) <= Rank(R5)))
       return SCALE_FACTOR_DRAW;
 
   // If the defending king blocks the pawn and the attacking king is too far
   // away, it's a draw.
-  if (   r <= RANK_5
+  if (   r <= Rank(R5)
       && bksq == wpsq + NORTH
       && distance(wksq, wpsq) - tempo >= 2
       && distance(wksq, brsq) - tempo >= 2)
@@ -487,8 +487,8 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
   // Pawn on the 7th rank supported by the rook from behind usually wins if the
   // attacking king is closer to the queening square than the defending king,
   // and the defending king cannot gain tempi by threatening the attacking rook.
-  if (   r == RANK_7
-      && f != FILE_A
+  if (   r == Rank(R7)
+      && f != File(A)
       && file_of(wrsq) == f
       && wrsq != queeningSq
       && (distance(wksq, queeningSq) < distance(bksq, queeningSq) - 2 + tempo)
@@ -496,7 +496,7 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
       return ScaleFactor(SCALE_FACTOR_MAX - 2 * distance(wksq, queeningSq));
 
   // Similar to the above, but with the pawn further back
-  if (   f != FILE_A
+  if (   f != File(A)
       && file_of(wrsq) == f
       && wrsq < wpsq
       && (distance(wksq, queeningSq) < distance(bksq, queeningSq) - 2 + tempo)
@@ -510,7 +510,7 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
 
   // If the pawn is not far advanced and the defending king is somewhere in
   // the pawn's path, it's probably a draw.
-  if (r <= RANK_4 && bksq > wpsq)
+  if (r <= Rank(R4) && bksq > wpsq)
   {
       if (file_of(bksq) == file_of(wpsq))
           return ScaleFactor(10);
@@ -528,7 +528,7 @@ ScaleFactor Endgame<KRPKB>::operator()(const Position& pos) const {
   assert(verify_material(pos, weakSide, BishopValueMg, 0));
 
   // Test for a rook pawn
-  if (pos.pieces(PAWN) & (FileABB | FileHBB))
+  if (pos.pieces(PAWN) & (FileABB | FileBB(H)))
   {
       Square ksq = pos.square<KING>(weakSide);
       Square bsq = pos.square<BISHOP>(weakSide);
@@ -541,7 +541,7 @@ ScaleFactor Endgame<KRPKB>::operator()(const Position& pos) const {
       // a fortress. Depending on the king position give a moderate
       // reduction or a stronger one if the defending king is near the
       // corner but not trapped there.
-      if (rk == RANK_5 && !opposite_colors(bsq, psq))
+      if (rk == Rank(R5) && !opposite_colors(bsq, psq))
       {
           int d = distance(psq + 3 * push, ksq);
 
@@ -555,7 +555,7 @@ ScaleFactor Endgame<KRPKB>::operator()(const Position& pos) const {
       // it's drawn if the bishop attacks the square in front of the
       // pawn from a reasonable distance and the defending king is near
       // the corner
-      if (   rk == RANK_6
+      if (   rk == Rank(R6)
           && distance(psq + 2 * push, ksq) <= 1
           && (PseudoAttacks[BISHOP][bsq] & (psq + push))
           && distance<File>(bsq, psq) >= 2)
@@ -587,7 +587,7 @@ ScaleFactor Endgame<KRPPKRP>::operator()(const Position& pos) const {
       && distance<File>(bksq, wpsq2) <= 1
       && relative_rank(strongSide, bksq) > r)
   {
-      assert(r > RANK_1 && r < RANK_7);
+      assert(r > Rank(R1) && r < Rank(R7));
       return ScaleFactor(KRPPKRPScaleFactors[r]);
   }
   return SCALE_FACTOR_NONE;
@@ -609,7 +609,7 @@ ScaleFactor Endgame<KPsK>::operator()(const Position& pos) const {
   // If all pawns are ahead of the king, on a single rook file and
   // the king is within one file of the pawns, it's a draw.
   if (   !(pawns & ~forward_ranks_bb(weakSide, ksq))
-      && !((pawns & ~FileABB) && (pawns & ~FileHBB))
+      && !((pawns & ~FileABB) && (pawns & ~FileBB(H)))
       &&  distance<File>(ksq, lsb(pawns)) <= 1)
       return SCALE_FACTOR_DRAW;
 
@@ -636,7 +636,7 @@ ScaleFactor Endgame<KBPKB>::operator()(const Position& pos) const {
   if (   file_of(weakKingSq) == file_of(pawnSq)
       && relative_rank(strongSide, pawnSq) < relative_rank(strongSide, weakKingSq)
       && (   opposite_colors(weakKingSq, strongBishopSq)
-          || relative_rank(strongSide, weakKingSq) <= RANK_6))
+          || relative_rank(strongSide, weakKingSq) <= Rank(R6)))
       return SCALE_FACTOR_DRAW;
 
   // Case 2: Opposite colored bishops
@@ -730,7 +730,7 @@ ScaleFactor Endgame<KBPKN>::operator()(const Position& pos) const {
   if (   file_of(weakKingSq) == file_of(pawnSq)
       && relative_rank(strongSide, pawnSq) < relative_rank(strongSide, weakKingSq)
       && (   opposite_colors(weakKingSq, strongBishopSq)
-          || relative_rank(strongSide, weakKingSq) <= RANK_6))
+          || relative_rank(strongSide, weakKingSq) <= Rank(R6)))
       return SCALE_FACTOR_DRAW;
 
   return SCALE_FACTOR_NONE;
@@ -797,7 +797,7 @@ ScaleFactor Endgame<KPKP>::operator()(const Position& pos) const {
 
   // If the pawn has advanced to the fifth rank or further, and is not a
   // rook pawn, it's too dangerous to assume that it's at least a draw.
-  if (rank_of(psq) >= RANK_5 && file_of(psq) != FILE_A)
+  if (rank_of(psq) >= Rank(R5) && file_of(psq) != File(A))
       return SCALE_FACTOR_NONE;
 
   // Probe the KPK bitbase with the weakest side's pawn removed. If it's a draw,

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -54,8 +54,8 @@ namespace {
 
     // Compute some compile time parameters relative to the white side
     constexpr Color     Them     = (Us == WHITE ? BLACK      : WHITE);
-    constexpr Bitboard  TRank7BB = (Us == WHITE ? Rank7BB    : Rank2BB);
-    constexpr Bitboard  TRank3BB = (Us == WHITE ? Rank3BB    : Rank6BB);
+    constexpr Bitboard  TRank7BB = (Us == WHITE ? RankBB(R7): RankBB(R2));
+    constexpr Bitboard  TRank3BB = (Us == WHITE ? RankBB(R3): RankBB(R6));
     constexpr Direction Up       = (Us == WHITE ? NORTH      : SOUTH);
     constexpr Direction UpRight  = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
     constexpr Direction UpLeft   = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
@@ -96,7 +96,7 @@ namespace {
             Bitboard dcCandidateQuiets = pos.blockers_for_king(Them) & pawnsNotOn7;
             if (dcCandidateQuiets)
             {
-                Bitboard dc1 = shift<Up>(dcCandidateQuiets) & emptySquares & ~file_bb(ksq);
+                Bitboard dc1 = shift<Up>(dcCandidateQuiets) & emptySquares & ~FileBB(ksq);
                 Bitboard dc2 = shift<Up>(dc1 & TRank3BB) & emptySquares;
 
                 b1 |= dc1;
@@ -162,7 +162,7 @@ namespace {
 
         if (pos.ep_square() != SQ_NONE)
         {
-            assert(rank_of(pos.ep_square()) == relative_rank(Us, RANK_6));
+            assert(rank_of(pos.ep_square()) == relative_rank(Us, R6));
 
             // An en passant capture can be an evasion only if the checking piece
             // is the double pushed pawn and so is in the target. Otherwise this

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -102,8 +102,8 @@ namespace {
         leverPush  = theirPawns & PawnAttacks[Us][s + Up];
         doubled    = ourPawns   & (s - Up);
         neighbours = ourPawns   & adjacent_files_bb(s);
-        phalanx    = neighbours & rank_bb(s);
-        support    = neighbours & rank_bb(s - Up);
+        phalanx    = neighbours & RankBB(s);
+        support    = neighbours & RankBB(s - Up);
 
         // A pawn is backward when it is behind all pawns of the same color on
         // the adjacent files and cannot safely advance. Phalanx and isolated
@@ -118,7 +118,7 @@ namespace {
         passed =   !(stoppers ^ lever)
                 || (   !(stoppers ^ leverPush)
                     && popcount(phalanx) >= popcount(leverPush))
-                || (   stoppers == square_bb(s + Up) && r >= RANK_5
+                || (   stoppers == square_bb(s + Up) && r >= Rank(R5)
                     && (shift<Up>(support) & ~(theirPawns | doubleAttackThem)));
 
         // Passed pawns will be properly scored later in evaluation when we have
@@ -192,20 +192,20 @@ void Entry::evaluate_shelter(const Position& pos, Square ksq, Score& shelter) {
 
   Score bonus = make_score(5, 5);
 
-  File center = clamp(file_of(ksq), FILE_B, FILE_G);
+  File center = clamp(file_of(ksq), File(B), File(G));
   for (File f = File(center - 1); f <= File(center + 1); ++f)
   {
-      b = ourPawns & file_bb(f);
-      Rank ourRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : RANK_1;
+      b = ourPawns & FileBB(f);
+      Rank ourRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : Rank(R1);
 
-      b = theirPawns & file_bb(f);
-      Rank theirRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : RANK_1;
+      b = theirPawns & FileBB(f);
+      Rank theirRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : Rank(R1);
 
       int d = std::min(f, ~f);
       bonus += make_score(ShelterStrength[d][ourRank], 0);
 
       if (ourRank && (ourRank == theirRank - 1))
-          bonus -= make_score(82 * (theirRank == RANK_3), 82 * (theirRank == RANK_3));
+          bonus -= make_score(82 * (theirRank == Rank(R3)), 82 * (theirRank == Rank(R3)));
       else
           bonus -= make_score(UnblockedStorm[d][theirRank], 0);
   }

--- a/src/position.h
+++ b/src/position.h
@@ -265,7 +265,7 @@ inline Square Position::ep_square() const {
 }
 
 inline bool Position::is_on_semiopen_file(Color c, Square s) const {
-  return !(pieces(c, PAWN) & file_bb(s));
+  return !(pieces(c, PAWN) & FileBB(s));
 }
 
 inline bool Position::can_castle(CastlingRight cr) const {
@@ -327,7 +327,7 @@ inline bool Position::pawn_passed(Color c, Square s) const {
 
 inline bool Position::advanced_pawn_push(Move m) const {
   return   type_of(moved_piece(m)) == PAWN
-        && relative_rank(sideToMove, to_sq(m)) > RANK_5;
+        && relative_rank(sideToMove, to_sq(m)) > Rank(R5);
 }
 
 inline int Position::pawns_on_same_color_squares(Color c, Square s) const {

--- a/src/types.h
+++ b/src/types.h
@@ -351,7 +351,7 @@ constexpr Square operator~(Square s) {
 }
 
 constexpr File operator~(File f) {
-  return File(f ^ File(H)); // Horizontal flip FILE_A -> FILE_H
+  return File(f ^ File(H)); // Horizontal flip File(A) -> File(H)
 }
 
 constexpr Piece operator~(Piece pc) {

--- a/src/types.h
+++ b/src/types.h
@@ -246,13 +246,8 @@ enum Direction : int {
   NORTH_WEST = NORTH + WEST
 };
 
-enum File : int {
-  FILE_A, FILE_B, FILE_C, FILE_D, FILE_E, FILE_F, FILE_G, FILE_H, FILE_NB
-};
-
-enum Rank : int {
-  RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_NB
-};
+enum File : int { A, B, C, D, E, F, G, H, FILE_NB };
+enum Rank : int { R1, R2, R3, R4, R5, R6, R7, R8, RANK_NB };
 
 
 /// Score enum stores a middlegame and an endgame value in a single integer (enum).
@@ -356,7 +351,7 @@ constexpr Square operator~(Square s) {
 }
 
 constexpr File operator~(File f) {
-  return File(f ^ FILE_H); // Horizontal flip FILE_A -> FILE_H
+  return File(f ^ File(H)); // Horizontal flip FILE_A -> FILE_H
 }
 
 constexpr Piece operator~(Piece pc) {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -287,7 +287,7 @@ string UCI::move(Move m, bool chess960) {
       return "0000";
 
   if (type_of(m) == CASTLING && !chess960)
-      to = make_square(to > from ? FILE_G : FILE_C, rank_of(from));
+      to = make_square(to > from ? File(G) : File(C), rank_of(from));
 
   string move = UCI::square(from) + UCI::square(to);
 


### PR DESCRIPTION
This is a non-functional simplification that uses constexpr to replace ranks, files, rank_bb, and file_bb.

I've done this before, but I thought of  way to do it that was substantially similar to master.
I don't think this is any less readable than master and removes about 30 lines.

Any perceived added work is done at compile time.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 59107 W: 13217 L: 13170 D: 32720
http://tests.stockfishchess.org/tests/view/5d4f602c0ebc5925cf105c8d
