### PR TITLE
Reintroduce last captures extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1121,6 +1121,11 @@ moves_loop: // When in check, search starts from here
       else if (    givesCheck
                && (pos.is_discovery_check_on_king(~us, move) || pos.see_ge(move)))
           extension = 1;
+		  
+      // Last captures extension
+      else if (   PieceValue[EG][pos.captured_piece()] > PawnValueEg
+               && pos.non_pawn_material() <= 2 * RookValueMg)
+          extension = 1;
 
       // Castling extension
       if (   type_of(move) == CASTLING


### PR DESCRIPTION
STC:
LLR: 2.93 (-2.94,2.94) {-0.50,1.50}
Total: 34840 W: 3834 L: 3682 D: 27324
Ptnml(0-2): 153, 2767, 11455, 2865, 180
https://tests.stockfishchess.org/tests/view/5f3bb380b38d442594aabefc

LTC:
LLR: 2.95 (-2.94,2.94) {0.25,1.75}
Total: 15832 W: 890 L: 776 D: 14166
Ptnml(0-2): 17, 669, 6429, 785, 16
https://tests.stockfishchess.org/tests/view/5f3c46a0a95672ddd56c632a

Bench: 4348811