### PR TITLE
Output the SSE2 flag in compiler_info

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -446,7 +446,7 @@ ifeq ($(neon),yes)
 endif
 
 ifeq ($(arch),x86_64)
-	CXXFLAGS += -DUSE_SSE2
+	CXXFLAGS += -msse2 -DUSE_SSE2
 endif
 
 ### 3.7 pext

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -222,6 +222,7 @@ const std::string compiler_info() {
   #if defined(USE_AVX512)
     compiler += " AVX512";
   #endif
+  compiler += (HasPext ? " BMI2" : "");
   #if defined(USE_AVX2)
     compiler += " AVX2";
   #endif
@@ -231,11 +232,14 @@ const std::string compiler_info() {
   #if defined(USE_SSSE3)
     compiler += " SSSE3";
   #endif
-    compiler += (HasPext ? " BMI2" : "");
-    compiler += (HasPopCnt ? " POPCNT" : "");
+  #if defined(USE_SSE2)
+    compiler += " SSE2";
+  #endif
+  compiler += (HasPopCnt ? " POPCNT" : "");
   #if defined(USE_MMX)
     compiler += " MMX";
   #endif
+
   #if !defined(NDEBUG)
     compiler += " DEBUG";
   #endif


### PR DESCRIPTION
was missing in the list of outputs, slightly reorder flags.
explicitly add -msse2 if USE_SSE2 (is implicit already, -msse -m64).

No functional change.