### PR TITLE
Merge Outpost and ReachableOutpost into a single parameter.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -139,7 +139,6 @@ namespace {
   constexpr Score PassedFile         = S( 11,  8);
   constexpr Score PawnlessFlank      = S( 17, 95);
   constexpr Score RestrictedPiece    = S(  7,  7);
-  constexpr Score ReachableOutpost   = S( 32, 10);
   constexpr Score RookOnQueenFile    = S(  7,  6);
   constexpr Score SliderOnQueen      = S( 59, 18);
   constexpr Score ThreatByKing       = S( 24, 89);
@@ -296,7 +295,7 @@ namespace {
                 score += Outpost * (Pt == KNIGHT ? 2 : 1);
 
             else if (Pt == KNIGHT && bb & b & ~pos.pieces(Us))
-                score += ReachableOutpost;
+                score += Outpost;
 
             // Knight and Bishop bonus for being right behind a pawn
             if (shift<Down>(pos.pieces(PAWN)) & s)


### PR DESCRIPTION
In November 2019, as a result of the simplification of rank-based outposts by https://github.com/official-stockfish/Stockfish/commit/37698b0396e26a0f1364912dd1feae5dae5892ef, separate bonuses were introduced for outposts that are currently occupied and outposts that are reachable on the next move.  However, the values of these two bonuses are quite similar, and they have remained that way for three months of development.  

It appears that we can safely retire the separate ReachableOutpost parameter and use the same Outpost bonus in both cases, restoring the basic principles of Stockfish outpost evaluation to their pre-November state, while also reducing the size of the parameter space.

STC:
LLR: 2.96 (-2.94,2.94) {-1.50,0.50}
Total: 47680 W: 9213 L: 9092 D: 29375
Ptnml(0-2): 776, 5573, 11071, 5594, 826
https://tests.stockfishchess.org/tests/view/5e51e33190a0a02810d09802

LTC:
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 14690 W: 1960 L: 1854 D: 10876
Ptnml(0-2): 93, 1381, 4317, 1435, 119
https://tests.stockfishchess.org/tests/view/5e52197990a0a02810d0980f

Bench: 4697493