### PR TITLE
Clarify between_bb

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -193,8 +193,8 @@ inline Bitboard adjacent_files_bb(Square s) {
 /// If the given squares are not on a same file/rank/diagonal, return 0.
 
 inline Bitboard between_bb(Square s1, Square s2) {
-  return LineBB[s1][s2] & ( (AllSquares << (s1 +  (s1 < s2)))
-                           ^(AllSquares << (s2 + !(s1 < s2))));
+  return LineBB[s1][s2] & ((AllSquares << s1) ^ (AllSquares << s2))
+                        &      ~square_bb(s1) &     ~square_bb(s2);
 }
 
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -194,7 +194,7 @@ inline Bitboard adjacent_files_bb(Square s) {
 
 inline Bitboard between_bb(Square s1, Square s2) {
   return LineBB[s1][s2] & ((AllSquares << s1) ^ (AllSquares << s2))
-                        &      ~square_bb(s1) &     ~square_bb(s2);
+                        & ~(square_bb(s1) | s2);
 }
 
 


### PR DESCRIPTION
This is a non-functional code-style change.  Not tested.

Master's between_bb does the s1/s2 additions to cleverly determine which squares to exclude from the returned Bitboard.  It's a bit more clear to just explicitly exclude them without any comparators.

I do not detect any speed difference.

EDIT: The simple version may be a simplification because it is less operations.