### PR TITLE
Wrong mate scores correction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -557,7 +557,7 @@ void Thread::search() {
           double bestMoveInstability = 1 + totBestMoveChanges / Threads.size();
 
           // Stop the search if we have only one legal move, or if available time elapsed
-          if (   rootMoves.size() == 1
+          if (   (rootMoves.size() == 1 && completedDepth > 6)
               || Time.elapsed() > Time.optimum() * fallingEval * reduction * bestMoveInstability)
           {
               // If we are allowed to ponder do not stop the search now but

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -556,7 +556,7 @@ void Thread::search() {
           }
           double bestMoveInstability = 1 + totBestMoveChanges / Threads.size();
 
-          // Stop the search if we have only one legal move, or if available time elapsed
+          // Stop the search if we have only one legal move and completed depth > 4, or if available time elapsed
           if (   (rootMoves.size() == 1 && completedDepth > 4)
               || Time.elapsed() > Time.optimum() * fallingEval * reduction * bestMoveInstability)
           {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -557,7 +557,7 @@ void Thread::search() {
           double bestMoveInstability = 1 + totBestMoveChanges / Threads.size();
 
           // Stop the search if we have only one legal move, or if available time elapsed
-          if (   (rootMoves.size() == 1 && completedDepth > 6)
+          if (   (rootMoves.size() == 1 && completedDepth > 4)
               || Time.elapsed() > Time.optimum() * fallingEval * reduction * bestMoveInstability)
           {
               // If we are allowed to ponder do not stop the search now but


### PR DESCRIPTION
This is a try correct some wrong mate scores observed on fishtest when SF exits at depth 1, generally when there is only one legal move.

See Issue #2707

STC non regression
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 32672 W: 6304 L: 6170 D: 20198
Ptnml(0-2): 498, 3688, 7854, 3774, 522 
https://tests.stockfishchess.org/tests/view/5ed4cd6ef29b40b0fc95a76b

Bench: 4704615