### PR TITLE
Adapt Makefile for armv7 (request for testing).

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -261,6 +261,10 @@ ifeq ($(COMP),gcc)
 		LDFLAGS += -m$(bits)
 	endif
 
+	ifeq ($(ARCH),armv7)
+		LDFLAGS += -latomic
+	endif
+
 	ifneq ($(KERNEL),Darwin)
 	   LDFLAGS += -Wl,--no-as-needed
 	endif
@@ -401,7 +405,6 @@ endif
 ifeq ($(prefetch),yes)
 	ifeq ($(sse),yes)
 		CXXFLAGS += -msse
-		DEPENDFLAGS += -msse
 	endif
 else
 	CXXFLAGS += -DNO_PREFETCH


### PR DESCRIPTION
Pass -latomic to the linker as this appears needed for gcc on armv7

Don't pass the target specific `-msse` to the dependency generation,
as this leads to an error with `make help`

based on discussion in https://github.com/official-stockfish/Stockfish/issues/2641
and https://github.com/official-stockfish/Stockfish/issues/2860

No functional change.