### PR TITLE
Simplify king_safety (remove do_king_safety)

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -224,7 +224,7 @@ Score Entry::king_safety(const Position& pos) {
   if (kingSquares[Us] == pos.square<KING>(Us) && castlingRights[Us] == pos.castling_rights(Us))
       return kingSafety[Us];
 
-  kingSquares[Us] = pos.square<KING>(Us);
+  Square ksq = kingSquares[Us] = pos.square<KING>(Us);
   castlingRights[Us] = pos.castling_rights(Us);
   auto compare = [](Score a, Score b) { return mg_value(a) < mg_value(b); };
 

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -40,13 +40,7 @@ struct Entry {
   int passed_count() const { return popcount(passedPawns[WHITE] | passedPawns[BLACK]); }
 
   template<Color Us>
-  Score king_safety(const Position& pos) {
-    return  kingSquares[Us] == pos.square<KING>(Us) && castlingRights[Us] == pos.castling_rights(Us)
-          ? kingSafety[Us] : (kingSafety[Us] = do_king_safety<Us>(pos));
-  }
-
-  template<Color Us>
-  Score do_king_safety(const Position& pos);
+  Score king_safety(const Position& pos);
 
   template<Color Us>
   Score evaluate_shelter(const Position& pos, Square ksq);


### PR DESCRIPTION
This is a non-functional patch that removes do_king_safety and simply checks of kingSafety has already been calculated at the beginning of king_safety().

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 84839 W: 18382 L: 18384 D: 48073 
http://tests.stockfishchess.org/tests/view/5dafab8f0ebc5902c06db018