### PR TITLE
Consolidate Piece Values

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -128,7 +128,7 @@ Value Endgame<KXK>::operator()(const Position& pos) const {
   Square loserKSq = pos.square<KING>(weakSide);
 
   Value result =  pos.non_pawn_material(strongSide)
-                + pos.count<PAWN>(strongSide) * PawnValueEg
+                + pos.count<PAWN>(strongSide) * piece_value(EG, PAWN)
                 + PushToEdges[loserKSq]
                 + PushClose[distance(winnerKSq, loserKSq)];
 
@@ -148,7 +148,7 @@ Value Endgame<KXK>::operator()(const Position& pos) const {
 template<>
 Value Endgame<KBNK>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, KnightValueMg + BishopValueMg, 0));
+  assert(verify_material(pos, strongSide, piece_value(MG, KNIGHT) + piece_value(MG, BISHOP), 0));
   assert(verify_material(pos, weakSide, VALUE_ZERO, 0));
 
   Square winnerKSq = pos.square<KING>(strongSide);
@@ -184,7 +184,7 @@ Value Endgame<KPK>::operator()(const Position& pos) const {
   if (!Bitbases::probe(wksq, psq, bksq, us))
       return VALUE_DRAW;
 
-  Value result = VALUE_KNOWN_WIN + PawnValueEg + Value(rank_of(psq));
+  Value result = VALUE_KNOWN_WIN + piece_value(EG, PAWN) + Value(rank_of(psq));
 
   return strongSide == pos.side_to_move() ? result : -result;
 }
@@ -197,7 +197,7 @@ Value Endgame<KPK>::operator()(const Position& pos) const {
 template<>
 Value Endgame<KRKP>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, RookValueMg, 0));
+  assert(verify_material(pos, strongSide, piece_value(MG, ROOK), 0));
   assert(verify_material(pos, weakSide, VALUE_ZERO, 1));
 
   Square wksq = relative_square(strongSide, pos.square<KING>(strongSide));
@@ -210,13 +210,13 @@ Value Endgame<KRKP>::operator()(const Position& pos) const {
 
   // If the stronger side's king is in front of the pawn, it's a win
   if (forward_file_bb(WHITE, wksq) & psq)
-      result = RookValueEg - distance(wksq, psq);
+      result = piece_value(EG, ROOK) - distance(wksq, psq);
 
   // If the weaker side's king is too far from the pawn and the rook,
   // it's a win.
   else if (   distance(bksq, psq) >= 3 + (pos.side_to_move() == weakSide)
            && distance(bksq, rsq) >= 3)
-      result = RookValueEg - distance(wksq, psq);
+      result = piece_value(EG, ROOK) - distance(wksq, psq);
 
   // If the pawn is far advanced and supported by the defending king,
   // the position is drawish
@@ -240,8 +240,8 @@ Value Endgame<KRKP>::operator()(const Position& pos) const {
 template<>
 Value Endgame<KRKB>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, RookValueMg, 0));
-  assert(verify_material(pos, weakSide, BishopValueMg, 0));
+  assert(verify_material(pos, strongSide, piece_value(MG, ROOK), 0));
+  assert(verify_material(pos, weakSide, piece_value(MG, BISHOP), 0));
 
   Value result = Value(PushToEdges[pos.square<KING>(weakSide)]);
   return strongSide == pos.side_to_move() ? result : -result;
@@ -253,8 +253,8 @@ Value Endgame<KRKB>::operator()(const Position& pos) const {
 template<>
 Value Endgame<KRKN>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, RookValueMg, 0));
-  assert(verify_material(pos, weakSide, KnightValueMg, 0));
+  assert(verify_material(pos, strongSide, piece_value(MG, ROOK), 0));
+  assert(verify_material(pos, weakSide, piece_value(MG, KNIGHT), 0));
 
   Square bksq = pos.square<KING>(weakSide);
   Square bnsq = pos.square<KNIGHT>(weakSide);
@@ -270,7 +270,7 @@ Value Endgame<KRKN>::operator()(const Position& pos) const {
 template<>
 Value Endgame<KQKP>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, QueenValueMg, 0));
+  assert(verify_material(pos, strongSide, piece_value(MG, QUEEN), 0));
   assert(verify_material(pos, weakSide, VALUE_ZERO, 1));
 
   Square winnerKSq = pos.square<KING>(strongSide);
