### PR TITLE
Pretty Generalized Shifting and Removed Directions

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -97,7 +97,7 @@ void Bitboards::init() {
               }
 
   Direction RookDirections[] = { NORTH, EAST, SOUTH, WEST };
-  Direction BishopDirections[] = { NORTH_EAST, SOUTH_EAST, SOUTH_WEST, NORTH_WEST };
+  Direction BishopDirections[] = { NORTH+EAST, SOUTH+EAST, SOUTH+WEST, NORTH+WEST };
 
   init_magics(RookTable, RookMagics, RookDirections);
   init_magics(BishopTable, BishopMagics, BishopDirections);

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -149,15 +149,19 @@ inline Bitboard file_bb(Square s) {
 
 
 /// shift() moves a bitboard one step along direction D
+constexpr bool westward(Direction D) { return (D & 7) == 7; }
+constexpr bool eastward(Direction D) { return (D & 7) == 1; }
+constexpr bool vertical(Direction D) { return (D & 7) == 0; }
 
 template<Direction D>
 constexpr Bitboard shift(Bitboard b) {
-  return  D == NORTH      ?  b             << 8 : D == SOUTH      ?  b             >> 8
-        : D == NORTH+NORTH?  b             <<16 : D == SOUTH+SOUTH?  b             >>16
-        : D == EAST       ? (b & ~FileHBB) << 1 : D == WEST       ? (b & ~FileABB) >> 1
-        : D == NORTH_EAST ? (b & ~FileHBB) << 9 : D == NORTH_WEST ? (b & ~FileABB) << 7
-        : D == SOUTH_EAST ? (b & ~FileHBB) >> 7 : D == SOUTH_WEST ? (b & ~FileABB) >> 9
-        : 0;
+
+    static_assert(westward(D) || eastward(D) || vertical(D),
+                   "Horizontal shifting limited to 1 step.");
+
+    return (D > 0 ? b << D : b >> -D) & (eastward(D) ? ~FileABB :
+                                         westward(D) ? ~FileHBB :
+                                         AllSquares);
 }
 
 
@@ -166,8 +170,8 @@ constexpr Bitboard shift(Bitboard b) {
 
 template<Color C>
 constexpr Bitboard pawn_attacks_bb(Bitboard b) {
-  return C == WHITE ? shift<NORTH_WEST>(b) | shift<NORTH_EAST>(b)
-                    : shift<SOUTH_WEST>(b) | shift<SOUTH_EAST>(b);
+  return C == WHITE ? shift<NORTH+WEST>(b) | shift<NORTH+EAST>(b)
+                    : shift<SOUTH+WEST>(b) | shift<SOUTH+EAST>(b);
 }
 
 
@@ -176,8 +180,8 @@ constexpr Bitboard pawn_attacks_bb(Bitboard b) {
 
 template<Color C>
 constexpr Bitboard pawn_double_attacks_bb(Bitboard b) {
-  return C == WHITE ? shift<NORTH_WEST>(b) & shift<NORTH_EAST>(b)
-                    : shift<SOUTH_WEST>(b) & shift<SOUTH_EAST>(b);
+  return C == WHITE ? shift<NORTH+WEST>(b) & shift<NORTH+EAST>(b)
+                    : shift<SOUTH+WEST>(b) & shift<SOUTH+EAST>(b);
 }
 
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -154,14 +154,15 @@ constexpr bool eastward(Direction D) { return (D & 7) == 1; }
 constexpr bool vertical(Direction D) { return (D & 7) == 0; }
 
 template<Direction D>
-constexpr Bitboard shift(Bitboard b) {
+inline Bitboard shift(Bitboard b) {
 
     static_assert(westward(D) || eastward(D) || vertical(D),
                    "Horizontal shifting limited to 1 step.");
 
-    return (D > 0 ? b << D : b >> -D) & (eastward(D) ? ~FileABB :
-                                         westward(D) ? ~FileHBB :
-                                         AllSquares);
+    Bitboard bb = eastward(D) ? b & ~FileHBB :
+                  westward(D) ? b & ~FileABB : b;
+
+    return (D > 0 ? bb << D : bb >> -D);
 }
 
 

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -57,8 +57,8 @@ namespace {
     constexpr Bitboard  TRank7BB = (Us == WHITE ? Rank7BB    : Rank2BB);
     constexpr Bitboard  TRank3BB = (Us == WHITE ? Rank3BB    : Rank6BB);
     constexpr Direction Up       = (Us == WHITE ? NORTH      : SOUTH);
-    constexpr Direction UpRight  = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
-    constexpr Direction UpLeft   = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
+    constexpr Direction UpRight  = (Us == WHITE ? NORTH+EAST : SOUTH+WEST);
+    constexpr Direction UpLeft   = (Us == WHITE ? NORTH+WEST : SOUTH+EAST);
 
     Bitboard emptySquares;
 

--- a/src/types.h
+++ b/src/types.h
@@ -237,11 +237,6 @@ enum Direction : int {
   EAST  =  1,
   SOUTH = -NORTH,
   WEST  = -EAST,
-
-  NORTH_EAST = NORTH + EAST,
-  SOUTH_EAST = SOUTH + EAST,
-  SOUTH_WEST = SOUTH + WEST,
-  NORTH_WEST = NORTH + WEST
 };
 
 enum File : int {


### PR DESCRIPTION
This is a non-functional simplification.  On my machines it generates exactly the same executable.

Some directions are removed.  NORTH_WEST is not any more clear than NORTH+WEST.

Generalized shifting (pretty version).  With a few constexpr (eastward, westward, etc.), the previous generalized shifting is much easier to read.  (See #2083 for previous discussions)

Shift can how handle any combination of directions as long as the result is no more than 1 step east or west.  Verified with a static_assert.

Brief test to verify nothing was broken:
http://tests.stockfishchess.org/tests/view/5d70407e0ebc5903bb9f3975
