### PR TITLE
Updated KNNKP: 240% improvement in KNNKP endings.

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -317,9 +317,8 @@ Value Endgame<KNNKP>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, 2 * KnightValueMg, 0));
   assert(verify_material(pos, weakSide, VALUE_ZERO, 1));
 
-  Value result =  2 * KnightValueEg
-                - PawnValueEg
-                + PushToEdges[pos.square<KING>(weakSide)];
+  Value result =   2 * KnightValueEg
+               - 250 * relative_rank(weakSide,pos.square<PAWN>(weakSide));
 
   return strongSide == pos.side_to_move() ? result : -result;
 }

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -310,7 +310,7 @@ Value Endgame<KQKR>::operator()(const Position& pos) const {
 }
 
 
-/// KNN vs KP. Simply push the opposing king to the corner
+/// KNN vs KP. Simply prevent weakside pawn from passing.
 template<>
 Value Endgame<KNNKP>::operator()(const Position& pos) const {
 


### PR DESCRIPTION
This is a functional change to KNNKP end game.  Home testing indicates a 240% improvement (in KNNKP end games).

Rationale: If any piece can capture the weak side pawn, it is a draw.  If not, the weak side promotes to queen and may win.  Thus, the only relevant issue is capture or promotion of the pawn.  Pushing the weak side King to the edge isn't helpful.

Does not regress against master.
STC
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 23164 W: 5084 L: 4966 D: 13114
http://tests.stockfishchess.org/tests/view/5dbb51aa0ebc5925b64ee0bc

Testing:
Could someone please verify my testing?  I have an .epd of KNNKP endings which you can use an an opening book in cutechess.  Make sure "-repeat" is set, and turn off resigning.

Here are my end game books:
https://drive.google.com/drive/folders/1AoGr2bt1xPSYYENCp-bdqfXMCKLc8gBy

bench 5117576
