### PR TITLE
Add a position to bench with high 50mr counter.

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -61,6 +61,8 @@ const vector<string> Defaults = {
   "1r3k2/4q3/2Pp3b/3Bp3/2Q2p2/1p1P2P1/1P2KP2/3N4 w - - 0 1",
   "6k1/4pp1p/3p2p1/P1pPb3/R7/1r2P1PP/3B1P2/6K1 w - - 0 1",
   "8/3p3B/5p2/5P2/p7/PP5b/k7/6K1 w - - 0 1",
+  "5rk1/q6p/2p3bR/1pPp1rP1/1P1Pp3/P3B1Q1/1K3P2/R7 w - - 93 90",
+  "4rrk1/1p1nq3/p7/2p1P1pp/3P2bp/3Q1Bn1/PPPB4/1K2R1NR w - - 40 21",
 
   // 5-man positions
   "8/8/8/8/5kp1/P7/8/1K1N4 w - - 0 1",     // Kc2 - mate


### PR DESCRIPTION
current bench is missing a position with high 50mr counter,
making most 'shuffle' tests based on 50mr > N seem non-functional.

This patch adds one fen (taken from a recent tcec game) with
high 50mr counter to address this issue.

Bench: 3968907