### PR TITLE
Connected / Blocked Simplification

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -163,4 +163,4 @@ Vince Negri (cuddlestmonkey)
 # Additionally, we acknowledge the authors and maintainers of fishtest,
 # an amazing and essential framework for the development of Stockfish!
 #
-# https://github.com/glinscott/fishtest/blob/master/AUTHORS.
+# https://github.com/glinscott/fishtest/blob/master/AUTHORS

--- a/AUTHORS
+++ b/AUTHORS
@@ -163,4 +163,4 @@ Vince Negri (cuddlestmonkey)
 # Additionally, we acknowledge the authors and maintainers of fishtest,
 # an amazing and essential framework for the development of Stockfish!
 #
-# https://github.com/glinscott/fishtest/blob/master/AUTHORS
+# https://github.com/glinscott/fishtest/blob/master/AUTHORS.

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -148,7 +148,7 @@ namespace {
         // Score this pawn
         if (support | phalanx)
         {
-            int v =  Connected[r] * (4 + 2 * bool(phalanx) - 2 * bool(opposed)) / 2
+            int v = Connected[r] * (2 + bool(phalanx) - bool(opposed))
             + 21 * popcount(support);
 
             score += make_score(v, v * (r - 2) / 4);

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -39,7 +39,7 @@ namespace {
   constexpr Score WeakUnopposed = S(13, 27);
 
   // Bonus for blocked pawns at 5th or 6th rank
-  constexpr Score BlockedPawn[2] = { S(-10, -3), S(-3, 3) };
+  constexpr Score BlockedPawn[2] = { S(-11, -4), S(-3, 4) };
 
   constexpr Score BlockedStorm[RANK_NB] = {
     S(0, 0), S(0, 0), S(76, 78), S(-10, 15), S(-7, 10), S(-4, 6), S(-1, 2)
@@ -148,8 +148,8 @@ namespace {
         // Score this pawn
         if (support | phalanx)
         {
-            int v =  Connected[r] * (4 + 2 * bool(phalanx) - 2 * bool(opposed) - bool(blocked)) / 2
-                   + 21 * popcount(support);
+            iint v =  Connected[r] * (4 + 2 * bool(phalanx) - 2 * bool(opposed)) / 2
+            + 21 * popcount(support);
 
             score += make_score(v, v * (r - 2) / 4);
         }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -148,7 +148,7 @@ namespace {
         // Score this pawn
         if (support | phalanx)
         {
-            iint v =  Connected[r] * (4 + 2 * bool(phalanx) - 2 * bool(opposed)) / 2
+            int v =  Connected[r] * (4 + 2 * bool(phalanx) - 2 * bool(opposed)) / 2
             + 21 * popcount(support);
 
             score += make_score(v, v * (r - 2) / 4);


### PR DESCRIPTION
There is no need to score blocked pawns at many places.
The idea originated from: Rocky
Tuning and testing by: Fauzi

Passed STC:
https://tests.stockfishchess.org/tests/view/5f04f8fd59f6f035328945d4
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 6352 W: 1299 L: 1118 D: 3935
Ptnml(0-2): 89, 695, 1469, 792, 131

Passed LTC:
https://tests.stockfishchess.org/tests/view/5f0527bd59f6f035328945e3
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 27648 W: 3517 L: 3433 D: 20698
Ptnml(0-2): 177, 2561, 8301, 2571, 214

Bench: 4734746
