### PR TITLE
Wuo2a

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-## Overvieww
+## Overview
 
 [![Build Status](https://travis-ci.org/official-stockfish/Stockfish.svg?branch=master)](https://travis-ci.org/official-stockfish/Stockfish)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/official-stockfish/Stockfish?branch=master&svg=true)](https://ci.appveyor.com/project/mcostalba/stockfish/branch/master)

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-## Overview
+## Overvieww
 
 [![Build Status](https://travis-ci.org/official-stockfish/Stockfish.svg?branch=master)](https://travis-ci.org/official-stockfish/Stockfish)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/official-stockfish/Stockfish?branch=master&svg=true)](https://ci.appveyor.com/project/mcostalba/stockfish/branch/master)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -32,11 +32,11 @@ namespace {
   #define S(mg, eg) make_score(mg, eg)
 
   // Pawn penalties
-  constexpr Score Backward      = S( 8, 26);
-  constexpr Score Doubled       = S(11, 56);
+  constexpr Score Backward      = S( 8, 27);
+  constexpr Score Doubled       = S(11, 55);
   constexpr Score Isolated      = S( 5, 17);
-  constexpr Score WeakLever     = S( 1, 53);
-  constexpr Score WeakUnopposed = S(14, 25);
+  constexpr Score WeakLever     = S( 2, 54);
+  constexpr Score WeakUnopposed = S(15, 25);
 
   // Bonus for blocked pawns at 5th or 6th rank
   constexpr Score BlockedPawn[2] = { S(-13, -4), S(-4, 3) };
@@ -46,7 +46,7 @@ namespace {
   };
 
   // Connected pawn bonus
-  constexpr int Connected[RANK_NB] = { 0, 6, 8, 11, 24, 45, 86 };
+  constexpr int Connected[RANK_NB] = { 0, 7, 8, 11, 24, 45, 85 };
 
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -32,21 +32,21 @@ namespace {
   #define S(mg, eg) make_score(mg, eg)
 
   // Pawn penalties
-  constexpr Score Backward      = S( 9, 24);
+  constexpr Score Backward      = S( 8, 26);
   constexpr Score Doubled       = S(11, 56);
-  constexpr Score Isolated      = S( 5, 15);
-  constexpr Score WeakLever     = S( 0, 56);
-  constexpr Score WeakUnopposed = S(13, 27);
+  constexpr Score Isolated      = S( 5, 17);
+  constexpr Score WeakLever     = S( 1, 53);
+  constexpr Score WeakUnopposed = S(14, 25);
 
   // Bonus for blocked pawns at 5th or 6th rank
-  constexpr Score BlockedPawn[2] = { S(-11, -4), S(-3, 4) };
+  constexpr Score BlockedPawn[2] = { S(-13, -4), S(-4, 3) };
 
   constexpr Score BlockedStorm[RANK_NB] = {
     S(0, 0), S(0, 0), S(76, 78), S(-10, 15), S(-7, 10), S(-4, 6), S(-1, 2)
   };
 
   // Connected pawn bonus
-  constexpr int Connected[RANK_NB] = { 0, 7, 8, 12, 29, 48, 86 };
+  constexpr int Connected[RANK_NB] = { 0, 6, 8, 11, 24, 45, 86 };
 
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
@@ -82,6 +82,7 @@ namespace {
 
     constexpr Color     Them = ~Us;
     constexpr Direction Up   = pawn_push(Us);
+    constexpr Direction Down = -Up;
 
     Bitboard neighbours, stoppers, support, phalanx, opposed;
     Bitboard lever, leverPush, blocked;
@@ -168,6 +169,12 @@ namespace {
         else if (backward)
             score -=  Backward
                     + WeakUnopposed * !opposed;
+                    
+                    else if (   !support
+                 && !(stoppers ^ opposed)
+                 && neighbours == (neighbours & shift<Down>(theirPawns)))
+            score -=   Isolated
+                     + WeakUnopposed * !opposed;
 
         if (!support)
             score -=  Doubled * doubled

--- a/src/types.h
+++ b/src/types.h
@@ -180,7 +180,7 @@ enum Value : int {
   VALUE_MATE_IN_MAX_PLY  =  VALUE_MATE - MAX_PLY,
   VALUE_MATED_IN_MAX_PLY = -VALUE_MATE_IN_MAX_PLY,
 
-  PawnValueMg   = 124,   PawnValueEg   = 206,
+  PawnValueMg   = 126,   PawnValueEg   = 208,
   KnightValueMg = 781,   KnightValueEg = 854,
   BishopValueMg = 825,   BishopValueEg = 915,
   RookValueMg   = 1276,  RookValueEg   = 1380,


### PR DESCRIPTION
Also consider a pawn weak unopposed when all its backward pawns are blocked by the opponent and it is not supported.

I hope that @ElbertoOne will come and give more insight on the patch since the idea is originated from him.
I did the tuning necessary to make this patch pass (I will not lie, it was a long and tiring process for me, but also very exciting and accomplishing once it works at the end)

STC Passed:
https://tests.stockfishchess.org/tests/view/5f274ee30f76e6fab81b9052
LLR: 2.93 (-2.94,2.94) {-0.50,1.50}
Total: 123448 W: 23549 L: 23183 D: 76716
Ptnml(0-2): 2120, 14195, 28716, 14585, 2108

LTC Passed:
https://tests.stockfishchess.org/tests/view/5f28372be2e38f643a6d5614
LLR: 2.97 (-2.94,2.94) {0.25,1.75}
Total: 95160 W: 11963 L: 11526 D: 71671
Ptnml(0-2): 607, 8552, 28894, 8851, 676