### PR TITLE
Simplify MCP in QS - bench:  3611906

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1532,7 +1532,7 @@ moves_loop: // When in check, search starts from here
           assert(type_of(move) != ENPASSANT); // Due to !pos.advanced_pawn_push
 
           // moveCount pruning
-          if (moveCount > abs(depth) + 2)
+          if (moveCount > 2)
               continue;
 
           futilityValue = futilityBase + PieceValue[EG][pos.piece_on(to_sq(move))];


### PR DESCRIPTION
Simplify MCP in QS by removing depth dependency.

STC
LLR: 2.94 (-2.94,2.94) {-1.25,0.25}
Total: 42960 W: 4741 L: 4661 D: 33558
Ptnml(0-2): 218, 3574, 13804, 3678, 206
https://tests.stockfishchess.org/tests/view/5f42e3f75089a564a10d8493

LTC
LLR: 2.94 (-2.94,2.94) {-0.75,0.25}
Total: 66672 W: 3563 L: 3508 D: 59601
Ptnml(0-2): 71, 3064, 26996, 3149, 56
https://tests.stockfishchess.org/tests/view/5f4353285089a564a10d84d0

Bench:  3611906 