### PR TITLE
Use bool for TT stages in movepick

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -26,8 +26,7 @@ namespace {
 
   enum Stages {
     CAPTURE_INIT, GOOD_CAPTURE, REFUTATION, QUIET_INIT, QUIET, BAD_CAPTURE,
-    EVASION_INIT, EVASION,
-    PROBCUT_INIT, PROBCUT,
+    EVASION_INIT, EVASION, PROBCUT_INIT, PROBCUT,
     QCAPTURE_INIT, QCAPTURE, QCHECK_INIT, QCHECK
   };
 
@@ -64,7 +63,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
   assert(d > 0);
 
   stage = pos.checkers() ? EVASION_INIT : CAPTURE_INIT;
-  useTTM = ((ttMove = ttm && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE));
+  useTTM = (ttMove = ttm && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE);
 }
 
 /// MovePicker constructor for quiescence search
@@ -75,9 +74,9 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
   assert(d <= 0);
 
   stage = pos.checkers() ? EVASION_INIT : QCAPTURE_INIT;
-  useTTM = ((ttMove =   (ttm
+  useTTM = (ttMove =   (ttm
           && (depth > DEPTH_QS_RECAPTURES || to_sq(ttm) == recaptureSquare)
-          && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE)));
+          && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE));
 }
 
 /// MovePicker constructor for ProbCut: we generate captures with SEE greater
@@ -88,10 +87,9 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePiece
   assert(!pos.checkers());
 
   stage = PROBCUT_INIT;
-  useTTM = ((ttMove =   ttm
-                      && pos.capture(ttm)
-                      && pos.pseudo_legal(ttm)
-                      && pos.see_ge(ttm, threshold) ? ttm : MOVE_NONE));
+  useTTM = (ttMove = ttm && pos.capture(ttm)
+                         && pos.pseudo_legal(ttm)
+                         && pos.see_ge(ttm, threshold) ? ttm : MOVE_NONE);
 }
 
 /// MovePicker::score() assigns a numerical value to each move in a list, used
@@ -156,7 +154,8 @@ top:
   case CAPTURE_INIT:
   case PROBCUT_INIT:
   case QCAPTURE_INIT:
-      if (!(useTTM = !useTTM)) return ttMove; //if set, unset and return ttm
+      if (!(useTTM = !useTTM))  //Swap the flag.  If then false, return ttMove
+          return ttMove;
 
       cur = endBadCaptures = moves;
       endMoves = generate<CAPTURES>(pos, cur);
@@ -223,7 +222,8 @@ top:
       return select<Next>([](){ return true; });
 
   case EVASION_INIT:
-      if (!(useTTM = !useTTM)) return ttMove; //if set, unset and return ttm
+      if (!(useTTM = !useTTM))  //Swap the flag.  If then false, return ttMove
+          return ttMove;
 
       cur = moves;
       endMoves = generate<EVASIONS>(pos, cur);

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -74,9 +74,9 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
   assert(d <= 0);
 
   stage = pos.checkers() ? EVASION_INIT : QCAPTURE_INIT;
-  useTTM = (ttMove =   (ttm
-          && (depth > DEPTH_QS_RECAPTURES || to_sq(ttm) == recaptureSquare)
-          && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE));
+  useTTM = (ttMove = (ttm && (depth > DEPTH_QS_RECAPTURES
+                              || to_sq(ttm) == recaptureSquare)
+                          && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE));
 }
 
 /// MovePicker constructor for ProbCut: we generate captures with SEE greater

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -25,10 +25,10 @@
 namespace {
 
   enum Stages {
-    MAIN_TT, CAPTURE_INIT, GOOD_CAPTURE, REFUTATION, QUIET_INIT, QUIET, BAD_CAPTURE,
-    EVASION_TT, EVASION_INIT, EVASION,
-    PROBCUT_TT, PROBCUT_INIT, PROBCUT,
-    QSEARCH_TT, QCAPTURE_INIT, QCAPTURE, QCHECK_INIT, QCHECK
+    CAPTURE_INIT, GOOD_CAPTURE, REFUTATION, QUIET_INIT, QUIET, BAD_CAPTURE,
+    EVASION_INIT, EVASION,
+    PROBCUT_INIT, PROBCUT,
+    QCAPTURE_INIT, QCAPTURE, QCHECK_INIT, QCHECK
   };
 
   // partial_insertion_sort() sorts moves in descending order up to and including
@@ -63,9 +63,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 
   assert(d > 0);
 
-  stage = pos.checkers() ? EVASION_TT : MAIN_TT;
-  ttMove = ttm && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE;
-  stage += (ttMove == MOVE_NONE);
+  stage = pos.checkers() ? EVASION_INIT : CAPTURE_INIT;
+  useTTM = ((ttMove = ttm && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE));
 }
 
 /// MovePicker constructor for quiescence search
