### PR TITLE
Speed bump in pawns.

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -95,9 +95,9 @@ namespace {
         Rank r = relative_rank(Us, s);
 
         // Flag the pawn
-        opposed    = theirPawns & forward_file_bb(Us, s);
-        blocked    = theirPawns & (s + Up);
         stoppers   = theirPawns & passed_pawn_span(Us, s);
+        opposed    = stoppers   & file_bb(s);
+        blocked    = theirPawns & (s + Up);
         lever      = theirPawns & PawnAttacks[Us][s];
         leverPush  = theirPawns & PawnAttacks[Us][s + Up];
         doubled    = ourPawns   & (s - Up);


### PR DESCRIPTION
This is a non-functional speed-up.  If we do opposed after stoppers, instead of "theirPawns & forward_file_bb(Us, s)" we can do "stoppers & file_bb(s)."  This eliminates an unnecessary forward_file_bb in favor of file_bb which is faster on my machines.

Master:
cycles 10,232,303,726
instructions 14,938,314,693
seconds: 2.9082

Patch:
cycles: 10,127,202,879
instructions 14,825,827,921
seconds 2.887


