### PR TITLE
Fix low node info string

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -965,7 +965,7 @@ moves_loop: // When in check, search starts from here
 
       ss->moveCount = ++moveCount;
 
-      if (rootNode && thisThread == Threads.main() && Time.elapsed() > 3000)
+      if (rootNode && thisThread == Threads.main() &&(Limits.nodes || Time.elapsed() > 3000))
           sync_cout << "info depth " << depth
                     << " currmove " << UCI::move(move, pos.is_chess960())
                     << " currmovenumber " << moveCount + thisThread->pvIdx << sync_endl;


### PR DESCRIPTION
Provide infostring at low node searches.
Fixes https://github.com/official-stockfish/Stockfish/issues/2757
No functional change.