### PR TITLE
Download the default NNUE net in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,15 +61,15 @@ before_build:
 
       # Download default NNUE net from fishtest
       $nnuenet = Get-Content -Path src\ucioption.cpp | Select-String -CaseSensitive -Pattern "Option" | Select-String -CaseSensitive -Pattern "nn-[a-z0-9]{12}.nnue"
-      $nnuenet -match "(?<nnuenet>nn-[a-z0-9]{12}.nnue)"
+      $dummy = $nnuenet -match "(?<nnuenet>nn-[a-z0-9]{12}.nnue)"
       $nnuenet = $Matches.nnuenet
-      Write-Host "Default net: " $nnuenet
+      Write-Host "Default net:" $nnuenet
       $nnuedownloadurl = "https://tests.stockfishchess.org/api/nn/$nnuenet"
-      $nnuefilepath = "src\$nnuenet"
+      $nnuefilepath = "src\%CONFIGURATION%\$nnuenet"
       if (Test-Path -Path $nnuefilepath) {
             Write-Host "Already available."
       } else {
-            Write-Host "Downloading " $nnuedownloadurl
+            Write-Host "Downloading" $nnuedownloadurl
             Invoke-WebRequest -Uri $nnuedownloadurl -OutFile $nnuefilepath
       }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,6 +59,19 @@ before_build:
       cmake -G "${g}" -A ${a} .
       Write-Host "Generated files for: " $g $a
 
+      # Download default NNUE net from fishtest
+      $nnuenet = Get-Content -Path ucioption.cpp | Select-String -CaseSensitive -Pattern "Option" | Select-String -CaseSensitive -Pattern "nn-[a-z0-9]{12}.nnue"
+      $nnuenet -match "(?<nnuenet>nn-[a-z0-9]{12}.nnue)"
+      $nnuenet = $Matches.nnuenet
+      Write-Host "Default net: " $nnuenet
+      $nnuedownloadurl = "https://tests.stockfishchess.org/api/nn/$nnuenet"
+      if (Test-Path -Path $nnuenet) {
+            Write-Host "Already available."
+      } else {
+            Write-Host "Downloading " $nnuedownloadurl
+            Invoke-WebRequest -Uri $nnuedownloadurl -OutFile $nnuenet
+      }
+
 build_script:
   - cmake --build . --config %CONFIGURATION% -- /verbosity:minimal
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,22 +59,22 @@ before_build:
       cmake -G "${g}" -A ${a} .
       Write-Host "Generated files for: " $g $a
 
+build_script:
+  - cmake --build . --config %CONFIGURATION% -- /verbosity:minimal
+  - ps: |
       # Download default NNUE net from fishtest
       $nnuenet = Get-Content -Path src\ucioption.cpp | Select-String -CaseSensitive -Pattern "Option" | Select-String -CaseSensitive -Pattern "nn-[a-z0-9]{12}.nnue"
       $dummy = $nnuenet -match "(?<nnuenet>nn-[a-z0-9]{12}.nnue)"
       $nnuenet = $Matches.nnuenet
       Write-Host "Default net:" $nnuenet
       $nnuedownloadurl = "https://tests.stockfishchess.org/api/nn/$nnuenet"
-      $nnuefilepath = "$CMAKE_RUNTIME_OUTPUT_DIRECTORY\$nnuenet"
+      $nnuefilepath = "src\%CONFIGURATION%\$nnuenet"
       if (Test-Path -Path $nnuefilepath) {
             Write-Host "Already available."
       } else {
-            Write-Host "Downloading" $nnuedownloadurl
+            Write-Host "Downloading $nnuedownloadurl to $nnuefilepath"
             Invoke-WebRequest -Uri $nnuedownloadurl -OutFile $nnuefilepath
       }
-
-build_script:
-  - cmake --build . --config %CONFIGURATION% -- /verbosity:minimal
 
 before_test:
   - cd src/%CONFIGURATION%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,7 @@ before_build:
       $nnuenet = $Matches.nnuenet
       Write-Host "Default net:" $nnuenet
       $nnuedownloadurl = "https://tests.stockfishchess.org/api/nn/$nnuenet"
