### PR TITLE
Don't rewrite more valuable data with less valuable data after probcut.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -925,9 +925,12 @@ namespace {
 
                 if (value >= probcutBeta)
                 {
-                    tte->save(posKey, value_to_tt(value, ss->ply), ttPv,
-                        BOUND_LOWER,
-                        depth - 3, move, ss->staticEval);
+                    if ( !(ttHit
+                       && tte->depth() >= depth - 3
+                       && ttValue != VALUE_NONE))
+                        tte->save(posKey, value_to_tt(value, ss->ply), ttPv,
+                            BOUND_LOWER,
+                            depth - 3, move, ss->staticEval);
                     return value;
                 }
             }


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5f0b52e959f6f035328949a6
LLR: 2.97 (-2.94,2.94) {-0.50,1.50}
Total: 52544 W: 10145 L: 9880 D: 32519
Ptnml(0-2): 853, 6097, 12121, 6334, 867 
passed LTC
https://tests.stockfishchess.org/tests/view/5f0bd94c59f6f035328949f3
LLR: 2.93 (-2.94,2.94) {0.25,1.75}
Total: 49576 W: 6164 L: 5863 D: 37549
Ptnml(0-2): 297, 4371, 15218, 4538, 364 

This patch wraps up work done in previous patch about interaction of probcut and transposition table, more or less removing last illogical part of it.
Previous logic could've been described as following :
1) if transposition table says that probcut will fail, don't try it;
2) if transposition table says that there is a capture that has search result >= probCutBeta, produce a cutoff;
3) do a probcut attempt - if it passes, write data in transposition table.
paragraph 3 has a bit of a problem - if tt depth is greater than probcut depth and it eval is greater than probcutBeta but transposition table move is not a capture if probcut succeeds we will rewrite more deep search result with reduced probcut search. 
This patch removes this interaction and allows engine to write probcut data only in case if probcut depth search is greater to transposition table depth.
Continuation of this patch may be the following - try more probcut attempts if evaluation from transposition table is good enough and it depth is also good enough, otherwise this logic is refined to the max.
bench 4924222