### PR TITLE
Fixes a TB bug that can give different benches with different compilers.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1964,7 +1964,7 @@ void Tablebases::rank_root_moves(Position& pos, Search::RootMoves& rootMoves) {
     if (RootInTB)
     {
         // Sort moves according to TB rank
-        std::sort(rootMoves.begin(), rootMoves.end(),
+        std::stable_sort(rootMoves.begin(), rootMoves.end(),
                   [](const RootMove &a, const RootMove &b) { return a.tbRank > b.tbRank; } );
 
         // Probe during search only if DTZ is not available and we are winning

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -758,7 +758,7 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
     if (entry->hasPawns) {
         idx = LeadPawnIdx[leadPawnsCnt][squares[0]];
 
-        std::sort(squares + 1, squares + leadPawnsCnt, pawns_comp);
+        std::stable_sort(squares + 1, squares + leadPawnsCnt, pawns_comp);
 
         for (int i = 1; i < leadPawnsCnt; ++i)
             idx += Binomial[i][MapPawns[squares[i]]];
@@ -859,7 +859,7 @@ encode_remaining:
 
     while (d->groupLen[++next])
     {
-        std::sort(groupSq, groupSq + d->groupLen[next]);
+        std::stable_sort(groupSq, groupSq + d->groupLen[next]);
         uint64_t n = 0;
 
         // Map down a square if "comes later" than a square in the previous


### PR DESCRIPTION
std::sort() is not stable so different implementations can produce different results.
To verify the bug add this fen  "8/6k1/5r2/8/8/8/1K6/Q7 w - - 0 1" at the top of benchmark.cpp and set the syzygy path to a full set of 345men.  With gcc 10.2.0 the bench is 4872790.  With MSVC 2017 it is 4619426.  After the fix they are both 4619426.
The changes in tbprobe.cpp are not strictly necessary for this particular case but could cause the same issue in the future.
I don't measure any speed difference but would like to hear from @syzygy1 if this is the best way to fix it.  For reference this was introduced here https://github.com/official-stockfish/Stockfish/pull/1467

bench: 3736029