### PR TITLE
Fix syzygy dependencies issue

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -35,10 +35,14 @@ BINDIR = $(PREFIX)/bin
 ### Built-in benchmark for pgo-builds
 PGOBENCH = ./$(EXE) bench
 
-### Object files
-OBJS = benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o \
-	material.o misc.o movegen.o movepick.o pawns.o position.o psqt.o \
-	search.o thread.o timeman.o tt.o uci.o ucioption.o tune.o syzygy/tbprobe.o
+### Source and object files
+SRCS = benchmark.cpp bitbase.cpp bitboard.cpp endgame.cpp evaluate.cpp main.cpp \
+	material.cpp misc.cpp movegen.cpp movepick.cpp pawns.cpp position.cpp psqt.cpp \
+	search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp
+
+OBJS = $(notdir $(SRCS:.cpp=.o))
+
+VPATH = syzygy
 
 ### Establish the operating system name
 KERNEL = $(shell uname -s)
@@ -445,12 +449,12 @@ clean: objclean profileclean
 
 # clean binaries and objects
 objclean:
-	@rm -f $(EXE) *.o ./syzygy/*.o
+	@rm -f $(EXE) *.o
 
 # clean auxiliary profiling files
 profileclean:
 	@rm -rf profdir
-	@rm -f bench.txt *.gcda ./syzygy/*.gcda *.gcno ./syzygy/*.gcno
+	@rm -f bench.txt *.gcda *.gcno
 	@rm -f stockfish.profdata *.profraw
 
 default:
@@ -536,7 +540,7 @@ icc-profile-use:
 	all
 
 .depend:
-	-@$(CXX) $(DEPENDFLAGS) -MM $(OBJS:.o=.cpp) > $@ 2> /dev/null
+	-$(CXX) $(DEPENDFLAGS) -MM $(SRCS) > $@ 2> /dev/null
 
 -include .depend
 


### PR DESCRIPTION
Fix error where syzygy/tbprobe.o is not rebuilt when a header file it depends on is updated. (Issue #2660)

Problem is caused by .depend being created with a rule for tbprobe.o not for syzygy/tbprobe.o.

- define SRCS list including syzygy/tbprobe.cpp
- define VPATH = syzygy so that make will look in syzygy folder if a required file is not found (idea from @gvreuls #2663)
- create OBJS from SRCS using gnu $(notdir ...) function to remove dirname so that object is built in current dir, matching the rule created in .depend

If you have an existing file syzygy/tbprobe.o (very likely) remove it with 'make clean', 'rm syzygy/tbprobe.o' or similar to allow successful builds with this change.

No functional change.