### PR TITLE
Tweak futility pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1003,7 +1003,11 @@ moves_loop: // When in check, search starts from here
               // Futility pruning: parent node (~2 Elo)
               if (   lmrDepth < 6
                   && !inCheck
-                  && ss->staticEval + 255 + 182 * lmrDepth <= alpha)
+                  && ss->staticEval + 255 + 182 * lmrDepth <= alpha
+                  &&  thisThread->mainHistory[us][from_to(move)]
+                    + (*contHist[0])[movedPiece][to_sq(move)]
+                    + (*contHist[1])[movedPiece][to_sq(move)]
+                    + (*contHist[3])[movedPiece][to_sq(move)] < 30000)
                   continue;
 
               // Prune moves with negative SEE (~10 Elo)


### PR DESCRIPTION
Exclude moves with a good history total from futility pruning.

STC:
LLR: 2.94 (-2.94,2.94) {-1.00,3.00}
Total: 20095 W: 4503 L: 4342 D: 11250
Ptnml(0-2): 362, 2380, 4422, 2486, 388
http://tests.stockfishchess.org/tests/view/5e0d7c5387585b1706b68370

LTC:
LLR: 2.94 (-2.94,2.94) {0.00,2.00}
Total: 53016 W: 8587 L: 8302 D: 36127
Ptnml(0-2): 353, 5397, 14751, 5545, 423
http://tests.stockfishchess.org/tests/view/5e0e30d062fb773bb7047e95

Bench: 5215200