### PR TITLE
Reintroduce king infiltration.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -708,14 +708,18 @@ namespace {
                            &&  outflanking < 0
                            && !pawnsOnBothFlanks;
 
+    bool infiltration = rank_of(pos.square<KING>(WHITE)) > RANK_4
+                     || rank_of(pos.square<KING>(BLACK)) < RANK_5;
+
     // Compute the initiative bonus for the attacking side
     int complexity =   9 * pe->passed_count()
                     + 11 * pos.count<PAWN>()
                     +  9 * outflanking
                     + 21 * pawnsOnBothFlanks
+                    + 24 * infiltration
                     + 51 * !pos.non_pawn_material()
                     - 43 * almostUnwinnable
-                    - 95 ;
+                    -110 ;
 
     // Give more importance to non-material score
     Value mg = mg_value(score);


### PR DESCRIPTION
passed STC
http://tests.stockfishchess.org/tests/view/5e3476f630ae32da08941d5c
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 75323 W: 14434 L: 14140 D: 46749
Ptnml(0-2): 1231, 8729, 17528, 8826, 1331 
passed LTC
http://tests.stockfishchess.org/tests/view/5e377353e70d848499f638c1
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 171466 W: 22223 L: 21561 D: 127682
Ptnml(0-2): 1204, 15951, 50831, 16397, 1312 
This patch reintroduces recently simplified king infiltration bonus in initiative calculation.
Effect is twice as high as it was while compensation is thrice as big.

bench 4869669