### PR TITLE
Speedup complexity

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -701,28 +701,7 @@ namespace {
   template<Tracing T>
   Score Evaluation<T>::initiative(Score score) const {
 
-    int outflanking =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
-                     - distance<Rank>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
-
-    bool pawnsOnBothFlanks =   (pos.pieces(PAWN) & QueenSide)
-                            && (pos.pieces(PAWN) & KingSide);
-
-    bool almostUnwinnable =   !pe->passed_count()
-                           &&  outflanking < 0
-                           && !pawnsOnBothFlanks;
-
-    bool infiltration = rank_of(pos.square<KING>(WHITE)) > RANK_4
-                     || rank_of(pos.square<KING>(BLACK)) < RANK_5;
-
-    // Compute the initiative bonus for the attacking side
-    int complexity =   9 * pe->passed_count()
-                    + 11 * pos.count<PAWN>()
-                    +  9 * outflanking
-                    + 21 * pawnsOnBothFlanks
-                    + 24 * infiltration
-                    + 51 * !pos.non_pawn_material()
-                    - 43 * almostUnwinnable
-                    -110 ;
+    int complexity = pe->get_complexity(pos) + 51 * !pos.non_pawn_material();
 
     Value mg = mg_value(score);
     Value eg = eg_value(score);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -254,7 +254,6 @@ template<Color Us>
 Score Entry::do_king_safety(const Position& pos) {
 
   Square ksq = pos.square<KING>(Us);
-  //kingSquares[Us] = ksq;
   castlingRights[Us] = pos.castling_rights(Us);
   auto compare = [](Score a, Score b) { return mg_value(a) < mg_value(b); };
 

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -51,6 +51,14 @@ struct Entry {
   template<Color Us>
   Score evaluate_shelter(const Position& pos, Square ksq);
 
+  int get_complexity(const Position& pos) {
+    return  kingSquares[WHITE] == pos.square<KING>(WHITE) 
+         && kingSquares[BLACK] == pos.square<KING>(BLACK)
+          ? complexity : (complexity = do_complexity(pos));
+  }
+  
+  int do_complexity(const Position& pos);
+
   Key key;
   Score scores[COLOR_NB];
   Bitboard passedPawns[COLOR_NB];
@@ -59,6 +67,7 @@ struct Entry {
   Square kingSquares[COLOR_NB];
   Score kingSafety[COLOR_NB];
   int castlingRights[COLOR_NB];
+  int complexity;
 };
 
 typedef HashTable<Entry, 131072> Table;


### PR DESCRIPTION
Save a part of complexity calculations in pawn entries.

STC
http://tests.stockfishchess.org/tests/view/5e7493ace42a5c3b3ca2e7e8
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 37554 W: 7456 L: 7224 D: 22874
Ptnml(0-2): 551, 4185, 9105, 4353, 583 

Bench 4952322 