### PR TITLE
Economize SF calculations at MG

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -816,7 +816,8 @@ namespace {
     // Interpolate between a middlegame and a (scaled by 'sf') endgame score
     if (me->game_phase() == PHASE_MIDGAME)
        v = mg_value(score);
-    else {
+    else
+    {
        ScaleFactor sf = scale_factor(eg_value(score));
        v =  mg_value(score) * int(me->game_phase())
           + eg_value(score) * int(PHASE_MIDGAME - me->game_phase()) * sf / SCALE_FACTOR_NORMAL;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -814,11 +814,15 @@ namespace {
     score += initiative(score);
 
     // Interpolate between a middlegame and a (scaled by 'sf') endgame score
-    ScaleFactor sf = scale_factor(eg_value(score));
-    v =  mg_value(score) * int(me->game_phase())
-       + eg_value(score) * int(PHASE_MIDGAME - me->game_phase()) * sf / SCALE_FACTOR_NORMAL;
+    if (me->game_phase() == PHASE_MIDGAME)
+       v = mg_value(score);
+    else {
+       ScaleFactor sf = scale_factor(eg_value(score));
+       v =  mg_value(score) * int(me->game_phase())
+          + eg_value(score) * int(PHASE_MIDGAME - me->game_phase()) * sf / SCALE_FACTOR_NORMAL;
 
-    v /= PHASE_MIDGAME;
+       v /= PHASE_MIDGAME;
+    }
 
     // In case of tracing add all remaining individual evaluation terms
     if (T)


### PR DESCRIPTION
Scale factor calculations are not necessary at middle game. Saving some of these instructions leads to a small ELO gain at STC.

First STC 
LLR: 2.94 (-2.94,2.94) [-1.50,4.50]
Total: 6252 W: 1414 L: 1287 D: 3551 
http://tests.stockfishchess.org/tests/view/5db2c44d0ebc590812751dbb

Second STC 
LLR: -2.96 (-2.94,2.94) [0.00,3.50]
Total: 107092 W: 23206 L: 23028 D: 60858 
http://tests.stockfishchess.org/tests/view/5db2d1a60ebc590812751e7e

(Non functional)
Same bench : 5115841
