### PR TITLE
Remove history bonus from Eval - Bench:  4335100

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -794,11 +794,7 @@ namespace {
     else
     {
         if ((ss-1)->currentMove != MOVE_NULL)
-        {
-            int bonus = -(ss-1)->statScore / 512;
-
-            ss->staticEval = eval = evaluate(pos) + bonus;
-        }
+            ss->staticEval = eval = evaluate(pos);
         else
             ss->staticEval = eval = -(ss-1)->staticEval + 2 * Tempo;
 


### PR DESCRIPTION
Remove history bonus from Eval

STC:
LLR: 2.92 (-2.94,2.94) {-1.50,0.50}
Total: 26776 W: 2787 L: 2725 D: 21264
https://tests.stockfishchess.org/tests/view/5f39d6beb38d442594aabd9b

LTC:
LLR: 2.93 (-2.94,2.94) {-1.50,0.50}
Total: 12968 W: 635 L: 608 D: 11725
https://tests.stockfishchess.org/tests/view/5f39decfb38d442594aabda7

Bench:  4335100