### PR TITLE
Backward pawn simplification

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -108,7 +108,7 @@ namespace {
         // A pawn is backward when it is behind all pawns of the same color on
         // the adjacent files and cannot safely advance.
         backward =  !(neighbours & forward_ranks_bb(Them, s + Up))
-                  && (stoppers & (leverPush | blocked));
+                  && (leverPush | blocked);
 
         // Compute additional span if pawn is not backward nor blocked
         if (!backward && !blocked)


### PR DESCRIPTION
It's not necessary to AND stoppers  w/ leverPush or blocked when computing backward.
No functional change
bench: 4053577