### PR TITLE
Tweak dbg mean and hit count functions

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -33,8 +33,7 @@ const std::string engine_info(bool to_uci = false);
 void prefetch(void* addr);
 void start_logger(const std::string& fname);
 
-void dbg_hit_on(bool b);
-void dbg_hit_on(bool c, bool b);
+void dbg_hit_on(bool b, bool c=true);
 void dbg_mean_of(int v);
 void dbg_print();
 


### PR DESCRIPTION
Add standard deviation to mean.
Unify dbg_hit_on function.
Tweak output to differentiate between hit and mean.

Use abs() to guarantee argument to sqrt() is non-negative. No mathematical need, just a safety net for unexpected floating point arithmetic.