### PR TITLE
Tweak reductions for captures/promotions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1186,6 +1186,10 @@ moves_loop: // When in check, search starts from here
               r -= ss->statScore / 16384;
           }
 
+          // Increase reduction for captures/promotions if late move and at low depth
+          else if (depth < 8 && moveCount > 2)
+              r++;
+
           Depth d = clamp(newDepth - r, 1, newDepth);
 
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, d, true);


### PR DESCRIPTION
From the third move reduce captures and promotions more if remaining depth is low.

STC:
LLR: 2.94 (-2.94,2.94) {-1.00,3.00}
Total: 25218 W: 5008 L: 4837 D: 15373
Ptnml(0-2): 439, 2950, 5717, 3001, 499
http://tests.stockfishchess.org/tests/view/5e1b33abd12216a2857e6359

LTC:
LLR: 2.95 (-2.94,2.94) {0.00,2.00}
Total: 35491 W: 4760 L: 4524 D: 26207
Ptnml(0-2): 264, 3288, 10413, 3460, 294
http://tests.stockfishchess.org/tests/view/5e1b88d5d12216a2857e6385

Bench: 4956329