### PR TITLE
History update for pruned captures

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1028,7 +1028,11 @@ moves_loop: // When in check, search starts from here
                   continue;
           }
           else if (!pos.see_ge(move, Value(-194) * depth)) // (~25 Elo)
-                  continue;
+          {
+              if (captureOrPromotion && captureCount < 32)
+                  capturesSearched[captureCount++] = move;
+              continue;
+          }
       }
 
       // Step 14. Extensions (~75 Elo)


### PR DESCRIPTION
Collect pruned capture moves also in the failed captures list so that they get an update in capture history.

STC:
LLR: 2.95 (-2.94,2.94) {-1.00,3.00}
Total: 11124 W: 2222 L: 2089 D: 6813
Ptnml(0-2): 186, 1280, 2506, 1381, 200
http://tests.stockfishchess.org/tests/view/5e28995fc3b97aa0d75bc294

LTC:
LLR: 2.94 (-2.94,2.94) {0.00,2.00}
Total: 25552 W: 3418 L: 3211 D: 18923
Ptnml(0-2): 168, 2354, 7538, 2490, 200
http://tests.stockfishchess.org/tests/view/5e2943734744cfa4d6af415b

Bench: 4941678