### PR TITLE
Fix race where it may cause a hang

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -93,7 +93,7 @@ void Thread::start_searching() {
 void Thread::wait_for_search_finished() {
 
   std::unique_lock<Mutex> lk(mutex);
-  cv.wait(lk, [&]{ return !searching; });
+  cv.wait(lk, [&]{ cv.notify_one(); return !searching; });
 }
 
 
@@ -114,8 +114,7 @@ void Thread::idle_loop() {
   {
       std::unique_lock<Mutex> lk(mutex);
       searching = false;
-      cv.notify_one(); // Wake up anyone waiting for search finished
-      cv.wait(lk, [&]{ return searching; });
+      cv.wait(lk, [&]{ cv.notify_one(); return searching; });
 
       if (exit)
           return;

--- a/src/thread_win32_osx.h
+++ b/src/thread_win32_osx.h
@@ -54,6 +54,8 @@ struct Mutex {
  ~Mutex() { DeleteCriticalSection(&cs); }
   void lock() { EnterCriticalSection(&cs); }
   void unlock() { LeaveCriticalSection(&cs); }
+  Mutex(const Mutex&) = delete;
+  Mutex& operator=(const Mutex&) = delete;
 
 private:
   CRITICAL_SECTION cs;


### PR DESCRIPTION
In case of the notifier thread doesn't find a waiter, and a subsequent wait consumes the notify in the same thread, it will give one back, if the predicate success, no more notify should fire, if it fails, this will essentially turn the offending thread into a spin loop waiting on the other threads to enter wait.

This patch also disallow default copy operators for Mutex(as per C++11 implementations), although that doesn't really affect us.
Using compiler default mutexes had issues described in the original comment, as tested recently they still cause minor slowdowns on MINGW compiles.

No functional change