### PR TITLE
Use queens of either color in RookOnQueenFile.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -347,8 +347,8 @@ namespace {
             if (relative_rank(Us, s) >= RANK_5)
                 score += RookOnPawn * popcount(pos.pieces(Them, PAWN) & PseudoAttacks[ROOK][s]);
 
-            // Bonus for rook on same file as their queen
-            if (file_bb(s) & pos.pieces(Them, QUEEN))
+            // Bonus for rook on the same file as a queen
+            if (file_bb(s) & pos.pieces(QUEEN))
                 score += RookOnQueenFile;
 
             // Bonus for rook on an open or semi-open file


### PR DESCRIPTION
The recently-added RookOnQueenFile evaluation term (https://github.com/official-stockfish/Stockfish/commit/36e4a86c08a4b79965d819b7893709245cad840a) provided a bonus for placing our rook on the same file as an enemy queen.  

Here, we relax a condition in this bonus, broadening its effect and solidifying its place in Stockfish's evaluation.  It is also strategically desirable to place the rook on the same file as a *friendly* queen, so the restriction on the queen's color is removed.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 66856 W: 14847 L: 14815 D: 37194
http://tests.stockfishchess.org/tests/view/5d7b3c6a0ebc5902d385bcf5

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 86786 W: 14264 L: 14248 D: 58274
http://tests.stockfishchess.org/tests/view/5d7b4e9b0ebc5902d385c178

Bench: 3703909