### PR TITLE
Search simplification

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1274,10 +1274,9 @@ moves_loop: // When in check, search starts from here
           }
       }
 
-      // For PV nodes only, do a full PV search on the first move or after a fail
-      // high (in the latter case search only if value < beta), otherwise let the
-      // parent node fail low with value <= alpha and try another move.
-      if (PvNode && (moveCount == 1 || (value > alpha && (rootNode || value < beta))))
+      // For PV nodes only, do a full PV search on the first move or after a fail high,
+      // otherwise let the parent node fail low with value <= alpha and try another move.
+      if (PvNode && (moveCount == 1 || value > alpha))
       {
           (ss+1)->pv = pv;
           (ss+1)->pv[0] = MOVE_NONE;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1274,10 +1274,9 @@ moves_loop: // When in check, search starts from here
           }
       }
 
-      // For PV nodes only, do a full PV search on the first move or after a fail
-      // high (in the latter case search only if value < beta), otherwise let the
-      // parent node fail low with value <= alpha and try another move.
-      if (PvNode && (moveCount == 1 || (value > alpha && (rootNode || value < beta))))
+      // For PV nodes only, do a full PV search on the first move or after a fail high,
+      // otherwise let the parent node fail low with value <= alpha and try another move.
+      if (PvNode && (moveCount == 1 || (value > alpha)))
       {
           (ss+1)->pv = pv;
           (ss+1)->pv[0] = MOVE_NONE;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1274,9 +1274,10 @@ moves_loop: // When in check, search starts from here
           }
       }
 
-      // For PV nodes only, do a full PV search on the first move or after a fail high,
-      // otherwise let the parent node fail low with value <= alpha and try another move.
-      if (PvNode && (moveCount == 1 || (value > alpha)))
+      // For PV nodes only, do a full PV search on the first move or after a fail
+      // high (in the latter case search only if value < beta), otherwise let the
+      // parent node fail low with value <= alpha and try another move.
+      if (PvNode && (moveCount == 1 || (value > alpha && (rootNode || value < beta))))
       {
           (ss+1)->pv = pv;
           (ss+1)->pv[0] = MOVE_NONE;


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f294e72a5abc164f05e4c7d
LLR: 2.97 (-2.94,2.94) {-1.50,0.50}
Total: 119344 W: 22540 L: 22522 D: 74282
Ptnml(0-2): 2073, 13759, 27890, 13977, 1973

LTC https://tests.stockfishchess.org/tests/view/5f2a7d9fa5abc164f05e4d0c
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 42672 W: 5239 L: 5179 D: 32254
Ptnml(0-2): 284, 3870, 12995, 3876, 311

bench: 4399403

Simplify search.