### PR TITLE
Fix a linker bug with Clang on Windows

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -595,6 +595,11 @@ ifeq ($(debug), no)
 		LDFLAGS += $(CXXFLAGS)
 	else ifeq ($(comp),clang)
 		CXXFLAGS += -flto=thin
+		ifneq ($(findstring MINGW,$(KERNEL)),)
+			CXXFLAGS += -fuse-ld=lld
+		else ifneq ($(findstring MSYS,$(KERNEL)),)
+			CXXFLAGS += -fuse-ld=lld
+		endif
 		LDFLAGS += $(CXXFLAGS)
 
 # GCC and CLANG use different methods for parallelizing LTO and CLANG pretends to be


### PR DESCRIPTION
When compiling 
make build ARCH=x86-64-bmi2 COMP=clang -j
with Clang version 10.0.1 (latest from MSYS2) on Windows the link step fails with:
```
benchmark.o: file not recognized: file format not recognized
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [Makefile:844: stockfish] Error 1
make[1]: Leaving directory '/c/Projects/forks/Stockfish/src'
make: *** [Makefile:716: build] Error 2
```
bench: 3736029