### PR TITLE
NNUE hits

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -34,6 +34,9 @@
 namespace Eval {
 
   bool useNNUE;
+  uint64_t hitsNNUE;
+  uint64_t evalCountNNUE;
+
   std::string eval_file_loaded="None";
 
   void init_NNUE() {
@@ -46,7 +49,8 @@ namespace Eval {
   }
 
   void verify_NNUE() {
-
+    hitsNNUE = evalCountNNUE = 0ULL;
+    
     std::string eval_file = std::string(Options["EvalFile"]);
     if (useNNUE && eval_file_loaded != eval_file)
     {
@@ -943,10 +947,14 @@ Value Eval::evaluate(const Position& pos) {
 
   if (Eval::useNNUE)
   {
+      evalCountNNUE++;
+
       Value v = eg_value(pos.psq_score());
       // Take NNUE eval only on balanced positions
-      if (abs(v) < NNUEThreshold)
-         return NNUE::evaluate(pos) + Tempo;
+    if (abs(v) < NNUEThreshold) {
+      hitsNNUE++;
+      return NNUE::evaluate(pos) + Tempo;
+    }
   }
   return Evaluation<NO_TRACE>(pos).value();
 }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -951,7 +951,8 @@ Value Eval::evaluate(const Position& pos) {
 
       Value v = eg_value(pos.psq_score());
       // Take NNUE eval only on balanced positions
-    if (abs(v) < NNUEThreshold) {
+    if (abs(v) < NNUEThreshold)
+    {
       hitsNNUE++;
       return NNUE::evaluate(pos) + Tempo;
     }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -951,11 +951,11 @@ Value Eval::evaluate(const Position& pos) {
 
       Value v = eg_value(pos.psq_score());
       // Take NNUE eval only on balanced positions
-    if (abs(v) < NNUEThreshold)
-    {
-      hitsNNUE++;
-      return NNUE::evaluate(pos) + Tempo;
-    }
+      if (abs(v) < NNUEThreshold)
+      {
+        hitsNNUE++;
+        return NNUE::evaluate(pos) + Tempo;
+      }
   }
   return Evaluation<NO_TRACE>(pos).value();
 }

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -31,6 +31,8 @@ namespace Eval {
   Value evaluate(const Position& pos);
 
   extern bool useNNUE;
+  extern uint64_t hitsNNUE;
+  extern uint64_t evalCountNNUE;
   extern std::string eval_file_loaded;
   void init_NNUE();
   void verify_NNUE();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1880,6 +1880,9 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
       if (elapsed > 1000) // Earlier makes little sense
           ss << " hashfull " << TT.hashfull();
 
+    if (Eval::useNNUE && Eval::evalCountNNUE)
+      ss << " nnuehits " << Eval::hitsNNUE * 1000 / Eval::evalCountNNUE;
+
       ss << " tbhits "   << tbHits
          << " time "     << elapsed
          << " pv";

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1880,8 +1880,10 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
       if (elapsed > 1000) // Earlier makes little sense
           ss << " hashfull " << TT.hashfull();
 
-    if (Eval::useNNUE && Eval::evalCountNNUE)
-      ss << " nnuehits " << Eval::hitsNNUE * 1000 / Eval::evalCountNNUE;
+      if (Eval::evalCountNNUE)
+      {
+        ss << " nnuehits " << Eval::hitsNNUE * 1000 / Eval::evalCountNNUE;
+      }
 
       ss << " tbhits "   << tbHits
          << " time "     << elapsed


### PR DESCRIPTION
Because of hybrid evaluation, even NNUE is on, users may not know if NNUE evaluation really works and how much/performance it is. The PR measures the proportion of NNUE evaluation calls over the total and prints out with other info. It works quite similar to other info such as tbhits, wdl. E.g.:

```
info depth 29 seldepth 38 multipv 1 score cp 32 nodes 34789383 nps 665838 hashfull 1000 nnuehits 816 tbhits 0 time 52249 pv e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f8c5 c2c3 c5b6 d2d4 e8g8 f1e1 d7d6 a2a4 a7a6 b5c6 b7c6 a4a5 b6a7 h2h3 e5d4 c3d4 h7h6 a1a4 f8e8 b1c3 a8b8 b2b4 f6d7 c1f4 d7f8 f4g3
```

The printing is `nnuehits 816`, a form of one-keyword one-value, thus it can run with all most all chess GUIs without making trouble. Those chess GUIs may not display that info but can ignore safely. Thus, for users' simpleness, I don't implement any special UCI option to turn it on (such as "UCI_nnuehits"). Let it always be on and wait for chess GUIs to support displaying.
