### PR TITLE
Use exploration rate for reductions.

### DIFF
--- a/src/thread.h
+++ b/src/thread.h
@@ -60,7 +60,7 @@ public:
 
   Pawns::Table pawnsTable;
   Material::Table materialTable;
-  size_t pvIdx, pvLast;
+  size_t pvIdx, pvLast, ttProgress;
   int selDepth, nmpMinPly;
   Color nmpColor;
   std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;


### PR DESCRIPTION
This patch measures how frequently search is exploring new configurations.
This is done be computing a running average of ttHit.
The ttProgress rate is somewhat low (e.g. 30% for startpos) in the normal case,
while it can be very high if no progress is made (e.g. 90% for the fortress I used for testing).

This information can be used to influence search.
In this patch, by adjusting reductions if the rate >50%.

passed STC:
LLR: 2.96 (-2.94,2.94) [-1.50,4.50]
Total: 26425 W: 5837 L: 5650 D: 14938
http://tests.stockfishchess.org/tests/view/5dcede8b0ebc5902563258fa

passted LTC:
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 32313 W: 5392 L: 5128 D: 21793
http://tests.stockfishchess.org/tests/view/5dcefb1f0ebc590256325c0e

Bench: 4892345