### PR TITLE
[NNUE] Clamp NNUE evaluation score

### DIFF
--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -152,7 +152,10 @@ namespace Eval::NNUE {
 
   // Evaluation function. Perform differential calculation.
   Value evaluate(const Position& pos) {
-    return ComputeScore(pos, false);
+    Value v = ComputeScore(pos, false);
+    v = Utility::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
+
+    return v;
   }
 
   // Evaluation function. Perform full calculation.


### PR DESCRIPTION
Add eval score clamp for safety. However bench doesn't change, the evaluation score seems to never be clamped, at least for now.

No functional change.