### PR TITLE
[Merged] Prevent "Smarter time management near stop limit" if ponder enabled.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -564,6 +564,7 @@ void Thread::search() {
                   Threads.stop = true;
           }
           else if (   Threads.increaseDepth
+                   && !mainThread->ponder
                    && Time.elapsed() > Time.optimum() * fallingEval * reduction * bestMoveInstability * 0.6)
                    Threads.increaseDepth = false;
           else


### PR DESCRIPTION
The recent PR #2482 has a flaw in that it stops searches getting deeper during pondering. This change fixes this by preventing iterations from being searched again if pondering is enabled.

CURRENTLY UNTESTED

Bench 4586187