### PR TITLE
Workaround for older compiler

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -414,7 +414,6 @@ class TBTables {
             return (TBTable<Type>*)(Type == WDL ? (void*)wdl : (void*)dtz);
         }
     };
-    static_assert(std::is_trivially_copyable<Entry>::value, "");
 
     static constexpr int Size = 1 << 12; // 4K table, indexed by key's 12 lsb
     static constexpr int Overflow = 1;  // Number of elements allowed to map to the last bucket


### PR DESCRIPTION
gcc < 5 doesn't fully support the c++11 `std::is_trivially_copyable<Entry>::value`
Remove it, as it is not essential.

fixes https://github.com/official-stockfish/Stockfish/issues/2681

No functional change.