### PR TITLE
Include cases with passed pawns in rook scale factor

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -783,7 +783,6 @@ namespace {
         }
         else if (  pos.non_pawn_material(WHITE) == RookValueMg
                 && pos.non_pawn_material(BLACK) == RookValueMg
-                && !pe->passed_pawns(strongSide)
                 && pos.count<PAWN>(strongSide) - pos.count<PAWN>(~strongSide) <= 1
                 && bool(KingSide & pos.pieces(strongSide, PAWN)) != bool(QueenSide & pos.pieces(strongSide, PAWN))
                 && (attacks_bb<KING>(pos.square<KING>(~strongSide)) & pos.pieces(~strongSide, PAWN)))


### PR DESCRIPTION
This will help scale down relatively high eval in drawish rook endgames with passed pawn like in TCEC S18 Superfinal Game 90.

Passed STC
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 50456 W: 9644 L: 9540 D: 31272
Ptnml(0-2): 760, 5637, 12332, 5737, 762
https://tests.stockfishchess.org/tests/view/5efcb76e59f6f035328940ed

Passed LTC
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 77264 W: 9518 L: 9518 D: 58228
Ptnml(0-2): 402, 6766, 24321, 6716, 427
https://tests.stockfishchess.org/tests/view/5efd2ad759f6f03532894143

Bench: 4431626