### PR TITLE
Simplify singularQuietLMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1196,7 +1196,7 @@ moves_loop: // When in check, search starts from here
 
           // Decrease reduction if ttMove has been singularly extended (~3 Elo)
           if (singularQuietLMR)
-              r -= 1 + formerPv;
+              r -= 2;
 
           if (!captureOrPromotion)
           {


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f4cb99aba100690c5cc5d37
LLR: 2.97 (-2.94,2.94) {-1.25,0.25}
Total: 44512 W: 4960 L: 4878 D: 34674
Ptnml(0-2): 238, 3737, 14219, 3829, 233

LTC https://tests.stockfishchess.org/tests/view/5f4e8474ba100690c5cc5e12
LLR: 2.93 (-2.94,2.94) {-0.75,0.25}
Total: 43032 W: 2298 L: 2227 D: 38507
Ptnml(0-2): 45, 1940, 17475, 2011, 45

bench: 3529107

Simplify singularQuietLMR