### PR TITLE
Introduce capture history pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1010,12 +1010,12 @@ moves_loop: // When in check, search starts from here
           // Skip quiet moves if movecount exceeds our FutilityMoveCount threshold
           moveCountPruning = moveCount >= futility_move_count(improving, depth);
 
+          // Reduced depth of the next LMR search
+          int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount), 0);
+
           if (   !captureOrPromotion
               && !givesCheck)
           {
-              // Reduced depth of the next LMR search
-              int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount), 0);
-
               // Countermoves based pruning (~20 Elo)
               if (   lmrDepth < 4 + ((ss-1)->statScore > 0 || (ss-1)->moveCount == 1)
                   && (*contHist[0])[movedPiece][to_sq(move)] < CounterMovePruneThreshold
@@ -1035,8 +1035,20 @@ moves_loop: // When in check, search starts from here
               if (!pos.see_ge(move, Value(-(32 - std::min(lmrDepth, 18)) * lmrDepth * lmrDepth)))
                   continue;
           }
-          else if (!pos.see_ge(move, Value(-194) * depth)) // (~25 Elo)
+          else 
+          {
+          if (!givesCheck)
+              {
+                  CapturePieceToHistory& captureHistory = thisThread->captureHistory;
+                  // Capture history pruning
+                  if (   lmrDepth < 1 
+                      && captureHistory[movedPiece][to_sq(move)][type_of(pos.piece_on(to_sq(move)))] < 0)
+                      continue;
+              }
+
+          if (!pos.see_ge(move, Value(-194) * depth)) // (~25 Elo)
               continue;
+          }
       }
 
       // Step 14. Extensions (~75 Elo)


### PR DESCRIPTION
passed STC 
https://tests.stockfishchess.org/tests/view/5e8c60d40ffd2be7f15e5470
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 23748 W: 4758 L: 4529 D: 14461
Ptnml(0-2): 421, 2712, 5400, 2899, 442 
passed LTC
https://tests.stockfishchess.org/tests/view/5e8c72bf0ffd2be7f15e547f
LLR: 2.96 (-2.94,2.94) {0.25,1.75}
Total: 17330 W: 2415 L: 2190 D: 12725
Ptnml(0-2): 126, 1561, 5107, 1704, 167 
This patch introduces heuristic that is similar to countermove based pruning but for captures - capture history pruning.
Idea is that we can (almost) safely prune really late captures with negative history if they don't give check so will most likely not produce some king-attacking tactic.
bench 4417023