### PR TITLE
Bonus for rook on same file as their queen.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -110,6 +110,10 @@ namespace {
   // no (friendly) pawn on the rook file.
   constexpr Score RookOnFile[] = { S(18, 7), S(44, 20) };
 
+  // RookOnQueenFile contains a bonus for each rook when on the same file
+  // as their queen.
+  constexpr Score RookOnQueenFile = S(11, 4);
+
   // ThreatByMinor/ByRook[attacked PieceType] contains bonuses according to
   // which piece type attacks which one. Attacks on lesser pieces which are
   // pawn-defended are not considered.
@@ -345,6 +349,10 @@ namespace {
             // Bonus for aligning rook with enemy pawns on the same rank/file
             if (relative_rank(Us, s) >= RANK_5)
                 score += RookOnPawn * popcount(pos.pieces(Them, PAWN) & PseudoAttacks[ROOK][s]);
+
+            // Bonus for rook on same file as their queen
+            if (file_bb(s) & pos.pieces(Them, QUEEN))
+                score += RookOnQueenFile;
 
             // Bonus for rook on an open or semi-open file
             if (pos.is_on_semiopen_file(Us, s))


### PR DESCRIPTION
This patch creates a simple bonus for a rook that is on the same file as the opponent's queen.

STC 10+0.1 th 1 :
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 45609 W: 10120 L: 9733 D: 25756

LTC 60+0.6 th 1 :
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 51651 W: 8606 L: 8288 D: 34757

Many thanks to @noobpwnftw for providing the extra cpu resources for fishtest which led to me doing these tests.

Bench: 4024461