### PR TITLE
No reachable Outpost bonus for bishops. 

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -135,7 +135,7 @@ namespace {
   constexpr Score KnightOnQueen      = S( 16, 12);
   constexpr Score LongDiagonalBishop = S( 45,  0);
   constexpr Score MinorBehindPawn    = S( 18,  3);
-  constexpr Score Outpost            = S( 16,  5);
+  constexpr Score Outpost            = S( 32, 10);
   constexpr Score PassedFile         = S( 11,  8);
   constexpr Score PawnlessFlank      = S( 17, 95);
   constexpr Score RestrictedPiece    = S(  7,  7);
@@ -298,10 +298,10 @@ namespace {
             // Bonus if piece is on an outpost square or can reach one
             bb = OutpostRanks & attackedBy[Us][PAWN] & ~pe->pawn_attacks_span(Them);
             if (bb & s)
-                score += Outpost * (Pt == KNIGHT ? 4 : 2);
-
-            else if (bb & b & ~pos.pieces(Us))
                 score += Outpost * (Pt == KNIGHT ? 2 : 1);
+
+            else if (Pt == KNIGHT && bb & b & ~pos.pieces(Us))
+                score += Outpost;
 
             // Knight and Bishop bonus for being right behind a pawn
             if (shift<Down>(pos.pieces(PAWN)) & s)


### PR DESCRIPTION
Previously, we used various control statements and ternary operators to divide Outpost into four bonuses, based on whether the outpost was for a knight or bishop, and whether it was currently an Outpost or merely a potential ("reachable") one in the future.  Bishop outposts, however, have traditionally been worth far less Elo in testing.  An attempt to remove them altogether passed STC, but failed LTC.

Here we include a narrower simplification, removing the reachable Outpost bonus for bishops.  This bonus was always suspect, given that its current implementation conflicts directly with BishopPawns.  BishopPawns penalizes our bishops based on the number of friendly pawns on the same color of square, but by definition, Outposts must be pawn-protected!  This PR helps to alleviate this conceptual contradiction without loss of Elo and with slightly simpler code.

On a code level, this allows us to simplify a ternary operator into the previous "if" block and distribute a multiplication into an existing constant Score.  On a conceptual level, we retire one of the four traditional Outpost bonuses.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 22277 W: 4882 L: 4762 D: 12633
http://tests.stockfishchess.org/tests/view/5d9aeed60ebc5902b6cf9751

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 51206 W: 8353 L: 8280 D: 34573
http://tests.stockfishchess.org/tests/view/5d9af1940ebc5902b6cf9cd5

Bench: 3941591