### PR TITLE
Tweak unsafe checks

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -441,10 +441,6 @@ namespace {
     else
         unsafeChecks |= knightChecks;
 
-    // Unsafe or occupied checking squares will also be considered, as long as
-    // the square is in the attacker's mobility area.
-    unsafeChecks &= mobilityArea[Them];
-
     // Find the squares that opponent attacks in our king flank, and the squares
     // which are attacked twice in that flank.
     b1 = attackedBy[Them][ALL_PIECES] & KingFlank[file_of(ksq)] & Camp;
@@ -457,7 +453,8 @@ namespace {
                  + 185 * popcount(kingRing[Us] & weak)
                  - 100 * bool(attackedBy[Us][KNIGHT] & attackedBy[Us][KING])
                  -  35 * bool(attackedBy[Us][BISHOP] & attackedBy[Us][KING])
-                 + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
+                 + 148 * popcount(unsafeChecks)
+                 +  98 * popcount(pos.blockers_for_king(Us))
                  - 873 * !pos.count<QUEEN>(Them)
                  -   6 * mg_value(score) / 8
                  +       mg_value(mobility[Them] - mobility[Us])


### PR DESCRIPTION
Remove mobility area for unsafe checks. Also separate the evaluation terms for unsafe checks and blockers for king with adjusted weights.

STC:
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 124526 W: 28292 L: 27504 D: 68730
http://tests.stockfishchess.org/tests/view/5d5138290ebc5925cf1070c3

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 84968 W: 14499 L: 14083 D: 56386
http://tests.stockfishchess.org/tests/view/5d527cfa0ebc5925cf107f93

Bench: 4139590