### PR TITLE
Simplify Time Management

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -69,28 +69,35 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
 
   timeLeft = slowMover * timeLeft / 100;
 
-  // For crazy fast games with little-to-no increment
-  if (limits.time[us] < 11000 && limits.inc[us] < moveOverhead)
+  // For fast games with little-to-no increment
+  if (limits.time[us] < 11000 && limits.inc[us] < 100)
   {
       scale = std::max(6.0 * (9.0 - std::log2(ply + 1)), 2.0);
-      optimumTime = std::max<int>(2 * minThinkingTime, timeLeft / scale);
+      optimumTime = std::max<int>(40, timeLeft / scale);
+      optimumTime = std::max<int>(minThinkingTime, timeLeft / scale);
 
       scale = std::max(1.7 * (8.0 - std::log2(ply + 1)), 0.5);
-      if (3*minThinkingTime < timeLeft / scale)
+      if (60 < timeLeft / scale)
           maximumTime = timeLeft / scale;
-      else if (3 * minThinkingTime > 0.8 * limits.time[us] - moveOverhead)
+      else if (60 > 0.8 * limits.time[us] - moveOverhead)
           maximumTime = 0.8 * limits.time[us] - moveOverhead;
       else
           maximumTime = 3 * optimumTime / 2;
+
+      maximumTime = std::max<int>(minThinkingTime, maximumTime);
   }
   else  //all other games
   {
-      double scale1 = std::max(2.0, 8.2 * (9.0 - std::log2(ply + 1)));
-      optimumTime = std::min<int>(0.2 * limits.time[us], timeLeft / scale1);
+      // The game is slow enough that we can safety steal from real game time
+      if (timeLeft == 0)
+          minThinkingTime = std::max<int>(minThinkingTime, limits.time[us] / 24);
+
+      scale = std::max(2.0, 8.2 * (9.0 - std::log2(ply + 1)));
+      optimumTime = std::min<int>(0.2 * limits.time[us], timeLeft / scale);
       optimumTime = std::max<int>(minThinkingTime, optimumTime);
 
-      double scale2 = std::max(0.5, 1.7 * (8.0 - std::log2(ply + 1)));
-      maximumTime = std::min<int>(0.8 * limits.time[us] - moveOverhead, timeLeft / scale2);
+      scale = std::max(0.5, 1.7 * (8.0 - std::log2(ply + 1)));
+      maximumTime = std::min<int>(0.8 * limits.time[us] - moveOverhead, timeLeft / scale);
       maximumTime = std::max<int>(minThinkingTime, maximumTime);
   }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -72,30 +72,13 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
 
   if (limits.movestogo == 0)
   {
-      // For fast games with little-to-no increment
-      if (limits.time[us] < 11000 && limits.inc[us] < moveOverhead)
-      {
-          scale = std::max(6.0 * (9.0 - std::log2(ply + 1)), 2.0);
-          optimumTime = std::max<int>(2 * minThinkingTime, timeLeft / scale);
-    
-          scale = std::max(1.7 * (8.0 - std::log2(ply + 1)), 0.5);
-          if (3 * minThinkingTime < timeLeft / scale)
-              maximumTime = timeLeft / scale;
-          else if (3 * minThinkingTime > 0.8 * limits.time[us] - moveOverhead)
-              maximumTime = 0.8 * limits.time[us] - moveOverhead;
-          else
-              maximumTime = 3 * optimumTime / 2;
-      }
-      else //we have time to maturely process moves
-      {
-          scale = std::max(2.0, 8.2 * (9.2 - std::log2(ply + 1)));
-          optimumTime = std::min<int>(0.2 * limits.time[us], timeLeft / scale);
-          optimumTime = std::max<int>(minThinkingTime, optimumTime);
-    
-          scale = std::max(0.5, 1.7 * (8.0 - std::log2(ply + 1)));
-          maximumTime = std::min<int>(0.8 * limits.time[us] - moveOverhead, timeLeft / scale);
-          maximumTime = std::max<int>(minThinkingTime, maximumTime);
-      }
+      scale = std::max(2.0, 8.2 * (9.2 - std::log2(ply + 1)));
+      optimumTime = std::min<int>(0.2 * limits.time[us], timeLeft / scale);
+      optimumTime = std::max<int>(minThinkingTime, optimumTime);
+
+      scale = std::max(0.5, 1.7 * (8.0 - std::log2(ply + 1)));
+      maximumTime = std::min<int>(0.8 * limits.time[us] - moveOverhead, timeLeft / scale);
+      maximumTime = std::max<int>(minThinkingTime, maximumTime);
   }
   else //x moves in y minutes (+ z increment)
   {

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -67,9 +67,7 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
 
   timeLeft = slowMover * timeLeft / 100;
 
-///  inc == 0 && movestogo == 0 means: x basetime  [sudden death!]
-///  inc >  0 && movestogo == 0 means: x basetime + z increment
-
+  /// movestogo == 0 means: x basetime (+ z increment)
   if (limits.movestogo == 0)
   {
       scale = std::max(2.0, 8.2 * (9.2 - std::log2(ply + 1)));
@@ -81,20 +79,18 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
       maximumTime = std::max<int>(minThinkingTime, maximumTime);
   }
 
-///  inc == 0 && movestogo != 0 means: x moves in y minutes
-///  inc >  0 && movestogo != 0 means: x moves in y minutes + z increment
-
+  /// movestogo != 0 means: x moves in y minutes (+ z increment)
   else
   {
-      double mid = (ply - 30.0) / 32.0;
-      scale = std::max(1.0, 1.6 - mid / (1 + std::abs(mid)));
-      optimumTime = timeLeft / (limits.movestogo / 1.6) / scale;
-      optimumTime = std::min<int>(limits.time[us] - 2 * limits.movestogo * moveOverhead, optimumTime);
+      double mid = (ply - 34.0) / 32.0;
+      scale = 1.7 / std::max(1.0, 1.7 - mid / (1 + std::abs(mid)));
+      optimumTime = scale * timeLeft / mtg;
+      optimumTime = std::max(minThinkingTime, optimumTime);
 
-      scale = std::min<double>(5.5, 1.5 + 0.1 * limits.movestogo);
-      maximumTime = std::min<int>(limits.time[us] - 2 * limits.movestogo * moveOverhead, scale * optimumTime);
+      scale = std::min(6.3, 1.5 + 0.11 * mtg);
+      maximumTime = std::min<int>(limits.time[us] - mtg * moveOverhead, scale * optimumTime);
   }
-    
+
   if (Options["Ponder"])
       optimumTime += optimumTime / 4;
 }

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -80,24 +80,21 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
   // game time for the current move, so also cap to 20% of available game time.
   if (limits.movestogo == 0)
   {
-      opt_scale = std::min(0.007 + std::pow(ply + 3, 0.5) / 250.0,
-                           0.2 * limits.time[us] / timeLeft);
-
+      opt_scale = std::min(0.007 + std::pow(ply + 3.0, 0.5) / 250.0,
+                           0.2 * limits.time[us] / double(timeLeft));
       max_scale = 4 + std::pow(ply + 3, 0.3);
   }
 
   // x moves in y seconds (+ z increment)
   else
   {
-      opt_scale = (0.8 + ply / 128.0) / mtg;
+      opt_scale = std::min((0.8 + ply / 128.0) / mtg,
+                            0.8 * limits.time[us] / double(timeLeft));
       max_scale = std::min(6.3, 1.5 + 0.11 * mtg);
   }
 
