### PR TITLE
Introduce futility margin array.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -63,9 +63,16 @@ namespace {
 
   // Razor and futility margins
   constexpr int RazorMargin = 661;
-  Value futility_margin(Depth d, bool improving) {
-    return Value((168 - 51 * improving) * d / ONE_PLY);
-  }
+  Value futility_margin[8][2] = {
+    { Value(   0), Value(   0) }, // depth 0
+    { Value( 381), Value(   0) }, // depth 1
+    { Value( 420), Value( 225) }, // depth 2
+    { Value( 524), Value( 406) }, // depth 3
+    { Value( 777), Value( 564) }, // depth 4
+    { Value( 864), Value( 653) }, // depth 5
+    { Value(1081), Value( 787) }, // depth 6
+    { Value(1201), Value( 872) }, // depth 7 
+    };
 
   // Reductions lookup table, initialized at startup
   int Reductions[MAX_MOVES]; // [depth or moveNumber]
@@ -789,8 +796,8 @@ namespace {
 
     // Step 8. Futility pruning: child node (~30 Elo)
     if (   !PvNode
-        &&  depth < 7 * ONE_PLY
-        &&  eval - futility_margin(depth, improving) >= beta
+        &&  depth < 8 * ONE_PLY
+        &&  eval - futility_margin[depth / ONE_PLY] [improving] >= beta
         &&  eval < VALUE_KNOWN_WIN) // Do not return unproven wins
         return eval;
 


### PR DESCRIPTION
passed LTC №1 with [0.5, 4.5] bounds
http://tests.stockfishchess.org/tests/view/5d5418090ebc5925cf109c26
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 85676 W: 14530 L: 14034 D: 57112 
passed LTC №2 with [0, 3.5] bounds
http://tests.stockfishchess.org/tests/view/5d55cde40ebc5925cf10b79d
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 33913 W: 5800 L: 5529 D: 22584 
bench 4087744
This is a continuation of a lot of people efforts (namely @jerrydonaldwatson) in improving child node futility pruning.
I counted at least 6 different patches that lowered maximum depth of it and made it more aggressive but failed to deliever at LTC. With recent @xoto10 patch (more like it proven non-linear scaling) I thought that this part of search also scales non - linearly.
So I decided to make array instead of a simple heuristic that spreads to higher depths and tune it at LTC. All tuning work done by @Alayan-stk-2 so big props to him because I don't really know how to use SF tuner :)
This patch had an STC run http://tests.stockfishchess.org/tests/view/5d53e9a40ebc5925cf109750 which was decent, but since it's an LTC tuning AND this part of code has non-linear scaling (according to my hypothesis) it should be tested at LTC and it passed 2 SPRTs there, both [0.5, 4.5] and [0, 3.5].
What can be done from this?
1) obviously more tuning with what we have. Maybe there is some more elo;
2) expand this array to higher depths - logically current hard cutoff at depth 7(previously depth 6) is not that logical at all :) Margins can grow really fast but them jumping from 1200/800 to sudden infinity makes close to 0 sence. 
This all probably will require a lot of LTC tuning with not that clear results but this tests do bring confidence that there is something more and they produce something that seem to scale well.