### PR TITLE
move count pruning search reduction 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1143,6 +1143,9 @@ moves_loop: // When in check, search starts from here
           if (ttPv)
               r -= 2;
 
+          if(moveCountPruning)
+              r += 1 - (ttPv && !PvNode);
+
           // Decrease reduction if opponent's move count is high (~5 Elo)
           if ((ss-1)->moveCount > 14)
               r--;


### PR DESCRIPTION
This patch applies a extension to search reduction logic in case the position is not ttPv && !PvNode and is pruned based on move count

passed STC
https://tests.stockfishchess.org/tests/view/5e8092bde42a5c3b3ca2ed35
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 78848 W: 15480 L: 15170 D: 48198 Elo +1.05
Ptnml(0-2): 1406, 9310, 17773, 9438, 1497  

passed LTC
https://tests.stockfishchess.org/tests/view/5e80bb13e42a5c3b3ca2ed4b
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 86596 W: 11451 L: 11033 D: 64112 Elo +1.44
Ptnml(0-2): 624, 7993, 25687, 8329, 665 

Bench: 5206406 