### PR TITLE
Simplify/Cleanup KBPsK endgame

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -344,13 +344,14 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
   // be detected even when the weaker side has some pawns.
   assert(pos.non_pawn_material(weakSide) == 0);
 
-  Bitboard pawns = pos.pieces(strongSide, PAWN);
+  Bitboard strongpawns = pos.pieces(strongSide, PAWN);
+  Bitboard allpawns = pos.pieces(PAWN);
 
-  // All pawns are on a single rook file?
-  if (!(pawns & ~FileABB) || !(pawns & ~FileHBB))
+  // All our pawns are on a single rook file?
+  if (!(strongpawns & ~FileABB) || !(strongpawns & ~FileHBB))
   {
       Square bishopSq = pos.square<BISHOP>(strongSide);
-      Square queeningSq = make_square(file_of(lsb(pawns)), relative_rank(strongSide, RANK_8));
+      Square queeningSq = make_square(file_of(lsb(strongpawns)), relative_rank(strongSide, RANK_8));
       Square weakkingSq = pos.square<KING>(weakSide);
 
       if (   opposite_colors(queeningSq, bishopSq)
@@ -359,7 +360,7 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
   }
 
   // If all the pawns are on the same B or G file, then it's potentially a draw
-  if ((!(pawns & ~FileBBB) || !(pawns & ~FileGBB))
+  if ((!(allpawns & ~FileBBB) || !(allpawns & ~FileGBB))
       && pos.non_pawn_material(weakSide) == 0
       && pos.count<PAWN>(weakSide) >= 1)
   {
@@ -373,8 +374,8 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
       // There's potential for a draw if our pawn is blocked on the 7th rank,
       // the bishop cannot attack it or they only have one pawn left
       if (   relative_rank(strongSide, weakPawnSq) == RANK_7
-          && (pos.pieces(strongSide, PAWN) & (weakPawnSq + pawn_push(weakSide)))
-          && (opposite_colors(bishopSq, weakPawnSq) || pos.count<PAWN>(strongSide) == 1))
+          && (strongpawns & (weakPawnSq + pawn_push(weakSide)))
+          && (opposite_colors(bishopSq, weakPawnSq) || !more_than_one(strongpawns)))
       {
           int strongKingDist = distance(weakPawnSq, strongKingSq);
           int weakKingDist = distance(weakPawnSq, weakKingSq);

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -340,18 +340,17 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
   assert(pos.non_pawn_material(strongSide) == BishopValueMg);
   assert(pos.count<PAWN>(strongSide) >= 1);
 
-  // No assertions about the pawn count of weakSide, because we want draws to
+  // No assertions about the material of weakSide, because we want draws to
   // be detected even when the weaker side has some pawns.
-  assert(pos.non_pawn_material(weakSide) == 0);
 
   Bitboard strongpawns = pos.pieces(strongSide, PAWN);
   Bitboard allpawns = pos.pieces(PAWN);
 
-  // All our pawns are on a single rook file?
+  // All strongSide pawns are on a single rook file?
   if (!(strongpawns & ~FileABB) || !(strongpawns & ~FileHBB))
   {
       Square bishopSq = pos.square<BISHOP>(strongSide);
-      Square queeningSq = make_square(file_of(lsb(strongpawns)), relative_rank(strongSide, RANK_8));
+      Square queeningSq = relative_square(strongSide, make_square(file_of(lsb(strongPawns)), RANK_8));
       Square weakkingSq = pos.square<KING>(weakSide);
 
       if (   opposite_colors(queeningSq, bishopSq)

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -340,32 +340,30 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
   assert(pos.non_pawn_material(strongSide) == BishopValueMg);
   assert(pos.count<PAWN>(strongSide) >= 1);
 
-  // No assertions about the material of weakSide, because we want draws to
+  // No assertions about the pawn count of weakSide, because we want draws to
   // be detected even when the weaker side has some pawns.
+  assert(pos.non_pawn_material(weakSide) == 0);
 
   Bitboard pawns = pos.pieces(strongSide, PAWN);
-  File pawnsFile = file_of(lsb(pawns));
 
   // All pawns are on a single rook file?
-  if (    (pawnsFile == FILE_A || pawnsFile == FILE_H)
-      && !(pawns & ~file_bb(pawnsFile)))
+  if (!(pawns & ~FileABB) || !(pawns & ~FileHBB))
   {
       Square bishopSq = pos.square<BISHOP>(strongSide);
-      Square queeningSq = relative_square(strongSide, make_square(pawnsFile, RANK_8));
-      Square kingSq = pos.square<KING>(weakSide);
+      Square queeningSq = make_square(file_of(lsb(pawns)), relative_rank(strongSide, RANK_8));
+      Square weakkingSq = pos.square<KING>(weakSide);
 
       if (   opposite_colors(queeningSq, bishopSq)
-          && distance(queeningSq, kingSq) <= 1)
+          && distance(queeningSq, weakkingSq) <= 1)
           return SCALE_FACTOR_DRAW;
   }
 
   // If all the pawns are on the same B or G file, then it's potentially a draw
-  if (    (pawnsFile == FILE_B || pawnsFile == FILE_G)
-      && !(pos.pieces(PAWN) & ~file_bb(pawnsFile))
+  if ((!(pawns & ~FileBBB) || !(pawns & ~FileGBB))
       && pos.non_pawn_material(weakSide) == 0
       && pos.count<PAWN>(weakSide) >= 1)
   {
-      // Get weakSide pawn that is closest to the home rank
+      // Get the least advanced weakSide pawn
       Square weakPawnSq = frontmost_sq(strongSide, pos.pieces(weakSide, PAWN));
 
       Square strongKingSq = pos.square<KING>(strongSide);

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -350,7 +350,7 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
   if (!(strongpawns & ~FileABB) || !(strongpawns & ~FileHBB))
   {
       Square bishopSq = pos.square<BISHOP>(strongSide);
-      Square queeningSq = relative_square(strongSide, make_square(file_of(lsb(strongPawns)), RANK_8));
+      Square queeningSq = relative_square(strongSide, make_square(file_of(lsb(strongpawns)), RANK_8));
       Square weakkingSq = pos.square<KING>(weakSide);
 
       if (   opposite_colors(queeningSq, bishopSq)


### PR DESCRIPTION
This is a non-functional simplification.
1) Clarify distinction between strong side pawns and all pawns.
2) Simplify and speed-up determination of pawns on the same file.
3) Clarify comments.
4) more_than_one() is probably faster than pos.count.

STC
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 40696 W: 7856 L: 7740 D: 25100
Ptnml(0-2): 584, 4519, 10054, 4579, 612
http://tests.stockfishchess.org/tests/view/5e6153b1e42a5c3b3ca2e1a9
