### PR TITLE
Simplify evaluation for blocked passers.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -591,25 +591,19 @@ namespace {
       return std::min(distance(pos.square<KING>(c), s), 5);
     };
 
-    Bitboard b, bb, squaresToQueen, unsafeSquares, candidatePassers, leverable;
+    Bitboard b, bb, squaresToQueen, unsafeSquares, blockedPassers, helpers;
     Score score = SCORE_ZERO;
 
     b = pe->passed_pawns(Us);
 
-    candidatePassers = b & shift<Down>(pos.pieces(Them, PAWN));
-    if (candidatePassers)
+    blockedPassers = b & shift<Down>(pos.pieces(Them, PAWN));
+    if (blockedPassers)
     {
-        // Can we lever the blocker of a candidate passer?
-        leverable =  shift<Up>(pos.pieces(Us, PAWN))
-                   & ~pos.pieces(Them)
-                   & (~attackedBy2[Them] | attackedBy[Us][ALL_PIECES])
-                   & (~(attackedBy[Them][KNIGHT] | attackedBy[Them][BISHOP])
-                     | (attackedBy[Us  ][KNIGHT] | attackedBy[Us  ][BISHOP]));
+        helpers =  shift<Up>(pos.pieces(Us, PAWN)) & ~pos.pieces(Them)
+                   & (~attackedBy2[Them] | attackedBy[Us][ALL_PIECES]);
 
-        // Remove candidate otherwise
-        b &= ~candidatePassers
-            | shift<WEST>(leverable)
-            | shift<EAST>(leverable);
+        // Remove blocked passers that don't have help to pass
+        b &= ~blockedPassers | shift<WEST>(helpers) | shift<EAST>(helpers);
     }
 
     while (b)


### PR DESCRIPTION
This is a functional simplification of the evaluation code for blocked passers.  I've also changed a few variable names for clarity.

STC
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 141984 W: 27450 L: 27466 D: 87068
Ptnml(0-2): 2414, 16511, 33175, 16461, 2431
https://tests.stockfishchess.org/tests/view/5ec4001b05aa4bc72d9759e7

LTC
LLR: 2.93 (-2.94,2.94) {-1.50,0.50}
Total: 30536 W: 3966 L: 3885 D: 22685
Ptnml(0-2): 216, 2841, 9073, 2922, 216
https://tests.stockfishchess.org/tests/view/5ec4bd0d377121ac09e101b7

bench 4704681