### PR TITLE
Remove KRPPKRPScaleFactors array.

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -59,7 +59,7 @@ namespace {
   inline int push_away(Square s1, Square s2) { return 120 - push_close(s1, s2); }
 
   // Pawn Rank based scaling factors used in KRPPKRP endgame
-  constexpr int KRPPKRPScaleFactors(int r) { return 7 * r; }
+  constexpr int KRPPKRPScaleFactors(int r) { return 9 + r * r; }
 
 #ifndef NDEBUG
   bool verify_material(const Position& pos, Color c, Value npm, int pawnsCnt) {

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -58,9 +58,6 @@ namespace {
   inline int push_close(Square s1, Square s2) { return 140 - 20 * distance(s1, s2); }
   inline int push_away(Square s1, Square s2) { return 120 - push_close(s1, s2); }
 
-  // Pawn Rank based scaling factors used in KRPPKRP endgame
-  constexpr int KRPPKRPScaleFactors(int r) { return 9 + r * r; }
-
 #ifndef NDEBUG
   bool verify_material(const Position& pos, Color c, Value npm, int pawnsCnt) {
     return pos.non_pawn_material(c) == npm && pos.count<PAWN>(c) == pawnsCnt;
@@ -589,7 +586,7 @@ ScaleFactor Endgame<KRPPKRP>::operator()(const Position& pos) const {
       && relative_rank(strongSide, bksq) > r)
   {
       assert(r > RANK_1 && r < RANK_7);
-      return ScaleFactor(KRPPKRPScaleFactors(r));
+      return ScaleFactor(7 * r);
   }
   return SCALE_FACTOR_NONE;
 }

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -59,7 +59,7 @@ namespace {
   inline int push_away(Square s1, Square s2) { return 120 - push_close(s1, s2); }
 
   // Pawn Rank based scaling factors used in KRPPKRP endgame
-  constexpr int KRPPKRPScaleFactors[RANK_NB] = { 0, 9, 10, 14, 21, 44, 0, 0 };
+  constexpr int KRPPKRPScaleFactors(int r) { return 7 * r; }
 
 #ifndef NDEBUG
   bool verify_material(const Position& pos, Color c, Value npm, int pawnsCnt) {
@@ -589,7 +589,7 @@ ScaleFactor Endgame<KRPPKRP>::operator()(const Position& pos) const {
       && relative_rank(strongSide, bksq) > r)
   {
       assert(r > RANK_1 && r < RANK_7);
-      return ScaleFactor(KRPPKRPScaleFactors[r]);
+      return ScaleFactor(KRPPKRPScaleFactors(r));
   }
   return SCALE_FACTOR_NONE;
 }


### PR DESCRIPTION
This is a functional (although bench does not change) simplification that removes the KRPPKRPScaleFactors array.  Note:  This is not the exact version that passed testing.

Also, these changes do not affect KRPPKRP endgames.  Patch vs master was 11450 games to 11400 games.  Slight better but probably just noise.

STC
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 47374 W: 9159 L: 9049 D: 29166
Ptnml(0-2): 707, 5325, 11560, 5341, 754 
http://tests.stockfishchess.org/tests/view/5e5ff464e42a5c3b3ca2e156

LTC
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 31268 W: 4064 L: 3995 D: 23209
Ptnml(0-2): 173, 2734, 9764, 2777, 186 
http://tests.stockfishchess.org/tests/view/5e61be6ce42a5c3b3ca2e1c1

Bench 5123316