### PR TITLE
Simplify QUIET_CHECKS in Movegen

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -277,15 +277,12 @@ ExtMove* generate<QUIET_CHECKS>(const Position& pos, ExtMove* moveList) {
   assert(!pos.checkers());
 
   Color us = pos.side_to_move();
-  Bitboard dc = pos.blockers_for_king(~us) & pos.pieces(us);
+  Bitboard dc = pos.blockers_for_king(~us) & pos.pieces(us) & ~pos.pieces(PAWN);
 
   while (dc)
   {
      Square from = pop_lsb(&dc);
      PieceType pt = type_of(pos.piece_on(from));
-
-     if (pt == PAWN)
-         continue; // Will be generated together with direct checks
 
      Bitboard b = pos.attacks_from(pt, from) & ~pos.pieces();
 


### PR DESCRIPTION
This is a non-functional simplification that is a bit faster on my machines.

100 runs of bench to depth 22:  master 40.75, patch 40.44.

STC
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 16258 W: 3259 L: 3116 D: 9883
Ptnml(0-2): 218, 1695, 4166, 1826, 224 
https://tests.stockfishchess.org/tests/view/5e8f94664ff721d0bce30dc7