### PR TITLE
Tweak futility pruning constants.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -708,8 +708,7 @@ namespace {
                        || rank_of(pos.square<KING>(BLACK)) < RANK_5;
 
     bool pawnsOnBothFlanks =   (pos.pieces(PAWN) & QueenSide)
-                            && (pos.pieces(PAWN) & KingSide)
-                            && (pos.pieces(PAWN) & ~CenterFiles);
+                            && (pos.pieces(PAWN) & KingSide);
 
     bool almostUnwinnable =   !pe->passed_count()
                            &&  outflanking < 0
@@ -720,10 +719,10 @@ namespace {
                     + 11 * pos.count<PAWN>()
                     +  9 * outflanking
                     + 12 * infiltration
-                    + 30 * pawnsOnBothFlanks
+                    + 21 * pawnsOnBothFlanks
                     + 51 * !pos.non_pawn_material()
                     - 43 * almostUnwinnable
-                    - 104 ;
+                    - 100 ;
 
     // Now apply the bonus: note that we find the attacking side by extracting the
     // sign of the midgame or endgame values, and that we carefully cap the bonus

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -708,7 +708,8 @@ namespace {
                        || rank_of(pos.square<KING>(BLACK)) < RANK_5;
 
     bool pawnsOnBothFlanks =   (pos.pieces(PAWN) & QueenSide)
-                            && (pos.pieces(PAWN) & KingSide);
+                            && (pos.pieces(PAWN) & KingSide)
+                            && (pos.pieces(PAWN) & ~CenterFiles);
 
     bool almostUnwinnable =   !pe->passed_count()
                            &&  outflanking < 0
@@ -719,10 +720,10 @@ namespace {
                     + 11 * pos.count<PAWN>()
                     +  9 * outflanking
                     + 12 * infiltration
-                    + 21 * pawnsOnBothFlanks
+                    + 30 * pawnsOnBothFlanks
                     + 51 * !pos.non_pawn_material()
                     - 43 * almostUnwinnable
-                    - 100 ;
+                    - 104 ;
 
     // Now apply the bonus: note that we find the attacking side by extracting the
     // sign of the midgame or endgame values, and that we carefully cap the bonus

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1015,11 +1015,11 @@ moves_loop: // When in check, search starts from here
               // Futility pruning: parent node (~5 Elo)
               if (   lmrDepth < 6
                   && !inCheck
-                  && ss->staticEval + 255 + 182 * lmrDepth <= alpha
+                  && ss->staticEval + 235 + 172 * lmrDepth <= alpha
                   &&  thisThread->mainHistory[us][from_to(move)]
                     + (*contHist[0])[movedPiece][to_sq(move)]
                     + (*contHist[1])[movedPiece][to_sq(move)]
-                    + (*contHist[3])[movedPiece][to_sq(move)] < 30000)
+                    + (*contHist[3])[movedPiece][to_sq(move)] < 25000)
                   continue;
 
               // Prune moves with negative SEE (~20 Elo)


### PR DESCRIPTION
Passed STC
LLR: 2.98 (-2.94,2.94) {-1.00,3.00}
Total: 15300 W: 3081 L: 2936 D: 9283
Ptnml(0-2): 260, 1816, 3382, 1900, 290 
http://tests.stockfishchess.org/tests/view/5e18da3b27dab692fcf9a158
Passed LTC
LLR: 2.94 (-2.94,2.94) {0.00,2.00}
Total: 108670 W: 14509 L: 14070 D: 80091
Ptnml(0-2): 813, 10259, 31736, 10665, 831 
http://tests.stockfishchess.org/tests/view/5e18fc9627dab692fcf9a180
Based on recent improvement of futility pruning by @locutus2 .
Lower futility margin to apply it for more nodes but as a compensation lower history threshold to apply it to less nodes.
Further work in tweaking constants can always be done - numbers are guessed "by hand" and are not results of some tuning, maybe there is some more elo to squeeze from this part of code.
Bench 4643972