### PR TITLE
Minor fixes for misc.cpp

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -155,9 +155,9 @@ const string engine_info(bool to_uci) {
 
 const std::string compiler_info() {
 
-  #define STRINGIFY2(x) #x
-  #define STRINGIFY(x) STRINGIFY2(x)
-  #define VER_STRING(major, minor, patch) STRINGIFY(major) "." STRINGIFY(minor) "." STRINGIFY(patch)
+  #define stringify2(x) #x
+  #define stringify(x) stringify2(x)
+  #define VER_STRING(major, minor, patch) stringify(major) "." stringify(minor) "." stringify(patch)
 
 /// Predefined macros hell:
 ///
@@ -175,12 +175,12 @@ const std::string compiler_info() {
   #elif __INTEL_COMPILER
      compiler += "Intel compiler ";
      compiler += "(version ";
-     compiler += STRINGIFY(__INTEL_COMPILER) " update " STRINGIFY(__INTEL_COMPILER_UPDATE);
+     compiler += stringify(__INTEL_COMPILER) " update " stringify(__INTEL_COMPILER_UPDATE);
      compiler += ")";
   #elif _MSC_VER
      compiler += "MSVC ";
      compiler += "(version ";
-     compiler += STRINGIFY(_MSC_FULL_VER) "." STRINGIFY(_MSC_BUILD);
+     compiler += stringify(_MSC_FULL_VER) "." stringify(_MSC_BUILD);
      compiler += ")";
   #elif __GNUC__
      compiler += "g++ (GNUC) ";
@@ -233,7 +233,7 @@ void dbg_print() {
 
   if (hits[0])
       cerr << "Total " << hits[0] << " Hits " << hits[1]
-           << " hit rate (%) " << 100 * hits[1] / hits[0] << endl;
+           << " hit rate (%) " << 100.0 * hits[1] / hits[0] << endl;
 
   if (means[0])
       cerr << "Total " << means[0] << " Mean "


### PR DESCRIPTION
Fixes conflict with tune.h STRINGIFY macro and fixes display of decimals in dbg_print.

No functional change.