### PR TITLE
Don't rely on continuation histories index 3 & 5 if we are in check.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -57,9 +57,9 @@ namespace {
 
 /// MovePicker constructor for the main search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh, const LowPlyHistory* lp,
-                       const CapturePieceToHistory* cph, const PieceToHistory** ch, Move cm, Move* killers, int pl)
+                       const CapturePieceToHistory* cph, const PieceToHistory** ch, Move cm, Move* killers, int pl, bool sp)
            : pos(p), mainHistory(mh), lowPlyHistory(lp), captureHistory(cph), continuationHistory(ch),
-             ttMove(ttm), refutations{{killers[0], 0}, {killers[1], 0}, {cm, 0}}, depth(d), ply(pl) {
+             ttMove(ttm), refutations{{killers[0], 0}, {killers[1], 0}, {cm, 0}}, depth(d), ply(pl), considerFollowHistories(sp) {
 
   assert(d > 0);
 
@@ -105,12 +105,15 @@ void MovePicker::score() {
                    + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))];
 
       else if (Type == QUIETS)
+      {
           m.value =      (*mainHistory)[pos.side_to_move()][from_to(m)]
                    + 2 * (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
                    + 2 * (*continuationHistory[1])[pos.moved_piece(m)][to_sq(m)]
-                   + 2 * (*continuationHistory[3])[pos.moved_piece(m)][to_sq(m)]
-                   +     (*continuationHistory[5])[pos.moved_piece(m)][to_sq(m)]
                    + (ply < MAX_LPH ?  4 * (*lowPlyHistory)[ply][from_to(m)] : 0);
+          if (considerFollowHistories)
+            m.value += 2 * (*continuationHistory[3])[pos.moved_piece(m)][to_sq(m)]
+                         + (*continuationHistory[5])[pos.moved_piece(m)][to_sq(m)];
+      }
 
       else // Type == EVASIONS
       {

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -134,7 +134,8 @@ public:
                                            const PieceToHistory**,
                                            Move,
                                            Move*,
-                                           int);
+                                           int,
+                                           bool);
   Move next_move(bool skipQuiets = false);
 
 private:
@@ -155,6 +156,7 @@ private:
   Value threshold;
   Depth depth;
   int ply;
+  bool considerFollowHistories;
   ExtMove moves[MAX_MOVES];
 };
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -924,6 +924,7 @@ namespace {
                                                                           [captureOrPromotion]
                                                                           [pos.moved_piece(move)]
                                                                           [to_sq(move)];
+                ss->inCheck = inCheck;
 
                 pos.do_move(move, st);
 
@@ -965,7 +966,8 @@ moves_loop: // When in check, search starts from here
                                       contHist,
                                       countermove,
                                       ss->killers,
-                                      depth > 12 ? ss->ply : MAX_PLY);
+                                      depth > 12 ? ss->ply : MAX_PLY,
+                                      !ss->inCheck);
 
     value = bestValue;
     singularLMR = moveCountPruning = false;
@@ -1150,6 +1152,7 @@ moves_loop: // When in check, search starts from here
                                                                 [captureOrPromotion]
                                                                 [movedPiece]
                                                                 [to_sq(move)];
+      ss->inCheck = inCheck;
 
       // Step 15. Make the move
       pos.do_move(move, st, givesCheck);
@@ -1710,8 +1713,12 @@ moves_loop: // When in check, search starts from here
   void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
 
     for (int i : {1, 2, 4, 6})
-        if (is_ok((ss-i)->currentMove))
+    {
+    	if (ss->inCheck && i > 2)
+    		break;
+      if (is_ok((ss-i)->currentMove))
             (*(ss-i)->continuationHistory)[pc][to] << bonus;
+    }
   }
 
 

--- a/src/search.h
+++ b/src/search.h
@@ -42,6 +42,7 @@ constexpr int CounterMovePruneThreshold = 0;
 struct Stack {
   Move* pv;
   PieceToHistory* continuationHistory;
+  bool inCheck;
   int ply;
   Move currentMove;
   Move excludedMove;


### PR DESCRIPTION
Seems that they don't work well on sharp positions where we can be checked.

Passed STC:
https://tests.stockfishchess.org/tests/view/5e9db1e9caaff5d60a50a89c
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 35346 W: 6873 L: 6634 D: 21839
Ptnml(0-2): 559, 4075, 8238, 4170, 631

Passed LTC:
https://tests.stockfishchess.org/tests/view/5e9e0ddecaaff5d60a50b0ac
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 117686 W: 15118 L: 14613 D: 87955
Ptnml(0-2): 835, 10745, 35208, 11190, 865

To continue from here:

-  probably we can simplify the patch by removing the new parameter in movepicker and just pos.checkers() while scoring quiet moves.
  Also the param in Stack seems not really necessary.
- maybe also include continuation move history 2

bench: 4898073