### PR TITLE
Give bonus for bishops that are alligned with enemy kingring.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -128,6 +128,7 @@ namespace {
 
   // Assorted bonuses and penalties
   constexpr Score BishopPawns         = S(  3,  7);
+  constexpr Score BishopOnKingRing    = S( 24,  0);
   constexpr Score BishopXRayPawns     = S(  4,  5);
   constexpr Score CorneredBishop      = S( 50, 50);
   constexpr Score FlankAttacks        = S(  8,  0);
@@ -288,8 +289,12 @@ namespace {
             kingAttackersWeight[Us] += KingAttackWeights[Pt];
             kingAttacksCount[Us] += popcount(b & attackedBy[Them][KING]);
         }
+
         else if (Pt == ROOK && (file_bb(s) & kingRing[Them]))
             score += RookOnKingRing;
+
+        else if (Pt == BISHOP && (attacks_bb<BISHOP>(s, pos.pieces(PAWN)) & kingRing[Them]))
+            score += BishopOnKingRing;
 
         int mob = popcount(b & mobilityArea[Us]);
 


### PR DESCRIPTION
Inspired from Vizvezdenec succesful patch "Give bonus for rooks that are alligned with enemy kingring" I reused this idea for bishops.
But here we only consider attacks that are not blocked by any pawn. Also we have a 50% higher bonus than for the rooks.

STC:
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 68960 W: 13495 L: 13202 D: 42263
Ptnml(0-2): 1213, 8018, 15802, 8157, 1290
https://tests.stockfishchess.org/tests/view/5ed27495042fa6d77c3553aa

LTC:
LLR: 2.96 (-2.94,2.94) {0.25,1.75}
Total: 54560 W: 7105 L: 6780 D: 40675
Ptnml(0-2): 379, 4986, 16254, 5253, 408
https://tests.stockfishchess.org/tests/view/5ed30375596e6dc1e1f97425

Bench: 4431918