### PR TITLE
Remove enums for Value and Depth.  Speed bump and some fixed types.

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -30,7 +30,7 @@ namespace {
 
   // Table used to drive the king towards the edge of the board
   // in KX vs K and KQ vs KR endgames.
-  constexpr int PushToEdges[SQUARE_NB] = {
+  constexpr Value PushToEdges[SQUARE_NB] = {
     100, 90, 80, 70, 70, 80, 90, 100,
      90, 70, 60, 50, 50, 60, 70,  90,
      80, 60, 40, 30, 30, 40, 60,  80,
@@ -43,7 +43,7 @@ namespace {
 
   // Table used to drive the king towards a corner square of the
   // right color in KBN vs K endgames.
-  constexpr int PushToCorners[SQUARE_NB] = {
+  constexpr Value PushToCorners[SQUARE_NB] = {
      6400, 6080, 5760, 5440, 5120, 4800, 4480, 4160,
      6080, 5760, 5440, 5120, 4800, 4480, 4160, 4480,
      5760, 5440, 4960, 4480, 4480, 4000, 4480, 4800,
@@ -55,8 +55,8 @@ namespace {
   };
 
   // Tables used to drive a piece towards or away from another piece
-  constexpr int PushClose[8] = { 0, 0, 100, 80, 60, 40, 20, 10 };
-  constexpr int PushAway [8] = { 0, 5, 20, 40, 60, 80, 90, 100 };
+  constexpr Value PushClose[8] = { 0, 0, 100, 80, 60, 40, 20, 10 };
+  constexpr Value PushAway [8] = { 0, 5, 20, 40, 60, 80, 90, 100 };
 
   // Pawn Rank based scaling factors used in KRPPKRP endgame
   constexpr int KRPPKRPScaleFactors[RANK_NB] = { 0, 9, 10, 14, 21, 44, 0, 0 };
@@ -184,7 +184,7 @@ Value Endgame<KPK>::operator()(const Position& pos) const {
   if (!Bitbases::probe(wksq, psq, bksq, us))
       return VALUE_DRAW;
 
-  Value result = VALUE_KNOWN_WIN + PawnValueEg + Value(rank_of(psq));
+  Value result = VALUE_KNOWN_WIN + PawnValueEg + rank_of(psq);
 
   return strongSide == pos.side_to_move() ? result : -result;
 }
@@ -224,10 +224,10 @@ Value Endgame<KRKP>::operator()(const Position& pos) const {
            && distance(bksq, psq) == 1
            && rank_of(wksq) >= RANK_4
            && distance(wksq, psq) > 2 + (pos.side_to_move() == strongSide))
-      result = Value(80) - 8 * distance(wksq, psq);
+      result = 80 - 8 * distance(wksq, psq);
 
   else
-      result =  Value(200) - 8 * (  distance(wksq, psq + SOUTH)
+      result =  200 - 8 * (  distance(wksq, psq + SOUTH)
                                   - distance(bksq, psq + SOUTH)
                                   - distance(psq, queeningSq));
 
@@ -243,7 +243,7 @@ Value Endgame<KRKB>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, RookValueMg, 0));
   assert(verify_material(pos, weakSide, BishopValueMg, 0));
 
-  Value result = Value(PushToEdges[pos.square<KING>(weakSide)]);
+  Value result = PushToEdges[pos.square<KING>(weakSide)];
   return strongSide == pos.side_to_move() ? result : -result;
 }
 
@@ -258,7 +258,7 @@ Value Endgame<KRKN>::operator()(const Position& pos) const {
 
   Square bksq = pos.square<KING>(weakSide);
   Square bnsq = pos.square<KNIGHT>(weakSide);
-  Value result = Value(PushToEdges[bksq] + PushAway[distance(bksq, bnsq)]);
+  Value result = PushToEdges[bksq] + PushAway[distance(bksq, bnsq)];
   return strongSide == pos.side_to_move() ? result : -result;
 }
 
@@ -277,7 +277,7 @@ Value Endgame<KQKP>::operator()(const Position& pos) const {
   Square loserKSq = pos.square<KING>(weakSide);
   Square pawnSq = pos.square<PAWN>(weakSide);
 
-  Value result = Value(PushClose[distance(winnerKSq, loserKSq)]);
+  Value result = PushClose[distance(winnerKSq, loserKSq)];
 
   if (   relative_rank(weakSide, pawnSq) != RANK_7
       || distance(loserKSq, pawnSq) != 1

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -74,8 +74,8 @@ using namespace Trace;
 namespace {
 
   // Threshold for lazy and space evaluation
-  constexpr Value LazyThreshold  = Value(1400);
-  constexpr Value SpaceThreshold = Value(12222);
+  constexpr Value LazyThreshold  = 1400;
+  constexpr Value SpaceThreshold = 12222;
 
   // KingAttackWeights[PieceType] contains king attack weights by piece type
   constexpr int KingAttackWeights[PIECE_TYPE_NB] = { 0, 0, 81, 52, 44, 10 };

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -29,7 +29,7 @@ class Position;
 
 namespace Eval {
 
-constexpr Value Tempo = Value(28); // Must be visible to search
+constexpr Value Tempo = 28; // Must be visible to search
 
 std::string trace(const Position& pos);
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -121,7 +121,7 @@ void MovePicker::score() {
       {
           if (pos.capture(m))
               m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
-                       - Value(type_of(pos.moved_piece(m)));
+                       - type_of(pos.moved_piece(m));
           else
               m.value =  (*mainHistory)[pos.side_to_move()][from_to(m)]
                        + (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
@@ -174,7 +174,7 @@ top:
 
   case GOOD_CAPTURE:
       if (select<Best>([&](){
-                       return pos.see_ge(*cur, Value(-55 * cur->value / 1024)) ?
+                       return pos.see_ge(*cur, -55 * cur->value / 1024) ?
                               // Move losing capture to endBadCaptures to be tried later
                               true : (*endBadCaptures++ = *cur, false); }))
           return *(cur - 1);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -28,7 +28,6 @@
 
 namespace {
 
-  #define V Value
   #define S(mg, eg) make_score(mg, eg)
 
   // Pawn penalties
@@ -45,10 +44,10 @@ namespace {
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
-    { V( -6), V( 81), V( 93), V( 58), V( 39), V( 18), V(  25) },
-    { V(-43), V( 61), V( 35), V(-49), V(-29), V(-11), V( -63) },
-    { V(-10), V( 75), V( 23), V( -2), V( 32), V(  3), V( -45) },
-    { V(-39), V(-13), V(-29), V(-52), V(-48), V(-67), V(-166) }
+    {  -6,  81,  93,  58,  39,  18,   25 },
+    { -43,  61,  35, -49, -29, -11,  -63 },
+    { -10,  75,  23,  -2,  32,   3,  -45 },
+    { -39, -13, -29, -52, -48, -67, -166 }
   };
 
   // Danger of enemy pawns moving toward our king by [distance from edge][rank].
@@ -56,14 +55,13 @@ namespace {
   // is behind our king. Note that UnblockedStorm[0][1-2] accommodate opponent pawn
   // on edge, likely blocked by our king.
   constexpr Value UnblockedStorm[int(FILE_NB) / 2][RANK_NB] = {
-    { V( 85), V(-289), V(-166), V(97), V(50), V( 45), V( 50) },
-    { V( 46), V( -25), V( 122), V(45), V(37), V(-10), V( 20) },
-    { V( -6), V(  51), V( 168), V(34), V(-2), V(-22), V(-14) },
-    { V(-15), V( -11), V( 101), V( 4), V(11), V(-15), V(-29) }
+    {  85, -289, -166, 97, 50,  45,  50 },
+    {  46,  -25,  122, 45, 37, -10,  20 },
+    {  -6,   51,  168, 34, -2, -22, -14 },
+    { -15,  -11,  101,  4, 11, -15, -29 }
   };
 
   #undef S
-  #undef V
 
   template<Color Us>
   Score evaluate(const Position& pos, Pawns::Entry* e) {

--- a/src/types.h
+++ b/src/types.h
@@ -168,7 +168,9 @@ enum Bound {
   BOUND_EXACT = BOUND_UPPER | BOUND_LOWER
 };
 
-enum Value : int {
+typedef int Value;
+
+constexpr Value
   VALUE_ZERO      = 0,
   VALUE_DRAW      = 0,
   VALUE_KNOWN_WIN = 10000,
@@ -184,9 +186,7 @@ enum Value : int {
   BishopValueMg = 825,   BishopValueEg = 915,
   RookValueMg   = 1276,  RookValueEg   = 1380,
   QueenValueMg  = 2538,  QueenValueEg  = 2682,
-
-  MidgameLimit  = 15258, EndgameLimit  = 3915
-};
+  MidgameLimit  = 15258, EndgameLimit  = 3915;
 
 enum PieceType {
   NO_PIECE_TYPE, PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING,
@@ -205,15 +205,13 @@ extern Value PieceValue[PHASE_NB][PIECE_NB];
 
 typedef int Depth;
 
-enum : int {
-
+constexpr Depth
   DEPTH_QS_CHECKS     =  0,
   DEPTH_QS_NO_CHECKS  = -1,
   DEPTH_QS_RECAPTURES = -5,
 
   DEPTH_NONE   = -6,
-  DEPTH_OFFSET = DEPTH_NONE,
-};
+  DEPTH_OFFSET = DEPTH_NONE;
 
 enum Square : int {
   SQ_A1, SQ_B1, SQ_C1, SQ_D1, SQ_E1, SQ_F1, SQ_G1, SQ_H1,
@@ -265,12 +263,12 @@ constexpr Score make_score(int mg, int eg) {
 /// and so is a right shift of a signed integer.
 inline Value eg_value(Score s) {
   union { uint16_t u; int16_t s; } eg = { uint16_t(unsigned(s + 0x8000) >> 16) };
-  return Value(eg.s);
+  return eg.s;
 }
 
 inline Value mg_value(Score s) {
   union { uint16_t u; int16_t s; } mg = { uint16_t(unsigned(s)) };
-  return Value(mg.s);
+  return mg.s;
 }
 
 #define ENABLE_BASE_OPERATORS_ON(T)                                \
@@ -293,7 +291,6 @@ constexpr int operator/(T d1, T d2) { return int(d1) / int(d2); }  \
 inline T& operator*=(T& d, int i) { return d = T(int(d) * i); }    \
 inline T& operator/=(T& d, int i) { return d = T(int(d) / i); }
 
-ENABLE_FULL_OPERATORS_ON(Value)
 ENABLE_FULL_OPERATORS_ON(Direction)
 
 ENABLE_INCR_OPERATORS_ON(PieceType)
@@ -307,12 +304,6 @@ ENABLE_BASE_OPERATORS_ON(Score)
 #undef ENABLE_FULL_OPERATORS_ON
 #undef ENABLE_INCR_OPERATORS_ON
 #undef ENABLE_BASE_OPERATORS_ON
-
-/// Additional operators to add integers to a Value
-constexpr Value operator+(Value v, int i) { return Value(int(v) + i); }
-constexpr Value operator-(Value v, int i) { return Value(int(v) - i); }
-inline Value& operator+=(Value& v, int i) { return v = v + i; }
-inline Value& operator-=(Value& v, int i) { return v = v - i; }
 
 /// Additional operators to add a Direction to a Square
 constexpr Square operator+(Square s, Direction d) { return Square(int(s) + int(d)); }


### PR DESCRIPTION
This is a non-functional simplification that makes "Value" and "Depth" an int and removes enums and Value-int operators.  This PR is the combination of two passing simplifications.

It is quite awkward for master to declare Value as an enum, then provide Value-int operators to allow integer operators to a Value. Thus, enum serves no real purpose (e.g. type safety) as Value can be any supported integer value.  Using constexpr works just as well and allows removal of all of the type casting.

TODO:   This version seems to be a bit faster than master.  The earlier failures were due to std::min, std::max using different typed parameters (causes an unexplained slowdown).  This patch would not pass without the casting in std::min (which cast a Value to a Value).  Thus there seems to be some speed issues with std::min/max when out argument types don't match.  I don't know why yet, but there is probably some performance boost if someone can figure that one out.

STC (Values)
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 10979 W: 2213 L: 2049 D: 6717
Ptnml(0-2): 146, 1203, 2672, 1277, 190
http://tests.stockfishchess.org/tests/view/5e2f425eab2d69d58394fcea

STC (Depth)
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 23317 W: 4662 L: 4523 D: 14132
Ptnml(0-2): 359, 2515, 5731, 2692, 342
http://tests.stockfishchess.org/tests/view/5e2f58d8ab2d69d58394fcfa


OTHER RELATED TESTING:
http://tests.stockfishchess.org/tests/view/5e2e84d5ab2d69d58394fc8c
http://tests.stockfishchess.org/tests/view/5e2b6005ab2d69d58394fa07
