### PR TITLE
Move outposts to pawns.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -259,11 +259,9 @@ namespace {
 
     constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
     constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
-    constexpr Bitboard OutpostRanks = (Us == WHITE ? Rank4BB | Rank5BB | Rank6BB
-                                                   : Rank5BB | Rank4BB | Rank3BB);
     const Square* pl = pos.squares<Pt>(Us);
 
-    Bitboard b, bb;
+    Bitboard b;
     Score score = SCORE_ZERO;
 
     attackedBy[Us][Pt] = 0;
@@ -296,11 +294,10 @@ namespace {
         if (Pt == BISHOP || Pt == KNIGHT)
         {
             // Bonus if piece is on an outpost square or can reach one
-            bb = OutpostRanks & attackedBy[Us][PAWN] & ~pe->pawn_attacks_span(Them);
-            if (bb & s)
+            if (pe->outpost_squares(Us) & s)
                 score += Outpost * (Pt == KNIGHT ? 4 : 2);
 
-            else if (bb & b & ~pos.pieces(Us))
+            else if (pe->outpost_squares(Us) & b & ~pos.pieces(Us))
                 score += Outpost * (Pt == KNIGHT ? 2 : 1);
 
             // Knight and Bishop bonus for being right behind a pawn

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -197,6 +197,13 @@ namespace {
     // The weights of the individual piece types are given by the elements in
     // the KingAttackWeights array.
     int kingAttackersWeight[COLOR_NB];
+
+    // kingAttacksCount[color] is the number of attacks by the given color to
+    // squares directly adjacent to the enemy king. Pieces which attack more
+    // than one square are counted multiple times. For instance, if there is
+    // a white knight on g5 and black's king is on g8, this white knight adds 2
+    // to kingAttacksCount[WHITE].
+    int kingAttacksCount[COLOR_NB];
   };
 
 
@@ -239,7 +246,7 @@ namespace {
         kingRing[Us] |= shift<EAST>(kingRing[Us]);
 
     kingAttackersCount[Them] = popcount(kingRing[Us] & pe->pawn_attacks(Them));
-    kingAttackersWeight[Them] = 0;
+    kingAttacksCount[Them] = kingAttackersWeight[Them] = 0;
 
     // Remove from kingRing[] the squares defended by two pawns
     kingRing[Us] &= ~dblAttackByPawn;
@@ -277,6 +284,7 @@ namespace {
         {
             kingAttackersCount[Us]++;
             kingAttackersWeight[Us] += KingAttackWeights[Pt];
+            kingAttacksCount[Us] += popcount(b & attackedBy[Them][KING]);
         }
 
         int mob = popcount(b & mobilityArea[Us]);
@@ -437,7 +445,7 @@ namespace {
     int kingFlankAttacks = popcount(b1) + popcount(b2);
 
     kingDanger +=        kingAttackersCount[Them] * kingAttackersWeight[Them]
-                 + 103 * kingAttackersCount[Them]
+                 +  69 * kingAttacksCount[Them]
                  + 185 * popcount(kingRing[Us] & weak)
                  - 100 * bool(attackedBy[Us][KNIGHT] & attackedBy[Us][KING])
                  -  35 * bool(attackedBy[Us][BISHOP] & attackedBy[Us][KING])

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -197,13 +197,6 @@ namespace {
     // The weights of the individual piece types are given by the elements in
     // the KingAttackWeights array.
     int kingAttackersWeight[COLOR_NB];
-
-    // kingAttacksCount[color] is the number of attacks by the given color to
-    // squares directly adjacent to the enemy king. Pieces which attack more
-    // than one square are counted multiple times. For instance, if there is
-    // a white knight on g5 and black's king is on g8, this white knight adds 2
-    // to kingAttacksCount[WHITE].
-    int kingAttacksCount[COLOR_NB];
   };
 
 
@@ -246,7 +239,7 @@ namespace {
         kingRing[Us] |= shift<EAST>(kingRing[Us]);
 
     kingAttackersCount[Them] = popcount(kingRing[Us] & pe->pawn_attacks(Them));
-    kingAttacksCount[Them] = kingAttackersWeight[Them] = 0;
+    kingAttackersWeight[Them] = 0;
 
     // Remove from kingRing[] the squares defended by two pawns
     kingRing[Us] &= ~dblAttackByPawn;
@@ -284,7 +277,6 @@ namespace {
         {
             kingAttackersCount[Us]++;
             kingAttackersWeight[Us] += KingAttackWeights[Pt];
-            kingAttacksCount[Us] += popcount(b & attackedBy[Them][KING]);
         }
 
         int mob = popcount(b & mobilityArea[Us]);
@@ -445,7 +437,7 @@ namespace {
     int kingFlankAttacks = popcount(b1) + popcount(b2);
 
     kingDanger +=        kingAttackersCount[Them] * kingAttackersWeight[Them]
-                 +  69 * kingAttacksCount[Them]
+                 + 103 * kingAttackersCount[Them]
                  + 185 * popcount(kingRing[Us] & weak)
                  - 100 * bool(attackedBy[Us][KNIGHT] & attackedBy[Us][KING])
                  -  35 * bool(attackedBy[Us][BISHOP] & attackedBy[Us][KING])

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -88,10 +88,9 @@ namespace {
 
     e->passedPawns[Us] = 0;
     e->kingSquares[Us] = SQ_NONE;
-    e->pawnAttacks[Us] = pawn_attacks_bb<Us>(ourPawns);
     e->outpostSquares[Them] = TheirOutpostRanks
-                            & pawn_attacks_bb<Them>(theirPawns)
-                            & ~e->pawnAttacks[Us];
+                  & pawn_attacks_bb<Them>(theirPawns)
+                  & ~(e->pawnAttacks[Us] = pawn_attacks_bb<Us>(ourPawns));
 
     // Loop through all pawns of the current color and score each pawn
     while ((s = *pl++) != SQ_NONE)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -70,6 +70,8 @@ namespace {
 
     constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
     constexpr Direction Up   = (Us == WHITE ? NORTH : SOUTH);
+    constexpr Bitboard TheirOutposts = (Us == BLACK ? Rank4BB | Rank5BB | Rank6BB
+                                                   : Rank3BB | Rank4BB | Rank5BB);
 
     Bitboard neighbours, stoppers, support, phalanx, opposed;
     Bitboard lever, leverPush, blocked;
@@ -85,7 +87,9 @@ namespace {
 
     e->passedPawns[Us] = 0;
     e->kingSquares[Us] = SQ_NONE;
-    e->pawnAttacks[Us] = e->pawnAttacksSpan[Us] = pawn_attacks_bb<Us>(ourPawns);
+    e->pawnAttacks[Us] = pawn_attacks_bb<Us>(ourPawns);
+    e->outpostSquares[Them] = pawn_attacks_bb<Them>(theirPawns)
+             & TheirOutposts & ~pawn_attacks_bb<Us>(pos.pieces(Us, PAWN));
 
     // Loop through all pawns of the current color and score each pawn
     while ((s = *pl++) != SQ_NONE)
@@ -110,9 +114,9 @@ namespace {
         backward =  !(neighbours & forward_ranks_bb(Them, s + Up))
                   && (stoppers & (leverPush | blocked));
 
-        // Compute additional span if pawn is not backward nor blocked
+        // If not backward or blocked, restrict opponent outpost squares
         if (!backward && !blocked)
-            e->pawnAttacksSpan[Us] |= pawn_attack_span(Us, s);
+            e->outpostSquares[Them] &= ~pawn_attack_span(Us, s);
 
         // A pawn is passed if one of the three following conditions is true:
         // (a) there is no stoppers except some levers

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -88,8 +88,8 @@ namespace {
     e->passedPawns[Us] = 0;
     e->kingSquares[Us] = SQ_NONE;
     e->pawnAttacks[Us] = pawn_attacks_bb<Us>(ourPawns);
-    e->outpostSquares[Them] = pawn_attacks_bb<Them>(theirPawns)
-             & TheirOutposts & ~pawn_attacks_bb<Us>(pos.pieces(Us, PAWN));
+    e->outpostSquares[Them] = pawn_attacks_bb<Them>(theirPawns) & TheirOutposts
+                            & ~pawn_attacks_bb<Us>(ourPawns);
 
     // Loop through all pawns of the current color and score each pawn
     while ((s = *pl++) != SQ_NONE)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -70,8 +70,9 @@ namespace {
 
     constexpr Color     Them = (Us == WHITE ? BLACK : WHITE);
     constexpr Direction Up   = (Us == WHITE ? NORTH : SOUTH);
-    constexpr Bitboard TheirOutposts = (Us == BLACK ? Rank4BB | Rank5BB | Rank6BB
-                                                   : Rank3BB | Rank4BB | Rank5BB);
+    constexpr Bitboard TheirOutpostRanks =
+              (Us == WHITE ? Rank3BB | Rank4BB | Rank5BB
+                           : Rank4BB | Rank5BB | Rank6BB);
 
     Bitboard neighbours, stoppers, support, phalanx, opposed;
     Bitboard lever, leverPush, blocked;
@@ -88,8 +89,9 @@ namespace {
     e->passedPawns[Us] = 0;
     e->kingSquares[Us] = SQ_NONE;
     e->pawnAttacks[Us] = pawn_attacks_bb<Us>(ourPawns);
-    e->outpostSquares[Them] = pawn_attacks_bb<Them>(theirPawns) & TheirOutposts
-                            & ~pawn_attacks_bb<Us>(ourPawns);
+    e->outpostSquares[Them] = TheirOutpostRanks
+                            & pawn_attacks_bb<Them>(theirPawns)
+                            & ~e->pawnAttacks[Us];
 
     // Loop through all pawns of the current color and score each pawn
     while ((s = *pl++) != SQ_NONE)

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -36,7 +36,7 @@ struct Entry {
   Score pawn_score(Color c) const { return scores[c]; }
   Bitboard pawn_attacks(Color c) const { return pawnAttacks[c]; }
   Bitboard passed_pawns(Color c) const { return passedPawns[c]; }
-  Bitboard pawn_attacks_span(Color c) const { return pawnAttacksSpan[c]; }
+  Bitboard outpost_squares(Color c) const { return outpostSquares[c]; }
   int passed_count() const { return popcount(passedPawns[WHITE] | passedPawns[BLACK]); }
 
   template<Color Us>
@@ -55,7 +55,7 @@ struct Entry {
   Score scores[COLOR_NB];
   Bitboard passedPawns[COLOR_NB];
   Bitboard pawnAttacks[COLOR_NB];
-  Bitboard pawnAttacksSpan[COLOR_NB];
+  Bitboard outpostSquares[COLOR_NB];
   Square kingSquares[COLOR_NB];
   Score kingSafety[COLOR_NB];
   int castlingRights[COLOR_NB];


### PR DESCRIPTION
This is a non-functional speedup that moves all outpost square calculations to pawns.cpp.

Benchmarks suggest a 0.5% speedup:
master ave nps: 1553707
patch ave nps: 1560879

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 38034 W: 8296 L: 8207 D: 21531 
http://tests.stockfishchess.org/tests/view/5d9b5c1d0ebc5902b6d0073e