### PR TITLE
Isolated pawns tweak (Bench: 4085694)

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -145,13 +145,13 @@ namespace {
 
         else if (!neighbours)
         {
-            score -=   Isolated
-                     + WeakUnopposed * !opposed;
-
-            if (   (ourPawns & forward_file_bb(Them, s))
-                && popcount(opposed) == 1
+            if (     opposed
+                &&  (ourPawns & forward_file_bb(Them, s))
                 && !(theirPawns & adjacent_files_bb(s)))
                 score -= Doubled;
+            else
+                score -=   Isolated
+                         + WeakUnopposed * !opposed;
         }
 
         else if (backward)


### PR DESCRIPTION
Give opposed doubled isolated pawns only the Doubled penalty. The other isolated pawns get the Isolated penalty and the WeakUnopposed penalty. I also replaced the popcount condition with an opposed check, which is non-functional, but probably gives a speadup.

Passed STC (https://tests.stockfishchess.org/tests/view/5ed0f0f0042fa6d77c3552f5):
LLR: 2.96 (-2.94,2.94) {-0.50,1.50}
Total: 121832 W: 23562 L: 23195 D: 75075
Ptnml(0-2): 2092, 14064, 28313, 14279, 2168

LTC: (https://tests.stockfishchess.org/tests/view/5ed22e40042fa6d77c355387)
LLR: 2.96 (-2.94,2.94) {0.25,1.75}
Total: 103368 W: 13232 L: 12768 D: 77368
Ptnml(0-2): 693, 9484, 30919, 9842, 746

Bench: 4085694