### PR TITLE
Follow up for ARCH=armv8

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -134,8 +134,8 @@ endif
 
 ifeq ($(ARCH),armv8)
 	arch = armv8-a
-	bits = 64
 	prefetch = yes
+	popcnt = yes
 endif
 
 ifeq ($(ARCH),ppc-32)
@@ -322,7 +322,7 @@ endif
 
 ### 3.6 popcnt
 ifeq ($(popcnt),yes)
-	ifeq ($(arch),ppc64)
+	ifeq ($(arch),$(filter $(arch),ppc64 armv8-a))
 		CXXFLAGS += -DUSE_POPCNT
 	else ifeq ($(comp),icc)
 		CXXFLAGS += -msse3 -DUSE_POPCNT


### PR DESCRIPTION
* bits = 64 is now the default
* Supports popcnt (thanks @daylen)

Tested with g++ (Ubuntu/Linaro 7.5.0-3ubuntu1~18.04) 7.5.0 on ThunderX CN8890.

Total time in ms for bench before:

    11499
    11475
    11499
    11364 (best run)
    11514

After:

    10406
    10447
    10360 (best run)
    10369
    10430

Also tested with clang version 6.0.0-1ubuntu2 (tags/RELEASE_600/final).

No functional change.