### PR TITLE
Remove check restriction from static evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -847,9 +847,6 @@ Value Eval::evaluate(const Position& pos) {
 
 std::string Eval::trace(const Position& pos) {
 
-  if (pos.checkers())
-      return "Total evaluation: none (in check)";
-
   std::memset(scores, 0, sizeof(scores));
 
   pos.this_thread()->contempt = SCORE_ZERO; // Reset any dynamic contempt


### PR DESCRIPTION
This is to address issue #2433.
It allows static evaluation to be run on a valid position when the side to move is in check. Realistically a static evaluation in such a situation is likely to be inaccurate and misleading, but it should be up to the user to interpret the results correctly.