### PR TITLE
A combo of parameters tweaks

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -733,7 +733,7 @@ namespace {
 
     // Compute the initiative bonus for the attacking side
     int complexity =   9 * pe->passed_count()
-                    + 11 * pos.count<PAWN>()
+                    + 12 * pos.count<PAWN>()
                     +  9 * outflanking
                     + 21 * pawnsOnBothFlanks
                     + 24 * infiltration

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -169,7 +169,7 @@ top:
 
   case GOOD_CAPTURE:
       if (select<Best>([&](){
-                       return pos.see_ge(*cur, Value(-55 * cur->value / 1024)) ?
+                       return pos.see_ge(*cur, Value(-69 * cur->value / 1024)) ?
                               // Move losing capture to endBadCaptures to be tried later
                               true : (*endBadCaptures++ = *cur, false); }))
           return *(cur - 1);


### PR DESCRIPTION
This patch is a combinaison of two recent parameters tweaks which had
failed narrowly (yellow) at long time control:

• improvement in move ordering during search by softening the distinction
  between bad captures and good captures during move generation, leading
  to improved awareness of Stockfish of potential piece sacrifices (idea
  by Rahul Dsilva)
• increase in the weight of pawns in the "initiative" part of the evaluation
  function. With this change Stockfish should have more incentive to exchange
  pawns when losing, and to keep pawns when winning.

STC:
LLR: 2.93 (-2.94,2.94) {-0.50,1.50}
Total: 10704 W: 2178 L: 1974 D: 6552
Ptnml(0-2): 168, 1185, 2464, 1345, 190
https://tests.stockfishchess.org/tests/view/5ec5553b377121ac09e1023d

LTC:
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 60592 W: 7835 L: 7494 D: 45263
Ptnml(0-2): 430, 5514, 18086, 5817, 449
https://tests.stockfishchess.org/tests/view/5ec55ca2377121ac09e10249

Closes https://github.com/official-stockfish/Stockfish/pull/2691

Bench: 4988657