### PR TITLE
Fix the TT probe corner case with key16==0

### DIFF
--- a/src/tt.h
+++ b/src/tt.h
@@ -25,13 +25,13 @@
 /// TTEntry struct is the 10 bytes transposition table entry, defined as below:
 ///
 /// key        16 bit
-/// move       16 bit
-/// value      16 bit
-/// eval value 16 bit
+/// depth       8 bit
 /// generation  5 bit
 /// pv node     1 bit
 /// bound type  2 bit
-/// depth       8 bit
+/// move       16 bit
+/// value      16 bit
+/// eval value 16 bit
 
 struct TTEntry {
 
@@ -47,11 +47,11 @@ private:
   friend class TranspositionTable;
 
   uint16_t key16;
+  uint8_t  depth8;
+  uint8_t  genBound8;
   uint16_t move16;
   int16_t  value16;
   int16_t  eval16;
-  uint8_t  genBound8;
-  uint8_t  depth8;
 };
 
 

--- a/src/types.h
+++ b/src/types.h
@@ -232,7 +232,8 @@ enum : int {
   DEPTH_QS_RECAPTURES = -5,
 
   DEPTH_NONE   = -6,
-  DEPTH_OFFSET = DEPTH_NONE
+
+  DEPTH_OFFSET = -7 // value used only for TT entry occupancy check
 };
 
 enum Square : int {


### PR DESCRIPTION
This PR consists of three patches:

**Patch 1: (the main one): Allow TT entries with key16==0 to be fetched**

Fix the issue where key16==0 would always result in TT entry being
flagged as not found. Instead, we'll use depth8 to detect whether the TT
entry is occupied. In order to do that, we'll change DEPTH_OFFSET
to -7 (depth8==0) to distinguish between unoccupied entry and
DEPTH_NONE (depth8==1).

**Patch 2: Reorder TT entry for slightly faster access**

Reorder the TT entry for slightly faster access. This patch basically just
recovers the lost performance due to patch 1 as per local testing. The main
point being that depth8 was the last field and gets available slightly later
than the first fields. Or that's at least the theory.

Details and rationale in commit message.

**Patch 3: Fix hashfull reporting corner case**

Fix hashfull reporting corner case. Since now we have a proper TT entry
occupancy test, let's fix this little corner case.

**Additional notes:**

- I've ran the search on a simple position to max depth with debug=yes. Asserts were not triggered. (Pos: 4k3/8/4K3/4R3/8/8/8/8 w - - 0 1 KR+K mate) . MAX_PLY is 246 and the new DEPTH_OFFSET is -7, so there should still be a bit of margin before depth8 overflow. (246 + 7 = 253 < 255)
- This patch is extracted and modified from #2755  . That PR has additional testing notes for very long searches. I don't know what part of this fix has in making the very long searches converge faster, but being able to use key16==0 shouldn't generally make anything worse--except perhaps for some pathological cases where the search relies on key16==0 not getting stored for some reason.
- The easiest repro for hashfull is to hack the default generation value to 248. Thus, first search has generation 0 and will report hashfull 1000.
- I used `sudo perf stat -r 5 -a -B -e cycles:u,instructions:u,branch-misses:u ./sf.sh` and sf.sh being a 1-liner `exec taskset -c 4 ./stockfish bench 16 1 17 >/dev/null 2>&1` to measure the perf for recovery. Not very accurate comparison vs vanilla, since patch 1 changes search branching. But fishtest seems to agree that we're not regressing.
- Thanks to @joergoster for pointing out that move16 is not the only field that can be used for TT entry occupancy test.

STC:
LLR: 2.95 (-2.94,2.94) {-0.25,1.25}
Total: 36848 W: 4091 L: 3898 D: 28859
Ptnml(0-2): 158, 2996, 11972, 3091, 207
https://tests.stockfishchess.org/tests/view/5f3f98d5dc02a01a0c2881f7

LTC:
LLR: 2.95 (-2.94,2.94) {0.25,1.25}
Total: 32280 W: 1828 L: 1653 D: 28799
Ptnml(0-2): 34, 1428, 13051, 1583, 44
https://tests.stockfishchess.org/tests/view/5f3fe77a87a5c3c63d8f5332
