### PR TITLE
Reformat code in little-endian patch

### DIFF
--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -77,7 +77,7 @@ namespace Eval::NNUE {
   bool ReadParameters(std::istream& stream, const AlignedPtr<T>& pointer) {
 
     std::uint32_t header;
-    header = read_le<std::uint32_t>(stream);
+    header = read_little_endian<std::uint32_t>(stream);
     if (!stream || header != T::GetHashValue()) return false;
     return pointer->ReadParameters(stream);
   }
@@ -92,13 +92,13 @@ namespace Eval::NNUE {
   }
 
   // Read network header
-  bool ReadHeader(std::istream& stream,
-    std::uint32_t* hash_value, std::string* architecture) {
-
+  bool ReadHeader(std::istream& stream, std::uint32_t* hash_value, std::string* architecture)
+  {
     std::uint32_t version, size;
-    version = read_le<std::uint32_t>(stream);
-    *hash_value = read_le<std::uint32_t>(stream);
-    size = read_le<std::uint32_t>(stream);
+
+    version     = read_little_endian<std::uint32_t>(stream);
+    *hash_value = read_little_endian<std::uint32_t>(stream);
+    size        = read_little_endian<std::uint32_t>(stream);
     if (!stream || version != kVersion) return false;
     architecture->resize(size);
     stream.read(&(*architecture)[0], size);

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -63,9 +63,9 @@ namespace Eval::NNUE::Layers {
     bool ReadParameters(std::istream& stream) {
       if (!previous_layer_.ReadParameters(stream)) return false;
       for (std::size_t i = 0; i < kOutputDimensions; ++i)
-        biases_[i] = read_le<BiasType>(stream);
+        biases_[i] = read_little_endian<BiasType>(stream);
       for (std::size_t i = 0; i < kOutputDimensions * kPaddedInputDimensions; ++i)
-        weights_[i] = read_le<WeightType>(stream);
+        weights_[i] = read_little_endian<WeightType>(stream);
       return !stream.fail();
     }
 

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -101,23 +101,25 @@ namespace Eval::NNUE {
   // Round n up to be a multiple of base
   template <typename IntType>
   constexpr IntType CeilToMultiple(IntType n, IntType base) {
-    return (n + base - 1) / base * base;
+      return (n + base - 1) / base * base;
   }
 
-  // Read a signed or unsigned integer from  a stream in little-endian order
+  // read_little_endian() is our utility to read an integer (signed or unsigned, any size)
+  // from a stream in little-endian order. We swap the byte order after the read if
+  // necessary to return a result with the byte ordering of the compiling machine.
   template <typename IntType>
-  inline IntType read_le(std::istream& stream) {
-    // Read the relevant bytes from the stream in little-endian order
-    std::uint8_t u[sizeof(IntType)];
-    stream.read(reinterpret_cast<char*>(u), sizeof(IntType));
-    // Use unsigned arithmetic to convert to machine order
-    typename std::make_unsigned<IntType>::type v = 0;
-    for (std::size_t i = 0; i < sizeof(IntType); ++i)
-      v = (v << 8) | u[sizeof(IntType) - i - 1];
-    // Copy the machine-ordered bytes into a potentially signed value
-    IntType w;
-    std::memcpy(&w, &v, sizeof(IntType));
-    return w;
+  inline IntType read_little_endian(std::istream& stream) {
+
+      IntType result;
+      std::uint8_t u[sizeof(IntType)];
+      typename std::make_unsigned<IntType>::type v = 0;
+
+      stream.read(reinterpret_cast<char*>(u), sizeof(IntType));
+      for (std::size_t i = 0; i < sizeof(IntType); ++i)
+          v = (v << 8) | u[sizeof(IntType) - i - 1];
+
+      std::memcpy(&result, &v, sizeof(IntType));
+      return result;
   }
 
 }  // namespace Eval::NNUE

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -56,9 +56,9 @@ namespace Eval::NNUE {
     // Read network parameters
     bool ReadParameters(std::istream& stream) {
       for (std::size_t i = 0; i < kHalfDimensions; ++i)
-        biases_[i] = read_le<BiasType>(stream);
+        biases_[i] = read_little_endian<BiasType>(stream);
       for (std::size_t i = 0; i < kHalfDimensions * kInputDimensions; ++i)
-        weights_[i] = read_le<WeightType>(stream);
+        weights_[i] = read_little_endian<WeightType>(stream);
       return !stream.fail();
     }
 


### PR DESCRIPTION
Reformat code and rename the function to "read_little_endian()" in the recent
commit by Ronald de Man for support of big endian systems.

closes https://github.com/official-stockfish/Stockfish/pull/3016

No functional change