### PR TITLE
Tuned Futility Equation

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -64,7 +64,7 @@ namespace {
   // Razor and futility margins
   constexpr int RazorMargin = 661;
   Value futility_margin(Depth d, bool improving) {
-    return Value((168 - 51 * improving) * d / ONE_PLY);
+    return Value(198 * (d / ONE_PLY) - 178 * improving);
   }
 
   // Reductions lookup table, initialized at startup


### PR DESCRIPTION
This is a functional change.

@Vizvezdenec array suggested that alternate values may be better. #2270 
I tuned some linear equations to more closely represent his values and it passed.  These values seem quite sensitive, so perhaps additional improvements can be found here.

STC
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 12257 W: 2820 L: 2595 D: 6842
http://tests.stockfishchess.org/tests/view/5d5b2f360ebc5925cf1111ac

LTC
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 20273 W: 3497 L: 3264 D: 13512
http://tests.stockfishchess.org/tests/view/5d5c0d250ebc5925cf111ac3

bench 4330402