### PR TITLE
More random draw evaluation.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -762,6 +762,9 @@ namespace {
         if (eval == VALUE_NONE)
             ss->staticEval = eval = evaluate(pos);
 
+        if (eval == VALUE_DRAW)
+            eval = value_draw(depth, thisThread);
+
         // Can ttValue be used as a better position evaluation?
         if (    ttValue != VALUE_NONE
             && (tte->bound() & (ttValue > eval ? BOUND_LOWER : BOUND_UPPER)))


### PR DESCRIPTION
use the randomized draw function value_draw() also for draw evalutions.

This extends the earlier commit
https://github.com/official-stockfish/Stockfish/commit/97d2cc9a9c1c4b6ff1b470676fa18c7fc6509886
which did this only for 3folds.

As in that case, this test was yellow at STC and LTC, but green at VLTC,
indicative of the fact that the higher the drawrate,
the more likely this is beneficial.

STC:
LLR: -2.96 (-2.94,2.94) [0.50,4.50]
Total: 83573 W: 18584 L: 18335 D: 46654
http://tests.stockfishchess.org/tests/view/5d84e44d0ebc5971531d4f94

LTC:
LLR: -2.96 (-2.94,2.94) [0.00,3.50]
Total: 92252 W: 15240 L: 15160 D: 61852
http://tests.stockfishchess.org/tests/view/5d865dd90ebc5971531d68e1

VLTC: 120+1.2 @ 2th
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 51902 W: 7323 L: 7028 D: 37551
http://tests.stockfishchess.org/tests/view/5d8763620ebc595f57c22b15

Bench: 3834101