### PR TITLE
[NNUE] UCI default crash fix

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -215,7 +215,7 @@ namespace {
 
 void UCI::init_nnue(const std::string& evalFile)
 {
-  if (UCI::use_nnue && !UCI::load_eval_finished)
+  if (Options["Use NNUE"] && !UCI::load_eval_finished)
   {
       // Load evaluation function from a file
       Eval::NNUE::load_eval(evalFile);

--- a/src/uci.h
+++ b/src/uci.h
@@ -79,7 +79,6 @@ Move to_move(const Position& pos, std::string& str);
 void init_nnue(const std::string& evalFile);
 
 extern bool load_eval_finished;
-extern bool use_nnue;
 
 } // namespace UCI
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -44,9 +44,8 @@ void on_threads(const Option& o) { Threads.set(size_t(o)); }
 void on_tb_path(const Option& o) { Tablebases::init(o); }
 
 void on_use_nnue(const Option& o) {
-  use_nnue = o;
 
-  if (use_nnue)
+  if (o)
     std::cout << "info string NNUE eval used" << std::endl;
   else
     std::cout << "info string Standard eval used" << std::endl;
@@ -204,6 +203,5 @@ Option& Option::operator=(const string& v) {
   return *this;
 }
 
-bool use_nnue = false;
 bool load_eval_finished = false;
 } // namespace UCI


### PR DESCRIPTION
Fix a crash that would happen when line 97 in ucioption.cpp was changed from
o["Use NNUE"]              << Option(false, on_use_nnue);
to
o["Use NNUE"]              << Option(true, on_use_nnue);
This was because the UCI::use_nnue variable was never updated to true.

bench: 4578298
NNUE: 3377227