### PR TITLE
Simplify the KPsK condition

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -589,8 +589,7 @@ ScaleFactor Endgame<KPsK>::operator()(const Position& pos) const {
   Bitboard strongPawns = pos.pieces(strongSide, PAWN);
 
   // If all pawns are ahead of the king on a single rook file, it's a draw.
-  if (   !(strongPawns & ~(FileABB | FileHBB))
-      && !(strongPawns & ~passed_pawn_span(weakSide, weakKing)))
+  if (!(strongPawns & ~((FileABB | FileHBB) & passed_pawn_span(weakSide, weakKing))))
       return SCALE_FACTOR_DRAW;
 
   return SCALE_FACTOR_NONE;


### PR DESCRIPTION
The expression resulting from commit 6c197c3964ca ("Corrects a
functional change in a cleanup patch.") can be simplified a bit.

No functional change.