### PR TITLE
Adjust singular extension search depth.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1055,9 +1055,9 @@ moves_loop: // When in check, search starts from here
           &&  pos.legal(move))
       {
           Value singularBeta = ttValue - (((ttPv && !PvNode) + 4) * depth) / 2;
-          Depth halfDepth = depth / 2;
+          Depth singularDepth = (depth - 1 + 3 * (ttPv && !PvNode)) / 2;
           ss->excludedMove = move;
-          value = search<NonPV>(pos, ss, singularBeta - 1, singularBeta, halfDepth, cutNode);
+          value = search<NonPV>(pos, ss, singularBeta - 1, singularBeta, singularDepth, cutNode);
           ss->excludedMove = MOVE_NONE;
 
           if (value < singularBeta)


### PR DESCRIPTION
passed STC
http://tests.stockfishchess.org/tests/view/5e72bbaae42a5c3b3ca2e75e
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 12692 W: 2608 L: 2389 D: 7695
Ptnml(0-2): 238, 1414, 2839, 1601, 254 
passed LTC
http://tests.stockfishchess.org/tests/view/5e731c07e42a5c3b3ca2e770
LLR: 2.96 (-2.94,2.94) {0.25,1.75}
Total: 145716 W: 19218 L: 18626 D: 107872
Ptnml(0-2): 1100, 13605, 42899, 14111, 1143 
This patch continues work on applying different singular extension search logic in case position is ttPv && !PvNode. Now it changes depth of this search, lower for every other node and higher for this types of nodes.
It's 3rd patch passed on this idea, it seems that for some unknown reason optimal singular extension search is heavily connected with node being part of PV or not.
bench 5398277