### PR TITLE
Expanded support for x86-32 architectures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,9 +67,10 @@ script:
   - make clean && make -j2 ARCH=x86-64 build && ../tests/signature.sh $benchref
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=general-64 build && ../tests/signature.sh $benchref; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=x86-32 optimize=no debug=yes build && ../tests/signature.sh $benchref; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=x86-32 build && ../tests/signature.sh $benchref; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=x86-32-sse41-popcnt build && ../tests/signature.sh $benchref; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=x86-32-sse2 build && ../tests/signature.sh $benchref; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=x86-32-mmx build && ../tests/signature.sh $benchref; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=general-32 build && ../tests/signature.sh $benchref; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=x86-32-old build && ../tests/signature.sh $benchref; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$COMP" == "gcc" ]]; then make clean && make -j2 ARCH=x86-64-modern profile-build && ../tests/signature.sh $benchref; fi
 
   # compile only for some more advanced architectures (might not run in travis)

--- a/src/Makefile
+++ b/src/Makefile
@@ -115,6 +115,7 @@ ifeq ($(findstring x86,$(ARCH)),x86)
 ifeq ($(findstring x86-32,$(ARCH)),x86-32)
 	arch = i386
 	bits = 32
+	sse = yes
 	mmx = yes
 else
 	arch = x86_64
@@ -579,7 +580,7 @@ help:
 	@echo "x86-64                  > x86 64-bit generic (with sse2 support)"
 	@echo "x86-32-sse41-popcnt     > x86 32-bit with sse41 and popcnt support"
 	@echo "x86-32-sse2             > x86 32-bit with sse2 support"
-	@echo "x86-32                  > x86 32-bit generic (with mmx support)"
+	@echo "x86-32                  > x86 32-bit generic (with mmx and sse support)"
 	@echo "ppc-64                  > PPC 64-bit"
 	@echo "ppc-32                  > PPC 32-bit"
 	@echo "armv7                   > ARMv7 32-bit"

--- a/src/Makefile
+++ b/src/Makefile
@@ -67,11 +67,12 @@ endif
 # bits = 64/32        --- -DIS_64BIT       --- 64-/32-bit operating system
 # prefetch = yes/no   --- -DUSE_PREFETCH   --- Use prefetch asm-instruction
 # popcnt = yes/no     --- -DUSE_POPCNT     --- Use popcnt asm-instruction
+# pext = yes/no       --- -DUSE_PEXT       --- Use pext x86_64 asm-instruction
 # sse = yes/no        --- -msse            --- Use Intel Streaming SIMD Extensions
+# sse2 = yes/no       --- -msse2           --- Use Intel Streaming SIMD Extensions 2
 # ssse3 = yes/no      --- -mssse3          --- Use Intel Supplemental Streaming SIMD Extensions 3
 # sse41 = yes/no      --- -msse4.1         --- Use Intel Streaming SIMD Extensions 4.1
 # avx2 = yes/no       --- -mavx2           --- Use Intel Advanced Vector Extensions 2
-# pext = yes/no       --- -DUSE_PEXT       --- Use pext x86_64 asm-instruction
 # avx512 = yes/no     --- -mavx512bw       --- Use Intel Advanced Vector Extensions 512
 # vnni = yes/no       --- -mavx512vnni     --- Use Intel Vector Neural Network Instructions 512
 # neon = yes/no       --- -DUSE_NEON       --- Use ARM SIMD architecture
@@ -94,10 +95,11 @@ prefetch = no
 popcnt = no
 mmx = no
 sse = no
+pext = no
+sse2 = no
 ssse3 = no
 sse41 = no
 avx2 = no
-pext = no
 avx512 = no
 vnni = no
 neon = no
@@ -105,83 +107,79 @@ ARCH = x86-64-modern
 
 ### 2.2 Architecture specific
 
-ifeq ($(ARCH),general-32)
-	arch = any
-	bits = 32
-endif
+ifeq ($(findstring x86,$(ARCH)),x86)
 
-ifeq ($(ARCH),x86-32-old)
+# x86-32/64
+
+ifeq ($(findstring x86-32,$(ARCH)),x86-32)
 	arch = i386
 	bits = 32
