### PR TITLE
Fix TT write in MultiPV case.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1339,7 +1339,7 @@ moves_loop: // When in check, search starts from here
     if (PvNode)
         bestValue = std::min(bestValue, maxValue);
 
-    if (!excludedMove)
+    if (!excludedMove && !(rootNode && thisThread->pvIdx))
         tte->save(posKey, value_to_tt(bestValue, ss->ply), ttPv,
                   bestValue >= beta ? BOUND_LOWER :
                   PvNode && bestMove ? BOUND_EXACT : BOUND_UPPER,


### PR DESCRIPTION
fixes an error reported earlier as https://github.com/official-stockfish/Stockfish/issues/2404 by @AndyGrant.

MultiPV at root shouldn't write to the TT for later lines, as that is neither the eval nor the bestmove for that position.
Fixing this error doesn't matter for playing games (http://tests.stockfishchess.org/tests/view/5dcdbd810ebc590256324a11).

However, it can lead to wrong mate announcements as reported by @uriblass. In particular the following testcase gives
wrong results for the second search, prior to this patch:

```
setoption name MultiPV value 2
position fen 5R2/2kB2p1/p2bR3/8/3p1B2/8/PPP5/2K5 b - - 0 49
go depth 40
position fen 2B2R2/3r2p1/p1kbR3/8/3p1B2/8/PPP5/2K5 b - - 8 48
go depth 40
```

fixes https://github.com/official-stockfish/Stockfish/issues/2561

Only affects MultiPV search.

Bench: 4705960