### PR TITLE
[NNUE] Enable NEON for armv8

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -229,6 +229,7 @@ ifeq ($(ARCH),armv8)
 	arch = armv8-a
 	prefetch = yes
 	popcnt = yes
+	neon = yes
 endif
 
 ifeq ($(ARCH),apple-silicon)


### PR DESCRIPTION
Per https://developer.android.com/ndk/guides/cpu-arm-neon "All ARMv8-based devices support Neon."

More discussion here: https://github.com/official-stockfish/Stockfish/pull/2899#issuecomment-669331705