### PR TITLE
Rank-based outposts

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -128,7 +128,7 @@ namespace {
   
   // OutpostRank[Rank] contains a bonus according to the rank of the outpost
   constexpr Score OutpostRank[RANK_NB] = {
-    S(0, 0), S(0, 0), S(0, 0), S(25, 15), S(36, 21), S(27, 15)
+    S(0, 0), S(0, 0), S(0, 0), S(28, 18), S(30, 24), S(32, 19)
   };
 
   // Assorted bonuses and penalties

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -128,7 +128,7 @@ namespace {
   
   // OutpostRank[Rank] contains a bonus according to the rank of the outpost
   constexpr Score OutpostRank[RANK_NB] = {
-    S(0, 0), S(0, 0), S(0, 0), S(28, 12), S(33, 18), S(30, 12)
+    S(0, 0), S(0, 0), S(0, 0), S(25, 15), S(36, 21), S(27, 15)
   };
 
   // Assorted bonuses and penalties

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -125,6 +125,11 @@ namespace {
   constexpr Score PassedRank[RANK_NB] = {
     S(0, 0), S(10, 28), S(17, 33), S(15, 41), S(62, 72), S(168, 177), S(276, 260)
   };
+  
+  // OutpostRank[Rank] contains a bonus according to the rank of the outpost
+  constexpr Score OutpostRank[RANK_NB] = {
+    S(0, 0), S(0, 0), S(0, 0), S(28, 12), S(33, 18), S(30, 12)
+  };
 
   // Assorted bonuses and penalties
   constexpr Score BishopPawns        = S(  3,  7);
@@ -292,7 +297,7 @@ namespace {
             // Bonus if piece is on an outpost square or can reach one
             bb = OutpostRanks & attackedBy[Us][PAWN] & ~pe->pawn_attacks_span(Them);
             if (s & bb)
-                score += Outpost * (Pt == KNIGHT ? 2 : 1);
+                score += OutpostRank[relative_rank(Us, s)] * (Pt == KNIGHT ? 2 : 1);
 
             else if (Pt == KNIGHT && bb & b & ~pos.pieces(Us))
                 score += Outpost;


### PR DESCRIPTION
Introduce OutpostRank[RANK_NB] which contains a bonus according to the rank of the outpost. The values are based on the trends of the Simultaneous Perturbation Stochastic Approximation (SPSA) tuning run with some manual tweaks. 

The differences of the mg values of this patch is not so significant for a bishop outpost but it is not the case for a knight outpost. The mg value for a Knight Outpost on the 6th rank (64) is more valuable than on the 4th rank (56).

Passed STC:
LLR: 2.96 (-2.94,2.94) [-1.50,4.50]
Total: 27454 W: 6059 L: 5869 D: 15526
http://tests.stockfishchess.org/tests/view/5dcadba20ebc590256922f09

Passed LTC:
LLR: 2.94 (-2.94,2.94) [0.00,3.50]
Total: 57950 W: 9443 L: 9112 D: 39395
http://tests.stockfishchess.org/tests/view/5dcaea880ebc5902569230bc

Bench: 4778405

----------------------------

The inspiration for this patch came from sg's attempt of modifying BishopPawns into a rank-based penalty.

Mstembera suggested that maybe the S(0, 0) ranks (3rd, 7th and also maybe 8th) can still be tuned. This would expand our definition of Outpost and OutpostRanks would be removed altogether.

Special thanks to 31m059 for all the help and excellent suggestions.

