### PR TITLE
NNUE - update Null Move Pruning parameters

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -827,7 +827,7 @@ namespace {
         && (ss-1)->statScore < 23824
         &&  eval >= beta
         &&  eval >= ss->staticEval
-        &&  ss->staticEval >= beta - 33 * depth - 33 * improving + 112 * ttPv + 311
+        &&  ss->staticEval >= beta - 28 * depth - 28 * improving + 94 * ttPv + 200
         && !excludedMove
         &&  pos.non_pawn_material(us)
         && (ss->ply >= thisThread->nmpMinPly || us != thisThread->nmpColor))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -827,7 +827,7 @@ namespace {
         && (ss-1)->statScore < 23824
         &&  eval >= beta
         &&  eval >= ss->staticEval
-        &&  ss->staticEval >= beta - 28 * depth - 28 * improving + 94 * ttPv + 200
+        &&  ss->staticEval >= beta + 200 - 28 * depth - 28 * improving + 94 * ttPv + 200
         && !excludedMove
         &&  pos.non_pawn_material(us)
         && (ss->ply >= thisThread->nmpMinPly || us != thisThread->nmpColor))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -827,7 +827,7 @@ namespace {
         && (ss-1)->statScore < 23824
         &&  eval >= beta
         &&  eval >= ss->staticEval
-        &&  ss->staticEval >= beta + 200 - 28 * depth - 28 * improving + 94 * ttPv + 200
+        &&  ss->staticEval >= beta - 28 * depth - 28 * improving + 94 * ttPv + 200
         && !excludedMove
         &&  pos.non_pawn_material(us)
         && (ss->ply >= thisThread->nmpMinPly || us != thisThread->nmpColor))


### PR DESCRIPTION
Static evaluation being more precise, we can lower the threshold for testing null move.

STC: https://tests.stockfishchess.org/tests/view/5f2dc38561e3b6af64881fec
LLR: 2.99 (-2.94,2.94) {-0.50,1.50}
Total: 6120 W: 903 L: 758 D: 4459
Ptnml(0-2): 44, 535, 1775, 644, 62 

LTC: https://tests.stockfishchess.org/tests/view/5f2dd55f61e3b6af64882003
LLR: 2.95 (-2.94,2.94) {0.25,1.75}
Total: 7424 W: 577 L: 463 D: 6384
Ptnml(0-2): 16, 375, 2824, 473, 24 

bench 4143353