### PR TITLE
Allow specifying the directory for the default net

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Currently, Stockfish has the following UCI options:
     The name of the file of the NNUE evaluation parameters. Depending on the GUI the
     filename should include the full path to the folder/directory that contains the file.
 
+    If the value ends in a directory separator (/ or \), then the value is the directory
+    where the default file is found.
+
   * #### Contempt
     A positive value for contempt favors middle game positions and avoids draws,
     effective for the classical evaluation only.

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -36,10 +36,31 @@ namespace Eval {
   bool useNNUE;
   std::string eval_file_loaded="None";
 
+  namespace {
+
+    std::string getEvalFile() {
+
+        std::string eval_file = std::string(Options["EvalFile"]);
+
+        // is the eval_file actually a directory prefix? if so, append the default file
+        if (!eval_file.empty() &&
+            (eval_file.back() ==  '/' || eval_file.back() == '\\'))
+        {
+            UCI::OptionsMap defaults;
+            UCI::init(defaults);
+
+            eval_file += std::string(defaults["EvalFile"]);
+        }
+
+        return eval_file;
+    }
+
+  } // namespace
+
   void init_NNUE() {
 
     useNNUE = Options["Use NNUE"];
-    std::string eval_file = std::string(Options["EvalFile"]);
+    std::string eval_file = getEvalFile();
     if (useNNUE && eval_file_loaded != eval_file)
         if (Eval::NNUE::load_eval_file(eval_file))
             eval_file_loaded = eval_file;
@@ -47,7 +68,7 @@ namespace Eval {
 
   void verify_NNUE() {
 
-    std::string eval_file = std::string(Options["EvalFile"]);
+    std::string eval_file = getEvalFile();
     if (useNNUE && eval_file_loaded != eval_file)
     {
         UCI::OptionsMap defaults;


### PR DESCRIPTION
Extend EvalFile UCI option semantics a bit. If the value ends
in a directory separator, consider the value as a prefix to the
default eval file path. This allows users to notice when the default
net has changed, in case they need to specify the absolute path to
the net.

No functional change.