### PR TITLE
Small speedup in make_scores

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -622,12 +622,12 @@ namespace {
             Square blockSq = s + Up;
 
             // Adjust bonus based on the king's proximity
-            bonus += make_score(0, (  king_proximity(Them, blockSq) * 5
+            bonus += make_score_eg((  king_proximity(Them, blockSq) * 5
                                     - king_proximity(Us,   blockSq) * 2) * w);
 
             // If blockSq is not the queening square then consider also a second push
             if (r != RANK_7)
-                bonus -= make_score(0, king_proximity(Us, blockSq + Up) * w);
+                bonus -= make_score_eg(king_proximity(Us, blockSq + Up) * w);
 
             // If the pawn is free to advance, then increase the bonus
             if (pos.empty(blockSq))
@@ -703,7 +703,7 @@ namespace {
 
     int bonus = popcount(safe) + popcount(behind & safe & ~attackedBy[Them][ALL_PIECES]);
     int weight = pos.count<ALL_PIECES>(Us) - 1;
-    Score score = make_score(bonus * weight * weight / 16, 0);
+    Score score = make_score_mg(bonus * weight * weight / 16);
 
     if (T)
         Trace::add(SPACE, Us, score);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -199,12 +199,12 @@ Score Entry::evaluate_shelter(const Position& pos, Square ksq) {
       int theirRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : 0;
 
       File d = map_to_queenside(f);
-      bonus += make_score(ShelterStrength[d][ourRank], 0);
+      bonus += make_score_mg(ShelterStrength[d][ourRank]);
 
       if (ourRank && (ourRank == theirRank - 1))
           bonus -= BlockedStorm * int(theirRank == RANK_3);
       else
-          bonus -= make_score(UnblockedStorm[d][theirRank], 0);
+          bonus -= make_score_mg(UnblockedStorm[d][theirRank]);
   }
 
   return bonus;
@@ -222,8 +222,8 @@ Score Entry::do_king_safety(const Position& pos) {
   castlingRights[Us] = pos.castling_rights(Us);
 
   Score shelters[3] = { evaluate_shelter<Us>(pos, ksq),
-                        make_score(-VALUE_INFINITE, 0),
-                        make_score(-VALUE_INFINITE, 0) };
+                        make_score_mg(-VALUE_INFINITE),
+                        make_score_mg(-VALUE_INFINITE) };
 
   // If we can castle use the bonus after castling if it is bigger
   if (pos.can_castle(Us & KING_SIDE))
@@ -245,7 +245,7 @@ Score Entry::do_king_safety(const Position& pos) {
   else while (pawns)
       minPawnDist = std::min(minPawnDist, distance(ksq, pop_lsb(&pawns)));
 
-  return shelters[0] - make_score(0, 16 * minPawnDist);
+  return shelters[0] - make_score_eg(16 * minPawnDist);
 }
 
 // Explicit template instantiation

--- a/src/types.h
+++ b/src/types.h
@@ -260,9 +260,18 @@ enum Rank : int {
 /// avoid left-shifting a signed int to avoid undefined behavior.
 enum Score : int { SCORE_ZERO };
 
+constexpr Score make_score_mg(int mg) {
+  return Score(mg);
+}
+
+constexpr Score make_score_eg(int eg) {
+  return Score((int)((unsigned int)eg << 16));
+}
+
 constexpr Score make_score(int mg, int eg) {
   return Score((int)((unsigned int)eg << 16) + mg);
 }
+
 
 /// Extracting the signed lower and upper 16 bits is not so trivial because
 /// according to the standard a simple cast to short is implementation defined


### PR DESCRIPTION
This is a non-functional speed-up and was NOT tested.  If we don't need mg or eg values in make_scores, just do one or the other.

master ave nps: 1492157
patch ave nps: 1505400