### PR TITLE
Do lmr for more captures.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1084,7 +1084,8 @@ moves_loop: // When in check, search starts from here
           && (  !captureOrPromotion
               || moveCountPruning
               || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha
-              || cutNode))
+              || cutNode
+              || thisThread->ttHitAverage < 3 * ttHitAverageResolution * ttHitAverageWindow / 8))
       {
           Depth r = reduction(improving, depth, moveCount);
 


### PR DESCRIPTION
passed STC
http://tests.stockfishchess.org/tests/view/5dd4d51df531e81cf278eaac
LLR: 2.97 (-2.94,2.94) [-1.50,4.50]
Total: 16495 W: 3591 L: 3434 D: 9470 
passed LTC
http://tests.stockfishchess.org/tests/view/5dd52265f531e81cf278eace
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 23598 W: 3956 L: 3716 D: 15926 
based on machinery introduced by vondele. Logic behind patch if relatively simple - if we reduce less with high hitrate of TT somewhat logical is to reduce more with low hitrate. For example enable all captures for LMR.
Constant is arbitrary and can be tweaked. :)
bench 5183523