-      $nnuefilepath = "src\%CONFIGURATION%\$nnuenet"
+      $nnuefilepath = "src\" + %CONFIGURATION% + "\$nnuenet"
       if (Test-Path -Path $nnuefilepath) {
             Write-Host "Already available."
       } else {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,7 @@ build_script:
       $nnuenet = $Matches.nnuenet
       Write-Host "Default net:" $nnuenet
       $nnuedownloadurl = "https://tests.stockfishchess.org/api/nn/$nnuenet"
-      $nnuefilepath = "src\" %CONFIGURATION% "\$nnuenet"
+      $nnuefilepath = "src\" + %CONFIGURATION% + "\$nnuenet"
       if (Test-Path -Path $nnuefilepath) {
             Write-Host "Already available."
       } else {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,11 +65,12 @@ before_build:
       $nnuenet = $Matches.nnuenet
       Write-Host "Default net: " $nnuenet
       $nnuedownloadurl = "https://tests.stockfishchess.org/api/nn/$nnuenet"
-      if (Test-Path -Path $nnuenet) {
+      $nnuefilepath = "src\$nnuenet"
+      if (Test-Path -Path $nnuefilepath) {
             Write-Host "Already available."
       } else {
             Write-Host "Downloading " $nnuedownloadurl
-            Invoke-WebRequest -Uri $nnuedownloadurl -OutFile $nnuenet
+            Invoke-WebRequest -Uri $nnuedownloadurl -OutFile $nnuefilepath
       }
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ before_build:
       Write-Host "Generated files for: " $g $a
 
       # Download default NNUE net from fishtest
-      $nnuenet = Get-Content -Path ucioption.cpp | Select-String -CaseSensitive -Pattern "Option" | Select-String -CaseSensitive -Pattern "nn-[a-z0-9]{12}.nnue"
+      $nnuenet = Get-Content -Path src\ucioption.cpp | Select-String -CaseSensitive -Pattern "Option" | Select-String -CaseSensitive -Pattern "nn-[a-z0-9]{12}.nnue"
       $nnuenet -match "(?<nnuenet>nn-[a-z0-9]{12}.nnue)"
       $nnuenet = $Matches.nnuenet
       Write-Host "Default net: " $nnuenet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,7 @@ before_build:
       $nnuenet = $Matches.nnuenet
       Write-Host "Default net:" $nnuenet
       $nnuedownloadurl = "https://tests.stockfishchess.org/api/nn/$nnuenet"
-      $nnuefilepath = "src\" + %CONFIGURATION% + "\$nnuenet"
+      $nnuefilepath = "$CMAKE_RUNTIME_OUTPUT_DIRECTORY\$nnuenet"
       if (Test-Path -Path $nnuefilepath) {
             Write-Host "Already available."
       } else {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,7 @@ build_script:
       $nnuenet = $Matches.nnuenet
       Write-Host "Default net:" $nnuenet
       $nnuedownloadurl = "https://tests.stockfishchess.org/api/nn/$nnuenet"
-      $nnuefilepath = "src\%CONFIGURATION%\$nnuenet"
+      $nnuefilepath = "src\" %CONFIGURATION% "\$nnuenet"
       if (Test-Path -Path $nnuefilepath) {
             Write-Host "Already available."
       } else {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,7 @@ build_script:
       $nnuenet = $Matches.nnuenet
       Write-Host "Default net:" $nnuenet
       $nnuedownloadurl = "https://tests.stockfishchess.org/api/nn/$nnuenet"
-      $nnuefilepath = "src\" + %CONFIGURATION% + "\$nnuenet"
+      $nnuefilepath = "src\${env:CONFIGURATION}\$nnuenet"
       if (Test-Path -Path $nnuefilepath) {
             Write-Host "Already available."
       } else {


### PR DESCRIPTION
This is a partial PR concerning NNUE CI and PGO builds requested by
@vondele, it modifies the appveyor script so it downloads the default
NNUE net before the stockfish bench is run.

If have avoided using aliases like cat and echo because I don't know if
these are defined in the appveyor environment.

Note: I can't guarantee 100% that this works because to my knowledge
there is no way of testing the script before making the PR.

No functional change.