### PR TITLE
Remove and replace DoubledIsolated penalty by Doubled

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -32,13 +32,12 @@ namespace {
   #define S(mg, eg) make_score(mg, eg)
 
   // Pawn penalties
-  constexpr Score Backward        = S( 9, 24);
-  constexpr Score BlockedStorm    = S(82, 82);
-  constexpr Score Doubled         = S(11, 56);
-  constexpr Score DoubledIsolated = S(15, 57);
-  constexpr Score Isolated        = S( 5, 15);
-  constexpr Score WeakLever       = S( 0, 56);
-  constexpr Score WeakUnopposed   = S(13, 27);
+  constexpr Score Backward      = S( 9, 24);
+  constexpr Score BlockedStorm  = S(82, 82);
+  constexpr Score Doubled       = S(11, 56);
+  constexpr Score Isolated      = S( 5, 15);
+  constexpr Score WeakLever     = S( 0, 56);
+  constexpr Score WeakUnopposed = S(13, 27);
 
   // Connected pawn bonus
   constexpr int Connected[RANK_NB] = { 0, 7, 8, 12, 29, 48, 86 };
@@ -152,7 +151,7 @@ namespace {
             if (   (ourPawns & forward_file_bb(Them, s))
                 && popcount(opposed) == 1
                 && !(theirPawns & adjacent_files_bb(s)))
-                score -= DoubledIsolated;
+                score -= Doubled;
         }
 
         else if (backward)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -34,7 +34,7 @@ namespace {
   // Pawn penalties
   constexpr Score Backward      = S( 9, 24);
   constexpr Score BlockedStorm  = S(82, 82);
-  constexpr Score Doubled       = S(11, 56);
+  constexpr Score Doubled        = S(11, 56);
   constexpr Score Isolated      = S( 5, 15);
   constexpr Score WeakLever     = S( 0, 56);
   constexpr Score WeakUnopposed = S(13, 27);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -34,7 +34,7 @@ namespace {
   // Pawn penalties
   constexpr Score Backward      = S( 9, 24);
   constexpr Score BlockedStorm  = S(82, 82);
-  constexpr Score Doubled        = S(11, 56);
+  constexpr Score Doubled       = S(11, 56);
   constexpr Score Isolated      = S( 5, 15);
   constexpr Score WeakLever     = S( 0, 56);
   constexpr Score WeakUnopposed = S(13, 27);


### PR DESCRIPTION
The values for both penalties were very close, so DoubledIsolated can be removed and replaced by Doubled.

Passed STC (simplification): https://tests.stockfishchess.org/tests/view/5ec7c18e2a585b485af54407
LLR: 2.97 (-2.94,2.94) {-1.50,0.50}
Total: 105360 W: 20175 L: 20136 D: 65049
Ptnml(0-2): 1803, 12230, 24572, 12275, 1800

Passed LTC:
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 15440 W: 1978 L: 1877 D: 11585
Ptnml(0-2): 92, 1405, 4667, 1422, 134

Bench: 4862947