### PR TITLE
Remove attacked pawns from storm evaluation

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -33,11 +33,12 @@ namespace {
 
   // Pawn penalties
   constexpr Score Backward      = S( 9, 24);
-  constexpr Score BlockedStorm  = S(82, 82);
   constexpr Score Doubled       = S(11, 56);
   constexpr Score Isolated      = S( 5, 15);
   constexpr Score WeakLever     = S( 0, 56);
   constexpr Score WeakUnopposed = S(13, 27);
+
+  constexpr Score BlockedStorm[RANK_NB]  = {S( 0, 0), S( 0, 0), S( 76, 78), S(-10, 15), S(-7, 10), S(-4, 6), S(-1, 2)};
 
   // Connected pawn bonus
   constexpr int Connected[RANK_NB] = { 0, 7, 8, 12, 29, 48, 86 };
@@ -200,8 +201,8 @@ Score Entry::evaluate_shelter(const Position& pos, Square ksq) {
   constexpr Color Them = ~Us;
 
   Bitboard b = pos.pieces(PAWN) & ~forward_ranks_bb(Them, ksq);
-  Bitboard ourPawns = b & pos.pieces(Us);
-  Bitboard theirPawns = b & pos.pieces(Them);
+  Bitboard ourPawns = b & pos.pieces(Us) & ~pawnAttacks[Them];
+  Bitboard theirPawns = b & pos.pieces(Them) & ~pawnAttacks[Us];
 
   Score bonus = make_score(5, 5);
 
@@ -218,7 +219,7 @@ Score Entry::evaluate_shelter(const Position& pos, Square ksq) {
       bonus += make_score(ShelterStrength[d][ourRank], 0);
 
       if (ourRank && (ourRank == theirRank - 1))
-          bonus -= BlockedStorm * int(theirRank == RANK_3);
+          bonus -= BlockedStorm[theirRank];
       else
           bonus -= make_score(UnblockedStorm[d][theirRank], 0);
   }


### PR DESCRIPTION
Remove attacked pawns from storm evaluation and make penalty dependent to the rank for blocked pawns.

STC: 
LLR: 2.96 (-2.94,2.94) {-0.50,1.50}
Total: 54456 W: 11009 L: 10737 D: 32710
Ptnml(0-2): 929, 6326, 12523, 6444, 1006 
https://tests.stockfishchess.org/tests/view/5ec962e4404591b2793008a5

LTC:
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 62448 W: 9018 L: 8664 D: 44766
Ptnml(0-2): 462, 5928, 18121, 6220, 493
https://tests.stockfishchess.org/tests/view/5ec976a8a586eee45aa2ab40

Non regression STC with "noob_3moves.epd" opening book
LLR: 3.81 (-2.94,2.94) {-1.50,0.50}
Total: 91896 W: 17770 L: 17653 D: 56473
Ptnml(0-2): 1598, 10782, 21124, 10793, 1651 
https://tests.stockfishchess.org/tests/view/5ec9b83ea586eee45aa2ab96

Bench 4488597