### PR TITLE
Clean Stockfish UCI options [RFC]

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Currently, Stockfish has the following UCI options:
     Output the N best lines (principal variations, PVs) when searching.
     Leave at 1 for best performance.
 
-  * #### Use NNUE
+  * #### UseNNUE
     Toggle between the NNUE and classical evaluation functions. If set to "true",
     the network parameters must be available to load from file (see also EvalFile).
 
@@ -68,7 +68,7 @@ Currently, Stockfish has the following UCI options:
     A positive value for contempt favors middle game positions and avoids draws,
     effective for the classical evaluation only.
 
-  * #### Analysis Contempt
+  * #### AnalysisContempt
     By default, contempt is set to prefer the side to move. Set this option to "White"
     or "Black" to analyse with contempt for that side, or "Off" to disable contempt.
 
@@ -90,10 +90,10 @@ Currently, Stockfish has the following UCI options:
     If enabled by UCI_LimitStrength, aim for an engine strength of the given Elo.
     This Elo rating has been calibrated at a time control of 60s+0.6s and anchored to CCRL 40/4.
 
-  * #### Skill Level
-    Lower the Skill Level in order to make Stockfish play weaker (see also UCI_LimitStrength).
-    Internally, MultiPV is enabled, and with a certain probability depending on the Skill Level a
-    weaker move will be played.
+  * #### SkillLevel
+    Lower the SkillLevel in order to make Stockfish play weaker (see also UCI_LimitStrength).
+    Internally, MultiPV is enabled, and with a certain probability depending on the skill
+    level a weaker move will be played.
 
   * #### SyzygyPath
     Path to the folders/directories storing the Syzygy tablebase files. Multiple
@@ -120,22 +120,22 @@ Currently, Stockfish has the following UCI options:
     Limit Syzygy tablebase probing to positions with at most this many pieces left
     (including kings and pawns).
 
-  * #### Move Overhead
+  * #### MoveOverhead
     Assume a time delay of x ms due to network and GUI overheads. This is useful to
     avoid losses on time in those cases.
 
-  * #### Slow Mover
+  * #### SlowMover
     Lower values will make Stockfish take less time in games, higher values will
     make it think longer.
 
-  * #### nodestime
+  * #### Nodestime
     Tells the engine to use nodes searched instead of wall time to account for
     elapsed time. Useful for engine testing.
 
-  * #### Clear Hash
+  * #### ClearHash
     Clear the hash table.
 
