### PR TITLE
Adjust classical eval usage for multicore case.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -945,7 +945,7 @@ Value Eval::evaluate(const Position& pos) {
   {
       Value v = eg_value(pos.psq_score());
       // Take NNUE eval only on balanced positions
-      if (abs(v) < NNUEThreshold)
+      if (pos.this_thread()->id() % 8 == 7 || abs(v) < NNUEThreshold)
          return NNUE::evaluate(pos) + Tempo;
   }
   return Evaluation<NO_TRACE>(pos).value();

--- a/src/thread.h
+++ b/src/thread.h
@@ -55,6 +55,7 @@ public:
   void start_searching();
   void wait_for_search_finished();
   int best_move_count(Move move) const;
+  int id() const { return idx; }
 
   Pawns::Table pawnsTable;
   Material::Table materialTable;


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5f32d66666a893ef3a025e40
LLR: 2.93 (-2.94,2.94) {-0.50,1.50}
Total: 13776 W: 1068 L: 975 D: 11733
Ptnml(0-2): 28, 820, 5112, 887, 41 
passed LTC
https://tests.stockfishchess.org/tests/view/5f330df766a893ef3a02633f
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 29392 W: 1226 L: 1091 D: 27075
Ptnml(0-2): 10, 971, 12610, 1084, 21 
For every 8th thread use only NNUE eval even if psq score is higher than NNUE threshold.
bench 4244812