### PR TITLE
Modify singular beta for positions that have been in pv.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -443,6 +443,8 @@ namespace {
     int kingFlankAttack = popcount(b1) + popcount(b2);
     int kingFlankDefense = popcount(b3);
 
+    kingDanger += 50 * bool(attackedBy[Them][ALL_PIECES] & forward_ranks_bb(Them, ksq) & kingRing[Us]);
+
     kingDanger +=        kingAttackersCount[Them] * kingAttackersWeight[Them]
                  + 185 * popcount(kingRing[Us] & weak)
                  + 148 * popcount(unsafeChecks)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -443,7 +443,7 @@ namespace {
     int kingFlankAttack = popcount(b1) + popcount(b2);
     int kingFlankDefense = popcount(b3);
 
-    kingDanger += 50 * bool(attackedBy[Them][ALL_PIECES] & forward_ranks_bb(Them, ksq) & kingRing[Us]);
+    kingDanger += 50 * bool(weak & forward_ranks_bb(Them, ksq) & kingRing[Us]);
 
     kingDanger +=        kingAttackersCount[Them] * kingAttackersWeight[Them]
                  + 185 * popcount(kingRing[Us] & weak)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -443,7 +443,7 @@ namespace {
     int kingFlankAttack = popcount(b1) + popcount(b2);
     int kingFlankDefense = popcount(b3);
 
-    kingDanger += 50 * bool(weak & forward_ranks_bb(Them, ksq) & kingRing[Us]);
+    kingDanger += 50 * popcount(weak & forward_ranks_bb(Them, ksq) & kingRing[Us]);
 
     kingDanger +=        kingAttackersCount[Them] * kingAttackersWeight[Them]
                  + 185 * popcount(kingRing[Us] & weak)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -443,8 +443,6 @@ namespace {
     int kingFlankAttack = popcount(b1) + popcount(b2);
     int kingFlankDefense = popcount(b3);
 
-    kingDanger += 50 * popcount(weak & forward_ranks_bb(Them, ksq) & kingRing[Us]);
-
     kingDanger +=        kingAttackersCount[Them] * kingAttackersWeight[Them]
                  + 185 * popcount(kingRing[Us] & weak)
                  + 148 * popcount(unsafeChecks)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1048,7 +1048,7 @@ moves_loop: // When in check, search starts from here
           &&  tte->depth() >= depth - 3
           &&  pos.legal(move))
       {
-          Value singularBeta = ttValue - ((3 * ttPv + 4) * depth) / 2;
+          Value singularBeta = ttValue - (((ttPv && !PvNode) + 4) * depth) / 2;
           Depth halfDepth = depth / 2;
           ss->excludedMove = move;
           value = search<NonPV>(pos, ss, singularBeta - 1, singularBeta, halfDepth, cutNode);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1048,7 +1048,7 @@ moves_loop: // When in check, search starts from here
           &&  tte->depth() >= depth - 3
           &&  pos.legal(move))
       {
-          Value singularBeta = ttValue - (ttPv + 2) * depth;
+          Value singularBeta = ttValue - ((ttPv + 4) * depth) / 2;
           Depth halfDepth = depth / 2;
           ss->excludedMove = move;
           value = search<NonPV>(pos, ss, singularBeta - 1, singularBeta, halfDepth, cutNode);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1008,7 +1008,7 @@ moves_loop: // When in check, search starts from here
               int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount), 0);
 
               // Countermoves based pruning (~20 Elo)
-              if (   (lmrDepth < 4 + ((ss-1)->statScore > 0 || (ss-1)->moveCount == 1)
+              if (   ((lmrDepth < 4 + ((ss-1)->statScore > 0 || (ss-1)->moveCount == 1))
                    || depth < 7)
                   && (*contHist[0])[movedPiece][to_sq(move)] < CounterMovePruneThreshold
                   && (*contHist[1])[movedPiece][to_sq(move)] < CounterMovePruneThreshold)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -888,7 +888,7 @@ namespace {
     // Step 10. ProbCut (~10 Elo)
     // If we have a good enough capture and a reduced search returns a value
     // much above beta, we can (almost) safely prune the previous move.
-    if (   !PvNode
+    if (   !ttPv
         &&  depth >= 5
         &&  abs(beta) < VALUE_MATE_IN_MAX_PLY)
     {
@@ -1116,7 +1116,7 @@ moves_loop: // When in check, search starts from here
       // re-searched at full depth.
       if (    depth >= 3
           &&  moveCount > 1 + 2 * rootNode
-          && (!rootNode || thisThread->best_move_count(move) == 0 || moveCount >= futility_move_count(false, depth))
+          && (!rootNode || thisThread->best_move_count(move) == 0)
           && (  !captureOrPromotion
               || moveCountPruning
               || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1116,7 +1116,7 @@ moves_loop: // When in check, search starts from here
       // re-searched at full depth.
       if (    depth >= 3
           &&  moveCount > 1 + 2 * rootNode
-          && (!rootNode || thisThread->best_move_count(move) == 0 || moveCount >= futility_move_count(improving, depth))
+          && (!rootNode || thisThread->best_move_count(move) == 0 || moveCount >= futility_move_count(false, depth))
           && (  !captureOrPromotion
               || moveCountPruning
               || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1008,7 +1008,7 @@ moves_loop: // When in check, search starts from here
               int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount), 0);
 
               // Countermoves based pruning (~20 Elo)
-              if (   lmrDepth < 4 + ((ss-1)->statScore > 0 || (ss-1)->moveCount == 1)
+              if (   lmrDepth < 4 + ((ss-1)->statScore > 0 || (ss-1)->moveCount == 1 || !ttPv)
                   && (*contHist[0])[movedPiece][to_sq(move)] < CounterMovePruneThreshold
                   && (*contHist[1])[movedPiece][to_sq(move)] < CounterMovePruneThreshold)
                   continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1116,7 +1116,7 @@ moves_loop: // When in check, search starts from here
       // re-searched at full depth.
       if (    depth >= 3
           &&  moveCount > 1 + 2 * rootNode
-          && (!rootNode || thisThread->best_move_count(move) == 0)
+          && (!rootNode || thisThread->best_move_count(move) == 0 || moveCount >= futility_move_count(improving, depth))
           && (  !captureOrPromotion
               || moveCountPruning
               || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1008,7 +1008,8 @@ moves_loop: // When in check, search starts from here
               int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount), 0);
 
               // Countermoves based pruning (~20 Elo)
-              if (   lmrDepth < 4 + ((ss-1)->statScore > 0 || (ss-1)->moveCount == 1 || !ttPv)
+              if (   (lmrDepth < 4 + ((ss-1)->statScore > 0 || (ss-1)->moveCount == 1)
+                   || depth < 7)
                   && (*contHist[0])[movedPiece][to_sq(move)] < CounterMovePruneThreshold
                   && (*contHist[1])[movedPiece][to_sq(move)] < CounterMovePruneThreshold)
                   continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -888,7 +888,7 @@ namespace {
     // Step 10. ProbCut (~10 Elo)
     // If we have a good enough capture and a reduced search returns a value
     // much above beta, we can (almost) safely prune the previous move.
-    if (   !ttPv
+    if (   !PvNode
         &&  depth >= 5
         &&  abs(beta) < VALUE_MATE_IN_MAX_PLY)
     {
@@ -1048,7 +1048,7 @@ moves_loop: // When in check, search starts from here
           &&  tte->depth() >= depth - 3
           &&  pos.legal(move))
       {
-          Value singularBeta = ttValue - 2 * depth;
+          Value singularBeta = ttValue - (ttPv + 2) * depth;
           Depth halfDepth = depth / 2;
           ss->excludedMove = move;
           value = search<NonPV>(pos, ss, singularBeta - 1, singularBeta, halfDepth, cutNode);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1008,8 +1008,7 @@ moves_loop: // When in check, search starts from here
               int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount), 0);
 
               // Countermoves based pruning (~20 Elo)
-              if (   ((lmrDepth < 4 + ((ss-1)->statScore > 0 || (ss-1)->moveCount == 1))
-                   || depth < 7)
+              if (   lmrDepth < 4 + ((ss-1)->statScore > 0 || (ss-1)->moveCount == 1)
                   && (*contHist[0])[movedPiece][to_sq(move)] < CounterMovePruneThreshold
                   && (*contHist[1])[movedPiece][to_sq(move)] < CounterMovePruneThreshold)
                   continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1048,7 +1048,7 @@ moves_loop: // When in check, search starts from here
           &&  tte->depth() >= depth - 3
           &&  pos.legal(move))
       {
-          Value singularBeta = ttValue - ((ttPv + 4) * depth) / 2;
+          Value singularBeta = ttValue - ((3 * ttPv + 4) * depth) / 2;
           Depth halfDepth = depth / 2;
           ss->excludedMove = move;
           value = search<NonPV>(pos, ss, singularBeta - 1, singularBeta, halfDepth, cutNode);


### PR DESCRIPTION
passed STC
http://tests.stockfishchess.org/tests/view/5e3f6d7ce70d848499f63bbc
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 154953 W: 29688 L: 29272 D: 95993
Ptnml(0-2): 2616, 17912, 36037, 18210, 2673 
passed LTC
http://tests.stockfishchess.org/tests/view/5e405561e70d848499f63bfa
LLR: 2.95 (-2.94,2.94) {0.25,1.75}
Total: 70974 W: 9305 L: 8932 D: 52737
Ptnml(0-2): 466, 6658, 20920, 6826, 569 
This patch lowers singular beta for positions that have been in pv and are not pv nodes. Initial attempts were for all ttpv hits but it seems that for pv nodes this idea scales negatively - 3 passed STCs there failed LTC.
Idea of using ttpv && !PvNode condition as an altering of search parameters can be tried in other search heuristics, also number tweaks can always be done.
bench 4932981