### PR TITLE
Use lowply-history also on low depths

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -110,7 +110,7 @@ void MovePicker::score() {
                    + 2 * (*continuationHistory[1])[pos.moved_piece(m)][to_sq(m)]
                    + 2 * (*continuationHistory[3])[pos.moved_piece(m)][to_sq(m)]
                    +     (*continuationHistory[5])[pos.moved_piece(m)][to_sq(m)]
-                   + (ply < MAX_LPH ?  4 * (*lowPlyHistory)[ply][from_to(m)] : 0);
+                   + (ply < MAX_LPH ? std::min(4, depth / 3) * (*lowPlyHistory)[ply][from_to(m)] : 0);
 
       else // Type == EVASIONS
       {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -969,7 +969,7 @@ moves_loop: // When in check, search starts from here
                                       contHist,
                                       countermove,
                                       ss->killers,
-                                      depth > 12 ? ss->ply : MAX_PLY);
+                                      ss->ply);
 
     value = bestValue;
     singularQuietLMR = moveCountPruning = false;


### PR DESCRIPTION
STC:
https://tests.stockfishchess.org/tests/view/5ed75078f29b40b0fc95a8b9
LLR: 2.93 (-2.94,2.94) {-0.50,1.50}
Total: 73928 W: 14301 L: 14005 D: 45622
Ptnml(0-2): 1243, 8572, 17096, 8752, 1301

LTC:
https://tests.stockfishchess.org/tests/view/5ed895e0f29b40b0fc95a976
LLR: 2.93 (-2.94,2.94) {0.25,1.75}
Total: 154848 W: 19684 L: 19074 D: 116090
Ptnml(0-2): 1048, 14108, 46627, 14468, 1173

N.B.: if the new formula in movepicker to balance out values
is really necessary will be subject of further investigations

bench: 4582693