### PR TITLE
Upgrade debug functions

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -248,9 +248,6 @@ Atomic64Map print_hits;
 Atomic64Map print_means;
 
 void hit_on_impl(loc_file_line info_str,bool b){
-  if(!print_hits[info_str])
-    print_hits[info_str][0]=0,print_hits[info_str][1]=0;
-
    ++print_hits[info_str][0];
    if(b)++print_hits[info_str][1];
 }
@@ -260,9 +257,6 @@ void hit_on_impl(loc_file_line info_str,bool c, bool b){
 }
 
 void mean_of_impl(loc_file_line info_str,int v){
- if(!print_means[info_str])
-  print_means[info_str][0]=0,print_means[info_str][1]=0;
-
  ++print_means[info_str][0];
  print_means[info_str][1] += v;
 }

--- a/src/misc.h
+++ b/src/misc.h
@@ -26,8 +26,12 @@
 #include <ostream>
 #include <string>
 #include <vector>
+#include <map>
+#include <atomic>
 
 #include "types.h"
+#include "uci.h" // for testing uci variables.
+
 
 const std::string engine_info(bool to_uci = false);
 const std::string compiler_info();
@@ -111,4 +115,50 @@ namespace WinProcGroup {
   void bindThisThread(size_t idx);
 }
 
+
+// get number of arguments with __NARG__
+#define __NARG__(...)  __NARG_I_(__VA_ARGS__,__RSEQ_N())
+#define __NARG_I_(...) __ARG_N(__VA_ARGS__)
+#define __ARG_N( \
+      _1, _2, _3, _4, _5, _6, _7, _8, _9,_10, \
+     _11,_12,_13,_14,_15,_16,_17,_18,_19,_20, \
+     _21,_22,_23,_24,_25,_26,_27,_28,_29,_30, \
+     _31,_32,_33,_34,_35,_36,_37,_38,_39,_40, \
+     _41,_42,_43,_44,_45,_46,_47,_48,_49,_50, \
+     _51,_52,_53,_54,_55,_56,_57,_58,_59,_60, \
+     _61,_62,_63,N,...) N
+#define __RSEQ_N() \
+     63,62,61,60,                   \
+     59,58,57,56,55,54,53,52,51,50, \
+     49,48,47,46,45,44,43,42,41,40, \
+     39,38,37,36,35,34,33,32,31,30, \
+     29,28,27,26,25,24,23,22,21,20, \
+     19,18,17,16,15,14,13,12,11,10, \
+     9,8,7,6,5,4,3,2,1,0
+
+// general definition for any function name
+#define _VFUNC_(name, n) name##n
+#define _VFUNC(name, n) _VFUNC_(name, n)
+#define VFUNC(func, ...) _VFUNC(func, __NARG__(__VA_ARGS__)) (__VA_ARGS__)
+
+
+#define stringify2(x) #x
+#define stringify(x) stringify2(x)
+#define stringifyany1(a) stringify(a)
+#define stringifyany2(a,b) stringify(a) "," stringify(b) 
+#define stringifyany(...) VFUNC(stringifyany,__VA_ARGS__) 
+  
+typedef const char*    loc_file_line; 
+typedef std::atomic<int64_t> int64StoreAtomic[2]; 
+typedef std::map < loc_file_line , int64StoreAtomic   > Atomic64Map;
+
+extern Atomic64Map print_hits;
+extern Atomic64Map print_means;
+#define hit_on(...) hit_on_impl(__FILE__ ":" stringify(__LINE__) " : hit_on(" stringifyany(__VA_ARGS__)  ")" ,__VA_ARGS__)
+#define mean_of(...)  mean_of_impl(__FILE__ ":" stringify(__LINE__) " : mean_of(" stringify(__VA_ARGS__)  ")" ,__VA_ARGS__)
+
+void hit_on_impl(loc_file_line info_str,bool b);
+void hit_on_impl(loc_file_line info_str,bool c, bool b);
+void mean_of_impl(loc_file_line info_str,int v);
+void dbg_print2();
 #endif // #ifndef MISC_H_INCLUDED

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1730,11 +1730,14 @@ void MainThread::check_time() {
 
   TimePoint elapsed = Time.elapsed();
   TimePoint tick = Limits.startTime + elapsed;
+  TimePoint updatediff =  Limits.use_time_management()?TimePoint(3000)
+        : std::min(elapsed/16,TimePoint(3000));
 
-  if (tick - lastInfoTime >= 1000)
+  if (tick - lastInfoTime >=  updatediff)
   {
       lastInfoTime = tick;
       dbg_print();
+      dbg_print2();
   }
 
   // We should not stop pondering until told so by the GUI

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -60,6 +60,7 @@ void init(OptionsMap& o) {
   constexpr int MaxHashMB = Is64Bit ? 131072 : 2048;
 
   o["Debug Log File"]        << Option("", on_logger);
+  o["Custom"]                << Option(0, INT32_MIN, INT32_MAX);
   o["Contempt"]              << Option(24, -100, 100);
   o["Analysis Contempt"]     << Option("Both var Off var White var Black var Both", "Both");
   o["Threads"]               << Option(1, 1, 512, on_threads);


### PR DESCRIPTION
Upgrade the Stockfish debug functions to another level, storing filename,line, and arguments for each call to hit_on/mean_of (dbg_hit_on/dbg_mean_of remain for compatibility with tuning branch).
UCI variables can debugged too with one custom variable added for testing (Options["Custom"]).

Early search can now be debugged easier with new interval for check_time calls for dbg_print() of "elapsed/16" (for non-time management modes only) which allows to zoom into early search.


Sample of new debug functions in action:
```
evaluate.cpp:793 : mean_of(abs(v))
Total: 2561034
Mean:  545.262

evaluate.cpp:797 : mean_of(!(more_than_one( pos.attackers_to(pos.square<KING>(strongside),pos.pieces(~strongside) ) )))
Total: 230057
Mean:  0.691946

evaluate.cpp:794 : hit_on(popcount(pos.blockers_for_king(strongside))>1)
Total:   2563681
Hits:    3527
Hitrate: 0.137576%

evaluate.cpp:795 : hit_on(strongside,pos.non_pawn_material() / 64 < 50)
Total:   1051552
Hits:    178729
Hitrate: 16.9967%

evaluate.cpp:796 : hit_on(popcount(pos.attackers_to(pos.square<KING>(strongside)))>1,abs(v)>1000)
Total:   686365
Hits:    83849
Hitrate: 12.2164%

evaluate.cpp:793 : mean_of(abs(v))
Total: 2563681
Mean:  545.205

evaluate.cpp:797 : mean_of(!(more_than_one( pos.attackers_to(pos.square<KING>(strongside),pos.pieces(~strongside) ) )))
Total: 230214
Mean:  0.691544

```

Example for UCI Custom variable use.
./stockfish
setoption name Custom value 60
go depth 50
```
evaluate.cpp:795 : hit_on(strongside,pos.non_pawn_material() / 64 < int(Options["Custom"]))
Total:   2963069
Hits:    4
Hitrate: 0.000134995%
```
Resolved conflicts with tuning branch in https://github.com/official-stockfish/Stockfish/pull/2517 which requires keeping old functions in misc.cpp


No functional change.