### PR TITLE
Anchored bishops

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -308,11 +308,12 @@ namespace {
             if (Pt == BISHOP)
             {
                 // Penalty according to number of pawns on the same color square as the
-                // bishop, bigger when the center files are blocked with pawns.
+                // bishop, bigger when the center files are blocked with pawns and smaller
+                // when the bishop is outside the pawn chain.
                 Bitboard blocked = pos.pieces(Us, PAWN) & shift<Down>(pos.pieces());
 
                 score -= BishopPawns * pos.pawns_on_same_color_squares(Us, s)
-                                     * (1 + popcount(blocked & CenterFiles));
+                                     * (1 + popcount(blocked & CenterFiles) - bool(attackedBy[Us][PAWN] & s));
 
                 // Bonus for bishop on a long diagonal which can "see" both center squares
                 if (more_than_one(attacks_bb<BISHOP>(s, pos.pieces(PAWN)) & Center))


### PR DESCRIPTION
Reduce the "bad bishop" penalty when the bishop is protected by
one of our pawns, as it may indicate that the bishop has found
a safe spot outside the pawn chain.

STC:
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 176942 W: 34142 L: 33696 D: 109104
Ptnml(0-2): 3129, 20422, 40919, 20876, 3125
http://tests.stockfishchess.org/tests/view/5e6f61aae42a5c3b3ca2e62d

LTC:
LLR: 2.95 (-2.94,2.94) {0.25,1.75}
Total: 42252 W: 5615 L: 5322 D: 31315
Ptnml(0-2): 308, 3881, 12500, 4084, 353
http://tests.stockfishchess.org/tests/view/5e701382e42a5c3b3ca2e661

Bench: 4963440