### PR TITLE
Tweak cutnode reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1173,6 +1173,10 @@ moves_loop: // When in check, search starts from here
       {
           Depth r = reduction(improving, depth, moveCount);
 
+          // Decrease reduction at non-check cut nodes for second move at low depths
+          if (cutNode && depth <= 10 && moveCount <= 2 && !ss->inCheck)
+              r--;
+
           // Decrease reduction if the ttHit running average is large
           if (thisThread->ttHitAverage > 473 * TtHitAverageResolution * TtHitAverageWindow / 1024)
               r--;


### PR DESCRIPTION
Less reduction for second move at non-check CUT node with depth <= 10

STC:
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 38680 W: 7490 L: 7245 D: 23945
Ptnml(0-2): 643, 4441, 8967, 4606, 683
https://tests.stockfishchess.org/tests/view/5f21e1782f7e63962b99f451

LTC:
LLR: 2.95 (-2.94,2.94) {0.25,1.75}
Total: 71976 W: 9003 L: 8636 D: 54337
Ptnml(0-2): 440, 6414, 21972, 6663, 499
https://tests.stockfishchess.org/tests/view/5f2245762f7e63962b99f4bd

Bench: 4623578