### PR TITLE
Sequencing tweak in tbprobe

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -730,8 +730,8 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
 
     // Then we reorder the pieces to have the same sequence as the one stored
     // in pieces[i]: the sequence that ensures the best compression.
-    for (int i = leadPawnsCnt; i < size; ++i)
-        for (int j = i; j < size; ++j)
+    for (int i = leadPawnsCnt; i < size - 1; ++i)
+        for (int j = i + 1; j < size; ++j)
             if (d->pieces[i] == pieces[j])
             {
                 std::swap(pieces[i], pieces[j]);


### PR DESCRIPTION
Non functional change

Followup of issue #2372

See comments on this issue where I proved that the proposed change
is more efficient on average than master on all type of sequences it
will usually be called.

However, with some compilers, for example GNC 6.1.0
this PR produces a bogus array bound warning on line 
` if (d->pieces[i] == pieces[j])`

bench: 5115841