### PR TITLE
[RFC] Provide WDL statistics

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -66,6 +66,11 @@ Currently, Stockfish has the following UCI options:
     If enabled by UCI_LimitStrength, aim for an engine strength of the given Elo.
     This Elo rating has been calibrated at a time control of 60s+0.6s and anchored to CCRL 40/4.
 
+  * #### UCI_ShowWDL
+    If enabled, show approximate WDL statistics as part of the engine output.
+    These WDL numbes model expected game outcomes for a given evalulation and game ply
+    as obtained during fishtest LTC games.
+
   * #### Move Overhead
     Assume a time delay of x ms due to network and GUI overheads. This is useful to
     avoid losses on time in those cases.

--- a/Readme.md
+++ b/Readme.md
@@ -68,8 +68,8 @@ Currently, Stockfish has the following UCI options:
 
   * #### UCI_ShowWDL
     If enabled, show approximate WDL statistics as part of the engine output.
-    These WDL numbes model expected game outcomes for a given evalulation and game ply
-    as obtained during fishtest LTC games.
+    These WDL numbers model expected game outcomes for a given evaluation and
+    game ply for engine self-play at fishtest LTC conditions (60+0.6s per game).
 
   * #### Move Overhead
     Assume a time delay of x ms due to network and GUI overheads. This is useful to

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -92,28 +92,6 @@ namespace {
     return VALUE_DRAW + Value(2 * (thisThread->nodes & 1) - 1);
   }
 
-  // The win rate model return the probability (per mille) of winning given
-  //  a game-ply and eval. The model fits rather accurately the LTC fishtest statistics.
-  int win_rate_model(int ply, Value v) {
-
-     // The model captures only up to 240 plies, so limit input (and rescale).
-     float m = std::min(240, ply) / 64.0;
-
-     // Coefficients of a 3rd order polynomial fit based on fishtest data
-     // for two parameters needed to transform eval to the argument of a
-     // logistic function.
-     float as[] = {-8.24404295, 64.23892342, -95.73056462, 153.86478679};
-     float bs[] = {-3.37154371, 28.44489198, -56.67657741,  72.05858751};
-     float a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
-     float b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];
-
-     // transform eval to cp with limited range
-     float x = Utility::clamp(float(100 * v) / PawnValueEg, -1000.0f, 1000.0f);
-
-     // return win rate in per mille (rounded to nearest)
-     return int(0.5 + 1000 / (1 + std::exp((a - x) / b)));
-  }
-
   // Skill structure is used to implement strength limit
   struct Skill {
     explicit Skill(int l) : level(l) {}
@@ -1858,12 +1836,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
          << " score "    << UCI::value(v);
 
       if (Options["UCI_ShowWDL"])
-      {
-          int wdl_w = win_rate_model(pos.game_ply(), v);
-          int wdl_l = win_rate_model(pos.game_ply(), -v);
-          int wdl_d = 1000 - wdl_w - wdl_l;
-          ss << " wdl " << wdl_w << " " << wdl_d << " " << wdl_l;
-      }
+          ss << UCI::wdl(v, pos.game_ply());
 
       if (!tb && i == pvIdx)
           ss << (v >= beta ? " lowerbound" : v <= alpha ? " upperbound" : "");

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -183,25 +183,25 @@ namespace {
          << "\nNodes/second    : " << 1000 * nodes / elapsed << endl;
   }
 
-  // The win rate model return the probability (per mille) of winning given
-  //  a game-ply and eval. The model fits rather accurately the LTC fishtest statistics.
+  // The win rate model returns the probability (per mille) of winning given an eval
+  // and a game-ply. The model fits rather accurately the LTC fishtest statistics.
   int win_rate_model(Value v, int ply) {
 
-     // The model captures only up to 240 plies, so limit input (and rescale).
-     float m = std::min(240, ply) / 64.0;
+     // The model captures only up to 240 plies, so limit input (and rescale)
+     double m = std::min(240, ply) / 64.0;
 
      // Coefficients of a 3rd order polynomial fit based on fishtest data
      // for two parameters needed to transform eval to the argument of a
      // logistic function.
-     float as[] = {-8.24404295, 64.23892342, -95.73056462, 153.86478679};
-     float bs[] = {-3.37154371, 28.44489198, -56.67657741,  72.05858751};
-     float a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
-     float b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];
+     double as[] = {-8.24404295, 64.23892342, -95.73056462, 153.86478679};
+     double bs[] = {-3.37154371, 28.44489198, -56.67657741,  72.05858751};
+     double a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
+     double b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];
 
-     // transform eval to cp with limited range
-     float x = Utility::clamp(float(100 * v) / PawnValueEg, -1000.0f, 1000.0f);
+     // Transform eval to centipawns with limited range
+     double x = Utility::clamp(double(100 * v) / PawnValueEg, -1000.0, 1000.0);
 
-     // return win rate in per mille (rounded to nearest)
+     // Return win rate in per mille (rounded to nearest)
      return int(0.5 + 1000 / (1 + std::exp((a - x) / b)));
   }
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -73,6 +73,7 @@ std::string value(Value v);
 std::string square(Square s);
 std::string move(Move m, bool chess960);
 std::string pv(const Position& pos, Depth depth, Value alpha, Value beta);
+std::string wdl(Value v, int ply);
 Move to_move(const Position& pos, std::string& str);
 
 } // namespace UCI

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -74,6 +74,7 @@ void init(OptionsMap& o) {
   o["UCI_AnalyseMode"]       << Option(false);
   o["UCI_LimitStrength"]     << Option(false);
   o["UCI_Elo"]               << Option(1350, 1350, 2850);
+  o["UCI_ShowWDL"]           << Option(true);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);
   o["Syzygy50MoveRule"]      << Option(true);


### PR DESCRIPTION
A number of engines, GUIs and tournaments start to report WDL estimates
along or instead of scores. This patch enables reporting of those stats
in a more or less standard way (http://www.talkchess.com/forum3/viewtopic.php?t=72140)

```
info depth 59 seldepth 78 multipv 1 score cp 80 wdl 313 675 12 lowerbound nodes 3568397124 nps 2847848 hashfull 1000 tbhits 0 time 1253015 pv f3h4
```

The model this reporting uses is based on data derived from a few million fishtest LTC games,
given a score and a game ply, a win rate is provided that matches rather closely,
especially in the intermediate range [0.05, 0.95] that data. Some data is shown at
https://github.com/glinscott/fishtest/wiki/UsefulData#win-loss-draw-statistics-of-ltc-games-on-fishtest
Making the conversion game ply dependent is important for a good fit, and is in line
with experience that a +1 score in the early midgame is more likely a win than in the late endgame.

Even when enabled, the printing of the info causes no significant overhead.

Passed STC:
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 197112 W: 37226 L: 37347 D: 122539
Ptnml(0-2): 2591, 21025, 51464, 20866, 2610
https://tests.stockfishchess.org/tests/view/5ef79ef4f993893290cc146b

The PR is for discussion, the comments will be updated with a comparison of model and data.

Bench: 4789930