### PR TITLE
Introduce anti-suicide feature

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -739,6 +739,7 @@ namespace {
                     + 24 * infiltration
                     + 51 * !pos.non_pawn_material()
                     - 43 * almostUnwinnable
+                    -  2 * pos.rule50_count()
                     -110 ;
 
     Value mg = mg_value(score);
@@ -778,8 +779,6 @@ namespace {
         }
         else
             sf = std::min(sf, 36 + 7 * pos.count<PAWN>(strongSide));
-
-        sf = std::max(0, sf - (pos.rule50_count() - 12) / 4);
     }
 
     return ScaleFactor(sf);
@@ -856,7 +855,14 @@ namespace {
         Trace::add(TOTAL, score);
     }
 
-    return  (pos.side_to_move() == WHITE ? v : -v) + Tempo; // Side to move point of view
+    // Side to move point of view
+    v = (pos.side_to_move() == WHITE ? v : -v) + Tempo; 
+
+    // Damp down the eval after 25 moves of shuffling
+    if (pos.rule50_count() > 50)
+        v = v * (6 + 5 * (100 - pos.rule50_count())) / 256;
+
+    return v;
   }
 
 } // namespace


### PR DESCRIPTION
In some recent tournament games, Stockfish exhibited the following
self-destructing behaviour. Stockfish was suffering in a long shuffle
session, having a bad evaluation in a blocked or semi-blocked position
for about 40 moves and yet the eval was sort of flatlined, indicating
that the opponent engine (Leela) had trouble converting the position.
Then, not long before the 50-moves draw rule would be reached,
the opponent would play its pieces to some strange places and SF would
push a pawn, thinking she would get a slightly "less worse" evaluation.
However, the slightly less worse evaluation would prove to be delusional,
the position with a sacrificed pawn crackable and SF eventually lost
these games.

This issue was discussed in the following thread: 
https://github.com/official-stockfish/Stockfish/issues/2620

This commit is our best attempt to patch this issue, so that SF gets
more patient in worse positions and tries to play for 50 moves as much
as possible and not suicide. The implementation uses pure evaluation
methods rather than search, damping down the eval after 25 moves of
shuffling (damping factor is linear, starting from 1.0 after 25 shuffling
moves and reaching 0.04 after 50 moves of shuffling). This damping
puts the burden on the attacking player to prove that he can break
the fortress, as now the search will get more and more optimistic
for the defending player to be able to reach a draw by 50 moves rule.

This solution seems to work as intended for the few cases extracted
from tournament losses, according to tests done by @vondele in the
following comments:
https://github.com/official-stockfish/Stockfish/issues/2620#issuecomment-616779979
https://github.com/snicolet/Stockfish/commit/a66d3c01bb453d91e21e50b0b431a67ca906e3c4#commitcomment-38963042

In Fishtest, the best result we managed to get after extensive testing
was a double yellow with Elo-gaining bounds (this patch), maybe because
the problem is quite rare at the short time controls we use in our tests
compared to the longer time controls used in tournament games:

STC:
LLR: -2.97 (-2.94,2.94) {-0.50,1.50}
Total: 201928 W: 38274 L: 38174 D: 125480
Ptnml(0-2): 3452, 23520, 46844, 23772, 3376
https://tests.stockfishchess.org/tests/view/5eb281dd2326444a3b6d3499

LTC:
LLR: -2.94 (-2.94,2.94) {0.25,1.75}
Total: 90232 W: 11446 L: 11353 D: 67433
Ptnml(0-2): 631, 8421, 26967, 8418, 679
https://tests.stockfishchess.org/tests/view/5eb34a862326444a3b6d37ff

Bench: 4834675