### PR TITLE
Add support for Windows large pages

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -138,6 +138,51 @@ more compact than Nalimov tablebases, while still storing all information
 needed for optimal play and in addition being able to take into account
 the 50-move rule.
 
+## Large Pages
+
+Stockfish supports large pages on Linux and Windows. Large pages make
+the hash access more efficient improving the engine speed, especially
+on large hash sizes. Typical increases are 5..10% in terms of nps, but
+speed increases up to 30% have been measured. The support is
+automatic. Stockfish attempts to use large pages when available and
+will fall back to regular memory allocation when this is not the case.
+
+### Support on Linux
+
+Large page support on Linux is obtained by the Linux kernel
+transparent huge pages functionality. Often, transparent huge pages
+are already enabled and no configuration is needed.
+
+To verify the use of transparent huge pages, the following command may
+be used:
+
+```
+  grep AnonHugePages /proc/meminfo
+```
+
+After launching the engine, this number should increase roughly by the
+configured size of the hash.
+
+For troubleshooting, file `/sys/kernel/mm/transparent_hugepage/enabled`
+controls whether transparent huge pages are enabled. Setting
+`always` or `madvise` should suffice for Stockfish.
+
+File `/sys/kernel/mm/transparent_hugepage/defrag` controls whether
+memory is attempted to be defragmented to make room for large pages
+when necessary. Setting `always`, `defer+madvise`, or `madvise` is
+recommended.
+
+### Support on Windows
+
+The use of large pages requires "Lock Pages in Memory" privilege. See
+[Enable the Lock Pages in Memory Option (Windows)](https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/enable-the-lock-pages-in-memory-option-windows)
+on how to enable this privilege. Logout/login may be needed
+afterwards. To determine whether large pages are in use, see the
+engine log.
+
+Due to memory fragmentation, memory with large pages may not be always
+possible to allocate even when enabled. When this is the case, reboot
+may be needed.
 
 ## Compiling Stockfish yourself from the sources
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,7 @@ int main(int argc, char* argv[]) {
 
   UCI::loop(argc, argv);
 
+  TT.resize(0); // release hash first to avoid segfault on waiting for search completion
   Threads.set(0);
   return 0;
 }

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -308,6 +308,71 @@ void* aligned_ttmem_alloc(size_t allocSize, void*& mem) {
   return mem;
 }
 
+#elif defined(_WIN64)
+
+static void* aligned_ttmem_alloc_large_pages(size_t allocSize) {
+
+  HANDLE hProcessToken { };
+  LUID luid { };
+  void* mem = nullptr;
+
+  const size_t largePageSize = GetLargePageMinimum();
+  if (!largePageSize)
+      return nullptr;
+
+  // We need SeLockMemoryPrivilege, so try to enable it for the process
+  if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &hProcessToken))
+      return nullptr;
+
+  if (LookupPrivilegeValue(NULL, SE_LOCK_MEMORY_NAME, &luid))
+  {
+      TOKEN_PRIVILEGES tp { };
+      TOKEN_PRIVILEGES prevTp { };
+      DWORD prevTpLen = 0;
+
+      tp.PrivilegeCount = 1;
+      tp.Privileges[0].Luid = luid;
+      tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+
+      // Try to enable SeLockMemoryPrivilege. Note that even if AdjustTokenPrivileges() succeeds,
+      // we still need to query GetLastError() to ensure that the privileges were actually obtained...
+      if (AdjustTokenPrivileges(
+              hProcessToken, FALSE, &tp, sizeof(TOKEN_PRIVILEGES), &prevTp, &prevTpLen) &&
+          GetLastError() == ERROR_SUCCESS)
+      {
+          // round up size to full pages and allocate
+          allocSize = (allocSize + largePageSize - 1) & ~size_t(largePageSize - 1);
+          mem = VirtualAlloc(
+              NULL, allocSize, MEM_RESERVE | MEM_COMMIT | MEM_LARGE_PAGES, PAGE_READWRITE);
+
+          // privilege no longer needed, restore previous state
+          AdjustTokenPrivileges(hProcessToken, FALSE, &prevTp, 0, NULL, NULL);
+      }
+  }
+
+  CloseHandle(hProcessToken);
+
+  return mem;
+}
+
+void* aligned_ttmem_alloc(size_t allocSize, void*& mem) {
+
+  // try allocate large pages
+  mem = aligned_ttmem_alloc_large_pages(allocSize);
+  if (mem)
+      sync_cout << "info string Hash table allocation: Windows large pages used." << sync_endl;
+  else
+      sync_cout << "info string Hash table allocation: Windows large pages not used." << sync_endl;
+
+  // fall back to regular allocation if necessary
+  if (!mem)
+      mem = VirtualAlloc(NULL, allocSize, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+
+  // NOTE: VirtualAlloc returns memory at page boundary, so no need to align for
+  // cachelines
+  return mem;
+}
+
 #else
 
 void* aligned_ttmem_alloc(size_t allocSize, void*& mem) {
@@ -317,6 +382,28 @@ void* aligned_ttmem_alloc(size_t allocSize, void*& mem) {
   mem = malloc(size);
   void* ret = reinterpret_cast<void*>((uintptr_t(mem) + alignment - 1) & ~uintptr_t(alignment - 1));
   return ret;
+}
+
+#endif
+
+/// aligned_ttmem_free will free the previously allocated ttmem
+#if defined(_WIN64)
+
+void aligned_ttmem_free(void* mem) {
+
+  if (!VirtualFree(mem, 0, MEM_RELEASE))
+  {
+      DWORD err = GetLastError();
+      std::cerr << "Failed to free transposition table. Error code: 0x" <<
+          std::hex << err << std::dec << std::endl;
+      exit(EXIT_FAILURE);
+  }
+}
+
+#else
+
+void aligned_ttmem_free(void *mem) {
+  free(mem);
 }
 
 #endif

--- a/src/misc.h
+++ b/src/misc.h
@@ -34,6 +34,7 @@ const std::string compiler_info();
 void prefetch(void* addr);
 void start_logger(const std::string& fname);
 void* aligned_ttmem_alloc(size_t size, void*& mem);
+void aligned_ttmem_free(void* mem);
 
 void dbg_hit_on(bool b);
 void dbg_hit_on(bool c, bool b);

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -63,7 +63,14 @@ void TranspositionTable::resize(size_t mbSize) {
 
   Threads.main()->wait_for_search_finished();
 
-  free(mem);
+  if (mem)
+      aligned_ttmem_free(mem);
+
+  if (!mbSize)
+  {
+      mem = nullptr;
+      return;
+  }
 
   clusterCount = mbSize * 1024 * 1024 / sizeof(Cluster);
   table = static_cast<Cluster*>(aligned_ttmem_alloc(clusterCount * sizeof(Cluster), mem));


### PR DESCRIPTION
As is with Linux, large pages may add a significant bump to nps
numbers, especially on large hashes.

On my Windows box, go depth 30 on startpos increases the speed from
13.8 Mnps to 14.6 Mnps with 32 GB hash when large pages are
enabled. This is roughly a +6% speed increase.

No functional change


**Note: Since this patch switches from malloc() to VirtualAlloc() even without large pages enabled, this patch should be tested on a NUMA machine for speed regressions before merge.**