### PR TITLE
Don't adjust MoveOverhead by increment

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -64,9 +64,6 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
   //Maximum move horizon of 50 moves
   int mtg = limits.movestogo ? std::min(limits.movestogo, 50) : 50;
 
-  // Adjust moveOverhead if there are tiny increments
-  moveOverhead = std::max(10, std::min<int>(limits.inc[us] / 2, moveOverhead));
-
   // Make sure timeLeft is > 0 since we may use it as a divisor
   TimePoint timeLeft =  std::max(TimePoint(1),
       limits.time[us] + limits.inc[us] * (mtg - 1) - moveOverhead * (2 + mtg));

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -68,7 +68,7 @@ void init(OptionsMap& o) {
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);
   o["Skill Level"]           << Option(20, 0, 20);
-  o["Move Overhead"]         << Option(30, 0, 5000);
+  o["Move Overhead"]         << Option(10, 0, 5000);
   o["Minimum Thinking Time"] << Option( 0, 0, 5000);
   o["Slow Mover"]            << Option(100, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);


### PR DESCRIPTION
This is a functional change to address a potential timing issue for slow networks.  Move Overhead is unnecessarily attached to increment which doesn't allow use of small increments on slow networks (needing high Move Overhead).

If we make Move Overhead default to 10ms this should work fine for all timed games.  Also, by not adjusting it we allow the user to set Move Overhead as they choose which will help users adjust time usage on slow networks.

Do I need to test other time controls?

STC, sudden death.
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 169368 W: 38023 L: 38054 D: 93291
Ptnml(0-2): 3767, 20250, 36595, 20391, 3681 
https://tests.stockfishchess.org/tests/view/5ebf25efe9d85f94dc42986f
