### PR TITLE
Tweak RestrictedPiece bonus

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -520,11 +520,11 @@ namespace {
     }
 
     // Bonus for restricting their piece moves
+    // Greater bonus when landing square is occupied
     b =   attackedBy[Them][ALL_PIECES]
        & ~stronglyProtected
        &  attackedBy[Us][ALL_PIECES];
-
-    score += RestrictedPiece * popcount(b);
+    score += RestrictedPiece * (popcount(b) + popcount(b & pos.pieces()));
 
     // Protected or unattacked squares
     safe = ~attackedBy[Them][ALL_PIECES] | attackedBy[Us][ALL_PIECES];


### PR DESCRIPTION
I can redo the test links if they are too progressively formatted (might look odd without monospace font). They do not exceed 72 characters though.

Removed an empty line to group the computation of `b` with the associated bonus (is a bit inconsistent currently).