@@ -282,7 +282,7 @@ Value Endgame<KQKP>::operator()(const Position& pos) const {
   if (   relative_rank(weakSide, pawnSq) != RANK_7
       || distance(loserKSq, pawnSq) != 1
       || !((FileABB | FileCBB | FileFBB | FileHBB) & pawnSq))
-      result += QueenValueEg - PawnValueEg;
+      result += piece_value(EG, QUEEN) - piece_value(EG, PAWN);
 
   return strongSide == pos.side_to_move() ? result : -result;
 }
@@ -295,14 +295,14 @@ Value Endgame<KQKP>::operator()(const Position& pos) const {
 template<>
 Value Endgame<KQKR>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, QueenValueMg, 0));
-  assert(verify_material(pos, weakSide, RookValueMg, 0));
+  assert(verify_material(pos, strongSide, piece_value(MG, QUEEN), 0));
+  assert(verify_material(pos, weakSide, piece_value(MG, ROOK), 0));
 
   Square winnerKSq = pos.square<KING>(strongSide);
   Square loserKSq = pos.square<KING>(weakSide);
 
-  Value result =  QueenValueEg
-                - RookValueEg
+  Value result =  piece_value(EG, QUEEN)
+                - piece_value(EG, ROOK)
                 + PushToEdges[loserKSq]
                 + PushClose[distance(winnerKSq, loserKSq)];
 
@@ -314,11 +314,11 @@ Value Endgame<KQKR>::operator()(const Position& pos) const {
 template<>
 Value Endgame<KNNKP>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, 2 * KnightValueMg, 0));
+  assert(verify_material(pos, strongSide, 2 * piece_value(MG, KNIGHT), 0));
   assert(verify_material(pos, weakSide, VALUE_ZERO, 1));
 
-  Value result =  2 * KnightValueEg
-                - PawnValueEg
+  Value result =  2 * piece_value(EG, KNIGHT)
+                - piece_value(EG, PAWN)
                 + PushToEdges[pos.square<KING>(weakSide)];
 
   return strongSide == pos.side_to_move() ? result : -result;
@@ -336,7 +336,7 @@ template<> Value Endgame<KNNK>::operator()(const Position&) const { return VALUE
 template<>
 ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
 
-  assert(pos.non_pawn_material(strongSide) == BishopValueMg);
+  assert(pos.non_pawn_material(strongSide) == piece_value(MG, BISHOP));
   assert(pos.count<PAWN>(strongSide) >= 1);
 
   // No assertions about the material of weakSide, because we want draws to
@@ -402,7 +402,7 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
 template<>
 ScaleFactor Endgame<KQKRPs>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, QueenValueMg, 0));
+  assert(verify_material(pos, strongSide, piece_value(MG, QUEEN), 0));
   assert(pos.count<ROOK>(weakSide) == 1);
   assert(pos.count<PAWN>(weakSide) >= 1);
 
@@ -430,8 +430,8 @@ ScaleFactor Endgame<KQKRPs>::operator()(const Position& pos) const {
 template<>
 ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, RookValueMg, 1));
-  assert(verify_material(pos, weakSide,   RookValueMg, 0));
+  assert(verify_material(pos, strongSide, piece_value(MG, ROOK), 1));
+  assert(verify_material(pos, weakSide,   piece_value(MG, ROOK), 0));
 
   // Assume strongSide is white and the pawn is on files A-D
   Square wksq = normalize(pos, strongSide, pos.square<KING>(strongSide));
@@ -524,8 +524,8 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
 template<>
 ScaleFactor Endgame<KRPKB>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, RookValueMg, 1));
-  assert(verify_material(pos, weakSide, BishopValueMg, 0));
+  assert(verify_material(pos, strongSide, piece_value(MG, ROOK), 1));
+  assert(verify_material(pos, weakSide, piece_value(MG, BISHOP), 0));
 
   // Test for a rook pawn
   if (pos.pieces(PAWN) & (FileABB | FileHBB))
@@ -570,8 +570,8 @@ ScaleFactor Endgame<KRPKB>::operator()(const Position& pos) const {
 template<>
 ScaleFactor Endgame<KRPPKRP>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, RookValueMg, 2));
-  assert(verify_material(pos, weakSide,   RookValueMg, 1));
+  assert(verify_material(pos, strongSide, piece_value(MG, ROOK), 2));
+  assert(verify_material(pos, weakSide,   piece_value(MG, ROOK), 1));
 
   Square wpsq1 = pos.squares<PAWN>(strongSide)[0];
   Square wpsq2 = pos.squares<PAWN>(strongSide)[1];
