### PR TITLE
Instructions to build on older Macintosh

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -370,7 +370,7 @@ else
 endif
 endif
 
-ifeq ($(KERNEL),Darwin)
+ifeq ($(KERNEL),Darwin) 
 	CXXFLAGS += -arch $(arch) -mmacosx-version-min=10.14
 	LDFLAGS += -arch $(arch) -mmacosx-version-min=10.14
 	XCRUN = xcrun


### PR DESCRIPTION
In recent Macs, it is possible to use the Clang compiler provided by Apple
to compile Stockfish out of the box, and this is the method used by default
in our Makefile (the Makefile sets the macosx-version-min=10.14 flag to select
the right libc++ library for the Clang compiler with recent c++17 support).

But is is quite possible to compile and run Stockfish on older Macs! Below
we describe a method to install a recent GNU compiler on these Macs, to get
the c++17 support. We have tested the following procedure to install gcc10 on
machines running Mac OS 10.7, Mac OS 10.9 and Mac OS 10.13:

1) install XCode for your machine.

2) install Apple command-line developer tools for XCode, by typing the following
   command in a Terminal:

```
      sudo xcode-select --install
```

3) go to the Stockfish "src", then try a default build and run Stockfish:

```
      make clean
      make build
      make net
      ./stockfish
```

4) if step 3 worked, congrats! You have a compiler recent enough on your Mac
to compile Stockfish. If not, continue with step 5 to install GNU gcc10 :-)

5) install the MacPorts package manager (https://www.macports.org/install.php),
for instance using the fast method in the "macOS Package (.pkg) Installer"
section of the page.

6) use the "port" command to install the gcc10 package of MacPorts by typing the
following command:

```
    sudo port install gcc10
```

With this step, MacPorts will install the gcc10 compiler under the name "g++-mp-10"
in the /opt/local/bin directory:

```
   which g++-mp-10

   /opt/local/bin/g++-mp-10       <--- answer
```

7) You can now go back to the "src" directory of Stockfish, and try to build
Stockfish by pointing at the right compiler:

```
   make clean
   make build COMP=gcc COMPCXX=/opt/local/bin/g++-mp-10
   make net
   ./stockfish
```

8) Enjoy Stockfish on Macintosh!

closes https://github.com/official-stockfish/Stockfish/pull/3049

No functional change