### PR TITLE
Quantize eval to multiples of 16.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -855,6 +855,8 @@ namespace {
         Trace::add(MOBILITY, mobility[WHITE], mobility[BLACK]);
     }
 
+    v = (v / 16) * 16;
+
     // Side to move point of view
     v = (pos.side_to_move() == WHITE ? v : -v) + Tempo;
 


### PR DESCRIPTION
remove some excess precision, helps searchs.

Effectively reintroduces 45dbd9cd0303d0db469670af8ec3598731a4eace,
with a slightly different context.

passed STC
LLR: 2.97 (-2.94,2.94) {-0.50,1.50}
Total: 197032 W: 37938 L: 37462 D: 121632
Ptnml(0-2): 3359, 22994, 45446, 23246, 3471
https://tests.stockfishchess.org/tests/view/5ee0c228f29b40b0fc95ae53

passed LTC
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 77696 W: 9970 L: 9581 D: 58145
Ptnml(0-2): 530, 7075, 23311, 7340, 592
https://tests.stockfishchess.org/tests/view/5ee21426f29b40b0fc95af43

passed LTC SMP
LLR: 2.96 (-2.94,2.94) {0.25,1.75}
Total: 64136 W: 7425 L: 7091 D: 49620
Ptnml(0-2): 345, 5416, 20228, 5718, 361 
https://tests.stockfishchess.org/tests/view/5ee387bbf29b40b0fc95b04c

Bench: 4562134