### PR TITLE
Remove the late irreversible move extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1123,12 +1123,6 @@ moves_loop: // When in check, search starts from here
           && popcount(pos.pieces(us) & ~pos.pieces(PAWN) & (to_sq(move) & KingSide ? KingSide : QueenSide)) <= 2)
           extension = 1;
 
-      // Late irreversible move extension
-      if (   move == ttMove
-          && pos.rule50_count() > 80
-          && (captureOrPromotion || type_of(movedPiece) == PAWN))
-          extension = 2;
-
       // Add extension to new depth
       newDepth += extension;
 


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f43f4a55089a564a10d851e
LLR: 2.94 (-2.94,2.94) {-1.25,0.25}
Total: 36992 W: 4104 L: 4020 D: 28868
Ptnml(0-2): 174, 2992, 12081, 3074, 175

LTC https://tests.stockfishchess.org/tests/view/5f44b7ae5089a564a10d8581
LLR: 2.97 (-2.94,2.94) {-0.75,0.25}
Total: 45184 W: 2401 L: 2336 D: 40447
Ptnml(0-2): 36, 1947, 18574, 1986, 49

bench: 3660774

Simplify away the late irreversible move extension.