### PR TITLE
Fully specialize Bitboard attacks_bb and attacks_from. This remove un…

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -171,9 +171,16 @@ constexpr Bitboard shift(Bitboard b) {
 /// from the squares in the given bitboard.
 
 template<Color C>
-constexpr Bitboard pawn_attacks_bb(Bitboard b) {
-  return C == WHITE ? shift<NORTH_WEST>(b) | shift<NORTH_EAST>(b)
-                    : shift<SOUTH_WEST>(b) | shift<SOUTH_EAST>(b);
+constexpr Bitboard pawn_attacks_bb(Bitboard b); //unused
+
+template<>
+constexpr Bitboard pawn_attacks_bb<WHITE>(Bitboard b) {
+    return shift<NORTH_WEST>(b) | shift<NORTH_EAST>(b);
+}
+
+template<>
+constexpr Bitboard pawn_attacks_bb<BLACK>(Bitboard b) {
+    return shift<SOUTH_WEST>(b) | shift<SOUTH_EAST>(b);
 }
 
 
@@ -263,11 +270,22 @@ template<class T> constexpr const T& clamp(const T& v, const T& lo, const T&  hi
 /// piece of type Pt (bishop or rook) placed on 's'.
 
 template<PieceType Pt>
-inline Bitboard attacks_bb(Square s, Bitboard occupied) {
+inline Bitboard attacks_bb(Square s, Bitboard occupied); //unused
 
-  const Magic& m = Pt == ROOK ? RookMagics[s] : BishopMagics[s];
-  return m.attacks[m.index(occupied)];
+template <>
+inline Bitboard attacks_bb<BISHOP>(Square s, Bitboard occupied) {
+
+    const Magic& m = BishopMagics[s];
+    return m.attacks[m.index(occupied)];
 }
+
+template <>
+inline Bitboard attacks_bb<ROOK>(Square s, Bitboard occupied) {
+
+    const Magic& m = RookMagics[s];
+    return m.attacks[m.index(occupied)];
+}
+
 
 inline Bitboard attacks_bb(PieceType pt, Square s, Bitboard occupied) {
 

--- a/src/position.h
+++ b/src/position.h
@@ -288,13 +288,29 @@ inline Square Position::castling_rook_square(CastlingRights cr) const {
   return castlingRookSquare[cr];
 }
 
-template<PieceType Pt>
-inline Bitboard Position::attacks_from(Square s) const {
-  static_assert(Pt != PAWN, "Pawn attacks need color");
+template<>
+inline Bitboard Position::attacks_from<KNIGHT>(Square s) const {
+    return PseudoAttacks[KNIGHT][s];
+}
 
-  return  Pt == BISHOP || Pt == ROOK ? attacks_bb<Pt>(s, byTypeBB[ALL_PIECES])
-        : Pt == QUEEN  ? attacks_from<ROOK>(s) | attacks_from<BISHOP>(s)
-        : PseudoAttacks[Pt][s];
+template<>
+inline Bitboard Position::attacks_from<BISHOP>(Square s) const {
+    return attacks_bb<BISHOP>(s, byTypeBB[ALL_PIECES]);
+}
+
+template<>
+inline Bitboard Position::attacks_from<ROOK>(Square s) const {
+    return attacks_bb<ROOK>(s, byTypeBB[ALL_PIECES]);
+}
+
+template<>
+inline Bitboard Position::attacks_from<QUEEN>(Square s) const {
+    return attacks_from<BISHOP>( s ) | attacks_from<ROOK>(s);
+}
+
+template<>
+inline Bitboard Position::attacks_from<KING>(Square s) const {
+    return PseudoAttacks[KING][s];
 }
 
 template<>


### PR DESCRIPTION

Commit | Specialization_attacks_bb (Fully specialize Bitboard attacks_bb and attacks_from. This remove unused attacks_bb and attacks_bb template instantiation.)
-- | --
Info | Fully specialize Bitboard attacks_bb and attacks_from. This remove unused attacks_bb and attacks_bb template instantiation.
Submitter | OuaisBla
TC | 10+0.1
SPRT | elo0: -1.50  alpha: 0.05  elo1: 0.50  beta: 0.05 (logistic)
LLR | 2.95 [-2.94,2.94] (accepted)
Elo | 2.26 [-0.68,5.16] (95%)
LOS | 93.5%
Games | 19536 [w:19.5%, l:18.8%, d:61.7%]
Link | /tests/view/5e5ddf13e42a5c3b3ca2e06f

https://tests.stockfishchess.org/tests/view/5e5ddf13e42a5c3b3ca2e06f

To explain a bit more, the attacks_bb and attacks_bb function are instianted by the pos.attack_from and pos.attack_from method respectively. The base code rely on conditional operation to exclude the calls leaving the choice to the compiler to exclude it or not in its binary.

The specialized template versions of attack_bb and pos. attack_from don't create the above functions at all and make the life easier for the compiler to make possibly better inlining decision.

Positive fishtest result and binary size change on my PC.

Base binary size: 558 Ko (572 095 octets)
New binary size: 557 Ko (570 553 octets)

Build using Cygwin and make ARCH=x86-64 COMP=gcc all