### PR TITLE
Refine scale factor of opposite colored bishops endgames.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -765,7 +765,7 @@ namespace {
         {
             if (   pos.non_pawn_material(WHITE) == BishopValueMg
                 && pos.non_pawn_material(BLACK) == BishopValueMg)
-                sf = 22;
+                sf = 18 + 4 * popcount(pe->passed_pawns(strongSide));
             else
                 sf = 22 + 3 * pos.count<ALL_PIECES>(strongSide);
         }


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5ead60966ffeed51f6e32591
LLR: 2.96 (-2.94,2.94) {-0.50,1.50}
Total: 50336 W: 9473 L: 9241 D: 31622
Ptnml(0-2): 570, 5371, 13098, 5515, 614 
passed LTC
https://tests.stockfishchess.org/tests/view/5ead6d3b6ffeed51f6e325b0
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 21952 W: 2810 L: 2603 D: 16539
Ptnml(0-2): 101, 1791, 7005, 1958, 121 
This patch makes it dependant on count of passed pawns of strong side instead of 22/64 in every case.
This is reintroduction of this dependance that was simplified away approximately a year ago - since then a lot of things were changed including code of passed pawns.
bench 4375972