### PR TITLE
[NNUE] Fix unused variable warning

### DIFF
--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -113,9 +113,10 @@ namespace Eval::NNUE::Layers {
 
   #elif defined(USE_SSSE3)
       constexpr IndexType kNumChunks = kInputDimensions / kSimdWidth;
-      const __m128i kZero = _mm_setzero_si128();
 
-  #ifndef USE_SSE41
+  #ifdef USE_SSE41
+      const __m128i kZero = _mm_setzero_si128();
+  #else
       const __m128i k0x80s = _mm_set1_epi8(-128);
   #endif
 

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -79,9 +79,10 @@ namespace Eval::NNUE {
 
   #elif defined(USE_SSSE3)
       constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
-      const __m128i kZero = _mm_setzero_si128();
 
-  #ifndef USE_SSE41
+  #ifdef USE_SSE41
+      const __m128i kZero = _mm_setzero_si128();
+  #else
       const __m128i k0x80s = _mm_set1_epi8(-128);
   #endif
 


### PR DESCRIPTION
for certain targets. Only define variable when needed.

No functional change.