### PR TITLE
Allow composing wtime/btime with other limits (closes #2767)

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -91,7 +91,7 @@ struct LimitsType {
   }
 
   bool use_time_management() const {
-    return !(mate | movetime | depth | nodes | perft | infinite);
+    return time[WHITE] || time[BLACK];
   }
 
   std::vector<Move> searchmoves;


### PR DESCRIPTION
Reviewing `search.cpp`, it looks like Stockfish is already prepared to mix time management and other limits, but so far simply didn't consider the clocks if any other limit was provided.