### PR TITLE
[NNUE] init networks also for cmdline use

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -238,6 +238,9 @@ void UCI::loop(int argc, char* argv[]) {
 
   pos.set(StartFEN, false, Options["Use NNUE"], &states->back(), Threads.main());
 
+  if (argc > 1)
+     init_nnue(Options["EvalFile"]);
+
   for (int i = 1; i < argc; ++i)
       cmd += std::string(argv[i]) + " ";
 


### PR DESCRIPTION
`./stockfish go depth 10`

now works if `Use NNUE` defaults to true.

No functional change