### PR TITLE
Add cast overload for option in various types.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -269,7 +269,7 @@ void MainThread::search() {
   Thread* bestThread = this;
 
   // Check if there are threads with a better score than main thread
-  if (    Options["MultiPV"] == 1
+  if ( size_t(Options["MultiPV"]) == 1
       && !Limits.depth
       && !(Skill(Options["Skill Level"]).enabled() || Options["UCI_LimitStrength"])
       &&  rootMoves[0].pv[0] != MOVE_NONE)
@@ -350,8 +350,9 @@ void Thread::search() {
   // for match (TC 60+0.6) results spanning a wide range of k values.
   PRNG rng(now());
   double floatLevel = Options["UCI_LimitStrength"] ?
-                        clamp(std::pow((Options["UCI_Elo"] - 1346.6) / 143.4, 1 / 0.806), 0.0, 20.0) :
-                        double(Options["Skill Level"]);
+    clamp(std::pow(( int( Options["UCI_Elo"] ) - 1346.6) / 143.4, 1 / 0.806), 0.0, 20.0) :
+    int(Options["Skill Level"]);
+
   int intLevel = int(floatLevel) +
                  ((floatLevel - int(floatLevel)) * 1024 > rng.rand<unsigned>() % 1024  ? 1 : 0);
   Skill skill(intLevel);

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -98,7 +98,9 @@ void Thread::idle_loop() {
   // some Windows NUMA hardware, for instance in fishtest. To make it simple,
   // just check if running threads are below a threshold, in this case all this
   // NUMA machinery is not needed.
-  if (Options["Threads"] > 8)
+  size_t const nbThreads = Options["Threads"];
+
+  if (nbThreads > 8u)
       WinProcGroup::bindThisThread(idx);
 
   while (true)

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -89,18 +89,20 @@ void TranspositionTable::clear() {
 
   std::vector<std::thread> threads;
 
-  for (size_t idx = 0; idx < Options["Threads"]; ++idx)
+  size_t const nbThreads = Options["Threads"];
+
+  for (size_t idx = 0; idx < nbThreads; ++idx)
   {
-      threads.emplace_back([this, idx]() {
+    threads.emplace_back([this, idx, nbThreads]() {
 
           // Thread binding gives faster search on systems with a first-touch policy
-          if (Options["Threads"] > 8)
+          if (nbThreads > 8)
               WinProcGroup::bindThisThread(idx);
 
           // Each thread will zero its part of the hash table
-          const size_t stride = clusterCount / Options["Threads"],
+          const size_t stride = clusterCount / nbThreads,
                        start  = stride * idx,
-                       len    = idx != Options["Threads"] - 1 ?
+                       len    = idx != nbThreads - 1 ?
                                 stride : clusterCount - start;
 
           std::memset(&table[start], 0, len * sizeof(Cluster));

--- a/src/uci.h
+++ b/src/uci.h
@@ -25,6 +25,8 @@
 #include <string>
 
 #include "types.h"
+#include "misc.h"
+
 
 class Position;
 
@@ -49,14 +51,21 @@ public:
   Option(OnChange = nullptr);
   Option(bool v, OnChange = nullptr);
   Option(const char* v, OnChange = nullptr);
-  Option(double v, int minv, int maxv, OnChange = nullptr);
+  Option(int v, int minv, int maxv, OnChange = nullptr);
   Option(const char* v, const char* cur, OnChange = nullptr);
 
   Option& operator=(const std::string&);
   void operator<<(const Option&);
-  operator double() const;
+  
+  operator bool() const;
+  operator int() const;
+  operator size_t() const;
+  operator TimePoint() const;
   operator std::string() const;
   bool operator==(const char*) const;
+
+  int MinValue() const { return min; }
+  int MaxValue() const { return max; }
 
 private:
   friend std::ostream& operator<<(std::ostream&, const OptionsMap&);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -121,15 +121,32 @@ Option::Option(bool v, OnChange f) : type("check"), min(0), max(0), on_change(f)
 Option::Option(OnChange f) : type("button"), min(0), max(0), on_change(f)
 {}
 
-Option::Option(double v, int minv, int maxv, OnChange f) : type("spin"), min(minv), max(maxv), on_change(f)
+Option::Option(int v, int minv, int maxv, OnChange f) : type("spin"), min(minv), max(maxv), on_change(f)
 { defaultValue = currentValue = std::to_string(v); }
 
 Option::Option(const char* v, const char* cur, OnChange f) : type("combo"), min(0), max(0), on_change(f)
 { defaultValue = v; currentValue = cur; }
 
-Option::operator double() const {
-  assert(type == "check" || type == "spin");
-  return (type == "spin" ? stof(currentValue) : currentValue == "true");
+
+Option::operator int() const {
+  assert(type == "spin");
+  return stoi(currentValue);
+}
+
+Option::operator size_t() const
+{
+  assert(type == "spin");
+  return stoull(currentValue);
+}
+
+Option::operator TimePoint() const {
+  assert(type == "spin");
+  return stoll(currentValue);
+}
+
+Option::operator bool() const {
+  assert(type == "check");
+  return currentValue == "true";
 }
 
 Option::operator std::string() const {


### PR DESCRIPTION
Remove double cast.
Add public getter for min and max value of an option to make them accessible.

From the UCI specifications:

type The option has type t. There are 5 different types of options the engine can send

- check a checkbox that can either be true or false
- spin a spin wheel that can be an integer in a certain range
- combo a combo box that can have different predefined strings as a value
- button a button that can be pressed to send a command to the engine
- string a text field that has a string as a value, an empty string has the value ""

This commit intents to make the StockFish code compliant to the UCI definition for handling UCI types for options.