### PR TITLE
simplified and increased threshold to account for pawn difference fro…

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -110,7 +110,7 @@ namespace {
   constexpr Value LazyThreshold1 =  Value(1400);
   constexpr Value LazyThreshold2 =  Value(1300);
   constexpr Value SpaceThreshold = Value(12222);
-  constexpr Value NNUEThreshold  =   Value(500);
+  constexpr Value NNUEThreshold  =   Value(520);
 
   // KingAttackWeights[PieceType] contains king attack weights by piece type
   constexpr int KingAttackWeights[PIECE_TYPE_NB] = { 0, 0, 81, 52, 44, 10 };
@@ -938,10 +938,9 @@ Value Eval::evaluate(const Position& pos) {
 
   if (Eval::useNNUE)
   {
-      Value balance = pos.non_pawn_material(WHITE) - pos.non_pawn_material(BLACK);
-      balance += 200 * (pos.count<PAWN>(WHITE) - pos.count<PAWN>(BLACK));
+      Value v = eg_value(pos.psq_score());
       // Take NNUE eval only on balanced positions
-      if (abs(balance) < NNUEThreshold)
+      if (abs(v) < NNUEThreshold)
          return NNUE::evaluate(pos) + Tempo;
   }
   return Evaluation<NO_TRACE>(pos).value();


### PR DESCRIPTION
…m old formula by 4%. Testing further increases later. Didn't understand why pawns had to be broken out as separate and 200 seemed close to 208 endgame pawn value, just 4% lower. Thanks to Fisherman for how to get the endgame values of material!

Bench is unchanged as far as I can tell.