### PR TITLE
Always print an info line before a bestmove

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1861,11 +1861,14 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
   {
       bool updated = rootMoves[i].score != -VALUE_INFINITE;
 
-      if (depth == 1 && !updated)
+      if (depth == 1 && !updated && i > 0)
           continue;
 
-      Depth d = updated ? depth : depth - 1;
+      Depth d = updated ? depth : std::max(1, depth - 1);
       Value v = updated ? rootMoves[i].score : rootMoves[i].previousScore;
+
+      if (v == -VALUE_INFINITE)
+          v = VALUE_ZERO;
 
       bool tb = TB::RootInTB && abs(v) < VALUE_MATE_IN_MAX_PLY;
       v = tb ? rootMoves[i].tbScore : v;


### PR DESCRIPTION
if very few nodes are being searched before a bestmove is reported,
an info line might be missing.

fixes https://github.com/official-stockfish/Stockfish/issues/2757

no functional change