-  * #### Debug Log File
+  * #### DebugLogFile
     Write all communication to and from the engine into a text file.
 
 ## Classical and NNUE evaluation

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -156,9 +156,9 @@ vector<string> setup_bench(const Position& current, istream& is) {
       else
       {
           if (evalType == "classical" || (evalType == "mixed" && posCounter % 2 == 0))
-              list.emplace_back("setoption name Use NNUE value false");
+              list.emplace_back("setoption name UseNNUE value false");
           else if (evalType == "NNUE" || (evalType == "mixed" && posCounter % 2 != 0))
-              list.emplace_back("setoption name Use NNUE value true");
+              list.emplace_back("setoption name UseNNUE value true");
           list.emplace_back("position fen " + fen);
           list.emplace_back(go);
           ++posCounter;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -38,7 +38,7 @@ namespace Eval {
 
   void init_NNUE() {
 
-    useNNUE = Options["Use NNUE"];
+    useNNUE = Options["UseNNUE"];
     std::string eval_file = std::string(Options["EvalFile"]);
     if (useNNUE && eval_file_loaded != eval_file)
         if (Eval::NNUE::load_eval_file(eval_file))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -265,7 +265,7 @@ void MainThread::search() {
 
   if (   int(Options["MultiPV"]) == 1
       && !Limits.depth
-      && !(Skill(Options["Skill Level"]).enabled() || int(Options["UCI_LimitStrength"]))
+      && !(Skill(Options["SkillLevel"]).enabled() || int(Options["UCI_LimitStrength"]))
       && rootMoves[0].pv[0] != MOVE_NONE)
       bestThread = Threads.get_best_thread();
 
@@ -336,7 +336,7 @@ void Thread::search() {
   PRNG rng(now());
   double floatLevel = Options["UCI_LimitStrength"] ?
                       Utility::clamp(std::pow((Options["UCI_Elo"] - 1346.6) / 143.4, 1 / 0.806), 0.0, 20.0) :
-                        double(Options["Skill Level"]);
+                        double(Options["SkillLevel"]);
   int intLevel = int(floatLevel) +
                  ((floatLevel - int(floatLevel)) * 1024 > rng.rand<unsigned>() % 1024  ? 1 : 0);
   Skill skill(intLevel);
@@ -353,10 +353,10 @@ void Thread::search() {
 
   // In analysis mode, adjust contempt in accordance with user preference
   if (Limits.infinite || Options["UCI_AnalyseMode"])
-      ct =  Options["Analysis Contempt"] == "Off"  ? 0
-          : Options["Analysis Contempt"] == "Both" ? ct
-          : Options["Analysis Contempt"] == "White" && us == BLACK ? -ct
-          : Options["Analysis Contempt"] == "Black" && us == WHITE ? -ct
+      ct =  Options["AnalysisContempt"] == "Off"  ? 0
+          : Options["AnalysisContempt"] == "Both" ? ct
+          : Options["AnalysisContempt"] == "White" && us == BLACK ? -ct
+          : Options["AnalysisContempt"] == "Black" && us == WHITE ? -ct
           : ct;
 
   // Evaluation score is from the white point of view
@@ -883,8 +883,8 @@ namespace {
         // there and in further interactions with transposition table cutoff depth is set to depth - 3
         // because probCut search has depth set to depth - 4 but we also do a move before it
         // so effective depth is equal to depth - 3
-        && !(   ttHit 
-             && tte->depth() >= depth - 3 
+        && !(   ttHit
+             && tte->depth() >= depth - 3
              && ttValue != VALUE_NONE
              && ttValue < probCutBeta))
     {

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -34,9 +34,9 @@ TimeManagement Time; // Our global time management object
 
 void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
 
-  TimePoint moveOverhead    = TimePoint(Options["Move Overhead"]);
-  TimePoint slowMover       = TimePoint(Options["Slow Mover"]);
-  TimePoint npmsec          = TimePoint(Options["nodestime"]);
+  TimePoint moveOverhead    = TimePoint(Options["MoveOverhead"]);
+  TimePoint slowMover       = TimePoint(Options["SlowMover"]);
+  TimePoint npmsec          = TimePoint(Options["Nodestime"]);
 
   // opt_scale is a percentage of available time to use for the current move.
   // max_scale is a multiplier applied to optimumTime.

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -100,9 +100,9 @@ namespace {
 
     is >> token; // Consume "name" token
 
-    // Read option name (can contain spaces)
+    // Read option name (ignore spaces)
     while (is >> token && token != "value")
-        name += (name.empty() ? "" : " ") + token;
+        name += token;
 
     // Read option value (can contain spaces)
     while (is >> token)

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -57,18 +57,18 @@ void init(OptionsMap& o) {
 
   constexpr int MaxHashMB = Is64Bit ? 33554432 : 2048;
 
-  o["Debug Log File"]        << Option("", on_logger);
+  o["DebugLogFile"]          << Option("", on_logger);
   o["Contempt"]              << Option(24, -100, 100);
-  o["Analysis Contempt"]     << Option("Both var Off var White var Black var Both", "Both");
+  o["AnalysisContempt"]      << Option("Both var Off var White var Black var Both", "Both");
   o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
-  o["Clear Hash"]            << Option(on_clear_hash);
+  o["ClearHash"]             << Option(on_clear_hash);
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);
-  o["Skill Level"]           << Option(20, 0, 20);
-  o["Move Overhead"]         << Option(10, 0, 5000);
-  o["Slow Mover"]            << Option(100, 10, 1000);
-  o["nodestime"]             << Option(0, 0, 10000);
+  o["SkillLevel"]            << Option(20, 0, 20);
+  o["MoveOverhead"]          << Option(10, 0, 5000);
+  o["SlowMover"]             << Option(100, 10, 1000);
+  o["Nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["UCI_AnalyseMode"]       << Option(false);
   o["UCI_LimitStrength"]     << Option(false);
@@ -78,7 +78,7 @@ void init(OptionsMap& o) {
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(7, 0, 7);
-  o["Use NNUE"]              << Option(false, on_use_NNUE);
+  o["UseNNUE"]               << Option(false, on_use_NNUE);
   o["EvalFile"]              << Option("nn-82215d0fd0df.nnue", on_eval_file);
 }
 


### PR DESCRIPTION
At the moment the list of UCI options for Stockfish has become quite large, and quite messy: the naming is irregular, some options are very rarely changed or nor used at all, and on the other side some options are controversial, leading to lengthy discussion and loss of energy for the project.

I start this pull request as a location to discuss the improvements we could do in this area. The future release of SF 12 will urge people writing scripts for Stockfish to update their scripts anyway, so it seems to be a good time to clean up and simplify our naming and usage of UCI options.

- [x] Remove space from option names
- [x] Capitalize "nodetime"
- [ ] Remove the Contempt and AnalysisContempt UCI options (and rename the contempt variables in the code, choosing suitable default values)
- [ ] Chose suitable defaults for SyzygyProbeDepth, Syzygy50MoveRule, SyzygyProbeLimit and remove them from the UCI options
- [ ] any others...

Any other ideas? Feel free to comment :-)

------------

No functional change