### PR TITLE
Increase weight for supported pawns

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -131,7 +131,7 @@ namespace {
         if (support | phalanx)
         {
             int v =  Connected[r] * (2 + bool(phalanx) - opposed)
-                   + 17 * popcount(support);
+                   + 21 * popcount(support);
 
             score += make_score(v, v * (r - 2) / 4);
         }


### PR DESCRIPTION
This patch changes the weight for counting supports of pawns
from 17 to 21. Hopefully Stockfish will accept to play a bit
more of closed or semi-closed positions.

STC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 13822 W: 3158 L: 2939 D: 7725
http://tests.stockfishchess.org/tests/view/5d89c3a10ebc595091802379

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 63066 W: 10590 L: 10236 D: 42240
http://tests.stockfishchess.org/tests/view/5d89ca7f0ebc595091802680

Future work: try to tweak the evaluation to better understand
the French structures.

Bench: 3618154