### PR TITLE
Introduce countermove based pruning for qsearch.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1570,6 +1570,12 @@ moves_loop: // When in check, search starts from here
                                                                 [pos.moved_piece(move)]
                                                                 [to_sq(move)];
 
+      if (  !captureOrPromotion
+          && moveCount >= abs(depth) + 1
+          && (*contHist[0])[pos.moved_piece(move)][to_sq(move)] < CounterMovePruneThreshold
+          && (*contHist[1])[pos.moved_piece(move)][to_sq(move)] < CounterMovePruneThreshold)
+          continue;
+
       // Make and search the move
       pos.do_move(move, st, givesCheck);
       value = -qsearch<NT>(pos, ss+1, -beta, -alpha, depth - 1);


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5f41220287a5c3c63d8f53c5
LLR: 2.93 (-2.94,2.94) {-0.25,1.25}
Total: 35944 W: 4127 L: 3929 D: 27888
Ptnml(0-2): 196, 2970, 11459, 3134, 213 
passed LTC
https://tests.stockfishchess.org/tests/view/5f41862f87a5c3c63d8f53e8
LLR: 2.95 (-2.94,2.94) {0.25,1.25}
Total: 138448 W: 7655 L: 7252 D: 123541
Ptnml(0-2): 145, 6247, 56043, 6638, 151 
This patch continues work of previous patch in introducing pruning heuristics in qsearch by analogy to main search, now with countermove based pruning.
Idea is that if move is late enough and is quite check (we do generate them in qsearch) and has bad enough countermove history - prune it.
bench 3586044