### PR TITLE
Fix parallel LTO issues on Windows

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -472,6 +472,11 @@ ifeq ($(debug), no)
 	ifeq ($(gccisclang),)
 		CXXFLAGS += -flto
 		LDFLAGS += $(CXXFLAGS) -flto=jobserver
+		ifneq ($(findstring MINGW,$(KERNEL)),)
+			LDFLAGS += -save-temps
+		else ifneq ($(findstring MSYS,$(KERNEL)),)
+			LDFLAGS += -save-temps
+		endif
 	else
 		CXXFLAGS += -flto=thin
 		LDFLAGS += $(CXXFLAGS)


### PR DESCRIPTION
This adds -save-temps to the linker flags when parallel LTO is used on MinGW/MSYS.
This fixes #2977, also see #2943

No functional change.