### PR TITLE
Simplify a candidate passer condition.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -639,9 +639,8 @@ namespace {
         } // r > RANK_3
 
         // Scale down bonus for candidate passers which need more than one
-        // pawn push to become passed, or have a pawn in front of them.
-        if (   !pos.pawn_passed(Us, s + Up)
-            || (pos.pieces(PAWN) & (s + Up)))
+        // pawn push to become passed.
+        if (!pos.pawn_passed(Us, s + Up))
             bonus = bonus / 2;
 
         score += bonus - PassedFile * edge_distance(file_of(s));


### PR DESCRIPTION
Prior to July 2019, we used a forward-file Bitboard to determine candidate passers.  We simplified this with commit https://github.com/official-stockfish/Stockfish/commit/13ba67801f0331e3ffde23794b989765af5a9aa2, replacing the entire forward file with just a single blocking square.

However, a recent commit https://github.com/official-stockfish/Stockfish/commit/f2430bf034cc31258c870797501bce0605bce3d0 by Michael Chaly (@Vizvezdenec) reintroduced a very similar condition, now applied to all passed pawns, not only candidate passers.  Knowing the history of the candidate passed pawns' code, this makes one of the conditions mostly obsolete and redundant.  

Its removal barely changes the bench number of nodes searched: out of more than 5 million, the value changes by less than 800.  The removal also has no noticeable effect on the Elo performance of Stockfish.

Where do we go from here?  In the past, tuning of the candidate passed pawns divisor showed some promise at STC.  After this is merged, I will attempt a few tweaks of this constant.

STC:
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 31528 W: 6208 L: 6061 D: 19259
Ptnml(0-2): 541, 3673, 7205, 3788, 557
https://tests.stockfishchess.org/tests/view/5e825db0e42a5c3b3ca2ee21

LTC:
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 38546 W: 5083 L: 5009 D: 28454
Ptnml(0-2): 299, 3628, 11362, 3668, 316
https://tests.stockfishchess.org/tests/view/5e826ec7e42a5c3b3ca2ee2a

Bench: 5139561