### PR TITLE
Modify castling extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1131,7 +1131,8 @@ moves_loop: // When in check, search starts from here
           extension = 1;
 
       // Castling extension
-      if (type_of(move) == CASTLING)
+      if (   type_of(move) == CASTLING
+          && popcount(pos.pieces(us) & ~pos.pieces(PAWN) & (to_sq(move) & KingSide ? KingSide : QueenSide)) <= 3)
           extension = 1;
 
       // Late irreversible move extension


### PR DESCRIPTION
Extend castling only if there are few friendly pieces on the castling side.

Inspired by silversolver1's (Rahul Dsilva) test
https://tests.stockfishchess.org/tests/view/5f0fef560640035f9d2978cf

STC:
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 7096 W: 947 L: 818 D: 5331
Ptnml(0-2): 32, 604, 2181, 665, 66
https://tests.stockfishchess.org/tests/view/5f309f729081672066537426

LTC:
LLR: 2.96 (-2.94,2.94) {0.25,1.75}
Total: 4712 W: 300 L: 215 D: 4197
Ptnml(0-2): 2, 190, 1895, 259, 10
https://tests.stockfishchess.org/tests/view/5f30a2039081672066537430

Bench: 4094850