### PR TITLE
Merge scale_factor() and mg/eg interpolation into initiative()

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -909,7 +909,7 @@ std::string Eval::trace(const Position& pos) {
      << " ------------+-------------+-------------+------------\n"
      << "       Total | " << Term(TOTAL);
 
-  ss << "\nTotal evaluation: " << to_cp(v) << " (white side)\n";
+  ss << "\nFinal evaluation: " << to_cp(v) << " (white side)\n";
 
   return ss.str();
 }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -759,12 +759,6 @@ namespace {
     mg += u;
     eg += v;
 
-    if (T)
-    {
-        Trace::add(INITIATIVE, make_score(u, v));
-        Trace::add(TOTAL, make_score(mg, eg));
-    }
-
     // Compute the scale factor for the winning side
 
     Color strongSide = eg > VALUE_DRAW ? WHITE : BLACK;
@@ -789,6 +783,12 @@ namespace {
     v =  mg * int(me->game_phase())
        + eg * int(PHASE_MIDGAME - me->game_phase()) * ScaleFactor(sf) / SCALE_FACTOR_NORMAL;
     v /= PHASE_MIDGAME;
+
+    if (T)
+    {
+        Trace::add(INITIATIVE, make_score(u, eg * ScaleFactor(sf) / SCALE_FACTOR_NORMAL - eg_value(score)));
+        Trace::add(TOTAL, make_score(mg, eg * ScaleFactor(sf) / SCALE_FACTOR_NORMAL));
+    }
 
     return Value(v);
   }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -756,12 +756,21 @@ namespace {
     int u = ((mg > 0) - (mg < 0)) * Utility::clamp(complexity + 50, -abs(mg), 0);
     int v = ((eg > 0) - (eg < 0)) * std::max(complexity, -abs(eg));
 
+    mg += u;
+    eg += v;
 
-    // Fetch eg scale factor, if not already specific, scale the endgame via general heuristics
+    if (T)
+    {
+        Trace::add(INITIATIVE, make_score(u, v));
+        Trace::add(TOTAL, make_score(mg, eg));
+    }
+
+    // Compute the scale factor for the winning side
 
     Color strongSide = eg > VALUE_DRAW ? WHITE : BLACK;
     int sf = me->scale_factor(pos, strongSide);
 
+    // If scale is not already specific, scale down the endgame via general heuristics
     if (sf == SCALE_FACTOR_NORMAL)
     {
         if (pos.opposite_bishops())
@@ -777,12 +786,10 @@ namespace {
     }
 
     // Interpolate between the middlegame and (scaled by 'sf') endgame score
-    v =  (mg + u) * int(me->game_phase())
-       + (eg + v) * int(PHASE_MIDGAME - me->game_phase()) * ScaleFactor(sf) / SCALE_FACTOR_NORMAL;
+    v =  mg * int(me->game_phase())
+       + eg * int(PHASE_MIDGAME - me->game_phase()) * ScaleFactor(sf) / SCALE_FACTOR_NORMAL;
     v /= PHASE_MIDGAME;
 
-    if (T)
-        Trace::add(INITIATIVE, make_score(0, v));
     return Value(v);
   }
 
@@ -848,7 +855,6 @@ namespace {
         Trace::add(IMBALANCE, me->imbalance());
         Trace::add(PAWN, pe->pawn_score(WHITE), pe->pawn_score(BLACK));
         Trace::add(MOBILITY, mobility[WHITE], mobility[BLACK]);
-        Trace::add(TOTAL, score);
     }
 
     // Side to move point of view


### PR DESCRIPTION
Merging this code into one function puts all the endgame adjustment into initiative() instead of spreading it across initiative() and scale_factor() with the final interpolation in value(). This makes value() cleaner while allowing mixing of the ideas in the former initiative() and scale_factor() functions.

Future work: hopefully this will encourage devs to try using scale_factor for initiative calcs and/or initiative elements in the calculation of scale_factor, leading to more sophisticated eg valuation.

No functional change.