### PR TITLE
Remove set statScore to zero

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -123,6 +123,7 @@ Pasquale Pigazzini (ppigazzini)
 Patrick Jansen (mibere)
 pellanda
 Peter Zsifkovits (CoffeeOne)
+Rahul Dsilva (silversolver1)
 Ralph Stößer (Ralph Stoesser)
 Raminder Singh
 renouve
@@ -158,7 +159,3 @@ Vince Negri (cuddlestmonkey)
 # an amazing and essential framework for the development of Stockfish!
 #
 # https://github.com/glinscott/fishtest/blob/master/AUTHORS
-
-
-
-

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1175,13 +1175,6 @@ moves_loop: // When in check, search starts from here
                              + (*contHist[3])[movedPiece][to_sq(move)]
                              - 4926;
 
-              // Reset statScore to zero if negative and most stats shows >= 0
-              if (    ss->statScore < 0
-                  && (*contHist[0])[movedPiece][to_sq(move)] >= 0
-                  && (*contHist[1])[movedPiece][to_sq(move)] >= 0
-                  && thisThread->mainHistory[us][from_to(move)] >= 0)
-                  ss->statScore = 0;
-
               // Decrease/increase reduction by comparing opponent's stat score (~10 Elo)
               if (ss->statScore >= -102 && (ss-1)->statScore < -114)
                   r--;


### PR DESCRIPTION
Simplification. Removes setting statScore to zero if negative. 

STC:
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 84820 W: 16100 L: 16033 D: 52687
Ptnml(0-2): 1442, 9865, 19723, 9944, 1436
https://tests.stockfishchess.org/tests/view/5e654fdae42a5c3b3ca2e2f8

LTC:
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 57658 W: 7435 L: 7391 D: 42832
Ptnml(0-2): 441, 5397, 17104, 5451, 436
https://tests.stockfishchess.org/tests/view/5e657ce9e42a5c3b3ca2e307

Rationale: The idea was basically to not change values to something they're not, especially as doing so would be altering the value from its true state. Essentially: if the statScore was in fact negative, why would we treat it as if it were not?

Also, my first passed LTC! And hopefully my first successful PR to something on Github! :)

Bench 5204700