### PR TITLE
Refine improving-logic

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -812,8 +812,8 @@ namespace {
         &&  eval <= alpha - RazorMargin)
         return qsearch<NT>(pos, ss, alpha, beta);
 
-    improving =   ss->staticEval >= (ss-2)->staticEval
-               || (ss-2)->staticEval == VALUE_NONE;
+    improving =  (ss-2)->staticEval == VALUE_NONE ? (ss->staticEval >= (ss-4)->staticEval
+              || (ss-4)->staticEval == VALUE_NONE) : ss->staticEval >= (ss-2)->staticEval;
 
     // Step 8. Futility pruning: child node (~30 Elo)
     if (   !PvNode


### PR DESCRIPTION
Don't rely on the assumption that we are improving after surviving a check. 
Instead, compare with the static evaluation of 2 moves before.

STC
https://tests.stockfishchess.org/tests/view/5dedfd7f3cff9a249bb9e44d
LLR: 2.95 (-2.94,2.94) [-1.50,4.50]
Total: 38859 W: 8621 L: 8397 D: 21841

LTC
https://tests.stockfishchess.org/tests/view/5dee1b5a3cff9a249bb9e465
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 51130 W: 8308 L: 7996 D: 34826

Bench: 5371271