-endif
-
-ifeq ($(ARCH),x86-32)
-	arch = i386
-	bits = 32
-	prefetch = yes
-	mmx = yes
-	sse = yes
-endif
-
-ifeq ($(ARCH),general-64)
-	arch = any
-endif
-
-ifeq ($(ARCH),x86-64)
+else
 	arch = x86_64
-	prefetch = yes
+	sse = yes
+	sse2 = yes
+endif
+
+ifeq ($(findstring -sse,$(ARCH)),-sse)
 	sse = yes
 endif
 
-ifeq ($(ARCH),x86-64-sse3-popcnt)
-	arch = x86_64
-	prefetch = yes
-	sse = yes
+ifeq ($(findstring -popcnt,$(ARCH)),-popcnt)
 	popcnt = yes
 endif
 
-ifeq ($(ARCH),x86-64-ssse3)
-	arch = x86_64
-	prefetch = yes
+ifeq ($(findstring -mmx,$(ARCH)),-mmx)
+	mmx = yes
+endif
+
+ifeq ($(findstring -sse2,$(ARCH)),-sse2)
+	sse = yes
+	sse2 = yes
+endif
+
+ifeq ($(findstring -ssse3,$(ARCH)),-ssse3)
 	sse = yes
 	ssse3 = yes
 endif
 
-ifeq ($(ARCH),$(filter $(ARCH),x86-64-sse41-popcnt x86-64-modern))
-	arch = x86_64
-	prefetch = yes
-	popcnt = yes
+ifeq ($(findstring -sse41,$(ARCH)),-sse41)
 	sse = yes
+	sse2 = yes
 	ssse3 = yes
 	sse41 = yes
 endif
 
-ifeq ($(ARCH),x86-64-avx2)
-	arch = x86_64
-	prefetch = yes
+ifeq ($(findstring -modern,$(ARCH)),-modern)
 	popcnt = yes
 	sse = yes
+	sse2 = yes
+	ssse3 = yes
+	sse41 = yes
+endif
+
+ifeq ($(findstring -avx2,$(ARCH)),-avx2)
+	popcnt = yes
+	sse = yes
+	sse2 = yes
 	ssse3 = yes
 	sse41 = yes
 	avx2 = yes
 endif
 
-ifeq ($(ARCH),x86-64-bmi2)
-	arch = x86_64
-	prefetch = yes
+ifeq ($(findstring -bmi2,$(ARCH)),-bmi2)
 	popcnt = yes
 	sse = yes
+	sse2 = yes
 	ssse3 = yes
 	sse41 = yes
 	avx2 = yes
 	pext = yes
 endif
 
-ifeq ($(ARCH),x86-64-avx512)
-	arch = x86_64
-	prefetch = yes
+ifeq ($(findstring -avx512,$(ARCH)),-avx512)
 	popcnt = yes
 	sse = yes
+	sse2 = yes
 	ssse3 = yes
 	sse41 = yes
 	avx2 = yes
@@ -189,17 +187,38 @@ ifeq ($(ARCH),x86-64-avx512)
 	avx512 = yes
 endif
 
-ifeq ($(ARCH),x86-64-vnni)
-	arch = x86_64
-	prefetch = yes
+ifeq ($(findstring -vnni,$(ARCH)),-vnni)
 	popcnt = yes
 	sse = yes
+	sse2 = yes
 	ssse3 = yes
 	sse41 = yes
 	avx2 = yes
 	pext = yes
 	avx512 = yes
 	vnni = yes
+endif
+
+ifeq ($(sse),yes)
+	prefetch = yes
+endif
+
+# 64-bit pext is not available on x86-32
+ifeq ($(bits),32)
+	pext = no
+endif
+
+else
+
+# all other architectures
+
+ifeq ($(ARCH),general-32)
+	arch = any
+	bits = 32
+endif
+
+ifeq ($(ARCH),general-64)
+	arch = any
 endif
 
 ifeq ($(ARCH),armv7)
@@ -231,6 +250,8 @@ ifeq ($(ARCH),ppc-64)
 	arch = ppc64
 	popcnt = yes
 	prefetch = yes
+endif
+
 endif
 
 ### ==========================================================================
@@ -453,6 +474,13 @@ ifeq ($(ssse3),yes)
 	endif
 endif
 