@@ -75,11 +74,10 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 
   assert(d <= 0);
 
-  stage = pos.checkers() ? EVASION_TT : QSEARCH_TT;
-  ttMove =   ttm
+  stage = pos.checkers() ? EVASION_INIT : QCAPTURE_INIT;
+  useTTM = ((ttMove =   (ttm
           && (depth > DEPTH_QS_RECAPTURES || to_sq(ttm) == recaptureSquare)
-          && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE;
-  stage += (ttMove == MOVE_NONE);
+          && pos.pseudo_legal(ttm) ? ttm : MOVE_NONE)));
 }
 
 /// MovePicker constructor for ProbCut: we generate captures with SEE greater
@@ -89,12 +87,11 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePiece
 
   assert(!pos.checkers());
 
-  stage = PROBCUT_TT;
-  ttMove =   ttm
-          && pos.capture(ttm)
-          && pos.pseudo_legal(ttm)
-          && pos.see_ge(ttm, threshold) ? ttm : MOVE_NONE;
-  stage += (ttMove == MOVE_NONE);
+  stage = PROBCUT_INIT;
+  useTTM = ((ttMove =   ttm
+                      && pos.capture(ttm)
+                      && pos.pseudo_legal(ttm)
+                      && pos.see_ge(ttm, threshold) ? ttm : MOVE_NONE));
 }
 
 /// MovePicker::score() assigns a numerical value to each move in a list, used
@@ -156,16 +153,11 @@ Move MovePicker::next_move(bool skipQuiets) {
 top:
   switch (stage) {
 
-  case MAIN_TT:
-  case EVASION_TT:
-  case QSEARCH_TT:
-  case PROBCUT_TT:
-      ++stage;
-      return ttMove;
-
   case CAPTURE_INIT:
   case PROBCUT_INIT:
   case QCAPTURE_INIT:
+      if (!(useTTM = !useTTM)) return ttMove; //if set, unset and return ttm
+
       cur = endBadCaptures = moves;
       endMoves = generate<CAPTURES>(pos, cur);
 
@@ -231,6 +223,8 @@ top:
       return select<Next>([](){ return true; });
 
   case EVASION_INIT:
+      if (!(useTTM = !useTTM)) return ttMove; //if set, unset and return ttm
+
       cur = moves;
       endMoves = generate<EVASIONS>(pos, cur);
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -149,6 +149,7 @@ private:
   const CapturePieceToHistory* captureHistory;
   const PieceToHistory** continuationHistory;
   Move ttMove;
+  bool useTTM;
   ExtMove refutations[3], *cur, *endMoves, *endBadCaptures;
   int stage;
   Square recaptureSquare;


### PR DESCRIPTION
This is a non-functional simplification.  If we use a bool as a flag for using the ttMove or not, we can remove all of the TT stages.  The bool (useTTM) is set once and checked once or twice (if there was a ttMove) in the INIT stages.

This decreases the jump table size, decreases the executable size, and is a bit faster on my machines (< 1%).  This patch is identical to the tested code, but with a better variable name and added comments for clarity.

STC
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 80802 W: 15670 L: 15602 D: 49530
Ptnml(0-2): 1337, 9181, 19268, 9307, 1308
https://tests.stockfishchess.org/tests/view/5e7e7705e42a5c3b3ca2ec71
