### PR TITLE
Remove Double Hashing

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -84,7 +84,8 @@ namespace {
 
 namespace Endgames {
 
-  std::pair<Map<Value>, Map<ScaleFactor>> maps;
+  HashFn hf = [](const Key& k) { return size_t(k); };
+  std::pair<Map<Value>, Map<ScaleFactor>> maps(Map<Value>(0, hf), Map<ScaleFactor>(0, hf));
 
   void init() {
 

--- a/src/endgame.h
+++ b/src/endgame.h
@@ -97,8 +97,9 @@ struct Endgame : public EndgameBase<T> {
 
 namespace Endgames {
 
+  typedef size_t(*HashFn)(const Key&);
   template<typename T> using Ptr = std::unique_ptr<EndgameBase<T>>;
-  template<typename T> using Map = std::unordered_map<Key, Ptr<T>>;
+  template<typename T> using Map = std::unordered_map<Key, Ptr<T>, HashFn>;
 
   extern std::pair<Map<Value>, Map<ScaleFactor>> maps;
 


### PR DESCRIPTION
In PR https://github.com/official-stockfish/Stockfish/pull/2269 we switched to using std::unordered_map.  Internally this uses std::hash to compute a hash key.  However in our use case our Key is already a pseudo random hash so hashing it again just wastes instructions. This patch eliminates the internal redundant hash. (Probing the endgame table doesn't happen often enough during bench to measure any speed difference as was also the case in the original PR.)

No functional change.
bench: 3494372