### PR TITLE
Popcount macros

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -24,7 +24,7 @@
 #include "bitboard.h"
 #include "misc.h"
 
- popcnt_table ;
+ popcnt_table
 uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 Bitboard SquareBB[SQUARE_NB];
@@ -68,7 +68,7 @@ const std::string Bitboards::pretty(Bitboard b) {
 
 void Bitboards::init() {
 
-    popcnt_init() ;
+    popcnt_init()
 
   for (Square s = SQ_A1; s <= SQ_H8; ++s)
       SquareBB[s] = (1ULL << s);

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -24,7 +24,7 @@
 #include "bitboard.h"
 #include "misc.h"
 
-uint8_t PopCnt16[1 << 16];
+ popcnt_table ;
 uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 Bitboard SquareBB[SQUARE_NB];
@@ -68,8 +68,7 @@ const std::string Bitboards::pretty(Bitboard b) {
 
 void Bitboards::init() {
 
-  for (unsigned i = 0; i < (1 << 16); ++i)
-      PopCnt16[i] = std::bitset<16>(i).count();
+    popcnt_init() ;
 
   for (Square s = SQ_A1; s <= SQ_H8; ++s)
       SquareBB[s] = (1ULL << s);

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -71,7 +71,7 @@ constexpr Bitboard KingFlank[FILE_NB] = {
   KingSide, KingSide, KingSide ^ FileEBB
 };
 
-extern uint8_t PopCnt16[1 << 16];
+ popcnt_table_extern ; 
 extern uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -71,7 +71,7 @@ constexpr Bitboard KingFlank[FILE_NB] = {
   KingSide, KingSide, KingSide ^ FileEBB
 };
 
- popcnt_table_extern ; 
+ popcnt_table_extern  
 extern uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];

--- a/src/types.h
+++ b/src/types.h
@@ -82,8 +82,14 @@
 
 #ifdef USE_POPCNT
 constexpr bool HasPopCnt = true;
+#define popcnt_init() 
+#define popcnt_table_extern   
+#define popcnt_table   
 #else
 constexpr bool HasPopCnt = false;
+#define popcnt_init()   for (unsigned i = 0; i < (1 << 16); ++i) PopCnt16[i] = std::bitset<16>(i).count();
+#define popcnt_table_extern extern uint8_t PopCnt16[1 << 16];
+#define popcnt_table uint8_t PopCnt16[1 << 16];
 #endif
 
 #ifdef USE_PEXT


### PR DESCRIPTION
Replaces popcnt16 array and its initialization with macros that expand dependent on types.h "HAS_POPCOUNT" definition, but does not introduce #ifdef blocks(conditional compilation). 
Effectively disables the 64kb array for vast majority of machines.

No functional change.