### PR TITLE
Revert functional change in a cleanup patch

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -589,8 +589,9 @@ ScaleFactor Endgame<KPsK>::operator()(const Position& pos) const {
   Bitboard strongPawns = pos.pieces(strongSide, PAWN);
 
   // If all pawns are ahead of the king on a single rook file, it's a draw.
-  if (!((strongPawns & ~FileABB) || (strongPawns & ~FileHBB)) &&
-      !(strongPawns & ~passed_pawn_span(weakSide, weakKing)))
+  if (   !(strongPawns & ~forward_ranks_bb(weakSide, weakKing))
+      && !((strongPawns & ~FileABB) && (strongPawns & ~FileHBB))
+      && distance<File>(weakKing, lsb(strongPawns)) <= 1)
       return SCALE_FACTOR_DRAW;
 
   return SCALE_FACTOR_NONE;


### PR DESCRIPTION
This reverts a functional change in this "Small cleanups" patch:
https://github.com/official-stockfish/Stockfish/commit/ddcbacd04d1c860e808202ce8c1206c8acdca627

With this patch, 8/8/5k1p/8/7p/7K/8/8 b - - 1 11 is again correctly evaluated as a draw.

No change to the default bench.