### PR TITLE
Adjust fallingEval with score change in last 5 iterations.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -335,6 +335,7 @@ void Thread::search() {
   MainThread* mainThread = (this == Threads.main() ? Threads.main() : nullptr);
   double timeReduction = 1, totBestMoveChanges = 0;
   Color us = rootPos.side_to_move();
+  int iterIdx = 0;
 
   std::memset(ss-7, 0, 10 * sizeof(Stack));
   for (int i = 7; i > 0; i--)
@@ -344,6 +345,16 @@ void Thread::search() {
 
   bestValue = delta = alpha = -VALUE_INFINITE;
   beta = VALUE_INFINITE;
+
+  if (mainThread)
+  {
+      if (mainThread->previousScore == VALUE_INFINITE)
+          for (int i=0; i<4; ++i)
+              mainThread->iterValue[i] = VALUE_ZERO;
+      else
+          for (int i=0; i<4; ++i)
+              mainThread->iterValue[i] = mainThread->previousScore;
+  }
 
   size_t multiPV = Options["MultiPV"];
 
@@ -520,7 +531,8 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (354 + 10 * (mainThread->previousScore - bestValue)) / 692.0;
+          double fallingEval = (354 +  6 * (mainThread->previousScore - bestValue)
+                                    +  6 * (mainThread->iterValue[iterIdx]  - bestValue)) / 692.0;
           fallingEval = clamp(fallingEval, 0.5, 1.5);
 
           // If the bestMove is stable over several iterations, reduce time accordingly
@@ -547,6 +559,9 @@ void Thread::search() {
                   Threads.stop = true;
           }
       }
+
+      mainThread->iterValue[iterIdx] = bestValue;
+      iterIdx = (iterIdx + 1) & 3;
   }
 
   if (!mainThread)

--- a/src/thread.h
+++ b/src/thread.h
@@ -88,6 +88,7 @@ struct MainThread : public Thread {
 
   double previousTimeReduction;
   Value previousScore;
+  Value iterValue[4];
   int callsCnt;
   bool stopOnPonderhit;
   std::atomic_bool ponder;


### PR DESCRIPTION
FallingEval adjusts the time used on a move depending on whether the position score is better or worse than on the previous move. This change adds a dependency on the score change in the last 4 iterations of the current search.

Tests with original code:
STC :
LLR: 2.97 (-2.94,2.94) [-1.50,4.50]
Total: 18728 W: 4170 L: 4005 D: 10553
https://tests.stockfishchess.org/tests/view/5de68a5bb407ee7bfda68a94

LTC :
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 180217 W: 29214 L: 28551 D: 122452
https://tests.stockfishchess.org/tests/view/5de690a4b407ee7bfda68a9a

Revised code using a simple array instead of a deque and different values gave a slightly quicker pass at LTC. PR now updated to use this:

STC :
LLR: 2.96 (-2.94,2.94) [-1.50,4.50]
Total: 18616 W: 4114 L: 3950 D: 10552
https://tests.stockfishchess.org/tests/view/5debb790b7bdefd50db28d14

LTC :
LLR: 2.96 (-2.94,2.94) [0.00,3.50]
Total: 134151 W: 21729 L: 21191 D: 91231
https://tests.stockfishchess.org/tests/view/5debc13fb7bdefd50db28d19

Bench 5122362