### PR TITLE
Use constexpr for Squares.

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -71,18 +71,18 @@ void Bitboards::init() {
   for (unsigned i = 0; i < (1 << 16); ++i)
       PopCnt16[i] = std::bitset<16>(i).count();
 
-  for (Square s = SQ_A1; s <= SQ_H8; ++s)
+  for (Square s = SQ(A,1); s <= SQ(H,8); ++s)
       SquareBB[s] = (1ULL << s);
 
-  for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
-      for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2)
+  for (Square s1 = SQ(A,1); s1 <= SQ(H,8); ++s1)
+      for (Square s2 = SQ(A,1); s2 <= SQ(H,8); ++s2)
               SquareDistance[s1][s2] = std::max(distance<File>(s1, s2), distance<Rank>(s1, s2));
 
   int steps[][5] = { {}, { 7, 9 }, { 6, 10, 15, 17 }, {}, {}, {}, { 1, 7, 8, 9 } };
 
   for (Color c : { WHITE, BLACK })
       for (PieceType pt : { PAWN, KNIGHT, KING })
-          for (Square s = SQ_A1; s <= SQ_H8; ++s)
+          for (Square s = SQ(A,1); s <= SQ(H,8); ++s)
               for (int i = 0; steps[pt][i]; ++i)
               {
                   Square to = s + Direction(c == WHITE ? steps[pt][i] : -steps[pt][i]);
@@ -102,13 +102,13 @@ void Bitboards::init() {
   init_magics(RookTable, RookMagics, RookDirections);
   init_magics(BishopTable, BishopMagics, BishopDirections);
 
-  for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
+  for (Square s1 = SQ(A,1); s1 <= SQ(H,8); ++s1)
   {
       PseudoAttacks[QUEEN][s1]  = PseudoAttacks[BISHOP][s1] = attacks_bb<BISHOP>(s1, 0);
       PseudoAttacks[QUEEN][s1] |= PseudoAttacks[  ROOK][s1] = attacks_bb<  ROOK>(s1, 0);
 
       for (PieceType pt : { BISHOP, ROOK })
-          for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2)
+          for (Square s2 = SQ(A,1); s2 <= SQ(H,8); ++s2)
               if (PseudoAttacks[pt][s1] & s2)
                   LineBB[s1][s2] = (attacks_bb(pt, s1, 0) & attacks_bb(pt, s2, 0)) | s1 | s2;
   }
@@ -150,7 +150,7 @@ namespace {
     Bitboard occupancy[4096], reference[4096], edges, b;
     int epoch[4096] = {}, cnt = 0, size = 0;
 
-    for (Square s = SQ_A1; s <= SQ_H8; ++s)
+    for (Square s = SQ(A,1); s <= SQ(H,8); ++s)
     {
         // Board edges are not considered in the relevant occupancies
         edges = ((Rank1BB | Rank8BB) & ~rank_bb(s)) | ((FileABB | FileHBB) & ~file_bb(s));
@@ -166,7 +166,7 @@ namespace {
 
         // Set the offset for the attacks table of the square. We have individual
         // table sizes for each square with "Fancy Magic Bitboards".
-        m.attacks = s == SQ_A1 ? table : magics[s - 1].attacks + size;
+        m.attacks = s == SQ(A,1)? table : magics[s - 1].attacks + size;
 
         // Use Carry-Rippler trick to enumerate all subsets of masks[s] and
         // store the corresponding sliding attack bitboard in reference[].

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -106,7 +106,7 @@ extern Magic RookMagics[SQUARE_NB];
 extern Magic BishopMagics[SQUARE_NB];
 
 inline Bitboard square_bb(Square s) {
-  assert(s >= SQ_A1 && s <= SQ_H8);
+  assert(s >= SQ(A,1) && s <= SQ(H,8));
   return SquareBB[s];
 }
 

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -160,7 +160,7 @@ Value Endgame<KBNK>::operator()(const Position& pos) const {
 
   Value result =  VALUE_KNOWN_WIN
                 + PushClose[distance(winnerKSq, loserKSq)]
-                + PushToCorners[opposite_colors(bishopSq, SQ_A1) ? ~loserKSq : loserKSq];
+                + PushToCorners[opposite_colors(bishopSq, SQ(A,1)) ? ~loserKSq : loserKSq];
 
   assert(abs(result) < VALUE_MATE_IN_MAX_PLY);
   return strongSide == pos.side_to_move() ? result : -result;
@@ -449,7 +449,7 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
   // queening square, use the third-rank defence.
   if (   r <= RANK_5
       && distance(bksq, queeningSq) <= 1
-      && wksq <= SQ_H5
+      && wksq <= SQ(H,5)
       && (rank_of(brsq) == RANK_6 || (r <= RANK_3 && rank_of(wrsq) != RANK_6)))
       return SCALE_FACTOR_DRAW;
 
@@ -469,9 +469,9 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
 
   // White pawn on a7 and rook on a8 is a draw if black's king is on g7 or h7
   // and the black rook is behind the pawn.
-  if (   wpsq == SQ_A7
-      && wrsq == SQ_A8
-      && (bksq == SQ_H7 || bksq == SQ_G7)
+  if (   wpsq == SQ(A,7)
+      && wrsq == SQ(A,8)
+      && ((bksq == SQ(H,7)) || (bksq == SQ(G,7)))
       && file_of(brsq) == FILE_A
       && (rank_of(brsq) <= RANK_3 || file_of(wksq) >= FILE_D || rank_of(wksq) <= RANK_5))
       return SCALE_FACTOR_DRAW;
@@ -749,7 +749,7 @@ ScaleFactor Endgame<KNPK>::operator()(const Position& pos) const {
   Square pawnSq     = normalize(pos, strongSide, pos.square<PAWN>(strongSide));
   Square weakKingSq = normalize(pos, strongSide, pos.square<KING>(weakSide));
 
-  if (pawnSq == SQ_A7 && distance(SQ_A8, weakKingSq) <= 1)
+  if (pawnSq == SQ(A,7) && distance(SQ(A,8), weakKingSq) <= 1)
       return SCALE_FACTOR_DRAW;
 
   return SCALE_FACTOR_NONE;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -323,7 +323,7 @@ namespace {
             // when that pawn is also blocked.
             if (   Pt == BISHOP
                 && pos.is_chess960()
-                && (s == relative_square(Us, SQ_A1) || s == relative_square(Us, SQ_H1)))
+                && (s == relative_square(Us, SQ(A,1) ) || s == relative_square(Us, SQ(H,1))))
             {
                 Direction d = pawn_push(Us) + (file_of(s) == FILE_A ? EAST : WEST);
                 if (pos.piece_on(s + d) == make_piece(Us, PAWN))

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -231,10 +231,10 @@ Score Entry::do_king_safety(const Position& pos) {
   // If we can castle use the bonus after castling if it is bigger
 
   if (pos.can_castle(Us & KING_SIDE))
-      shelter = std::max(shelter, evaluate_shelter<Us>(pos, relative_square(Us, SQ_G1)), compare);
+      shelter = std::max(shelter, evaluate_shelter<Us>(pos, relative_square(Us, SQ(G,1))), compare);
 
   if (pos.can_castle(Us & QUEEN_SIDE))
-      shelter = std::max(shelter, evaluate_shelter<Us>(pos, relative_square(Us, SQ_C1)), compare);
+      shelter = std::max(shelter, evaluate_shelter<Us>(pos, relative_square(Us, SQ(C,1))), compare);
 
   // In endgame we like to bring our king near our closest pawn
   Bitboard pawns = pos.pieces(Us, PAWN);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -147,7 +147,7 @@ void Position::init() {
   PRNG rng(1070372);
 
   for (Piece pc : Pieces)
-      for (Square s = SQ_A1; s <= SQ_H8; ++s)
+      for (Square s = SQ(A,1); s <= SQ(H,8); ++s)
           Zobrist::psq[pc][s] = rng.rand<Key>();
 
   for (File f = FILE_A; f <= FILE_H; ++f)
@@ -172,8 +172,8 @@ void Position::init() {
   std::memset(cuckooMove, 0, sizeof(cuckooMove));
   int count = 0;
   for (Piece pc : Pieces)
-      for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
-          for (Square s2 = Square(s1 + 1); s2 <= SQ_H8; ++s2)
+      for (Square s1 = SQ(A,1); s1 <= SQ(H,8); ++s1)
+          for (Square s2 = Square(s1 + 1); s2 <= SQ(H,8); ++s2)
               if (PseudoAttacks[type_of(pc)][s1] & s2)
               {
                   Move move = make_move(s1, s2);
@@ -235,7 +235,7 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
 
   unsigned char col, row, token;
   size_t idx;
-  Square sq = SQ_A8;
+  Square s = SQ(A,8);
   std::istringstream ss(fenStr);
 
   std::memset(this, 0, sizeof(Position));
@@ -249,15 +249,15 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
   while ((ss >> token) && !isspace(token))
   {
       if (isdigit(token))
-          sq += (token - '0') * EAST; // Advance the given number of files
+          s += (token - '0') * EAST; // Advance the given number of files
 
       else if (token == '/')
-          sq += 2 * SOUTH;
+          s += 2 * SOUTH;
 
       else if ((idx = PieceToChar.find(token)) != string::npos)
       {
-          put_piece(Piece(idx), sq);
-          ++sq;
+          put_piece(Piece(idx), s);
+          ++s;
       }
   }
 
@@ -280,10 +280,10 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
       token = char(toupper(token));
 
       if (token == 'K')
-          for (rsq = relative_square(c, SQ_H1); piece_on(rsq) != rook; --rsq) {}
+          for (rsq = relative_square(c, SQ(H,1)); piece_on(rsq) != rook; --rsq) {}
 
       else if (token == 'Q')
-          for (rsq = relative_square(c, SQ_A1); piece_on(rsq) != rook; ++rsq) {}
+          for (rsq = relative_square(c, SQ(A,1)); piece_on(rsq) != rook; ++rsq) {}
 
       else if (token >= 'A' && token <= 'H')
           rsq = make_square(File(token - 'A'), relative_rank(c, RANK_1));
@@ -337,8 +337,8 @@ void Position::set_castling_right(Color c, Square rfrom) {
   castlingRightsMask[rfrom] |= cr;
   castlingRookSquare[cr] = rfrom;
 
-  Square kto = relative_square(c, cr & KING_SIDE ? SQ_G1 : SQ_C1);
-  Square rto = relative_square(c, cr & KING_SIDE ? SQ_F1 : SQ_D1);
+  Square kto = relative_square(c, cr & KING_SIDE ? SQ(G,1) : SQ(C,1));
+  Square rto = relative_square(c, cr & KING_SIDE ? SQ(F,1) : SQ(D,1));
 
   castlingPath[cr] =   (between_bb(rfrom, rto) | between_bb(kfrom, kto) | rto | kto)
                     & ~(square_bb(kfrom) | rfrom);
@@ -559,7 +559,7 @@ bool Position::legal(Move m) const {
   {
       // After castling, the rook and king final positions are the same in
       // Chess960 as they would be in standard chess.
-      to = relative_square(us, to > from ? SQ_G1 : SQ_C1);
+      to = relative_square(us, to > from ? SQ(G,1) : SQ(C,1));
       Direction step = to > from ? WEST : EAST;
 
       for (Square s = to; s != from; s += step)
@@ -700,8 +700,8 @@ bool Position::gives_check(Move m) const {
   {
       Square kfrom = from;
       Square rfrom = to; // Castling is encoded as 'King captures the rook'
-      Square kto = relative_square(sideToMove, rfrom > kfrom ? SQ_G1 : SQ_C1);
-      Square rto = relative_square(sideToMove, rfrom > kfrom ? SQ_F1 : SQ_D1);
+      Square kto = relative_square(sideToMove, rfrom > kfrom ? SQ(G,1) : SQ(C,1));
+      Square rto = relative_square(sideToMove, rfrom > kfrom ? SQ(F,1) : SQ(D,1));
 
       return   (PseudoAttacks[ROOK][rto] & square<KING>(~sideToMove))
             && (attacks_bb<ROOK>(rto, (pieces() ^ kfrom ^ rfrom) | rto | kto) & square<KING>(~sideToMove));
@@ -967,8 +967,8 @@ void Position::do_castling(Color us, Square from, Square& to, Square& rfrom, Squ
 
   bool kingSide = to > from;
   rfrom = to; // Castling is encoded as "king captures friendly rook"
-  rto = relative_square(us, kingSide ? SQ_F1 : SQ_D1);
-  to = relative_square(us, kingSide ? SQ_G1 : SQ_C1);
+  rto = relative_square(us, kingSide ? SQ(F,1) : SQ(D,1));
+  to  = relative_square(us, kingSide ? SQ(G,1) : SQ(C,1));
 
   // Remove both pieces first since squares could overlap in Chess960
   remove_piece(make_piece(us, KING), Do ? from : to);

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -117,7 +117,7 @@ void init() {
 
       Score score = make_score(PieceValue[MG][pc], PieceValue[EG][pc]);
 
-      for (Square s = SQ_A1; s <= SQ_H8; ++s)
+      for (Square s = SQ(A,1); s <= SQ(H,8); ++s)
       {
           File f = map_to_queenside(file_of(s));
           psq[ pc][ s] = score + (type_of(pc) == PAWN ? PBonus[rank_of(s)][file_of(s)]

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1261,14 +1261,14 @@ void Tablebases::init(const std::string& paths) {
 
     // MapB1H1H7[] encodes a square below a1-h8 diagonal to 0..27
     int code = 0;
-    for (Square s = sq(A,1); s <= sq(H,8); ++s)
+    for (Square s = SQ(A,1); s <= SQ(H,8); ++s)
         if (off_A1H8(s) < 0)
             MapB1H1H7[s] = code++;
 
     // MapA1D1D4[] encodes a square in the a1-d1-d4 triangle to 0..9
     std::vector<Square> diagonal;
     code = 0;
-    for (Square s = sq(A,1); s <= sq(D,4); ++s)
+    for (Square s = SQ(A,1); s <= SQ(D,4); ++s)
         if (off_A1H8(s) < 0 && file_of(s) <= FILE_D)
             MapA1D1D4[s] = code++;
 
@@ -1285,10 +1285,10 @@ void Tablebases::init(const std::string& paths) {
     std::vector<std::pair<int, Square>> bothOnDiagonal;
     code = 0;
     for (int idx = 0; idx < 10; idx++)
-        for (Square s1 = sq(A,1); s1 <= sq(D,4); ++s1)
-            if (MapA1D1D4[s1] == idx && (idx || s1 == sq(B,1))) // SQ_B1 is mapped to 0
+        for (Square s1 = SQ(A,1); s1 <= SQ(D,4); ++s1)
+            if (MapA1D1D4[s1] == idx && (idx || s1 == SQ(B,1))) // SQ_B1 is mapped to 0
             {
-                for (Square s2 = sq(A,1); s2 <= sq(H,8); ++s2)
+                for (Square s2 = SQ(A,1); s2 <= SQ(H,8); ++s2)
                     if ((PseudoAttacks[KING][s1] | s1) & s2)
                         continue; // Illegal position
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1261,14 +1261,14 @@ void Tablebases::init(const std::string& paths) {
 
     // MapB1H1H7[] encodes a square below a1-h8 diagonal to 0..27
     int code = 0;
-    for (Square s = SQ_A1; s <= SQ_H8; ++s)
+    for (Square s = sq(A,1); s <= sq(H,8); ++s)
         if (off_A1H8(s) < 0)
             MapB1H1H7[s] = code++;
 
     // MapA1D1D4[] encodes a square in the a1-d1-d4 triangle to 0..9
     std::vector<Square> diagonal;
     code = 0;
-    for (Square s = SQ_A1; s <= SQ_D4; ++s)
+    for (Square s = sq(A,1); s <= sq(D,4); ++s)
         if (off_A1H8(s) < 0 && file_of(s) <= FILE_D)
             MapA1D1D4[s] = code++;
 
@@ -1285,10 +1285,10 @@ void Tablebases::init(const std::string& paths) {
     std::vector<std::pair<int, Square>> bothOnDiagonal;
     code = 0;
     for (int idx = 0; idx < 10; idx++)
-        for (Square s1 = SQ_A1; s1 <= SQ_D4; ++s1)
-            if (MapA1D1D4[s1] == idx && (idx || s1 == SQ_B1)) // SQ_B1 is mapped to 0
+        for (Square s1 = sq(A,1); s1 <= sq(D,4); ++s1)
+            if (MapA1D1D4[s1] == idx && (idx || s1 == sq(B,1))) // SQ_B1 is mapped to 0
             {
-                for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2)
+                for (Square s2 = sq(A,1); s2 <= sq(H,8); ++s2)
                     if ((PseudoAttacks[KING][s1] | s1) & s2)
                         continue; // Illegal position
 

--- a/src/types.h
+++ b/src/types.h
@@ -215,20 +215,6 @@ enum : int {
   DEPTH_OFFSET = DEPTH_NONE,
 };
 
-enum Square : int {
-  SQ_A1, SQ_B1, SQ_C1, SQ_D1, SQ_E1, SQ_F1, SQ_G1, SQ_H1,
-  SQ_A2, SQ_B2, SQ_C2, SQ_D2, SQ_E2, SQ_F2, SQ_G2, SQ_H2,
-  SQ_A3, SQ_B3, SQ_C3, SQ_D3, SQ_E3, SQ_F3, SQ_G3, SQ_H3,
-  SQ_A4, SQ_B4, SQ_C4, SQ_D4, SQ_E4, SQ_F4, SQ_G4, SQ_H4,
-  SQ_A5, SQ_B5, SQ_C5, SQ_D5, SQ_E5, SQ_F5, SQ_G5, SQ_H5,
-  SQ_A6, SQ_B6, SQ_C6, SQ_D6, SQ_E6, SQ_F6, SQ_G6, SQ_H6,
-  SQ_A7, SQ_B7, SQ_C7, SQ_D7, SQ_E7, SQ_F7, SQ_G7, SQ_H7,
-  SQ_A8, SQ_B8, SQ_C8, SQ_D8, SQ_E8, SQ_F8, SQ_G8, SQ_H8,
-  SQ_NONE,
-
-  SQUARE_NB = 64
-};
-
 enum Direction : int {
   NORTH =  8,
   EAST  =  1,
@@ -242,12 +228,17 @@ enum Direction : int {
 };
 
 enum File : int {
-  FILE_A, FILE_B, FILE_C, FILE_D, FILE_E, FILE_F, FILE_G, FILE_H, FILE_NB
+  FILE_A, FILE_B, FILE_C, FILE_D, FILE_E, FILE_F, FILE_G, FILE_H, FILE_NB,
+  A = FILE_A, B, C, D, E, F, G, H
 };
 
 enum Rank : int {
   RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_NB
 };
+
+enum Square : int { SQ_NONE = 64, SQUARE_NB = 64 };
+
+constexpr Square SQ(File f, int r) { return Square(8 * (r - 1) + f); }
 
 
 /// Score enum stores a middlegame and an endgame value in a single integer (enum).
@@ -351,7 +342,7 @@ constexpr Color operator~(Color c) {
 }
 
 constexpr Square operator~(Square s) {
-  return Square(s ^ SQ_A8); // Vertical flip SQ_A1 -> SQ_A8
+  return Square(s ^ SQ(A,8)); // Vertical flip SQ_A1 -> SQ_A8
 }
 
 constexpr Piece operator~(Piece pc) {
@@ -392,7 +383,7 @@ inline Color color_of(Piece pc) {
 }
 
 constexpr bool is_ok(Square s) {
-  return s >= SQ_A1 && s <= SQ_H8;
+  return s >= SQ(A,1) && s <= SQ(H,8);
 }
 
 constexpr File file_of(Square s) {


### PR DESCRIPTION
This is a non-functional code-style change.

A simple constexpr can handle all of the squares, so the long list of every square (most of which are unused) can be removed.  All square values are determined at compile-time.

I do not believe this needs testing. It generates exactly the same executable.