### PR TITLE
Pawn value

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -181,7 +181,7 @@ enum Value : int {
   VALUE_MATE_IN_MAX_PLY  =  VALUE_MATE - MAX_PLY,
   VALUE_MATED_IN_MAX_PLY = -VALUE_MATE_IN_MAX_PLY,
 
-  PawnValueMg   = 128 + 4,   PawnValueEg   = 213 + 7,
+  PawnValueMg   = 124,   PawnValueEg   = 206,
   KnightValueMg = 781,   KnightValueEg = 854,
   BishopValueMg = 825,   BishopValueEg = 915,
   RookValueMg   = 1276,  RookValueEg   = 1380,

--- a/src/types.h
+++ b/src/types.h
@@ -181,7 +181,7 @@ enum Value : int {
   VALUE_MATE_IN_MAX_PLY  =  VALUE_MATE - MAX_PLY,
   VALUE_MATED_IN_MAX_PLY = -VALUE_MATE_IN_MAX_PLY,
 
-  PawnValueMg   = 124,   PawnValueEg   = 206,
+  PawnValueMg   = 124,   PawnValueEg   = 206, 
   KnightValueMg = 781,   KnightValueEg = 854,
   BishopValueMg = 825,   BishopValueEg = 915,
   RookValueMg   = 1276,  RookValueEg   = 1380,

--- a/src/types.h
+++ b/src/types.h
@@ -181,7 +181,7 @@ enum Value : int {
   VALUE_MATE_IN_MAX_PLY  =  VALUE_MATE - MAX_PLY,
   VALUE_MATED_IN_MAX_PLY = -VALUE_MATE_IN_MAX_PLY,
 
-  PawnValueMg   = 128,   PawnValueEg   = 213,
+  PawnValueMg   = 128 + 4,   PawnValueEg   = 213 + 7,
   KnightValueMg = 781,   KnightValueEg = 854,
   BishopValueMg = 825,   BishopValueEg = 915,
   RookValueMg   = 1276,  RookValueEg   = 1380,


### PR DESCRIPTION
Small tune of PawnValue parameters -4 / -7 with "closedpos.epd" opening book.

STC:
LLR: 2.96 (-2.94,2.94) {-0.50,1.50}
Total: 58776 W: 11787 L: 11511 D: 35478
Ptnml(0-2): 975, 6876, 13443, 7086, 1008 
https://tests.stockfishchess.org/tests/view/5eb5aa712326444a3b6d3e33

LTC:
LLR: 2.98 (-2.94,2.94) {0.25,1.75}
Total: 137544 W: 19687 L: 19115 D: 98742
Ptnml(0-2): 988, 13219, 39901, 13561, 1103 
https://tests.stockfishchess.org/tests/view/5eb67a392326444a3b6d3e9a

Non regression STC with "noob_3moves.epd" opening book
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 98168 W: 18545 L: 18499 D: 61124
Ptnml(0-2): 1647, 11396, 22951, 11444, 1646 
https://tests.stockfishchess.org/tests/view/5eb7e489e0300e8e8c896203

Bench 4696646