### PR TITLE
Dynamic complexity

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -698,8 +698,8 @@ namespace {
   template<Tracing T>
   Score Evaluation<T>::initiative(Score score) const {
 
-    Value mg = mg_value(score);
-    Value eg = eg_value(score);
+    Value mg = mg_value(score) / 2;
+    Value eg = eg_value(score) / 2;
 
     int outflanking =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
                      - distance<Rank>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
@@ -811,7 +811,7 @@ namespace {
                + passed< WHITE>() - passed< BLACK>()
                + space<  WHITE>() - space<  BLACK>();
 
-    score += dynScore + initiative(dynScore);
+    score += dynScore + initiative(dynScore * 2 + score);
 
     // Interpolate between a middlegame and a (scaled by 'sf') endgame score
     ScaleFactor sf = scale_factor(eg_value(score));

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -698,10 +698,6 @@ namespace {
   template<Tracing T>
   Score Evaluation<T>::initiative(Score score, Score materialScore) const {
 
-    score = (score * 2 - materialScore) / 2;
-    Value mg = mg_value(score);
-    Value eg = eg_value(score);
-
     int outflanking =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
                      - distance<Rank>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
 
@@ -724,6 +720,11 @@ namespace {
                     + 51 * !pos.non_pawn_material()
                     - 43 * almostUnwinnable
                     - 100 ;
+
+    // Give more importance to non-material score
+    score = (score * 2 - materialScore) / 2;
+    Value mg = mg_value(score);
+    Value eg = eg_value(score);
 
     // Now apply the bonus: note that we find the attacking side by extracting the
     // sign of the midgame or endgame values, and that we carefully cap the bonus

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -798,19 +798,20 @@ namespace {
     initialize<BLACK>();
 
     // Pieces should be evaluated first (populate attack tables)
-    score +=  pieces<WHITE, KNIGHT>() - pieces<BLACK, KNIGHT>()
-            + pieces<WHITE, BISHOP>() - pieces<BLACK, BISHOP>()
-            + pieces<WHITE, ROOK  >() - pieces<BLACK, ROOK  >()
-            + pieces<WHITE, QUEEN >() - pieces<BLACK, QUEEN >();
+    Score dynScore;
+    dynScore =  pieces<WHITE, KNIGHT>() - pieces<BLACK, KNIGHT>()
+              + pieces<WHITE, BISHOP>() - pieces<BLACK, BISHOP>()
+              + pieces<WHITE, ROOK  >() - pieces<BLACK, ROOK  >()
+              + pieces<WHITE, QUEEN >() - pieces<BLACK, QUEEN >();
 
-    score += mobility[WHITE] - mobility[BLACK];
+    dynScore += mobility[WHITE] - mobility[BLACK];
 
-    score +=  king<   WHITE>() - king<   BLACK>()
-            + threats<WHITE>() - threats<BLACK>()
-            + passed< WHITE>() - passed< BLACK>()
-            + space<  WHITE>() - space<  BLACK>();
+    dynScore +=  king<   WHITE>() - king<   BLACK>()
+               + threats<WHITE>() - threats<BLACK>()
+               + passed< WHITE>() - passed< BLACK>()
+               + space<  WHITE>() - space<  BLACK>();
 
-    score += initiative(score);
+    score += dynScore + initiative(dynScore);
 
     // Interpolate between a middlegame and a (scaled by 'sf') endgame score
     ScaleFactor sf = scale_factor(eg_value(score));


### PR DESCRIPTION
Instead of computing the initiative bonus on the material score + dynamic score
compute it on (material score/2) + dynamic score,

Passed STC
http://tests.stockfishchess.org/tests/view/5e2c4945ab2d69d58394fa8f
LLR: 2.94 (-2.94,2.94) {-1.00,3.00}
Total: 39387 W: 7594 L: 7386 D: 24407
Ptnml(0-2): 658, 4519, 9165, 4649, 697

Passed LTC
http://tests.stockfishchess.org/tests/view/5e2c85ccab2d69d58394faa7
LLR: 2.95 (-2.94,2.94) {0.00,2.00}
Total: 32588 W: 4206 L: 3986 D: 24396
Ptnml(0-2): 244, 2909, 9738, 3111, 253

bench: 4958282
bench rebased on master #2514: 4765486