### PR TITLE
Do more aggressive futility pruning for captures.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1055,7 +1055,7 @@ moves_loop: // When in check, search starts from here
                   && !(PvNode && abs(bestValue) < 2)
                   && PieceValue[MG][type_of(movedPiece)] >= PieceValue[MG][type_of(pos.piece_on(to_sq(move)))]
                   && !ss->inCheck
-                  && ss->staticEval + 267 + 391 * lmrDepth
+                  && ss->staticEval + 178 + 261 * lmrDepth
                      + PieceValue[MG][type_of(pos.piece_on(to_sq(move)))] <= alpha)
                   continue;
 


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5f2da79e61e3b6af64881fd2
LLR: 3.87 (-2.94,2.94) {-0.50,1.50}
Total: 27256 W: 3809 L: 3593 D: 19854
Ptnml(0-2): 221, 2578, 7830, 2762, 237 
passed LTC
https://tests.stockfishchess.org/tests/view/5f2df92061e3b6af64882012
LLR: 4.97 (-2.94,2.94) {0.25,1.75}
Total: 43624 W: 3095 L: 2820 D: 37709
Ptnml(0-2): 66, 2410, 16608, 2639, 89 
This patch lines up with other patches which use better eval to produce more aggressive cutoffs based on static evaluation of position, it allows more aggressive futility pruning for captures - so now we will be producing them with bigger evaluation of position, so more often.
bench 4706516