### PR TITLE
Remove previousScore adjustment of delta.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -433,7 +433,7 @@ void Thread::search() {
           if (rootDepth >= 4)
           {
               Value previousScore = rootMoves[pvIdx].previousScore;
-              delta = Value(21 + abs(previousScore) / 256);
+              delta = Value(21);
               alpha = std::max(previousScore - delta,-VALUE_INFINITE);
               beta  = std::min(previousScore + delta, VALUE_INFINITE);
 


### PR DESCRIPTION
STC:
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 14580 W: 2904 L: 2731 D: 8945
Ptnml(0-2): 243, 1665, 3339, 1762, 281
https://tests.stockfishchess.org/tests/view/5e7d080ae42a5c3b3ca2ebc6

LTC:
LLR: 2.63 (-2.94,2.94) {-1.50,0.50}
Total: 59726 W: 7781 L: 7755 D: 44190
Ptnml(0-2): 444, 5546, 17841, 5604, 428
https://tests.stockfishchess.org/tests/view/5e7d11b3e42a5c3b3ca2ebd3

Bench 5247262
