### PR TITLE
Display NEON in compiler string

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -242,6 +242,9 @@ const std::string compiler_info() {
   #if defined(USE_MMX)
     compiler += " MMX";
   #endif
+  #if defined(USE_NEON)
+    compiler += " NEON";
+  #endif
 
   #if !defined(NDEBUG)
     compiler += " DEBUG";


### PR DESCRIPTION
NEON is the ARM SIMD instruction set. For parity with Intel intrinsics, display `NEON` when printing the compiler string if NEON instructions were used.