### PR TITLE
Retire candidate passed pawns.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -598,7 +598,8 @@ namespace {
 
         Score bonus = PassedRank[r];
 
-        if (r > RANK_3)
+        if (   r > RANK_3
+            && pos.pawn_passed(Us, s + Up))
         {
             int w = 5 * r - 13;
             Square blockSq = s + Up;
@@ -637,11 +638,6 @@ namespace {
                 bonus += make_score(k * w, k * w);
             }
         } // r > RANK_3
-
-        // Scale down bonus for candidate passers which need more than one
-        // pawn push to become passed.
-        if (!pos.pawn_passed(Us, s + Up))
-            bonus = bonus / 2;
 
         score += bonus - PassedFile * edge_distance(file_of(s));
     }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -598,8 +598,7 @@ namespace {
 
         Score bonus = PassedRank[r];
 
-        if (   r > RANK_3
-            && pos.pawn_passed(Us, s + Up))
+        if (r > RANK_3)
         {
             int w = 5 * r - 13;
             Square blockSq = s + Up;


### PR DESCRIPTION
This patch is a second and more ambitious simplification motivated by a recent commit https://github.com/official-stockfish/Stockfish/commit/f2430bf034cc31258c870797501bce0605bce3d0 by Michael Chaly (@Vizvezdenec), which found that a condition traditionally applied to candidate passed pawns was better when applied to _all_ passed pawns.

Although the candidate passed pawn coefficient has long been set to 1/2, both increases and decreases of this coefficient easily passed STC.  I began to consider changing it further to either 0 or 1, which would retire this evaluation term altogether.  

Indeed, retiring this code returned strong results (estimated between +2 and +3 Elo) at both STC and LTC; finishing with LOS of 93% and 96% respectively.  Although SPRT Elo estimates have wide error bars and can be unreliable, we have evidence to suggest that this may be an Elo gain.

Before this commit, some pawns were considered "candidate" passed pawns and given half bonus.  After this commit, all of these pawns are scored as passed pawns, and they do not receive less bonus.

---

This PR and commit are dedicated to our colleague Stefan Geschwentner (@locutus2), one of the most respected and accomplished members of the Stockfish developer community.  Stockfish is a volunteer project and has always thrived because of Stefan's talent, insight, generosity, and dedication.  Welcome back, Stefan!

STC: 
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 21806 W: 4320 L: 4158 D: 13328
Ptnml(0-2): 367, 2526, 5001, 2596, 413
https://tests.stockfishchess.org/tests/view/5e86b4724411759d9d098639

LTC:
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 12590 W: 1734 L: 1617 D: 9239
Ptnml(0-2): 96, 1187, 3645, 1238, 129
https://tests.stockfishchess.org/tests/view/5e86d2874411759d9d098640

Bench: 4935780