### PR TITLE
NNUE evaluation threshold

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -945,6 +945,7 @@ Value Eval::evaluate(const Position& pos) {
   {
       Value balance = pos.non_pawn_material(WHITE) - pos.non_pawn_material(BLACK);
       balance += 200 * (pos.count<PAWN>(WHITE) - pos.count<PAWN>(BLACK));
+      // Take NNUE eval only on balanced positions
       if (abs(balance) < NNUEThreshold)
          return NNUE::evaluate(pos);
   }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -110,6 +110,7 @@ namespace {
   constexpr Value LazyThreshold1  = Value(1400);
   constexpr Value LazyThreshold2  = Value(1300);
   constexpr Value SpaceThreshold = Value(12222);
+  constexpr Value NNUEThreshold   =  Value(500);
 
   // KingAttackWeights[PieceType] contains king attack weights by piece type
   constexpr int KingAttackWeights[PIECE_TYPE_NB] = { 0, 0, 81, 52, 44, 10 };
@@ -941,9 +942,13 @@ make_v:
 Value Eval::evaluate(const Position& pos) {
 
   if (Eval::useNNUE)
-      return NNUE::evaluate(pos);
-  else
-      return Evaluation<NO_TRACE>(pos).value();
+  {
+      Value balance = pos.non_pawn_material(WHITE) - pos.non_pawn_material(BLACK);
+      balance += 200 * (pos.count<PAWN>(WHITE) - pos.count<PAWN>(BLACK));
+      if (abs(balance) < NNUEThreshold)
+         return NNUE::evaluate(pos);
+  }
+  return Evaluation<NO_TRACE>(pos).value();
 }
 
 /// trace() is like evaluate(), but instead of returning a value, it returns


### PR DESCRIPTION
The idea is to use NNUE only on quite balanced material positions. This bring a big speedup on research since NNUE eval is slower than classical eval for most of the hardwares and specially on unbalanced positions with LazyEval.

STC: https://tests.stockfishchess.org/tests/view/5f2c2680b3ebe5cbfee85b61
LLR: 2.95 (-2.94,2.94) {-0.50,1.50}
Total: 3168 W: 560 L: 400 D: 2208
Ptnml(0-2): 21, 294, 819, 404, 46 

LTC: https://tests.stockfishchess.org/tests/view/5f2c2ca6b3ebe5cbfee85b69
LLR: 2.98 (-2.94,2.94) {0.25,1.75}
Total: 3200 W: 287 L: 183 D: 2730
Ptnml(0-2): 4, 149, 1191, 251, 5 

Bench 4746616