### PR TITLE
Min attacker loop2

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -54,30 +54,33 @@ constexpr Piece Pieces[] = { W_PAWN, W_KNIGHT, W_BISHOP, W_ROOK, W_QUEEN, W_KING
 // min_attacker() is a helper function used by see_ge() to locate the least
 // valuable attacker for the side to move, remove the attacker we just found
 // from the bitboards and scan for new X-ray attacks behind it.
-PieceType min_attacker(const Bitboard* byTypeBB, Square to, Bitboard stmAttackers,
+inline PieceType min_attacker(const Bitboard* byTypeBB, Square to, Bitboard stmAttackers,
                        Bitboard& occupied, Bitboard& attackers) {
 PieceType CUR; Bitboard b;
 for(CUR = PAWN; CUR < KING ; CUR=PieceType(CUR+1)){
   b = stmAttackers & byTypeBB[CUR];
-if(b)break;}
-if(CUR != KING){
+  if(b) break;
+  }
+if(CUR != KING){//PAWN,KNIGHT,BISHOP,ROOk,QUEEN
   occupied ^= lsb(b); // Remove the attacker from occupied
   // Add any X-ray attack behind the just removed piece. For instance with
   // rooks in a8 and a7 attacking a1, after removing a7 we add rook in a8.
   // Note that new added attackers can be of any color.
-  if (CUR == PAWN || CUR == BISHOP || CUR == QUEEN)
-      attackers |= attacks_bb<BISHOP>(to, occupied) & (byTypeBB[BISHOP] | byTypeBB[QUEEN]);
-
-  if (CUR == ROOK || CUR == QUEEN)
-      attackers |= attacks_bb<ROOK>(to, occupied) & (byTypeBB[ROOK] | byTypeBB[QUEEN]);
-  // X-ray may add already processed pieces because byTypeBB[] is constant: in
+  if(CUR!=KNIGHT){//PAWN,BISHOP,ROOK,QUEEN
+   if(CUR!=ROOK){//PAWN,BISHOP,QUEEN
+     attackers |= attacks_bb<BISHOP>(to, occupied) & (byTypeBB[BISHOP] | byTypeBB[QUEEN]);
+     }
+   if(CUR>=ROOK){//ROOK,QUEEN
+    attackers |= attacks_bb<ROOK>(to, occupied) & (byTypeBB[ROOK] | byTypeBB[QUEEN]);
+     }
+  } 
+   // X-ray may add already processed pieces because byTypeBB[] is constant: in
    // the rook example, now attackers contains _again_ rook in a7, so remove it.
- attackers &= occupied;
+   attackers &= occupied;
+  }
+
+  return CUR;
  }
-
-return CUR;
-}
-
 
 } // namespace
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -54,33 +54,38 @@ constexpr Piece Pieces[] = { W_PAWN, W_KNIGHT, W_BISHOP, W_ROOK, W_QUEEN, W_KING
 // min_attacker() is a helper function used by see_ge() to locate the least
 // valuable attacker for the side to move, remove the attacker we just found
 // from the bitboards and scan for new X-ray attacks behind it.
-inline PieceType min_attacker(const Bitboard* byTypeBB, Square to, Bitboard stmAttackers,
-                       Bitboard& occupied, Bitboard& attackers) {
-PieceType CUR; Bitboard b;
-for(CUR = PAWN; CUR < KING ; CUR=PieceType(CUR+1)){
-  b = stmAttackers & byTypeBB[CUR];
-  if(b) break;
+inline PieceType min_attacker(const Bitboard* byTypeBB, Square to,
+                              Bitboard stmAttackers, Bitboard& occupied,
+                              Bitboard& attackers) {
+  PieceType currentPiece;
+  Bitboard b;
+  for (currentPiece = PAWN; currentPiece < KING;
+       currentPiece = PieceType(currentPiece + 1)) {
+    b = stmAttackers & byTypeBB[currentPiece];
+    if (b) break;
   }
-if(CUR != KING){//PAWN,KNIGHT,BISHOP,ROOk,QUEEN
-  occupied ^= lsb(b); // Remove the attacker from occupied
-  // Add any X-ray attack behind the just removed piece. For instance with
-  // rooks in a8 and a7 attacking a1, after removing a7 we add rook in a8.
-  // Note that new added attackers can be of any color.
-  if(CUR!=KNIGHT){//PAWN,BISHOP,ROOK,QUEEN
-   if(CUR!=ROOK){//PAWN,BISHOP,QUEEN
-     attackers |= attacks_bb<BISHOP>(to, occupied) & (byTypeBB[BISHOP] | byTypeBB[QUEEN]);
-     }
-   if(CUR>=ROOK){//ROOK,QUEEN
-    attackers |= attacks_bb<ROOK>(to, occupied) & (byTypeBB[ROOK] | byTypeBB[QUEEN]);
-     }
-  } 
-   // X-ray may add already processed pieces because byTypeBB[] is constant: in
-   // the rook example, now attackers contains _again_ rook in a7, so remove it.
-   attackers &= occupied;
+  if (currentPiece != KING) {  // PAWN,KNIGHT,BISHOP,ROOK,QUEEN
+    occupied ^= lsb(b);  // Remove the attacker from occupied
+    // Add any X-ray attack behind the just removed piece. For instance with
+    // rooks in a8 and a7 attacking a1, after removing a7 we add rook in a8.
+    // Note that new added attackers can be of any color.
+    if (currentPiece != KNIGHT) {  // PAWN,BISHOP,ROOK,QUEEN
+      if (currentPiece != ROOK) {  // PAWN,BISHOP,QUEEN
+        attackers |= attacks_bb<BISHOP>(to, occupied) &
+                     (byTypeBB[BISHOP] | byTypeBB[QUEEN]);
+      }
+      if (currentPiece >= ROOK) {  // ROOK,QUEEN
+        attackers |=
+            attacks_bb<ROOK>(to, occupied) & (byTypeBB[ROOK] | byTypeBB[QUEEN]);
+      }
+    }
+    // X-ray may add already processed pieces because byTypeBB[] is constant: in
+    // the rook example, now attackers contains _again_ rook in a7, so remove it.
+    attackers &= occupied;
   }
 
-  return CUR;
- }
+  return currentPiece;
+}
 
 } // namespace
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -54,36 +54,30 @@ constexpr Piece Pieces[] = { W_PAWN, W_KNIGHT, W_BISHOP, W_ROOK, W_QUEEN, W_KING
 // min_attacker() is a helper function used by see_ge() to locate the least
 // valuable attacker for the side to move, remove the attacker we just found
 // from the bitboards and scan for new X-ray attacks behind it.
-
-template<PieceType Pt>
 PieceType min_attacker(const Bitboard* byTypeBB, Square to, Bitboard stmAttackers,
                        Bitboard& occupied, Bitboard& attackers) {
-
-  Bitboard b = stmAttackers & byTypeBB[Pt];
-  if (!b)
-      return min_attacker<PieceType(Pt + 1)>(byTypeBB, to, stmAttackers, occupied, attackers);
-
+PieceType CUR; Bitboard b;
+for(CUR = PAWN; CUR < KING ; CUR=PieceType(CUR+1)){
+  b = stmAttackers & byTypeBB[CUR];
+if(b)break;}
+if(CUR != KING){
   occupied ^= lsb(b); // Remove the attacker from occupied
-
   // Add any X-ray attack behind the just removed piece. For instance with
   // rooks in a8 and a7 attacking a1, after removing a7 we add rook in a8.
   // Note that new added attackers can be of any color.
-  if (Pt == PAWN || Pt == BISHOP || Pt == QUEEN)
+  if (CUR == PAWN || CUR == BISHOP || CUR == QUEEN)
       attackers |= attacks_bb<BISHOP>(to, occupied) & (byTypeBB[BISHOP] | byTypeBB[QUEEN]);
 
-  if (Pt == ROOK || Pt == QUEEN)
+  if (CUR == ROOK || CUR == QUEEN)
       attackers |= attacks_bb<ROOK>(to, occupied) & (byTypeBB[ROOK] | byTypeBB[QUEEN]);
-
   // X-ray may add already processed pieces because byTypeBB[] is constant: in
-  // the rook example, now attackers contains _again_ rook in a7, so remove it.
-  attackers &= occupied;
-  return Pt;
+   // the rook example, now attackers contains _again_ rook in a7, so remove it.
+ attackers &= occupied;
+ }
+
+return CUR;
 }
 
-template<>
-PieceType min_attacker<KING>(const Bitboard*, Square, Bitboard, Bitboard&, Bitboard&) {
-  return KING; // No need to update bitboards: it is the last cycle
-}
 
 } // namespace
 
@@ -1096,7 +1090,7 @@ bool Position::see_ge(Move m, Value threshold) const {
 
       // Locate and remove the next least valuable attacker, and add to
       // the bitboard 'attackers' the possibly X-ray attackers behind it.
-      nextVictim = min_attacker<PAWN>(byTypeBB, to, stmAttackers, occupied, attackers);
+      nextVictim = min_attacker(byTypeBB, to, stmAttackers, occupied, attackers);
 
       stm = ~stm; // Switch side to move
 


### PR DESCRIPTION
Transforms min_attacker into a loop, removing the templates.
Passed STC(ELO:+2.50):
LLR: 2.95 (-2.94,2.94) {-1.00,3.00}
Total: 12915 W: 2882 L: 2767 D: 7266
Ptnml(0-2): 152, 1316, 3419, 1375, 181
http://tests.stockfishchess.org/tests/view/5e0d735687585b1706b68366

LTC isn't required for speedup, so LTC test was cancelled.
No functional change.