### PR TITLE
Use posix_memalign instead of aligned_alloc

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -303,7 +303,8 @@ void* aligned_ttmem_alloc(size_t allocSize, void*& mem) {
 
   constexpr size_t alignment = 2 * 1024 * 1024; // assumed 2MB page sizes
   size_t size = ((allocSize + alignment - 1) / alignment) * alignment; // multiple of alignment
-  mem = aligned_alloc(alignment, size);
+  if (posix_memalign(&mem, alignment, size))
+     mem = nullptr;
   madvise(mem, allocSize, MADV_HUGEPAGE);
   return mem;
 }


### PR DESCRIPTION
should be a little more portable to older linux systems (before glibc-2.16).

fixes https://github.com/official-stockfish/Stockfish/issues/2665

No functional change.