### PR TITLE
Simplify see pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1464,9 +1464,7 @@ moves_loop: // When in check, search starts from here
                        && !pos.capture(move);
 
       // Don't search moves with negative SEE values
-      if (  (!inCheck || evasionPrunable)
-          && !(givesCheck && pos.is_discovery_check_on_king(~pos.side_to_move(), move))
-          && !pos.see_ge(move))
+      if (  (!inCheck || evasionPrunable) && !pos.see_ge(move))
           continue;
 
       // Speculative prefetch as early as possible


### PR DESCRIPTION
This is a functional simplification that simplifies pruning moves with negative SEE values.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 18847 W: 4211 L: 4084 D: 10552
http://tests.stockfishchess.org/tests/view/5de983f2caa7c610e4d1866e

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 25556 W: 4200 L: 4087 D: 17269
http://tests.stockfishchess.org/tests/view/5de99e21caa7c610e4d18676

Bench 5390930