### PR TITLE
Updated default contempt C=14

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -60,7 +60,7 @@ void init(OptionsMap& o) {
   constexpr int MaxHashMB = Is64Bit ? 33554432 : 2048;
 
   o["Debug Log File"]        << Option("", on_logger);
-  o["Contempt"]              << Option(24, -100, 100);
+  o["Contempt"]              << Option(14, -500, 500);
   o["Analysis Contempt"]     << Option("Both var Off var White var Black var Both", "Both");
   o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);


### PR DESCRIPTION
Updated default contempt based on latest no regression testing.

C=14
STC https://tests.stockfishchess.org/tests/view/5ee56ca7ca6c451633a99fa7
LLR: 2.93 (-2.94,2.94) {-1.50,0.50}
Total: 15768 W: 2504 L: 2373 D: 10891
Ptnml(0-2): 177, 1596, 4213, 1715, 183 

Edit: fixed LTC link.  Thanks to @ElbertoOne
https://tests.stockfishchess.org/tests/view/5ee5e36eca6c451633a9a0d3
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 39544 W: 3433 L: 3405 D: 32706
Ptnml(0-2): 117, 2786, 13955, 2780, 134 


Note:
C=18 passed STC but failed LTC.  
https://tests.stockfishchess.org/tests/view/5ee5395eca6c451633a99f27
https://tests.stockfishchess.org/tests/view/5ee5bde6ca6c451633a9a09b
C=16 failed STC(probably a bit unlucky).
https://tests.stockfishchess.org/tests/view/5ee5d745ca6c451633a9a0c7

If it's ok w/ the maintainers we could also increase the range of contempt beyond +-100.  In human handicap matches I need something like rook odds but I still want SF to not take a quick draw.  Just let me know.

@snicolet rightly pointed out that contempt is a good thing for fishtest (to improve test resolution and make more efficient use of test resources.)  We can use any value we want for that purpose by making it a separate fishtest default on the test creation page just as we have separate hash size defaults.  I don't know what value that should be however if different at all.

Finally, please let's discuss the best contempt value for the TCEC SuFi in some other appropriate place but not in this PR.

bench: 4245202