### PR TITLE
Late move reduction, captures and CUT nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1074,7 +1074,8 @@ moves_loop: // When in check, search starts from here
           &&  moveCount > 1 + 3 * rootNode
           && (  !captureOrPromotion
               || moveCountPruning
-              || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha))
+              || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha
+              || cutNode))
       {
           Depth r = reduction(improving, depth, moveCount);
 


### PR DESCRIPTION
Passed STC
http://tests.stockfishchess.org/tests/view/5d5b2f8e0ebc5925cf1111b8
LLR: 2.96 (-2.94,2.94) [0.50,4.50]
Total: 36026 W: 8122 L: 7779 D: 20125 
Passed LTC
http://tests.stockfishchess.org/tests/view/5d5b40c80ebc5925cf111353
LLR: 3.22 (-2.94,2.94) [0.00,3.50]
Total: 133502 W: 22508 L: 21943 D: 89051 
Expand of sg's original idea
bench 4192814