### PR TITLE
Give bonus for rooks that are alligned with enemy kingring.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -143,6 +143,7 @@ namespace {
   constexpr Score PassedFile          = S( 11,  8);
   constexpr Score PawnlessFlank       = S( 17, 95);
   constexpr Score RestrictedPiece     = S(  7,  7);
+  constexpr Score RookOnKingRing      = S( 16,  0);
   constexpr Score RookOnQueenFile     = S(  5,  9);
   constexpr Score SliderOnQueen       = S( 59, 18);
   constexpr Score ThreatByKing        = S( 24, 89);
@@ -287,6 +288,8 @@ namespace {
             kingAttackersWeight[Us] += KingAttackWeights[Pt];
             kingAttacksCount[Us] += popcount(b & attackedBy[Them][KING]);
         }
+        else if (Pt == ROOK && (file_bb(s) & kingRing[Them]))
+            score += RookOnKingRing;
 
         int mob = popcount(b & mobilityArea[Us]);
 


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5ecb093680f2c838b96550f9
LLR: 2.93 (-2.94,2.94) {-0.50,1.50}
Total: 53672 W: 10535 L: 10265 D: 32872
Ptnml(0-2): 952, 6210, 12258, 6448, 968 
passed LTC
https://tests.stockfishchess.org/tests/view/5ecb639f80f2c838b9655117
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 62424 W: 8094 L: 7748 D: 46582
Ptnml(0-2): 426, 5734, 18565, 6042, 445 
Idea of this patch is that if rooks are not directly attacking opponent king they can support king attacks staying behind pawns or minor pieces and be really deadly if position slightly opens up at enemy king ring ranks.
Loosely based on some stockfish games where it underestimated attacks on it king when enemy has one or two rooks supporting pawn pushes towards it king.
bench 4652138