### PR TITLE
Speedup OppositBishop calculations

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -327,6 +327,11 @@ void Position::set_check_info(StateInfo* si) const {
   si->checkSquares[KING]   = 0;
 }
 
+void Position::set_OppositeBishops(StateInfo* si) const {
+  si->opposite_bishops = pieceCount[W_BISHOP] == 1
+                      && pieceCount[B_BISHOP] == 1
+                      && opposite_colors(square<BISHOP>(WHITE), square<BISHOP>(BLACK));
+}
 
 /// Position::set_state() computes the hash keys of the position, and other
 /// data that once computed is updated incrementally as moves are made.
@@ -339,6 +344,8 @@ void Position::set_state(StateInfo* si) const {
   si->pawnKey = Zobrist::noPawns;
   si->nonPawnMaterial[WHITE] = si->nonPawnMaterial[BLACK] = VALUE_ZERO;
   si->checkersBB = attackers_to(square<KING>(sideToMove)) & pieces(~sideToMove);
+  
+  set_OppositeBishops(si);
 
   set_check_info(si);
 
@@ -859,6 +866,10 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           }
       }
   }
+
+  // Update Opposite_Bishops
+  if ((type_of(captured) == BISHOP) || (type_of(m) == PROMOTION))
+    set_OppositeBishops(st);
 
   assert(pos_is_ok());
 }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -868,7 +868,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   }
 
   // Update Opposite_Bishops
-  if ((type_of(captured) == BISHOP) || (type_of(m) == PROMOTION))
+  if (type_of(captured) == BISHOP || promotion_type(m) == BISHOP)
     set_OppositeBishops(st);
 
   assert(pos_is_ok());

--- a/src/position.h
+++ b/src/position.h
@@ -44,6 +44,7 @@ struct StateInfo {
   int    rule50;
   int    pliesFromNull;
   Square epSquare;
+  bool       opposite_bishops;
 
   // Not copied when making a move (will be recomputed anyhow)
   Key        key;
@@ -169,6 +170,7 @@ public:
 private:
   // Initialization helpers (used while setting up a position)
   void set_castling_right(Color c, Square rfrom);
+  void set_OppositeBishops(StateInfo* si) const;
   void set_state(StateInfo* si) const;
   void set_check_info(StateInfo* si) const;
 
@@ -372,9 +374,7 @@ inline int Position::rule50_count() const {
 }
 
 inline bool Position::opposite_bishops() const {
-  return   pieceCount[W_BISHOP] == 1
-        && pieceCount[B_BISHOP] == 1
-        && opposite_colors(square<BISHOP>(WHITE), square<BISHOP>(BLACK));
+  return   st->opposite_bishops;
 }
 
 inline bool Position::is_chess960() const {


### PR DESCRIPTION
Save opposite bishops boolean in state info. Opposite bishops are called only if there is a bishop capture or a bishop promotion.

STC
http://tests.stockfishchess.org/tests/view/5e748183e42a5c3b3ca2e7de
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 88574 W: 17268 L: 16964 D: 54342
Ptnml(0-2): 1308, 9884, 21658, 10070, 1367 

Bench 4952322
