### PR TITLE
Introduce futility pruning for captures

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1049,6 +1049,13 @@ moves_loop: // When in check, search starts from here
                   && captureHistory[movedPiece][to_sq(move)][type_of(pos.piece_on(to_sq(move)))] < 0)
                   continue;
 
+              // Futility pruning for captures
+              if (   !givesCheck
+                  && lmrDepth < 6
+                  && !ss->inCheck
+                  && ss->staticEval + 270 + 384 * lmrDepth + PieceValue[MG][type_of(pos.piece_on(to_sq(move)))] <= alpha)
+                  continue;
+
               // See based pruning
               if (!pos.see_ge(move, Value(-194) * depth)) // (~25 Elo)
                   continue;


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5ea8544b53a4548a0348ee5b
LLR: 2.95 (-2.94,2.94) {-0.50,1.50}
Total: 236040 W: 44420 L: 43894 D: 147726
Ptnml(0-2): 3830, 27202, 55496, 27596, 3896 
passed LTC
https://tests.stockfishchess.org/tests/view/5ea87c842141237a731f0c7d
LLR: 2.95 (-2.94,2.94) {0.25,1.75}
Total: 81336 W: 10429 L: 10028 D: 60879
Ptnml(0-2): 589, 7356, 24404, 7703, 616 
Idea is somewhat similar to futility pruning for quiet moves - if late enough capture doesn't give check and static eval is much lower than alpha we can almost safely assume that this capture wouldn't be a good move.
bench 4405247