### PR TITLE
Change Clamp to Median

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -236,8 +236,8 @@ namespace {
     attackedBy2[Us] = dblAttackByPawn | (attackedBy[Us][KING] & attackedBy[Us][PAWN]);
 
     // Init our king safety tables
-    Square s = make_square(Utility::clamp(file_of(ksq), FILE_B, FILE_G),
-                           Utility::clamp(rank_of(ksq), RANK_2, RANK_7));
+    Square s = make_square(Utility::median(file_of(ksq), FILE_B, FILE_G),
+                           Utility::median(rank_of(ksq), RANK_2, RANK_7));
     kingRing[Us] = PseudoAttacks[KING][s] | s;
 
     kingAttackersCount[Them] = popcount(kingRing[Us] & pe->pawn_attacks(Them));

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -129,7 +129,7 @@ Entry* probe(const Position& pos) {
 
   Value npm_w = pos.non_pawn_material(WHITE);
   Value npm_b = pos.non_pawn_material(BLACK);
-  Value npm   = Utility::clamp(npm_w + npm_b, EndgameLimit, MidgameLimit);
+  Value npm   = Utility::median(npm_w + npm_b, EndgameLimit, MidgameLimit);
 
   // Map total non-pawn material into [PHASE_ENDGAME, PHASE_MIDGAME]
   e->gamePhase = Phase(((npm - EndgameLimit) * PHASE_MIDGAME) / (MidgameLimit - EndgameLimit));

--- a/src/misc.h
+++ b/src/misc.h
@@ -66,9 +66,9 @@ std::ostream& operator<<(std::ostream&, SyncCout);
 
 namespace Utility {
 
-/// Clamp a value between lo and hi. Available in c++17.
-template<class T> constexpr const T& clamp(const T& v, const T& lo, const T& hi) {
-  return v < lo ? lo : v > hi ? hi : v;
+/// Given any three values, return the one in the middle.
+template<class T> constexpr const T& median(const T& v1, const T& v2, const T& v3) {
+  return std::max(std::min(v1,v2), std::min(std::max(v1,v2), v3));
 }
 
 }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -199,7 +199,7 @@ Score Entry::evaluate_shelter(const Position& pos, Square ksq) {
 
   Score bonus = make_score(5, 5);
 
-  File center = Utility::clamp(file_of(ksq), FILE_B, FILE_G);
+  File center = Utility::median(file_of(ksq), FILE_B, FILE_G);
   for (File f = File(center - 1); f <= File(center + 1); ++f)
   {
       b = ourPawns & file_bb(f);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -366,7 +366,7 @@ void Thread::search() {
   // for match (TC 60+0.6) results spanning a wide range of k values.
   PRNG rng(now());
   double floatLevel = Options["UCI_LimitStrength"] ?
-                      Utility::clamp(std::pow((Options["UCI_Elo"] - 1346.6) / 143.4, 1 / 0.806), 0.0, 20.0) :
+                      Utility::median(std::pow((Options["UCI_Elo"] - 1346.6) / 143.4, 1 / 0.806), 0.0, 20.0) :
                         double(Options["Skill Level"]);
   int intLevel = int(floatLevel) +
                  ((floatLevel - int(floatLevel)) * 1024 > rng.rand<unsigned>() % 1024  ? 1 : 0);
@@ -539,7 +539,7 @@ void Thread::search() {
       {
           double fallingEval = (332 +  6 * (mainThread->bestPreviousScore - bestValue)
                                     +  6 * (mainThread->iterValue[iterIdx]  - bestValue)) / 704.0;
-          fallingEval = Utility::clamp(fallingEval, 0.5, 1.5);
+          fallingEval = Utility::median(fallingEval, 0.5, 1.5);
 
           // If the bestMove is stable over several iterations, reduce time accordingly
           timeReduction = lastBestMoveDepth + 9 < completedDepth ? 1.94 : 0.91;
@@ -1235,7 +1235,7 @@ moves_loop: // When in check, search starts from here
                 r++;
           }
 
-          Depth d = Utility::clamp(newDepth - r, 1, newDepth);
+          Depth d = Utility::median(newDepth - r, 1, newDepth);
 
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, d, true);
 


### PR DESCRIPTION
This is a non-functional code style change that removes clamp and replaces it with median.

If you don't provide clamp values in the correct order, you will NOT get the correct return value.  This has bit me a few times and will likely catch other devs in the future. Check yourself. . . if you haven't memorized the order of parameters for clamp, this patch may be for you.

This median function is better because it will always return the correct value regardless of the order of the parameters.

I preferred to change the name so that we don't confuse it with clamp(...) in the c++ standard.

Does not seem to regress against master.

STC
LLR: 2.93 (-2.94,2.94) {-1.50,0.50}
Total: 12784 W: 2505 L: 2377 D: 7902
Ptnml(0-2): 129, 1241, 3541, 1335, 146 
https://tests.stockfishchess.org/tests/view/5ea86edb2141237a731f0c1e

bench 4808463