### PR TITLE
Simplify pawn_attacks.

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -166,8 +166,7 @@ constexpr Bitboard shift(Bitboard b) {
 
 template<Color C>
 constexpr Bitboard pawn_attacks_bb(Bitboard b) {
-  return C == WHITE ? shift<NORTH_WEST>(b) | shift<NORTH_EAST>(b)
-                    : shift<SOUTH_WEST>(b) | shift<SOUTH_EAST>(b);
+  return shift<up(C) + WEST>(b) | shift<up(C) + EAST>(b);
 }
 
 
@@ -176,8 +175,7 @@ constexpr Bitboard pawn_attacks_bb(Bitboard b) {
 
 template<Color C>
 constexpr Bitboard pawn_double_attacks_bb(Bitboard b) {
-  return C == WHITE ? shift<NORTH_WEST>(b) & shift<NORTH_EAST>(b)
-                    : shift<SOUTH_WEST>(b) & shift<SOUTH_EAST>(b);
+  return shift<up(C) + WEST>(b) & shift<up(C) + EAST>(b);
 }
 
 

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -374,7 +374,7 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
       // There's potential for a draw if our pawn is blocked on the 7th rank,
       // the bishop cannot attack it or they only have one pawn left
       if (   relative_rank(strongSide, weakPawnSq) == RANK_7
-          && (pos.pieces(strongSide, PAWN) & (weakPawnSq + pawn_push(weakSide)))
+          && (pos.pieces(strongSide, PAWN) & (weakPawnSq + up(weakSide)))
           && (opposite_colors(bishopSq, weakPawnSq) || pos.count<PAWN>(strongSide) == 1))
       {
           int strongKingDist = distance(weakPawnSq, strongKingSq);
@@ -534,7 +534,7 @@ ScaleFactor Endgame<KRPKB>::operator()(const Position& pos) const {
       Square bsq = pos.square<BISHOP>(weakSide);
       Square psq = pos.square<PAWN>(strongSide);
       Rank rk = relative_rank(strongSide, psq);
-      Direction push = pawn_push(strongSide);
+      Direction push = up(strongSide);
 
       // If the pawn is on the 5th rank and the pawn (currently) is on
       // the same color square as the bishop then there is a chance of
@@ -667,12 +667,12 @@ ScaleFactor Endgame<KBPPKB>::operator()(const Position& pos) const {
 
   if (relative_rank(strongSide, psq1) > relative_rank(strongSide, psq2))
   {
-      blockSq1 = psq1 + pawn_push(strongSide);
+      blockSq1 = psq1 + up(strongSide);
       blockSq2 = make_square(file_of(psq2), rank_of(psq1));
   }
   else
   {
-      blockSq1 = psq2 + pawn_push(strongSide);
+      blockSq1 = psq2 + up(strongSide);
       blockSq2 = make_square(file_of(psq1), rank_of(psq2));
   }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -332,9 +332,9 @@ namespace {
                 && pos.is_chess960()
                 && (s == relative_square(Us, SQ_A1) || s == relative_square(Us, SQ_H1)))
             {
-                Direction d = pawn_push(Us) + (file_of(s) == FILE_A ? EAST : WEST);
+                Direction d = up(Us) + (file_of(s) == FILE_A ? EAST : WEST);
                 if (pos.piece_on(s + d) == make_piece(Us, PAWN))
-                    score -= !pos.empty(s + d + pawn_push(Us))                ? CorneredBishop * 4
+                    score -= !pos.empty(s + d + up(Us))                ? CorneredBishop * 4
                             : pos.piece_on(s + d + d) == make_piece(Us, PAWN) ? CorneredBishop * 2
                                                                               : CorneredBishop;
             }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -301,7 +301,7 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
       st->epSquare = make_square(File(col - 'a'), Rank(row - '1'));
 
       if (   !(attackers_to(st->epSquare) & pieces(sideToMove, PAWN))
-          || !(pieces(~sideToMove, PAWN) & (st->epSquare + pawn_push(~sideToMove))))
+          || !(pieces(~sideToMove, PAWN) & (st->epSquare + up(~sideToMove))))
           st->epSquare = SQ_NONE;
   }
   else
@@ -541,7 +541,7 @@ bool Position::legal(Move m) const {
   if (type_of(m) == ENPASSANT)
   {
       Square ksq = square<KING>(us);
-      Square capsq = to - pawn_push(us);
+      Square capsq = to - up(us);
       Bitboard occupied = (pieces() ^ from ^ capsq) | to;
 
       assert(to == ep_square());
@@ -622,11 +622,11 @@ bool Position::pseudo_legal(const Move m) const {
           return false;
 
       if (   !(attacks_from<PAWN>(from, us) & pieces(~us) & to) // Not a capture
-          && !((from + pawn_push(us) == to) && empty(to))       // Not a single push
-          && !(   (from + 2 * pawn_push(us) == to)              // Not a double push
+          && !((from + up(us) == to) && empty(to))       // Not a single push
+          && !(   (from + 2 * up(us) == to)              // Not a double push
                && (rank_of(from) == relative_rank(us, RANK_2))
                && empty(to)
-               && empty(to - pawn_push(us))))
+               && empty(to - up(us))))
           return false;
   }
   else if (!(attacks_from(type_of(pc), from) & to))
@@ -771,7 +771,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       {
           if (type_of(m) == ENPASSANT)
           {
-              capsq -= pawn_push(us);
+              capsq -= up(us);
 
               assert(pc == make_piece(us, PAWN));
               assert(to == st->epSquare);
@@ -826,9 +826,9 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   {
       // Set en-passant square if the moved pawn can be captured
       if (   (int(to) ^ int(from)) == 16
-          && (attacks_from<PAWN>(to - pawn_push(us), us) & pieces(them, PAWN)))
+          && (attacks_from<PAWN>(to - up(us), us) & pieces(them, PAWN)))
       {
-          st->epSquare = to - pawn_push(us);
+          st->epSquare = to - up(us);
           k ^= Zobrist::enpassant[file_of(st->epSquare)];
       }
 
@@ -939,7 +939,7 @@ void Position::undo_move(Move m) {
 
           if (type_of(m) == ENPASSANT)
           {
-              capsq -= pawn_push(us);
+              capsq -= up(us);
 
               assert(type_of(pc) == PAWN);
               assert(to == st->previous->epSquare);

--- a/src/types.h
+++ b/src/types.h
@@ -420,7 +420,7 @@ constexpr Rank relative_rank(Color c, Square s) {
   return relative_rank(c, rank_of(s));
 }
 
-constexpr Direction pawn_push(Color c) {
+constexpr Direction up(Color c) {
   return c == WHITE ? NORTH : SOUTH;
 }
 


### PR DESCRIPTION
This is a non-functional non-tested code-style change.

If we replace pawn_push with up, we can use it to simplify pawn_attacks_bb and pawn_double_attacks_bb.