### PR TITLE
Upgrade debug functions, thread-local version

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -46,6 +46,9 @@ typedef bool(*fun3_t)(HANDLE, CONST GROUP_AFFINITY*, PGROUP_AFFINITY);
 #include <iostream>
 #include <sstream>
 #include <vector>
+#include <map>
+#include <string>
+
 
 #ifdef __linux__
 #include <stdlib.h>
@@ -160,8 +163,8 @@ const string engine_info(bool to_uci) {
 
 const std::string compiler_info() {
 
-  #define stringify2(x) #x
-  #define stringify(x) stringify2(x)
+  
+  
   #define make_version_string(major, minor, patch) stringify(major) "." stringify(minor) "." stringify(patch)
 
 /// Predefined macros hell:
@@ -226,7 +229,6 @@ const std::string compiler_info() {
   return compiler;
 }
 
-
 /// Debug functions used mainly to collect run-time statistics
 static std::atomic<int64_t> hits[2], means[2];
 
@@ -245,6 +247,53 @@ void dbg_print() {
            << (double)means[1] / means[0] << endl;
 }
 
+
+
+thread_local Atomic64Map print_hits;
+thread_local Atomic64Map print_means;
+
+void hit_on_impl(loc_file_line info_str, bool b)
+{
+    ++print_hits[info_str][0];
+    if (b)
+        ++print_hits[info_str][1];
+}
+
+void hit_on_impl(loc_file_line info_str, bool c, bool b)
+{
+    if (c)
+        hit_on_impl(info_str, b);
+}
+
+void mean_of_impl(loc_file_line info_str, int v)
+{
+    ++print_means[info_str][0];
+    print_means[info_str][1] += v;
+}
+
+
+void dbg_print2()
+{
+    for (Thread* th : Threads)
+    {
+        for (auto& it : print_hits)
+        {
+
+            if (it.second[0])
+                cerr << endl
+                     << it.first << "\nThread:" << th->idx << "\n Total:   " << it.second[0]
+                     << "\nHits:    " << it.second[1]
+                     << "\nHitrate: " << (100.0 * it.second[1]) / it.second[0] << "%" << endl;
+        }
+        for (auto& it : print_means)
+        {
+            if (it.second[0])
+                cerr << endl
+                     << it.first << "\nThread:" << th->idx << "\nTotal: " << it.second[0]
+                     << "\nMean:  " << (double)it.second[1] / it.second[0] << endl;
+        }
+    }
+}
 
 /// Used to serialize access to std::cout to avoid multiple threads writing at
 /// the same time.

--- a/src/misc.h
+++ b/src/misc.h
@@ -26,8 +26,12 @@
 #include <ostream>
 #include <string>
 #include <vector>
+#include <map>
+#include <atomic>
 
 #include "types.h"
+#include "uci.h" // for testing uci variables.
+
 
 const std::string engine_info(bool to_uci = false);
 const std::string compiler_info();
@@ -112,4 +116,50 @@ namespace WinProcGroup {
   void bindThisThread(size_t idx);
 }
 
+
+// get number of arguments with __NARG__
+#define __NARG__(...)  __NARG_I_(__VA_ARGS__,__RSEQ_N())
+#define __NARG_I_(...) __ARG_N(__VA_ARGS__)
+#define __ARG_N( \
+      _1, _2, _3, _4, _5, _6, _7, _8, _9,_10, \
+     _11,_12,_13,_14,_15,_16,_17,_18,_19,_20, \
+     _21,_22,_23,_24,_25,_26,_27,_28,_29,_30, \
+     _31,_32,_33,_34,_35,_36,_37,_38,_39,_40, \
+     _41,_42,_43,_44,_45,_46,_47,_48,_49,_50, \
+     _51,_52,_53,_54,_55,_56,_57,_58,_59,_60, \
+     _61,_62,_63,N,...) N
+#define __RSEQ_N() \
+     63,62,61,60,                   \
+     59,58,57,56,55,54,53,52,51,50, \
+     49,48,47,46,45,44,43,42,41,40, \
+     39,38,37,36,35,34,33,32,31,30, \
+     29,28,27,26,25,24,23,22,21,20, \
+     19,18,17,16,15,14,13,12,11,10, \
+     9,8,7,6,5,4,3,2,1,0
+
+// general definition for any function name
+#define _VFUNC_(name, n) name##n
+#define _VFUNC(name, n) _VFUNC_(name, n)
+#define VFUNC(func, ...) _VFUNC(func, __NARG__(__VA_ARGS__)) (__VA_ARGS__)
+
+
+#define stringify2(x) #x
+#define stringify(x) stringify2(x)
+#define stringifyany1(a) stringify(a)
+#define stringifyany2(a,b) stringify(a) "," stringify(b) 
+#define stringifyany(...) VFUNC(stringifyany,__VA_ARGS__) 
+  
+typedef const char*    loc_file_line; 
+typedef std::atomic<int64_t> int64StoreAtomic[2]; 
+typedef std::map < loc_file_line , int64StoreAtomic   > Atomic64Map;
+
+extern thread_local Atomic64Map print_hits;
+extern thread_local Atomic64Map print_means;
+#define hit_on(...) hit_on_impl(__FILE__ ":" stringify(__LINE__) " : hit_on(" stringifyany(__VA_ARGS__)  ")" ,__VA_ARGS__)
+#define mean_of(...)  mean_of_impl(__FILE__ ":" stringify(__LINE__) " : mean_of(" stringify(__VA_ARGS__)  ")" ,__VA_ARGS__)
+
+void hit_on_impl(loc_file_line info_str,bool b);
+void hit_on_impl(loc_file_line info_str,bool c, bool b);
+void mean_of_impl(loc_file_line info_str,int v);
+void dbg_print2();
 #endif // #ifndef MISC_H_INCLUDED

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1730,11 +1730,14 @@ void MainThread::check_time() {
 
   TimePoint elapsed = Time.elapsed();
   TimePoint tick = Limits.startTime + elapsed;
+  TimePoint updatediff =  Limits.use_time_management()?TimePoint(3000)
+        : std::min(elapsed/16,TimePoint(3000));
 
-  if (tick - lastInfoTime >= 1000)
+  if (tick - lastInfoTime >=  updatediff)
   {
       lastInfoTime = tick;
       dbg_print();
+      dbg_print2();
   }
 
   // We should not stop pondering until told so by the GUI

--- a/src/thread.h
+++ b/src/thread.h
@@ -74,6 +74,7 @@ public:
   CapturePieceToHistory captureHistory;
   ContinuationHistory continuationHistory[2][2];
   Score contempt;
+  friend void dbg_print2();
 };
 
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -60,6 +60,7 @@ void init(OptionsMap& o) {
   constexpr int MaxHashMB = Is64Bit ? 131072 : 2048;
 
   o["Debug Log File"]        << Option("", on_logger);
+  o["Custom"]                << Option(0, INT32_MIN, INT32_MAX);
   o["Contempt"]              << Option(24, -100, 100);
   o["Analysis Contempt"]     << Option("Both var Off var White var Black var Both", "Both");
   o["Threads"]               << Option(1, 1, 512, on_threads);


### PR DESCRIPTION
Upgrade the Stockfish debug functions to another level, storing filename,line, thread index and arguments for each call to hit_on/mean_of (dbg_hit_on/dbg_mean_of remain for compatibility with tuning branch).
UCI variables can debugged too with one custom variable added for testing (Options["Custom"]).

Early search can now be debugged easier with new interval for check_time calls for dbg_print() of "elapsed/16" (for non-time management modes only) which allows to zoom into early search.
This version also allows debugging unique per-thread variables (printing 0 for mainThread).


Sample of new thread-local version:
```
evaluate.cpp:816 : mean_of(eg_value(score))
Thread:52
Total: 17420
Mean:  84.1338

evaluate.cpp:816 : mean_of(eg_value(score))
Thread:53
Total: 17420
Mean:  84.1338

evaluate.cpp:816 : mean_of(eg_value(score))
Thread:54
Total: 17420
Mean:  84.1338

```
Sample of UCI debugging:
./stockfish
setoption name Custom value 40
setoption name Threads value 4
go depth 20
```
evaluate.cpp:816 : mean_of(eg_value(score)< int(Options["Custom"]))
Thread:0
Total: 1162650
Mean:  0.445352

evaluate.cpp:816 : mean_of(eg_value(score)< int(Options["Custom"]))
Thread:1
Total: 1162650
Mean:  0.445352

evaluate.cpp:816 : mean_of(eg_value(score)< int(Options["Custom"]))
Thread:2
Total: 1162650
Mean:  0.445352

evaluate.cpp:816 : mean_of(eg_value(score)< int(Options["Custom"]))
Thread:3
Total: 1162650
Mean:  0.445352

```
Fixes issues from https://github.com/official-stockfish/Stockfish/pull/2518 by making the map thread_local.
No functional change.
