### PR TITLE
Popcount isolation

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -24,7 +24,8 @@
 #include "bitboard.h"
 #include "misc.h"
 
-uint8_t PopCnt16[1 << 16];
+// Only creates the array if there is no hardware popcount support:
+PopCnt<HasPopCnt> popcount;   // HasPopCnt is defined in types.h
 uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 Bitboard SquareBB[SQUARE_NB];
@@ -67,9 +68,6 @@ const std::string Bitboards::pretty(Bitboard b) {
 /// startup and relies on global objects to be already zero-initialized.
 
 void Bitboards::init() {
-
-  for (unsigned i = 0; i < (1 << 16); ++i)
-      PopCnt16[i] = std::bitset<16>(i).count();
 
   for (Square s = SQ_A1; s <= SQ_H8; ++s)
       SquareBB[s] = (1ULL << s);

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -22,7 +22,7 @@
 #define BITBOARD_H_INCLUDED
 
 #include <string>
-
+#include <bitset>
 #include "types.h"
 
 namespace Bitbases {
@@ -71,7 +71,6 @@ constexpr Bitboard KingFlank[FILE_NB] = {
   KingSide, KingSide, KingSide ^ FileEBB
 };
 
-extern uint8_t PopCnt16[1 << 16];
 extern uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];
@@ -285,23 +284,33 @@ inline Bitboard attacks_bb(PieceType pt, Square s, Bitboard occupied) {
 
 /// popcount() counts the number of non-zero bits in a bitboard
 
-inline int popcount(Bitboard b) {
+template <bool> struct PopCnt {};
 
-#ifndef USE_POPCNT
-
-  union { Bitboard bb; uint16_t u[4]; } v = { b };
-  return PopCnt16[v.u[0]] + PopCnt16[v.u[1]] + PopCnt16[v.u[2]] + PopCnt16[v.u[3]];
-
-#elif defined(_MSC_VER) || defined(__INTEL_COMPILER)
-
+template <> struct PopCnt<true> {
+    int operator () (Bitboard b) const {
+#if defined(_MSC_VER) || defined(__INTEL_COMPILER)
   return (int)_mm_popcnt_u64(b);
-
-#else // Assumed gcc or compatible compiler
-
-  return __builtin_popcountll(b);
-
+#else
+ return __builtin_popcountll(b); 
 #endif
 }
+};
+
+template <> struct PopCnt<false> {
+    PopCnt() {
+        for (unsigned i = 0; i < (1 << 16); ++i)
+            PopCnt16[i] = std::bitset<16>(i).count();
+    }
+
+    int operator () (Bitboard b) const {
+        union { Bitboard bb; uint16_t u[4]; } v = { b };
+        return PopCnt16[v.u[0]] + PopCnt16[v.u[1]] + PopCnt16[v.u[2]] + PopCnt16[v.u[3]];
+    }
+
+    uint8_t PopCnt16[1 << 16];
+};
+
+extern PopCnt<HasPopCnt> popcount; 
 
 
 /// lsb() and msb() return the least/most significant bit in a non-zero bitboard

--- a/src/types.h
+++ b/src/types.h
@@ -104,6 +104,7 @@ typedef uint64_t Bitboard;
 constexpr int MAX_MOVES = 256;
 constexpr int MAX_PLY   = 246;
 
+extern PopCnt<HasPopCnt> popcount;   //globally visible
 /// A move needs 16 bits to be stored
 ///
 /// bit  0- 5: destination square (from 0 to 63)


### PR DESCRIPTION
This is compromise solution from PR https://github.com/official-stockfish/Stockfish/pull/2476 that allows to use the old popcnt16 array for speed, but only if popcount(HAS_POPCOUNT)  is not defined - otherwise the 64kb array is never used or filled.

Its not conditional compilation(no ifdefs added), using HasPopCnt to specialize the popcnt struct.
Original idea by @gvreuls from here  https://github.com/official-stockfish/Stockfish/pull/2476#issuecomment-571730881 
A non-regression test is added here(to ensure the struct has no overhead with 64-bit on fishtest, the main test is travis CI compliance):
http://tests.stockfishchess.org/tests/view/5e14eb1d61fe5f83a67dd8c8

No functional change.