### PR TITLE
CMH inCheck Dimension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -334,7 +334,7 @@ void Thread::search() {
 
   std::memset(ss-7, 0, 10 * sizeof(Stack));
   for (int i = 7; i > 0; i--)
-      (ss-i)->continuationHistory = &this->continuationHistory[0][NO_PIECE][0]; // Use as a sentinel
+      (ss-i)->continuationHistory = &this->continuationHistory[0][0][NO_PIECE][0]; // Use as a sentinel
 
   ss->pv = pv;
 
@@ -816,7 +816,7 @@ namespace {
         Depth R = (835 + 70 * depth) / 256 + std::min(int(eval - beta) / 185, 3);
 
         ss->currentMove = MOVE_NULL;
-        ss->continuationHistory = &thisThread->continuationHistory[0][NO_PIECE][0];
+        ss->continuationHistory = &thisThread->continuationHistory[0][0][NO_PIECE][0];
 
         pos.do_null_move(st);
 
@@ -867,7 +867,7 @@ namespace {
                 probCutCount++;
 
                 ss->currentMove = move;
-                ss->continuationHistory = &thisThread->continuationHistory[priorCapture][pos.moved_piece(move)][to_sq(move)];
+                ss->continuationHistory = &thisThread->continuationHistory[inCheck][priorCapture][pos.moved_piece(move)][to_sq(move)];
 
                 assert(depth >= 5);
 
@@ -1068,7 +1068,7 @@ moves_loop: // When in check, search starts from here
 
       // Update the current move (this must be done after singular extension search)
       ss->currentMove = move;
-      ss->continuationHistory = &thisThread->continuationHistory[priorCapture][movedPiece][to_sq(move)];
+      ss->continuationHistory = &thisThread->continuationHistory[inCheck][priorCapture][movedPiece][to_sq(move)];
 
       // Step 15. Make the move
       pos.do_move(move, st, givesCheck);
@@ -1475,7 +1475,7 @@ moves_loop: // When in check, search starts from here
       }
 
       ss->currentMove = move;
-      ss->continuationHistory = &thisThread->continuationHistory[priorCapture][pos.moved_piece(move)][to_sq(move)];
+      ss->continuationHistory = &thisThread->continuationHistory[inCheck][priorCapture][pos.moved_piece(move)][to_sq(move)];
 
       // Make and search the move
       pos.do_move(move, st, givesCheck);

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -70,13 +70,15 @@ void Thread::clear() {
   mainHistory.fill(0);
   captureHistory.fill(0);
 
-  for (StatsType c : { NoCaptures, Captures })
-      for (auto& to : continuationHistory[c])
-          for (auto& h : to)
-              h->fill(0);
+  for (bool inCheck : { false, true })
+	  for (StatsType c : { NoCaptures, Captures })
+		  for (auto& to : continuationHistory[inCheck][c])
+			  for (auto& h : to)
+				  h->fill(0);
 
-  for (StatsType c : { NoCaptures, Captures })
-      continuationHistory[c][NO_PIECE][0]->fill(Search::CounterMovePruneThreshold - 1);
+  for (bool inCheck : { false, true })
+	  for (StatsType c : { NoCaptures, Captures })
+      continuationHistory[inCheck][c][NO_PIECE][0]->fill(Search::CounterMovePruneThreshold - 1);
 }
 
 /// Thread::start_searching() wakes up the thread that will start the search

--- a/src/thread.h
+++ b/src/thread.h
@@ -71,7 +71,7 @@ public:
   CounterMoveHistory counterMoves;
   ButterflyHistory mainHistory;
   CapturePieceToHistory captureHistory;
-  ContinuationHistory continuationHistory[2];
+  ContinuationHistory continuationHistory[2][2];
   Score contempt;
 };
 


### PR DESCRIPTION
Introduce separate counter-move tables for inCheck

Enhance counter-move history table by adding a inCheck dimension.  This doubles
the size of the table but provides more accurate move ordering.

STC: (yellow)
LLR: -2.94 (-2.94,2.94) [0.50,4.50]
Total: 36217 W: 7790 L: 7777 D: 20650
http://tests.stockfishchess.org/tests/view/5d9b9a290ebc5902b6d04fe0


LTC:
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 36665 W: 6063 L: 5788 D: 24814
http://tests.stockfishchess.org/tests/view/5d9b9fcc0ebc5902b6d05985

Bench:  4066614