### PR TITLE
Simplify LMR - bench: 3624569

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1160,7 +1160,6 @@ moves_loop: // When in check, search starts from here
       // re-searched at full depth.
       if (    depth >= 3
           &&  moveCount > 1 + 2 * rootNode + 2 * (PvNode && abs(bestValue) < 2)
-          && (!rootNode || thisThread->best_move_count(move) == 0)
           && (  !captureOrPromotion
               || moveCountPruning
               || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -51,17 +51,6 @@ Thread::~Thread() {
 }
 
 
-/// Thread::bestMoveCount(Move move) return best move counter for the given root move
-
-int Thread::best_move_count(Move move) const {
-
-  auto rm = std::find(rootMoves.begin() + pvIdx,
-                      rootMoves.begin() + pvLast, move);
-
-  return rm != rootMoves.begin() + pvLast ? rm->bestMoveCount : 0;
-}
-
-
 /// Thread::clear() reset histories, usually before a new game
 
 void Thread::clear() {

--- a/src/thread.h
+++ b/src/thread.h
@@ -54,7 +54,6 @@ public:
   void idle_loop();
   void start_searching();
   void wait_for_search_finished();
-  int best_move_count(Move move) const;
 
   Pawns::Table pawnsTable;
   Material::Table materialTable;


### PR DESCRIPTION
Simplify LMR at Root node

STC:
LLR: 2.94 (-2.94,2.94) {-1.25,0.25}
Total: 71520 W: 7649 L: 7614 D: 56257
Ptnml(0-2): 346, 5845, 23349, 5868, 352
https://tests.stockfishchess.org/tests/view/5f4be8c0ba100690c5cc5cbb

LTC:
LLR: 2.95 (-2.94,2.94) {-0.75,0.25}
Total: 74832 W: 3997 L: 3948 D: 66887
Ptnml(0-2): 77, 3422, 30362, 3485, 70
https://tests.stockfishchess.org/tests/view/5f4c603eba100690c5cc5d0e

Bench:  3624569
