### PR TITLE
Denormalize KRKP

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -181,15 +181,15 @@ Value Endgame<KRKP>::operator()(const Position& pos) const {
   assert(verify_material(pos, strongSide, RookValueMg, 0));
   assert(verify_material(pos, weakSide, VALUE_ZERO, 1));
 
-  Square strongKing = relative_square(strongSide, pos.square<KING>(strongSide));
-  Square weakKing   = relative_square(strongSide, pos.square<KING>(weakSide));
-  Square strongRook = relative_square(strongSide, pos.square<ROOK>(strongSide));
-  Square weakPawn   = relative_square(strongSide, pos.square<PAWN>(weakSide));
-  Square queeningSquare = make_square(file_of(weakPawn), RANK_1);
+  Square strongKing = pos.square<KING>(strongSide);
+  Square weakKing   = pos.square<KING>(weakSide);
+  Square strongRook = pos.square<ROOK>(strongSide);
+  Square weakPawn   = pos.square<PAWN>(weakSide);
+  Square queeningSquare = make_square(file_of(weakPawn), relative_rank(weakSide, RANK_8));
   Value result;
 
   // If the stronger side's king is in front of the pawn, it's a win
-  if (forward_file_bb(WHITE, strongKing) & weakPawn)
+  if (forward_file_bb(strongSide, strongKing) & weakPawn)
       result = RookValueEg - distance(strongKing, weakPawn);
 
   // If the weaker side's king is too far from the pawn and the rook,
@@ -200,15 +200,15 @@ Value Endgame<KRKP>::operator()(const Position& pos) const {
 
   // If the pawn is far advanced and supported by the defending king,
   // the position is drawish
-  else if (   rank_of(weakKing) <= RANK_3
+  else if (   relative_rank(strongSide, weakKing) <= RANK_3
            && distance(weakKing, weakPawn) == 1
-           && rank_of(strongKing) >= RANK_4
+           && relative_rank(strongSide, strongKing) >= RANK_4
            && distance(strongKing, weakPawn) > 2 + (pos.side_to_move() == strongSide))
       result = Value(80) - 8 * distance(strongKing, weakPawn);
 
   else
-      result =  Value(200) - 8 * (  distance(strongKing, weakPawn + SOUTH)
-                                  - distance(weakKing, weakPawn + SOUTH)
+      result =  Value(200) - 8 * (  distance(strongKing, weakPawn + pawn_push(weakSide))
+                                  - distance(weakKing, weakPawn + pawn_push(weakSide))
                                   - distance(weakPawn, queeningSquare));
 
   return strongSide == pos.side_to_move() ? result : -result;


### PR DESCRIPTION
This is a non-functional code style change that denormalizes the KRKP endgame.  For me, this is a bit easier to read, and it's a little less code.

Here's why it's less code, since it may not be immediately apparent:

relative_square() and relative_rank() are 2 operations, a rank_of() is a single shift, and a pawn_push is a ternary operator.

For the relevant changes, master does 10 operations (4 relative_squares, and two rank_of).
This patch reduces the relevant code to 6 operations (3 relative_ranks) and 2 pawn_pushes.

I don't suspect this needs to be tested, but I'm happy to do it if requested.