### PR TITLE
Tune razor and futility margins

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -65,9 +65,9 @@ namespace {
   constexpr uint64_t ttHitAverageResolution = 1024;
 
   // Razor and futility margins
-  constexpr int RazorMargin = 661;
+  constexpr int RazorMargin = 594;
   Value futility_margin(Depth d, bool improving) {
-    return Value(198 * (d - improving));
+    return Value(232 * (d - improving));
   }
 
   // Reductions lookup table, initialized at startup


### PR DESCRIPTION
Tuning was done with Bayesian optimisation with the following parameters:
Acquisition function: Expected Improvement
alpha: 0.05
xi: 1e-4
TC: 60+0.6
Number of iterations: 100
Initial points: 5
Batch size: 20 games

STC
http://tests.stockfishchess.org/tests/view/5dee291e3cff9a249bb9e470
LLR: 2.97 (-2.94,2.94) [-1.50,4.50]
Total: 19586 W: 4382 L: 4214 D: 10990

LTC
http://tests.stockfishchess.org/tests/view/5dee4e273cff9a249bb9e473
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 38840 W: 6315 L: 6036 D: 26489

Bench 5767220