### PR TITLE
Remove passed pawn extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1126,12 +1126,6 @@ moves_loop: // When in check, search starts from here
                && (pos.is_discovery_check_on_king(~us, move) || pos.see_ge(move)))
           extension = 1;
 
-      // Passed pawn extension
-      else if (   move == ss->killers[0]
-               && pos.advanced_pawn_push(move)
-               && pos.pawn_passed(us, to_sq(move)))
-          extension = 1;
-
       // Last captures extension
       else if (   PieceValue[EG][pos.captured_piece()] > PawnValueEg
                && pos.non_pawn_material() <= 2 * RookValueMg)


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f3955f0e98b6c64b3df41d7
LLR: 2.96 (-2.94,2.94) {-1.50,0.50}
Total: 31992 W: 3611 L: 3548 D: 24833
Ptnml(0-2): 174, 2658, 10273, 2713, 178

LTC https://tests.stockfishchess.org/tests/view/5f399e41e98b6c64b3df4210
LLR: 3.01 (-2.94,2.94) {-1.50,0.50}
Total: 29568 W: 1488 L: 1480 D: 26600
Ptnml(0-2): 40, 1272, 12142, 1300, 30

bench: 3844671

Remove passed pawn extension.