### PR TITLE
Simplify advanced pawn push pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -967,8 +967,7 @@ moves_loop: // When in check, search starts from here
           moveCountPruning = moveCount >= futility_move_count(improving, depth);
 
           if (   !captureOrPromotion
-              && !givesCheck
-              && (!PvNode || !pos.advanced_pawn_push(move) || pos.non_pawn_material(~us) > BishopValueMg))
+              && !givesCheck)
           {
               // Reduced depth of the next LMR search
               int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount), 0);


### PR DESCRIPTION
passed STC
http://tests.stockfishchess.org/tests/view/5dcdb3110ebc5902563249d7
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 159143 W: 34271 L: 34418 D: 90454 
passed LTC
http://tests.stockfishchess.org/tests/view/5dd05e820ebc5902579e1fb8
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 63900 W: 10375 L: 10322 D: 43203 
This patch simplifies away all conditions related to advanced pawn pushes in shallow depth pruning.
Idea is based on fact that in master we have advanced pawn pushes not being pruned what we are only in PV node and when non-pawn material of opponent is > Bishop, so pretty rarely. With this patch we will have all pruning heuristics working for this moves as for every other move.
bench 4490045