### PR TITLE
Revert LTO for mingw on windows.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -344,9 +344,19 @@ endif
 ### needs access to the optimization flags.
 ifeq ($(optimize),yes)
 ifeq ($(debug), no)
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang))
 		CXXFLAGS += -flto
 		LDFLAGS += $(CXXFLAGS)
+	endif
+
+# To use LTO and static linking on windows, the tool chain requires a recent gcc:
+# gcc version 10.1 in msys2 or TDM-GCC version 9.2 are know to work, older might not.
+# So, only enable it for a cross from Linux by default.
+	ifeq ($(comp),mingw)
+	ifeq ($(KERNEL),Linux)
+		CXXFLAGS += -flto
+		LDFLAGS += $(CXXFLAGS)
+	endif
 	endif
 endif
 endif


### PR DESCRIPTION
LTO with static linking is still only working with the latest versions of gcc,
causing problems for some devs.

fixes https://github.com/official-stockfish/Stockfish/issues/2769

No functional change.