### PR TITLE
QS Pruning Simplification bench: 3823111

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1565,7 +1565,7 @@ moves_loop: // When in check, search starts from here
                                                                 [to_sq(move)];
 
       if (  !captureOrPromotion
-          && moveCount >= abs(depth) + 1
+          && moveCount
           && (*contHist[0])[pos.moved_piece(move)][to_sq(move)] < CounterMovePruneThreshold
           && (*contHist[1])[pos.moved_piece(move)][to_sq(move)] < CounterMovePruneThreshold)
           continue;


### PR DESCRIPTION
Remove depth dependence in QS pruning

STC:
LLR: 2.95 (-2.94,2.94) {-1.25,0.25}
Total: 40536 W: 4442 L: 4358 D: 31736
Ptnml(0-2): 209, 3330, 13118, 3390, 221
https://tests.stockfishchess.org/tests/view/5f49035b3def6407861152f9

LTC:
LLR: 2.95 (-2.94,2.94) {-0.75,0.25}
Total: 97104 W: 5164 L: 5130 D: 86810
Ptnml(0-2): 103, 4478, 39377, 4470, 124
https://tests.stockfishchess.org/tests/view/5f4939d53def640786115322

Bench:  3823111