### PR TITLE
Remove unnecessay legality check after reording pos.legal(move) check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1079,8 +1079,7 @@ moves_loop: // When in check, search starts from here
        /* &&  ttValue != VALUE_NONE Already implicit in the next condition */
           &&  abs(ttValue) < VALUE_KNOWN_WIN
           && (tte->bound() & BOUND_LOWER)
-          &&  tte->depth() >= depth - 3
-          &&  pos.legal(move))
+          &&  tte->depth() >= depth - 3)
       {
           Value singularBeta = ttValue - ((formerPv + 4) * depth) / 2;
           Depth singularDepth = (depth - 1 + 3 * formerPv) / 2;


### PR DESCRIPTION
Removing  unnecessary move legality check in singular extension section, because after the patch "Do move legality check before pruning" the legality check is performed before  this section.

non-functional. 