### PR TITLE
Travis CI: The sudo: tag is deprecates in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: cpp
-sudo: required
 dist: xenial
 
 matrix:


### PR DESCRIPTION
__sudo: required__ no longer is.