### PR TITLE
Simplify Connected Pawn Scoring

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -130,7 +130,7 @@ namespace {
         // Score this pawn
         if (support | phalanx)
         {
-            int v =  Connected[r] * (phalanx ? 3 : 2) / (opposed ? 2 : 1)
+            int v =  Connected[r] * (2 + bool(phalanx) - bool(opposed))
                    + 17 * popcount(support);
 
             score += make_score(v, v * (r - 2) / 4);


### PR DESCRIPTION
This is a functional simplification that seems to perform well.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 11354 W: 2579 L: 2437 D: 6338
http://tests.stockfishchess.org/tests/view/5d8151f00ebc5971531d244f

LTC
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 41221 W: 7001 L: 6913 D: 27307
http://tests.stockfishchess.org/tests/view/5d818f930ebc5971531d26d6

Bench 3959889