### PR TITLE
Consolidate attacks_from and pieces

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -114,8 +114,7 @@ public:
   Bitboard attackers_to(Square s) const;
   Bitboard attackers_to(Square s, Bitboard occupied) const;
   Bitboard attacks_from(PieceType pt, Square s) const;
-  template<PieceType> Bitboard attacks_from(Square s) const;
-  template<PieceType> Bitboard attacks_from(Square s, Color c) const;
+  template<PieceType> Bitboard attacks_from(Square s, Color c = WHITE) const;
   Bitboard slider_blockers(Bitboard sliders, Square s, Bitboard& pinners) const;
 
   // Properties of moves
@@ -285,16 +284,11 @@ inline Square Position::castling_rook_square(CastlingRights cr) const {
 }
 
 template<PieceType Pt>
-inline Bitboard Position::attacks_from(Square s) const {
-  assert(Pt != PAWN);
-  return  Pt == BISHOP || Pt == ROOK ? attacks_bb<Pt>(s, byTypeBB[ALL_PIECES])
+inline Bitboard Position::attacks_from(Square s, Color c) const {
+  return  Pt == PAWN ? PawnAttacks[c][s]
+        : Pt == BISHOP || Pt == ROOK ? attacks_bb<Pt>(s, byTypeBB[ALL_PIECES])
         : Pt == QUEEN  ? attacks_from<ROOK>(s) | attacks_from<BISHOP>(s)
         : PseudoAttacks[Pt][s];
-}
-
-template<>
-inline Bitboard Position::attacks_from<PAWN>(Square s, Color c) const {
-  return PawnAttacks[c][s];
 }
 
 inline Bitboard Position::attacks_from(PieceType pt, Square s) const {

--- a/src/position.h
+++ b/src/position.h
@@ -83,8 +83,7 @@ public:
   const std::string fen() const;
 
   // Position representation
-  Bitboard pieces() const;
-  Bitboard pieces(PieceType pt) const;
+  Bitboard pieces(PieceType pt = ALL_PIECES) const;
   Bitboard pieces(PieceType pt1, PieceType pt2) const;
   Bitboard pieces(Color c) const;
   Bitboard pieces(Color c, PieceType pt) const;
@@ -216,10 +215,6 @@ inline Piece Position::piece_on(Square s) const {
 
 inline Piece Position::moved_piece(Move m) const {
   return board[from_sq(m)];
-}
-
-inline Bitboard Position::pieces() const {
-  return byTypeBB[ALL_PIECES];
 }
 
 inline Bitboard Position::pieces(PieceType pt) const {


### PR DESCRIPTION
This is a non-functional patch that consolidates some methods in position.

GOOD: Convenient to have ALL of the attacks_from go in the same method.  This simplifies the code and removes about 10 lines.

BAD: It is a bit strange to have a  default color for attacks_from, but the color is completely ignored for all piece types other than PAWN.  Also, I suppose someone could do attacks_from\<PAWN\>(s) and they would get attacks in WHITE's direction without specifying any color.

I hereby yield to the all mighty stockfish gods.  Do what you will. .  

STC
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 52775 W: 11523 L: 11463 D: 29789
http://tests.stockfishchess.org/tests/view/5da94a020ebc597ba8edb0da
