### PR TITLE
Remove one condition in probcut TTmove skipping

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -909,7 +909,6 @@ namespace {
         while (   (move = mp.next_move()) != MOVE_NONE
                && probCutCount < 2 + 2 * cutNode
                && !(   move == ttMove
-                    && (tte->bound() & BOUND_LOWER)
                     && tte->depth() >= depth - 4
                     && ttValue < raisedBeta))
             if (move != excludedMove && pos.legal(move))


### PR DESCRIPTION
the removed condition appears illogical and is not needed.

passed STC:
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 80418 W: 15217 L: 15144 D: 50057
Ptnml(0-2): 1341, 9399, 18679, 9426, 1364
https://tests.stockfishchess.org/tests/view/5e977eb5c9ada107a0370d6b

passed LTC:
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 49878 W: 6299 L: 6247 D: 37332
Ptnml(0-2): 327, 4677, 14897, 4693, 345
https://tests.stockfishchess.org/tests/view/5e97e07dc9ada107a0370e53

Bench: 4758578