@@ -624,8 +624,8 @@ ScaleFactor Endgame<KPsK>::operator()(const Position& pos) const {
 template<>
 ScaleFactor Endgame<KBPKB>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, BishopValueMg, 1));
-  assert(verify_material(pos, weakSide,   BishopValueMg, 0));
+  assert(verify_material(pos, strongSide, piece_value(MG, BISHOP), 1));
+  assert(verify_material(pos, weakSide,   piece_value(MG, BISHOP), 0));
 
   Square pawnSq = pos.square<PAWN>(strongSide);
   Square strongBishopSq = pos.square<BISHOP>(strongSide);
@@ -651,8 +651,8 @@ ScaleFactor Endgame<KBPKB>::operator()(const Position& pos) const {
 template<>
 ScaleFactor Endgame<KBPPKB>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, BishopValueMg, 2));
-  assert(verify_material(pos, weakSide,   BishopValueMg, 0));
+  assert(verify_material(pos, strongSide, piece_value(MG, BISHOP), 2));
+  assert(verify_material(pos, weakSide,   piece_value(MG, BISHOP), 0));
 
   Square wbsq = pos.square<BISHOP>(strongSide);
   Square bbsq = pos.square<BISHOP>(weakSide);
@@ -720,8 +720,8 @@ ScaleFactor Endgame<KBPPKB>::operator()(const Position& pos) const {
 template<>
 ScaleFactor Endgame<KBPKN>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, BishopValueMg, 1));
-  assert(verify_material(pos, weakSide, KnightValueMg, 0));
+  assert(verify_material(pos, strongSide, piece_value(MG, BISHOP), 1));
+  assert(verify_material(pos, weakSide, piece_value(MG, KNIGHT), 0));
 
   Square pawnSq = pos.square<PAWN>(strongSide);
   Square strongBishopSq = pos.square<BISHOP>(strongSide);
@@ -742,7 +742,7 @@ ScaleFactor Endgame<KBPKN>::operator()(const Position& pos) const {
 template<>
 ScaleFactor Endgame<KNPK>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, KnightValueMg, 1));
+  assert(verify_material(pos, strongSide, piece_value(MG, KNIGHT), 1));
   assert(verify_material(pos, weakSide, VALUE_ZERO, 0));
 
   // Assume strongSide is white and the pawn is on files A-D
