### PR TITLE
Parallelize Link Time Optimization for GCC, CLANG and MINGW

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -506,7 +506,7 @@ ifeq ($(debug), no)
 # GCC and CLANG use different methods for parallelizing LTO and CLANG pretends to be
 # GCC on some systems.
 	else ifeq ($(comp),gcc)
-    ifeq ($(gccisclang),)
+	ifeq ($(gccisclang),)
 		CXXFLAGS += -flto
 		LDFLAGS += $(CXXFLAGS) -flto=jobserver
 	else

--- a/src/Makefile
+++ b/src/Makefile
@@ -507,12 +507,12 @@ ifeq ($(debug), no)
 # GCC on some systems.
 	else ifeq ($(comp),gcc)
     ifeq ($(gccisclang),)
-    	CXXFLAGS += -flto
-    	LDFLAGS += $(CXXFLAGS) -flto=jobserver
-    else
+		CXXFLAGS += -flto
+		LDFLAGS += $(CXXFLAGS) -flto=jobserver
+	else
 		CXXFLAGS += -flto=thin
 		LDFLAGS += $(CXXFLAGS)
-    endif
+	endif
 
 # To use LTO and static linking on windows, the tool chain requires a recent gcc:
 # gcc version 10.1 in msys2 or TDM-GCC version 9.2 are know to work, older might not.

--- a/src/Makefile
+++ b/src/Makefile
@@ -282,6 +282,9 @@ ifeq ($(COMP),gcc)
 	ifneq ($(KERNEL),Darwin)
 	   LDFLAGS += -Wl,--no-as-needed
 	endif
+	
+	$gccversion=$(shell $(CXX) --version)
+	$gccisclang=$(findstring clang,$(gccversion))
 endif
 
 ifeq ($(COMP),mingw)
@@ -496,18 +499,28 @@ endif
 ### needs access to the optimization flags.
 ifeq ($(optimize),yes)
 ifeq ($(debug), no)
-	ifeq ($(comp),$(filter $(comp),gcc clang))
-		CXXFLAGS += -flto
+	ifeq ($(comp),clang)
+		CXXFLAGS += -flto=thin
 		LDFLAGS += $(CXXFLAGS)
-	endif
+
+# GCC and CLANG use different methods for parallelizing LTO and CLANG pretends to be
+# GCC on some systems.
+	else ifeq ($(comp),gcc)
+    ifeq ($(gccisclang),)
+    	CXXFLAGS += -flto
+    	LDFLAGS += $(CXXFLAGS) -flto=jobserver
+    else
+		CXXFLAGS += -flto=thin
+		LDFLAGS += $(CXXFLAGS)
+    endif
 
 # To use LTO and static linking on windows, the tool chain requires a recent gcc:
 # gcc version 10.1 in msys2 or TDM-GCC version 9.2 are know to work, older might not.
 # So, only enable it for a cross from Linux by default.
-	ifeq ($(comp),mingw)
+	else ifeq ($(comp),mingw)
 	ifeq ($(KERNEL),Linux)
 		CXXFLAGS += -flto
-		LDFLAGS += $(CXXFLAGS)
+		LDFLAGS += $(CXXFLAGS) -flto=jobserver
 	endif
 	endif
 endif
@@ -693,7 +706,7 @@ config-sanity:
 	@test "$(comp)" = "gcc" || test "$(comp)" = "icc" || test "$(comp)" = "mingw" || test "$(comp)" = "clang"
 
 $(EXE): $(OBJS)
-	$(CXX) -o $@ $(OBJS) $(LDFLAGS)
+	+$(CXX) -o $@ $(OBJS) $(LDFLAGS)
 
 clang-profile-make:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \

--- a/src/Makefile
+++ b/src/Makefile
@@ -283,8 +283,8 @@ ifeq ($(COMP),gcc)
 	   LDFLAGS += -Wl,--no-as-needed
 	endif
 	
-	$gccversion=$(shell $(CXX) --version)
-	$gccisclang=$(findstring clang,$(gccversion))
+	gccversion = $(shell $(CXX) --version)
+	gccisclang = $(findstring clang,$(gccversion))
 endif
 
 ifeq ($(COMP),mingw)


### PR DESCRIPTION
This patch tries to run multiple LTO threads in parallel, speeding up the build process of optimized builds if the `-j` make parameter is used. This mitigates the longer linking times of optimized builds since the integration of the NNUE code.

I've tried a similar PR #1712  some two years ago but it ran into trouble with old compiler versions then. Since we're on the C++17 standard now these old compilers should be obsolete.

No functional change.