### PR TITLE
Extend irreversible moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1107,6 +1107,12 @@ moves_loop: // When in check, search starts from here
       if (type_of(move) == CASTLING)
           extension = 1;
 
+      // Late irreversible move extension
+      if (   move == ttMove
+          && pos.rule50_count() > 80
+          && (captureOrPromotion || type_of(movedPiece) == PAWN))
+          extension = 2;
+
       // Add extension to new depth
       newDepth += extension;
 


### PR DESCRIPTION
if these are ttMoves and played in positions with a high value of the rule50 counter. The unusual extension of 2 is safe in this context as awarding it will reset the rule50 counter, making sure it is awarded very rarely in a search path.

This patch partially addresses https://github.com/official-stockfish/Stockfish/issues/2620 as it should make it less likely to play a move that resets the counter, but that is worse than alternative moves after a slightly deeper search.

passed STC:
LLR: 2.96 (-2.94,2.94) {-0.50,1.50}
Total: 71658 W: 13840 L: 13560 D: 44258
Ptnml(0-2): 1058, 7921, 17643, 8097, 1110
https://tests.stockfishchess.org/tests/view/5e90d0f6754c3424c4cf9f41

passed LTC:
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 85082 W: 11069 L: 10680 D: 63333
Ptnml(0-2): 459, 6982, 27259, 7393, 448
https://tests.stockfishchess.org/tests/view/5e917470af0a0143109dc341

Bench: 4499282