### PR TITLE
Use posix_memalign for Apple Silicon instead of _mm_malloc

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -51,7 +51,7 @@ typedef bool(*fun3_t)(HANDLE, CONST GROUP_AFFINITY*, PGROUP_AFFINITY);
 #include <sys/mman.h>
 #endif
 
-#if (defined(__APPLE__) && defined(_LIBCPP_HAS_C11_FEATURES)) || defined(__ANDROID__) || defined(__OpenBSD__) || (defined(__GLIBCXX__) && !defined(_GLIBCXX_HAVE_ALIGNED_ALLOC) && !defined(_WIN32))
+#if defined(__APPLE__) || defined(__ANDROID__) || defined(__OpenBSD__) || (defined(__GLIBCXX__) && !defined(_GLIBCXX_HAVE_ALIGNED_ALLOC) && !defined(_WIN32))
 #define POSIXALIGNEDALLOC
 #include <stdlib.h>
 #endif
@@ -328,7 +328,7 @@ void* std_aligned_alloc(size_t alignment, size_t size) {
   if(posix_memalign(&pointer, alignment, size) == 0)
       return pointer;
   return nullptr;
-#elif (defined(_WIN32) || (defined(__APPLE__) && !defined(_LIBCPP_HAS_C11_FEATURES)))
+#elif defined(_WIN32)
   return _mm_malloc(size, alignment);
 #else
   return std::aligned_alloc(alignment, size);
@@ -338,7 +338,7 @@ void* std_aligned_alloc(size_t alignment, size_t size) {
 void std_aligned_free(void* ptr) {
 #if defined(POSIXALIGNEDALLOC)
   free(ptr);
-#elif (defined(_WIN32) || (defined(__APPLE__) && !defined(_LIBCPP_HAS_C11_FEATURES)))
+#elif defined(_WIN32)
   _mm_free(ptr);
 #else
   free(ptr);


### PR DESCRIPTION
At HEAD we cannot build for Apple Silicon: 

```
misc.cpp:332:10: error: use of undeclared identifier '_mm_malloc'
  return _mm_malloc(size, alignment);
         ^
misc.cpp:342:3: error: use of undeclared identifier '_mm_free'
  _mm_free(ptr);
  ^
```

because we don't have Intel Intrinsics. Also, it seems like `_LIBCPP_HAS_C11_FEATURES` is false on macOS 11.0 beta (and maybe prior versions of macOS, although all prior versions run on Intel so we didn't see this issue).

Regardless, macOS has `posix_memalign()` [since ~2014](https://stackoverflow.com/questions/196329/osx-lacks-memalign/22876707#22876707) so we can simplify the code and just use that for all Apple platforms.