### PR TITLE
Simplify hashfull calculation.

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -148,7 +148,7 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 int TranspositionTable::hashfull() const {
 
   int cnt = 0;
-  for (int i = 1; i <= 1000; ++i)
+  for (int i = 0; i < 1000; ++i)
       for (int j = 0; j < ClusterSize; ++j)
           cnt += (table[i].entry[j].genBound8 & 0xF8) == generation8;
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -148,9 +148,9 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 int TranspositionTable::hashfull() const {
 
   int cnt = 0;
-  for (int i = 0; i < 1000 / ClusterSize; ++i)
+  for (int i = 1; i <= 1000; ++i)
       for (int j = 0; j < ClusterSize; ++j)
           cnt += (table[i].entry[j].genBound8 & 0xF8) == generation8;
 
-  return cnt * 1000 / (ClusterSize * (1000 / ClusterSize));
+  return cnt / ClusterSize;
 }


### PR DESCRIPTION
We can simplify the calculation of the hashfull info by looping over exact 1,000 entries,
and then divide the result by ClusterSize.
The additional effort of looping over 2/3 more entries than current master seems to be compensated by the simpler calculation.

Passed non-regression LTC https://tests.stockfishchess.org/tests/view/5e30079dab2d69d58394fd5d
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 30125 W: 3987 L: 3926 D: 22212
Ptnml(0-2): 177, 2504, 9558, 2642, 141 

No functional change.