### PR TITLE
Disable runtime type information

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -147,7 +147,7 @@ endif
 
 ### 3.1 Selecting compiler (default = gcc)
 
-CXXFLAGS += -Wall -Wcast-qual -fno-exceptions -std=c++11 $(EXTRACXXFLAGS)
+CXXFLAGS += -Wall -Wcast-qual -fno-exceptions -fno-rtti -std=c++11 $(EXTRACXXFLAGS)
 DEPENDFLAGS += -std=c++11
 LDFLAGS += $(EXTRALDFLAGS)
 
@@ -290,7 +290,7 @@ ifeq ($(optimize),yes)
 			CXXFLAGS += -fno-gcse -mthumb -march=armv7-a -mfloat-abi=softfp
 		endif
 	endif
-	
+
 	ifeq ($(comp),$(filter $(comp),gcc clang icc))
 		ifeq ($(KERNEL),Darwin)
 			CXXFLAGS += -mdynamic-no-pic


### PR DESCRIPTION
Currently we do not make use of dynamic_cast or typeid, etc.
It's a relatively small difference, but in general we shouldn't pay for
what we don't use, and overall, this produces a slightly smaller binary.

No functional change.