### PR TITLE
Fix build on ARM Linux

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -172,9 +172,11 @@ ifeq ($(COMP),gcc)
 			CXXFLAGS += -m$(bits)
 			LDFLAGS += -m$(bits)
 		endif
-	else
 		CXXFLAGS += -m$(bits)
 		LDFLAGS += -m$(bits)
+		ifeq ($(OS),GNU/Linux)
+			LDFLAGS += -latomic
+		endif
 	endif
 
 	ifneq ($(KERNEL),Darwin)

--- a/src/Makefile
+++ b/src/Makefile
@@ -172,8 +172,10 @@ ifeq ($(COMP),gcc)
 			CXXFLAGS += -m$(bits)
 			LDFLAGS += -m$(bits)
 		endif
-		CXXFLAGS += -m$(bits)
-		LDFLAGS += -m$(bits)
+		ifeq ($(findstring '--enable-multilib',$(shell gcc -v 2>&1)),'--enable-multilib')
+			CXXFLAGS += -m$(bits)
+			LDFLAGS += -m$(bits)
+		endif
 		ifeq ($(OS),GNU/Linux)
 			LDFLAGS += -latomic
 		endif


### PR DESCRIPTION
Need to explicitly link against libatomic on (non-Android) ARM Linux w/ GCC.

Also remove -m$(bits) from general CXX+LDFLAGS as this breaks if GCC is built without multilib support.