### PR TITLE
Change scale factor in opposite-color bishop endings

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -761,11 +761,16 @@ namespace {
     // If scale is not already specific, scale down the endgame via general heuristics
     if (sf == SCALE_FACTOR_NORMAL)
     {
-        if (   pos.opposite_bishops()
-            && pos.non_pawn_material() == 2 * BishopValueMg)
-            sf = 22;
+        if (pos.opposite_bishops())
+        {
+            if (   pos.non_pawn_material(WHITE) == BishopValueMg
+                && pos.non_pawn_material(BLACK) == BishopValueMg)
+                sf = 22;
+            else
+                sf = 22 + 3 * pos.count<ALL_PIECES>(strongSide);
+        }
         else
-            sf = std::min(sf, 36 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide));
+            sf = std::min(sf, 36 + 7 * pos.count<PAWN>(strongSide));
 
         sf = std::max(0, sf - (pos.rule50_count() - 12) / 4);
     }


### PR DESCRIPTION
This change varies the scale factor with the total number of pieces and pawns on the strongSide.

STC :
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 150920 W: 28828 L: 28422 D: 93670    +0.65 Elo
Ptnml(0-2): 2507, 17548, 35030, 17782, 2593
https://tests.stockfishchess.org/tests/view/5e983eb2c00499c5410f4951

LTC :
LLR: 2.95 (-2.94,2.94) {0.25,1.75}
Total: 69238 W: 8810 L: 8446 D: 51982   +1.58 Elo
Ptnml(0-2): 451, 6276, 20879, 6484, 529
https://tests.stockfishchess.org/tests/view/5e985b27c00499c5410f4987

The scaled formula doesn't mesh exactly with the existing fixed value of 22 for single bishops with unstated number of pawns, perhaps further work can remove the special case and use a single formula.

Bench 4574606