### PR TITLE
Use classical eval in case if evaluation of position at previous ply is high enough.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -117,6 +117,7 @@ namespace {
   constexpr Value SpaceThreshold = Value(12222);
   constexpr Value NNUEThreshold1 =   Value(550);
   constexpr Value NNUEThreshold2 =   Value(150);
+  constexpr Value NNUEThreshold3 =   Value(1000);
 
   // KingAttackWeights[PieceType] contains king attack weights by piece type
   constexpr int KingAttackWeights[PIECE_TYPE_NB] = { 0, 0, 81, 52, 44, 10 };
@@ -938,10 +939,11 @@ make_v:
 /// evaluate() is the evaluator for the outer world. It returns a static
 /// evaluation of the position from the point of view of the side to move.
 
-Value Eval::evaluate(const Position& pos) {
+Value Eval::evaluate(const Position& pos, Value previousEval) {
 
   bool classical = !Eval::useNNUE
-                ||  abs(eg_value(pos.psq_score())) * 16 > NNUEThreshold1 * (16 + pos.rule50_count());
+                ||  abs(eg_value(pos.psq_score())) * 16 > NNUEThreshold1 * (16 + pos.rule50_count())
+                ||  previousEval > NNUEThreshold3;
   Value v = classical ? Evaluation<NO_TRACE>(pos).value()
                       : NNUE::evaluate(pos) * 5 / 4 + Tempo;
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -28,7 +28,7 @@ class Position;
 namespace Eval {
 
   std::string trace(const Position& pos);
-  Value evaluate(const Position& pos);
+  Value evaluate(const Position& pos, Value previousEval);
 
   extern bool useNNUE;
   extern std::string eval_file_loaded;

--- a/src/search.h
+++ b/src/search.h
@@ -45,6 +45,7 @@ struct Stack {
   Move excludedMove;
   Move killers[2];
   Value staticEval;
+  Value previousEval;
   int statScore;
   int moveCount;
   bool inCheck;


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5f3da11aa95672ddd56c6426
LLR: 2.92 (-2.94,2.94) {-0.50,1.50}
Total: 18656 W: 2103 L: 1970 D: 14583
Ptnml(0-2): 101, 1479, 6034, 1614, 100 
passed LTC
https://tests.stockfishchess.org/tests/view/5f3de718a95672ddd56c6434
LLR: 2.93 (-2.94,2.94) {0.25,1.75}
Total: 35480 W: 1963 L: 1793 D: 31724
Ptnml(0-2): 37, 1541, 14417, 1705, 40 
This patch continues work on hybrid NNUE/classical evaluation, there we use an idea that if evaluation of a previous ply was really really big than probably position is close to winning/losing even if there are no big material difference so we can also use classical eval for a speedup.
bench 4294149