### PR TITLE
Apply multicut pruning more often.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1091,6 +1091,17 @@ moves_loop: // When in check, search starts from here
           // a soft bound.
           else if (singularBeta >= beta)
               return singularBeta;
+
+          //if out eval of ttMove is greater than beta we try also if there is other move that
+          //pushes it over beta, if so also produce a cutoff
+          else if (ttValue >= beta)
+          {
+          ss->excludedMove = move;
+          value = search<NonPV>(pos, ss, beta - 1, beta, (depth + 3) / 2, cutNode);
+          ss->excludedMove = MOVE_NONE;
+          if (value >= beta)
+              return beta;
+          }
       }
 
       // Check extension (~2 Elo)


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5e9a162b5b664cdba0ce6e28
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 58238 W: 11192 L: 10917 D: 36129
Ptnml(0-2): 1007, 6704, 13442, 6939, 1027 
passed LTC
https://tests.stockfishchess.org/tests/view/5e9a1e845b664cdba0ce7411
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 137852 W: 17460 L: 16899 D: 103493
Ptnml(0-2): 916, 12610, 41383, 13031, 986 
This patch increases number of nodes where we produce multicut cutoffs.
Idea is that if our ttMove failed to produce a singular extension but ttValue is greater than beta we can afford to do one more reduced search near beta excluding ttMove to see if it will produce fail high - and if it does so produce muticut by analogy to existing logic.
bench 4493278