### PR TITLE
Disable dynamic contempt when Analysis Contempt option is set to Off

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -417,7 +417,7 @@ void Thread::search() {
               beta  = std::min(previousScore + delta, VALUE_INFINITE);
 
               // Adjust contempt based on root move's previousScore (dynamic contempt)
-			  int dt = Options["Dynamic Contempt"];
+              int dt = Options["Dynamic Contempt"];
               int dct = ct + dt * (86 * previousScore / (abs(previousScore) + 176));
 
               contempt = (us == WHITE ?  make_score(dct, dct / 2)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -364,14 +364,19 @@ void Thread::search() {
   multiPV = std::min(multiPV, rootMoves.size());
 
   int ct = int(Options["Contempt"]) * PawnValueEg / 100; // From centipawns
+  int dt = 1;
 
   // In analysis mode, adjust contempt in accordance with user preference
   if (Limits.infinite || Options["UCI_AnalyseMode"])
+  {
       ct =  Options["Analysis Contempt"] == "Off"  ? 0
           : Options["Analysis Contempt"] == "Both" ? ct
           : Options["Analysis Contempt"] == "White" && us == BLACK ? -ct
           : Options["Analysis Contempt"] == "Black" && us == WHITE ? -ct
           : ct;
+      dt =  Options["Analysis Contempt"] == "Off"  ? 0
+          : dt;
+  }
 
   // Evaluation score is from the white point of view
   contempt = (us == WHITE ?  make_score(ct, ct / 2)
@@ -417,7 +422,7 @@ void Thread::search() {
               beta  = std::min(previousScore + delta, VALUE_INFINITE);
 
               // Adjust contempt based on root move's previousScore (dynamic contempt)
-              int dct = ct + 86 * previousScore / (abs(previousScore) + 176);
+              int dct = ct + dt * (86 * previousScore / (abs(previousScore) + 176));
 
               contempt = (us == WHITE ?  make_score(dct, dct / 2)
                                       : -make_score(dct, dct / 2));

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -364,19 +364,14 @@ void Thread::search() {
   multiPV = std::min(multiPV, rootMoves.size());
 
   int ct = int(Options["Contempt"]) * PawnValueEg / 100; // From centipawns
-  int dt = 1;
 
   // In analysis mode, adjust contempt in accordance with user preference
   if (Limits.infinite || Options["UCI_AnalyseMode"])
-  {
       ct =  Options["Analysis Contempt"] == "Off"  ? 0
           : Options["Analysis Contempt"] == "Both" ? ct
           : Options["Analysis Contempt"] == "White" && us == BLACK ? -ct
           : Options["Analysis Contempt"] == "Black" && us == WHITE ? -ct
           : ct;
-      dt =  Options["Analysis Contempt"] == "Off"  ? 0
-          : dt;
-  }
 
   // Evaluation score is from the white point of view
   contempt = (us == WHITE ?  make_score(ct, ct / 2)
@@ -422,6 +417,7 @@ void Thread::search() {
               beta  = std::min(previousScore + delta, VALUE_INFINITE);
 
               // Adjust contempt based on root move's previousScore (dynamic contempt)
+			  int dt = Options["Dynamic Contempt"];
               int dct = ct + dt * (86 * previousScore / (abs(previousScore) + 176));
 
               contempt = (us == WHITE ?  make_score(dct, dct / 2)

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -61,6 +61,7 @@ void init(OptionsMap& o) {
 
   o["Debug Log File"]        << Option("", on_logger);
   o["Contempt"]              << Option(24, -100, 100);
+  o["Dynamic Contempt"]      << Option(true);
   o["Analysis Contempt"]     << Option("Both var Off var White var Black var Both", "Both");
   o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);


### PR DESCRIPTION
This patch disables dynamic contempt when Analysis Contempt option is set to Off. It's obvious that users who set Analysis Contempt to Off want Stockfish to display objective eveluation - not influenced by previousScore. This is non-functional change - related only to the analysis mode. This patch is a result of my trying to solve https://github.com/official-stockfish/Stockfish/issues/2343.