### PR TITLE
Introduce a program path specifier for the UCI EvalFile option

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -23,6 +23,7 @@
 #include <iomanip>
 #include <sstream>
 #include <iostream>
+#include <filesystem>
 
 #include "bitboard.h"
 #include "evaluate.h"
@@ -33,6 +34,21 @@
 
 namespace Eval {
 
+namespace {
+
+  void substitute_program_path(std::string& file_path) {
+
+      const auto index = file_path.find("~");
+      if (index != std::string::npos)
+      {
+          file_path.replace(index, 1, ProgramPath);
+          file_path = std::filesystem::canonical(std::filesystem::path(file_path)).string();
+      }
+  }
+
+}
+
+
   bool useNNUE;
   std::string eval_file_loaded="None";
 
@@ -40,6 +56,7 @@ namespace Eval {
 
     useNNUE = Options["Use NNUE"];
     std::string eval_file = std::string(Options["EvalFile"]);
+    substitute_program_path(eval_file);
     if (useNNUE && eval_file_loaded != eval_file)
         if (Eval::NNUE::load_eval_file(eval_file))
             eval_file_loaded = eval_file;
@@ -48,6 +65,7 @@ namespace Eval {
   void verify_NNUE() {
 
     std::string eval_file = std::string(Options["EvalFile"]);
+    substitute_program_path(eval_file);
     if (useNNUE && eval_file_loaded != eval_file)
     {
         UCI::OptionsMap defaults;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 */
 
 #include <iostream>
+#include <filesystem>
 
 #include "bitboard.h"
 #include "endgame.h"
@@ -34,6 +35,8 @@ namespace PSQT {
 int main(int argc, char* argv[]) {
 
   std::cout << engine_info() << std::endl;
+
+  ProgramPath = std::filesystem::path(argv[0]).remove_filename().string();
 
   UCI::init(Options);
   Tune::init();

--- a/src/uci.h
+++ b/src/uci.h
@@ -77,5 +77,6 @@ Move to_move(const Position& pos, std::string& str);
 } // namespace UCI
 
 extern UCI::OptionsMap Options;
+extern std::string     ProgramPath;
 
 #endif // #ifndef UCI_H_INCLUDED

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -31,6 +31,7 @@
 using std::string;
 
 UCI::OptionsMap Options; // Global object
+std::string     ProgramPath;
 
 namespace UCI {
 
@@ -79,7 +80,7 @@ void init(OptionsMap& o) {
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(7, 0, 7);
   o["Use NNUE"]              << Option(false, on_use_NNUE);
-  o["EvalFile"]              << Option("nn-82215d0fd0df.nnue", on_eval_file);
+  o["EvalFile"]              << Option("~/nn-82215d0fd0df.nnue", on_eval_file);
 }
 
 


### PR DESCRIPTION
This patch introduces ~ as a specifier for the directory where the stockfish executable resides. This makes it possible to specify the absolute path of an NNUE EvalFile without knowing its actual location on disk so EvalFiles don't have to be copied to GUI work directories.

No functional change.