### PR TITLE
Simplify OCB scale factor

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -752,7 +752,7 @@ namespace {
     {
         if (   pos.opposite_bishops()
             && pos.non_pawn_material() == 2 * BishopValueMg)
-            sf = 16 + 4 * pe->passed_count();
+            sf = 22 ;
         else
             sf = std::min(sf, 36 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide));
 


### PR DESCRIPTION
Stockfish is continually improving. Patches that gain elo in the past may no longer be needed as stockfish improved elsewhere. This patch removes passed_count dependence in OCB scale factor. Use the mean of passed_count to compensate. This changes the base value from 16 to 22.

Passed STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 57879 W: 12657 L: 12607 D: 32615
http://tests.stockfishchess.org/tests/view/5dd1644f42928ff08153dc1e

Passed LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 121648 W: 19622 L: 19659 D: 82367
http://tests.stockfishchess.org/tests/view/5dd24572ccb823d41d4b47bb

Bench: 4942036

----------------------------

Run-Time Statistics
Step 2/4. Running benchmark for pgo-build ...
./stockfish.exe bench > /dev/null

Position: 1/46  Position: 2/46  Position: 3/46  Position: 4/46  Position: 5/46
Total 57 Mean 1.33333

Position: 6/46  Position: 7/46  Position: 8/46  Position: 9/46
Total 57 Mean 1.33333

Position: 10/46  Position: 11/46  Position: 12/46  Position: 13/46
Total 57 Mean 1.33333

Position: 14/46  Position: 15/46  Position: 16/46  Position: 17/46  Position: 18/46  Position: 19/46 
Position: 20/46
Total 60 Mean 1.35

Position: 21/46  Position: 22/46  Position: 23/46  Position: 24/46  Position: 25/46  Position: 26/46 
Position: 27/46  Position: 28/46  Position: 29/46  Position: 30/46  Position: 31/46  Position: 32/46
Total 110 Mean 1.45455

Position: 33/46  Position: 34/46  Position: 35/46  Position: 36/46  Position: 37/46  Position: 38/46
Total 110 Mean 1.45455

Position: 39/46  Position: 40/46  Position: 41/46  Position: 42/46  Position: 43/46  Position: 44/46
Position: 45/46  Position: 46/46
Total 110 Mean 1.45455

===========================
Total time (ms) : 6945
Nodes searched  : 4496847
Nodes/second    : 647494

Passed Count Mean: 1.3877