### PR TITLE
Weak queen protection

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -518,7 +518,7 @@ namespace {
            | (nonPawnEnemies & attackedBy2[Us]);
         score += Hanging * popcount(weak & b);
 
-        score += make_score(4, 4) * popcount(weak & attackedBy[Them][QUEEN]);
+        score += make_score(6, 0) * popcount(weak & attackedBy[Them][QUEEN]);
     }
 
     // Bonus for restricting their piece moves

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -517,6 +517,7 @@ namespace {
            | (nonPawnEnemies & attackedBy2[Us]);
         score += Hanging * popcount(weak & b);
 
+        // Additional bonus if weak piece is only protected by a queen
         score += make_score(14, 0) * popcount(weak & attackedBy[Them][QUEEN]);
     }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -517,6 +517,8 @@ namespace {
         b =  ~attackedBy[Them][ALL_PIECES]
            | (nonPawnEnemies & attackedBy2[Us]);
         score += Hanging * popcount(weak & b);
+
+        score += make_score(4, 4) * popcount(weak & attackedBy[Them][QUEEN]);
     }
 
     // Bonus for restricting their piece moves

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -114,11 +114,11 @@ namespace {
   // which piece type attacks which one. Attacks on lesser pieces which are
   // pawn-defended are not considered.
   constexpr Score ThreatByMinor[PIECE_TYPE_NB] = {
-    S(0, 0), S(6, 32), S(59, 41), S(79, 56), S(90, 119), S(79, 161)
+    S(0, 0), S(5, 32), S(58, 41), S(78, 56), S(90, 119), S(79, 161)
   };
 
   constexpr Score ThreatByRook[PIECE_TYPE_NB] = {
-    S(0, 0), S(3, 44), S(38, 71), S(38, 61), S(0, 38), S(51, 38)
+    S(0, 0), S(2, 44), S(37, 71), S(37, 61), S(0, 38), S(51, 38)
   };
 
   // PassedRank[Rank] contains a bonus according to the rank of a passed pawn
@@ -518,7 +518,7 @@ namespace {
            | (nonPawnEnemies & attackedBy2[Us]);
         score += Hanging * popcount(weak & b);
 
-        score += make_score(8, 0) * popcount(weak & attackedBy[Them][QUEEN]);
+        score += make_score(10, 0) * popcount(weak & attackedBy[Them][QUEEN]);
     }
 
     // Bonus for restricting their piece moves

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -518,7 +518,7 @@ namespace {
            | (nonPawnEnemies & attackedBy2[Us]);
         score += Hanging * popcount(weak & b);
 
-        score += make_score(6, 0) * popcount(weak & attackedBy[Them][QUEEN]);
+        score += make_score(8, 0) * popcount(weak & attackedBy[Them][QUEEN]);
     }
 
     // Bonus for restricting their piece moves

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -114,11 +114,11 @@ namespace {
   // which piece type attacks which one. Attacks on lesser pieces which are
   // pawn-defended are not considered.
   constexpr Score ThreatByMinor[PIECE_TYPE_NB] = {
-    S(0, 0), S(5, 32), S(58, 41), S(78, 56), S(90, 119), S(79, 161)
+    S(0, 0), S(5, 32), S(57, 41), S(77, 56), S(88, 119), S(79, 161)
   };
 
   constexpr Score ThreatByRook[PIECE_TYPE_NB] = {
-    S(0, 0), S(2, 44), S(37, 71), S(37, 61), S(0, 38), S(51, 38)
+    S(0, 0), S(2, 44), S(36, 71), S(36, 61), S(0, 38), S(51, 38)
   };
 
   // PassedRank[Rank] contains a bonus according to the rank of a passed pawn
@@ -518,7 +518,7 @@ namespace {
            | (nonPawnEnemies & attackedBy2[Us]);
         score += Hanging * popcount(weak & b);
 
-        score += make_score(10, 0) * popcount(weak & attackedBy[Them][QUEEN]);
+        score += make_score(14, 0) * popcount(weak & attackedBy[Them][QUEEN]);
     }
 
     // Bonus for restricting their piece moves


### PR DESCRIPTION
Extra penalty if weak piece is only protected by a queen.

STC:
http://tests.stockfishchess.org/tests/view/5e53c6ab84a82b4acd4148fa
LLR: 2.96 (-2.94,2.94) {-0.50,1.50}
Total: 44630 W: 8615 L: 8359 D: 27656
Ptnml(0-2): 746, 5156, 10323, 5276, 814 

LTC:
http://tests.stockfishchess.org/tests/view/5e54e05d84a82b4acd414947
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 175480 W: 23085 L: 22409 D: 129986
Ptnml(0-2): 1264, 16494, 51678, 16910, 1394 

Bench: 4923286