### PR TITLE
[NNUE] Fix redundant loading data

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -133,7 +133,7 @@ namespace {
         else if (token == "infinite")  limits.infinite = 1;
         else if (token == "ponder")    ponderMode = true;
 
-    if (!limits.infinite) {
+    if (!limits.perft) {
       init_nnue(Options["EvalFile"]);
     }    
     Threads.start_thinking(pos, states, limits, ponderMode);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -133,6 +133,9 @@ namespace {
         else if (token == "infinite")  limits.infinite = 1;
         else if (token == "ponder")    ponderMode = true;
 
+    if (!limits.infinite) {
+      init_nnue(Options["EvalFile"]);
+    }    
     Threads.start_thinking(pos, states, limits, ponderMode);
   }
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -49,8 +49,6 @@ void on_use_nnue(const Option& o) {
     std::cout << "info string NNUE eval used" << std::endl;
   else
     std::cout << "info string Standard eval used" << std::endl;
-
-  init_nnue(Options["EvalFile"]);
 }
 
 void on_eval_file(const Option& o) {


### PR DESCRIPTION
Whenever a user turns on NNUE mode (`setoption name Use NNUE value true`) the default network is autoloaded immediately. If the user wants to run the engine with another network he has to load again, making redundancy and confusion.

- Delete the default network may avoid that loading but create an error message.
- Change the order of commands for setting options (say `EvalFile` before `Use NNUE`) is good but not the solution since it depends on chess GUIs

In this PR, the initialization of the network is removed when setting the option `Use NNUE` and add to command `go` instead (there is an existent place to init in command `ucinewgame`).