### PR TITLE
Raise stack size to 8MB for pthreads

### DIFF
--- a/src/thread_win32_osx.h
+++ b/src/thread_win32_osx.h
@@ -73,11 +73,14 @@ typedef std::condition_variable ConditionVariable;
 /// adjust it to TH_STACK_SIZE. The implementation calls pthread_create() with
 /// proper stack size parameter.
 
-#if defined(__APPLE__)
+/// On toolchains where pthread is always available, ensure minimum stack size
+/// instead of relying on linker defaults which may be platform-specific.
+
+#if defined(__APPLE__) || defined(__MINGW32__) || defined(__MINGW64__)
 
 #include <pthread.h>
 
-static const size_t TH_STACK_SIZE = 2 * 1024 * 1024;
+static const size_t TH_STACK_SIZE = 8 * 1024 * 1024;
 
 template <class T, class P = std::pair<T*, void(T::*)()>>
 void* start_routine(void* ptr)


### PR DESCRIPTION
It seems there is no other way to specify stack size on std::thread than linker flags and the effective flags are named differently in many toolchains. On toolchains where pthread is always available, this patch put the stack size change in the C++ code to ensure minimum stack size, instead of relying on linker defaults which may be platform-specific.

Also raises default stack size on OSX to current Linux default (8MB) just to be safe.

No functional change