### PR TITLE
-mpfu is not required on armv8 architecture on Linux 

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -241,7 +241,7 @@ ifeq ($(ARCH),armv7-neon)
 endif
 
 ifeq ($(ARCH),armv8)
-	arch = armv8-a
+	arch = armv8
 	prefetch = yes
 	popcnt = yes
 	neon = yes
@@ -285,7 +285,7 @@ ifeq ($(COMP),gcc)
 	CXX=g++
 	CXXFLAGS += -pedantic -Wextra -Wshadow
 
-	ifeq ($(arch),$(filter $(arch),armv7 armv8-a))
+	ifeq ($(arch),$(filter $(arch),armv7 armv8))
 		ifeq ($(OS),Android)
 			CXXFLAGS += -m$(bits)
 			LDFLAGS += -m$(bits)
@@ -387,7 +387,7 @@ ifeq ($(COMP),ndk)
 		CXXFLAGS += -mthumb -march=armv7-a -mfloat-abi=softfp -mfpu=neon
 		STRIP=arm-linux-androideabi-strip
 	endif
-	ifeq ($(arch),armv8-a)
+	ifeq ($(arch),armv8)
 		comp=aarch64-linux-android21-clang
 		CXX=aarch64-linux-android21-clang++
 		STRIP=aarch64-linux-android-strip
@@ -476,7 +476,7 @@ endif
 
 ### 3.6 popcnt
 ifeq ($(popcnt),yes)
-	ifeq ($(arch),$(filter $(arch),ppc64 armv7 armv8-a arm64))
+	ifeq ($(arch),$(filter $(arch),ppc64 armv7 armv8 arm64))
 		CXXFLAGS += -DUSE_POPCNT
 	else ifeq ($(comp),icc)
 		CXXFLAGS += -msse3 -DUSE_POPCNT
@@ -539,7 +539,9 @@ ifeq ($(neon),yes)
 	CXXFLAGS += -DUSE_NEON
 	ifeq ($(KERNEL),Linux)
 	ifneq ($(COMP),ndk)
+	ifneq ($(arch),armv8)
 		CXXFLAGS += -mfpu=neon
+	endif
 	endif
 	endif
 endif
@@ -780,7 +782,7 @@ config-sanity:
 	@test "$(optimize)" = "yes" || test "$(optimize)" = "no"
 	@test "$(arch)" = "any" || test "$(arch)" = "x86_64" || test "$(arch)" = "i386" || \
 	 test "$(arch)" = "ppc64" || test "$(arch)" = "ppc" || \
-	 test "$(arch)" = "armv7" || test "$(arch)" = "armv8-a" || test "$(arch)" = "arm64"
+	 test "$(arch)" = "armv7" || test "$(arch)" = "armv8" || test "$(arch)" = "arm64"
 	@test "$(bits)" = "32" || test "$(bits)" = "64"
 	@test "$(prefetch)" = "yes" || test "$(prefetch)" = "no"
 	@test "$(popcnt)" = "yes" || test "$(popcnt)" = "no"


### PR DESCRIPTION
-mpfu is not required on AArch64 / armv8 architecture on Linux and throws an error if present.

See the [Arm Compiler Reference](https://developer.arm.com/documentation/dui0774/f/Compiler-Command-line-Options/-mfpu)

I have also simplified arch= to armv8 from armv8-a as the -a suffix was superfluous (and probably was meant to refer to Android). 

This PR has been tested on gcc and clang on Gentoo-64 and Raspian-64 on a Raspberry Pi 4

Closes issue [3056](https://github.com/official-stockfish/Stockfish/issues/3056)

No functional change

