### PR TITLE
Remove conditional_more_than_two.

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -130,12 +130,6 @@ constexpr bool more_than_one(Bitboard b) {
   return b & (b - 1);
 }
 
-/// Counts the occupation of the bitboard depending on the occupation of SQ_A1
-/// as in `b & (1ULL << SQ_A1) ? more_than_two(b) : more_than_one(b)`
-
-constexpr bool conditional_more_than_two(Bitboard b) {
-  return b & (b - 1) & (b - 2);
-}
 
 constexpr bool opposite_colors(Square s1, Square s2) {
   return (s1 + rank_of(s1) + s2 + rank_of(s2)) & 1;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -310,13 +310,15 @@ namespace {
 
         if (Pt == BISHOP || Pt == KNIGHT)
         {
-            // Bonus if piece is on an outpost square or can reach one
+            // Bonus if the piece is on an outpost square or can reach one
+            // Reduced bonus for knights (BadOutpost) if few relevant targets
             bb = OutpostRanks & attackedBy[Us][PAWN] & ~pe->pawn_attacks_span(Them);
+            Bitboard targets = pos.pieces(Them) & ~pos.pieces(PAWN);
+
             if (   Pt == KNIGHT
-                && bb & s & ~CenterFiles
-                && !(b & pos.pieces(Them) & ~pos.pieces(PAWN))
-                && !conditional_more_than_two(
-                      pos.pieces(Them) & ~pos.pieces(PAWN) & (s & QueenSide ? QueenSide : KingSide)))
+                && bb & s & ~CenterFiles // on a side outpost
+                && !(b & targets)        // no relevant attacks
+                && (!more_than_one(targets & (s & QueenSide ? QueenSide : KingSide))))
                 score += BadOutpost;
             else if (bb & s)
                 score += Outpost[Pt == BISHOP];


### PR DESCRIPTION
This is a functional simplification that removes the conditional_more_than_two.  Note the very minor change to the bench value.

I think it is a mild improvement because the conditional_more_than_two is quite strange and kooky.

This is NOT the exact version that passed.  I have changed a variable name and removed another variable.

See this thread for relevant comments on the passing branch.
https://github.com/protonspring/Stockfish/compare/d89730d5c8...ff35b50c7d

STC
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 59760 W: 11411 L: 11311 D: 37038
Ptnml(0-2): 992, 6863, 14044, 7015, 966 
https://tests.stockfishchess.org/tests/view/5f179988c09435d870cb9b9a

LTC
LLR: 2.93 (-2.94,2.94) {-1.50,0.50}
Total: 45208 W: 5553 L: 5497 D: 34158
Ptnml(0-2): 315, 4081, 13761, 4127, 320 
https://tests.stockfishchess.org/tests/view/5f184847c09435d870cb9bee

bench 4578290