### PR TITLE
Fix output of PV lines with invalid scores

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1727,7 +1727,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
 
   for (size_t i = 0; i < multiPV; ++i)
   {
-      bool updated = (i <= pvIdx && rootMoves[i].score != -VALUE_INFINITE);
+      bool updated = rootMoves[i].score != -VALUE_INFINITE;
 
       if (depth == 1 && !updated)
           continue;


### PR DESCRIPTION
in a MultiPV search.

This is a follow-up patch to https://github.com/official-stockfish/Stockfish/commit/8b15961349e18a9ba113973c53f53913d0cd0fad and makes the fix finally complete.

As reported on the forum here https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/PrnoDLvMvro it is possible, on very rare occasions, that we are trying to print a PV line with an invalid `previousScore`, although this line has a valid actual `score`.

The reason is the `i <= pvIdx` condition which probably is a leftover from the times there was a special root search function. This check is no longer needed today and prevents PV lines past the current one (current pvIdx) to be flagged as `updated` even though they do have a valid score.

No functional change.