### PR TITLE
Tweak single queen endgame scaling.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -789,7 +789,8 @@ namespace {
                 && (attacks_bb<KING>(pos.square<KING>(~strongSide)) & pos.pieces(~strongSide, PAWN)))
             sf = 36;
         else if (pos.count<QUEEN>() == 1)
-            sf = 37;
+            sf = 37 + 3 * (pos.count<QUEEN>(WHITE) == 1 ? pos.count<BISHOP>(BLACK) + pos.count<KNIGHT>(BLACK)
+                                                        : pos.count<BISHOP>(WHITE) + pos.count<KNIGHT>(WHITE));
         else
             sf = std::min(sf, 36 + 7 * pos.count<PAWN>(strongSide));
     }


### PR DESCRIPTION
Increase scaling factor for each minor of the opponent side of the queen.

STC:
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 14528 W: 2860 L: 2653 D: 9015
Ptnml(0-2): 217, 1632, 3408, 1741, 266
https://tests.stockfishchess.org/tests/view/5ef98384020eec13834a96a0

LTC:
LLR: 2.95 (-2.94,2.94) {0.25,1.75}
Total: 34584 W: 4371 L: 4111 D: 26102
Ptnml(0-2): 205, 3080, 10501, 3262, 244
https://tests.stockfishchess.org/tests/view/5ef99972020eec13834a96c9

Bench: 4523573