### PR TITLE
Isolate early rootDepth(<12) from LazyEval

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -786,9 +786,11 @@ namespace {
 
     // Early exit if score is high
     Value v = (mg_value(score) + eg_value(score)) / 2;
-    if (abs(v) > LazyThreshold + pos.non_pawn_material() / 64)
+if(!T){ 
+    if (pos.this_thread()->rootDepth >6 
+      && abs(v) > LazyThreshold + pos.non_pawn_material() / 64)
        return pos.side_to_move() == WHITE ? v : -v;
-
+}
     // Main evaluation begins here
 
     initialize<WHITE>();

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -787,7 +787,7 @@ namespace {
     // Early exit if score is high
     Value v = (mg_value(score) + eg_value(score)) / 2;
 if(!T){ 
-    if (pos.this_thread()->rootDepth >6 
+    if (pos.this_thread()->rootDepth >11 
       && abs(v) > LazyThreshold + pos.non_pawn_material() / 64)
        return pos.side_to_move() == WHITE ? v : -v;
 }


### PR DESCRIPTION
This patch is one of attempts to reduce influence of LazyEval: this one simply cuts out the early portion of the search(the >11 was selected for highest depth passing STC).
Additionally, added !T(TRACING) for UCI 'eval' command  compatibility.
Passed STC(ELO:+4.64 ):
LLR: 2.94 (-2.94,2.94) {-1.00,3.00}
Total: 7936 W: 1807 L: 1683 D: 4446
Ptnml(0-2): 123, 931, 1773, 972, 163 
http://tests.stockfishchess.org/tests/view/5e0c26b59d3fbe26f672d52c
Passed LTC(ELO:+1.47 ):
LLR: 2.94 (-2.94,2.94) {0.00,2.00}
Total: 61359 W: 10022 L: 9705 D: 41632
Ptnml(0-2): 468, 6287, 16907, 6463, 538 
http://tests.stockfishchess.org/tests/view/5e0c6ebff9e17fb4192cdf59

Bench:4600726