### PR TITLE
Don't write to continuation histories ss-4, ss-6 when in check.

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -49,6 +49,7 @@ struct Stack {
   Value staticEval;
   int statScore;
   int moveCount;
+  bool inCheck;
 };
 
 


### PR DESCRIPTION
Passed STC:
https://tests.stockfishchess.org/tests/view/5e9ee24acaaff5d60a50b812
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 61774 W: 11725 L: 11449 D: 38600
Ptnml(0-2): 971, 7211, 14322, 7337, 1046

Passed LTC:
https://tests.stockfishchess.org/tests/view/5e9eecb7caaff5d60a50b831
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 250822 W: 32067 L: 31179 D: 187576
Ptnml(0-2): 1745, 23126, 74824, 23928, 1788


A very similar but uncommitable patch also passed:
STC:
https://tests.stockfishchess.org/tests/view/5e9db1e9caaff5d60a50a89c
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 35346 W: 6873 L: 6634 D: 21839
Ptnml(0-2): 559, 4075, 8238, 4170, 631

LTC:
https://tests.stockfishchess.org/tests/view/5e9e0ddecaaff5d60a50b0ac
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 117686 W: 15118 L: 14613 D: 87955
Ptnml(0-2): 835, 10745, 35208, 11190, 865

P.S.: Now the variable inCheck has moved into the Stack. This looks a bit ugly
but was necessary & I hope this information can be useful also for future patches.

bench: 4808463