### PR TITLE
Improve the anti-shuffling policy

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -743,7 +743,6 @@ namespace {
                     + 24 * infiltration
                     + 51 * !pos.non_pawn_material()
                     - 43 * almostUnwinnable
-                    -  2 * pos.rule50_count()
                     -110 ;
 
     Value mg = mg_value(score);
@@ -857,7 +856,12 @@ namespace {
     }
 
     // Side to move point of view
-    return (pos.side_to_move() == WHITE ? v : -v) + Tempo;
+    v = (pos.side_to_move() == WHITE ? v : -v) + Tempo;
+
+    // Damp down the evaluation linearly when shuffling
+    v = v * (100 - pos.rule50_count()) / 100;
+
+    return v;
   }
 
 } // namespace


### PR DESCRIPTION
We replace the current decrease of the complexity term in initiative
when shuffling by a direct damping of the evaluation. This scheme may
have two benefits over the initiative approach:

a) the damping effect is more brutal for fortresses with heavy pieces
   on the board, because the initiative term is almost an endgame term;

b) the initiative implementation had a funny side effect, almost a bug,
   in the rare positions where mg > 0, eg < 0 and the tampered eval
   returned a positive value (ie with heavy pieces still on the board):
   sending eg to zero via shuffling would **increase** the tampered
   eval instead of decreasing it, which is somewhat illogical. This
   patch avoids this phenomenon.

How to continue after this patch ? It would be interesting to understand
the effect of storing the evaluations in the transposition tables during
shuffling periods.

STC:
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 43072 W: 8373 L: 8121 D: 26578
Ptnml(0-2): 729, 4954, 9940, 5162, 751
https://tests.stockfishchess.org/tests/view/5ee008ebf29b40b0fc95ade2

LTC:
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 37376 W: 4816 L: 4543 D: 28017
Ptnml(0-2): 259, 3329, 11286, 3508, 306
https://tests.stockfishchess.org/tests/view/5ee03b06f29b40b0fc95ae0c

Closes https://github.com/official-stockfish/Stockfish/pull/2727

Bench: 4757174