### PR TITLE
Fix avx512 build.

### DIFF
--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -21,7 +21,10 @@
 #ifndef NNUE_COMMON_H_INCLUDED
 #define NNUE_COMMON_H_INCLUDED
 
-#if defined(USE_AVX2)
+#if defined(USE_AVX512)
+#include <avx512fintrin.h>
+
+#elif defined(USE_AVX2)
 #include <immintrin.h>
 
 #elif defined(USE_SSE41)


### PR DESCRIPTION
The x86-64-avx512 architecture fails to build after #2962
This fixes things.