### PR TITLE
Remove popcnt16 array and use standard C++ bitset instead

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -24,7 +24,6 @@
 #include "bitboard.h"
 #include "misc.h"
 
-uint8_t PopCnt16[1 << 16];
 uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 Bitboard SquareBB[SQUARE_NB];
@@ -67,9 +66,6 @@ const std::string Bitboards::pretty(Bitboard b) {
 /// startup and relies on global objects to be already zero-initialized.
 
 void Bitboards::init() {
-
-  for (unsigned i = 0; i < (1 << 16); ++i)
-      PopCnt16[i] = std::bitset<16>(i).count();
 
   for (Square s = SQ_A1; s <= SQ_H8; ++s)
       SquareBB[s] = (1ULL << s);

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -22,6 +22,7 @@
 #define BITBOARD_H_INCLUDED
 
 #include <string>
+#include <bitset>
 
 #include "types.h"
 
@@ -71,7 +72,6 @@ constexpr Bitboard KingFlank[FILE_NB] = {
   KingSide, KingSide, KingSide ^ FileEBB
 };
 
-extern uint8_t PopCnt16[1 << 16];
 extern uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];
@@ -289,8 +289,7 @@ inline int popcount(Bitboard b) {
 
 #ifndef USE_POPCNT
 
-  union { Bitboard bb; uint16_t u[4]; } v = { b };
-  return PopCnt16[v.u[0]] + PopCnt16[v.u[1]] + PopCnt16[v.u[2]] + PopCnt16[v.u[3]];
+return std::bitset<64>(b).count();
 
 #elif defined(_MSC_VER) || defined(__INTEL_COMPILER)
 


### PR DESCRIPTION
This patch removes the ancient array for speed counting popcount for some compilers without popcount  intrinsincs: such compilers are not supported anymore due bitboard.h dependence on lsb/msb intrinsics from MSVC/GCC/Intel C+++ compilers:
Line 369 of bitboard.h 
#else  // Compiler is neither GCC nor MSVC compatible

#error "Compiler not supported."

#endif
https://github.com/official-stockfish/Stockfish/pull/620 (Original change was to support 32-bit machines)
No functional change.