### PR TITLE
Speed-up in forward_file(...)

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -239,7 +239,19 @@ inline Bitboard forward_ranks_bb(Color c, Square s) {
 /// line in front of the given one, from the point of view of the given color.
 
 inline Bitboard forward_file_bb(Color c, Square s) {
-  return forward_ranks_bb(c, s) & file_bb(s);
+
+  if (c == WHITE)
+  {
+      Bitboard b = shift<NORTH>(square_bb(s));
+      b |= b << 8; b |= b << 16; b |= b << 32;
+      return b;
+  }
+  else
+  {
+      Bitboard b = shift<SOUTH>(square_bb(s));
+      b |= b >> 8; b |= b >> 16; b |= b >> 32;
+      return b;
+  }
 }
 
 


### PR DESCRIPTION
This is a non-functional speed-up.  the code is ugly, but this is faster on my machines.  Perhaps I could do this same thing with shift, but it would be a longer read.  Suggestions?

MASTER
cycles: 185,490,528,662
instructions: 277,767,410,618
time: 53.02

PATCH
cycles: 181,779,716,802
instructions: 271,132,375,118
time: 51.98
