### PR TITLE
Remove castling extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1131,11 +1131,6 @@ moves_loop: // When in check, search starts from here
                && pos.non_pawn_material() <= 2 * RookValueMg)
           extension = 1;
 
-      // Castling extension
-      if (   type_of(move) == CASTLING
-          && popcount(pos.pieces(us) & ~pos.pieces(PAWN) & (to_sq(move) & KingSide ? KingSide : QueenSide)) <= 2)
-          extension = 1;
-
       // Late irreversible move extension
       if (   move == ttMove
           && pos.rule50_count() > 80


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f3956c2e98b6c64b3df41e2
LLR: 2.97 (-2.94,2.94) {-1.50,0.50}
Total: 95152 W: 10113 L: 10145 D: 74894
Ptnml(0-2): 461, 7874, 30926, 7866, 449

LTC https://tests.stockfishchess.org/tests/view/5f3a2ee6b38d442594aabdd9
LLR: 2.92 (-2.94,2.94) {-1.50,0.50}
Total: 12064 W: 620 L: 589 D: 10855
Ptnml(0-2): 10, 518, 4946, 547, 11

bench: 4260976

Remove castling extension.