### PR TITLE
Fix NNUE build on macOS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -363,8 +363,8 @@ endif
 endif
 
 ifeq ($(KERNEL),Darwin)
-	CXXFLAGS += -arch $(arch) -mmacosx-version-min=10.9
-	LDFLAGS += -arch $(arch) -mmacosx-version-min=10.9
+	CXXFLAGS += -arch $(arch) -mmacosx-version-min=10.15
+	LDFLAGS += -arch $(arch) -mmacosx-version-min=10.15
 endif
 
 ### Travis CI script uses COMPILER to overwrite CXX

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -32,6 +32,7 @@ ExtPieceSquare kpp_board_index[PIECE_NB] = {
     { PS_NONE,     PS_NONE     }
 };
 
+
 namespace Eval::NNUE {
 
   // Input feature converter

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -32,7 +32,6 @@ ExtPieceSquare kpp_board_index[PIECE_NB] = {
     { PS_NONE,     PS_NONE     }
 };
 
-
 namespace Eval::NNUE {
 
   // Input feature converter
@@ -57,7 +56,7 @@ namespace Eval::NNUE {
   template <typename T>
   void Initialize(AlignedPtr<T>& pointer) {
 
-    pointer.reset(reinterpret_cast<T*>(std::aligned_alloc(alignof(T), sizeof(T))));
+    pointer.reset(reinterpret_cast<T*>(aligned_alloc(alignof(T), sizeof(T))));
     std::memset(pointer.get(), 0, sizeof(T));
   }
 


### PR DESCRIPTION
Fixes the two issues mentioned in https://github.com/official-stockfish/Stockfish/issues/2823#issuecomment-663904905.

Specifically:

1. Makefile: Updates the min macOS version to 10.15 from 10.9, because aligned_alloc is only available in 10.15+.
2. On macOS, `aligned_alloc` is in the global namespace. Remove `std::` from `std::aligned_alloc`. This still builds on Linux.

Testing:
- Compiled with clang on macOS 10.15 `make build ARCH=x86-64-bmi2`
- Compiled with GCC on Ubuntu 18.04.3 `make build ARCH=x86-64-avx512`