### PR TITLE
[NNUE] Cleanup and optimize SSE/AVX code

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -455,7 +455,7 @@ endif
 ifeq ($(avx512),yes)
 	CXXFLAGS += -DUSE_AVX512
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw msys2))
-		CXXFLAGS += -mavx512bw
+		CXXFLAGS += -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl
 	endif
 endif
 


### PR DESCRIPTION
Most of this is from the original PR https://github.com/nodchip/Stockfish/pull/69
See previous comments there.  Thanks to @sf-x.

1) Optimize and clean up Propagate() code in affine_transform.h
In the original PR I measured (and some people verified) speed gains of 8% to 10%.
In this branch I measure the same speedups to be more modest. I'm not sure why.
AVX512  6%
AVX2  1%
SSSE3  5%

2) Add AVX512 support to RefreshAccumulator().  AVX512 is now 8% faster than AVX2.

3) Enable all lowest common denominator(Skylake) AVX512 instructions in the Makefile.
A nice reference here: https://en.wikichip.org/wiki/x86/avx-512

No functional change

bench: 4578298
NNUE: 3377227