### PR TITLE
Remove last captures extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1126,11 +1126,6 @@ moves_loop: // When in check, search starts from here
                && (pos.is_discovery_check_on_king(~us, move) || pos.see_ge(move)))
           extension = 1;
 
-      // Last captures extension
-      else if (   PieceValue[EG][pos.captured_piece()] > PawnValueEg
-               && pos.non_pawn_material() <= 2 * RookValueMg)
-          extension = 1;
-
       // Castling extension
       if (   type_of(move) == CASTLING
           && popcount(pos.pieces(us) & ~pos.pieces(PAWN) & (to_sq(move) & KingSide ? KingSide : QueenSide)) <= 2)


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f395657e98b6c64b3df41dd
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 144664 W: 15426 L: 15537 D: 113701
Ptnml(0-2): 612, 11341, 48537, 11230, 612

LTC https://tests.stockfishchess.org/tests/view/5f3a2ec7b38d442594aabdd7
LLR: 2.96 (-2.94,2.94) {-1.50,0.50}
Total: 22728 W: 1161 L: 1146 D: 20421
Ptnml(0-2): 21, 960, 9388, 973, 22

bench: 4004346

Remove last captures extension.