### PR TITLE
Tuned scores for safe checks and minor piece king protectors

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -305,10 +305,8 @@ namespace {
                 score += MinorBehindPawn;
 
             // Penalty if the piece is far from the king
-            if (Pt == KNIGHT)
-              score -= KnightKingProtector * distance(pos.square<KING>(Us), s);
-            else
-              score -= BishopKingProtector * distance(pos.square<KING>(Us), s);
+            score -= (Pt == KNIGHT ? KnightKingProtector
+                                   : BishopKingProtector) * distance(pos.square<KING>(Us), s);
 
             if (Pt == BISHOP)
             {

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -81,10 +81,10 @@ namespace {
   constexpr int KingAttackWeights[PIECE_TYPE_NB] = { 0, 0, 81, 52, 44, 10 };
 
   // Penalties for enemy's safe checks
-  constexpr int QueenSafeCheck  = 780;
-  constexpr int RookSafeCheck   = 1078;
-  constexpr int BishopSafeCheck = 635;
-  constexpr int KnightSafeCheck = 790;
+  constexpr int QueenSafeCheck  = 772;
+  constexpr int RookSafeCheck   = 1084;
+  constexpr int BishopSafeCheck = 645;
+  constexpr int KnightSafeCheck = 792;
 
 #define S(mg, eg) make_score(mg, eg)
 
@@ -131,11 +131,14 @@ namespace {
   constexpr Score CorneredBishop      = S( 50, 50);
   constexpr Score FlankAttacks        = S(  8,  0);
   constexpr Score Hanging             = S( 69, 36);
-  constexpr Score KingProtector       = S(  7,  8);
+  constexpr Score BishopKingProtector = S(  6,  9);
+  constexpr Score KnightKingProtector = S(  8,  9);
   constexpr Score KnightOnQueen       = S( 16, 11);
   constexpr Score LongDiagonalBishop  = S( 45,  0);
   constexpr Score MinorBehindPawn     = S( 18,  3);
-  constexpr Score Outpost             = S( 30, 21);
+  constexpr Score KnightOutpost       = S( 56, 36);
+  constexpr Score BishopOutpost       = S( 30, 23);
+  constexpr Score ReachableOutpost    = S( 31, 22);
   constexpr Score PassedFile          = S( 11,  8);
   constexpr Score PawnlessFlank       = S( 17, 95);
   constexpr Score RestrictedPiece     = S(  7,  7);
@@ -293,17 +296,19 @@ namespace {
             // Bonus if piece is on an outpost square or can reach one
             bb = OutpostRanks & attackedBy[Us][PAWN] & ~pe->pawn_attacks_span(Them);
             if (bb & s)
-                score += Outpost * (Pt == KNIGHT ? 2 : 1);
-
+                score += (Pt == KNIGHT) ? KnightOutpost : BishopOutpost;
             else if (Pt == KNIGHT && bb & b & ~pos.pieces(Us))
-                score += Outpost;
+                score += ReachableOutpost;
 
             // Bonus for a knight or bishop shielded by pawn
             if (shift<Down>(pos.pieces(PAWN)) & s)
                 score += MinorBehindPawn;
 
             // Penalty if the piece is far from the king
-            score -= KingProtector * distance(pos.square<KING>(Us), s);
+            if (Pt == KNIGHT)
+              score -= KnightKingProtector * distance(pos.square<KING>(Us), s);
+            else
+              score -= BishopKingProtector * distance(pos.square<KING>(Us), s);
 
             if (Pt == BISHOP)
             {
@@ -399,7 +404,7 @@ namespace {
     // Enemy rooks checks
     rookChecks = b1 & safe & attackedBy[Them][ROOK];
     if (rookChecks)
-        kingDanger += more_than_one(rookChecks) ? RookSafeCheck * 3/2
+        kingDanger += more_than_one(rookChecks) ? RookSafeCheck * 175/100
                                                 : RookSafeCheck;
     else
         unsafeChecks |= b1 & attackedBy[Them][ROOK];
@@ -412,7 +417,7 @@ namespace {
                  & ~attackedBy[Us][QUEEN]
                  & ~rookChecks;
     if (queenChecks)
-        kingDanger += more_than_one(queenChecks) ? QueenSafeCheck * 3/2
+        kingDanger += more_than_one(queenChecks) ? QueenSafeCheck * 145/100
                                                  : QueenSafeCheck;
 
     // Enemy bishops checks: we count them only if they are from squares from
@@ -430,7 +435,7 @@ namespace {
     // Enemy knights checks
     knightChecks = pos.attacks_from<KNIGHT>(ksq) & attackedBy[Them][KNIGHT];
     if (knightChecks & safe)
-        kingDanger += more_than_one(knightChecks & safe) ? KnightSafeCheck * 3/2
+        kingDanger += more_than_one(knightChecks & safe) ? KnightSafeCheck * 162/100
                                                          : KnightSafeCheck;
     else
         unsafeChecks |= knightChecks;


### PR DESCRIPTION
This is a combo of two param tuning tests that were yellow STC individually but passed STC+LTC when combined together. Both tests were related to king safety - one tuned safe check weights, the other tuned knight and bishop king protector weights separately with some compensation in the high outpost bonuses given to the minor pieces.

STC Green
LLR: 2.95 (-2.94,2.94) {-0.50,1.50}
Total: 39892 W: 7594 L: 7350 D: 24948
Ptnml(0-2): 643, 4559, 9314, 4771, 659
https://tests.stockfishchess.org/tests/view/5ea49635b908f6dd28f34b82

LTC Green
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 104934 W: 13300 L: 12834 D: 78800
Ptnml(0-2): 697, 9571, 31514, 9939, 746
https://tests.stockfishchess.org/tests/view/5ea4abf6b908f6dd28f34bcb

Further progress could be made through tuning scores for knight/bishop bonuses and penalties separately. Scores related to distance from another piece may be worth more attention, since the bishop is a long-range piece and the knight is not.

These are the two yellow STC tests:

- safe check weights - [yellow at 350k with +316 W/L spread](https://tests.stockfishchess.org/tests/view/5e9f14c6706a5136207c77f2)
- minor piece king protectors - [yellow at 269k with +198 W/L spread](https://tests.stockfishchess.org/tests/view/5ea25d332bbc513269426a87)


Bench 5007022