### PR TITLE
Fix a Windows crash on exit without 'quit' command

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,6 @@ int main(int argc, char* argv[]) {
 
   UCI::loop(argc, argv);
 
-  TT.resize(0);
   Threads.set(0);
   return 0;
 }

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -390,7 +390,7 @@ void* aligned_ttmem_alloc(size_t allocSize, void*& mem) {
 
 void aligned_ttmem_free(void* mem) {
 
-  if (!VirtualFree(mem, 0, MEM_RELEASE))
+  if (mem && !VirtualFree(mem, 0, MEM_RELEASE))
   {
       DWORD err = GetLastError();
       std::cerr << "Failed to free transposition table. Error code: 0x" <<

--- a/src/misc.h
+++ b/src/misc.h
@@ -34,7 +34,7 @@ const std::string compiler_info();
 void prefetch(void* addr);
 void start_logger(const std::string& fname);
 void* aligned_ttmem_alloc(size_t size, void*& mem);
-void aligned_ttmem_free(void* mem);
+void aligned_ttmem_free(void* mem); // nop if mem == nullptr
 
 void dbg_hit_on(bool b);
 void dbg_hit_on(bool c, bool b);

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -63,14 +63,7 @@ void TranspositionTable::resize(size_t mbSize) {
 
   Threads.main()->wait_for_search_finished();
 
-  if (mem)
-      aligned_ttmem_free(mem);
-
-  if (!mbSize)
-  {
-      mem = nullptr;
-      return;
-  }
+  aligned_ttmem_free(mem);
 
   clusterCount = mbSize * 1024 * 1024 / sizeof(Cluster);
   table = static_cast<Cluster*>(aligned_ttmem_alloc(clusterCount * sizeof(Cluster), mem));

--- a/src/tt.h
+++ b/src/tt.h
@@ -75,7 +75,7 @@ class TranspositionTable {
   static_assert(sizeof(Cluster) == 32, "Unexpected Cluster size");
 
 public:
- ~TranspositionTable() { free(mem); }
+ ~TranspositionTable() { aligned_ttmem_free(mem); }
   void new_search() { generation8 += 8; } // Lower 3 bits are used by PV flag and Bound
   TTEntry* probe(const Key key, bool& found) const;
   int hashfull() const;


### PR DESCRIPTION
There was a bug in commit d4763424d2728fe2dfd0a6fe747666feb6a2fdbb
(Add support for Windows large pages) that could result in trying to
free memory allocated with VirtualAlloc incorrectly with free().

Fix this by reverting the TT.resize(0) logic in the previous commit,
and instead, we'll just call aligned_ttmem_free() in
TranspositionTable::~TranspositionTable().