### PR TITLE
Increase base time use and limit max used.

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -77,9 +77,9 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
   // game time for the current move, so also cap to 20% of available game time.
   if (limits.movestogo == 0)
   {
-      opt_scale = std::min(0.007 + std::pow(ply + 3.0, 0.5) / 250.0,
+      opt_scale = std::min(0.008 + std::pow(ply + 3.0, 0.5) / 250.0,
                            0.2 * limits.time[us] / double(timeLeft));
-      max_scale = 4 + std::pow(ply + 3, 0.3);
+      max_scale = 4 + std::min(36, ply) / 12.0;
   }
 
   // x moves in y seconds (+ z increment)


### PR DESCRIPTION
This change increases the base part of optimumTime at all depths. It also reduces the size of max_scale and thus maximumTime by using a linear scale instead of pow(x, 0.3) and by limiting max_scale to no more than 7 (previously as high as 8 or 9 at very high depths).

Tested using the closedpos book:

STC 10+0.1:
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 83696 W: 16813 L: 16508 D: 50375
Ptnml(0-2): 1315, 9649, 19686, 9812, 1386
https://tests.stockfishchess.org/tests/view/5ebfa92de9d85f94dc42989b

LTC 60+0.6:
LLR: 2.95 (-2.94,2.94) {0.25,1.75}
Total: 39384 W: 5868 L: 5582 D: 27934
Ptnml(0-2): 276, 3697, 11489, 3925, 305
https://tests.stockfishchess.org/tests/view/5ec0a6dce9d85f94dc42995a

Test for non-regression:

STC Sudden Death 10+0 :
LLR: 2.94 (-2.94,2.94) {-2.00,0.00}
Total: 111976 W: 25661 L: 25768 D: 60547
Ptnml(0-2): 2567, 13420, 24118, 13319, 2564
https://tests.stockfishchess.org/tests/view/5ec23b3be9d85f94dc429a58

It may be possible to continue this process as max_scale stilll seems quite large to me.

Bench 4395562