### PR TITLE
Add doubled isolated pawn penalty.

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -32,12 +32,13 @@ namespace {
   #define S(mg, eg) make_score(mg, eg)
 
   // Pawn penalties
-  constexpr Score Backward      = S( 9, 24);
-  constexpr Score BlockedStorm  = S(82, 82);
-  constexpr Score Doubled       = S(11, 56);
-  constexpr Score Isolated      = S( 5, 15);
-  constexpr Score WeakLever     = S( 0, 56);
-  constexpr Score WeakUnopposed = S(13, 27);
+  constexpr Score Backward        = S( 9, 24);
+  constexpr Score BlockedStorm    = S(82, 82);
+  constexpr Score Doubled         = S(11, 56);
+  constexpr Score DoubledIsolated = S(15, 57);
+  constexpr Score Isolated        = S( 5, 15);
+  constexpr Score WeakLever       = S( 0, 56);
+  constexpr Score WeakUnopposed   = S(13, 27);
 
   // Connected pawn bonus
   constexpr int Connected[RANK_NB] = { 0, 7, 8, 12, 29, 48, 86 };
@@ -144,8 +145,15 @@ namespace {
         }
 
         else if (!neighbours)
+        {
             score -=   Isolated
                      + WeakUnopposed * !opposed;
+
+            if (   (ourPawns & forward_file_bb(Them, s))
+                && popcount(opposed) == 1
+                && !(theirPawns & adjacent_files_bb(s)))
+                score -= DoubledIsolated;
+        }
 
         else if (backward)
             score -=   Backward


### PR DESCRIPTION
If a doubled isolated pawn is stopped only by a single opponent pawn on the same file give an additional penalty.

Thanks to NKONSTANTAKIS which shared this idea on the forum https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/vC4Qn-PMlS4.

STC:
LLR: 2.96 (-2.94,2.94) {-0.50,1.50}
Total: 84872 W: 16688 L: 16370 D: 51814
Ptnml(0-2): 1507, 9940, 19274, 10158, 1557
https://tests.stockfishchess.org/tests/view/5ec65bd955202b947dc5d4ac

LTC:
LLR: 2.93 (-2.94,2.94) {0.25,1.75}
Total: 58104 W: 7614 L: 7278 D: 43212
Ptnml(0-2): 411, 5369, 17196, 5625, 451
https://tests.stockfishchess.org/tests/view/5ec6e9f2c23f5b0710632b19

Bench: 5148950