### PR TITLE
Exclude kings and queens of either color from mobilityArea. 

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -114,11 +114,11 @@ namespace {
   // which piece type attacks which one. Attacks on lesser pieces which are
   // pawn-defended are not considered.
   constexpr Score ThreatByMinor[PIECE_TYPE_NB] = {
-    S(0, 0), S(0, 31), S(39, 42), S(57, 44), S(68, 112), S(62, 120)
+    S(0, 0), S(0, 31), S(39, 42), S(57, 44), S(68, 112), S(67, 130)
   };
 
   constexpr Score ThreatByRook[PIECE_TYPE_NB] = {
-    S(0, 0), S(0, 24), S(38, 71), S(38, 61), S(0, 38), S(51, 38)
+    S(0, 0), S(0, 24), S(38, 71), S(38, 61), S(0, 38), S(56, 48)
   };
 
   // PassedRank[Rank] contains a bonus according to the rank of a passed pawn
@@ -228,7 +228,7 @@ namespace {
 
     // Squares occupied by those pawns, by our king or queen or controlled by
     // enemy pawns are excluded from the mobility area.
-    mobilityArea[Us] = ~(b | pos.pieces(Us, KING, QUEEN) | pe->pawn_attacks(Them));
+    mobilityArea[Us] = ~(b | pos.pieces(KING, QUEEN) | pe->pawn_attacks(Them));
 
     // Initialize attackedBy[] for king and pawns
     attackedBy[Us][KING] = pos.attacks_from<KING>(ksq);


### PR DESCRIPTION
Prior to this commit, we deliberately only excluded our own king and queen from the mobility area.  The inclusion of enemy queens produced a small increase in mobility when the enemy queen was attacked by our knights, bishops, rooks, or queen.  

However, this subtly "hidden" bonus overlapped quite directly with other, explicitly named terms.  Knight and bishop attacks on the queen were already handled by ThreatByMinor[QUEEN].  Rook attacks on the queen were largely handled by ThreatByRook[QUEEN] and the recently-added RookOnQueenFile.  Therefore, this small bonus of +1 mobility actually just replicated existing functionality in many cases.

We therefore simplify it away, with small increases in the values of ThreatByMinor[QUEEN] and ThreatByRook[QUEEN] to compensate.  The result is approximately Elo-neutral and produces a cleaner parameter space for our evaluation, reducing redundancy in our evaluation terms.

This compensation was very approximate, and it may be worthwhile to re-tune any evaluation terms that recently overlapped with this code.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 93668 W: 20568 L: 20588 D: 52512
http://tests.stockfishchess.org/tests/view/5d7af9e00ebc5902d385b02f

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 90671 W: 15137 L: 15128 D: 60406
http://tests.stockfishchess.org/tests/view/5d7b23b10ebc5902d385b9e3

Bench: 3612071