### PR TITLE
Tweak knight mobility.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -91,8 +91,8 @@ namespace {
   // MobilityBonus[PieceType-2][attacked] contains bonuses for middle and end game,
   // indexed by piece type and number of attacked squares in the mobility area.
   constexpr Score MobilityBonus[][32] = {
-    { S(-62,-81), S(-53,-56), S(-12,-30), S( -4,-14), S(  3,  8), S( 13, 15), // Knight
-      S( 22, 23), S( 28, 27), S( 33, 33) },
+    { S(-62,-81), S(-53,-56), S(-12,-31), S( -4,-16), S(  3,  5), S( 13, 11), // Knight
+      S( 22, 17), S( 28, 20), S( 33, 25) },
     { S(-48,-59), S(-20,-23), S( 16, -3), S( 26, 13), S( 38, 24), S( 51, 42), // Bishop
       S( 55, 54), S( 63, 57), S( 63, 65), S( 68, 73), S( 81, 78), S( 81, 86),
       S( 91, 88), S( 98, 97) },


### PR DESCRIPTION
New tuned values for knight mobility in endgames.

STC:
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 112576 W: 21999 L: 21644 D: 68933
Ptnml(0-2): 2009, 13084, 25735, 13463, 1997
https://tests.stockfishchess.org/tests/view/5ec58379377121ac09e10272

LTC:
LLR: 2.95 (-2.94,2.94) {0.25,1.75}
Total: 125192 W: 16200 L: 15671 D: 93321
Ptnml(0-2): 891, 11584, 37182, 11983, 956
https://tests.stockfishchess.org/tests/view/5ec5c0b8377121ac09e1028b

Bench: 4659875