### PR TITLE
Shuffle detection

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -619,7 +619,6 @@ namespace {
     moveCount = captureCount = quietCount = singularLMR = ss->moveCount = 0;
     bestValue = -VALUE_INFINITE;
     maxValue = VALUE_INFINITE;
-    ss->ksq = pos.square<KING>(us);
 
     // Check for the available remaining time
     if (thisThread == Threads.main())

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -581,7 +581,7 @@ namespace {
 
     // If opponent is shuffling for several moves without pushing our king to move, we can hope for a draw
     ss->ksq = pos.square<KING>(pos.side_to_move());
-    if (   std::min(ss->ply,pos.rule50_count()) > 24
+    if (   std::min(ss->ply,pos.rule50_count()) > 26
         && distance<Square>(ss->ksq, (ss-18)->ksq) <= 1
         && beta < 0
         && depth < 4 * ONE_PLY)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -584,7 +584,7 @@ namespace {
     if (   std::min(ss->ply,pos.rule50_count()) > 26
         && distance<Square>(ss->ksq, (ss-22)->ksq) <= 1
         && beta < 0
-        && depth < 4 * ONE_PLY)
+        && (depth < 4 * ONE_PLY || std::min(ss->ply,pos.rule50_count()) > 38))
     {
         //sync_cout << "Shuffling = " << pos.fen() << sync_endl;
         return VALUE_DRAW;
@@ -1101,6 +1101,12 @@ moves_loop: // When in check, search starts from here
           // Reduction if other threads are searching this position.
           if (th.marked())
               r += ONE_PLY;
+
+          // Increase reduction for weak side king moves in shuffling positions
+          /*if (std::min(ss->ply,pos.rule50_count()) > 12
+              && beta < 0
+              && type_of(movedPiece) == KING)
+              r += 2 * ONE_PLY;*/
 
           // Decrease reduction if position is or has been on the PV
           if (ttPv)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -582,10 +582,13 @@ namespace {
     // If opponent is shuffling for several moves without pushing our king to move, we can hope for a draw
     ss->ksq = pos.square<KING>(pos.side_to_move());
     if (   std::min(ss->ply,pos.rule50_count()) > 26
-        && distance<Square>(ss->ksq, (ss-18)->ksq) <= 1
+        && distance<Square>(ss->ksq, (ss-22)->ksq) <= 1
         && beta < 0
         && depth < 4 * ONE_PLY)
+    {
+        //sync_cout << "Shuffling = " << pos.fen() << sync_endl;
         return VALUE_DRAW;
+    }
 
     // Dive into quiescence search when the depth reaches zero
     if (depth < ONE_PLY)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -585,10 +585,7 @@ namespace {
         && distance<Square>(ss->ksq, (ss-20)->ksq) <= 1
         && beta < 0
         && (depth < 4 * ONE_PLY || std::min(ss->ply,pos.rule50_count()) > 34))
-    {
-        //sync_cout << "Shuffling = " << pos.fen() << sync_endl;
         return value_draw(depth, pos.this_thread());
-    }
 
     // Dive into quiescence search when the depth reaches zero
     if (depth < ONE_PLY)
@@ -1101,12 +1098,6 @@ moves_loop: // When in check, search starts from here
           // Reduction if other threads are searching this position.
           if (th.marked())
               r += ONE_PLY;
-
-          // Increase reduction for weak side king moves in shuffling positions
-          /*if (std::min(ss->ply,pos.rule50_count()) > 12
-              && beta < 0
-              && type_of(movedPiece) == KING)
-              r += 2 * ONE_PLY;*/
 
           // Decrease reduction if position is or has been on the PV
           if (ttPv)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -587,7 +587,7 @@ namespace {
         && (depth < 4 * ONE_PLY || std::min(ss->ply,pos.rule50_count()) > 38))
     {
         //sync_cout << "Shuffling = " << pos.fen() << sync_endl;
-        return VALUE_DRAW;
+        return value_draw(depth, pos.this_thread());
     }
 
     // Dive into quiescence search when the depth reaches zero

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -579,6 +579,14 @@ namespace {
             return alpha;
     }
 
+    // If opponent is shuffling for several moves without pushing our king to move, we can hope for a draw
+    ss->ksq = pos.square<KING>(pos.side_to_move());
+    if (   std::min(ss->ply,pos.rule50_count()) > 24
+        && distance<Square>(ss->ksq, (ss-18)->ksq) <= 1
+        && beta < 0
+        && depth < 4 * ONE_PLY)
+        return VALUE_DRAW;
+
     // Dive into quiescence search when the depth reaches zero
     if (depth < ONE_PLY)
         return qsearch<NT>(pos, ss, alpha, beta);
@@ -608,6 +616,7 @@ namespace {
     moveCount = captureCount = quietCount = singularLMR = ss->moveCount = 0;
     bestValue = -VALUE_INFINITE;
     maxValue = VALUE_INFINITE;
+    ss->ksq = pos.square<KING>(us);
 
     // Check for the available remaining time
     if (thisThread == Threads.main())

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -581,10 +581,10 @@ namespace {
 
     // If opponent is shuffling for several moves without pushing our king to move, we can hope for a draw
     ss->ksq = pos.square<KING>(pos.side_to_move());
-    if (   std::min(ss->ply,pos.rule50_count()) > 26
-        && distance<Square>(ss->ksq, (ss-22)->ksq) <= 1
+    if (   std::min(ss->ply,pos.rule50_count()) > 22
+        && distance<Square>(ss->ksq, (ss-20)->ksq) <= 1
         && beta < 0
-        && (depth < 4 * ONE_PLY || std::min(ss->ply,pos.rule50_count()) > 38))
+        && (depth < 4 * ONE_PLY || std::min(ss->ply,pos.rule50_count()) > 34))
     {
         //sync_cout << "Shuffling = " << pos.fen() << sync_endl;
         return value_draw(depth, pos.this_thread());

--- a/src/search.h
+++ b/src/search.h
@@ -49,6 +49,7 @@ struct Stack {
   Value staticEval;
   int statScore;
   int moveCount;
+  Square ksq;
 };
 
 


### PR DESCRIPTION
If one side plays several reversible moves without pushing the other side to move its king. The position is probably shuffling.
The patch helps to prune unuseful lines and concentrate on moves that push weak side king to move. If it is not possible, position is probably a draw.
To avoid false draws, 2 limits :
- 22 moves with search depth < 4
- 34 moves with any search depth

The patch passes VLTC but it is possible that in some special positions it leads to wrong draws or (limited) hangs.

Some solved positions
8/1p6/1Pp4q/p1Ppk3/P2Pp1p1/4PpPp/3K1P1P/1R6 b - - 0 2
q1B5/1P1q4/8/8/8/6R1/8/1K1k4 w - - 0 1 
8/8/3P3k/8/1p6/8/1P6/1K3n2 b - - 0 1

STC, non regression :
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 46889 W: 10244 L: 10172 D: 26473 
http://tests.stockfishchess.org/tests/view/5d8e76e20ebc590f3bebcec8

VLTC : 
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 185876 W: 27843 L: 27199 D: 130834 
http://tests.stockfishchess.org/tests/view/5d8bc33d0ebc59509180f42f

Bench: 4006014
