### PR TITLE
Initialize the dynamic contempt value from the thread constructor. Th…

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -770,6 +770,7 @@ namespace {
   template<Tracing T>
   Value Evaluation<T>::value() {
 
+    // Eval is never called when in check
     assert(!pos.checkers());
 
     // Probe the material hash table
@@ -853,8 +854,6 @@ Value Eval::evaluate(const Position& pos) {
 std::string Eval::trace(const Position& pos) {
 
   std::memset(scores, 0, sizeof(scores));
-
-  pos.this_thread()->contempt = SCORE_ZERO; // Reset any dynamic contempt
 
   Value v = Evaluation<TRACE>(pos).value();
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -34,7 +34,7 @@ ThreadPool Threads; // Global object
 /// Thread constructor launches the thread and waits until it goes to sleep
 /// in idle_loop(). Note that 'searching' and 'exit' should be already set.
 
-Thread::Thread(size_t n) : idx(n), stdThread(&Thread::idle_loop, this) {
+Thread::Thread(size_t n) : idx(n), stdThread(&Thread::idle_loop, this), contempt(SCORE_ZERO) {
 
   wait_for_search_finished();
 }


### PR DESCRIPTION
…e initialization from the trace() function is not required anymore.

This prevents a crash when calling evaluate() function with a position object without the thread member previously assigned. This way, a user can call trace function for static evaluation at any time.
This prevents also possible side effect of randomly reseting the value if the trace function is called from the GUI with the "eval" command while the search loop is running.