### PR TITLE
Clear hash when changing NNUE

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -30,6 +30,7 @@
 #include "pawns.h"
 #include "thread.h"
 #include "uci.h"
+#include "tt.h"
 
 namespace Eval {
 
@@ -37,7 +38,7 @@ namespace Eval {
   std::string eval_file_loaded="None";
 
   void init_NNUE() {
-    Search::clear();
+    TT.clear();    
     useNNUE = Options["Use NNUE"];
     std::string eval_file = std::string(Options["EvalFile"]);
     if (useNNUE && eval_file_loaded != eval_file)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -37,7 +37,7 @@ namespace Eval {
   std::string eval_file_loaded="None";
 
   void init_NNUE() {
-
+    Search::clear();
     useNNUE = Options["Use NNUE"];
     std::string eval_file = std::string(Options["EvalFile"]);
     if (useNNUE && eval_file_loaded != eval_file)


### PR DESCRIPTION
Use may want to change NNUE when playing. When NNUE turns on/off or the EvalFile changed, computing caches should be reset since the evaluation changed. Look like Syzygy cache is still fine and we don't need to clear it. We should clear hash only by using the function TT.clear(). I don't use the function Search::clear() since it initializes both threads and the Syzygy table.