### PR TITLE
Extend last non-pawn captures

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1052,7 +1052,7 @@ moves_loop: // When in check, search starts from here
       // Last captures extension
       else if (PvNode
                && PieceValue[EG][pos.captured_piece()] > PawnValueEg
-               && pos.non_pawn_material() < 4000)
+               && pos.non_pawn_material() < 2600)
           extension = 1;
 
       // Castling extension

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1050,7 +1050,7 @@ moves_loop: // When in check, search starts from here
           extension = 1;
 
       // Last captures extension
-      else if (PvNode
+      else if (   PvNode
                && PieceValue[EG][pos.captured_piece()] > PawnValueEg
                && pos.non_pawn_material() < 2600)
           extension = 1;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1049,6 +1049,12 @@ moves_loop: // When in check, search starts from here
                && pos.pawn_passed(us, to_sq(move)))
           extension = 1;
 
+      // Last captures extension
+      else if (PvNode
+               && PieceValue[EG][pos.captured_piece()] > PawnValueEg
+               && pos.non_pawn_material() < 4000)
+          extension = 1;
+
       // Castling extension
       if (type_of(move) == CASTLING)
           extension = 1;


### PR DESCRIPTION
Extend last non-pawn captures at PV line because they are in general decisive moves with clear EG result.

STC
http://tests.stockfishchess.org/tests/view/5ddafc86e75c0005326d2140
LLR: 2.96 (-2.94,2.94) [-1.50,4.50]
Total: 9892 W: 2238 L: 2099 D: 5555 

LTC
http://tests.stockfishchess.org/tests/view/5ddb0401e75c0005326d2150
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 30369 W: 5013 L: 4756 D: 20600 

bench 5059526