### PR TITLE
Fix insufficient keys

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -662,7 +662,7 @@ namespace {
     // search to overwrite a previous full search TT value, so we use a different
     // position key in case of an excluded move.
     excludedMove = ss->excludedMove;
-    posKey = pos.key() ^ (Key(excludedMove) << 48); // Isn't a very good hash
+    posKey = pos.key() ^ make_key(excludedMove);
     tte = TT.probe(posKey, ttHit);
     ttValue = ttHit ? value_from_tt(tte->value(), ss->ply, pos.rule50_count()) : VALUE_NONE;
     ttMove =  rootNode ? thisThread->rootMoves[thisThread->pvIdx].pv[0]

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -662,7 +662,7 @@ namespace {
     // search to overwrite a previous full search TT value, so we use a different
     // position key in case of an excluded move.
     excludedMove = ss->excludedMove;
-    posKey = pos.key() ^ make_key(excludedMove);
+    posKey = excludedMove == MOVE_NONE ? pos.key() : pos.key() ^ make_key(excludedMove);
     tte = TT.probe(posKey, ttHit);
     ttValue = ttHit ? value_from_tt(tte->value(), ss->ply, pos.rule50_count()) : VALUE_NONE;
     ttMove =  rootNode ? thisThread->rootMoves[thisThread->pvIdx].pv[0]

--- a/src/types.h
+++ b/src/types.h
@@ -455,6 +455,10 @@ constexpr bool is_ok(Move m) {
   return from_sq(m) != to_sq(m); // Catch MOVE_NULL and MOVE_NONE
 }
 
+constexpr Key make_key(uint64_t seed) {
+  return seed * 6364136223846793005ULL + 1442695040888963407ULL;
+}
+
 #endif // #ifndef TYPES_H_INCLUDED
 
 #include "tune.h" // Global visibility to tuning setup

--- a/src/types.h
+++ b/src/types.h
@@ -455,6 +455,7 @@ constexpr bool is_ok(Move m) {
   return from_sq(m) != to_sq(m); // Catch MOVE_NULL and MOVE_NONE
 }
 
+/// Based on a congruential pseudo random number generator
 constexpr Key make_key(uint64_t seed) {
   return seed * 6364136223846793005ULL + 1442695040888963407ULL;
 }


### PR DESCRIPTION
This fixes an old issue where we want to make a position unique but only change a small number of bits in the key instead of all 64 of them randomly.   This is fragile and can lead to non uniqueness issues in the TT.

```Key make_key(uint64_t seed)```
takes any integer and produces a unique random 64 bit key.  It is computationally the fastest  way I know of and is based on a congruential pseudo random number generator using well tested constants by Donald Knuth.
https://en.wikipedia.org/wiki/Linear_congruential_generator

I am opening this PR per request by @snicolet but I apologize for not doing this earlier myself.
https://github.com/snicolet/Stockfish/commit/23b56aa1ee1079e22e212ecd2d3d5c0f5e0910f0

bench: 4626776

STC https://tests.stockfishchess.org/tests/view/5ef6c78f761b685b4c724bb6
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 154320 W: 29343 L: 29376 D: 95601
Ptnml(0-2): 2543, 18170, 35891, 17889, 2667

LTC https://tests.stockfishchess.org/tests/view/5ef7d1a9020eec13834a940e
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 53488 W: 6629 L: 6584 D: 40275
Ptnml(0-2): 372, 4878, 16183, 4955, 356 