### PR TITLE
Replace Edges and Corner arrays in endgames.cpp

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -257,8 +257,6 @@ template<> inline int distance<Square>(Square x, Square y) { return SquareDistan
 
 inline File edge_distance(File f) { return std::min(f, File(FILE_H - f)); }
 inline Rank edge_distance(Rank r) { return std::min(r, Rank(RANK_8 - r)); }
-inline int edge_distance(Square s) { return std::min<int>(edge_distance(file_of(s)), edge_distance(rank_of(s))); }
-inline int corner_distance(Square s) { return edge_distance(file_of(s)) + edge_distance(rank_of(s)); }
 
 /// attacks_bb() returns a bitboard representing all the squares attacked by a
 /// piece of type Pt (bishop or rook) placed on 's'.

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -255,6 +255,11 @@ template<> inline int distance<File>(Square x, Square y) { return std::abs(file_
 template<> inline int distance<Rank>(Square x, Square y) { return std::abs(rank_of(x) - rank_of(y)); }
 template<> inline int distance<Square>(Square x, Square y) { return SquareDistance[x][y]; }
 
+inline int edge_distance(File f) { return std::min(f, File(FILE_H - f)); }
+inline int edge_distance(Rank r) { return std::min(r, Rank(RANK_8 - r)); }
+inline int edge_distance(Square s) { return std::min(edge_distance(file_of(s)), edge_distance(rank_of(s))); }
+inline int corner_distance(Square s) { return edge_distance(file_of(s)) + edge_distance(rank_of(s)); }
+
 template<class T> constexpr const T& clamp(const T& v, const T& lo, const T&  hi) {
   return v < lo ? lo : v > hi ? hi : v;
 }

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -35,7 +35,7 @@ namespace {
       return 90 - (7 * fd * fd / 2 + 7 * rd * rd / 2);
   }
 
-  // Used to drive the king towards a A1, H8 corner in KBN vs K endgames.
+  // Used to drive the king towards A1H8 corners in KBN vs K endgames.
   inline int push_to_corner(Square s) {
       return abs(7 - rank_of(s) - file_of(s));
   }

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -28,31 +28,15 @@ using std::string;
 
 namespace {
 
-  // Table used to drive the king towards the edge of the board
+  // Used to drive the king towards the edge of the board
   // in KX vs K and KQ vs KR endgames.
-  constexpr int PushToEdges[SQUARE_NB] = {
-    100, 90, 80, 70, 70, 80, 90, 100,
-     90, 70, 60, 50, 50, 60, 70,  90,
-     80, 60, 40, 30, 30, 40, 60,  80,
-     70, 50, 30, 20, 20, 30, 50,  70,
-     70, 50, 30, 20, 20, 30, 50,  70,
-     80, 60, 40, 30, 30, 40, 60,  80,
-     90, 70, 60, 50, 50, 60, 70,  90,
-    100, 90, 80, 70, 70, 80, 90, 100
-  };
+  inline int push_to_edge(Square s) {
+      return 100 - 10 * (corner_distance(s));}
 
-  // Table used to drive the king towards a corner square of the
-  // right color in KBN vs K endgames.
-  constexpr int PushToCorners[SQUARE_NB] = {
-     6400, 6080, 5760, 5440, 5120, 4800, 4480, 4160,
-     6080, 5760, 5440, 5120, 4800, 4480, 4160, 4480,
-     5760, 5440, 4960, 4480, 4480, 4000, 4480, 4800,
-     5440, 5120, 4480, 3840, 3520, 4480, 4800, 5120,
-     5120, 4800, 4480, 3520, 3840, 4480, 5120, 5440,
-     4800, 4480, 4000, 4480, 4480, 4960, 5440, 5760,
-     4480, 4160, 4480, 4800, 5120, 5440, 5760, 6080,
-     4160, 4480, 4800, 5120, 5440, 5760, 6080, 6400
-  };
+  // Used to drive the king towards a A1, H8 corner in KBN vs K endgames.
+  inline int push_to_corner(Square s) {
+      return abs(7 - rank_of(s) - file_of(s));
+  }
 
   // Drive a piece close to or away from another piece
   inline int push_close(Square s1, Square s2) { return 140 - 20 * distance(s1, s2); }
@@ -129,7 +113,7 @@ Value Endgame<KXK>::operator()(const Position& pos) const {
 
   Value result =  pos.non_pawn_material(strongSide)
                 + pos.count<PAWN>(strongSide) * PawnValueEg
-                + PushToEdges[loserKSq]
+                + push_to_edge(loserKSq)
                 + push_close(winnerKSq, loserKSq);
 
   if (   pos.count<QUEEN>(strongSide)
@@ -158,9 +142,9 @@ Value Endgame<KBNK>::operator()(const Position& pos) const {
   // If our bishop does not attack A1/H8, we flip the enemy king square
   // to drive to opposite corners (A8/H1).
 
-  Value result =  VALUE_KNOWN_WIN
+  Value result =  (VALUE_KNOWN_WIN + 4160)
                 + push_close(winnerKSq, loserKSq)
-                + PushToCorners[opposite_colors(bishopSq, SQ_A1) ? ~loserKSq : loserKSq];
+                + 320 * push_to_corner(opposite_colors(bishopSq, SQ_A1) ? flip_file(loserKSq) : loserKSq);
 
   assert(abs(result) < VALUE_TB_WIN_IN_MAX_PLY);
   return strongSide == pos.side_to_move() ? result : -result;
@@ -243,7 +227,7 @@ Value Endgame<KRKB>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, RookValueMg, 0));
   assert(verify_material(pos, weakSide, BishopValueMg, 0));
 
-  Value result = Value(PushToEdges[pos.square<KING>(weakSide)]);
+  Value result = Value(push_to_edge(pos.square<KING>(weakSide)));
   return strongSide == pos.side_to_move() ? result : -result;
 }
 
@@ -258,7 +242,7 @@ Value Endgame<KRKN>::operator()(const Position& pos) const {
 
   Square bksq = pos.square<KING>(weakSide);
   Square bnsq = pos.square<KNIGHT>(weakSide);
-  Value result = Value(PushToEdges[bksq] + push_away(bksq, bnsq));
+  Value result = Value(push_to_edge(bksq) + push_away(bksq, bnsq));
   return strongSide == pos.side_to_move() ? result : -result;
 }
 
@@ -303,7 +287,7 @@ Value Endgame<KQKR>::operator()(const Position& pos) const {
 
   Value result =  QueenValueEg
                 - RookValueEg
-                + PushToEdges[loserKSq]
+                + push_to_edge(loserKSq)
                 + push_close(winnerKSq, loserKSq);
 
   return strongSide == pos.side_to_move() ? result : -result;
@@ -319,7 +303,7 @@ Value Endgame<KNNKP>::operator()(const Position& pos) const {
   assert(verify_material(pos, weakSide, VALUE_ZERO, 1));
 
   Value result =      PawnValueEg
-               +  2 * PushToEdges[pos.square<KING>(weakSide)]
+               +  2 * push_to_edge(pos.square<KING>(weakSide))
                - 10 * relative_rank(weakSide, pos.square<PAWN>(weakSide));
 
   return strongSide == pos.side_to_move() ? result : -result;

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -31,7 +31,9 @@ namespace {
   // Used to drive the king towards the edge of the board
   // in KX vs K and KQ vs KR endgames.
   inline int push_to_edge(Square s) {
-      return 100 - 13 * corner_distance(s);}
+      int rd = edge_distance(rank_of(s)), fd = edge_distance(file_of(s));
+      return 90 - (7 * fd * fd / 2 + 7 * rd * rd / 2);
+  }
 
   // Used to drive the king towards a A1, H8 corner in KBN vs K endgames.
   inline int push_to_corner(Square s) {
@@ -139,9 +141,9 @@ Value Endgame<KBNK>::operator()(const Position& pos) const {
   // If our bishop does not attack A1/H8, we flip the enemy king square
   // to drive to opposite corners (A8/H1).
 
-  Value result =  (VALUE_KNOWN_WIN + 4160)
+  Value result =  (VALUE_KNOWN_WIN + 3520)
                 + push_close(winnerKSq, loserKSq)
-                + 320 * push_to_corner(opposite_colors(bishopSq, SQ_A1) ? flip_file(loserKSq) : loserKSq);
+                + 420 * push_to_corner(opposite_colors(bishopSq, SQ_A1) ? flip_file(loserKSq) : loserKSq);
 
   assert(abs(result) < VALUE_TB_WIN_IN_MAX_PLY);
   return strongSide == pos.side_to_move() ? result : -result;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -643,7 +643,7 @@ namespace {
             || (pos.pieces(PAWN) & (s + Up)))
             bonus = bonus / 2;
 
-        score += bonus - PassedFile * map_to_queenside(file_of(s));
+        score += bonus - PassedFile * edge_distance(file_of(s));
     }
 
     if (T)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -202,7 +202,7 @@ Score Entry::evaluate_shelter(const Position& pos, Square ksq) {
       b = theirPawns & file_bb(f);
       int theirRank = b ? relative_rank(Us, frontmost_sq(Them, b)) : 0;
 
-      File d = map_to_queenside(f);
+      File d = File(edge_distance(f));
       bonus += make_score(ShelterStrength[d][ourRank], 0);
 
       if (ourRank && (ourRank == theirRank - 1))

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 
 #include "types.h"
+#include "bitboard.h"
 
 namespace PSQT {
 
@@ -111,7 +112,7 @@ void init() {
 
       for (Square s = SQ_A1; s <= SQ_H8; ++s)
       {
-          File f = map_to_queenside(file_of(s));
+          File f = File(edge_distance(file_of(s)));
           psq[ pc][ s] = score + (type_of(pc) == PAWN ? PBonus[rank_of(s)][file_of(s)]
                                                       : Bonus[pc][rank_of(s)][f]);
           psq[~pc][flip_rank(s)] = -psq[pc][s];

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -705,7 +705,7 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
 
         std::swap(squares[0], *std::max_element(squares, squares + leadPawnsCnt, pawns_comp));
 
-        tbFile = map_to_queenside(file_of(squares[0]));
+        tbFile = File(edge_distance(file_of(squares[0])));
     }
 
     // DTZ tables are one-sided, i.e. they store positions only for white to

--- a/src/types.h
+++ b/src/types.h
@@ -370,10 +370,6 @@ constexpr Piece operator~(Piece pc) {
   return Piece(pc ^ 8); // Swap color of piece B_KNIGHT -> W_KNIGHT
 }
 
-inline File map_to_queenside(File f) {
-  return std::min(f, File(FILE_H - f)); // Map files ABCDEFGH to files ABCDDCBA
-}
-
 constexpr CastlingRights operator&(Color c, CastlingRights cr) {
   return CastlingRights((c == WHITE ? WHITE_CASTLING : BLACK_CASTLING) & cr);
 }


### PR DESCRIPTION
This is a functional simplification that removes the large arrays in endgames.cpp.  I submit this version (ps_endgames9) because it performed best at LTC, but may regress a little at STC.  In this patch, the values are closer to master, but are more expensive to calculate.

ps_endgames8 is faster, but less accurate.  This seems to support better at STC performance, but worse at LTC.  This may be just noise, I don't know.  Is ps_endgames8 better?
http://tests.stockfishchess.org/tests/user/protonspring

STC
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 174724 W: 33325 L: 33404 D: 107995
Ptnml(0-2): 2503, 19607, 43181, 19608, 2463 
http://tests.stockfishchess.org/tests/view/5e6448ffe42a5c3b3ca2e287

LTC
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 35640 W: 4679 L: 4621 D: 26340
Ptnml(0-2): 189, 2991, 11424, 3005, 211 
http://tests.stockfishchess.org/tests/view/5e650b24e42a5c3b3ca2e2d8

Bench 5070301