### PR TITLE
Scale down complexity for almost unwinnable endgames

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -720,12 +720,15 @@ namespace {
     bool pawnsOnBothFlanks =   (pos.pieces(PAWN) & QueenSide)
                             && (pos.pieces(PAWN) & KingSide);
 
+    bool almostUnwinnable = !pe->passed_count() && (outflanking < 0) && !pawnsOnBothFlanks;
+
     // Compute the initiative bonus for the attacking side
     int complexity =   9 * pe->passed_count()
                     + 11 * pos.count<PAWN>()
                     +  9 * outflanking
                     + 18 * pawnsOnBothFlanks
                     + 49 * !pos.non_pawn_material()
+                    - 36 * almostUnwinnable
                     -103 ;
 
     // Now apply the bonus: note that we find the attacking side by extracting


### PR DESCRIPTION
passed STC
LLR: 2.94 (-2.94,2.94) [0.50,4.50]
Total: 15843 W: 3601 L: 3359 D: 8883 
passed LTC
LLR: 2.96 (-2.94,2.94) [0.00,3.50] 
Total: 121275 W: 20107 L: 19597 D: 81571 
This patch greatly scales down complexity of 1 flank endgames where stronger side is not outflanking weaker side and no passed pawns are present.
This should improve stockfish evaluation of obvious 4 vs 3, 3 vs 2 and 2 vs 1 draws in rook/queen/knight/bishop solo flank endgames where strong side can't make progress.
Some other values for this bonus (or overall retuning of complexity) can be done further.
bench 3830387