### PR TITLE
Improve KBPKB

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -611,7 +611,7 @@ ScaleFactor Endgame<KBPKB>::operator()(const Position& pos) const {
   // Case 1: Defending king blocks the pawn, and cannot be driven away
   if (   (forward_file_bb(strongSide, pawnSq) & weakKingSq)
       && (   opposite_colors(weakKingSq, strongBishopSq)
-          || relative_rank(strongSide, weakKingSq) <= RANK_6))
+          || relative_rank(strongSide, weakKingSq) <= RANK_5))
       return SCALE_FACTOR_DRAW;
 
   // Case 2: Opposite colored bishops


### PR DESCRIPTION
In my short tests of 2000 KBPsKB games, this was better than master 2:1.  Does not regress in normal games.

STC
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 55064 W: 10484 L: 10386 D: 34194
Ptnml(0-2): 824, 6175, 13447, 6251, 835 
https://tests.stockfishchess.org/tests/view/5ee7d12aaae8aec816ab75be