### PR TITLE
Show compiler info at startup

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,7 @@ namespace PSQT {
 int main(int argc, char* argv[]) {
 
   std::cout << engine_info() << std::endl;
+  std::cout << compiler_info() << std::endl;
 
   UCI::init(Options);
   PSQT::init();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,6 @@ namespace PSQT {
 int main(int argc, char* argv[]) {
 
   std::cout << engine_info() << std::endl;
-  std::cout << compiler_info() << std::endl;
 
   UCI::init(Options);
   PSQT::init();

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -144,6 +144,62 @@ const string engine_info(bool to_uci) {
 }
 
 
+/// compiler_info() returns a string trying to describe the compiler we use
+
+const std::string compiler_info() {
+
+  #define STRINGIFY(x) #x
+  #define VER_STRING(major, minor, patch) STRINGIFY(major) "." STRINGIFY(minor) "." STRINGIFY(patch)
+
+/// Predefined macros hell:
+///
+/// __GNUC__           Compiler is gcc, Clang or Intel on Linux
+/// __INTEL_COMPILER   Compiler is Intel
+/// _MSC_VER           Compiler is MSVC or Intel on Windows
+/// _WIN32             Building on Windows (any)
+/// _WIN64             Building on Windows 64 bit
+
+  std::string compiler = "\nCompiled by ";
+
+  #ifdef __clang__
+     compiler += "clang++ ";
+     compiler += VER_STRING(__clang_major__, __clang_minor__, __clang_patchlevel__);
+  #elif __INTEL_COMPILER
+     compiler += "Intel compiler ";
+     compiler += "(unknown version)";
+  #elif _MSC_VER 
+     compiler += "MSVC ";
+     compiler += "(unknown version)";
+  #elif __GNUC__
+     compiler += "g++ (GNUC) ";
+     compiler += VER_STRING(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+  #else
+     compiler += "Unknown compiler ";
+     compiler += "(unknown version)";
+  #endif
+
+  #if defined(__APPLE__) 
+     compiler += " on Apple";
+  #elif defined(__MINGW32__)
+     compiler += " on MingGW32";
+  #elif defined(__MINGW64__)
+     compiler += " on MingGW64";
+  #else
+     compiler += " on unknown system";
+  #endif
+
+  compiler += "\n __VERSION__ macro expands to: ";
+  #ifdef __VERSION__
+  compiler += __VERSION__;
+  #else
+  compiler += "(undefined macro)";
+  #endif
+  compiler += "\n";
+
+  return compiler;
+}
+
+
 /// Debug functions used mainly to collect run-time statistics
 static std::atomic<int64_t> hits[2], means[2];
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -148,7 +148,8 @@ const string engine_info(bool to_uci) {
 
 const std::string compiler_info() {
 
-  #define STRINGIFY(x) #x
+  #define STRINGIFY2(x) #x
+  #define STRINGIFY(x) STRINGIFY2(x)
   #define VER_STRING(major, minor, patch) STRINGIFY(major) "." STRINGIFY(minor) "." STRINGIFY(patch)
 
 /// Predefined macros hell:

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -188,9 +188,9 @@ const std::string compiler_info() {
   #elif defined(__CYGWIN__)
      compiler += " on Cygwin";
   #elif defined(__MINGW64__)
-     compiler += " on MingGW64";
+     compiler += " on MinGW64";
   #elif defined(__MINGW32__)
-     compiler += " on MingGW32";
+     compiler += " on MinGW32";
   #elif defined(__ANDROID__)
      compiler += " on Android";
   #elif defined(__linux__)

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -166,10 +166,14 @@ const std::string compiler_info() {
      compiler += VER_STRING(__clang_major__, __clang_minor__, __clang_patchlevel__);
   #elif __INTEL_COMPILER
      compiler += "Intel compiler ";
-     compiler += "(unknown version)";
-  #elif _MSC_VER 
+     compiler += "(update ";
+     compiler += __INTEL_COMPILER_UPDATE;
+     compiler += ")";
+  #elif _MSC_VER
      compiler += "MSVC ";
-     compiler += "(unknown version)";
+     compiler += "(version ";
+     compiler += STRINGIFY(_MSC_FULL_VER) "." STRINGIFY(_MSC_BUILD);
+     compiler += ")";
   #elif __GNUC__
      compiler += "g++ (GNUC) ";
      compiler += VER_STRING(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
@@ -190,9 +194,9 @@ const std::string compiler_info() {
 
   compiler += "\n __VERSION__ macro expands to: ";
   #ifdef __VERSION__
-  compiler += __VERSION__;
+     compiler += __VERSION__;
   #else
-  compiler += "(undefined macro)";
+     compiler += "(undefined macro)";
   #endif
   compiler += "\n";
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -168,7 +168,7 @@ const std::string compiler_info() {
   #elif __INTEL_COMPILER
      compiler += "Intel compiler ";
      compiler += "(version ";
-     compîler += STRINGIFY(__INTEL_COMPILER) " update " STRINGIFY(__INTEL_COMPILER_UPDATE);
+     compiler += STRINGIFY(__INTEL_COMPILER) " update " STRINGIFY(__INTEL_COMPILER_UPDATE);
      compiler += ")";
   #elif _MSC_VER
      compiler += "MSVC ";

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -167,8 +167,8 @@ const std::string compiler_info() {
      compiler += VER_STRING(__clang_major__, __clang_minor__, __clang_patchlevel__);
   #elif __INTEL_COMPILER
      compiler += "Intel compiler ";
-     compiler += "(update ";
-     compiler += __INTEL_COMPILER_UPDATE;
+     compiler += "(version ";
+     compîler += STRINGIFY(__INTEL_COMPILER) " update " STRINGIFY(__INTEL_COMPILER_UPDATE);
      compiler += ")";
   #elif _MSC_VER
      compiler += "MSVC ";
@@ -185,10 +185,20 @@ const std::string compiler_info() {
 
   #if defined(__APPLE__) 
      compiler += " on Apple";
-  #elif defined(__MINGW32__)
-     compiler += " on MingGW32";
+  #elif defined(__CYGWIN__)
+     compiler += " on Cygwin";
   #elif defined(__MINGW64__)
      compiler += " on MingGW64";
+  #elif defined(__MINGW32__)
+     compiler += " on MingGW32";
+  #elif defined(__ANDROID__)
+     compiler += " on Android";
+  #elif defined(__linux__)
+     compiler += " on Linux";
+  #elif defined(_WIN64)
+     compiler += " on Microsoft Windows 64-bit";
+  #elif defined(_WIN32)
+     compiler += " on Microsoft Windows 32-bit";
   #else
      compiler += " on unknown system";
   #endif

--- a/src/misc.h
+++ b/src/misc.h
@@ -30,6 +30,7 @@
 #include "types.h"
 
 const std::string engine_info(bool to_uci = false);
+const std::string compiler_info();
 void prefetch(void* addr);
 void start_logger(const std::string& fname);
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -230,10 +230,11 @@ void UCI::loop(int argc, char* argv[]) {
       else if (token == "isready")    sync_cout << "readyok" << sync_endl;
 
       // Additional custom non-UCI commands, mainly for debugging
-      else if (token == "flip")  pos.flip();
-      else if (token == "bench") bench(pos, is, states);
-      else if (token == "d")     sync_cout << pos << sync_endl;
-      else if (token == "eval")  sync_cout << Eval::trace(pos) << sync_endl;
+      else if (token == "flip")     pos.flip();
+      else if (token == "bench")    bench(pos, is, states);
+      else if (token == "d")        sync_cout << pos << sync_endl;
+      else if (token == "eval")     sync_cout << Eval::trace(pos) << sync_endl;
+      else if (token == "compiler") sync_cout << compiler_info() << sync_endl;
       else
           sync_cout << "Unknown command: " << cmd << sync_endl;
 


### PR DESCRIPTION
This patch shows a description of the compiler used to compile Stockfish when starting from the console.

Usage:
```
./stockfish
compiler
```

Example of output:
```
Stockfish 240919 64 POPCNT by T. Romstad, M. Costalba, J. Kiiski, G. Linscott

Compiled by clang++ 9.0.0 on Apple
 __VERSION__ macro expands to: 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)
```

No functional change