### PR TITLE
Simplify Time Management

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -69,8 +69,8 @@ void init(OptionsMap& o) {
   o["MultiPV"]               << Option(1, 1, 500);
   o["Skill Level"]           << Option(20, 0, 20);
   o["Move Overhead"]         << Option(30, 0, 5000);
-  o["Minimum Thinking Time"] << Option(20, 0, 5000);
-  o["Slow Mover"]            << Option(84, 10, 1000);
+  o["Minimum Thinking Time"] << Option( 0, 0, 5000);
+  o["Slow Mover"]            << Option(100, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["UCI_AnalyseMode"]       << Option(false);


### PR DESCRIPTION
This is a functional simplification of the time management system. 

With this patch, there is a simple equation for each of two distinct time controls: basetime + increment, and x moves in y seconds (+increment).  These equations are easy to plot and understand making future modifications or adding additional time controls much easier.

SlowMover is reset to 100 so that is has no effect unless a user changes it.  I think this should be removed, but I don’t do it here.

There are two scaling variables: opt_scale and max_scale.  Opt_scale is a scale factor (or percentage) of time to use for this current move.  Max_scale is a scale factor to apply to the resulting optimumTime.

There seems to be some elo gain in most scenarios (2-4 ELO at LTC) and many of these will likely pass STC/LTC.  I believe better performance is attributable to one of two things:

1) minThinkingTime was not allowing reasonable time calculations for very short games like 10+0 or 10+0.01.  This is because adding almost no increment and substracting move overhead for 50 moves quickly results in almost 0 time very early in the game.  Master depended on minThinkingTime to handle these short games instead of good time management.  This patch addresses this issue by lowering minThinkingTime to 0 and adjusting moverOverhead if there are very low increments.

2) Notice that the time distribution curves tail downward for the first 10 moves or so.  This causes less time to attribute for very early moves leaving more time available for middle moves where more important decisions happen.

TODO: Ultimately, it would be better to adjust time usage by characteristics of the position rather than ply.  Other options may be non_pawn_material, King castling, # of pawns, ave rank of pieces, position complexity, mg/eg ratios, any combination, or anything else.

Here is a summary of tests for this version at different time controls.  Performance looks pretty good to me, but there may be other time controls that lose elo.

SMP 5+0.05
LLR: 2.97 (-2.94,2.94) {-1.50,0.50}
Total: 46544 W: 7175 L: 7089 D: 32280
Ptnml(0-2): 508, 4826, 12517, 4914, 507
https://tests.stockfishchess.org/tests/user/protonspring
 
STC
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 20480 W: 3872 L: 3718 D: 12890
Ptnml(0-2): 295, 2364, 4824, 2406, 351
https://tests.stockfishchess.org/tests/view/5ebc343e7dd5693aad4e6873

STC, sudden death
LLR: 2.93 (-2.94,2.94) {-1.50,0.50}
Total: 7024 W: 1706 L: 1489 D: 3829
Ptnml(0-2): 149, 813, 1417, 938, 195
https://tests.stockfishchess.org/tests/view/5ebc346f7dd5693aad4e6875

STC, TCEC style
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 4192 W: 1014 L: 811 D: 2367
Ptnml(0-2): 66, 446, 912, 563, 109
https://tests.stockfishchess.org/tests/view/5ebc34857dd5693aad4e6877

40/10
LLR: 2.93 (-2.94,2.94) {-1.50,0.50}
Total: 54032 W: 10592 L: 10480 D: 32960
Ptnml(0-2): 967, 6148, 12677, 6254, 970 
https://tests.stockfishchess.org/tests/view/5ebc50597dd5693aad4e688d
 
LTC, sudden death
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 9152 W: 1391 L: 1263 D: 6498
Ptnml(0-2): 75, 888, 2526, 1008, 79 
https://tests.stockfishchess.org/tests/view/5ebc6f5c7dd5693aad4e689b
 
LTC
LLR: 2.98 (-2.94,2.94) {-1.50,0.50}
Total: 12344 W: 1563 L: 1459 D: 9322
Ptnml(0-2): 70, 1103, 3740, 1171, 88
https://tests.stockfishchess.org/tests/view/5ebc6f4c7dd5693aad4e6899

Bench 4696646