### PR TITLE
Pawns in midgame

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -814,6 +814,12 @@ namespace {
     // imbalance. Score is computed internally from the white point of view.
     Score score = pos.psq_score() + me->imbalance() + pos.this_thread()->contempt;
 
+    int contempt = mg_value(pos.this_thread()->contempt);
+    int p = pos.count<PAWN>();
+    score += contempt > 0 ?  make_score(-p, 0) :
+             contempt < 0 ? -make_score(-p, 0)
+                          : SCORE_ZERO;
+
     // Probe the pawn hash table
     pe = Pawns::probe(pos);
     score += pe->pawn_score(WHITE) - pe->pawn_score(BLACK);


### PR DESCRIPTION
Let Stockfish try to open the position a tiny bit in early midgame when it
has the advantage.

STC:
LLR: 2.95 (-2.94,2.94) {-0.50,1.50}
Total: 21496 W: 4009 L: 3797 D: 13690
Ptnml(0-2): 331, 2344, 5211, 2506, 356
https://tests.stockfishchess.org/tests/view/5ee5af0eca6c451633a9a063

LTC:
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 59288 W: 6806 L: 6488 D: 45994
Ptnml(0-2): 302, 5006, 18757, 5230, 349
https://tests.stockfishchess.org/tests/view/5ee5b1ebca6c451633a9a07a

closes https://github.com/official-stockfish/Stockfish/pull/2739

Bench: 4768885