### PR TITLE
Simplify lowply-history logic

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -957,7 +957,7 @@ moves_loop: // When in check, search starts from here
                                       contHist,
                                       countermove,
                                       ss->killers,
-																			depth > 12 ? ss->ply : MAX_PLY);
+                                      depth > 12 ? ss->ply : MAX_PLY);
 
     value = bestValue;
     singularLMR = moveCountPruning = false;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -957,7 +957,7 @@ moves_loop: // When in check, search starts from here
                                       contHist,
                                       countermove,
                                       ss->killers,
-                                      depth > 12 && ttPv ? ss->ply : MAX_PLY);
+																			depth > 12 ? ss->ply : MAX_PLY);
 
     value = bestValue;
     singularLMR = moveCountPruning = false;


### PR DESCRIPTION
Don't restrict usage of the new low-ply heuristic to ttPv nodes exclusively

passed STC:
http://tests.stockfishchess.org/tests/view/5e5634f284a82b4acd41499a
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 152796 W: 29146 L: 29178 D: 94472
Ptnml(0-2): 2590, 17792, 35628, 17836, 2552

passed LTC:
http://tests.stockfishchess.org/tests/view/5e575d4984a82b4acd4149e8
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 20078 W: 2688 L: 2587 D: 14803
Ptnml(0-2): 139, 1914, 5853, 1973, 160

bench: 4923286