### PR TITLE
[NNUE] Address single bench and PGO issues

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -117,6 +117,7 @@ vector<string> setup_bench(const Position& current, istream& is) {
   string limit     = (is >> token) ? token : "13";
   string fenFile   = (is >> token) ? token : "default";
   string limitType = (is >> token) ? token : "depth";
+  string evType    = (is >> token) ? token : "Blend";
 
   go = limitType == "eval" ? "eval" : "go " + limitType + " " + limit;
 
@@ -146,6 +147,7 @@ vector<string> setup_bench(const Position& current, istream& is) {
 
   list.emplace_back("setoption name Threads value " + threads);
   list.emplace_back("setoption name Hash value " + ttSize);
+  list.emplace_back("setoption name Eval Type value " + evType);
   list.emplace_back("ucinewgame");
 
   for (const string& fen : fens)

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -27,12 +27,18 @@
 
 class Position;
 
+enum EvalType {
+  ET_CLASSIC,
+  ET_NNUE,
+  ET_BLEND
+};
+
 namespace Eval {
 
   std::string trace(const Position& pos);
   Value evaluate(const Position& pos);
 
-  extern bool useNNUE;
+  extern EvalType evalType;
   extern std::string eval_file_loaded;
   void init_NNUE();
   void verify_NNUE();

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -219,7 +219,7 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
           auto pc = Piece(idx);
           put_piece(pc, sq);
 
-          if (Eval::useNNUE)
+          if (Eval::evalType != ET_CLASSIC)
           {
               // Kings get a fixed ID, other pieces get ID in order of placement
               piece_id =
@@ -775,7 +775,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       else
           st->nonPawnMaterial[them] -= PieceValue[MG][captured];
 
-      if (Eval::useNNUE)
+      if (Eval::evalType != ET_CLASSIC)
       {
           dp.dirty_num = 2; // 2 pieces moved
           dp1 = piece_id_on(capsq);
@@ -821,7 +821,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   // Move the piece. The tricky Chess960 castling is handled earlier
   if (type_of(m) != CASTLING)
   {
-      if (Eval::useNNUE)
+      if (Eval::evalType != ET_CLASSIC)
       {
           dp0 = piece_id_on(from);
           dp.pieceId[0] = dp0;
@@ -854,7 +854,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           remove_piece(to);
           put_piece(promotion, to);
 
-          if (Eval::useNNUE)
+          if (Eval::evalType != ET_CLASSIC)
           {
               dp0 = piece_id_on(to);
               evalList.put_piece(dp0, to, promotion);
@@ -952,7 +952,7 @@ void Position::undo_move(Move m) {
   {
       move_piece(to, from); // Put the piece back at the source square
 
-      if (Eval::useNNUE)
+      if (Eval::evalType != ET_CLASSIC)
       {
           PieceId dp0 = st->dirtyPiece.pieceId[0];
           evalList.put_piece(dp0, from, pc);
@@ -975,7 +975,7 @@ void Position::undo_move(Move m) {
 
           put_piece(st->capturedPiece, capsq); // Restore the captured piece
 
-          if (Eval::useNNUE)
+          if (Eval::evalType != ET_CLASSIC)
           {
               PieceId dp1 = st->dirtyPiece.pieceId[1];
               assert(evalList.piece_with_id(dp1).from[WHITE] == PS_NONE);
@@ -1003,7 +1003,7 @@ void Position::do_castling(Color us, Square from, Square& to, Square& rfrom, Squ
   rto = relative_square(us, kingSide ? SQ_F1 : SQ_D1);
   to = relative_square(us, kingSide ? SQ_G1 : SQ_C1);
 
-  if (Eval::useNNUE)
+  if (Eval::evalType != ET_CLASSIC)
   {
       PieceId dp0, dp1;
       auto& dp = st->dirtyPiece;
@@ -1048,7 +1048,7 @@ void Position::do_null_move(StateInfo& newSt) {
   assert(!checkers());
   assert(&newSt != st);
 
-  if (Eval::useNNUE)
+  if (Eval::evalType != ET_CLASSIC)
   {
       std::memcpy(&newSt, st, sizeof(StateInfo));
       st->accumulator.computed_score = false;

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -42,7 +42,7 @@ void on_hash_size(const Option& o) { TT.resize(size_t(o)); }
 void on_logger(const Option& o) { start_logger(o); }
 void on_threads(const Option& o) { Threads.set(size_t(o)); }
 void on_tb_path(const Option& o) { Tablebases::init(o); }
-void on_use_NNUE(const Option& ) { Eval::init_NNUE(); }
+void on_eval_type(const Option& ) { Eval::init_NNUE(); }
 void on_eval_file(const Option& ) { Eval::init_NNUE(); }
 
 /// Our case insensitive less() function as required by UCI protocol
@@ -80,7 +80,7 @@ void init(OptionsMap& o) {
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(7, 0, 7);
-  o["Use NNUE"]              << Option(false, on_use_NNUE);
+  o["Eval Type"]             << Option("Classic var Classic var NNUE var Blend", "Classic", on_eval_type);
   o["EvalFile"]              << Option("nn-c157e0a5755b.nnue", on_eval_file);
 }
 


### PR DESCRIPTION
- Produce a single bench that depends on both Standard and NNUE evals
- PGO builds now optimize both Standard and NNUE code paths

Separate benches are still available individually by
stockfish.exe bench 16 1 13 default depth classic
stockfish.exe bench 16 1 13 default depth NNUE
and remain unchanged as 4578298 and 3377227 respectively.

bench: 4471333 (with  nn-c157e0a5755b.nnue present)
bench: 5196721  (without nn-c157e0a5755b.nnue present) This now fails due to new nnue-player-wip.
