### PR TITLE
Enemy pawn squares are unavailable space.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -693,7 +693,7 @@ namespace {
 
     // Find the available squares for our pieces inside the area defined by SpaceMask
     Bitboard safe =   SpaceMask
-                   & ~pos.pieces(Us, PAWN)
+                   & ~pos.pieces(PAWN)
                    & ~attackedBy[Them][PAWN];
 
     // Find all squares which are at most three squares behind some friendly pawn


### PR DESCRIPTION
Previously, in Stockfish's space calculations, we considered a square unavailable for our pieces if it was occupied by a friendly pawn or attacked by an enemy one.  The exclusion of enemy pawns seemed a bit strange--after all, they could be defended by any number of enemy non-pawn pieces.  An enemy pawn in our space is often a significant difficulty and can exert a lot of influence, even if not defended, if we cannot attack it.

Excluding all pawns, not merely our own, yields slightly simpler code and a sensible interpretation, for no noticeable change in Elo.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 52238 W: 11526 L: 11465 D: 29247
http://tests.stockfishchess.org/tests/view/5d885f0d0ebc5906dd3ea226

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 77027 W: 12639 L: 12607 D: 51781
http://tests.stockfishchess.org/tests/view/5d8863fb0ebc5906dd3ea6c8

Bench: 4192130