### PR TITLE
x86 TT hash --- suboptimal 0x66 instruction prefix generated

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -202,7 +202,7 @@ Score Entry::evaluate_shelter(const Position& pos, Square ksq) {
 
   Bitboard b = pos.pieces(PAWN) & ~forward_ranks_bb(Them, ksq);
   Bitboard ourPawns = b & pos.pieces(Us) & ~pawnAttacks[Them];
-  Bitboard theirPawns = b & pos.pieces(Them) & ~pawnAttacks[Us];
+  Bitboard theirPawns = b & pos.pieces(Them);
 
   Score bonus = make_score(5, 5);
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -28,10 +28,9 @@
 #include "tt.h"
 #include "uci.h"
 
-/* because in many platforms, operating with 32 bits is more efficient than
- * doing so with 16 bits, yet compilers may choose to deploy 16 bit arithmetic
- * taking the code literally.
- */
+// because in many platforms, operating with 32 bits is more efficient than
+// doing so with 16 bits, yet compilers may choose to deploy 16 bit arithmetic
+// taking the code literally.
 typedef uint_fast16_t fastuint16;
 
 TranspositionTable TT; // Our global transposition table
@@ -41,13 +40,14 @@ TranspositionTable TT; // Our global transposition table
 
 void TTEntry::save(Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev) {
   const fastuint16 hashKey16 = (fastuint16)(k >> 48);
+  const fastuint16 probeKey = (fastuint16)key16;
 
   // Preserve any existing move for the same position
-  if (m || hashKey16 != (fastuint16)key16)
+  if (m || hashKey16 != probeKey)
       move16 = (uint16_t)m;
 
   // Overwrite less valuable entries
-  if (  hashKey16 != (fastuint16)key16
+  if (  hashKey16 != probeKey
       || d - DEPTH_OFFSET > depth8 - 4
       || b == BOUND_EXACT)
   {
@@ -124,10 +124,10 @@ void TranspositionTable::clear() {
 TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 
   TTEntry* const tte = first_entry(key);
-  const fastuint16 key16 = key >> 48;  // Use the high 16 bits as key inside the cluster
+  const fastuint16 key16 = (fastuint16)(key >> 48);  // Use the high 16 bits as key inside the cluster
 
   for (int i = 0; i < ClusterSize; ++i) {
-      const fastuint16 probeKey = tte[i].key16;
+      const fastuint16 probeKey = (fastuint16)tte[i].key16;
 
       if (!probeKey || probeKey == key16)
       {

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -31,7 +31,7 @@
 // because in many platforms, operating with 32 bits is more efficient than
 // doing so with 16 bits, yet compilers may choose to deploy 16 bit arithmetic
 // taking the code literally.
-typedef uint_fast16_t fastuint16;
+typedef uint32_t fastuint16;
 
 TranspositionTable TT; // Our global transposition table
 


### PR DESCRIPTION
Some compilers, like gcc (Gentoo 9.2.0-r2 p3) 9.2.0, emit code like this in TT::probe():

test dx, dx
je ...
cmp bx, dx
je ...

Similar behavior was observed with gcc 10.1 and gcc trunk at godbolt.org.

This is suboptimal because the instructions contain 0x66 LCP prefixes.  Said prefixes should be avoided as per the Intel optimization manual (in this particular case, because shorter instructions are better).  For some reason, gcc refuses to perform the operations in 32 bit arithmetic.  With these changes, the following code is emitted instead.

test edx, edx
je ...
cmp ebx, edx
je ...

Note that this code now also benefits from avoiding REX prefixes (by not typecasting the operations to 64 bits), which is better as per the Intel optimization manual (shorter instructions are better).

Thanks go to skiminki for helpful assistance.