### PR TITLE
Remove the popcount in the doubled isolated pawns penalty condition (Bench: 4668875)

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -147,8 +147,8 @@ namespace {
             score -=   Isolated
                      + WeakUnopposed * !opposed;
 
-            if (   (ourPawns & forward_file_bb(Them, s))
-                && popcount(opposed) == 1
+            if (    opposed
+                && (ourPawns & forward_file_bb(Them, s))
                 && !(theirPawns & adjacent_files_bb(s)))
                 score -= Doubled;
         }


### PR DESCRIPTION
In #PR2694 a penalty for doubled isolated pawns was introduced. The condition for giving this penalty included:
`&& popcount(opposed) == 1`, so requiring that the doubled pawns have exactly one opposing pawn.
This popcount check is unnecessary and can be replaced by:
`&& opposed`.
The reason for this is that the penalty that is imposed in case of 2 or more opposing pawns will be cancelled out by the penalty for the opposing side (so both sides have the penalty in this case, giving no change in overall evaluation).
So it is safe to replace the popcount condition with just a check for opposing pawns.
No functional change.
Bench: 4668875