### PR TITLE
fix redundant syzygy initialisation

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1263,6 +1263,9 @@ void Tablebases::init(const std::string& paths) {
 
     TBTables.clear();
     MaxCardinality = 0;
+    if (TBFile::Paths == paths)
+        return;
+  
     TBFile::Paths = paths;
 
     if (paths.empty() || paths == "<empty>")

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1261,11 +1261,12 @@ WDLScore search(Position& pos, ProbeState* result) {
 /// safe, nor it needs to be.
 void Tablebases::init(const std::string& paths) {
 
-    TBTables.clear();
-    MaxCardinality = 0;
     if (TBFile::Paths == paths)
         return;
-  
+    
+    TBTables.clear();
+    MaxCardinality = 0;
+
     TBFile::Paths = paths;
 
     if (paths.empty() || paths == "<empty>")


### PR DESCRIPTION
When playing I see Stockfish prints annoyingly `info string` about Syzygy few times:

```
setoption name SyzygyPath value /Users/syzygy345
info string Found 145 tablebases
ucinewgame
info string Found 145 tablebases
```

It turns out after initializing, Stockfish continues initializing Syzygy whenever it receives the command "ucinewgame". That is redundant and violated the comment `"Tablebases::init() is called at startup and after every change to 'SyzygyPath' UCI option to (re)create the various tables."`

This PR is simply to compare the path of Syzygy to stop initializing if there is no change.
