### PR TITLE
Acknowledge fishtest authors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -133,3 +133,7 @@ Tom Vijlbrief (tomtor)
 Torsten Franz (torfranz)
 Uri Blass (uriblass)
 Vince Negri
+
+# Additionally, we acknowledge the authors of fishtest,
+# an essential framework for the development of Stockfish:
+# https://github.com/glinscott/fishtest/blob/master/AUTHORS


### PR DESCRIPTION
Explicitly acknowledge fishtest authors.
Their efforts are almost invisible,
but essential for the project.

No functional change.