### PR TITLE
Refine interaction between space bonus and number of blocked pawns.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -695,7 +695,7 @@ namespace {
     behind |= shift<Down+Down>(behind);
 
     int bonus = popcount(safe) + popcount(behind & safe & ~attackedBy[Them][ALL_PIECES]);
-    int weight = pos.count<ALL_PIECES>(Us) - 2 + pe->blocked_count() / 2;
+    int weight = pos.count<ALL_PIECES>(Us) - 3 + std::min(pe->blocked_count(), 9);
     Score score = make_score(bonus * weight * weight / 16, 0);
 
     if (T)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -106,7 +106,7 @@ namespace {
         phalanx    = neighbours & rank_bb(s);
         support    = neighbours & rank_bb(s - Up);
 
-        e->blockedCount[Us] += bool(blocked);
+        e->blockedCount[Us] += bool(blocked || more_than_one(leverPush));
 
         // A pawn is backward when it is behind all pawns of the same color on
         // the adjacent files and cannot safely advance.


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5e94560663d105aebbab243d
LLR: 2.96 (-2.94,2.94) {-0.50,1.50}
Total: 29500 W: 5842 L: 5603 D: 18055
Ptnml(0-2): 504, 3443, 6677, 3562, 564 
passed LTC
https://tests.stockfishchess.org/tests/view/5e95b383c2aaa99f75d1a14d
LLR: 2.95 (-2.94,2.94) {0.25,1.75}
Total: 63504 W: 8329 L: 7974 D: 47201
Ptnml(0-2): 492, 5848, 18720, 6197, 495 
This patch refines recently introduced interaction between space bonus and number of blocked pawns in position.
1) pawns counts as blocked also if it push square is attacked by 2 enemy pawns;
2) overall dependance is stronger as well as offset;
3) bonus increase is capped at 9 blocked pawns in position (maximum is obviously 16 :) ).
bench 4956028