### PR TITLE
Less null move pruning if the position was previously in PV.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -841,7 +841,7 @@ namespace {
         && (ss-1)->statScore < 23397
         &&  eval >= beta
         &&  eval >= ss->staticEval
-        &&  ss->staticEval >= beta - 32 * depth + 292 - improving * 30
+        &&  ss->staticEval >= beta - 32 * depth - 30 * improving + 120 * ttPv + 292
         && !excludedMove
         &&  pos.non_pawn_material(us)
         && (ss->ply >= thisThread->nmpMinPly || us != thisThread->nmpColor))


### PR DESCRIPTION
Stockfish's search algorithm uses an approach known as "null move pruning" (NMP) or the "null move heuristic."  Briefly, if our opponent's previous moves gave us a much better position than we otherwise would have had if the opponent played differently, we assume the opponent will not choose this position (a "beta cutoff").  If our position is so strong, that we could make no move at all (a "null move") and still maintain such an advantage, then we assume we could produce a beta cutoff if we actually made a move to improve our position further.

Stockfish first checks through a long list of conditions to try to avoid applying this heuristic in circumstances where it could be dangerous, such as zugzwang positions.  For example, it is required that the current node not be a PvNode and that we have non-pawn material.  In general, we require that the static evaluation be greater than beta, but we lower this requirement when the depth is large (away from the leaf nodes) or when the static evaluation tells us our position is improving.  This patch counteracts this leniency: we require a higher evaluation before applying NMP, if this position has previously been in the PV, as determined by the transposition table.  (If the position is currently in the PV, NMP is never applied anyway.)

The intention of the patch is to avoid aggressive pruning in positions which have previously been found to be important (PV nodes).  If we already do not apply NMP for current PV nodes, it makes sense to apply it less often for positions that have previously been PV nodes too.

We also reorder some of the code on this line for improved clarity.

Where do we go from here?

- The new coefficient in this patch was chosen arbitrarily, but progressively better results were found every time it was increased.  The natural follow-up (which I will submit after this PR is merged) will be to test larger values.

- After attempting to refine this parameter with quick manual efforts, the parameters in this line may be a promising target for tuning with SPSA (as suggested by J. Gonzalez, @gonzalezjo) or Bayesian optimization.

Many thanks to Stefan Geschwentner (@locutus2), whose efforts with `ttPv` inspired my own.  I would also like to recognize Joost VandeVondele (@vondele), our new maintainer, for his wonderful dedication to the Stockfish project, and Stéphane Nicolet (@snicolet), our outgoing maintainer, for his extensive and selfless service to the community.  Thanks also to all our generous CPU donors, volunteer approvers, and Fishtest developers and maintainers!

STC:
LLR: 2.96 (-2.94,2.94) {-1.00,3.00}
Total: 14959 W: 2921 L: 2782 D: 9256
Ptnml(0-2): 254, 1679, 3493, 1762, 282
http://tests.stockfishchess.org/tests/view/5e2f6637ab2d69d58394fcfd

LTC:
LLR: 2.95 (-2.94,2.94) {0.00,2.00}
Total: 6442 W: 899 L: 753 D: 4790
Ptnml(0-2): 42, 549, 1885, 659, 61
http://tests.stockfishchess.org/tests/view/5e2f767bab2d69d58394fd04

Bench: 4725546