### PR TITLE
Pawn attack span improvement

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -135,7 +135,7 @@ namespace {
   constexpr Score KnightOnQueen      = S( 16, 12);
   constexpr Score LongDiagonalBishop = S( 45,  0);
   constexpr Score MinorBehindPawn    = S( 18,  3);
-  constexpr Score Outpost            = S( 18,  6);
+  constexpr Score Outpost            = S( 16,  5);
   constexpr Score PassedFile         = S( 11,  8);
   constexpr Score PawnlessFlank      = S( 17, 95);
   constexpr Score RestrictedPiece    = S(  7,  7);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -110,6 +110,8 @@ namespace {
         backward =  !(neighbours & forward_ranks_bb(Them, s))
                   && (stoppers & (leverPush | (s + Up)));
 
+        // Span of backward pawns and span behind opposed pawns are not taken
+        // in pawn_attack_span BB.
         if (!backward || phalanx)
         {
             if(opposed)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -94,8 +94,6 @@ namespace {
 
         Rank r = relative_rank(Us, s);
 
-        e->pawnAttacksSpan[Us] |= pawn_attack_span(Us, s);
-
         // Flag the pawn
         opposed    = theirPawns & forward_file_bb(Us, s);
         stoppers   = theirPawns & passed_pawn_span(Us, s);
@@ -111,6 +109,15 @@ namespace {
         // pawns will be excluded when the pawn is scored.
         backward =  !(neighbours & forward_ranks_bb(Them, s))
                   && (stoppers & (leverPush | (s + Up)));
+
+        if (!backward || phalanx)
+        {
+            if(opposed)
+                e->pawnAttacksSpan[Us] |= (pawn_attack_span(Us, s) & 
+                    ~pawn_attack_span(Us, frontmost_sq(Them, theirPawns & forward_file_bb(Us, s))));
+            else
+                e->pawnAttacksSpan[Us] |= pawn_attack_span(Us, s);
+        }
 
         // A pawn is passed if one of the three following conditions is true:
         // (a) there is no stoppers except some levers

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -111,7 +111,7 @@ namespace {
                   && (stoppers & (leverPush | (s + Up)));
 
         // Span of backward pawns and span behind opposed pawns are not taken
-        // in pawn_attack_span BB.
+        // in pawn_attack_span BB. 
         if (!backward || phalanx)
         {
             if(opposed)


### PR DESCRIPTION
Remove pawn attack span for backward pawns and behind opposed pawns. This is a typical scheme in positional play and one of weaknesses of SF in multiple high level games.

STC
LLR: -2.95 (-2.94,2.94) [0.50,4.50]
Total: 66843 W: 14884 L: 14717 D: 37242 
http://tests.stockfishchess.org/tests/view/5d8dcb1b0ebc590f3beb2956

LTC
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 77699 W: 12993 L: 12602 D: 52104 
http://tests.stockfishchess.org/tests/view/5d8de9bc0ebc590f3beb3d00

Bench : 3965294