### PR TITLE
Simplify between_bb

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -199,8 +199,8 @@ inline Bitboard adjacent_files_bb(Square s) {
 /// If the given squares are not on a same file/rank/diagonal, return 0.
 
 inline Bitboard between_bb(Square s1, Square s2) {
-  return LineBB[s1][s2] & ( (AllSquares << (s1 +  (s1 < s2)))
-                           ^(AllSquares << (s2 + !(s1 < s2))));
+  return LineBB[s1][s2] & ((AllSquares          << (s1 < s2 ? s2 : s1))
+                        ^ ((AllSquares ^ SQ_A1) << (s1 < s2 ? s1 : s2)));
 }
 
 


### PR DESCRIPTION
This is a non-functional simplification that removes the addition operators in between_bb.  I do not detect any significant performance difference, but it should be a bit faster.