### PR TITLE
[NNUE] Update default net to nn-82215d0fd0df.nnue

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -79,7 +79,7 @@ void init(OptionsMap& o) {
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(7, 0, 7);
   o["Use NNUE"]              << Option(false, on_use_NNUE);
-  o["EvalFile"]              << Option("nn-112bb1c8cdb5.nnue", on_eval_file);
+  o["EvalFile"]              << Option("nn-82215d0fd0df.nnue", on_eval_file);
 }
 
 


### PR DESCRIPTION
Net created at: 20200812-2257

Bench: 3935117

passed STC: https://tests.stockfishchess.org/tests/view/5f340ca99e5f2effc089da17
LLR: 2.96 (-2.94,2.94) {-0.50,1.50}
Total: 5744 W: 756 L: 627 D: 4361
Ptnml(0-2): 28, 485, 1731, 586, 42

passed LTC: https://tests.stockfishchess.org/tests/view/5f341eba9e5f2effc089da23
LLR: 2.94 (-2.94,2.94) {0.25,1.75}
Total: 17136 W: 1041 L: 917 D: 15178
Ptnml(0-2): 13, 813, 6807, 907, 28