### PR TITLE
Adjust singular LMR for positions seen in PV.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1149,7 +1149,7 @@ moves_loop: // When in check, search starts from here
 
           // Decrease reduction if ttMove has been singularly extended (~3 Elo)
           if (singularLMR)
-              r -= 2;
+              r -= 1 + (ttPv && !PvNode);
 
           if (!captureOrPromotion)
           {


### PR DESCRIPTION
passed STC
http://tests.stockfishchess.org/tests/view/5e700737e42a5c3b3ca2e659
LLR: 2.95 (-2.94,2.94) {-0.50,1.50}
Total: 140608 W: 27053 L: 26659 D: 86896
Ptnml(0-2): 2425, 16337, 32439, 16625, 2478 
passed LTC
http://tests.stockfishchess.org/tests/view/5e7068eae42a5c3b3ca2e687
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 79318 W: 10463 L: 10064 D: 58791
Ptnml(0-2): 567, 7416, 23359, 7685, 632 
This patch continues work on altering search for ttPv nodes, using recent idea to alter it more in not PvNodes. Previous tweak based on this idea adjusted singularBeta - this one adjusts value of singularLMR, so they are both related to singular extension search. 
bench 5199515