### PR TITLE
Futility pruning tweak

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -816,7 +816,7 @@ namespace {
 
     // Step 8. Futility pruning: child node (~50 Elo)
     if (   !PvNode
-        &&  depth < 6
+        &&  depth < 8
         &&  eval - futility_margin(depth, improving) >= beta
         &&  eval < VALUE_KNOWN_WIN) // Do not return unproven wins
         return eval;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -816,7 +816,7 @@ namespace {
 
     // Step 8. Futility pruning: child node (~50 Elo)
     if (   !PvNode
-        &&  depth < 8
+        &&  depth < 6
         &&  eval - futility_margin(depth, improving) >= beta
         &&  eval < VALUE_KNOWN_WIN) // Do not return unproven wins
         return eval;


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f2d237161e3b6af64881f43
LLR: 2.96 (-2.94,2.94) {-0.50,1.50}
Total: 12712 W: 1823 L: 1664 D: 9225
Ptnml(0-2): 122, 1166, 3627, 1313, 128

LTC https://tests.stockfishchess.org/tests/view/5f2d473061e3b6af64881f6f
LLR: 2.96 (-2.94,2.94) {0.25,1.75}
Total: 12104 W: 912 L: 788 D: 10404
Ptnml(0-2): 13, 665, 4582, 769, 23

Tweak futility pruning depth.

bench: 4271421