### PR TITLE
Keep low ply history from previous move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -357,6 +357,9 @@ void Thread::search() {
               mainThread->iterValue[i] = mainThread->bestPreviousScore;
   }
 
+  std::copy(&lowPlyHistory[2][0], &lowPlyHistory.back().back() + 1, &lowPlyHistory[0][0]);
+  std::fill(&lowPlyHistory[MAX_LPH - 2][0], &lowPlyHistory.back().back() + 1, 0);
+
   size_t multiPV = Options["MultiPV"];
 
   // Pick integer skill levels, but non-deterministically round up or down

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -212,7 +212,6 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
       th->rootDepth = th->completedDepth = 0;
       th->rootMoves = rootMoves;
       th->rootPos.set(pos.fen(), pos.is_chess960(), &setupStates->back(), th);
-      th->lowPlyHistory.fill(0);
   }
 
   setupStates->back() = tmp;


### PR DESCRIPTION
This patch keeps the low-ply history from the previous move, shifting the data down by 2 ply.

Tested with closedpos book:

STC:
LLR: 2.93 (-2.94,2.94) {-0.50,1.50}
Total: 71584 W: 14175 L: 13891 D: 43518
Ptnml(0-2): 1069, 8228, 16993, 8354, 1148
https://tests.stockfishchess.org/tests/view/5ec0eaafe9d85f94dc429974

LTC:
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 96552 W: 13946 L: 13498 D: 69108
Ptnml(0-2): 676, 9082, 28375, 9404, 739
https://tests.stockfishchess.org/tests/view/5ec145efe9d85f94dc4299b0

Bench 4395562