### PR TITLE
Advise the kernel to use huge pages (Linux)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -358,6 +358,11 @@ ifeq ($(OS), Android)
 	LDFLAGS += -fPIE -pie
 endif
 
+### 3.10 madvise + transparent huge pages
+ifeq ($(KERNEL),Linux)
+	CXXFLAGS += -DUSE_MADVISE_HUGEPAGE
+endif
+
 
 ### ==========================================================================
 ### Section 4. Public targets

--- a/src/misc.h
+++ b/src/misc.h
@@ -33,6 +33,14 @@ const std::string engine_info(bool to_uci = false);
 void prefetch(void* addr);
 void start_logger(const std::string& fname);
 
+// The assumed cache line size. When C++17 is universally available, we should
+// use std::hardware_destructive_interference_size.
+constexpr size_t CacheLineSize = 64;
+
+// Returns aligned memory pointer for transposition table. To free, use
+// free(mem).
+void* aligned_ttmem_alloc(size_t size, void** mem);
+
 void dbg_hit_on(bool b);
 void dbg_hit_on(bool c, bool b);
 void dbg_mean_of(int v);

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -66,7 +66,8 @@ void TranspositionTable::resize(size_t mbSize) {
   clusterCount = mbSize * 1024 * 1024 / sizeof(Cluster);
 
   free(mem);
-  mem = malloc(clusterCount * sizeof(Cluster) + CacheLineSize - 1);
+
+  table = static_cast<Cluster*>(aligned_ttmem_alloc(clusterCount * sizeof(Cluster), &mem));
 
   if (!mem)
   {
@@ -75,7 +76,6 @@ void TranspositionTable::resize(size_t mbSize) {
       exit(EXIT_FAILURE);
   }
 
-  table = (Cluster*)((uintptr_t(mem) + CacheLineSize - 1) & ~(CacheLineSize - 1));
   clear();
 }
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -66,7 +66,6 @@ private:
 
 class TranspositionTable {
 
-  static constexpr int CacheLineSize = 64;
   static constexpr int ClusterSize = 3;
 
   struct Cluster {


### PR DESCRIPTION
Align the TT allocation by 2M to make it huge page friendly and advise the
kernel to use huge pages.

Benchmarks on my i7-8700K (6C/12T) box: (3 runs per bench per config)

```
                   vanilla (nps)               hugepages (nps)              avg
=================================================================================
bench              3012490  3024364  3036331   3071052  3067544  3071052    +1.5%
bench 16 12 20     19237932 19050166 19085315  19266346 19207025 19548758   +1.1%
bench 16384 12 20  18182313 18371581 18336838  19381275 19738012 19620225   +7.0%
```

On my box, huge pages have a significant perf impact when using a big
hash size. They also speed up TT initialization big time:

```
                                 vanilla (s)  huge pages (s)  speed-up
======================================================================
time stockfish bench 16384 1 1   5.37         1.48            3.6x
```

In practice, huge pages with auto-defrag may always be enabled in the
system, in which case this patch essentially does nothing. But this
depends on the values in /sys/kernel/mm/transparent_hugepage/enabled
and /sys/kernel/mm/transparent_hugepage/defrag, which are
distro-specific. Not all distros use always/always here, as these
settings are not automatic wins for all applications.

But in any case, it won't hurt to align the TT by the huge page size
and explicitly request huge pages, to ensure huge pages when they are
supported.

NO FUNCTIONAL CHANGE.