### PR TITLE
Introduce bad outpost penalty

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -130,6 +130,10 @@ constexpr bool more_than_one(Bitboard b) {
   return b & (b - 1);
 }
 
+constexpr bool more_than_two(Bitboard b) {
+  return b & (b - 1) & (b - 2);
+}
+
 constexpr bool opposite_colors(Square s1, Square s2) {
   return (s1 + rank_of(s1) + s2 + rank_of(s2)) & 1;
 }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -312,8 +312,9 @@ namespace {
             // Bonus if piece is on an outpost square or can reach one
             bb = OutpostRanks & attackedBy[Us][PAWN] & ~pe->pawn_attacks_span(Them);
             if (   Pt == KNIGHT 
-                && bb & s & ~CenterFiles & (Us == WHITE ? Rank6BB | Rank5BB : Rank3BB | Rank4BB)
+                && bb & s & ~CenterFiles
                 && !(b & pos.pieces(Them) & ~pos.pieces(PAWN))
+                && !more_than_one((pos.pieces(Them) & ~pos.pieces(PAWN)) & ((s & QueenSide) ? QueenSide : KingSide))
                 && b & pos.pieces(Them, PAWN) & attackedBy[Them][PAWN] & ~attackedBy[Us][PAWN])
                 score += BadOutpost;
             else if (bb & s)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -134,7 +134,7 @@ namespace {
   };
 
   // Assorted bonuses and penalties
-  constexpr Score BadOutpost          = S(  5,  5);
+  constexpr Score BadOutpost          = S( 15, 15);
   constexpr Score BishopOnKingRing    = S( 24,  0);
   constexpr Score BishopPawns         = S(  3,  7);
   constexpr Score BishopXRayPawns     = S(  4,  5);
@@ -309,14 +309,13 @@ namespace {
 
         if (Pt == BISHOP || Pt == KNIGHT)
         {
+            // Bonus if piece is on an outpost square or can reach one
             bb = OutpostRanks & attackedBy[Us][PAWN] & ~pe->pawn_attacks_span(Them);
-            // Penalty if knight is on a bad outpost square
             if (   Pt == KNIGHT 
-                && bb & s & ~CenterFiles & (Us == WHITE ? Rank6BB : Rank3BB)
+                && bb & s & ~CenterFiles & (Us == WHITE ? Rank6BB | Rank5BB : Rank3BB | Rank4BB)
                 && !(b & pos.pieces(Them) & ~pos.pieces(PAWN))
                 && b & pos.pieces(Them, PAWN) & attackedBy[Them][PAWN] & ~attackedBy[Us][PAWN])
-                score -= BadOutpost;
-            // Bonus if piece is on an outpost square or can reach one
+                score += BadOutpost;
             else if (bb & s)
                 score += Outpost[Pt == BISHOP];
             else if (Pt == KNIGHT && bb & b & ~pos.pieces(Us))

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -134,7 +134,7 @@ namespace {
   };
 
   // Assorted bonuses and penalties
-  constexpr Score BadOutpost          = S(  7, 36);
+  constexpr Score BadOutpost          = S(  0, 36);
   constexpr Score BishopOnKingRing    = S( 24,  0);
   constexpr Score BishopPawns         = S(  3,  7);
   constexpr Score BishopXRayPawns     = S(  4,  5);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -134,7 +134,7 @@ namespace {
   };
 
   // Assorted bonuses and penalties
-  constexpr Score BadOutpost          = S( 23, 36);
+  constexpr Score BadOutpost          = S(  7, 36);
   constexpr Score BishopOnKingRing    = S( 24,  0);
   constexpr Score BishopPawns         = S(  3,  7);
   constexpr Score BishopXRayPawns     = S(  4,  5);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -134,7 +134,7 @@ namespace {
   };
 
   // Assorted bonuses and penalties
-  constexpr Score BadOutpost          = S( 15, 36);
+  constexpr Score BadOutpost          = S( 23, 36);
   constexpr Score BishopOnKingRing    = S( 24,  0);
   constexpr Score BishopPawns         = S(  3,  7);
   constexpr Score BishopXRayPawns     = S(  4,  5);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -134,7 +134,7 @@ namespace {
   };
 
   // Assorted bonuses and penalties
-  constexpr Score BadOutpost          = S( 15, 15);
+  constexpr Score BadOutpost          = S( 15, 36);
   constexpr Score BishopOnKingRing    = S( 24,  0);
   constexpr Score BishopPawns         = S(  3,  7);
   constexpr Score BishopXRayPawns     = S(  4,  5);
@@ -314,7 +314,7 @@ namespace {
             if (   Pt == KNIGHT 
                 && bb & s & ~CenterFiles
                 && !(b & pos.pieces(Them) & ~pos.pieces(PAWN))
-                && !more_than_one((pos.pieces(Them) & ~pos.pieces(PAWN)) & ((s & QueenSide) ? QueenSide : KingSide)))
+                && !more_than_two((pos.pieces(Them) & ~pos.pieces(PAWN)) & ((s & QueenSide) ? QueenSide : KingSide)))
                 score += BadOutpost;
             else if (bb & s)
                 score += Outpost[Pt == BISHOP];

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -134,7 +134,7 @@ namespace {
   };
 
   // Assorted bonuses and penalties
-  constexpr Score BadOutpost          = S(  0, 36);
+  constexpr Score BadOutpost          = S( -7, 36);
   constexpr Score BishopOnKingRing    = S( 24,  0);
   constexpr Score BishopPawns         = S(  3,  7);
   constexpr Score BishopXRayPawns     = S(  4,  5);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -134,6 +134,7 @@ namespace {
   };
 
   // Assorted bonuses and penalties
+  constexpr Score BadOutpost          = S(  5,  5);
   constexpr Score BishopOnKingRing    = S( 24,  0);
   constexpr Score BishopPawns         = S(  3,  7);
   constexpr Score BishopXRayPawns     = S(  4,  5);
@@ -308,9 +309,15 @@ namespace {
 
         if (Pt == BISHOP || Pt == KNIGHT)
         {
-            // Bonus if piece is on an outpost square or can reach one
             bb = OutpostRanks & attackedBy[Us][PAWN] & ~pe->pawn_attacks_span(Them);
-            if (bb & s)
+            // Penalty if knight is on a bad outpost square
+            if (   Pt == KNIGHT 
+                && bb & s & ~CenterFiles & (Us == WHITE ? Rank6BB : Rank3BB)
+                && !(b & pos.pieces(Them) & ~pos.pieces(PAWN))
+                && b & pos.pieces(Them, PAWN) & attackedBy[Them][PAWN] & ~attackedBy[Us][PAWN])
+                score -= BadOutpost;
+            // Bonus if piece is on an outpost square or can reach one
+            else if (bb & s)
                 score += Outpost[Pt == BISHOP];
             else if (Pt == KNIGHT && bb & b & ~pos.pieces(Us))
                 score += ReachableOutpost;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -314,8 +314,7 @@ namespace {
             if (   Pt == KNIGHT 
                 && bb & s & ~CenterFiles
                 && !(b & pos.pieces(Them) & ~pos.pieces(PAWN))
-                && !more_than_one((pos.pieces(Them) & ~pos.pieces(PAWN)) & ((s & QueenSide) ? QueenSide : KingSide))
-                && b & pos.pieces(Them, PAWN) & attackedBy[Them][PAWN] & ~attackedBy[Us][PAWN])
+                && !more_than_one((pos.pieces(Them) & ~pos.pieces(PAWN)) & ((s & QueenSide) ? QueenSide : KingSide)))
                 score += BadOutpost;
             else if (bb & s)
                 score += Outpost[Pt == BISHOP];


### PR DESCRIPTION
In some French games, Stockfish likes to bring the Knight to a bad outpost spot. This is evident in TCEC S18 Superfinal Game 63, where there is a Knight outpost on the queenside but is actually useless. Stockfish is effectively playing a piece down while holding ground against Leela's break on the kingside.

This patch turns the +56 mg bonus for a Knight outpost into a -7 mg penalty if it satisfies the following conditions:
1. The outpost square is not on the CenterFiles (i.e. not on files C,D,E and F)
2. The knight is not attacking non pawn enemies.
3. The side where the outpost is located contains only few enemies.

Passed STC:
LLR: 2.93 (-2.94,2.94) {-0.50,1.50}
Total: 6960 W: 1454 L: 1247 D: 4259
Ptnml(0-2): 115, 739, 1610, 856, 160
https://tests.stockfishchess.org/tests/view/5f08221059f6f0353289477e

Passed LTC:
LLR: 2.98 (-2.94,2.94) {0.25,1.75}
Total: 21440 W: 2767 L: 2543 D: 16130
Ptnml(0-2): 122, 1904, 6462, 2092, 140
https://tests.stockfishchess.org/tests/view/5f0838ed59f6f035328947a2

Bench: 4651788

----------------------------
Thank you to apospa...@gmail.com for bringing this to my attention and for providing insights.
See https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/dEXNzSIBgZU
Reference game: https://tcec-chess.com/#div=sf&game=63&season=18