### PR TITLE
Remove KNPKB endgame.

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -80,7 +80,6 @@ namespace Endgames {
     add<KNNKP>("KNNKP");
 
     add<KNPK>("KNPK");
-    add<KNPKB>("KNPKB");
     add<KRPKR>("KRPKR");
     add<KRPKB>("KRPKB");
     add<KBPKB>("KBPKB");
@@ -728,27 +727,6 @@ ScaleFactor Endgame<KNPK>::operator()(const Position& pos) const {
 
   if (pawnSq == SQ_A7 && distance(SQ_A8, weakKingSq) <= 1)
       return SCALE_FACTOR_DRAW;
-
-  return SCALE_FACTOR_NONE;
-}
-
-
-/// KNP vs KB. If knight can block bishop from taking pawn, it's a win.
-/// Otherwise the position is drawn.
-template<>
-ScaleFactor Endgame<KNPKB>::operator()(const Position& pos) const {
-
-  assert(verify_material(pos, strongSide, KnightValueMg, 1));
-  assert(verify_material(pos, weakSide, BishopValueMg, 0));
-
-  Square pawnSq = pos.square<PAWN>(strongSide);
-  Square bishopSq = pos.square<BISHOP>(weakSide);
-  Square weakKingSq = pos.square<KING>(weakSide);
-
-  // King needs to get close to promoting pawn to prevent knight from blocking.
-  // Rules for this are very tricky, so just approximate.
-  if (forward_file_bb(strongSide, pawnSq) & pos.attacks_from<BISHOP>(bishopSq))
-      return ScaleFactor(distance(weakKingSq, pawnSq));
 
   return SCALE_FACTOR_NONE;
 }

--- a/src/endgame.h
+++ b/src/endgame.h
@@ -58,7 +58,6 @@ enum EndgameCode {
   KBPPKB,  // KBPP vs KB
   KBPKN,   // KBP vs KN
   KNPK,    // KNP vs K
-  KNPKB,   // KNP vs KB
   KPKP     // KP vs KP
 };
 


### PR DESCRIPTION
This is a functional simplification that removes the KNPKB endgame. 

Independent testing on only KNPKB positions suggests that this endgame may cause a slight regression (patch vs master: 1635/1589).  Does not regress against master in other games.

STC
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 71376 W: 13794 L: 13719 D: 43863
Ptnml(0-2): 1066, 8092, 17290, 8181, 1059
https://tests.stockfishchess.org/tests/view/5e76c3d5e42a5c3b3ca2e8be

LTC
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 28394 W: 3731 L: 3662 D: 21001
Ptnml(0-2): 167, 2339, 9116, 2408, 167
https://tests.stockfishchess.org/tests/view/5e76e5eae42a5c3b3ca2e8d3

Bench 5480811