### PR TITLE
Tweak reductions for evading moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1212,7 +1212,7 @@ moves_loop: // When in check, search starts from here
               // hence break make_move(). (~2 Elo)
               else if (    type_of(move) == NORMAL
                        && !pos.see_ge(reverse_move(move)))
-                  r -= 2 + ttPv - (type_of(movedPiece) == PAWN);
+                  r -= 2 + formerPv - (type_of(movedPiece) == PAWN);
 
               ss->statScore =  thisThread->mainHistory[us][from_to(move)]
                              + (*contHist[0])[movedPiece][to_sq(move)]


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5f2399232f7e63962b99f517
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 154008 W: 29345 L: 28935 D: 95728
Ptnml(0-2): 2574, 17878, 35726, 18216, 2610 
passed LTC
https://tests.stockfishchess.org/tests/view/5f23c7d12f7e63962b99f51f
LLR: 2.93 (-2.94,2.94) {0.25,1.75}
Total: 28664 W: 3612 L: 3370 D: 21682
Ptnml(0-2): 151, 2575, 8711, 2671, 224 
Change condition in less reduction for evading moves from ttPv to formerPv. 
Rebased to latest master.
bench 3993616