### PR TITLE
Some small tidyup.

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -46,7 +46,6 @@ struct StateInfo {
   Square epSquare;
 
   // Not copied when making a move (will be recomputed anyhow)
-  int repetition;
   Key        key;
   Bitboard   checkersBB;
   Piece      capturedPiece;
@@ -54,6 +53,7 @@ struct StateInfo {
   Bitboard   blockersForKing[COLOR_NB];
   Bitboard   pinners[COLOR_NB];
   Bitboard   checkSquares[PIECE_TYPE_NB];
+  int        repetition;
 };
 
 /// A list to keep track of the position states along the setup moves (from the

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -344,10 +344,8 @@ void Thread::search() {
   beta = VALUE_INFINITE;
 
   if (mainThread && mainThread->previousScore != VALUE_INFINITE)
-  {
       for (int i = 0; i < 4; ++i)
           mainThread->iterValue[i] = mainThread->previousScore;
-  }
 
   size_t multiPV = Options["MultiPV"];
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -237,11 +237,8 @@ void MainThread::search() {
   else
   {
       for (Thread* th : Threads)
-      {
-          th->bestMoveChanges = 0;
           if (th != this)
               th->start_searching();
-      }
 
       Thread::search(); // Let's start searching!
   }
@@ -346,14 +343,10 @@ void Thread::search() {
   bestValue = delta = alpha = -VALUE_INFINITE;
   beta = VALUE_INFINITE;
 
-  if (mainThread)
+  if (mainThread && mainThread->previousScore != VALUE_INFINITE)
   {
-      if (mainThread->previousScore == VALUE_INFINITE)
-          for (int i=0; i<4; ++i)
-              mainThread->iterValue[i] = VALUE_ZERO;
-      else
-          for (int i=0; i<4; ++i)
-              mainThread->iterValue[i] = mainThread->previousScore;
+      for (int i = 0; i < 4; ++i)
+          mainThread->iterValue[i] = mainThread->previousScore;
   }
 
   size_t multiPV = Options["MultiPV"];

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -168,6 +168,9 @@ void ThreadPool::clear() {
   main()->callsCnt = 0;
   main()->previousScore = VALUE_INFINITE;
   main()->previousTimeReduction = 1.0;
+
+  for (int i = 0; i < 4; ++i)
+      main()->iterValue[i] = VALUE_ZERO;
 }
 
 /// ThreadPool::start_thinking() wakes up main thread waiting in idle_loop() and
@@ -207,7 +210,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
 
   for (Thread* th : *this)
   {
-      th->nodes = th->tbHits = th->nmpMinPly = 0;
+      th->nodes = th->tbHits = th->bestMoveChanges = th->nmpMinPly = 0;
       th->rootDepth = th->completedDepth = 0;
       th->rootMoves = rootMoves;
       th->rootPos.set(pos.fen(), pos.is_chess960(), &setupStates->back(), th);


### PR DESCRIPTION
This patch is a small tidyup/rearranging of code.

Move `repetition` variable inside the StateInfo object down so that it doesn't get copied.
This solves https://github.com/official-stockfish/Stockfish/issues/2443.

Initialize `bestMoveChanges` along with other counters in ThreadPool::start_thinking().

Move the initialization of the main thread's `iterValue` array into ThreadPool::clear(),
where we also reset `previousScore`.

No functional change.