### PR TITLE
Increase reduction for captures that don't produce check if static eval is bad enough.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1190,8 +1190,14 @@ moves_loop: // When in check, search starts from here
           }
 
           // Increase reduction for captures/promotions if late move and at low depth
-          else if (depth < 8 && moveCount > 2)
+          else 
+          {
+          if (depth < 8 && moveCount > 2)
               r++;
+
+          if (!givesCheck && ss->staticEval + PieceValue[EG][pos.captured_piece()] + 200 * depth <= alpha)
+              r++;
+          }
 
           Depth d = Utility::clamp(newDepth - r, 1, newDepth);
 


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5e8514b44411759d9d098543
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 46196 W: 9039 L: 8781 D: 28376
Ptnml(0-2): 750, 5412, 10628, 5446, 862 
passed LTC
https://tests.stockfishchess.org/tests/view/5e8530134411759d9d09854c
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 23462 W: 3228 L: 2988 D: 17246
Ptnml(0-2): 186, 2125, 6849, 2405, 166 
Idea behind this patch is that if static eval is really bad so capturing of current piece on spot will still produce position with eval much lower than alpha then our best chance is to create some kind of king attack. So captures without check are mostly worse than captures with check and can be reduced more.
There are a lot of things that can be tried on top of this idea - depth function is a complete guess so parameter tweaks or type of it is an object to change (no one says that it should be linear), this idea can be tried on quiet moves, maybe captures with really good history shouldn't be reduced that much, etc.
bench 5183250