### PR TITLE
Map posKey to 0 in case of excludedMove

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -676,7 +676,7 @@ namespace {
 
     // Step 4. Transposition table lookup. We don't want the score of a partial
     // search to overwrite a previous full search TT value, so we use a different
-    // position key in case of an excluded move.
+    // and basically unused position key in case of an excluded move.
     excludedMove = ss->excludedMove;
     posKey = excludedMove ? 0 : pos.key();
     tte = TT.probe(posKey, ttHit);
@@ -916,7 +916,7 @@ namespace {
     }
 
     // Step 11. Internal iterative deepening (~2 Elo)
-    if (depth >= 7 && !ttMove)
+    if (depth >= 8 && !ttMove)
     {
         search<NT>(pos, ss, alpha, beta, depth - 7, cutNode);
 
@@ -1333,6 +1333,7 @@ moves_loop: // When in check, search starts from here
     assert(alpha >= -VALUE_INFINITE && alpha < beta && beta <= VALUE_INFINITE);
     assert(PvNode || (alpha == beta - 1));
     assert(depth <= 0);
+    assert(ss->excludedMove == MOVE_NONE);
 
     Move pv[MAX_PLY+1];
     StateInfo st;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -678,7 +678,7 @@ namespace {
     // search to overwrite a previous full search TT value, so we use a different
     // position key in case of an excluded move.
     excludedMove = ss->excludedMove;
-    posKey = pos.key() ^ Key(excludedMove << 16); // Isn't a very good hash
+    posKey = excludedMove ? 0 : pos.key();
     tte = TT.probe(posKey, ttHit);
     ttValue = ttHit ? value_from_tt(tte->value(), ss->ply, pos.rule50_count()) : VALUE_NONE;
     ttMove =  rootNode ? thisThread->rootMoves[thisThread->pvIdx].pv[0]

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1333,7 +1333,6 @@ moves_loop: // When in check, search starts from here
     assert(alpha >= -VALUE_INFINITE && alpha < beta && beta <= VALUE_INFINITE);
     assert(PvNode || (alpha == beta - 1));
     assert(depth <= 0);
-    assert(ss->excludedMove == MOVE_NONE);
 
     Move pv[MAX_PLY+1];
     StateInfo st;


### PR DESCRIPTION
in the case of excluded move we don't save search results to TT... so there's nothing to read there either.
Instead of trying to construct a (poor) new hash, just map these to 0.

passed STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 27423 W: 6080 L: 5970 D: 15373
http://tests.stockfishchess.org/tests/view/5dfa29c6cde01bf360ab7976

passed LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 224628 W: 35865 L: 36060 D: 152703
http://tests.stockfishchess.org/tests/view/5dfa780181e8c7e718ececb8

Bench: 5406272