### PR TITLE
Clean-up en passant processing

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -178,9 +178,9 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
 
    4) En passant target square (in algebraic notation). If there's no en passant
       target square, this is "-". If a pawn has just made a 2-square move, this
-      is the position "behind" the pawn. This is recorded only if there is a pawn
-      in position to make an en passant capture, and if there really is a pawn
-      that might have advanced two squares.
+      is the position "behind" the pawn. Following X-FEN standard, this is recorded only
+      if there is a pawn in position to make an en passant capture, and if there really
+      is a pawn that might have advanced two squares.
 
    5) Halfmove clock. This is the number of halfmoves since the last pawn advance
       or capture. This is used to determine if a draw can be claimed under the
@@ -251,17 +251,26 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
       set_castling_right(c, rsq);
   }
 
-  // 4. En passant square. Ignore if no pawn capture is possible
+  // 4. En passant square.
+  // Ignore if square is invalid or not on side to move relative rank 6.
+  bool enpassant = false;
+  
   if (   ((ss >> col) && (col >= 'a' && col <= 'h'))
-      && ((ss >> row) && (row == '3' || row == '6')))
+      && ((ss >> row) && (row == (sideToMove == WHITE ? '6' : '3'))))
   {
       st->epSquare = make_square(File(col - 'a'), Rank(row - '1'));
-
-      if (   !(attackers_to(st->epSquare) & pieces(sideToMove, PAWN))
-          || !(pieces(~sideToMove, PAWN) & (st->epSquare + pawn_push(~sideToMove))))
-          st->epSquare = SQ_NONE;
+      
+      // En passant square will be considered only if
+      // a) side to move have a pawn threatening epSquare
+      // b) there is an enemy pawn in front of epSquare
+      // c) there is no piece on epSquare or behind epSquare
+      enpassant = 
+          pawn_attacks_bb(~sideToMove, st->epSquare) & pieces(sideToMove, PAWN)
+      && (pieces(~sideToMove, PAWN) & (st->epSquare + pawn_push(~sideToMove)))
+      && !(pieces() & (st->epSquare | (st->epSquare + pawn_push(sideToMove))));
   }
-  else
+
+  if (!enpassant)
       st->epSquare = SQ_NONE;
 
   // 5-6. Halfmove clock and fullmove number


### PR DESCRIPTION
This PR aims to
- better document how we process the ep square (if any) given a
position fen command
- output more meaningful (and consistent) debug fen on the "d"
command.

In short, according to fen standard, if white starts the game with 1.e4, fen standard would record e3 as an e.p square.
But master is already cleaning this, following the x-fen standard.

This pr goes a step further, and following x-fen cleans up the ep square when it
is not on relative rank 6 of side to move. It also cleans up ep square
if ep square not empty or square behind it is not empty.

All these are obvious bogus ue of ep square.


Effect of pr can be seen in following examples

position fen 4r3/5k2/8/4Pp2/8/8/8/4K3 w - f6 0 29
d
position fen 4r3/5P1k/8/4Pp2/8/8/8/4K3 w - f6 0 29
d
position fen 4r3/5p1k/8/4Pp2/8/8/8/4K3 w - f6 0 29
d
position fen 4r3/5p1k/5p2/4Pp2/8/8/8/4K3 w - f6 0 29
d
position fen 4r3/5p1k/5P2/4Pp2/8/8/8/4K3 w - f6 0 29
d
position fen 4r3/7k/5p2/4Pp2/8/8/8/4K3 w - f6 0 29
d
position fen 4r3/7k/5P2/4Pp2/8/8/8/4K3 w - f6 0 29
d
position fen 7k/8/8/8/8/8/1Pp5/7K w - c3 0 29
d
position fen 4r3/7k/8/4Pp2/8/8/8/4K3 w - f6 0 29
d

looking at the fen which are printed _just below_ the diagram
-master outputs ep square for all the above except the last
-this pr output ep square only for the last

reference:
https://en.wikipedia.org/wiki/X-FEN#Encoding_en-passant
issue #2784

we could do a little bit more, like cleaning ep square if capture would leave the king en prise,
but this is not a requirement of fen or x-fen, 

bench: 4882833