### PR TITLE
[NNUE] Update default net to nn-112bb1c8cdb5.nnue

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -79,7 +79,7 @@ void init(OptionsMap& o) {
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(7, 0, 7);
   o["Use NNUE"]              << Option(false, on_use_NNUE);
-  o["EvalFile"]              << Option("nn-9931db908a9b.nnue", on_eval_file);
+  o["EvalFile"]              << Option("nn-112bb1c8cdb5.nnue", on_eval_file);
 }
 
 


### PR DESCRIPTION
First trained net using search eval instead of pv leaf static eval.

Net created at: 20200810-0744

Bench: 4084753

passed STC: https://tests.stockfishchess.org/tests/view/5f30995d90816720665373f8
LLR: 2.93 (-2.94,2.94) {-0.50,1.50}
Total: 15416 W: 2071 L: 1920 D: 11425
Ptnml(0-2): 123, 1376, 4563, 1519, 127

passed LTC: https://tests.stockfishchess.org/tests/view/5f30a104908167206653742b
LLR: 2.93 (-2.94,2.94) {0.25,1.75}
Total: 29792 W: 2003 L: 1834 D: 25955
Ptnml(0-2): 50, 1541, 11550, 1700, 55