### PR TITLE
Updated KNNKP endgame.

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -310,16 +310,17 @@ Value Endgame<KQKR>::operator()(const Position& pos) const {
 }
 
 
-/// KNN vs KP. Simply push the opposing king to the corner
+/// KNN vs KP. Very drawish, but there are some mate opportunities if we can
+//  press the weakSide King to a corner before the pawn advances too much.
 template<>
 Value Endgame<KNNKP>::operator()(const Position& pos) const {
 
   assert(verify_material(pos, strongSide, 2 * KnightValueMg, 0));
   assert(verify_material(pos, weakSide, VALUE_ZERO, 1));
 
-  Value result =  2 * KnightValueEg
-                - PawnValueEg
-                + PushToEdges[pos.square<KING>(weakSide)];
+  Value result =      PawnValueEg
+               +  2 * PushToEdges[pos.square<KING>(weakSide)]
+               - 10 * relative_rank(weakSide, pos.square<PAWN>(weakSide));
 
   return strongSide == pos.side_to_move() ? result : -result;
 }


### PR DESCRIPTION
This is a patch that significantly improves KNNKP endgames.  My testing suggests this is better than master by 3:1 (in these specific endings).

Theory:  KNNK is a dead draw, however the presence of the additional weakSide pawn opens up some mate opportunities.  The idea is to block the pawn (preferably behind the Troitsky line) with one of the knights and press the weakSide king into a corner.  If we can stalemate the king, we release the pawn with the knight (to avoid actual stalemate), and use the knight to complete the mate before the pawn promotes.  This is also why there is an additional penalty for advancement of the pawn.

Please help verify:  You can download my KNNvKPFens.epd and use it as an opening book in cutechess.  https://drive.google.com/drive/folders/1AoGr2bt1xPSYYENCp-bdqfXMCKLc8gBy

Set book depth to 1, repeat on, random order, disable resigning and draws.

This patch does not regress against master in normal games:

STC
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 96616 W: 18459 L: 18424 D: 59733
Ptnml(0-2): 1409, 10812, 23802, 10905, 1380 
http://tests.stockfishchess.org/tests/view/5e49dfe6f8d1d52b40cd31bc

LTC
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 49726 W: 6340 L: 6304 D: 37082
Ptnml(0-2): 239, 4227, 15906, 4241, 250 
http://tests.stockfishchess.org/tests/view/5e4ab9ee16fb3df8c4cc01d0

Bench 4981770