### PR TITLE
Simplify minPawnDistance

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -244,7 +244,7 @@ Score Entry::do_king_safety(const Position& pos) {
 
   // In endgame we like to bring our king near our closest pawn
   Bitboard pawns = pos.pieces(Us, PAWN);
-  int minPawnDist = pawns ? 8 : 0;
+  int minPawnDist = 6;
 
   if (pawns & PseudoAttacks[KING][ksq])
       minPawnDist = 1;


### PR DESCRIPTION
This is a functional simplification which fixes an awkward numerical cliff.

With master king_safety, no pawns is scored higher than pawn(s) that is/are far from the king.  This may motivate SF to throw away pawns to increase king safety.  With this patch, there is a consistent value for minPawnDistance where losing a pawn never increases king safety.

STC
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 45548 W: 8624 L: 8525 D: 28399
Ptnml(0-2): 592, 4937, 11587, 5096, 562
https://tests.stockfishchess.org/tests/view/5e98ced630be947a14e9ddc5

LTC
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 42084 W: 5292 L: 5242 D: 31550
Ptnml(0-2): 193, 3703, 13252, 3649, 245
https://tests.stockfishchess.org/tests/view/5e98e22e30be947a14e9de07

bench 4600292