### PR TITLE
Small cleanup of value_draw()

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1141,6 +1141,12 @@ bool Position::is_draw(int ply) const {
 }
 
 
+/// Add a small random component (+-1) to VALUE_DRAW evaluations to avoid 3fold-blindness
+
+Value Position::value_draw() const {
+  return VALUE_DRAW + Value(2 * (thisThread->nodes.load(std::memory_order_relaxed) & 1) - 1);
+}
+
 // Position::has_repeated() tests whether there has been at least one repetition
 // of positions since the last capture or pawn move.
 

--- a/src/position.h
+++ b/src/position.h
@@ -161,6 +161,7 @@ public:
   Score psq_score() const;
   Value non_pawn_material(Color c) const;
   Value non_pawn_material() const;
+  Value value_draw() const;
 
   // Position consistency check, for debugging
   bool pos_is_ok() const;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,11 +84,6 @@ namespace {
     return d > 17 ? -8 : 22 * d * d + 151 * d - 140;
   }
 
-  // Add a small random component to draw evaluations to avoid 3fold-blindness
-  Value value_draw(Thread* thisThread) {
-    return VALUE_DRAW + Value(2 * (thisThread->nodes & 1) - 1);
-  }
-
   // Skill structure is used to implement strength limit
   struct Skill {
     explicit Skill(int l) : level(l) {}
@@ -574,7 +569,7 @@ namespace {
         && !rootNode
         && pos.has_game_cycle(ss->ply))
     {
-        alpha = value_draw(pos.this_thread());
+        alpha = pos.value_draw();
         if (alpha >= beta)
             return alpha;
     }
@@ -624,7 +619,7 @@ namespace {
             || pos.is_draw(ss->ply)
             || ss->ply >= MAX_PLY)
             return (ss->ply >= MAX_PLY && !inCheck) ? evaluate(pos)
-                                                    : value_draw(pos.this_thread());
+                                                    : pos.value_draw();
 
         // Step 3. Mate distance pruning. Even if we mate at the next move our score
         // would be at best mate_in(ss->ply+1), but if alpha is already bigger because
@@ -763,7 +758,7 @@ namespace {
             ss->staticEval = eval = evaluate(pos);
 
         if (eval == VALUE_DRAW)
-            eval = value_draw(thisThread);
+            eval = pos.value_draw();
 
         // Can ttValue be used as a better position evaluation?
         if (    ttValue != VALUE_NONE


### PR DESCRIPTION
by making value_draw() part of Position one can simplify the signature.

Tested for no regression at STC:

LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 58502 W: 12654 L: 12604 D: 33244
http://tests.stockfishchess.org/tests/view/5dc046630ebc590375849d5f

No functional change.