### PR TITLE
Fallback to NNUE

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -114,7 +114,8 @@ namespace {
   constexpr Value LazyThreshold1 =  Value(1400);
   constexpr Value LazyThreshold2 =  Value(1300);
   constexpr Value SpaceThreshold = Value(12222);
-  constexpr Value NNUEThreshold  =   Value(575);
+  constexpr Value NNUEThreshold1 =   Value(550);
+  constexpr Value NNUEThreshold2 =   Value(150);
 
   // KingAttackWeights[PieceType] contains king attack weights by piece type
   constexpr int KingAttackWeights[PIECE_TYPE_NB] = { 0, 0, 81, 52, 44, 10 };
@@ -939,9 +940,12 @@ make_v:
 Value Eval::evaluate(const Position& pos) {
 
   bool classical = !Eval::useNNUE
-                ||  abs(eg_value(pos.psq_score())) >= NNUEThreshold * (16 + pos.rule50_count()) / 16;
+                ||  abs(eg_value(pos.psq_score())) * 16 > NNUEThreshold1 * (16 + pos.rule50_count());
   Value v = classical ? Evaluation<NO_TRACE>(pos).value()
                       : NNUE::evaluate(pos) * 5 / 4 + Tempo;
+
+  if (classical && Eval::useNNUE && abs(v) * 16 < NNUEThreshold2 * (16 + pos.rule50_count()))
+      v = NNUE::evaluate(pos) * 5 / 4 + Tempo;
 
   // Damp down the evaluation linearly when shuffling
   v = v * (100 - pos.rule50_count()) / 100;


### PR DESCRIPTION
If the classical eval ends up much smaller than estimated fall back to NNUE.
Also use multiply instead of divide for the threshold comparison for smoother transitions without rounding.

STC https://tests.stockfishchess.org/tests/view/5f3a5011b38d442594aabdfe
LLR: 2.96 (-2.94,2.94) {-0.50,1.50}
Total: 57352 W: 6325 L: 6135 D: 44892
Ptnml(0-2): 277, 4748, 18482, 4846, 323 

LTC https://tests.stockfishchess.org/tests/view/5f3aee9db38d442594aabe82
LLR: 2.95 (-2.94,2.94) {0.25,1.75}
Total: 16232 W: 897 L: 781 D: 14554
Ptnml(0-2): 19, 679, 6616, 771, 31 

bench: 3937056