### PR TITLE
Current Capture CMH - Bench:  4423737

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -867,7 +867,7 @@ namespace {
                 probCutCount++;
 
                 ss->currentMove = move;
-                ss->continuationHistory = &thisThread->continuationHistory[inCheck][priorCapture][pos.moved_piece(move)][to_sq(move)];
+                ss->continuationHistory = &thisThread->continuationHistory[inCheck][true][pos.moved_piece(move)][to_sq(move)];
 
                 assert(depth >= 5);
 
@@ -1068,7 +1068,7 @@ moves_loop: // When in check, search starts from here
 
       // Update the current move (this must be done after singular extension search)
       ss->currentMove = move;
-      ss->continuationHistory = &thisThread->continuationHistory[inCheck][priorCapture][movedPiece][to_sq(move)];
+      ss->continuationHistory = &thisThread->continuationHistory[inCheck][captureOrPromotion][movedPiece][to_sq(move)];
 
       // Step 15. Make the move
       pos.do_move(move, st, givesCheck);
@@ -1337,7 +1337,6 @@ moves_loop: // When in check, search starts from here
     (ss+1)->ply = ss->ply + 1;
     bestMove = MOVE_NONE;
     inCheck = pos.checkers();
-    priorCapture = pos.captured_piece();
     moveCount = 0;
 
     // Check for an immediate draw or maximum ply reached
@@ -1475,7 +1474,7 @@ moves_loop: // When in check, search starts from here
       }
 
       ss->currentMove = move;
-      ss->continuationHistory = &thisThread->continuationHistory[inCheck][priorCapture][pos.moved_piece(move)][to_sq(move)];
+      ss->continuationHistory = &thisThread->continuationHistory[inCheck][pos.capture_or_promotion(move)][pos.moved_piece(move)][to_sq(move)];
 
       // Make and search the move
       pos.do_move(move, st, givesCheck);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1323,7 +1323,7 @@ moves_loop: // When in check, search starts from here
     Move ttMove, move, bestMove;
     Depth ttDepth;
     Value bestValue, value, ttValue, futilityValue, futilityBase, oldAlpha;
-    bool ttHit, pvHit, inCheck, givesCheck, evasionPrunable, priorCapture;
+    bool ttHit, pvHit, inCheck, givesCheck, evasionPrunable;
     int moveCount;
 
     if (PvNode)


### PR DESCRIPTION
Use current capture to index the CMH table instead of prior capture

STC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 61908 W: 13626 L: 13220 D: 35062
http://tests.stockfishchess.org/tests/view/5da8aa670ebc597ba8eda558


LTC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 49057 W: 8071 L: 7765 D: 33221
http://tests.stockfishchess.org/tests/view/5da8e99d0ebc597ba8eda9ca


Bench:  4423737