### PR TITLE
Scale down endgame factor when shuffling

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -769,8 +769,9 @@ namespace {
             && pos.non_pawn_material() == 2 * BishopValueMg)
             sf = 16 + 4 * pe->passed_count();
         else
-            sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
+            sf = std::min(sf, 36 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide));
 
+        sf = std::max(0, sf - (pos.rule50_count() - 12) / 4  );
     }
 
     return ScaleFactor(sf);


### PR DESCRIPTION
This patch decreases the endgame scale factor using the 50 moves counter.
Looking at some games with this patch, this seems to have two effects on
the playing style:

1) when no progress can be made in late endgames (for instance in fortresses
   or opposite bishops endgames) the evaluation will be largely tamed down
   towards a draw value.

2) more interestingly, there is also a small effect in the midgame play because
   Stockfish will panic a little bit if there are more than four consecutive
   shuffling moves with an advantage: the engine will try to move a pawn or to
   exchange a piece to keep the advantage, so the follow-ups of the position
   will be discovered earlier by the alpha-beta search.

passed STC:
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 23017 W: 5080 L: 4805 D: 13132
http://tests.stockfishchess.org/tests/view/5d7e4aef0ebc59069c36fc74

passed LTC:
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 30746 W: 5171 L: 4911 D: 20664
http://tests.stockfishchess.org/tests/view/5d7e513d0ebc59069c36ff26

Pull request: https://github.com/official-stockfish/Stockfish/pull/2304

Bench: 4272173