### PR TITLE
Limit shuffle extensions. Take 2.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -394,6 +394,7 @@ void Thread::search() {
 
       size_t pvFirst = 0;
       pvLast = 0;
+      previousNodes = nodes;
 
       // MultiPV loop. We perform a full root search for each PV line
       for (pvIdx = 0; pvIdx < multiPV && !Threads.stop; ++pvIdx)
@@ -1003,7 +1004,7 @@ moves_loop: // When in check, search starts from here
       else if (   PvNode
                && pos.rule50_count() > 18
                && depth < 3
-               && ++thisThread->shuffleExts < thisThread->nodes.load(std::memory_order_relaxed) / 4)  // To avoid too many extensions
+               && 4 * thisThread->previousNodes < thisThread->nodes.load(std::memory_order_relaxed))  // To avoid too many extensions
           extension = 1;
 
       // Passed pawn extension

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1004,7 +1004,7 @@ moves_loop: // When in check, search starts from here
       else if (   PvNode
                && pos.rule50_count() > 18
                && depth < 3
-               && 4 * thisThread->previousNodes < thisThread->nodes.load(std::memory_order_relaxed))  // To avoid too many extensions
+               && 4 * thisThread->previousNodes > thisThread->nodes.load(std::memory_order_relaxed))  // To avoid too many extensions
           extension = 1;
 
       // Passed pawn extension

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -207,7 +207,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
 
   for (Thread* th : *this)
   {
-      th->shuffleExts = th->nodes = th->tbHits = th->nmpMinPly = 0;
+      th->nodes = th->tbHits = th->nmpMinPly = 0;
       th->rootDepth = th->completedDepth = 0;
       th->rootMoves = rootMoves;
       th->rootPos.set(pos.fen(), pos.is_chess960(), &setupStates->back(), th);

--- a/src/thread.h
+++ b/src/thread.h
@@ -60,7 +60,7 @@ public:
 
   Pawns::Table pawnsTable;
   Material::Table materialTable;
-  size_t pvIdx, pvLast, shuffleExts;
+  size_t pvIdx, pvLast, previousNodes;
   int selDepth, nmpMinPly;
   Color nmpColor;
   std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;


### PR DESCRIPTION
closes https://github.com/official-stockfish/Stockfish/issues/2389 and alternative to https://github.com/official-stockfish/Stockfish/pull/2392

This is a different way to limit shuffle extensions, and fixes more fundamentally the problem by making sure that shuffle extensions never cause rootDepth iterations too stall. Rather than fixing the ratio of shuffle Extensions to nodes searched, this turns off shuffle extensions if the number of nodes needed in this iteration exceeds 4x the number needed for the previous iteration. This guarantees progress in go depth N searches.

Upon reflection, I think this is the better approach.

Bench: 4985720