### PR TITLE
Reintroduce late irreversible move extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1134,6 +1134,12 @@ moves_loop: // When in check, search starts from here
       // Castling extension
       if (type_of(move) == CASTLING)
           extension = 1;
+	  
+      // Late irreversible move extension
+      if (   move == ttMove
+          && pos.rule50_count() > 80
+          && (captureOrPromotion || type_of(movedPiece) == PAWN))
+          extension = 1;
 
       // Add extension to new depth
       newDepth += extension;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1139,7 +1139,7 @@ moves_loop: // When in check, search starts from here
       if (   move == ttMove
           && pos.rule50_count() > 80
           && (captureOrPromotion || type_of(movedPiece) == PAWN))
-          extension = 1;
+          extension = 2;
 
       // Add extension to new depth
       newDepth += extension;


### PR DESCRIPTION
Reintroduce vondele's late irreversible move extension for fortress keeping. This was removed when we only had classical eval. Now that we have the NNUE net, it seems that this is useful again.

STC:
LLR: 2.93 (-2.94,2.94) {-0.50,1.50}
Total: 5352 W: 787 L: 653 D: 3912
Ptnml(0-2): 34, 451, 1579, 571, 41
https://tests.stockfishchess.org/tests/view/5f2dc8ad61e3b6af64881ff0

LTC:
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 14416 W: 1013 L: 891 D: 12512
Ptnml(0-2): 15, 722, 5623, 822, 26
https://tests.stockfishchess.org/tests/view/5f2e0e3661e3b6af6488201e

Bench: 4349889