### PR TITLE
Remove candidate passers w/o feasible lever

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -118,6 +118,7 @@ namespace {
         // (a) there is no stoppers except some levers
         // (b) the only stoppers are the leverPush, but we outnumber them
         // (c) there is only one front stopper which can be levered.
+        //     (Refined in Evaluation::passed)
         passed =   !(stoppers ^ lever)
                 || (   !(stoppers ^ leverPush)
                     && popcount(phalanx) >= popcount(leverPush))


### PR DESCRIPTION
Objections from anyone to code style would best be raised now. Specifically regarding

1. the way I nest operations in lengthy instructions and
2. the use of `const` to help readers and compiler to better understand the computations.

Commit message will not show the fancy ASCII if viewed without monospace font. I like including the pictures though - nobody should be bothered reading text or even diff. The text will remain readable. Wrapped at 50/72.

Testing on takes 4 and 5 is ongoing but not promising.

I add a comment in `pawns.cpp` to remind readers that identification of candidate passers continues in `evaluate.cpp`.

I use the phrasing "candidate passer" with a meaning _distinct_ from the one used in recent "Retire candidate passed pawns" commit, which abandoned spacial handling of a different form of "candidate passer".

You do not need to edit this commit. Comment here - I will edit the branch as required.