### PR TITLE
Increase reductions for multicore usage.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -194,7 +194,7 @@ namespace {
 void Search::init() {
 
   for (int i = 1; i < MAX_MOVES; ++i)
-      Reductions[i] = int((24.8 + std::log(Threads.size()) / 2) * std::log(i));
+      Reductions[i] = int((24.8 + std::log(Threads.size())) * std::log(i));
 }
 
 


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5e874f5a4411759d9d098696
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 9162 W: 1558 L: 1385 D: 6219
Ptnml(0-2): 90, 958, 2343, 1069, 121 
passed LTC
https://tests.stockfishchess.org/tests/view/5e8762804411759d9d09869f
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 79364 W: 9541 L: 9159 D: 60664
Ptnml(0-2): 462, 6880, 24661, 7172, 507 
This patch strenghtens effect of reduction increase with core count twice.
Most logical way will be to try to strenghten it even more.
bench 4742598