### PR TITLE
Scale down eval for drawish rook endgames.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -782,6 +782,13 @@ namespace {
             else
                 sf = 22 + 3 * pos.count<ALL_PIECES>(strongSide);
         }
+        else if(   pos.non_pawn_material(WHITE) == RookValueMg
+                && pos.non_pawn_material(BLACK) == RookValueMg
+                && !pe->passed_pawns(strongSide)
+                && pos.count<PAWN>(strongSide) - pos.count<PAWN>(~strongSide) <= 1
+                && bool(KingSide & pos.pieces(strongSide, PAWN)) != bool(QueenSide & pos.pieces(strongSide, PAWN))
+                && (attacks_bb<KING>(pos.square<KING>(~strongSide)) & pos.pieces(~strongSide, PAWN)))
+            sf = 36;
         else
             sf = std::min(sf, 36 + 7 * pos.count<PAWN>(strongSide));
     }


### PR DESCRIPTION
STC:
LLR: 2.96 (-2.94,2.94) {-0.50,1.50}
Total: 82136 W: 15694 L: 15407 D: 51035
Ptnml(0-2): 1076, 8960, 20767, 9131, 1134
https://tests.stockfishchess.org/tests/view/5ef86cf8020eec13834a94dd

LTC:
LLR: 2.93 (-2.94,2.94) {0.25,1.75}
Total: 70200 W: 8787 L: 8440 D: 52973
Ptnml(0-2): 325, 5983, 22170, 6264, 358
https://tests.stockfishchess.org/tests/view/5ef88225020eec13834a950a

Bench: 4608067