### PR TITLE
Fix issue https://github.com/official-stockfish/Stockfish/issues/2975

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -416,7 +416,7 @@ endif
 ifeq ($(avx512),yes)
 	CXXFLAGS += -DUSE_AVX512
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
-		CXXFLAGS += -mavx512bw
+		CXXFLAGS += -mavx512f -mavx512bw
 	endif
 endif
 

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -126,8 +126,7 @@ namespace Eval::NNUE::Layers {
             const auto iv256  = reinterpret_cast<const __m256i*>(&input_vector[kNumChunks]);
             const auto row256 = reinterpret_cast<const __m256i*>(&row[kNumChunks]);
             __m256i product256 = _mm256_maddubs_epi16(_mm256_loadA_si256(&iv256[0]), _mm256_load_si256(&row256[0]));
-            product256 = _mm256_madd_epi16(product256, _mm256_set1_epi16(1));
-            sum = _mm512_add_epi32(sum, _mm512_zextsi256_si512(product256));
+            sum = _mm512_add_epi32(sum, _mm512_cvtepi16_epi32(product256));
         }
         output[i] = _mm512_reduce_add_epi32(sum) + biases_[i];
 


### PR DESCRIPTION
This now compiles for me in windows using gcc 7.3, 8.1, and 10.1 and is actually a bit simpler.
After changing the code I could compile but was getting these errors
https://stackoverflow.com/questions/43152633/invalid-register-for-seh-savexmm-in-cygwin
with the older gcc versions but not 10.1.
The -fno-asynchronous-unwind-tables flag fixes those.
If there is a way to check gcc version in the Makefile we could skip this flag for gcc 10 and higher.
(I don't have gcc 9 to test)

Also @vondele asked if we need to adjust the avx512 flags.
We need -mavx512bw and -mavx512f.  gcc silently includes -mavx512f when -mavx512bw is specified
but it's probably better to be explicit. (you can test this by adding -mno-avx512f to master and see it fail)
All avx512 implementations however also provide -mavx512cd -mavx512dq -mavx512vl instructions so
we can safely include them too.
https://en.wikichip.org/wiki/x86/avx-512
I measure no speed difference so either way is fine.

No functional change
NNUE: 3994357
bench: 4733874