### PR TITLE
Introduce king infiltration bonus

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -712,14 +712,19 @@ namespace {
                            &&  outflanking < 0
                            && !pawnsOnBothFlanks;
 
+
+    bool kingInfiltration = !(rank_of(pos.square<KING>(WHITE)) < RANK_5 
+                           && rank_of(pos.square<KING>(BLACK)) > RANK_4); 
+
     // Compute the initiative bonus for the attacking side
     int complexity =   9 * pe->passed_count()
                     + 11 * pos.count<PAWN>()
                     +  9 * outflanking
                     + 21 * pawnsOnBothFlanks
                     + 51 * !pos.non_pawn_material()
+                    + 12 * kingInfiltration
                     - 43 * almostUnwinnable
-                    - 95 ;
+                    - 100 ;
 
     // Now apply the bonus: note that we find the attacking side by extracting the
     // sign of the midgame or endgame values, and that we carefully cap the bonus


### PR DESCRIPTION
passed STC
http://tests.stockfishchess.org/tests/view/5e0e6fd1e97ea42ea89da9b3
LLR: 2.94 (-2.94,2.94) {-1.00,3.00}
Total: 10533 W: 2372 L: 2242 D: 5919
Ptnml(0-2): 196, 1198, 2352, 1316, 202 
passed LTC
http://tests.stockfishchess.org/tests/view/5e0e857ae97ea42ea89da9cc
LLR: 2.96 (-2.94,2.94) {0.00,2.00}
Total: 15074 W: 2563 L: 2381 D: 10130
Ptnml(0-2): 118, 1500, 4111, 1663, 129 
Idea is somewhat similar to outflanking - endgames are hard to win if each king is on it side of the board. So this adds extra bonus for one of kings crossing the middle line.
bench 4957780