### PR TITLE
Simplify kingdanger

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -449,13 +449,13 @@ namespace {
                  + 148 * popcount(unsafeChecks)
                  +  98 * popcount(pos.blockers_for_king(Us))
                  +  69 * kingAttacksCount[Them]
-                 +   4 * (kingFlankAttack - kingFlankDefense)
                  +   3 * kingFlankAttack * kingFlankAttack / 8
                  +       mg_value(mobility[Them] - mobility[Us])
                  - 873 * !pos.count<QUEEN>(Them)
                  - 100 * bool(attackedBy[Us][KNIGHT] & attackedBy[Us][KING])
                  -   6 * mg_value(score) / 8
-                 -   7;
+                 -   4 * kingFlankDefense
+                 +  37;
 
     // Transform the kingDanger units into a Score, and subtract it from the evaluation
     if (kingDanger > 100)


### PR DESCRIPTION
passed STC
http://tests.stockfishchess.org/tests/view/5ddc2b99e0b4af579302bacf
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 19660 W: 4309 L: 4184 D: 11167
passed LTC
http://tests.stockfishchess.org/tests/view/5ddc3168e0b4af579302bade
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 24362 W: 3974 L: 3859 D: 16529
This patch is a cleanup/simplification of king flank defenders patch, removes king flanks attacks linear dependance in kingdanger. Result of experiments with quadratic kingflank defenders scaling. Rebased on the latest master.
bench 5742013
