### PR TITLE
[NNUE] Eval types, bench, PGO

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -117,6 +117,7 @@ vector<string> setup_bench(const Position& current, istream& is) {
   string limit     = (is >> token) ? token : "13";
   string fenFile   = (is >> token) ? token : "default";
   string limitType = (is >> token) ? token : "depth";
+  string evalType  = (is >> token) ? token : "Blend";
 
   go = limitType == "eval" ? "eval" : "go " + limitType + " " + limit;
 
@@ -146,6 +147,7 @@ vector<string> setup_bench(const Position& current, istream& is) {
 
   list.emplace_back("setoption name Threads value " + threads);
   list.emplace_back("setoption name Hash value " + ttSize);
+  list.emplace_back("setoption name Eval Type value " + evalType);
   list.emplace_back("ucinewgame");
 
   for (const string& fen : fens)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -900,10 +900,13 @@ make_v:
 /// evaluation of the position from the point of view of the side to move.
 
 Value Eval::evaluate(const Position& pos) {
-  if (pos.use_nnue())
+  
+  if (pos.eval_type() == ET_NNUE)
     return NNUE::evaluate(pos);
-  else
+  else if(pos.eval_type() == ET_STANDARD)
     return Evaluation<NO_TRACE>(pos).value();
+  else
+    return (NNUE::evaluate(pos) + Evaluation<NO_TRACE>(pos).value()) / 2;
 }
 
 /// trace() is like evaluate(), but instead of returning a value, it returns
@@ -921,7 +924,7 @@ std::string Eval::trace(const Position& pos) {
 
   Value v;
 
-  if (pos.use_nnue())
+  if (pos.eval_type() == ET_NNUE)
   {
     v = NNUE::evaluate(pos);
   }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -80,7 +80,7 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
   {
       StateInfo st;
       Position p;
-      p.set(pos.fen(), pos.is_chess960(), pos.use_nnue(), &st, pos.this_thread());
+      p.set(pos.fen(), pos.is_chess960(), pos.eval_type(), &st, pos.this_thread());
       Tablebases::ProbeState s1, s2;
       Tablebases::WDLScore wdl = Tablebases::probe_wdl(p, &s1);
       int dtz = Tablebases::probe_dtz(p, &s2);
@@ -154,7 +154,7 @@ void Position::init() {
 /// This function is not very robust - make sure that input FENs are correct,
 /// this is assumed to be the responsibility of the GUI.
 
-Position& Position::set(const string& fenStr, bool isChess960, bool useNnue, StateInfo* si, Thread* th) {
+Position& Position::set(const string& fenStr, bool isChess960, EvalType evType, StateInfo* si, Thread* th) {
 /*
    A FEN string defines a particular position using only the ASCII character set.
 
@@ -219,7 +219,7 @@ Position& Position::set(const string& fenStr, bool isChess960, bool useNnue, Sta
           auto pc = Piece(idx);
           put_piece(pc, sq);
 
-          if (useNnue)
+          if (evType != ET_STANDARD)
           {
             // Kings get a fixed ID, other pieces get ID in order of placement
             piece_id =
@@ -295,7 +295,7 @@ Position& Position::set(const string& fenStr, bool isChess960, bool useNnue, Sta
   gamePly = std::max(2 * (gamePly - 1), 0) + (sideToMove == BLACK);
 
   chess960 = isChess960;
-  nnue = useNnue;
+  evalType = evType;
   thisThread = th;
   set_state(st);
 
@@ -404,7 +404,7 @@ Position& Position::set(const string& code, Color c, StateInfo* si) {
   string fenStr = "8/" + sides[0] + char(8 - sides[0].length() + '0') + "/8/8/8/8/"
                        + sides[1] + char(8 - sides[1].length() + '0') + "/8 w - - 0 10";
 
-  return set(fenStr, false, false, si, nullptr);
+  return set(fenStr, false, ET_STANDARD, si, nullptr);
 }
 
 
@@ -776,7 +776,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       else
           st->nonPawnMaterial[them] -= PieceValue[MG][captured];
 
-      if (use_nnue())
+      if (eval_type() != ET_STANDARD)
           dp1 = piece_id_on(capsq);
 
       // Update board and piece lists
@@ -795,7 +795,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       // Reset rule 50 counter
       st->rule50 = 0;
 
-      if (use_nnue())
+      if (eval_type() != ET_STANDARD)
       {
           dp.dirty_num = 2; // 2 pieces moved
           dp.pieceId[1] = dp1;
@@ -828,7 +828,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
 
   // Move the piece. The tricky Chess960 castling is handled earlier
   if (type_of(m) != CASTLING) {
-    if (use_nnue())
+    if (eval_type() != ET_STANDARD)
     {
         dp0 = piece_id_on(from);
         dp.pieceId[0] = dp0;
@@ -860,7 +860,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           remove_piece(to);
           put_piece(promotion, to);
 
-          if (use_nnue())
+          if (eval_type() != ET_STANDARD)
           {
               dp0 = piece_id_on(to);
               evalList.put_piece(dp0, to, promotion);
@@ -959,7 +959,7 @@ void Position::undo_move(Move m) {
       
       move_piece(to, from); // Put the piece back at the source square
 
-      if (use_nnue())
+      if (eval_type() != ET_STANDARD)
       {
           PieceId dp0 = st->dirtyPiece.pieceId[0];
           evalList.put_piece(dp0, from, pc);
@@ -982,7 +982,7 @@ void Position::undo_move(Move m) {
 
           put_piece(st->capturedPiece, capsq); // Restore the captured piece
 
-          if (use_nnue())
+          if (eval_type() != ET_STANDARD)
           {
               PieceId dp1 = st->dirtyPiece.pieceId[1];
               assert(evalList.piece_with_id(dp1).from[WHITE] == PS_NONE);
@@ -1010,7 +1010,7 @@ void Position::do_castling(Color us, Square from, Square& to, Square& rfrom, Squ
   rto = relative_square(us, kingSide ? SQ_F1 : SQ_D1);
   to = relative_square(us, kingSide ? SQ_G1 : SQ_C1);
 
-  if (use_nnue())
+  if (eval_type() != ET_STANDARD)
   {
     PieceId dp0, dp1;
     auto& dp = st->dirtyPiece;
@@ -1066,7 +1066,7 @@ void Position::do_null_move(StateInfo& newSt) {
   st->key ^= Zobrist::side;
   prefetch(TT.first_entry(st->key));
 
-  if (use_nnue())
+  if (eval_type() != ET_STANDARD)
       st->accumulator.computed_score = false;
 
   ++st->rule50;
@@ -1323,7 +1323,7 @@ void Position::flip() {
   std::getline(ss, token); // Half and full moves
   f += token;
 
-  set(f, is_chess960(), use_nnue(), st, this_thread());
+  set(f, is_chess960(), eval_type(), st, this_thread());
 
   assert(pos_is_ok());
 }

--- a/src/position.h
+++ b/src/position.h
@@ -86,7 +86,7 @@ public:
   Position& operator=(const Position&) = delete;
 
   // FEN string input/output
-  Position& set(const std::string& fenStr, bool isChess960,  bool useNnue, StateInfo* si, Thread* th);
+  Position& set(const std::string& fenStr, bool isChess960, EvalType evType, StateInfo* si, Thread* th);
   Position& set(const std::string& code, Color c, StateInfo* si);
   const std::string fen() const;
 
@@ -157,7 +157,7 @@ public:
   Color side_to_move() const;
   int game_ply() const;
   bool is_chess960() const;
-  bool use_nnue() const;
+  EvalType eval_type() const;
   Thread* this_thread() const;
   bool is_draw(int ply) const;
   bool has_game_cycle(int ply) const;
@@ -207,7 +207,7 @@ private:
   Thread* thisThread;
   StateInfo* st;
   bool chess960;
-  bool nnue;
+  EvalType evalType;
 
   // List of pieces used in NNUE evaluation function
   EvalList evalList;
@@ -376,8 +376,8 @@ inline bool Position::is_chess960() const {
   return chess960;
 }
 
-inline bool Position::use_nnue() const {
-  return nnue;
+inline EvalType Position::eval_type() const {
+  return evalType;
 }
 
 inline bool Position::capture_or_promotion(Move m) const {

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -216,7 +216,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
       th->nodes = th->tbHits = th->nmpMinPly = th->bestMoveChanges = 0;
       th->rootDepth = th->completedDepth = 0;
       th->rootMoves = rootMoves;
-      th->rootPos.set(pos.fen(), pos.is_chess960(), pos.use_nnue(), &setupStates->back(), th);
+      th->rootPos.set(pos.fen(), pos.is_chess960(), pos.eval_type(), &setupStates->back(), th);
   }
 
   setupStates->back() = tmp;

--- a/src/types.h
+++ b/src/types.h
@@ -302,6 +302,12 @@ extern ExtPieceSquare kpp_board_index[PIECE_NB];
 constexpr bool is_ok(PieceId pid);
 constexpr Square rotate180(Square sq);
 
+enum EvalType {
+  ET_STANDARD,
+  ET_NNUE,
+  ET_BLEND
+};
+
 // Structure holding which tracked piece (PieceId) is where (PieceSquare)
 class EvalList
 {

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -43,17 +43,22 @@ void on_logger(const Option& o) { start_logger(o); }
 void on_threads(const Option& o) { Threads.set(size_t(o)); }
 void on_tb_path(const Option& o) { Tablebases::init(o); }
 
-void on_use_nnue(const Option& o) {
+void on_eval_type(const Option& o) {
 
-  if (o)
-    std::cout << "info string NNUE eval used" << std::endl;
+  if (o == "Standard")
+      std::cout << "info string Standard eval used" << std::endl;
   else
-    std::cout << "info string Standard eval used" << std::endl;
+  {
+      if (o == "NNUE")
+          std::cout << "info string NNUE eval used" << std::endl;
+      else // "Blend"
+          std::cout << "info string Blended eval used" << std::endl;
 
-  init_nnue(Options["EvalFile"]);
+      init_nnue(Options["NNUE Net"]);
+  }
 }
 
-void on_eval_file(const Option& o) {
+void on_nnue_net(const Option& o) {
   load_eval_finished = false;
   init_nnue(o);
 }
@@ -93,8 +98,8 @@ void init(OptionsMap& o) {
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(7, 0, 7);
-  o["Use NNUE"]              << Option(false, on_use_nnue);
-  o["EvalFile"]              << Option("nn-c157e0a5755b.nnue", on_eval_file);
+  o["Eval Type"]             << Option("Standard var Standard var NNUE var Blend", "Standard", on_eval_type);
+  o["NNUE Net"]              << Option("nn-c157e0a5755b.nnue", on_nnue_net);
 }
 
 


### PR DESCRIPTION
- Produce a single bench that depends on both Standard and NNUE evals
- PGO builds optimize both Standard and NNUE code paths

Separate benches can still be obtained individually by
stockfish.exe bench 16 1 13 default depth standard
stockfish.exe bench 16 1 13 default depth NNUE
and remain unchanged as  4578298 and 3377227 respectively.

bench: 4471333