### PR TITLE
Remove passed test from almostUnwinnable.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -707,8 +707,7 @@ namespace {
     bool pawnsOnBothFlanks =   (pos.pieces(PAWN) & QueenSide)
                             && (pos.pieces(PAWN) & KingSide);
 
-    bool almostUnwinnable =   !pe->passed_count()
-                           &&  outflanking < 0
+    bool almostUnwinnable =   outflanking < 0
                            && !pawnsOnBothFlanks;
 
     bool infiltration = rank_of(pos.square<KING>(WHITE)) > RANK_4


### PR DESCRIPTION
This simplification allows the almostUnwinnable flag to match endgames where the pawns are all on the same flank but are not symmetrical.

STC:
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 23356 W: 4543 L: 4395 D: 14418
Ptnml(0-2): 346, 2651, 5582, 2707, 392
https://tests.stockfishchess.org/tests/view/5e7b8f57e42a5c3b3ca2eb09

LTC:
LLR: 2.96 (-2.94,2.94) {-1.50,0.50}
Total: 31778 W: 4097 L: 4023 D: 23658
Ptnml(0-2): 199, 2853, 9729, 2891, 217
https://tests.stockfishchess.org/tests/view/5e7ba5ade42a5c3b3ca2eb16

Further work: the size of the constant applied to almostUnwinnable might benefit from tuning now.

Bench 4777139
