### PR TITLE
Shallow depth pruning on NonPV advanced pawn push

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1022,7 +1022,7 @@ moves_loop: // When in check, search starts from here
 
           if (   !captureOrPromotion
               && !givesCheck
-              && (!pos.advanced_pawn_push(move) || pos.non_pawn_material(~us) > BishopValueMg))
+              && (!PvNode || !pos.advanced_pawn_push(move) || pos.non_pawn_material(~us) > BishopValueMg))
           {
               // Move count based pruning
               if (moveCountPruning)


### PR DESCRIPTION
Usually advanced pawn pushes are not considered in shallow depth pruning
because it is risky to do so with possible promotions near the horizon.
However, this heuristic is not also beneficial on NonPV nodes since we
can afford to take slightly more risk on less important nodes.

STC:
LLR: 2.95 (-2.94,2.94) [-1.50,4.50]
Total: 54530 W: 11955 L: 11686 D: 30889
http://tests.stockfishchess.org/tests/view/5dc7dda30ebc5902ea57efd0

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 77336 W: 12786 L: 12399 D: 52151
http://tests.stockfishchess.org/tests/view/5dc8050d0ebc5902ea57f491

Bench: 4099208