### PR TITLE
Allow implicit conversions between Move/Extmove

### DIFF
--- a/src/movegen.h
+++ b/src/movegen.h
@@ -40,12 +40,11 @@ struct ExtMove {
   Move move;
   int value;
 
+  ExtMove(){};
+  ExtMove(Move m) : move(m), value(VALUE_ZERO) { }
+
   operator Move() const { return move; }
   void operator=(Move m) { move = m; }
-
-  // Inhibit unwanted implicit conversions to Move
-  // with an ambiguity that yields to a compile error.
-  operator float() const = delete;
 };
 
 inline bool operator<(const ExtMove& f, const ExtMove& s) {

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -59,7 +59,7 @@ namespace {
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Move cm, Move* killers)
            : pos(p), mainHistory(mh), captureHistory(cph), continuationHistory(ch),
-             refutations{{killers[0], 0}, {killers[1], 0}, {cm, 0}}, depth(d) {
+             refutations{killers[0], killers[1], cm}, depth(d) {
 
   assert(d > 0);
 


### PR DESCRIPTION
This is a non-functional code-style change.

A comment in movegen.h suggests that we don't want implicit conversion from ExtMove to Move.  However, we are implicitly converting from ExtMove to Move all over the place (movepick.cpp and movegen.cpp).  Providing the conversions in the ExtMove struct allows the compiler to convert between Moves and ExtMoves as needed which seems like a better solution.

STC
LLR: 2.96 (-2.94,2.94) {-1.50,0.50}
Total: 87295 W: 16662 L: 16607 D: 54026
Ptnml(0-2): 1276, 9787, 21507, 9726, 1332
http://tests.stockfishchess.org/tests/view/5e3db801e70d848499f63b27