### PR TITLE
Do last caprute extensions for every single node.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1050,8 +1050,7 @@ moves_loop: // When in check, search starts from here
           extension = 1;
 
       // Last captures extension
-      else if (   PvNode
-               && PieceValue[EG][pos.captured_piece()] > PawnValueEg
+      else if (   PieceValue[EG][pos.captured_piece()] > PawnValueEg
                && pos.non_pawn_material() <= 2 * RookValueMg)
           extension = 1;
 


### PR DESCRIPTION
passed STC 
http://tests.stockfishchess.org/tests/view/5deb9a3eb7bdefd50db28d0e
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 80244 W: 17421 L: 17414 D: 45409 
passed LTC
http://tests.stockfishchess.org/tests/view/5deba860b7bdefd50db28d11
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 21506 W: 3565 L: 3446 D: 14495 
This patch simplifies latest @MJZ1977 elo gainer. Seems like PvNode check in condition of last capture extension is not needed.
Note - even if this is a simplification it actually causes this extension to be applied more often, thus strenghtening effect of this patch.
bench 5417656