### PR TITLE
SimplyMoveImportance2

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -44,11 +44,8 @@ namespace {
 
   double move_importance(int ply) {
 
-    constexpr double XScale = 6.85;
-    constexpr double XShift = 64.5;
-    constexpr double Skew   = 0.171;
-
-    return pow((1 + exp((ply - XShift) / XScale)), -Skew) + DBL_MIN; // Ensure non-zero
+  double pl=double(ply);
+  return  ( 100000000.0/(100000000.0+(pl*pl*pl*pl)));
   }
 
   template<TimeType T>


### PR DESCRIPTION
Simplify moveImportance() to ply^4 formula:
Passed STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00] ELO:+1.43
Total: 16619 W: 3668 L: 3578 D: 9373
Ptnml(0-2): 207, 1815, 4188, 1869, 225 
http://tests.stockfishchess.org/tests/view/5e038ba0c13ac2425c4a9bb1

Passed LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00] ELO:+0.39
Total: 28211 W: 4498 L: 4439 D: 19274
Ptnml(0-2): 148, 2398, 8918, 2460, 147 
http://tests.stockfishchess.org/tests/view/5e03c138c13ac2425c4a9bcc

VTLC verification parked here(current LLR -1.10):
LLR: -1.10 (-2.94,2.94) [-3.00,1.00]
Total: 7966 W: 1121 L: 1168 D: 5677
Ptnml(0-2): 38, 712, 2502, 676, 30 
http://tests.stockfishchess.org/tests/view/5e043975c13ac2425c4a9bdd

No functional change