### PR TITLE
Adjust reductions based on the number of threads.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,6 @@ int main(int argc, char* argv[]) {
   Position::init();
   Bitbases::init();
   Endgames::init();
-  Search::init();
   Threads.set(Options["Threads"]);
   Search::clear(); // After threads are up
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -191,7 +191,7 @@ namespace {
 void Search::init() {
 
   for (int i = 1; i < MAX_MOVES; ++i)
-      Reductions[i] = int(23.4 * std::log(i));
+      Reductions[i] = int((23.4 + std::log(Threads.size()) / 2) * std::log(i));
 }
 
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -148,6 +148,9 @@ void ThreadPool::set(size_t requested) {
 
       // Reallocate the hash with the new threadpool size
       TT.resize(Options["Hash"]);
+
+      // Init thread number dependent search params.
+      Search::init();
   }
 }
 


### PR DESCRIPTION
in lazySMP it makes sense to prune a little more, as multiple threads search wider.
We thus increase the prefactor of the reductions slowly as a function of the threads.
The prefactor of the log(threads) term is a parameter, this PR uses 1/2 after testing.

passed STC @ 8threads
LLR: 2.96 (-2.94,2.94) [0.50,4.50]
Total: 118125 W: 23151 L: 22462 D: 72512
http://tests.stockfishchess.org/tests/view/5d8bbf4d0ebc59509180f217

passed LTC @ 8threads
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 67546 W: 10630 L: 10279 D: 46637
http://tests.stockfishchess.org/tests/view/5d8c463b0ebc5950918167e8

passed ~LTC @ 14threads
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 74271 W: 12421 L: 12040 D: 49810
http://tests.stockfishchess.org/tests/view/5d8db1f50ebc590f3beb24ef

a larger prefactor (1) passed similar tests at STC and LTC (8th),
while a large one (2) passed STC quickly but failed LTC (8th).

For the single-threaded case there is no functional change.

Bench: 4088701