### PR TITLE
Set Use NNUE by default to true

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -78,7 +78,7 @@ void init(OptionsMap& o) {
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(7, 0, 7);
-  o["Use NNUE"]              << Option(false, on_use_NNUE);
+  o["Use NNUE"]              << Option(true, on_use_NNUE);
   // The default must follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work.
   o["EvalFile"]              << Option("nn-82215d0fd0df.nnue", on_eval_file);


### PR DESCRIPTION
Since the initial stages of the merge, progress has been made so that
this seems the best option now:

* NNUE is clearly stronger on most relevant hardware and time controls
* All of our CI and testing infrastructure has been adjusted
* The default net is easy to get (further ideas #3030)

fixes https://github.com/official-stockfish/Stockfish/issues/2861

No functional change.