### PR TITLE
[NNUE] Improve handling of 'evalnn' command

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -40,8 +40,6 @@ namespace Trace {
 
   Score scores[TERM_NB][COLOR_NB];
 
-  double to_cp(Value v) { return double(v) / PawnValueEg; }
-
   void add(int idx, Color c, Score s) {
     scores[idx][c] = s;
   }
@@ -52,8 +50,8 @@ namespace Trace {
   }
 
   std::ostream& operator<<(std::ostream& os, Score s) {
-    os << std::setw(5) << to_cp(mg_value(s)) << " "
-       << std::setw(5) << to_cp(eg_value(s));
+    os << std::setw(5) << Eval::to_cp(mg_value(s)) << " "
+       << std::setw(5) << Eval::to_cp(eg_value(s));
     return os;
   }
 
@@ -895,6 +893,9 @@ make_v:
 
 } // namespace
 
+double Eval::to_cp(Value v) {
+  return double(v) / PawnValueEg;
+}
 
 /// evaluate() is the evaluator for the outer world. It returns a static
 /// evaluation of the position from the point of view of the side to move.

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -32,6 +32,8 @@ namespace Eval {
 std::string trace(const Position& pos);
 Value evaluate(const Position& pos);
 
+double to_cp(Value v);
+
 namespace NNUE {
 
 Value evaluate(const Position& pos);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <cmath>
 #include <iostream>
+#include <iomanip>
 #include <sstream>
 #include <string>
 
@@ -215,11 +216,11 @@ namespace {
 
 void UCI::init_nnue(const std::string& evalFile)
 {
-  if (Options["Use NNUE"] && !UCI::load_eval_finished)
+  if (Options["Use NNUE"] && !UCI::nnue_eval_loaded)
   {
       // Load evaluation function from a file
       Eval::NNUE::load_eval(evalFile);
-      UCI::load_eval_finished = true;
+      UCI::nnue_eval_loaded = true;
   }
 }
 
@@ -290,8 +291,15 @@ void UCI::loop(int argc, char* argv[]) {
       else if (token == "d")        sync_cout << pos << sync_endl;
       else if (token == "eval")     sync_cout << Eval::trace(pos) << sync_endl;
       else if (token == "compiler") sync_cout << compiler_info() << sync_endl;
-      else if (token == "evalnn")   sync_cout << "NNUE evaluation: "
-                                    << Eval::NNUE::compute_eval(pos) << sync_endl;
+      else if (token == "evalnn") {
+        sync_cout << "NNUE evaluation: " << IO_UNLOCK;
+        if (!nnue_eval_loaded)
+          sync_cout << "N/A" << sync_endl;
+        else
+          sync_cout << std::fixed << std::setprecision(2)
+                    << Eval::to_cp(Eval::NNUE::compute_eval(pos))
+                    << sync_endl;
+      }
       else
           sync_cout << "Unknown command: " << cmd << sync_endl;
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -78,7 +78,7 @@ Move to_move(const Position& pos, std::string& str);
 
 void init_nnue(const std::string& evalFile);
 
-extern bool load_eval_finished;
+extern bool nnue_eval_loaded;
 
 } // namespace UCI
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -54,7 +54,7 @@ void on_use_nnue(const Option& o) {
 }
 
 void on_eval_file(const Option& o) {
-  load_eval_finished = false;
+  nnue_eval_loaded = false;
   init_nnue(o);
 }
 
@@ -203,5 +203,5 @@ Option& Option::operator=(const string& v) {
   return *this;
 }
 
-bool load_eval_finished = false;
+bool nnue_eval_loaded = false;
 } // namespace UCI


### PR DESCRIPTION
Output is now converted to centipawns and formatted correctly. Improved handling if NNUE eval is not available.

No functional change.