@@ -761,8 +761,8 @@ ScaleFactor Endgame<KNPK>::operator()(const Position& pos) const {
 template<>
 ScaleFactor Endgame<KNPKB>::operator()(const Position& pos) const {
 
-  assert(verify_material(pos, strongSide, KnightValueMg, 1));
-  assert(verify_material(pos, weakSide, BishopValueMg, 0));
+  assert(verify_material(pos, strongSide, piece_value(MG, KNIGHT), 1));
+  assert(verify_material(pos, weakSide, piece_value(MG, BISHOP), 0));
 
   Square pawnSq = pos.square<PAWN>(strongSide);
   Square bishopSq = pos.square<BISHOP>(weakSide);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -40,7 +40,7 @@ namespace Trace {
 
   Score scores[TERM_NB][COLOR_NB];
 
-  double to_cp(Value v) { return double(v) / PawnValueEg; }
+  double to_cp(Value v) { return double(v) / piece_value(EG, PAWN); }
 
   void add(int idx, Color c, Score s) {
     scores[idx][c] = s;
@@ -752,7 +752,7 @@ namespace {
     if (sf == SCALE_FACTOR_NORMAL)
     {
         if (   pos.opposite_bishops()
-            && pos.non_pawn_material() == 2 * BishopValueMg)
+            && pos.non_pawn_material() == 2 * piece_value(MG, BISHOP))
             sf = 16 + 4 * pe->passed_count();
         else
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -64,17 +64,17 @@ namespace {
   // Helper used to detect a given material distribution
   bool is_KXK(const Position& pos, Color us) {
     return  !more_than_one(pos.pieces(~us))
-          && pos.non_pawn_material(us) >= RookValueMg;
+          && pos.non_pawn_material(us) >= piece_value(MG, ROOK);
   }
 
   bool is_KBPsK(const Position& pos, Color us) {
-    return   pos.non_pawn_material(us) == BishopValueMg
+    return   pos.non_pawn_material(us) == piece_value(MG, BISHOP)
           && pos.count<PAWN  >(us) >= 1;
   }
 
   bool is_KQKRPs(const Position& pos, Color us) {
     return  !pos.count<PAWN>(us)
-          && pos.non_pawn_material(us) == QueenValueMg
+          && pos.non_pawn_material(us) == piece_value(MG, QUEEN)
           && pos.count<ROOK>(~us) == 1
           && pos.count<PAWN>(~us) >= 1;
   }
@@ -195,13 +195,13 @@ Entry* probe(const Position& pos) {
   // Zero or just one pawn makes it difficult to win, even with a small material
   // advantage. This catches some trivial draws like KK, KBK and KNK and gives a
   // drawish scale factor for cases such as KRKBP and KmmKm (except for KBBKN).
-  if (!pos.count<PAWN>(WHITE) && npm_w - npm_b <= BishopValueMg)
-      e->factor[WHITE] = uint8_t(npm_w <  RookValueMg   ? SCALE_FACTOR_DRAW :
-                                 npm_b <= BishopValueMg ? 4 : 14);
+  if (!pos.count<PAWN>(WHITE) && npm_w - npm_b <= piece_value(MG, BISHOP))
+      e->factor[WHITE] = uint8_t(npm_w <  piece_value(MG, ROOK)   ? SCALE_FACTOR_DRAW :
+                                 npm_b <= piece_value(MG, BISHOP) ? 4 : 14);
 
-  if (!pos.count<PAWN>(BLACK) && npm_b - npm_w <= BishopValueMg)
-      e->factor[BLACK] = uint8_t(npm_b <  RookValueMg   ? SCALE_FACTOR_DRAW :
-                                 npm_w <= BishopValueMg ? 4 : 14);
+  if (!pos.count<PAWN>(BLACK) && npm_b - npm_w <= piece_value(MG, BISHOP))
+      e->factor[BLACK] = uint8_t(npm_b <  piece_value(MG, ROOK)   ? SCALE_FACTOR_DRAW :
+                                 npm_w <= piece_value(MG, BISHOP) ? 4 : 14);
 
   // Evaluate the material imbalance. We use PIECE_TYPE_NONE as a place holder
   // for the bishop pair "extended piece", which allows us to be more flexible

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -107,7 +107,7 @@ void MovePicker::score() {
 
   for (auto& m : *this)
       if (Type == CAPTURES)
-          m.value =  int(PieceValue[MG][pos.piece_on(to_sq(m))]) * 6
+          m.value =  int(piece_value(MG, pos.piece_on(to_sq(m)))) * 6
                    + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))];
 
       else if (Type == QUIETS)
@@ -120,7 +120,7 @@ void MovePicker::score() {
       else // Type == EVASIONS
       {
           if (pos.capture(m))
-              m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
+              m.value =  piece_value(MG, pos.piece_on(to_sq(m)))
                        - Value(type_of(pos.moved_piece(m)));
           else
               m.value =  (*mainHistory)[pos.side_to_move()][from_to(m)]

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -387,7 +387,7 @@ void Position::set_state(StateInfo* si) const {
           si->pawnKey ^= Zobrist::psq[pc][s];
 
       else if (type_of(pc) != KING)
-          si->nonPawnMaterial[color_of(pc)] += PieceValue[MG][pc];
+          si->nonPawnMaterial[color_of(pc)] += piece_value(MG, pc);
   }
 
   if (si->epSquare != SQ_NONE)
@@ -785,7 +785,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           st->pawnKey ^= Zobrist::psq[captured][capsq];
       }
       else
-          st->nonPawnMaterial[them] -= PieceValue[MG][captured];
+          st->nonPawnMaterial[them] -= piece_value(MG, captured);
 
       // Update board and piece lists
       remove_piece(captured, capsq);
@@ -849,7 +849,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
                             ^ Zobrist::psq[pc][pieceCount[pc]];
 
           // Update material
-          st->nonPawnMaterial[us] += PieceValue[MG][promotion];
+          st->nonPawnMaterial[us] += piece_value(MG, promotion);
       }
 
       // Update pawn hash key and prefetch access to pawnsTable
@@ -1061,14 +1061,14 @@ bool Position::see_ge(Move m, Value threshold) const {
 
   // The opponent may be able to recapture so this is the best result
   // we can hope for.
-  balance = PieceValue[MG][piece_on(to)] - threshold;
+  balance = piece_value(MG, piece_on(to)) - threshold;
 
   if (balance < VALUE_ZERO)
       return false;
 
   // Now assume the worst possible result: that the opponent can
   // capture our piece for free.
-  balance -= PieceValue[MG][nextVictim];
+  balance -= piece_value(MG, nextVictim);
 
   // If it is enough (like in PxQ) then return immediately. Note that
   // in case nextVictim == KING we always return here, this is ok
@@ -1107,7 +1107,7 @@ bool Position::see_ge(Move m, Value threshold) const {
       //
       assert(balance < VALUE_ZERO);
 
-      balance = -balance - 1 - PieceValue[MG][nextVictim];
+      balance = -balance - 1 - piece_value(MG, nextVictim);
 
       // If balance is still non-negative after giving away nextVictim then we
       // win. The only thing to be careful about it is that we should revert

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -22,11 +22,6 @@
 
 #include "types.h"
 
-Value PieceValue[PHASE_NB][PIECE_NB] = {
-  { VALUE_ZERO, PawnValueMg, KnightValueMg, BishopValueMg, RookValueMg, QueenValueMg },
-  { VALUE_ZERO, PawnValueEg, KnightValueEg, BishopValueEg, RookValueEg, QueenValueEg }
-};
-
 namespace PSQT {
 
 #define S(mg, eg) make_score(mg, eg)
@@ -112,16 +107,13 @@ void init() {
 
   for (Piece pc = W_PAWN; pc <= W_KING; ++pc)
   {
-      PieceValue[MG][~pc] = PieceValue[MG][pc];
-      PieceValue[EG][~pc] = PieceValue[EG][pc];
-
-      Score score = make_score(PieceValue[MG][pc], PieceValue[EG][pc]);
+      Score score = make_score(piece_value(MG, pc), piece_value(EG, pc));
 
       for (Square s = SQ_A1; s <= SQ_H8; ++s)
       {
           File f = std::min(file_of(s), ~file_of(s));
           psq[ pc][ s] = score + (type_of(pc) == PAWN ? PBonus[rank_of(s)][file_of(s)]
-                                                      : Bonus[pc][rank_of(s)][f]);
+                                                      : Bonus[type_of(pc)][rank_of(s)][f]);
           psq[~pc][~s] = -psq[pc][s];
       }
   }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -364,7 +364,7 @@ void Thread::search() {
 
   multiPV = std::min(multiPV, rootMoves.size());
 
-  int ct = int(Options["Contempt"]) * PawnValueEg / 100; // From centipawns
+  int ct = int(Options["Contempt"]) * piece_value(EG, PAWN) / 100; // From centipawns
 
   // In analysis mode, adjust contempt in accordance with user preference
   if (Limits.infinite || Options["UCI_AnalyseMode"])
@@ -1024,7 +1024,7 @@ moves_loop: // When in check, search starts from here
 
           if (   !captureOrPromotion
               && !givesCheck
-              && (!pos.advanced_pawn_push(move) || pos.non_pawn_material(~us) > BishopValueMg))
+              && (!pos.advanced_pawn_push(move) || pos.non_pawn_material(~us) > piece_value(MG, BISHOP)))
           {
               // Move count based pruning
               if (moveCountPruning)
@@ -1079,7 +1079,7 @@ moves_loop: // When in check, search starts from here
           && (!rootNode || thisThread->best_move_count(move) == 0)
           && (  !captureOrPromotion
               || moveCountPruning
-              || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha
+              || ss->staticEval + piece_value(EG, pos.captured_piece()) <= alpha
               || cutNode))
       {
           Depth r = reduction(improving, depth, moveCount);
@@ -1274,7 +1274,7 @@ moves_loop: // When in check, search starts from here
         // Quiet best move: update move sorting heuristics
         if (!pos.capture_or_promotion(bestMove))
             update_quiet_stats(pos, ss, bestMove, quietsSearched, quietCount,
-                               stat_bonus(depth + (bestValue > beta + PawnValueMg ? ONE_PLY : DEPTH_ZERO)));
+                               stat_bonus(depth + (bestValue > beta + piece_value(MG, PAWN) ? ONE_PLY : DEPTH_ZERO)));
 
         update_capture_stats(pos, bestMove, capturesSearched, captureCount, stat_bonus(depth + ONE_PLY));
 
@@ -1436,7 +1436,7 @@ moves_loop: // When in check, search starts from here
       {
           assert(type_of(move) != ENPASSANT); // Due to !pos.advanced_pawn_push
 
-          futilityValue = futilityBase + PieceValue[EG][pos.piece_on(to_sq(move))];
+          futilityValue = futilityBase + piece_value(EG, pos.piece_on(to_sq(move)));
 
           if (futilityValue <= alpha)
           {
@@ -1627,7 +1627,7 @@ moves_loop: // When in check, search starts from here
 
     // RootMoves are already sorted by score in descending order
     Value topScore = rootMoves[0].score;
-    int delta = std::min(topScore - rootMoves[multiPV - 1].score, PawnValueMg);
+    int delta = std::min(topScore - rootMoves[multiPV - 1].score, piece_value(MG, PAWN));
     int weakness = 120 - 2 * level;
     int maxScore = -VALUE_INFINITE;
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1555,9 +1555,9 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
         // 1 cp to cursed wins and let it grow to 49 cp as the positions gets
         // closer to a real win.
         m.tbScore =  r >= bound ? VALUE_MATE - MAX_PLY - 1
-                   : r >  0     ? Value((std::max( 3, r - 800) * int(PawnValueEg)) / 200)
+                   : r >  0     ? Value((std::max( 3, r - 800) * int(piece_value(EG, PAWN))) / 200)
                    : r == 0     ? VALUE_DRAW
-                   : r > -bound ? Value((std::min(-3, r + 800) * int(PawnValueEg)) / 200)
+                   : r > -bound ? Value((std::min(-3, r + 800) * int(piece_value(EG, PAWN))) / 200)
                    :             -VALUE_MATE + MAX_PLY + 1;
     }
 

--- a/src/types.h
+++ b/src/types.h
@@ -195,8 +195,8 @@ enum Piece {
 };
 
 constexpr Value PieceValue[PHASE_NB][PIECE_NB] = {
-  { VALUE_ZERO, Value(128), Value(782), Value(830), Value(1289), Value(2529)},
-  { VALUE_ZERO, Value(213), Value(865), Value(918), Value(1378), Value(2687)}
+  { VALUE_ZERO, Value(128), Value(782), Value(830), Value(1289), Value(2529) },
+  { VALUE_ZERO, Value(213), Value(865), Value(918), Value(1378), Value(2687) }
 };
 
 enum Depth : int {

--- a/src/types.h
+++ b/src/types.h
@@ -178,12 +178,6 @@ enum Value : int {
   VALUE_MATE_IN_MAX_PLY  =  VALUE_MATE - 2 * MAX_PLY,
   VALUE_MATED_IN_MAX_PLY = -VALUE_MATE + 2 * MAX_PLY,
 
-  PawnValueMg   = 128,   PawnValueEg   = 213,
-  KnightValueMg = 782,   KnightValueEg = 865,
-  BishopValueMg = 830,   BishopValueEg = 918,
-  RookValueMg   = 1289,  RookValueEg   = 1378,
-  QueenValueMg  = 2529,  QueenValueEg  = 2687,
-
   MidgameLimit  = 15258, EndgameLimit  = 3915
 };
 
@@ -200,7 +194,10 @@ enum Piece {
   PIECE_NB = 16
 };
 
-extern Value PieceValue[PHASE_NB][PIECE_NB];
+constexpr Value PieceValue[PHASE_NB][PIECE_NB] = {
+  { VALUE_ZERO, Value(128), Value(782), Value(830), Value(1289), Value(2529)},
+  { VALUE_ZERO, Value(213), Value(865), Value(918), Value(1378), Value(2687)}
+};
 
 enum Depth : int {
 
@@ -383,6 +380,14 @@ constexpr Piece make_piece(Color c, PieceType pt) {
 
 constexpr PieceType type_of(Piece pc) {
   return PieceType(pc & 7);
+}
+
+constexpr Value piece_value(Phase ph, PieceType pt) {
+  return PieceValue[ph][pt];
+}
+
+constexpr Value piece_value(Phase ph, Piece pc) {
+  return PieceValue[ph][type_of(pc)];
 }
 
 inline Color color_of(Piece pc) {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -255,7 +255,7 @@ string UCI::value(Value v) {
   stringstream ss;
 
   if (abs(v) < VALUE_MATE - MAX_PLY)
-      ss << "cp " << v * 100 / PawnValueEg;
+      ss << "cp " << v * 100 / piece_value(EG, PAWN);
   else
       ss << "mate " << (v > 0 ? VALUE_MATE - v + 1 : -VALUE_MATE - v) / 2;
 


### PR DESCRIPTION
This is a non-functional simplification.

Adds a constexpr array for piece values in EG, MG, and consolidate all piece values to use the array.  Adds two accessor functions that takes Pieces, or PieceTypes.
Removes the special value array in psqt and equalization assignment for BLACK.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 17593 W: 3889 L: 3760 D: 9944 
http://tests.stockfishchess.org/tests/view/5d645b780ebc5939d09f50ea

bench 3568210