### PR TITLE
Simplify away internal iterative deepening

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -939,15 +939,9 @@ namespace {
             }
     }
 
-    // Step 11. Internal iterative deepening (~1 Elo)
-    if (depth >= 7 && !ttMove)
-    {
-        search<NT>(pos, ss, alpha, beta, depth - 7, cutNode);
-
-        tte = TT.probe(posKey, ttHit);
-        ttValue = ttHit ? value_from_tt(tte->value(), ss->ply, pos.rule50_count()) : VALUE_NONE;
-        ttMove = ttHit ? tte->move() : MOVE_NONE;
-    }
+    // Step 11. If position is unknown, decrease depth by 2
+    if (PvNode && depth >= 6 && !ttMove)
+        depth -= 2;
 
 moves_loop: // When in check, search starts from here
 


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f3ce6eaa95672ddd56c637e
LLR: 2.97 (-2.94,2.94) {-0.50,1.50}
Total: 41096 W: 4421 L: 4257 D: 32418
Ptnml(0-2): 207, 3259, 13460, 3407, 215

LTC (old) https://tests.stockfishchess.org/tests/view/5f3d7d4fa95672ddd56c640b
LLR: 2.92 (-2.94,2.94) {-1.50,0.50}
Total: 26032 W: 1320 L: 1309 D: 23403
Ptnml(0-2): 22, 1152, 10654, 1169, 19

LTC (new) https://tests.stockfishchess.org/tests/view/5f3e31e0a95672ddd56c6464
LLR: 2.95 (-2.94,2.94) {-0.75,0.25}
Total: 34160 W: 1844 L: 1766 D: 30550
Ptnml(0-2): 33, 1533, 13876, 1599, 39

bench: 3849173

Remove the iterative deepening step. Instead, simplify it for a depth reduction if position is unknown.