### PR TITLE
Remove unnecessary not inCheck in Futility pruning: parent node

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1039,7 +1039,6 @@ moves_loop: // When in check, search starts from here
 
               // Futility pruning: parent node (~2 Elo)
               if (   lmrDepth < 6
-                  && !inCheck
                   && ss->staticEval + 250 + 211 * lmrDepth <= alpha)
                   continue;
 


### PR DESCRIPTION
Non functional simplification.  Please advise if I should run LTC, but I believe it should not be needed.
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 51991 W: 11219 L: 11157 D: 29615
```
TC | 10+0.1
-- | --
SPRT | elo0: -3.00  alpha: 0.05  elo1: 1.00  beta: 0.05
LLR | 2.95 [-2.94,2.94] (accepted)
Elo | -0.02 [-2.27,2.07] (95%)
LOS | 49.4%
Games | 51991 [w:21.6%, l:21.5%, d:57.0%]
```
Link: http://tests.stockfishchess.org/tests/view/5dc782620ebc5902ea57e23c

Bench: 4362323 (no change)