### PR TITLE
Slight speep up fetching the endgame table.

### DIFF
--- a/src/endgame.h
+++ b/src/endgame.h
@@ -21,7 +21,7 @@
 #ifndef ENDGAME_H_INCLUDED
 #define ENDGAME_H_INCLUDED
 
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -98,14 +98,14 @@ struct Endgame : public EndgameBase<T> {
 namespace Endgames {
 
   template<typename T> using Ptr = std::unique_ptr<EndgameBase<T>>;
-  template<typename T> using Map = std::map<Key, Ptr<T>>;
+  template<typename T> using Map = std::unordered_map<Key, Ptr<T>>;
 
   extern std::pair<Map<Value>, Map<ScaleFactor>> maps;
 
   void init();
 
   template<typename T>
-  Map<T>& map() {
+  Map<T> & map() {
     return std::get<std::is_same<T, ScaleFactor>::value>(maps);
   }
 
@@ -119,7 +119,9 @@ namespace Endgames {
 
   template<typename T>
   const EndgameBase<T>* probe(Key key) {
-    return map<T>().count(key) ? map<T>()[key].get() : nullptr;
+    Map<T> const &m = map<T>();
+    typename Map<T>::const_iterator it = m.find(key);
+    return it != m.end() ? it->second.get() : nullptr;
   }
 }
 


### PR DESCRIPTION
,Replace calls to count(key) + operator[key] with a single call to find(key).
Replace the std::map with std::unordered_map which provide O(1) access, although the map has a really small number of objects. Maybe a std::vector or std::array using the endgame code as the index would improve this further a bit.

Tests has been run. Very slight improvement, but no regression. 

http://tests.stockfishchess.org/tests/view/5d5432210ebc5925cf109d61