### PR TITLE
Simplify Weak Lever

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -71,10 +71,10 @@ namespace {
     constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
     constexpr Direction Up   = (Us == WHITE ? NORTH : SOUTH);
 
-    Bitboard neighbours, stoppers, doubled, support, phalanx;
+    Bitboard neighbours, stoppers, support, phalanx;
     Bitboard lever, leverPush;
     Square s;
-    bool opposed, backward, passed;
+    bool opposed, backward, passed, doubled;
     Score score = SCORE_ZERO;
     const Square* pl = pos.squares<PAWN>(Us);
 
@@ -142,14 +142,9 @@ namespace {
         else if (backward)
             score -= Backward + WeakUnopposed * int(!opposed);
 
-        if (doubled && !support)
-            score -= Doubled;
+        if (!support)
+            score -= Doubled * doubled + WeakLever * more_than_one(lever);;
     }
-
-    // Penalize our unsupported pawns attacked twice by enemy pawns
-    score -= WeakLever * popcount(  ourPawns
-                                  & doubleAttackThem
-                                  & ~e->pawnAttacks[Us]);
 
     return score;
   }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -143,7 +143,7 @@ namespace {
             score -= Backward + WeakUnopposed * int(!opposed);
 
         if (!support)
-            score -= Doubled * doubled + WeakLever * int(more_than_one(lever));
+            score -= Doubled * int(doubled) + WeakLever * int(more_than_one(lever));
     }
 
     return score;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -143,7 +143,7 @@ namespace {
             score -= Backward + WeakUnopposed * int(!opposed);
 
         if (!support)
-            score -= Doubled * doubled + WeakLever * more_than_one(lever);;
+            score -= Doubled * doubled + WeakLever * int(more_than_one(lever));
     }
 
     return score;


### PR DESCRIPTION
This is a simplification that integrated WeakLever into doubled pawns.  The bench does not change.

Since we already check for !support for Doubled pawns, it's trivial to check for weak lever by just checking more_than_one(lever).

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 26757 W: 5842 L: 5731 D: 15184 
http://tests.stockfishchess.org/tests/view/5d77ee220ebc5902d384e5a4