### PR TITLE
Dynamic Complexity 2

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -168,7 +168,7 @@ namespace {
     template<Color Us> Score passed() const;
     template<Color Us> Score space() const;
     ScaleFactor scale_factor(Value eg) const;
-    Score initiative(Score score, Score materialScore) const;
+    Score initiative(Score score) const;
 
     const Position& pos;
     Material::Entry* me;
@@ -696,7 +696,7 @@ namespace {
   // known attacking/defending status of the players.
 
   template<Tracing T>
-  Score Evaluation<T>::initiative(Score score, Score materialScore) const {
+  Score Evaluation<T>::initiative(Score score) const {
 
     int outflanking =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
                      - distance<Rank>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
@@ -722,7 +722,7 @@ namespace {
                     - 100 ;
 
     // Give more importance to non-material score
-    score = (score * 2 - materialScore) / 2;
+    score = score - pos.psq_score() / 2;
     Value mg = mg_value(score);
     Value eg = eg_value(score);
 
@@ -815,7 +815,7 @@ namespace {
             + passed< WHITE>() - passed< BLACK>()
             + space<  WHITE>() - space<  BLACK>();
 
-    score += initiative(score, materialScore);
+    score += initiative(score);
 
     // Interpolate between a middlegame and a (scaled by 'sf') endgame score
     ScaleFactor sf = scale_factor(eg_value(score));

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -794,9 +794,6 @@ namespace {
     if (abs(v) > LazyThreshold + pos.non_pawn_material() / 64)
        return pos.side_to_move() == WHITE ? v : -v;
 
-    // Remember this score
-    Score materialScore = score;
-
     // Main evaluation begins here
 
     initialize<WHITE>();


### PR DESCRIPTION
Adjust initiative score by psqt/2 instead of materialScore/2

Tested as a simplification against #2516

Passed STC
http://tests.stockfishchess.org/tests/view/5e2e667dab2d69d58394fc73
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 23198 W: 4506 L: 4353 D: 14339
Ptnml(0-2): 396, 2615, 5380, 2728, 418

Passed LTC
http://tests.stockfishchess.org/tests/view/5e2ed75cab2d69d58394fcbf
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 8519 W: 1179 L: 1062 D: 6278
Ptnml(0-2): 50, 775, 2472, 843, 74

Rebased on latest master
bench:  4684459