### PR TITLE
Small speedup in between_bb

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -199,8 +199,8 @@ inline Bitboard adjacent_files_bb(Square s) {
 /// If the given squares are not on a same file/rank/diagonal, return 0.
 
 inline Bitboard between_bb(Square s1, Square s2) {
-  return LineBB[s1][s2] & ( (AllSquares << (s1 +  (s1 < s2)))
-                           ^(AllSquares << (s2 + !(s1 < s2))));
+  return LineBB[s1][s2] & ( (AllSquares <<  (s1 < s2 ? s2 : s1))
+                           ^(AllSquares << ((s1 < s2 ? s1 : s2) + 1)));
 }
 
 


### PR DESCRIPTION
This is a non-functional speed-up in between_bb.  Turns out this ternary version is a bit faster than master.

On my machine:
master: 1616125 nps
  patch: 1620343 nps

More info in #2458 

Testing by others would be appreciated.