### PR TITLE
Adjust aspiration window with eval

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -412,7 +412,7 @@ void Thread::search() {
           if (rootDepth >= 4)
           {
               Value previousScore = rootMoves[pvIdx].previousScore;
-              delta = Value(23);
+              delta = Value(21 + (abs(previousScore) / 128));
               alpha = std::max(previousScore - delta,-VALUE_INFINITE);
               beta  = std::min(previousScore + delta, VALUE_INFINITE);
 


### PR DESCRIPTION
This patch changes the base aspiration window size depending on the evaluation's absolute value, increasing it away from zero. This stems from the observation that the further away from zero, the more likely the evaluation is to change significantly with more depth. Conversely, a tighter aspiration window is more efficient when close to zero.

A beneficial side-effect is that analysis of won positions without a quick mate is less prone to waste nodes in repeated fail-high that change the eval by tiny steps.

Many thanks to @noobpwnftw for his hardware contribution that allowed the 155K games LTC to complete in less than two hours.

STC:
LLR: 2.96 (-2.94,2.94) [0.50,4.50]
Total: 60102 W: 13327 L: 12868 D: 33907
http://tests.stockfishchess.org/tests/view/5d9a70d40ebc5902b6cf39ba

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 155553 W: 25745 L: 25141 D: 104667
http://tests.stockfishchess.org/tests/view/5d9a7ca30ebc5902b6cf4028

Future work : the values used in this patch were only a reasonable guess. Further testing should unveil more optimal values. However, the aspiration window is rather tight with a minimum of 21 internal units, so discrete integers put a practical limitation to such tweaking.

More exotic experiments around the aspiration window parameters could also be tried, but efficient conditions to adjust the base aspiration window size or allow it to not be centered on the current evaluation are not obvious.

The aspiration window increases after a fail-high or a fail-low is another avenue to explore for potential enhancements.

Bench: 4043748