### PR TITLE
Small simplification by reusing function is_discovery_check_on_king

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1460,7 +1460,7 @@ moves_loop: // When in check, search starts from here
 
       // Don't search moves with negative SEE values
       if (  (!inCheck || evasionPrunable)
-          && (!givesCheck || !(pos.blockers_for_king(~pos.side_to_move()) & from_sq(move)))
+          && (!givesCheck || !(pos.is_discovery_check_on_king(~pos.side_to_move(), move)))
           && !pos.see_ge(move))
           continue;
 


### PR DESCRIPTION
Makes the code a bit easer to read

Stc non-regression-test:
http://tests.stockfishchess.org/tests/view/5da4449b0ebc597ba8ed5b89
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 24122 W: 5312 L: 5195 D: 13615

no functional change

bench: 4053577