### PR TITLE
[NNUE] Small fixes

### DIFF
--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -133,12 +133,21 @@ namespace Eval::NNUE {
     fileName = evalFile;
 
     std::ifstream stream(evalFile, std::ios::binary);
+
+    if (!stream) {
+        std::cout << "info string Error: " << fileName
+                  << " not found" << std::endl;
+        return;
+    }
+
     const bool result = ReadParameters(stream);
 
     if (!result)
-        std::cout << "Error! " << fileName << " not found or wrong format" << std::endl;
+        std::cout << "info string Error: format of " << fileName
+                  << " not recognized" << std::endl;
     else
-        std::cout << "info string NNUE " << fileName << " found & loaded" << std::endl;
+        std::cout << "info string NNUE " << fileName
+                  << " found & loaded" << std::endl;
   }
 
   // Evaluation function. Perform differential calculation.

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -97,6 +97,8 @@ void init(OptionsMap& o) {
   o["SyzygyProbeLimit"]      << Option(7, 0, 7);
   o["Use NNUE"]              << Option(false, on_use_nnue);
   o["EvalFile"]              << Option("nn-c157e0a5755b.nnue", on_eval_file);
+
+  Eval::useNNUE = Options["Use NNUE"];
 }
 
 


### PR DESCRIPTION
Improved UCI output if eval file is not found or not recognized.

Initialized variable Eval::useNNUE, otherwise its default value
is not recognized before setting "Use NNUE" option. For example,
./stockfish bench was broken if default "Use NNUE" value was "true".

Fixes #2886.

No functional change.