### PR TITLE
Explicitly rely on pthreads if possible

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -417,6 +417,7 @@ endif
 
 ### On mingw use Windows threads, otherwise POSIX
 ifneq ($(comp),mingw)
+	CXXFLAGS += -DUSE_PTHREADS
 	# On Android Bionic's C library comes with its own pthread implementation bundled in
 	ifneq ($(OS),Android)
 		# Haiku has pthreads in its libroot, so only link it in on other platforms

--- a/src/thread_win32_osx.h
+++ b/src/thread_win32_osx.h
@@ -27,7 +27,7 @@
 /// The implementation calls pthread_create() with the stack size parameter
 /// equal to the linux 8MB default, on platforms that support it.
 
-#if defined(__APPLE__) || defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(__APPLE__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(USE_PTHREADS)
 
 #include <pthread.h>
 


### PR DESCRIPTION
allows us to set the needed stacksize on thread creation.

Useful for environments with too small a default stack size (e.g. Alpine Linux with musl).

Passed STC, no regression:

LLR: 2.96 (-2.94,2.94) {-1.25,0.25}
Total: 17816 W: 1344 L: 1275 D: 15197
Ptnml(0-2): 30, 1057, 6682, 1092, 47
https://tests.stockfishchess.org/tests/view/5f402b5587a5c3c63d8f534d

Bench: 3849173