### PR TITLE
Move compare operator into ExtMove struct.

### DIFF
--- a/src/movegen.h
+++ b/src/movegen.h
@@ -42,15 +42,12 @@ struct ExtMove {
 
   operator Move() const { return move; }
   void operator=(Move m) { move = m; }
+  bool operator<(const ExtMove& s) { return value < s.value; }
 
   // Inhibit unwanted implicit conversions to Move
   // with an ambiguity that yields to a compile error.
   operator float() const = delete;
 };
-
-inline bool operator<(const ExtMove& f, const ExtMove& s) {
-  return f.value < s.value;
-}
 
 template<GenType>
 ExtMove* generate(const Position& pos, ExtMove* moveList);


### PR DESCRIPTION
This is a non-functional simplification that does not change the resulting binary.

STC
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 22208 W: 4319 L: 4175 D: 13714
Ptnml(0-2): 318, 2434, 5468, 2541, 336
http://tests.stockfishchess.org/tests/view/5e3978d3e70d848499f63982