### PR TITLE
Use program path as fallback location for eval file (option2)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,3 +86,5 @@ before_test:
       Write-Host "Engine bench:" $r
       Write-Host "Reference bench:" $bench
       If ($r -ne $bench) { exit 1 }
+  - ./stockfish bench > /dev/null
+  - stockfish bench > /dev/null

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,5 +86,4 @@ before_test:
       Write-Host "Engine bench:" $r
       Write-Host "Reference bench:" $bench
       If ($r -ne $bench) { exit 1 }
-  - ./stockfish bench
   - stockfish bench

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,5 +86,5 @@ before_test:
       Write-Host "Engine bench:" $r
       Write-Host "Reference bench:" $bench
       If ($r -ne $bench) { exit 1 }
-  - ./stockfish bench > /dev/null
-  - stockfish bench > /dev/null
+  - ./stockfish bench
+  - stockfish bench

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -23,10 +23,12 @@
 #include <iomanip>
 #include <sstream>
 #include <iostream>
+#include <vector>
 
 #include "bitboard.h"
 #include "evaluate.h"
 #include "material.h"
+#include "misc.h"
 #include "pawns.h"
 #include "thread.h"
 #include "uci.h"
@@ -34,15 +36,20 @@
 namespace Eval {
 
   bool useNNUE;
-  std::string eval_file_loaded="None";
+  std::string eval_file_loaded = "None";
 
   void init_NNUE() {
 
+    std::vector<std::string> dirs = { "" , CommandLine::binaryDirectory };
+
     useNNUE = Options["Use NNUE"];
     std::string eval_file = std::string(Options["EvalFile"]);
-    if (useNNUE && eval_file_loaded != eval_file)
-        if (Eval::NNUE::load_eval_file(eval_file))
-            eval_file_loaded = eval_file;
+
+    if (useNNUE)
+        for (std::string directory : dirs)
+            if (   eval_file_loaded != eval_file
+                && Eval::NNUE::load_eval_file(directory + eval_file))
+                eval_file_loaded = eval_file;
   }
 
   void verify_NNUE() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@ int main(int argc, char* argv[]) {
 
   std::cout << engine_info() << std::endl;
 
+  CommandLine::init(argc, argv);
   UCI::init(Options);
   Tune::init();
   PSQT::init();

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -132,6 +132,7 @@ public:
 
 } // namespace
 
+
 /// engine_info() returns the full name of the current Stockfish version. This
 /// will be either "Stockfish <Tag> DD-MM-YY" (where DD-MM-YY is the date when
 /// the program was compiled) or "Stockfish <Version>", depending on whether
@@ -589,3 +590,64 @@ void bindThisThread(size_t idx) {
 #endif
 
 } // namespace WinProcGroup
+
+#ifdef _WIN32
+#include <direct.h>
+#define GETCWD _getcwd
+#else
+#include <unistd.h>
+#define GETCWD getcwd
+#endif
+
+namespace CommandLine {
+
+string argv0;            // path+name of the executable binary, as given by argv[0]
+string binaryDirectory;  // path of the executable directory
+string workingDirectory; // path of the working directory
+string pathSeparator;    // Separator for our current OS
+
+void init(int argc, char* argv[]) {
+    (void)argc;
+    string separator;
+
+    // extract the path+name of the executable binary
+#ifdef _WIN32
+    // Under windows argv[0] may not have the extension. Also _get_pgmptr() had
+    // issues in some windows 10 versions, so check returned values carefully.
+    char* pgmptr = nullptr;
+    if (!_get_pgmptr(&pgmptr) && pgmptr != nullptr && *pgmptr)
+        argv0 = pgmptr;
+    else
+        argv0 = argv[0];
+    pathSeparator = "\\";
+#else
+    argv0 = argv[0];
+    pathSeparator = "/";
+#endif
+
+    // extract the working directory
+    workingDirectory = "";
+    char buff[40000];
+    char* cwd = GETCWD(buff, 40000);
+    if (cwd)
+        workingDirectory = cwd;
+
+    // extract the binary directory path from argv0
+    binaryDirectory = argv0;
+    size_t pos = binaryDirectory.find_last_of("\\/");
+    if (pos == std::string::npos)
+        binaryDirectory = "." + pathSeparator;
+    else
+        binaryDirectory.resize(pos + 1);
+
+    // pattern replacement: "./" at the start of path is replaced by the working directory
+    if (binaryDirectory.find("." + pathSeparator) == 0)
+        binaryDirectory.replace(0, 1, workingDirectory);
+
+    std::cerr << "workingDirectory =  " << workingDirectory << std::endl;
+    std::cerr << "argv0            =  " << argv0            << std::endl;
+    std::cerr << "binaryDirectory  =  " << binaryDirectory  << std::endl;
+}
+
+
+} // namespace CommandLine

--- a/src/misc.h
+++ b/src/misc.h
@@ -42,9 +42,7 @@ void dbg_mean_of(int v);
 void dbg_print();
 
 typedef std::chrono::milliseconds::rep TimePoint; // A value in milliseconds
-
 static_assert(sizeof(TimePoint) == sizeof(int64_t), "TimePoint should be 64 bits");
-
 inline TimePoint now() {
   return std::chrono::duration_cast<std::chrono::milliseconds>
         (std::chrono::steady_clock::now().time_since_epoch()).count();
@@ -124,6 +122,13 @@ inline uint64_t mul_hi64(uint64_t a, uint64_t b) {
 
 namespace WinProcGroup {
   void bindThisThread(size_t idx);
+}
+
+namespace CommandLine {
+  void init(int argc, char* argv[]);
+
+  extern std::string binaryDirectory;  // path of the executable directory
+  extern std::string workingDirectory; // path of the working directory
 }
 
 #endif // #ifndef MISC_H_INCLUDED


### PR DESCRIPTION
This patch uses the program path (ie the the directory where the Stockfish
executable resides) as a fallback location to find the NNUE EvalFile. This
makes it possible to use NNUE eval files located in the Stockfish directory,
even in GUI which change the working directory under our feet.

No functional change.