### PR TITLE
Remove old zobrist trick for castling rights

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -119,15 +119,7 @@ void Position::init() {
       Zobrist::enpassant[f] = rng.rand<Key>();
 
   for (int cr = NO_CASTLING; cr <= ANY_CASTLING; ++cr)
-  {
-      Zobrist::castling[cr] = 0;
-      Bitboard b = cr;
-      while (b)
-      {
-          Key k = Zobrist::castling[1ULL << pop_lsb(&b)];
-          Zobrist::castling[cr] ^= k ? k : rng.rand<Key>();
-      }
-  }
+      Zobrist::castling[cr] = rng.rand<Key>();
 
   Zobrist::side = rng.rand<Key>();
   Zobrist::noPawns = rng.rand<Key>();
@@ -780,9 +772,9 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   // Update castling rights if needed
   if (st->castlingRights && (castlingRightsMask[from] | castlingRightsMask[to]))
   {
-      int cr = castlingRightsMask[from] | castlingRightsMask[to];
-      k ^= Zobrist::castling[st->castlingRights & cr];
-      st->castlingRights &= ~cr;
+      k ^= Zobrist::castling[st->castlingRights];
+      st->castlingRights &= ~(castlingRightsMask[from] | castlingRightsMask[to]);
+      k ^= Zobrist::castling[st->castlingRights];
   }
 
   // Move the piece. The tricky Chess960 castling is handled earlier


### PR DESCRIPTION
Removes an 8 year old micro optimization aimed at 32-bit architectures because back then doing an xor of a Key could not be done in one instruction.  See original commit here
https://github.com/official-stockfish/Stockfish/commit/821e1c72337e435d805aa2e29743d8b79c9d65a9

STC https://tests.stockfishchess.org/tests/view/5ef5833dde213bf647527d0c
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 162648 W: 31053 L: 31097 D: 100498
Ptnml(0-2): 2841, 18966, 37715, 19000, 2802 

LTC https://tests.stockfishchess.org/tests/view/5ef7b1bbf993893290cc1489
LLR: 2.93 (-2.94,2.94) {-1.50,0.50}
Total: 62360 W: 7617 L: 7586 D: 47157
Ptnml(0-2): 423, 5662, 18994, 5663, 438 

bench: 4512232