### PR TITLE
Remove uithread.

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -191,9 +191,8 @@ void UCI::loop(int argc, char* argv[]) {
   Position pos;
   string token, cmd;
   StateListPtr states(new std::deque<StateInfo>(1));
-  auto uiThread = std::make_shared<Thread>(0);
 
-  pos.set(StartFEN, false, &states->back(), uiThread.get());
+  pos.set(StartFEN, false, &states->back(), Threads.main());
 
   for (int i = 1; i < argc; ++i)
       cmd += std::string(argv[i]) + " ";


### PR DESCRIPTION
With the current questions and issues around threading, I had a look at #2299.

It seems there was a problem with data races when requesting [eval](https://github.com/official-stockfish/Stockfish/blob/a858defd332bddd828c9280a9e326a0b750b3dda/src/uci.cpp#L236) via uci while a search was already running. To fix this  an extra thread [uithread](https://github.com/official-stockfish/Stockfish/blob/a858defd332bddd828c9280a9e326a0b750b3dda/src/uci.cpp#L194) was created, presumably to avoid an overlap with Threads.main() that was causing problems.
Making this eval request seems to be outside the scope of UCI, and Vondele also [reports](https://github.com/official-stockfish/Stockfish/issues/2299#issuecomment-532802263) that the data race is not even fixed reliably by this change. I suggest we simplify the threading here by removing this uithread and refusing to respond to `eval` requests when a search is already running.

Bench 4272173