-  optimumTime = opt_scale * timeLeft;
-  optimumTime = std::max(minThinkingTime, optimumTime);
-
-  // Always make sure maximumTime is less than 80% of available time
-  maximumTime = std::min(0.8 * limits.time[us] - moveOverhead, max_scale * optimumTime);
+  optimumTime = std::max(minThinkingTime, opt_scale * timeLeft);
+  maximumTime = std::min(0.9 * limits.time[us] - moveOverhead, max_scale * optimumTime);
 
   if (Options["Ponder"])
       optimumTime += optimumTime / 4;

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -59,16 +59,16 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
 
   int mtg = limits.movestogo ? std::min(limits.movestogo, 50) : 50;
 
+  // Adjust moveOverhead to support tiny increments (if needed)
+  moveOverhead = std::max(10, std::min<int>(limits.inc[us] / 2, moveOverhead));
+
   TimePoint timeLeft =  std::max(TimePoint(0),
       limits.time[us] + limits.inc[us] * (mtg - 1) - moveOverhead * (2 + mtg));
 
   timeLeft = slowMover * timeLeft / 100;
 
-///
 ///  inc == 0 && movestogo == 0 means: x basetime  [sudden death!]
-///  inc == 0 && movestogo != 0 means: x moves in y minutes
 ///  inc >  0 && movestogo == 0 means: x basetime + z increment
