### PR TITLE
Remove late irreversible move extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1067,7 +1067,7 @@ moves_loop: // When in check, search starts from here
       // search of (alpha-s, beta-s), and just one fails high on (alpha, beta),
       // then that move is singular and should be extended. To verify this we do
       // a reduced search on all the other moves but the ttMove and if the
-      // result is lower than ttValue minus a margin then we will extend the ttMove.
+      // result is lower than ttValue minus a margin, then we will extend the ttMove.
       if (    depth >= 6
           &&  move == ttMove
           && !rootNode

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1131,12 +1131,6 @@ moves_loop: // When in check, search starts from here
       if (type_of(move) == CASTLING)
           extension = 1;
 
-      // Late irreversible move extension
-      if (   move == ttMove
-          && pos.rule50_count() > 80
-          && (captureOrPromotion || type_of(movedPiece) == PAWN))
-          extension = 2;
-
       // Add extension to new depth
       newDepth += extension;
 


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f1c9669c09435d870cb9de9
LLR: 2.93 (-2.94,2.94) {-1.50,0.50}
Total: 38584 W: 7464 L: 7342 D: 23778
Ptnml(0-2): 581, 4328, 9365, 4424, 594

LTC https://tests.stockfishchess.org/tests/view/5f1d2e22c09435d870cb9e21
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 27840 W: 3417 L: 3353 D: 21070
Ptnml(0-2): 120, 2315, 8994, 2363, 128

bench: 4829418

Remove late irreversible move extension.