### PR TITLE
Improve handling of queen imbalance

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -577,17 +577,21 @@ namespace {
     // Bonus for threats on the next moves against enemy queen
     if (pos.count<QUEEN>(Them) == 1)
     {
+        bool queenImbalance = pos.count<QUEEN>() == 1;
+
         Square s = pos.square<QUEEN>(Them);
-        safe = mobilityArea[Us] & ~stronglyProtected;
+        safe =   mobilityArea[Us]
+              & ~pos.pieces(Us, PAWN)
+              & ~stronglyProtected;
 
         b = attackedBy[Us][KNIGHT] & attacks_bb<KNIGHT>(s);
 
-        score += KnightOnQueen * popcount(b & safe);
+        score += KnightOnQueen * popcount(b & safe) * (1 + queenImbalance);
 
         b =  (attackedBy[Us][BISHOP] & attacks_bb<BISHOP>(s, pos.pieces()))
            | (attackedBy[Us][ROOK  ] & attacks_bb<ROOK  >(s, pos.pieces()));
 
-        score += SliderOnQueen * popcount(b & safe & attackedBy2[Us]);
+        score += SliderOnQueen * popcount(b & safe & attackedBy2[Us]) * (1 + queenImbalance);
     }
 
     if (T)


### PR DESCRIPTION
We double the bonus for potential threats by minors and rooks against
our queen, in case of "queen vs pieces imbalance". Hopefully this will
improve a little bit the evaluation for this well-known Stockfish weakness.

passed STC:
LLR: 2.93 (-2.94,2.94) {-0.50,1.50} 
Total: 72976 W: 14003 L: 13710 D: 45263 
Ptnml(0-2): 1218, 8370, 17094, 8513, 1293
https://tests.stockfishchess.org/tests/view/5efa50eb020eec13834a977d

passed LTC:
LLR: 2.93 (-2.94,2.94) {0.25,1.75} 
Total: 22232 W: 2779 L: 2560 D: 16893 
Ptnml(0-2): 129, 1885, 6896, 2050, 156
https://tests.stockfishchess.org/tests/view/5f1fdd2dc09435d870cb9f13

closes https://github.com/official-stockfish/Stockfish/pull/2864

Bench: 4100247