### PR TITLE
Avoid sending info strings before 'uci' has been received

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -358,12 +358,21 @@ static void* aligned_ttmem_alloc_large_pages(size_t allocSize) {
 
 void* aligned_ttmem_alloc(size_t allocSize, void*& mem) {
 
+  static bool firstCall = true;
+
   // try to allocate large pages
   mem = aligned_ttmem_alloc_large_pages(allocSize);
-  if (mem)
-      sync_cout << "info string Hash table allocation: Windows large pages used." << sync_endl;
-  else
-      sync_cout << "info string Hash table allocation: Windows large pages not used." << sync_endl;
+
+  // Suppress info strings on the first call. The first call occurs before 'uci'
+  // is received.
+  if (!firstCall)
+  {
+      if (mem)
+          sync_cout << "info string Hash table allocation: Windows large pages used." << sync_endl;
+      else
+          sync_cout << "info string Hash table allocation: Windows large pages not used." << sync_endl;
+  }
+  firstCall = false;
 
   // fall back to regular, page aligned, allocation if necessary
   if (!mem)


### PR DESCRIPTION
Do not send the following info string on the first call to
aligned_ttmem_alloc() on Windows:

  info string Hash table allocation: Windows large pages [not] used.

The first call occurs before the 'uci' command has been received. This
confuses some GUIs, which expect the first engine-sent command to be
'id' as the response to the 'uci' command.

No functional change.