### PR TITLE
Change default benchmark to NNUE

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -116,7 +116,7 @@ vector<string> setup_bench(const Position& current, istream& is) {
   string limit     = (is >> token) ? token : "13";
   string fenFile   = (is >> token) ? token : "default";
   string limitType = (is >> token) ? token : "depth";
-  string evalType  = (is >> token) ? token : "mixed";
+  string evalType  = (is >> token) ? token : "NNUE";
 
   go = limitType == "eval" ? "eval" : "go " + limitType + " " + limit;
 


### PR DESCRIPTION
Now that NNUE is the default Stockfish eval, change the default benchmark behaviour to NNUE

No functional change