### PR TITLE
Remove limit for updating searched moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -589,7 +589,7 @@ namespace {
     assert(!(PvNode && cutNode));
     assert(depth / ONE_PLY * ONE_PLY == depth);
 
-    Move pv[MAX_PLY+1], capturesSearched[32], quietsSearched[64];
+    Move pv[MAX_PLY+1], movesSearched[MAX_MOVES];
     StateInfo st;
     TTEntry* tte;
     Key posKey;
@@ -1243,11 +1243,11 @@ moves_loop: // When in check, search starts from here
 
       if (move != bestMove)
       {
-          if (captureOrPromotion && captureCount < 32)
-              capturesSearched[captureCount++] = move;
+          if (captureOrPromotion)
+              movesSearched[MAX_MOVES - ++captureCount] = move;
 
-          else if (!captureOrPromotion && quietCount < 64)
-              quietsSearched[quietCount++] = move;
+          else
+              movesSearched[quietCount++] = move;
       }
     }
 
@@ -1273,10 +1273,10 @@ moves_loop: // When in check, search starts from here
     {
         // Quiet best move: update move sorting heuristics
         if (!pos.capture_or_promotion(bestMove))
-            update_quiet_stats(pos, ss, bestMove, quietsSearched, quietCount,
+            update_quiet_stats(pos, ss, bestMove, movesSearched, quietCount,
                                stat_bonus(depth + (bestValue > beta + PawnValueMg ? ONE_PLY : DEPTH_ZERO)));
 
-        update_capture_stats(pos, bestMove, capturesSearched, captureCount, stat_bonus(depth + ONE_PLY));
+        update_capture_stats(pos, bestMove, movesSearched + MAX_MOVES - captureCount, captureCount, stat_bonus(depth + ONE_PLY));
 
         // Extra penalty for a quiet TT or main killer move in previous ply when it gets refuted
         if (   ((ss-1)->moveCount == 1 || ((ss-1)->currentMove == (ss-1)->killers[0]))


### PR DESCRIPTION
Right now we update stats for up to 64 quiets and 32 captures.
We can instead use a single array with MAX_MOVES size to update all
moves searched. This is enough to hold all possible moves. For
partitioning, the front is used for quiets, and the back for captures.

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 50510 W: 11149 L: 11084 D: 28277
http://tests.stockfishchess.org/tests/view/5d8267fb0ebc5971531d30f5

LTC:
LLR: 3.04 (-2.94,2.94) [-3.00,1.00]
Total: 63254 W: 10455 L: 10397 D: 42402
http://tests.stockfishchess.org/tests/view/5d82f6600ebc5971531d385c

Bench: 4272173