+ifeq ($(sse2),yes)
+	CXXFLAGS += -DUSE_SSE2
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+		CXXFLAGS += -msse2
+	endif
+endif
+
 ifeq ($(mmx),yes)
 	CXXFLAGS += -DUSE_MMX
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
@@ -462,10 +490,6 @@ endif
 
 ifeq ($(neon),yes)
 	CXXFLAGS += -DUSE_NEON
-endif
-
-ifeq ($(arch),x86_64)
-	CXXFLAGS += -msse2 -DUSE_SSE2
 endif
 
 ### 3.7 pext
@@ -550,9 +574,14 @@ help:
 	@echo "x86-64-modern           > common modern CPU, currently x86-64-sse41-popcnt"
 	@echo "x86-64-ssse3            > x86 64-bit with ssse3 support"
 	@echo "x86-64-sse3-popcnt      > x86 64-bit with sse3 and popcnt support"
-	@echo "x86-64                  > x86 64-bit generic"
-	@echo "x86-32                  > x86 32-bit (also enables MMX and SSE)"
-	@echo "x86-32-old              > x86 32-bit fall back for old hardware"
+	@echo "x86-64                  > x86 64-bit generic (includes sse2 support)"
+	@echo "x86-32-vnni             |"
+	@echo "x86-32-...              | same as for x86-64"
+	@echo "x86-32-sse3-popcnt      |"
+	@echo "x86-32-sse2             > x86 32-bit with sse2 support"
+	@echo "x86-32-mmx-sse          > x86 32-bit with mmx and sse support"
+	@echo "x86-32-mmx              > x86 32-bit with mmx support"
+	@echo "x86-32                  > x86 32-bit generic"
 	@echo "ppc-64                  > PPC 64-bit"
 	@echo "ppc-32                  > PPC 32-bit"
 	@echo "armv7                   > ARMv7 32-bit"
@@ -580,7 +609,7 @@ help:
 	@echo "make -j build ARCH=x86-64-ssse3 COMP=clang"
 	@echo ""
 ifneq ($(empty_arch), yes)
-	@echo "-------------------------------\n"
+	@echo "-------------------------------"
 	@echo "The selected architecture $(ARCH) will enable the following configuration: "
 	@$(MAKE) ARCH=$(ARCH) COMP=$(COMP) config-sanity
 endif
@@ -660,11 +689,13 @@ config-sanity:
 	@echo "os: '$(OS)'"
 	@echo "prefetch: '$(prefetch)'"
 	@echo "popcnt: '$(popcnt)'"
+	@echo "pext: '$(pext)'"
 	@echo "sse: '$(sse)'"
+	@echo "mmx: '$(mmx)'"
+	@echo "sse2: '$(sse2)'"
 	@echo "ssse3: '$(ssse3)'"
 	@echo "sse41: '$(sse41)'"
 	@echo "avx2: '$(avx2)'"
-	@echo "pext: '$(pext)'"
 	@echo "avx512: '$(avx512)'"
 	@echo "vnni: '$(vnni)'"
 	@echo "neon: '$(neon)'"
@@ -685,11 +716,13 @@ config-sanity:
 	@test "$(bits)" = "32" || test "$(bits)" = "64"
 	@test "$(prefetch)" = "yes" || test "$(prefetch)" = "no"
 	@test "$(popcnt)" = "yes" || test "$(popcnt)" = "no"
+	@test "$(pext)" = "yes" || test "$(pext)" = "no"
 	@test "$(sse)" = "yes" || test "$(sse)" = "no"
+	@test "$(mmx)" = "yes" || test "$(mmx)" = "no"
+	@test "$(sse2)" = "yes" || test "$(sse2)" = "no"
 	@test "$(ssse3)" = "yes" || test "$(ssse3)" = "no"
 	@test "$(sse41)" = "yes" || test "$(sse41)" = "no"
 	@test "$(avx2)" = "yes" || test "$(avx2)" = "no"
-	@test "$(pext)" = "yes" || test "$(pext)" = "no"
 	@test "$(avx512)" = "yes" || test "$(avx512)" = "no"
 	@test "$(vnni)" = "yes" || test "$(vnni)" = "no"
 	@test "$(neon)" = "yes" || test "$(neon)" = "no"

--- a/src/Makefile
+++ b/src/Makefile
@@ -142,6 +142,7 @@ endif
 
 ifeq ($(findstring -ssse3,$(ARCH)),-ssse3)
 	sse = yes
