### PR TITLE
Simplify futility pruning parent node

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1024,10 +1024,9 @@ moves_loop: // When in check, search starts from here
               if (   lmrDepth < 6
                   && !inCheck
                   && ss->staticEval + 235 + 172 * lmrDepth <= alpha
-                  &&  thisThread->mainHistory[us][from_to(move)]
-                    + (*contHist[0])[movedPiece][to_sq(move)]
+                  &&  (*contHist[0])[movedPiece][to_sq(move)]
                     + (*contHist[1])[movedPiece][to_sq(move)]
-                    + (*contHist[3])[movedPiece][to_sq(move)] < 25000)
+                    + (*contHist[3])[movedPiece][to_sq(move)] < 27400)
                   continue;
 
               // Prune moves with negative SEE (~20 Elo)


### PR DESCRIPTION
continuation histories seem to be more accurate than main history stats for this purpose

STC:
http://tests.stockfishchess.org/tests/view/5e6b88dfe42a5c3b3ca2e4ab
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 113356 W: 21725 L: 21696 D: 69935
Ptnml(0-2): 1999, 13255, 26163, 13240, 2021

LTC:
http://tests.stockfishchess.org/tests/view/5e6babbfe42a5c3b3ca2e4c2
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 22164 W: 2917 L: 2821 D: 16426
Ptnml(0-2): 173, 2040, 6548, 2160, 161

bench: 4839496