### PR TITLE
Add rank based bonus for blocked pawns.

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -38,6 +38,9 @@ namespace {
   constexpr Score WeakLever     = S( 0, 56);
   constexpr Score WeakUnopposed = S(13, 27);
 
+  // Bonus for blocked pawns at 5th or 6th rank.
+  constexpr Score BlockedPawn[2] = { S(-10, -3), S(-3, 3) };
+
   constexpr Score BlockedStorm[RANK_NB] = {
     S(0, 0), S(0, 0), S(76, 78), S(-10, 15), S(-7, 10), S(-4, 6), S(-1, 2)
   };
@@ -169,6 +172,9 @@ namespace {
         if (!support)
             score -=  Doubled * doubled
                     + WeakLever * more_than_one(lever);
+
+        if (blocked && r > RANK_4)
+            score += BlockedPawn[r-4];
     }
 
     return score;


### PR DESCRIPTION
This is a rewrite of my original idea which uses only two parameters. Thanks to rocky640 for pointing this out.

STC:
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 50800 W: 9707 L: 9446 D: 31647
Ptnml(0-2): 831, 5851, 11822, 6018, 878
https://tests.stockfishchess.org/tests/view/5f00b4f359f6f03532894304

LTC:
LLR: 2.93 (-2.94,2.94) {0.25,1.75}
Total: 52064 W: 6477 L: 6167 D: 39420
Ptnml(0-2): 331, 4628, 15834, 4878, 361
https://tests.stockfishchess.org/tests/view/5f0115fe59f6f03532894345

Bench: 4882833