### PR TITLE
Small speedup in between_bb

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -199,8 +199,8 @@ inline Bitboard adjacent_files_bb(Square s) {
 /// If the given squares are not on a same file/rank/diagonal, return 0.
 
 inline Bitboard between_bb(Square s1, Square s2) {
-  return LineBB[s1][s2] & ( (AllSquares << (s1 +  (s1 < s2)))
-                           ^(AllSquares << (s2 + !(s1 < s2))));
+  Bitboard b = LineBB[s1][s2] & ((AllSquares << s1) ^ (AllSquares << s2));
+  return b & (b - 1);
 }
 
 


### PR DESCRIPTION
I thoroughly tested at least a dozen versions of between_bb.  This one is the fastest on my machines (about 30% faster on between_bb calls).  The resulting speed-up for the whole executable is pretty modest.

Master bench ave nps: 1632109
Patch bench ave nps: 1635998

1 million calls of between_bb:
Master ave: 8.1 sec
Patch ave: 5.1 sec.

STC
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 155755 W: 29605 L: 29648 D: 96502
Ptnml(0-2): 2239, 17439, 38549, 17368, 2249 
http://tests.stockfishchess.org/tests/view/5e1f917b72790daaa907ce50