### PR TITLE
PR_LEBestMoveChanges13

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -786,7 +786,8 @@ namespace {
 
     // Early exit if score is high
     Value v = (mg_value(score) + eg_value(score)) / 2;
-    if (abs(v) > LazyThreshold + pos.non_pawn_material() / 64)
+     if ( (pos.this_thread()->bestMoveChanges < 13)
+       && (abs(v) > LazyThreshold + pos.non_pawn_material() / 64))
        return pos.side_to_move() == WHITE ? v : -v;
 
     // Main evaluation begins here

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -786,10 +786,11 @@ namespace {
 
     // Early exit if score is high
     Value v = (mg_value(score) + eg_value(score)) / 2;
+    if(!T){//Fix for UCI command 'eval';
      if ( (pos.this_thread()->bestMoveChanges < 13)
        && (abs(v) > LazyThreshold + pos.non_pawn_material() / 64))
        return pos.side_to_move() == WHITE ? v : -v;
-
+    }
     // Main evaluation begins here
 
     initialize<WHITE>();


### PR DESCRIPTION
Lazy Eval enabled only if BestMoveChanges <13.
Passed STC:
LLR: 2.93 (-2.94,2.94) [-1.50,4.50] +2.40 ELO
Total: 13580 W: 3050 L: 2929 D: 7601
Ptnml(0-2): 154, 1439, 3508, 1466, 200

http://tests.stockfishchess.org/tests/view/5e049323c13ac2425c4a9ca5

Passed LTC:
LLR: 2.94 (-2.94,2.94) [0.00,3.50] +7.99ELO
Total: 4509 W: 793 L: 688 D: 3028
Ptnml(0-2): 12, 280, 1535, 366, 22  
http://tests.stockfishchess.org/tests/view/5e049d66c13ac2425c4a9cb8

20+0.2 TC with 128MB hash test:
LLR: -0.80 (-2.94,2.94) [0.00,3.50]
Total: 62834 W: 9414 L: 9286 D: 44134
Ptnml(0-2): 411, 6059, 18264, 6214, 394 


http://tests.stockfishchess.org/tests/view/5e04dfe8c13ac2425c4a9d03

Bench:5184081