### PR TITLE
Introduce separate counter-move tables for captures

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -112,10 +112,10 @@ void MovePicker::score() {
 
       else if (Type == QUIETS)
           m.value =  (*mainHistory)[pos.side_to_move()][from_to(m)]
-                   + (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
-                   + (*continuationHistory[1])[pos.moved_piece(m)][to_sq(m)]
-                   + (*continuationHistory[3])[pos.moved_piece(m)][to_sq(m)]
-                   + (*continuationHistory[5])[pos.moved_piece(m)][to_sq(m)] / 2;
+                   + 2 * (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
+                   + 2 * (*continuationHistory[1])[pos.moved_piece(m)][to_sq(m)]
+                   + 2 * (*continuationHistory[3])[pos.moved_piece(m)][to_sq(m)]
+                   + (*continuationHistory[5])[pos.moved_piece(m)][to_sq(m)];
 
       else // Type == EVASIONS
       {
@@ -206,7 +206,7 @@ top:
           endMoves = generate<QUIETS>(pos, cur);
 
           score<QUIETS>();
-          partial_insertion_sort(cur, endMoves, -4000 * depth / ONE_PLY);
+          partial_insertion_sort(cur, endMoves, -3000 * depth / ONE_PLY);
       }
 
       ++stage;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -335,7 +335,11 @@ void Thread::search() {
 
   std::memset(ss-7, 0, 10 * sizeof(Stack));
   for (int i = 7; i > 0; i--)
-     (ss-i)->continuationHistory = &this->continuationHistory[NO_PIECE][0]; // Use as sentinel
+  {
+      (ss-i)->continuationHistory = &this->continuationHistory[0][NO_PIECE][0]; // Use as sentinel
+      (ss-i)->continuationHistory = &this->continuationHistory[1][NO_PIECE][0]; // Use as sentinel
+  {
+     
   ss->pv = pv;
 
   bestValue = delta = alpha = -VALUE_INFINITE;
@@ -816,7 +820,7 @@ namespace {
         Depth R = ((835 + 70 * depth / ONE_PLY) / 256 + std::min(int(eval - beta) / 185, 3)) * ONE_PLY;
 
         ss->currentMove = MOVE_NULL;
-        ss->continuationHistory = &thisThread->continuationHistory[NO_PIECE][0];
+        ss->continuationHistory = &thisThread->continuationHistory[0][NO_PIECE][0];
 
         pos.do_null_move(st);
 
@@ -867,7 +871,7 @@ namespace {
                 probCutCount++;
 
                 ss->currentMove = move;
-                ss->continuationHistory = &thisThread->continuationHistory[pos.moved_piece(move)][to_sq(move)];
+                ss->continuationHistory = &thisThread->continuationHistory[bool(pos.captured_piece())][pos.moved_piece(move)][to_sq(move)];
 
                 assert(depth >= 5 * ONE_PLY);
 
@@ -1069,7 +1073,7 @@ moves_loop: // When in check, search starts from here
 
       // Update the current move (this must be done after singular extension search)
       ss->currentMove = move;
-      ss->continuationHistory = &thisThread->continuationHistory[movedPiece][to_sq(move)];
+      ss->continuationHistory = &thisThread->continuationHistory[bool(pos.captured_piece())][movedPiece][to_sq(move)];
 
       // Step 15. Make the move
       pos.do_move(move, st, givesCheck);
@@ -1476,7 +1480,7 @@ moves_loop: // When in check, search starts from here
       }
 
       ss->currentMove = move;
-      ss->continuationHistory = &thisThread->continuationHistory[pos.moved_piece(move)][to_sq(move)];
+      ss->continuationHistory = &thisThread->continuationHistory[bool(pos.captured_piece())][pos.moved_piece(move)][to_sq(move)];
 
       // Make and search the move
       pos.do_move(move, st, givesCheck);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -335,7 +335,7 @@ void Thread::search() {
 
   std::memset(ss-7, 0, 10 * sizeof(Stack));
   for (int i = 7; i > 0; i--)
-      (ss-i)->continuationHistory = &this->continuationHistory[0][NO_PIECE][0]; // Use as sentinel
+      (ss-i)->continuationHistory = &this->continuationHistory[0][NO_PIECE][0]; // Use as a sentinel
 
   ss->pv = pv;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -335,11 +335,8 @@ void Thread::search() {
 
   std::memset(ss-7, 0, 10 * sizeof(Stack));
   for (int i = 7; i > 0; i--)
-  {
       (ss-i)->continuationHistory = &this->continuationHistory[0][NO_PIECE][0]; // Use as sentinel
-      (ss-i)->continuationHistory = &this->continuationHistory[1][NO_PIECE][0]; // Use as sentinel
-  {
-     
+
   ss->pv = pv;
 
   bestValue = delta = alpha = -VALUE_INFINITE;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -69,12 +69,15 @@ void Thread::clear() {
   counterMoves.fill(MOVE_NONE);
   mainHistory.fill(0);
   captureHistory.fill(0);
+ 
+  for (int i = 0; i < 2; i++)
+  {
+      for (auto& to : continuationHistory[i])
+          for (auto& h : to)
+              h->fill(0);
 
-  for (auto& to : continuationHistory)
-      for (auto& h : to)
-          h->fill(0);
-
-  continuationHistory[NO_PIECE][0]->fill(Search::CounterMovePruneThreshold - 1);
+      continuationHistory[i][NO_PIECE][0]->fill(Search::CounterMovePruneThreshold - 1);
+  }
 }
 
 /// Thread::start_searching() wakes up the thread that will start the search

--- a/src/thread.h
+++ b/src/thread.h
@@ -71,7 +71,7 @@ public:
   CounterMoveHistory counterMoves;
   ButterflyHistory mainHistory;
   CapturePieceToHistory captureHistory;
-  ContinuationHistory continuationHistory;
+  ContinuationHistory continuationHistory[2];
   Score contempt;
 };
 


### PR DESCRIPTION
Enhance CMH table by adding a capture Boolean dimension.
This will double the CMH table but provide more accurate move stats

STC:
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 79702 W: 17720 L: 17164 D: 44818
http://tests.stockfishchess.org/tests/view/5d97945e0ebc590c21aa724b

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 29147 W: 4907 L: 4651 D: 19589
http://tests.stockfishchess.org/tests/view/5d97ccb90ebc590c21aa7bc0

Bench:  4131643