+	sse2 = yes
 	ssse3 = yes
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -69,6 +69,7 @@ endif
 # popcnt = yes/no     --- -DUSE_POPCNT     --- Use popcnt asm-instruction
 # pext = yes/no       --- -DUSE_PEXT       --- Use pext x86_64 asm-instruction
 # sse = yes/no        --- -msse            --- Use Intel Streaming SIMD Extensions
+# mmx = yes/no        --- -mmmx            --- Use Intel MMX instructions
 # sse2 = yes/no       --- -msse2           --- Use Intel Streaming SIMD Extensions 2
 # ssse3 = yes/no      --- -mssse3          --- Use Intel Supplemental Streaming SIMD Extensions 3
 # sse41 = yes/no      --- -msse4.1         --- Use Intel Streaming SIMD Extensions 4.1
@@ -93,9 +94,9 @@ sanitize = no
 bits = 64
 prefetch = no
 popcnt = no
-mmx = no
-sse = no
 pext = no
+sse = no
+mmx = no
 sse2 = no
 ssse3 = no
 sse41 = no
@@ -114,6 +115,7 @@ ifeq ($(findstring x86,$(ARCH)),x86)
 ifeq ($(findstring x86-32,$(ARCH)),x86-32)
 	arch = i386
 	bits = 32
+	mmx = yes
 else
 	arch = x86_64
 	sse = yes
@@ -574,14 +576,10 @@ help:
 	@echo "x86-64-modern           > common modern CPU, currently x86-64-sse41-popcnt"
 	@echo "x86-64-ssse3            > x86 64-bit with ssse3 support"
 	@echo "x86-64-sse3-popcnt      > x86 64-bit with sse3 and popcnt support"
-	@echo "x86-64                  > x86 64-bit generic (includes sse2 support)"
-	@echo "x86-32-vnni             |"
-	@echo "x86-32-...              | same as for x86-64"
-	@echo "x86-32-sse3-popcnt      |"
+	@echo "x86-64                  > x86 64-bit generic (with sse2 support)"
+	@echo "x86-32-sse41-popcnt     > x86 32-bit with sse41 and popcnt support"
 	@echo "x86-32-sse2             > x86 32-bit with sse2 support"
-	@echo "x86-32-mmx-sse          > x86 32-bit with mmx and sse support"
-	@echo "x86-32-mmx              > x86 32-bit with mmx support"
-	@echo "x86-32                  > x86 32-bit generic"
+	@echo "x86-32                  > x86 32-bit generic (with mmx support)"
 	@echo "ppc-64                  > PPC 64-bit"
 	@echo "ppc-32                  > PPC 32-bit"
 	@echo "armv7                   > ARMv7 32-bit"


### PR DESCRIPTION
On an x86 processor, all vector instructions supported in 64-bit mode are also supported in 32-bit mode. The current Makefile, however, only supports MMX.

Attempts to work around this limitation by manually adding e.g. "sse41=yes" to the make command fail, because the Makefile adds -DUSE_SSE2 only for x86-64. The NNUE code requires USE_SSE2 to be set for USE_SSE41 to compile.

Instead of only fixing the USE_SSE2 problem, it seems better to make the choice between x86-64 and x86-32 and the choice between the supported (vector) instruction sets orthogonal. That is what this patch does.

If I understand correctly, SSE2 was part of x86-64 from the start. This means that there are three extra x86-32 architectures:

x86-32-sse2
x86-32-mmx-sse
x86-32-mmx

SSE2 and MMX are relevant for NNUE. SSE provides the prefetch instruction.

The only non-orthogonality is pext, which is available on x86-32 but only in 32-bit form (so can't be used).

In the Makefile, I moved "pext" to in between "popcnt" and "sse" because that seems to make sense. It is not one of the vector instruction sets.

I believe there is no change in behaviour, apart from renaming x86-32 to x86-32-mmx-sse and x86-32-old to x86-32.

No change to the C++ code is needed. I have tested various x86-32 architectures and they all compiled and (as far as I could test) gave correct node counts. The speed up from current x86-32/new x86-32-mmx-sse to new x86-32-modern is considerable (bench nps from about 750knps to about 1300knps on my system).

No functional change.