### PR TITLE
Simplify Futility Move Count

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -79,7 +79,7 @@ namespace {
   }
 
   constexpr int futility_move_count(bool improving, Depth depth) {
-    return (5 + depth * depth) * (1 + improving) / 2 - 1;
+    return (4 + depth * depth) / (2 - improving);
   }
 
   // History and stats update bonus, based on depth

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -70,7 +70,7 @@ namespace {
     return Value(217 * (d - improving));
   }
 
-  // Reductions lookup table, initialized at startup.
+  // Reductions lookup table, initialized at startup
   int Reductions[MAX_MOVES]; // [depth or moveNumber]
 
   Depth reduction(bool i, Depth d, int mn) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -70,7 +70,7 @@ namespace {
     return Value(217 * (d - improving));
   }
 
-  // Reductions lookup table, initialized at startup
+  // Reductions lookup table, initialized at startup.
   int Reductions[MAX_MOVES]; // [depth or moveNumber]
 
   Depth reduction(bool i, Depth d, int mn) {


### PR DESCRIPTION
This is a functional simplification of futility move count.  Previously, removing a single constant did not qualify as a simplification.  This removes two, so it probably qualifies.  I post for consideration due to the relatively good LTC performance.

STC
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 62050 W: 11903 L: 11802 D: 38345
Ptnml(0-2): 1002, 7346, 14283, 7320, 1065
http://tests.stockfishchess.org/tests/view/5e41d73be70d848499f63c6d

LTC
LLR: 2.93 (-2.94,2.94) {-1.50,0.50}
Total: 12850 W: 1679 L: 1572 D: 9599
Ptnml(0-2): 82, 1171, 3818, 1249, 96
http://tests.stockfishchess.org/tests/view/5e42bf07e70d848499f63cc0

Bench 4762351