### PR TITLE
Remove evasionPrunable

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1398,7 +1398,7 @@ moves_loop: // When in check, search starts from here
     Move ttMove, move, bestMove;
     Depth ttDepth;
     Value bestValue, value, ttValue, futilityValue, futilityBase, oldAlpha;
-    bool ttHit, pvHit, inCheck, givesCheck, captureOrPromotion, evasionPrunable;
+    bool ttHit, pvHit, inCheck, givesCheck, captureOrPromotion;
     int moveCount;
 
     if (PvNode)
@@ -1527,14 +1527,8 @@ moves_loop: // When in check, search starts from here
           }
       }
 
-      // Detect non-capture evasions that are candidates to be pruned
-      evasionPrunable =    inCheck
-                       &&  (depth != 0 || moveCount > 2)
-                       &&  bestValue > VALUE_TB_LOSS_IN_MAX_PLY
-                       && !pos.capture(move);
-
       // Don't search moves with negative SEE values
-      if (  (!inCheck || evasionPrunable) && !pos.see_ge(move))
+      if (  !inCheck && !pos.see_ge(move))
           continue;
 
       // Speculative prefetch as early as possible


### PR DESCRIPTION
Simplification. Removes evasionPrunable

STC:
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 25656 W: 4979 L: 4826 D: 15851
Ptnml(0-2): 414, 2971, 5964, 3006, 473
https://tests.stockfishchess.org/tests/view/5e93dbd72cb65b3059c33819

LTC:
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 43732 W: 5656 L: 5593 D: 32483
Ptnml(0-2): 324, 4072, 13009, 4139, 322
https://tests.stockfishchess.org/tests/view/5e93e37c2cb65b3059c33825

Bench: 4797141