### PR TITLE
Introduce midgame initiative

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -169,7 +169,7 @@ namespace {
     template<Color Us> Score passed() const;
     template<Color Us> Score space() const;
     ScaleFactor scale_factor(Value eg) const;
-    Score initiative(Value eg) const;
+    Score initiative(Value mg, Value eg) const;
 
     const Position& pos;
     Material::Entry* me;
@@ -717,7 +717,7 @@ namespace {
   // known attacking/defending status of the players.
 
   template<Tracing T>
-  Score Evaluation<T>::initiative(Value eg) const {
+  Score Evaluation<T>::initiative(Value mg, Value eg) const {
 
     int outflanking =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
                      - distance<Rank>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
@@ -743,10 +743,12 @@ namespace {
     // that the endgame score will never change sign after the bonus.
     int v = ((eg > 0) - (eg < 0)) * std::max(complexity, -abs(eg));
 
-    if (T)
-        Trace::add(INITIATIVE, make_score(0, v));
+    int v1 = ((mg > 0) - (mg < 0)) * std::max(std::min(complexity + 50, 0), -abs(mg));
 
-    return make_score(0, v);
+    if (T)
+        Trace::add(INITIATIVE, make_score(v1, v));
+
+    return make_score(v1, v);
   }
 
 
@@ -822,7 +824,7 @@ namespace {
             + passed< WHITE>() - passed< BLACK>()
             + space<  WHITE>() - space<  BLACK>();
 
-    score += initiative(eg_value(score));
+    score += initiative(mg_value(score), eg_value(score));
 
     // Interpolate between a middlegame and a (scaled by 'sf') endgame score
     ScaleFactor sf = scale_factor(eg_value(score));


### PR DESCRIPTION
Use fraction of negative complexity also in midgame evaluation

STC run was stopped after 200k games (and not converging):
http://tests.stockfishchess.org/tests/view/5d7cfdb10ebc5902d386572c
LLR: -1.75 (-2.94,2.94) [0.50,4.50]
Total: 200319 W: 44197 L: 43310 D: 112812
passed speculative LTC
http://tests.stockfishchess.org/tests/view/5d7d14680ebc5902d3866196
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 41051 W: 6858 L: 6570 D: 27623
This patch finally introduces something that was tried for years - midgame score dependance on complexity of position. 
The most obvious field of play of this patch will be (again!) 4 vs 3 etc same flank endgames where sides have a lot of non-pawn material (4 vs 3 draw mostly remains the same draw even if we add a lot of equal material to both sides but eval will be much higher because we are further from endgame).
This is the first and not really precise version, a lot of other stuff can be tried on top of it (separate complexity for middlegame, some more terms, even simple retuning of values).
bench 4248476