### PR TITLE
Use equations for PushAway and PushClose

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -54,7 +54,7 @@ namespace {
      4160, 4480, 4800, 5120, 5440, 5760, 6080, 6400
   };
 
-  // Tables used to drive a piece towards or away from another piece
+  // Drive a piece close to or away from another piece
   inline int push_close(Square s1, Square s2) { return 140 - 20 * distance(s1, s2); }
   inline int push_away(Square s1, Square s2) { return 120 - push_close(s1, s2); }
 

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -56,7 +56,7 @@ namespace {
 
   // Tables used to drive a piece towards or away from another piece
   inline int push_close(Square s1, Square s2) { return 140 - 20 * distance(s1, s2); }
-  inline int push_away(Square s1, Square s2) { return 20 * distance(s1, s2) - 20; }
+  inline int push_away(Square s1, Square s2) { return 120 - push_close(s1, s2); }
 
   // Pawn Rank based scaling factors used in KRPPKRP endgame
   constexpr int KRPPKRPScaleFactors[RANK_NB] = { 0, 9, 10, 14, 21, 44, 0, 0 };

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -55,8 +55,8 @@ namespace {
   };
 
   // Tables used to drive a piece towards or away from another piece
-  constexpr int PushClose[8] = { 0, 0, 100, 80, 60, 40, 20, 10 };
-  constexpr int PushAway [8] = { 0, 5, 20, 40, 60, 80, 90, 100 };
+  inline int push_close(Square s1, Square s2) { return 140 - 20 * distance(s1, s2); }
+  inline int push_away(Square s1, Square s2) { return 20 * distance(s1, s2) - 20; }
 
   // Pawn Rank based scaling factors used in KRPPKRP endgame
   constexpr int KRPPKRPScaleFactors[RANK_NB] = { 0, 9, 10, 14, 21, 44, 0, 0 };
@@ -130,7 +130,7 @@ Value Endgame<KXK>::operator()(const Position& pos) const {
   Value result =  pos.non_pawn_material(strongSide)
                 + pos.count<PAWN>(strongSide) * PawnValueEg
                 + PushToEdges[loserKSq]
-                + PushClose[distance(winnerKSq, loserKSq)];
+                + push_close(winnerKSq, loserKSq);
 
   if (   pos.count<QUEEN>(strongSide)
       || pos.count<ROOK>(strongSide)
@@ -159,7 +159,7 @@ Value Endgame<KBNK>::operator()(const Position& pos) const {
   // to drive to opposite corners (A8/H1).
 
   Value result =  VALUE_KNOWN_WIN
-                + PushClose[distance(winnerKSq, loserKSq)]
+                + push_close(winnerKSq, loserKSq)
                 + PushToCorners[opposite_colors(bishopSq, SQ_A1) ? ~loserKSq : loserKSq];
 
   assert(abs(result) < VALUE_TB_WIN_IN_MAX_PLY);
@@ -258,7 +258,7 @@ Value Endgame<KRKN>::operator()(const Position& pos) const {
 
   Square bksq = pos.square<KING>(weakSide);
   Square bnsq = pos.square<KNIGHT>(weakSide);
-  Value result = Value(PushToEdges[bksq] + PushAway[distance(bksq, bnsq)]);
+  Value result = Value(PushToEdges[bksq] + push_away(bksq, bnsq));
   return strongSide == pos.side_to_move() ? result : -result;
 }
 
@@ -277,7 +277,7 @@ Value Endgame<KQKP>::operator()(const Position& pos) const {
   Square loserKSq = pos.square<KING>(weakSide);
   Square pawnSq = pos.square<PAWN>(weakSide);
 
-  Value result = Value(PushClose[distance(winnerKSq, loserKSq)]);
+  Value result = Value(push_close(winnerKSq, loserKSq));
 
   if (   relative_rank(weakSide, pawnSq) != RANK_7
       || distance(loserKSq, pawnSq) != 1
@@ -304,7 +304,7 @@ Value Endgame<KQKR>::operator()(const Position& pos) const {
   Value result =  QueenValueEg
                 - RookValueEg
                 + PushToEdges[loserKSq]
-                + PushClose[distance(winnerKSq, loserKSq)];
+                + push_close(winnerKSq, loserKSq);
 
   return strongSide == pos.side_to_move() ? result : -result;
 }


### PR DESCRIPTION
This is a functional simplification.  I was trying to replace all of the tables, but in doing so, found that this particular version seems to do very well at LTC.  I think we should commit this, then I can continue.  This version is slightly simplified from the one that passed STC.

Both LTC tests are included.  I honestly can't explain the difference.  The change is pretty minimal.

STC
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 57864 W: 11092 L: 11001 D: 35771
Ptnml(0-2): 826, 6458, 14320, 6455, 873 
http://tests.stockfishchess.org/tests/view/5e5da5b6e42a5c3b3ca2e05c

LTC
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 7198 W: 982 L: 883 D: 5333
Ptnml(0-2): 33, 575, 2296, 650, 45 
http://tests.stockfishchess.org/tests/view/5e5df13ae42a5c3b3ca2e077

LTC (This exact version. . . more simplified)
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 5392 W: 729 L: 631 D: 4032
Ptnml(0-2): 23, 405, 1751, 485, 32 
http://tests.stockfishchess.org/tests/view/5e5ead99e42a5c3b3ca2e0e4

Bench 5123316