### PR TITLE
Simplify futility equation

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -64,7 +64,7 @@ namespace {
   // Razor and futility margins
   constexpr int RazorMargin = 661;
   Value futility_margin(Depth d, bool improving) {
-    return Value(198 * (d / ONE_PLY) - 178 * improving);
+    return Value(198 * (d / ONE_PLY - improving));
   }
 
   // Reductions lookup table, initialized at startup


### PR DESCRIPTION
This is a functional simplification.  The 178 constant for the new futility equation can be removed.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 42626 W: 9508 L: 9428 D: 23690 
http://tests.stockfishchess.org/tests/view/5d5d4e320ebc5925cf11254e

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 26182 W: 4432 L: 4320 D: 17430 
http://tests.stockfishchess.org/tests/view/5d5df70d0ebc5925cf112fee

bench 3985701