-///  inc >  0 && movestogo != 0 means: x moves in y minutes + z increment
 
   if (limits.movestogo == 0)
   {
@@ -80,7 +80,11 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
       maximumTime = std::min<int>(0.8 * limits.time[us] - moveOverhead, timeLeft / scale);
       maximumTime = std::max<int>(minThinkingTime, maximumTime);
   }
-  else //x moves in y minutes (+ z increment)
+
+///  inc == 0 && movestogo != 0 means: x moves in y minutes
+///  inc >  0 && movestogo != 0 means: x moves in y minutes + z increment
+
+  else
   {
       double mid = (ply - 30.0) / 32.0;
       scale = std::max(1.0, 1.6 - mid / (1 + std::abs(mid)));

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -31,7 +31,7 @@ TimeManagement Time; // Our global time management object
 /// init() is called at the beginning of the search and calculates the bounds
 /// of time allowed for the current game ply.  We currently support:
 //      1) x basetime (+z increment)
-//      2) x basetime in y seconds (+z increment)
+//      2) x moves in y seconds (+z increment)
 
 void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -82,15 +82,9 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
           maximumTime = 0.8 * limits.time[us] - moveOverhead;
       else
           maximumTime = 3 * optimumTime / 2;
-
-      maximumTime = std::max<int>(minThinkingTime, maximumTime);
   }
   else  //all other games
   {
-      // The game is slow enough that we can safety steal from real game time
-      if (timeLeft == 0)
-          minThinkingTime = std::max<int>(minThinkingTime, limits.time[us] / 24);
-
       scale = std::max(2.0, 8.2 * (9.2 - std::log2(ply + 1)));
       optimumTime = std::min<int>(0.2 * limits.time[us], timeLeft / scale);
       optimumTime = std::max<int>(minThinkingTime, optimumTime);

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -70,16 +70,15 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
   timeLeft = slowMover * timeLeft / 100;
 
   // For fast games with little-to-no increment
-  if (limits.time[us] < 11000 && limits.inc[us] < 100)
+  if (limits.time[us] < 11000 && limits.inc[us] < moveOverhead)
   {
       scale = std::max(6.0 * (9.0 - std::log2(ply + 1)), 2.0);
-      optimumTime = std::max<int>(40, timeLeft / scale);
-      optimumTime = std::max<int>(minThinkingTime, timeLeft / scale);
+      optimumTime = std::max<int>(2 * minThinkingTime, timeLeft / scale);
 
       scale = std::max(1.7 * (8.0 - std::log2(ply + 1)), 0.5);
-      if (60 < timeLeft / scale)
+      if (3 * minThinkingTime < timeLeft / scale)
           maximumTime = timeLeft / scale;
-      else if (60 > 0.8 * limits.time[us] - moveOverhead)
+      else if (3 * minThinkingTime > 0.8 * limits.time[us] - moveOverhead)
           maximumTime = 0.8 * limits.time[us] - moveOverhead;
       else
           maximumTime = 3 * optimumTime / 2;
@@ -92,7 +91,7 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
       if (timeLeft == 0)
           minThinkingTime = std::max<int>(minThinkingTime, limits.time[us] / 24);
 
-      scale = std::max(2.0, 8.2 * (9.0 - std::log2(ply + 1)));
+      scale = std::max(2.0, 8.2 * (9.2 - std::log2(ply + 1)));
       optimumTime = std::min<int>(0.2 * limits.time[us], timeLeft / scale);
       optimumTime = std::max<int>(minThinkingTime, optimumTime);
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -70,7 +70,7 @@ void init(OptionsMap& o) {
   o["Skill Level"]           << Option(20, 0, 20);
   o["Move Overhead"]         << Option(30, 0, 5000);
   o["Minimum Thinking Time"] << Option(20, 0, 5000);
-  o["Slow Mover"]            << Option(84, 10, 1000);
+  o["Slow Mover"]            << Option(100, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["UCI_AnalyseMode"]       << Option(false);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -68,7 +68,7 @@ void init(OptionsMap& o) {
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);
   o["Skill Level"]           << Option(20, 0, 20);
-  o["Move Overhead"]         << Option(10, 0, 5000);
+  o["Move Overhead"]         << Option(30, 0, 5000);
   o["Minimum Thinking Time"] << Option( 0, 0, 5000);
   o["Slow Mover"]            << Option(100, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -68,8 +68,8 @@ void init(OptionsMap& o) {
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);
   o["Skill Level"]           << Option(20, 0, 20);
-  o["Move Overhead"]         << Option(30, 0, 5000);
-  o["Minimum Thinking Time"] << Option(20, 0, 5000);
+  o["Move Overhead"]         << Option(10, 0, 5000);
+  o["Minimum Thinking Time"] << Option( 0, 0, 5000);
   o["Slow Mover"]            << Option(100, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);


### PR DESCRIPTION
This is a functional simplification that dramatically simplifies time management.  After significant mathematical modeling, these simple log equations closely follow what master was doing.  I need help and suggestions.  I don’t think this is commit-able as is, but it probably can be.  Please help me clean this up and make recommendations.

GOOD
1. Instead of 2500 calls to move_importance per move, we have a single log equation.
2.  Much less code.
3.  May result in some elo.
4.  Can more easily be tuned.
5.  Can customize certain special time scenarios like when time increment is lower than move overhead.
6.  Allocates less time for the first 10 ply and allows move time for middlegame moves.  I suspect this is where some of the performance comes from.
7. slowMover is adjusted to 100, so that it by default has no impact.  Can this be removed?

BAD
1.  I don’t like the special cases for different game types, but this may actually be a benefit because we can optimize each type of timed game.
2.  minThinkingTime breaks stuff.  If you change this value, is has a big impact.
-----It might be a good idea to change the 2*minThinkingTime to 40 or similar.
3.  I have no idea how this performs for 40/10 games.

Test results for this exact version:

STC
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 45456 W: 8647 L: 8524 D: 28285
Ptnml(0-2): 781, 5230, 10547, 5425, 745 
https://tests.stockfishchess.org/tests/view/5eae21756ffeed51f6e328a0

STC – sudden death
LLR: 2.93 (-2.94,2.94) {-1.50,0.50}
Total: 16640 W: 3944 L: 3736 D: 8960
Ptnml(0-2): 430, 1934, 3413, 2084, 459 
https://tests.stockfishchess.org/tests/view/5eae2f5f6ffeed51f6e328ad

STC – TCEC style
LLR: 2.96 (-2.94,2.94) {-1.50,0.50}
Total: 60784 W: 13459 L: 13331 D: 33994
Ptnml(0-2): 1292, 7447, 12829, 7489, 1335 
https://tests.stockfishchess.org/tests/view/5eae37346ffeed51f6e328e2

LTC
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 40208 W: 5179 L: 5112 D: 29917
Ptnml(0-2): 281, 3741, 12010, 3774, 298
https://tests.stockfishchess.org/tests/view/5eae60c76ffeed51f6e32902


Other good test results:
60+0.06: https://tests.stockfishchess.org/tests/view/5eabaee909d25e8e50581794
https://tests.stockfishchess.org/tests/view/5eab39ef09d25e8e50581756
https://tests.stockfishchess.org/tests/view/5eab24e409d25e8e50581729
https://tests.stockfishchess.org/tests/view/5ea9d73169c5cb4e2aeb8313
https://tests.stockfishchess.org/tests/view/5ea9d17d69c5cb4e2aeb830b
https://tests.stockfishchess.org/tests/view/5ea9d70e69c5cb4e2aeb8311
