### PR TITLE
Use a std::bitset for KPKBitbase.

### DIFF
--- a/src/bitbase.cpp
+++ b/src/bitbase.cpp
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <numeric>
 #include <vector>
+#include <bitset>
 
 #include "bitboard.h"
 #include "types.h"
@@ -32,7 +33,7 @@ namespace {
   constexpr unsigned MAX_INDEX = 2*24*64*64; // stm * psq * wksq * bksq = 196608
 
   // Each uint32_t stores results of 32 positions, one per bit
-  uint32_t KPKBitbase[MAX_INDEX / 32];
+  std::bitset<MAX_INDEX> KPKBitbase;
 
   // A KPK bitbase index is an integer in [0, IndexMax] range
   //
@@ -77,8 +78,7 @@ bool Bitbases::probe(Square wksq, Square wpsq, Square bksq, Color us) {
 
   assert(file_of(wpsq) <= FILE_D);
 
-  unsigned idx = index(us, bksq, wksq, wpsq);
-  return KPKBitbase[idx / 32] & (1 << (idx & 0x1F));
+  return KPKBitbase[index(us, bksq, wksq, wpsq)];
 }
 
 
@@ -100,7 +100,7 @@ void Bitbases::init() {
   // Map 32 results into one KPKBitbase[] entry
   for (idx = 0; idx < MAX_INDEX; ++idx)
       if (db[idx] == WIN)
-          KPKBitbase[idx / 32] |= 1 << (idx & 0x1F);
+          KPKBitbase.set(idx);
 }
 
 


### PR DESCRIPTION
This is a non-functional simplification.  Looks like std::bitset works good for the KPKBitbase.  Thanks for Jorg Oster for helping get the speed up ([] accessor is faster than test()).

Speed testing:  10k calls to probe:
master 9.8 sec
Patch 9.8 sec.

STC
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 100154 W: 19025 L: 18992 D: 62137
Ptnml(0-2): 1397, 11376, 24572, 11254, 1473
http://tests.stockfishchess.org/tests/view/5e21e601346e35ac603b7d2b