### PR TITLE
Simplify singularQuietLMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1095,7 +1095,7 @@ moves_loop: // When in check, search starts from here
           if (value < singularBeta)
           {
               extension = 1;
-              singularQuietLMR = !ttCapture;
+              singularQuietLMR = true;
           }
 
           // Multi-cut pruning
@@ -1196,7 +1196,7 @@ moves_loop: // When in check, search starts from here
 
           // Decrease reduction if ttMove has been singularly extended (~3 Elo)
           if (singularQuietLMR)
-              r -= 1 + formerPv;
+              r -= 1;
 
           if (!captureOrPromotion)
           {


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f4cba05ba100690c5cc5d39
LLR: 2.95 (-2.94,2.94) {-1.25,0.25}
Total: 30848 W: 3322 L: 3227 D: 24299
Ptnml(0-2): 168, 2442, 10094, 2567, 153

LTC https://tests.stockfishchess.org/tests/view/5f4cf219ba100690c5cc5d4d
LLR: 2.96 (-2.94,2.94) {-0.75,0.25}
Total: 79512 W: 4179 L: 4135 D: 71198
Ptnml(0-2): 74, 3600, 32361, 3650, 71

bench: 3478013

Simplify singularQuietLMR.