### PR TITLE
Don't attempt probcut for not good enough ttmoves.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -906,8 +906,12 @@ namespace {
         MovePicker mp(pos, ttMove, raisedBeta - ss->staticEval, &captureHistory);
         int probCutCount = 0;
 
-        while (  (move = mp.next_move()) != MOVE_NONE
-               && probCutCount < 2 + 2 * cutNode)
+        while (  (  move = mp.next_move()) != MOVE_NONE
+               &&   probCutCount < 2 + 2 * cutNode
+               && !(    move == ttMove 
+                    && (tte->bound() & BOUND_LOWER) 
+                    && tte->depth() >= depth - 4 
+                    && ttValue < raisedBeta))
             if (move != excludedMove && pos.legal(move))
             {
                 assert(pos.capture_or_promotion(move));


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5e9673ddc2718dee3c822920
LLR: 2.95 (-2.94,2.94) {-0.50,1.50}
Total: 72148 W: 14038 L: 13741 D: 44369
Ptnml(0-2): 1274, 8326, 16615, 8547, 1312 
passed LTC
https://tests.stockfishchess.org/tests/view/5e96b378c2718dee3c8229bf
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 89054 W: 11418 L: 10996 D: 66640
Ptnml(0-2): 623, 8113, 26643, 8515, 633 
This idea is loosely based on xoroshiro idea about raisedBeta and ttmoves.
If our ttmove have low enough ttvalue and is deep enough (deeper than our probcut depth) it makes no sence to try it for a probcut cutoff since it already more or less failed to produce one according to transposition table. Better to try other moves.
bench 4952731