### PR TITLE
Support 256-bit VNNI / check ARCH string

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -213,7 +213,7 @@ ifeq ($(bits),32)
 	pext = no
 endif
 
-ifneq ($(shell echo $(ARCH) | sed -E 's/x86-(32|64)(-sse|-popcnt|-mmx|-sse2|-ssse3|-sse41|-modern|-avx2|-bmi2|-avx512|-vnni)*/OK/'),OK)
+ifneq ($(shell echo $(ARCH) | sed -E 's/x86-(32|64)(-sse|-popcnt|-mmx|-sse2|-sse3|-ssse3|-sse41|-modern|-avx2|-bmi2|-avx512|-vnni)*/OK/'),OK)
 	arch =
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -213,7 +213,7 @@ ifeq ($(bits),32)
 	pext = no
 endif
 
-ifneq ($(shell echo $(ARCH) | sed 's/x86-\(32\|64\)\(-sse\|-popcnt\|-mmx\|-sse2\|-ssse3\|-sse41\|-modern\|-avx2\|-bmi2\|-avx512\|-vnni\)*/OK/'),OK)
+ifneq ($(shell echo $(ARCH) | sed -E 's/x86-(32|64)(-sse|-popcnt|-mmx|-sse2|-ssse3|-sse41|-modern|-avx2|-bmi2|-avx512|-vnni)*/OK/'),OK)
 	arch =
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -109,6 +109,7 @@ STRIP = strip
 
 ### 2.2 Architecture specific
 
+
 ifeq ($(findstring x86,$(ARCH)),x86)
 
 # x86-32/64
@@ -200,7 +201,6 @@ ifeq ($(findstring -vnni,$(ARCH)),-vnni)
 	sse41 = yes
 	avx2 = yes
 	pext = yes
-	avx512 = yes
 	vnni = yes
 endif
 
@@ -211,6 +211,10 @@ endif
 # 64-bit pext is not available on x86-32
 ifeq ($(bits),32)
 	pext = no
+endif
+
+ifneq ($(shell echo $(ARCH) | sed 's/x86-\(32\|64\)\(-sse\|-popcnt\|-mmx\|-sse2\|-ssse3\|-sse41\|-modern\|-avx2\|-bmi2\|-avx512\|-vnni\)*/OK/'),OK)
+	arch =
 endif
 
 else
@@ -612,8 +616,9 @@ help:
 	@echo ""
 	@echo "Supported archs:"
 	@echo ""
-	@echo "x86-64-vnni             > x86 64-bit with vnni support"
+	@echo "x86-64-avx512-vnni      > x86 64-bit with 512-bit vnni support"
 	@echo "x86-64-avx512           > x86 64-bit with avx512 support"
+	@echo "x86-64-avx2-vnni        > x86 64-bit with 256-bit vnni support"
 	@echo "x86-64-bmi2             > x86 64-bit with bmi2 support"
 	@echo "x86-64-avx2             > x86 64-bit with avx2 support"
 	@echo "x86-64-sse41-popcnt     > x86 64-bit with sse41 and popcnt support"

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -85,8 +85,10 @@ namespace Eval::NNUE::Layers {
 
   #elif defined(USE_AVX2)
       constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
-      const __m256i kOnes = _mm256_set1_epi16(1);
       const auto input_vector = reinterpret_cast<const __m256i*>(input);
+  #if !defined(USE_VNNI)
+      const __m256i kOnes = _mm256_set1_epi16(1);
+  #endif
 
   #elif defined(USE_SSE2)
       constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
@@ -145,9 +147,13 @@ namespace Eval::NNUE::Layers {
         __m256i sum = _mm256_setzero_si256();
         const auto row = reinterpret_cast<const __m256i*>(&weights_[offset]);
         for (IndexType j = 0; j < kNumChunks; ++j) {
+  #if defined(USE_VNNI)
+          sum = _mm256_dpbusd_epi32(sum, _mm256_loadA_si256(&input_vector[j]), _mm256_load_si256(&row[j]));
+  #else
           __m256i product = _mm256_maddubs_epi16(_mm256_loadA_si256(&input_vector[j]), _mm256_load_si256(&row[j]));
           product = _mm256_madd_epi16(product, kOnes);
           sum = _mm256_add_epi32(sum, product);
+  #endif
         }
         __m128i sum128 = _mm_add_epi32(_mm256_castsi256_si128(sum), _mm256_extracti128_si256(sum, 1));
         sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_BADC));

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -66,6 +66,11 @@
 #endif
 #endif
 
+// Prevent _mm_empty() if SSE2 is used.
+#if defined(USE_SSE2)
+#undef USE_MMAX
+#endif
+
 namespace Eval::NNUE {
 
   // Version of the evaluation file

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -68,7 +68,7 @@
 
 // Prevent _mm_empty() if SSE2 is used.
 #if defined(USE_SSE2)
-#undef USE_MMAX
+#undef USE_MMX
 #endif
 
 namespace Eval::NNUE {


### PR DESCRIPTION
This patch corresponds to #3038 (256-bit VNNI) with a slightly different approach to the Makefile.

To enable 256-bit VNNI:
make ARCH = x86-64-vnni
(Also enables avx2 and pext.)

To enable 512-bit VNNI:
make ARCH = x86-64-avx512-vnni
(Also enables avx512, which already enabled pext.)

The Makefile now makes sure that the ARCH string is valid (if x86-):
x86-(32|64)(-mmx|-sse|...|-vnni)*

`make ARCH=x86-64-garbage` now results in an error.

There is one more change in nnue_common.h: if USE_SSE2 is set, USE_MMX is undefined to make sure that the various _mm_empty() instructions are skipped. (This could also be done in a separate patch or as part of "small cleanups".)

No functional change.