### PR TITLE
Template some bitboard stuff.

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -208,34 +208,41 @@ inline Bitboard between_bb(Square s1, Square s2) {
 /// in front of the given one, from the point of view of the given color. For instance,
 /// forward_ranks_bb(BLACK, SQ_D3) will return the 16 squares on ranks 1 and 2.
 
-inline Bitboard forward_ranks_bb(Color c, Square s) {
-  return c == WHITE ? ~Rank1BB << 8 * (rank_of(s) - RANK_1)
+template<Color C> inline Bitboard forward_ranks_bb(Square s) {
+  return C == WHITE ? ~Rank1BB << 8 * (rank_of(s) - RANK_1)
                     : ~Rank8BB >> 8 * (RANK_8 - rank_of(s));
+}
+
+inline Bitboard forward_ranks_bb(Color c, Square s) {
+  return c == WHITE ? forward_ranks_bb<WHITE>(s) : forward_ranks_bb<BLACK>(s);
 }
 
 
 /// forward_file_bb() returns a bitboard representing all the squares along the
 /// line in front of the given one, from the point of view of the given color.
 
-inline Bitboard forward_file_bb(Color c, Square s) {
-  return forward_ranks_bb(c, s) & file_bb(s);
+template<Color C> inline Bitboard forward_file_bb(Square s) {
+  return forward_ranks_bb<C>(s) & file_bb(s);
 }
 
+inline Bitboard forward_file_bb(Color c, Square s) {
+  return c == WHITE ? forward_file_bb<WHITE>(s) : forward_file_bb<BLACK>(s);
+}
 
 /// pawn_attack_span() returns a bitboard representing all the squares that can
 /// be attacked by a pawn of the given color when it moves along its file,
 /// starting from the given square.
 
-inline Bitboard pawn_attack_span(Color c, Square s) {
-  return forward_ranks_bb(c, s) & adjacent_files_bb(s);
+template<Color C> inline Bitboard pawn_attack_span(Square s) {
+  return forward_ranks_bb<C>(s) & adjacent_files_bb(s);
 }
 
 
 /// passed_pawn_span() returns a bitboard which can be used to test if a pawn of
 /// the given color and on the given square is a passed pawn.
 
-inline Bitboard passed_pawn_span(Color c, Square s) {
-  return forward_ranks_bb(c, s) & (adjacent_files_bb(s) | file_bb(s));
+template<Color C> inline Bitboard passed_pawn_span(Square s) {
+  return forward_ranks_bb<C>(s) & (adjacent_files_bb(s) | file_bb(s));
 }
 
 

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -209,7 +209,7 @@ Value Endgame<KRKP>::operator()(const Position& pos) const {
   Value result;
 
   // If the stronger side's king is in front of the pawn, it's a win
-  if (forward_file_bb(WHITE, wksq) & psq)
+  if (forward_file_bb<WHITE>(wksq) & psq)
       result = RookValueEg - distance(wksq, psq);
 
   // If the weaker side's king is too far from the pawn and the rook,

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -613,7 +613,7 @@ namespace {
             if (pos.empty(blockSq))
             {
                 squaresToQueen = forward_file_bb(Us, s);
-                unsafeSquares = passed_pawn_span(Us, s);
+                unsafeSquares = passed_pawn_span<Us>(s);
 
                 bb = forward_file_bb(Them, s) & pos.pieces(ROOK, QUEEN);
 

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -97,7 +97,7 @@ namespace {
         // Flag the pawn
         opposed    = theirPawns & forward_file_bb(Us, s);
         blocked    = theirPawns & (s + Up);
-        stoppers   = theirPawns & passed_pawn_span(Us, s);
+        stoppers   = theirPawns & passed_pawn_span<Us>(s);
         lever      = theirPawns & PawnAttacks[Us][s];
         leverPush  = theirPawns & PawnAttacks[Us][s + Up];
         doubled    = ourPawns   & (s - Up);
@@ -112,7 +112,7 @@ namespace {
 
         // Compute additional span if pawn is not backward nor blocked
         if (!backward && !blocked)
-            e->pawnAttacksSpan[Us] |= pawn_attack_span(Us, s);
+            e->pawnAttacksSpan[Us] |= pawn_attack_span<Us>(s);
 
         // A pawn is passed if one of the three following conditions is true:
         // (a) there is no stoppers except some levers

--- a/src/position.h
+++ b/src/position.h
@@ -323,7 +323,8 @@ inline bool Position::is_discovery_check_on_king(Color c, Move m) const {
 }
 
 inline bool Position::pawn_passed(Color c, Square s) const {
-  return !(pieces(~c, PAWN) & passed_pawn_span(c, s));
+  return !(pieces(~c, PAWN) & (c == WHITE ? passed_pawn_span<WHITE>(s)
+                                          : passed_pawn_span<BLACK>(s)));
 }
 
 inline bool Position::advanced_pawn_push(Move m) const {


### PR DESCRIPTION
This is a non-functional speed-up.  By templating a few of these bitboard operations, more calculations can be done at compile time.  On my machines, the speed-up is less than 1% so I didn't expect it to pass -1.5,4.  Since it passed, I submit here for consideration.

I could add for passed_pawn_span, and also perhaps frontmost_sq.

Benchmarks from others would be very valuable.

STC
LLR: 2.95 (-2.94,2.94) [-1.50,4.50]
Total: 10488 W: 2365 L: 2256 D: 5867
Ptnml(0-2): 114, 1091, 2739, 1161, 133
http://tests.stockfishchess.org/tests/view/5dfc1742e70446e17e45100d

I did not plan an LTC because it is non-functional.

Bench 5371271