### PR TITLE
Remove all FULL_OPERATORS

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -862,7 +862,7 @@ encode_remaining:
         {
             auto f = [&](Square s) { return groupSq[i] > s; };
             auto adjust = std::count_if(squares, groupSq, f);
-            n += Binomial[i + 1][groupSq[i] - adjust - 8 * remainingPawns];
+            n += Binomial[i + 1][int(groupSq[i]) - adjust - 8 * remainingPawns];
         }
 
         remainingPawns = false;

--- a/src/types.h
+++ b/src/types.h
@@ -169,8 +169,7 @@ enum Bound {
 };
 
 typedef int Value;
-constexpr Value
-  VALUE_ZERO      = 0,
+  constexpr Value VALUE_ZERO      = 0,
   VALUE_DRAW      = 0,
   VALUE_KNOWN_WIN = 10000,
   VALUE_MATE      = 32000,
@@ -204,9 +203,7 @@ enum Piece {
 extern Value PieceValue[PHASE_NB][PIECE_NB];
 
 typedef int Depth;
-
-constexpr Depth ONE_PLY = 1,
-
+  constexpr Depth ONE_PLY = 1,
   DEPTH_ZERO          =  0 * ONE_PLY,
   DEPTH_QS_CHECKS     =  0 * ONE_PLY,
   DEPTH_QS_NO_CHECKS  = -1 * ONE_PLY,
@@ -233,8 +230,7 @@ enum Square : int {
 };
 
 typedef int Direction;
-
-constexpr Direction  NORTH =  8,
+  constexpr Direction  NORTH =  8,
   EAST  =  1,
   SOUTH = -NORTH,
   WEST  = -EAST,

--- a/src/types.h
+++ b/src/types.h
@@ -168,7 +168,8 @@ enum Bound {
   BOUND_EXACT = BOUND_UPPER | BOUND_LOWER
 };
 
-enum Value : int {
+typedef int Value;
+constexpr Value
   VALUE_ZERO      = 0,
   VALUE_DRAW      = 0,
   VALUE_KNOWN_WIN = 10000,
@@ -185,8 +186,7 @@ enum Value : int {
   RookValueMg   = 1289,  RookValueEg   = 1378,
   QueenValueMg  = 2529,  QueenValueEg  = 2687,
 
-  MidgameLimit  = 15258, EndgameLimit  = 3915
-};
+  MidgameLimit  = 15258, EndgameLimit  = 3915;
 
 enum PieceType {
   NO_PIECE_TYPE, PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING,
@@ -203,9 +203,9 @@ enum Piece {
 
 extern Value PieceValue[PHASE_NB][PIECE_NB];
 
-enum Depth : int {
+typedef int Depth;
 
-  ONE_PLY = 1,
+constexpr Depth ONE_PLY = 1,
 
   DEPTH_ZERO          =  0 * ONE_PLY,
   DEPTH_QS_CHECKS     =  0 * ONE_PLY,
@@ -214,8 +214,7 @@ enum Depth : int {
 
   DEPTH_NONE   = -6 * ONE_PLY,
   DEPTH_OFFSET = DEPTH_NONE,
-  DEPTH_MAX    = MAX_PLY * ONE_PLY
-};
+  DEPTH_MAX    = MAX_PLY * ONE_PLY;
 
 static_assert(!(ONE_PLY & (ONE_PLY - 1)), "ONE_PLY is not a power of 2");
 
@@ -233,8 +232,9 @@ enum Square : int {
   SQUARE_NB = 64
 };
 
-enum Direction : int {
-  NORTH =  8,
+typedef int Direction;
+
+constexpr Direction  NORTH =  8,
   EAST  =  1,
   SOUTH = -NORTH,
   WEST  = -EAST,
@@ -242,8 +242,7 @@ enum Direction : int {
   NORTH_EAST = NORTH + EAST,
   SOUTH_EAST = SOUTH + EAST,
   SOUTH_WEST = SOUTH + WEST,
-  NORTH_WEST = NORTH + WEST
-};
+  NORTH_WEST = NORTH + WEST;
 
 enum File : int {
   FILE_A, FILE_B, FILE_C, FILE_D, FILE_E, FILE_F, FILE_G, FILE_H, FILE_NB
@@ -288,19 +287,6 @@ inline T& operator-=(T& d1, T d2) { return d1 = d1 - d2; }
 inline T& operator++(T& d) { return d = T(int(d) + 1); }           \
 inline T& operator--(T& d) { return d = T(int(d) - 1); }
 
-#define ENABLE_FULL_OPERATORS_ON(T)                                \
-ENABLE_BASE_OPERATORS_ON(T)                                        \
-constexpr T operator*(int i, T d) { return T(i * int(d)); }        \
-constexpr T operator*(T d, int i) { return T(int(d) * i); }        \
-constexpr T operator/(T d, int i) { return T(int(d) / i); }        \
-constexpr int operator/(T d1, T d2) { return int(d1) / int(d2); }  \
-inline T& operator*=(T& d, int i) { return d = T(int(d) * i); }    \
-inline T& operator/=(T& d, int i) { return d = T(int(d) / i); }
-
-ENABLE_FULL_OPERATORS_ON(Value)
-ENABLE_FULL_OPERATORS_ON(Depth)
-ENABLE_FULL_OPERATORS_ON(Direction)
-
 ENABLE_INCR_OPERATORS_ON(PieceType)
 ENABLE_INCR_OPERATORS_ON(Piece)
 ENABLE_INCR_OPERATORS_ON(Square)
@@ -309,15 +295,8 @@ ENABLE_INCR_OPERATORS_ON(Rank)
 
 ENABLE_BASE_OPERATORS_ON(Score)
 
-#undef ENABLE_FULL_OPERATORS_ON
 #undef ENABLE_INCR_OPERATORS_ON
 #undef ENABLE_BASE_OPERATORS_ON
-
-/// Additional operators to add integers to a Value
-constexpr Value operator+(Value v, int i) { return Value(int(v) + i); }
-constexpr Value operator-(Value v, int i) { return Value(int(v) - i); }
-inline Value& operator+=(Value& v, int i) { return v = v + i; }
-inline Value& operator-=(Value& v, int i) { return v = v - i; }
 
 /// Additional operators to add a Direction to a Square
 constexpr Square operator+(Square s, Direction d) { return Square(int(s) + int(d)); }


### PR DESCRIPTION
This is a non-functional simplification that removes all of the FULL_OPERATORS definitions.

I'm not sure Value, Depth, or Direction should be enums.  I guess it provides some type checking but also requires custom operator overloads.  Using typdef instead of enum allows removal of all of the FULL_OPERATORS.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 17119 W: 3718 L: 3588 D: 9813
http://tests.stockfishchess.org/tests/view/5d9655a10ebc590c21aa5c2a