### PR TITLE
More LMR at root, unless a fail low might happen.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1115,7 +1115,7 @@ moves_loop: // When in check, search starts from here
       // Step 16. Reduced depth search (LMR, ~200 Elo). If the move fails high it will be
       // re-searched at full depth.
       if (    depth >= 3
-          &&  moveCount > 1 + 2 * rootNode
+          &&  moveCount > 1 + rootNode + (rootNode && bestValue < alpha)
           && (!rootNode || thisThread->best_move_count(move) == 0)
           && (  !captureOrPromotion
               || moveCountPruning


### PR DESCRIPTION
passed STC:
 LLR: 2.94 (-2.94,2.94) {-1.00,3.00}
Total: 25428 W: 4960 L: 4789 D: 15679
Ptnml(0-2): 424, 2948, 5832, 3045, 460
http://tests.stockfishchess.org/tests/view/5e1c9afed12216a2857e6401

passed LTC:
 LLR: 2.94 (-2.94,2.94) {0.00,2.00}
Total: 187423 W: 24253 L: 23599 D: 139571
Ptnml(0-2): 1284, 17437, 55536, 18085, 1292
http://tests.stockfishchess.org/tests/view/5e1ceb9975be933c8fe635a3

Bench: 5156767