### PR TITLE
Simplify. In BlockedStorm, theirPawns includes ones attacked by us.

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -202,7 +202,7 @@ Score Entry::evaluate_shelter(const Position& pos, Square ksq) {
 
   Bitboard b = pos.pieces(PAWN) & ~forward_ranks_bb(Them, ksq);
   Bitboard ourPawns = b & pos.pieces(Us) & ~pawnAttacks[Them];
-  Bitboard theirPawns = b & pos.pieces(Them) & ~pawnAttacks[Us];
+  Bitboard theirPawns = b & pos.pieces(Them);
 
   Score bonus = make_score(5, 5);
 


### PR DESCRIPTION
Pawns heading towards our king tend to be dangerous whether or not we are attacking them so remove this test.

STC:
LLR: 2.93 (-2.94,2.94) {-1.50,0.50}
Total: 91184 W: 18196 L: 18137 D: 54851
Ptnml(0-2): 1580, 10656, 21092, 10653, 1611
https://tests.stockfishchess.org/tests/view/5ecc3f7080f2c838b9655841

LTC:
LLR: 2.93 (-2.94,2.94) {-1.50,0.50}
Total: 14152 W: 2045 L: 1937 D: 10170
Ptnml(0-2): 99, 1325, 4130, 1413, 109
https://tests.stockfishchess.org/tests/view/5ecc4f3180f2c838b9655861

Bench 4828973
