### PR TITLE
Introduce distrib target in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -617,6 +617,7 @@ help:
 	@echo "profile-build           > Faster build (with profile-guided optimization)"
 	@echo "strip                   > Strip executable"
 	@echo "install                 > Install executable"
+	@echo "distrib                 > Create an archive with engine and default nnue net"
 	@echo "clean                   > Clean up"
 	@echo ""
 	@echo "Supported archs:"
@@ -668,7 +669,7 @@ ifneq ($(empty_arch), yes)
 endif
 
 
-.PHONY: help build profile-build strip install clean net objclean profileclean \
+.PHONY: help build profile-build strip install distrib clean net objclean profileclean \
         config-sanity icc-profile-use icc-profile-make gcc-profile-use gcc-profile-make \
         clang-profile-use clang-profile-make
 
@@ -698,10 +699,21 @@ install:
 	-cp $(EXE) $(BINDIR)
 	-strip $(BINDIR)/$(EXE)
 
-#clean all
+# clean all
 clean: objclean profileclean
-	@rm -f .depend *~ core
+	@rm -f .depend *~ core stockfish.tar.gz
 
+# clean binaries and objects
+objclean:
+	@rm -f $(EXE) *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
+
+# clean auxiliary profiling files
+profileclean:
+	@rm -rf profdir
+	@rm -f bench.txt *.gcda *.gcno ./syzygy/*.gcda ./nnue/*.gcda ./nnue/features/*.gcda *.s
+	@rm -f stockfish.profdata *.profraw
+
+# net
 net:
 	$(eval nnuenet := $(shell grep EvalFile ucioption.cpp | grep Option | sed 's/.*\(nn-[a-z0-9]\{12\}.nnue\).*/\1/'))
 	@echo "Default net: $(nnuenet)"
@@ -725,16 +737,10 @@ net:
             echo "shasum / sha256sum not found, skipping net validation"; \
         fi
 
-
-# clean binaries and objects
-objclean:
-	@rm -f $(EXE) *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
-
-# clean auxiliary profiling files
-profileclean:
-	@rm -rf profdir
-	@rm -f bench.txt *.gcda *.gcno ./syzygy/*.gcda ./nnue/*.gcda ./nnue/features/*.gcda *.s
-	@rm -f stockfish.profdata *.profraw
+# distrib
+distrib: net
+	@rm -f stockfish.tar.gz
+	tar -czf stockfish.tar.gz $(EXE) $(nnuenet)
 
 default:
 	help


### PR DESCRIPTION
We introduce a "distrib" taget in the Makefile to create a compressed tar archive
containing the stockfish binary and the default nnue net side-by-side.

For instance, you can use the following commands:

```
    make build
    make distrib
```

This will build Stockfish, then create a "stockfish.tar.gz" archive containing the
engine executable and its recommended default net (note: the default nnue net will
be downloaded transparently (if necessary) for inclusion in the archive).

Of course, you can build an optimized version of Stockfish if you wish instead
of the above default build, just replace the `make build` line by a more complicated
build command.

The aim is to help people distributing Stockfish (for instance, Abrok) to distribute
also the recommended net, so that the engine and its evaluation file stay side-by-side
for the users.

No functional change.

---
Also clean and reorder other targets in the Makefile while there.