### PR TITLE
Bishop penalty if access towards center blocked by our pawn

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -137,6 +137,7 @@ namespace {
   constexpr Score MinorBehindPawn    = S( 18,  3);
   constexpr Score Outpost            = S( 30, 21);
   constexpr Score PassedFile         = S( 11,  8);
+  constexpr Score PawnBlocksBishop   = S( 16, 16);
   constexpr Score PawnlessFlank      = S( 17, 95);
   constexpr Score RestrictedPiece    = S(  7,  7);
   constexpr Score ReachableOutpost   = S( 32, 10);
@@ -318,13 +319,17 @@ namespace {
                 if (more_than_one(attacks_bb<BISHOP>(s, pos.pieces(PAWN)) & Center))
                     score += LongDiagonalBishop;
 
+                // Penalty for bishop with own pawn blocking access to center of board
+                Direction d = pawn_push(Us) + (file_of(s) < FILE_E ? EAST : WEST);
+                if (pos.piece_on(s + d) == make_piece(Us, PAWN))
+                    score -= PawnBlocksBishop;
+
                 // An important Chess960 pattern: a cornered bishop blocked by a friendly
                 // pawn diagonally in front of it is a very serious problem, especially
                 // when that pawn is also blocked.
                 if (   pos.is_chess960()
                     && (s == relative_square(Us, SQ_A1) || s == relative_square(Us, SQ_H1)))
                 {
-                    Direction d = pawn_push(Us) + (file_of(s) == FILE_A ? EAST : WEST);
                     if (pos.piece_on(s + d) == make_piece(Us, PAWN))
                         score -= !pos.empty(s + d + pawn_push(Us))                ? CorneredBishop * 4
                                 : pos.piece_on(s + d + d) == make_piece(Us, PAWN) ? CorneredBishop * 2


### PR DESCRIPTION
Initial tests passed STC and failed LTC (yellow):

STC 10+0.1 :
LLR: 2.94 (-2.94,2.94) {-1.00,3.00}
Total: 27971 W: 5518 L: 5341 D: 17112
Ptnml(0-2): 464, 3231, 6437, 3317, 509
https://tests.stockfishchess.org/tests/view/5e2f25c3ab2d69d58394fcd7

LTC 60+0.06 :
LLR: -2.94 (-2.94,2.94) {0.00,2.00}
Total: 54183 W: 7159 L: 7147 D: 39877
Ptnml(0-2): 410, 5251, 15744, 5210, 443
https://tests.stockfishchess.org/tests/view/5e2f389bab2d69d58394fce4

A second LTC was started to keep fishtest busy when there were many cores and ended up passing:

LTC 60+0.6 :
LLR: 2.96 (-2.94,2.94) {0.00,2.00}
Total: 65715 W: 8632 L: 8312 D: 48771
Ptnml(0-2): 498, 5958, 19201, 6285, 492
https://tests.stockfishchess.org/tests/view/5e3339ff708b13464ceea325

Bench 4896615

I'm not claiming this is ready to merge, it took 2 LTC's to pass, and we now have stricter requirements for both STC and LTC anyway. What should I do next? (if anything)