### PR TITLE
Adjust history threshold for quiet moves futility pruning.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1006,7 +1006,8 @@ moves_loop: // When in check, search starts from here
                   && ss->staticEval + 235 + 172 * lmrDepth <= alpha
                   &&  (*contHist[0])[movedPiece][to_sq(move)]
                     + (*contHist[1])[movedPiece][to_sq(move)]
-                    + (*contHist[3])[movedPiece][to_sq(move)] < 27400)
+                    + (*contHist[3])[movedPiece][to_sq(move)]
+                    + (*contHist[5])[movedPiece][to_sq(move)] / 2 < 31400)
                   continue;
 
               // Prune moves with negative SEE (~20 Elo)


### PR DESCRIPTION
passed STC:
https://tests.stockfishchess.org/tests/view/5ee3f88bca6c451633a9959f
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 55984 W: 10822 L: 10552 D: 34610
Ptnml(0-2): 952, 6435, 12941, 6719, 945 
passed LTC:
https://tests.stockfishchess.org/tests/view/5ee4186dca6c451633a995cf
LLR: 2.96 (-2.94,2.94) {0.25,1.75}
Total: 41712 W: 5402 L: 5114 D: 31196
Ptnml(0-2): 293, 3766, 12469, 4016, 312 
This patch adjusts threshold for futility pruning of quiet moves using conthist 5 in the same way as it is used in movepicker.
bench 4715960