### PR TITLE
Introduce king flank defenders

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -446,6 +446,8 @@ namespace {
 
     int kingFlankAttacks = popcount(b1) + popcount(b2);
 
+    kingDanger += 4 * (kingFlankAttacks - popcount(KingFlank[file_of(ksq)] & Camp & attackedBy[Us][ALL_PIECES]));
+
     kingDanger +=        kingAttackersCount[Them] * kingAttackersWeight[Them]
                  + 185 * popcount(kingRing[Us] & weak)
                  + 148 * popcount(unsafeChecks)


### PR DESCRIPTION
passed STC 
http://tests.stockfishchess.org/tests/view/5dcf40560ebc590256325f30
LLR: 2.96 (-2.94,2.94) [-1.50,4.50]
Total: 26298 W: 5819 L: 5632 D: 14847 
passed LTC
http://tests.stockfishchess.org/tests/view/5dcfa5760ebc590256326464
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 30600 W: 5042 L: 4784 D: 20774 
this patch introduces what I've been trying for quite some time - dependance of kingdanger from kingflank defenders to not overestimate attacking power if opponent has enough defenders of king position. We already have some form of it in bishop and knight defenders - this is further work in this direction.
What to do based on this? 
1) constant is arbitrary. Maybe it is not optimal;
2) maybe we can use quadratic formula as in kingflankattacks;
3) simplification into alrealy existing terms is always a possibility :) ;
4) overall kingdanger tuning always can be done.
bench 4496847