### PR TITLE
Type Safety for CastlingRights

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -812,7 +812,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   // Update castling rights if needed
   if (st->castlingRights && (castlingRightsMask[from] | castlingRightsMask[to]))
   {
-      int cr = castlingRightsMask[from] | castlingRightsMask[to];
+      CastlingRights cr = castlingRightsMask[from] | castlingRightsMask[to];
       k ^= Zobrist::castling[st->castlingRights & cr];
       st->castlingRights &= ~cr;
   }

--- a/src/position.h
+++ b/src/position.h
@@ -40,7 +40,7 @@ struct StateInfo {
   Key    pawnKey;
   Key    materialKey;
   Value  nonPawnMaterial[COLOR_NB];
-  int    castlingRights;
+  CastlingRights castlingRights;
   int    rule50;
   int    pliesFromNull;
   Square epSquare;
@@ -99,7 +99,7 @@ public:
   bool is_on_semiopen_file(Color c, Square s) const;
 
   // Castling
-  int castling_rights(Color c) const;
+  CastlingRights castling_rights(Color c) const;
   bool can_castle(CastlingRights cr) const;
   bool castling_impeded(CastlingRights cr) const;
   Square castling_rook_square(CastlingRights cr) const;
@@ -186,7 +186,7 @@ private:
   int pieceCount[PIECE_NB];
   Square pieceList[PIECE_NB][16];
   int index[SQUARE_NB];
-  int castlingRightsMask[SQUARE_NB];
+  CastlingRights castlingRightsMask[SQUARE_NB];
   Square castlingRookSquare[CASTLING_RIGHT_NB];
   Bitboard castlingPath[CASTLING_RIGHT_NB];
   int gamePly;
@@ -272,7 +272,7 @@ inline bool Position::can_castle(CastlingRights cr) const {
   return st->castlingRights & cr;
 }
 
-inline int Position::castling_rights(Color c) const {
+inline CastlingRights Position::castling_rights(Color c) const {
   return st->castlingRights & (c == WHITE ? WHITE_CASTLING : BLACK_CASTLING);
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -288,6 +288,10 @@ inline T& operator--(T& d) { return d = T(int(d) - 1); }
 ENABLE_BASE_OPERATORS_ON(T)                                        \
 constexpr T operator*(int i, T d) { return T(i * int(d)); }        \
 constexpr T operator*(T d, int i) { return T(int(d) * i); }        \
+constexpr T operator&(int d1, T d2) { return T(int(d1) & int(d2));} \
+inline T& operator&=(T& d1, T d2) { return d1 = d1 & d2; }          \
+constexpr T operator|(int d1, T d2) { return T(int(d1) | int(d2));} \
+inline T& operator|=(T& d1, T d2) { return d1 = d1 | d2; }          \
 constexpr T operator/(T d, int i) { return T(int(d) / i); }        \
 constexpr int operator/(T d1, T d2) { return int(d1) / int(d2); }  \
 inline T& operator*=(T& d, int i) { return d = T(int(d) * i); }    \
@@ -295,6 +299,7 @@ inline T& operator/=(T& d, int i) { return d = T(int(d) / i); }
 
 ENABLE_FULL_OPERATORS_ON(Value)
 ENABLE_FULL_OPERATORS_ON(Direction)
+ENABLE_FULL_OPERATORS_ON(CastlingRights)
 
 ENABLE_INCR_OPERATORS_ON(PieceType)
 ENABLE_INCR_OPERATORS_ON(Piece)
@@ -360,23 +365,6 @@ constexpr Piece operator~(Piece pc) {
 
 inline File map_to_queenside(File f) {
   return std::min(f, File(FILE_H - f)); // Map files ABCDEFGH to files ABCDDCBA
-}
-
-/// Operators for CastlingRights
-constexpr CastlingRights operator&(CastlingRights cr1, CastlingRights cr2) {
-  return CastlingRights(int(cr1) & int(cr2));
-}
-
-inline CastlingRights operator&=(CastlingRights& cr1, CastlingRights cr2) {
-  return cr1 = cr1 & cr2;
-}
-
-constexpr CastlingRights operator|(CastlingRights cr1, CastlingRights cr2) {
-  return CastlingRights(int(cr1) | int(cr2));
-}
-
-inline CastlingRights operator|=(CastlingRights& cr1, CastlingRights cr2) {
-  return cr1 = cr1 | cr2;
 }
 
 constexpr CastlingRights operator&(Color c, CastlingRights cr) {

--- a/src/types.h
+++ b/src/types.h
@@ -288,7 +288,7 @@ inline T& operator--(T& d) { return d = T(int(d) - 1); }
 constexpr T operator&(int d1, T d2) { return T(int(d1) & int(d2));} \
 inline T& operator&=(T& d1, T d2) { return d1 = d1 & d2; }          \
 constexpr T operator|(int d1, T d2) { return T(int(d1) | int(d2));} \
-inline T& operator|=(T& d1, T d2) { return d1 = d1 | d2; }          \
+inline T& operator|=(T& d1, T d2) { return d1 = d1 | d2; }
 
 #define ENABLE_FULL_OPERATORS_ON(T)                                \
 ENABLE_BASE_OPERATORS_ON(T)                                        \

--- a/src/types.h
+++ b/src/types.h
@@ -362,8 +362,29 @@ inline File map_to_queenside(File f) {
   return std::min(f, File(FILE_H - f)); // Map files ABCDEFGH to files ABCDDCBA
 }
 
+/// Operators for CastlingRights
+constexpr CastlingRights operator&(CastlingRights cr1, CastlingRights cr2) {
+  return CastlingRights(int(cr1) & int(cr2));
+}
+
+inline CastlingRights operator&=(CastlingRights& cr1, CastlingRights cr2) {
+  return cr1 = cr1 & cr2;
+}
+
+constexpr CastlingRights operator|(CastlingRights cr1, CastlingRights cr2) {
+  return CastlingRights(int(cr1) | int(cr2));
+}
+
+inline CastlingRights operator|=(CastlingRights& cr1, CastlingRights cr2) {
+  return cr1 = cr1 | cr2;
+}
+
 constexpr CastlingRights operator&(Color c, CastlingRights cr) {
   return CastlingRights((c == WHITE ? WHITE_CASTLING : BLACK_CASTLING) & cr);
+}
+
+constexpr CastlingRights operator~(CastlingRights cr) {
+  return CastlingRights(~(int(cr)));
 }
 
 constexpr Value mate_in(int ply) {

--- a/src/types.h
+++ b/src/types.h
@@ -284,14 +284,16 @@ inline T& operator-=(T& d1, T d2) { return d1 = d1 - d2; }
 inline T& operator++(T& d) { return d = T(int(d) + 1); }           \
 inline T& operator--(T& d) { return d = T(int(d) - 1); }
 
-#define ENABLE_FULL_OPERATORS_ON(T)                                \
-ENABLE_BASE_OPERATORS_ON(T)                                        \
-constexpr T operator*(int i, T d) { return T(i * int(d)); }        \
-constexpr T operator*(T d, int i) { return T(int(d) * i); }        \
+#define ENABLE_BITWISE_OPERATORS_ON(T)                              \
 constexpr T operator&(int d1, T d2) { return T(int(d1) & int(d2));} \
 inline T& operator&=(T& d1, T d2) { return d1 = d1 & d2; }          \
 constexpr T operator|(int d1, T d2) { return T(int(d1) | int(d2));} \
 inline T& operator|=(T& d1, T d2) { return d1 = d1 | d2; }          \
+
+#define ENABLE_FULL_OPERATORS_ON(T)                                \
+ENABLE_BASE_OPERATORS_ON(T)                                        \
+constexpr T operator*(int i, T d) { return T(i * int(d)); }        \
+constexpr T operator*(T d, int i) { return T(int(d) * i); }        \
 constexpr T operator/(T d, int i) { return T(int(d) / i); }        \
 constexpr int operator/(T d1, T d2) { return int(d1) / int(d2); }  \
 inline T& operator*=(T& d, int i) { return d = T(int(d) * i); }    \
@@ -299,7 +301,7 @@ inline T& operator/=(T& d, int i) { return d = T(int(d) / i); }
 
 ENABLE_FULL_OPERATORS_ON(Value)
 ENABLE_FULL_OPERATORS_ON(Direction)
-ENABLE_FULL_OPERATORS_ON(CastlingRights)
+ENABLE_BITWISE_OPERATORS_ON(CastlingRights)
 
 ENABLE_INCR_OPERATORS_ON(PieceType)
 ENABLE_INCR_OPERATORS_ON(Piece)


### PR DESCRIPTION
This is a non-functional code-style change that provides type safety for CastlingRights which (in master) is sometimes an int and sometimes a CastlingRights.

This generates exactly the same executable, so I don't believe testing is necessary.