### PR TITLE
[NNUE] Add authors to the AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,14 +1,17 @@
 # List of authors for Stockfish, as of March 30, 2020
 
+# Founders of the Stockfish project and fishtest infrastructure
 Tord Romstad (romstad)
 Marco Costalba (mcostalba)
 Joona Kiiski (zamar)
 Gary Linscott (glinscott)
 
-Yu Nasu (ynasu87)              # The original inventor of NNUE
-Motohiro Isozaki (yaneurao)    # The author of the training data generator and the trainer
-Hisayori Noda (nodchip)        # Ported NNUE to Stockfish.
+# Authors and inventors of NNUE, training, NNUE port
+Yu Nasu (ynasu87)
+Motohiro Isozaki (yaneurao)
+Hisayori Noda (nodchip)
 
+# all other authors of the code in alphabetical order
 Aditya (absimaldata)
 Adrian Petrescu (apetresc)
 Ajith Chandy Jose (ajithcj)
@@ -120,6 +123,7 @@ Nicklas Persson (NicklasPersson)
 Niklas Fiekas (niklasf)
 Nikolay Kostov (NikolayIT)
 Nguyen Pham
+Norman Schmidt (FireFather)
 Ondrej Mosnáček (WOnder93)
 Oskar Werkelin Ahlin
 Pablo Vazquez
@@ -139,6 +143,7 @@ Richard Lloyd
 Rodrigo Exterckötter Tjäder
 Ron Britvich (Britvich)
 Ronald de Man (syzygy1, syzygy)
+rqs
 Ryan Schmitt
 Ryan Takker
 Sami Kiminki (skiminki)
@@ -147,6 +152,7 @@ Sergei Antonov (saproj)
 Sergei Ivanov (svivanov72)
 sf-x
 Shane Booth (shane31)
+Shawn Varghese (xXH4CKST3RXx)
 Stefan Geschwentner (locutus2)
 Stefano Cardanobile (Stefano80)
 Steinar Gunderson (sesse)
@@ -159,9 +165,11 @@ Tom Vijlbrief (tomtor)
 Tomasz Sobczyk (Sopel97)
 Torsten Franz (torfranz, tfranzer)
 Tracey Emery (basepr1me)
+tttak
 Unai Corzo (unaiic)
 Uri Blass (uriblass)
 Vince Negri (cuddlestmonkey)
+zz4032
 
 
 # Additionally, we acknowledge the authors and maintainers of fishtest,


### PR DESCRIPTION
add missing contributors based on git commit history

@tttak           
@HiraokaTakuya
@zz4032
@FireFather
@rqs
@xXH4CKST3RXx

I have added you the AUTHORS file, based on the commit history. If you would like to have your full name added to the file (or need to correct a mistake I made), please reply to this PR (even if already closed).

Get it touch if you are one of the missing authors (No name) and would like to be added.