### PR TITLE
Less pruning in draw PV lines.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1055,6 +1055,7 @@ moves_loop: // When in check, search starts from here
               // Futility pruning for captures
               if (   !givesCheck
                   && lmrDepth < 6
+                  && !(PvNode && abs(bestValue) < 2)
                   && !ss->inCheck
                   && ss->staticEval + 270 + 384 * lmrDepth + PieceValue[MG][type_of(pos.piece_on(to_sq(move)))] <= alpha)
                   continue;


### PR DESCRIPTION
no futility pruning for certain captures if the PvNode has a draw eval.

passed STC:
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 59392 W: 11576 L: 11302 D: 36514
Ptnml(0-2): 977, 6816, 13920, 6922, 1061
https://tests.stockfishchess.org/tests/view/5ed0b1bb042fa6d77c355295

passed LTC:
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 64040 W: 8273 L: 7923 D: 47844
Ptnml(0-2): 424, 5842, 19220, 6028, 506
https://tests.stockfishchess.org/tests/view/5ed145e0042fa6d77c35531c

Bench: 4704615