### PR TITLE
Scale up space weight with number of blocked pawns.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -678,7 +678,7 @@ namespace {
     behind |= shift<Down+Down>(behind);
 
     int bonus = popcount(safe) + popcount(behind & safe & ~attackedBy[Them][ALL_PIECES]);
-    int weight = pos.count<ALL_PIECES>(Us) - 1;
+    int weight = pos.count<ALL_PIECES>(Us) - 2 + pe->blocked_count() / 2;
     Score score = make_score(bonus * weight * weight / 16, 0);
 
     if (T)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -86,6 +86,7 @@ namespace {
     e->passedPawns[Us] = 0;
     e->kingSquares[Us] = SQ_NONE;
     e->pawnAttacks[Us] = e->pawnAttacksSpan[Us] = pawn_attacks_bb<Us>(ourPawns);
+    e->blockedCount[Us] = 0;
 
     // Loop through all pawns of the current color and score each pawn
     while ((s = *pl++) != SQ_NONE)
@@ -104,6 +105,8 @@ namespace {
         neighbours = ourPawns   & adjacent_files_bb(s);
         phalanx    = neighbours & rank_bb(s);
         support    = neighbours & rank_bb(s - Up);
+
+        e->blockedCount[Us] += bool(blocked);
 
         // A pawn is backward when it is behind all pawns of the same color on
         // the adjacent files and cannot safely advance.

--- a/src/pawns.h
+++ b/src/pawns.h
@@ -38,6 +38,7 @@ struct Entry {
   Bitboard passed_pawns(Color c) const { return passedPawns[c]; }
   Bitboard pawn_attacks_span(Color c) const { return pawnAttacksSpan[c]; }
   int passed_count() const { return popcount(passedPawns[WHITE] | passedPawns[BLACK]); }
+  int blocked_count() const { return blockedCount[WHITE] + blockedCount[BLACK]; }
 
   template<Color Us>
   Score king_safety(const Position& pos) {
@@ -59,6 +60,7 @@ struct Entry {
   Square kingSquares[COLOR_NB];
   Score kingSafety[COLOR_NB];
   int castlingRights[COLOR_NB];
+  int blockedCount[COLOR_NB];
 };
 
 typedef HashTable<Entry, 131072> Table;


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5e919eefaf0a0143109dc8ce
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 16994 W: 3389 L: 3172 D: 10433
Ptnml(0-2): 277, 1931, 3918, 2040, 331 
passed LTC
https://tests.stockfishchess.org/tests/view/5e91d04faf0a0143109dc8ea
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 133386 W: 17316 L: 16763 D: 99307
Ptnml(0-2): 945, 12407, 39524, 12784, 1033 
This idea is loosely based on stockfish losses in closed positions in different tournaments. Space weight symmetrically increases for both sides the more blocked position is.
bench 4742259