### PR TITLE
Count only the most advanced passed pawn for each file.

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -124,6 +124,8 @@ namespace {
                 || (   stoppers == blocked && r >= RANK_5
                     && (shift<Up>(support) & ~(theirPawns | doubleAttackThem)));
 
+        passed &= !(forward_file_bb(Us, s) & ourPawns);
+
         // Passed pawns will be properly scored later in evaluation when we have
         // full attack info.
         if (passed)


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5e802037e42a5c3b3ca2ed07
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 215296 W: 41843 L: 41341 D: 132112
Ptnml(0-2): 3688, 25313, 49304, 25495, 3848 
passed LTC
https://tests.stockfishchess.org/tests/view/5e806441e42a5c3b3ca2ed2b
LLR: 2.95 (-2.94,2.94) {0.25,1.75}
Total: 74050 W: 9761 L: 9379 D: 54910
Ptnml(0-2): 510, 6838, 22025, 7064, 588 
This patch adjusts definition of passed pawns - if there is a pawn of our color in the same file in front of a current pawn it's no longer counts as passed.
The most logical adjustment to be done on top of this patch is to increase of passed pawn bonuses since there are less passed pawns overall, so some tweaks/tuning can be done.
bench 5363819