### PR TITLE
Defer hash table resize and avoid redundant clears

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -150,9 +150,6 @@ void ThreadPool::set(size_t requested) {
           push_back(new Thread(size()));
       clear();
 
-      // Reallocate the hash with the new threadpool size
-      TT.resize(Options["Hash"]);
-
       // Init thread number dependent search params.
       Search::init();
   }

--- a/src/tt.h
+++ b/src/tt.h
@@ -79,8 +79,10 @@ public:
   void new_search() { generation8 += 8; } // Lower 3 bits are used by PV flag and Bound
   TTEntry* probe(const Key key, bool& found) const;
   int hashfull() const;
-  void resize(size_t mbSize);
-  void clear();
+
+  void resizeIfChanged(); // trigger resize if options changed
+  void clear();           // clear if hash is dirty
+  void markDirty() { dirty = true; } // mark the hash dirty
 
   // The 32 lowest order bits of the key are used to get the index of the cluster
   TTEntry* first_entry(const Key key) const {
@@ -92,7 +94,13 @@ private:
 
   size_t clusterCount;
   Cluster* table;
-  void* mem;
+  void* mem = nullptr;
+  bool dirty = false;
+
+  // Current TT config values -- used to trigger resize in resizeIfChanged()
+  size_t memMb = 0;
+  size_t numThreads = 0;
+
   uint8_t generation8; // Size must be not bigger than TTEntry::genBound8
 };
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -37,8 +37,7 @@ UCI::OptionsMap Options; // Global object
 namespace UCI {
 
 /// 'On change' actions, triggered by an option's value change
-void on_clear_hash(const Option&) { Search::clear(); }
-void on_hash_size(const Option& o) { TT.resize(o); }
+void on_clear_hash(const Option&) { TT.markDirty(); TT.resizeIfChanged(); Search::clear(); }
 void on_logger(const Option& o) { start_logger(o); }
 void on_threads(const Option& o) { Threads.set(o); }
 void on_tb_path(const Option& o) { Tablebases::init(o); }
@@ -63,7 +62,7 @@ void init(OptionsMap& o) {
   o["Contempt"]              << Option(24, -100, 100);
   o["Analysis Contempt"]     << Option("Both var Off var White var Black var Both", "Both");
   o["Threads"]               << Option(1, 1, 512, on_threads);
-  o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
+  o["Hash"]                  << Option(16, 1, MaxHashMB);
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);


### PR DESCRIPTION
**This is a usability improvement for faster Stockfish initialization.**

Defer hash table resize until the hash is actually needed. That is,
either when 'isready' or a search start command is received. This has
the following benefits:

- Stockfish initializes faster, especially on big hash sizes, since
  setting 'Threads' and 'Hash' will now trigger only 1 hash
  resize. Further, this removes the speed difference related to the
  order of setting "Hash" and "Threads".
- The initial default hash is never allocated in case the user sets
  the hash table size.

Add also tracking for whether the hash is dirty to avoid redundant
clears. This speeds up the initialization further.

With these improvements, Stockfish initialization is improved
drastically in the TCEC "Blue" machine: (176 threads, 128 GB hash)

<pre>Case  Init sequence style (SF ver)   Process launch to search start
===================================================================
 (1)  Default Cutechess (SF-dev)     59.0641s
 (2)  TCEC Cutechess-cli (SF-dev)     8.980s
 (3)  Either (SF-dev + this patch)    4.853s</pre>

The init sequence used in testing is as follows: (Default Cutechess style)

<pre>  uci
  setoption name Hash value 131072
  setoption name Threads value 176
  setoption name OwnBook value false
  setoption name Ponder value false
  ucinewgame
  isready
  position startpos
  isready
  go depth 1</pre>

The TCEC-patched Cutechess sets "Threads" before "Hash", since this
order is much faster on many engines, including SF-dev before this
patch.

Similarly, many regular users will also encounter speedups. The above
init sequence on my box measures the following times for the different
cases: (Intel Core i7-8700k, 12 threads, 16 GB hash)

<pre> (1)  2.347s
 (2)  1.430s
 (3)  0.975s</pre>

This patch makes my chess GUI (chessx) also start the analysis
noticeably faster. Response time improves from approx 2s to 1s from
pressing 'Analyze' to first output. (Same i7-8700k, 11 threads, 16 GB
hash)

No functional change