### PR TITLE
Display classic and NNUE evaluation in trace mode

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1013,5 +1013,6 @@ std::string Eval::trace(const Position& pos) {
   v = pos.side_to_move() == WHITE ? v : -v;
   ss << "\nFinal evaluation:     " << to_cp(v) << " (white side)\n";
 
+
   return ss.str();
 }


### PR DESCRIPTION
This is a non functional patch which aims to display at the same moment the classic and the NNUE evaluation if "use NNUE" is true.

This can be helpful to compare classic and NNUE evaluations easily without having to change the NNUE option or having two different settings of stockfish.

No functional change. 