### PR TITLE
RFC  Include 4-men syzygy WDL and DTZ in the binary

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -65,6 +65,9 @@ const vector<string> Defaults = {
   "3Qb1k1/1r2ppb1/pN1n2q1/Pp1Pp1Pr/4P2p/4BP2/4B1R1/1R5K b - - 11 40",
   "4k3/3q1r2/1N2r1b1/3ppN2/2nPP3/1B1R2n1/2R1Q3/3K4 w - - 5 1",
 
+  // 4-man positions
+  "8/6k1/5r2/8/8/8/1K6/Q7 w - - 0 1"       // Kc3 - mate in 27
+
   // 5-man positions
   "8/8/8/8/5kp1/P7/8/1K1N4 w - - 0 1",     // Kc2 - mate
   "8/8/8/5N2/8/p7/8/2NK3k w - - 0 1",      // Na2 - mate

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -43,7 +43,7 @@
 //     const unsigned char *const gEmbeddedNNUEEnd;     // a marker to the end
 //     const unsigned int         gEmbeddedNNUESize;    // the size of the embedded file
 // Note that this does not work in Microsof Visual Studio.
-#if !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
+#if !defined(_MSC_VER) && !defined(EMBEDDING_OFF)
   INCBIN(EmbeddedNNUE, EvalFileDefaultName);
 #else
   const unsigned char        gEmbeddedNNUEData[1] = {0x0};

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <type_traits>
 #include <mutex>
+#include <unordered_map>
 
 #include "../bitboard.h"
 #include "../movegen.h"
@@ -34,8 +35,37 @@
 #include "../search.h"
 #include "../types.h"
 #include "../uci.h"
+#include "../incbin/incbin.h"
 
 #include "tbprobe.h"
+
+// Macro to embed the default 4-men syzygy file data in the engine binary (using incbin.h, by Dale Weiler).
+// This macro invocation will declare the following three variables
+//     const unsigned char        gEmbedded4menData[];  // a pointer to the embedded data
+//     const unsigned char *const gEmbedded4menEnd;     // a marker to the end
+//     const unsigned int         gEmbedded4menSize;    // the size of the embedded file
+// Note that this does not work in Microsof Visual Studio.
+#if !defined(EMBEDDING_OFF)
+#if !defined(_MSC_VER)
+#undef  INCBIN_ALIGNMENT
+#define INCBIN_ALIGNMENT 64
+INCBIN(Embedded4men, "syzygy/4men.syz");
+#else
+const unsigned int gEmbedded4menSize = 4350016;
+alignas(64) unsigned char gEmbedded4menData[gEmbedded4menSize];
+static struct LoadBin {
+    LoadBin() {
+        FILE* fp = fopen("../../src/syzygy/4men.syz", "rb");
+        if (fp) {
+            fread(gEmbedded4menData, 1, gEmbedded4menSize, fp);
+            fclose(fp);
+        }
+    };
+} loadBin;
+#endif
+#else
+const unsigned char* const gEmbedded4menData = nullptr;
+#endif
 
 #ifndef _WIN32
 #include <fcntl.h>
@@ -68,6 +98,8 @@ inline WDLScore operator-(WDLScore d) { return WDLScore(-int(d)); }
 inline Square operator^(Square s, int i) { return Square(int(s) ^ i); }
 
 const std::string PieceToChar = " PNBRQK  pnbrqk";
+
+bool internal4Men = true;
 
 int MapPawns[SQUARE_NB];
 int MapB1H1H7[SQUARE_NB];
@@ -158,6 +190,31 @@ struct LR {
 
 static_assert(sizeof(LR) == 3, "LR tree entry must be 3 bytes");
 
+
+#define M(c, ow, oz) { #c".rtbw", ow }, { #c".rtbz", oz }
+static const std::unordered_map<std::string, int> offset4Men = {
+    M( KBvK,       0, 1264384), M( KNvK,     128, 1264512), M( KPvK,    256, 1264640),
+    M( KQvK,    8128, 1268864), M( KRvK,    8448, 1274240), M(KBBvK,   8704, 1282560),
+    M(KBNvK,   66752, 1418880), M(KBPvK,   74432, 1880768), M(KBvKB, 155904, 1956608),
+    M(KBvKN,  157184, 1956736), M(KBvKP,  159488, 1956864), M(KNNvK, 267008, 1962880),
+    M(KNPvK,  268416, 1963008), M(KNvKN,  361664, 2074112), M(KNvKP, 362880, 2074240),
+    M(KPPvK,  510976, 2084928), M(KPvKP,  536128, 2093632), M(KQBvK, 781504, 2148160),
+    M(KQNvK,  786496, 2287296), M(KQPvK,  790144, 2443776), M(KQQvK, 802688, 2476032),
+    M(KQRvK,  809792, 2502016), M(KQvKB,  814400, 2546176), M(KQvKN, 821120, 2741440),
+    M(KQvKP,  831232, 2904128), M(KQvKQ,  889344, 3109952), M(KQvKR, 905920, 3116736),
+    M(KRBvK,  926464, 3425792), M(KRNvK,  929344, 3687616), M(KRPvK, 931712, 3983296),
+    M(KRRvK,  936896, 3996288), M(KRvKB,  938880, 4049856), M(KRvKN, 971840, 4059840),
+    M(KRvKP, 1071936, 4153088), M(KRvKR, 1251392, 4346560)
+};
+#undef M
+
+inline const void* get_4men(const std::string& str)
+{
+    assert(gEmbedded4menData);
+    auto it = offset4Men.find(str);
+    return it != offset4Men.end() ? &gEmbedded4menData[it->second] : nullptr;
+}
+
 // Tablebases data layout is structured as following:
 //
 //  TBFile:   memory maps/unmaps the physical .rtbw and .rtbz files
@@ -182,19 +239,26 @@ public:
 
     TBFile(const std::string& f) {
 
+        if (internal4Men)
+        {
+            fname = f;
+        }
+        else
+        {
 #ifndef _WIN32
-        constexpr char SepChar = ':';
+            constexpr char SepChar = ':';
 #else
-        constexpr char SepChar = ';';
+            constexpr char SepChar = ';';
 #endif
-        std::stringstream ss(Paths);
-        std::string path;
+            std::stringstream ss(Paths);
+            std::string path;
 
-        while (std::getline(ss, path, SepChar)) {
-            fname = path + "/" + f;
-            std::ifstream::open(fname);
-            if (is_open())
-                return;
+            while (std::getline(ss, path, SepChar)) {
+                fname = path + "/" + f;
+                std::ifstream::open(fname);
+                if (is_open())
+                    return;
+            }
         }
     }
 
@@ -202,73 +266,88 @@ public:
     // closed after mapping.
     uint8_t* map(void** baseAddress, uint64_t* mapping, TBType type) {
 
-        assert(is_open());
+        if (internal4Men)
+        {
+            if (is_open())
+                close();
 
-        close(); // Need to re-open to get native file descriptor
+            *baseAddress = const_cast<void*>(get_4men(fname));
+            *mapping = 0;
+
+            if (!*baseAddress)
+                return nullptr;
+        }
+        else
+        {
+            assert(is_open());
+
+            close(); // Need to re-open to get native file descriptor
 
 #ifndef _WIN32
-        struct stat statbuf;
-        int fd = ::open(fname.c_str(), O_RDONLY);
+            struct stat statbuf;
+            int fd = ::open(fname.c_str(), O_RDONLY);
 
-        if (fd == -1)
-            return *baseAddress = nullptr, nullptr;
+            if (fd == -1)
+                return *baseAddress = nullptr, nullptr;
 
-        fstat(fd, &statbuf);
+            fstat(fd, &statbuf);
 
-        if (statbuf.st_size % 64 != 16)
-        {
-            std::cerr << "Corrupt tablebase file " << fname << std::endl;
-            exit(EXIT_FAILURE);
-        }
+            if (statbuf.st_size % 64 != 16)
+            {
+                std::cerr << "Corrupt tablebase file " << fname << std::endl;
+                exit(EXIT_FAILURE);
+            }
 
-        *mapping = statbuf.st_size;
-        *baseAddress = mmap(nullptr, statbuf.st_size, PROT_READ, MAP_SHARED, fd, 0);
+            *mapping = statbuf.st_size;
+            *baseAddress = mmap(nullptr, statbuf.st_size, PROT_READ, MAP_SHARED, fd, 0);
 #if defined(MADV_RANDOM)
-        madvise(*baseAddress, statbuf.st_size, MADV_RANDOM);
+            madvise(*baseAddress, statbuf.st_size, MADV_RANDOM);
 #endif
-        ::close(fd);
+            ::close(fd);
 
-        if (*baseAddress == MAP_FAILED)
-        {
-            std::cerr << "Could not mmap() " << fname << std::endl;
-            exit(EXIT_FAILURE);
-        }
+            if (*baseAddress == MAP_FAILED)
+            {
+                std::cerr << "Could not mmap() " << fname << std::endl;
+                exit(EXIT_FAILURE);
+            }
 #else
-        // Note FILE_FLAG_RANDOM_ACCESS is only a hint to Windows and as such may get ignored.
-        HANDLE fd = CreateFile(fname.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
-                               OPEN_EXISTING, FILE_FLAG_RANDOM_ACCESS, nullptr);
+            // Note FILE_FLAG_RANDOM_ACCESS is only a hint to Windows and as such may get ignored.
+            HANDLE fd = CreateFile(fname.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+                                   OPEN_EXISTING, FILE_FLAG_RANDOM_ACCESS, nullptr);
 
-        if (fd == INVALID_HANDLE_VALUE)
-            return *baseAddress = nullptr, nullptr;
+            if (fd == INVALID_HANDLE_VALUE)
+                return *baseAddress = nullptr, nullptr;
 
-        DWORD size_high;
-        DWORD size_low = GetFileSize(fd, &size_high);
+            DWORD size_high;
+            DWORD size_low = GetFileSize(fd, &size_high);
 
-        if (size_low % 64 != 16)
-        {
-            std::cerr << "Corrupt tablebase file " << fname << std::endl;
-            exit(EXIT_FAILURE);
-        }
+            if (size_low % 64 != 16)
+            {
+                std::cerr << "Corrupt tablebase file " << fname << std::endl;
+                exit(EXIT_FAILURE);
+            }
 
-        HANDLE mmap = CreateFileMapping(fd, nullptr, PAGE_READONLY, size_high, size_low, nullptr);
-        CloseHandle(fd);
+            HANDLE mmap = CreateFileMapping(fd, nullptr, PAGE_READONLY, size_high, size_low, nullptr);
+            CloseHandle(fd);
 
-        if (!mmap)
-        {
-            std::cerr << "CreateFileMapping() failed" << std::endl;
-            exit(EXIT_FAILURE);
-        }
+            if (!mmap)
+            {
+                std::cerr << "CreateFileMapping() failed" << std::endl;
+                exit(EXIT_FAILURE);
+            }
 
-        *mapping = (uint64_t)mmap;
-        *baseAddress = MapViewOfFile(mmap, FILE_MAP_READ, 0, 0, 0);
+            *mapping = (uint64_t)mmap;
+            *baseAddress = MapViewOfFile(mmap, FILE_MAP_READ, 0, 0, 0);
 
-        if (!*baseAddress)
-        {
-            std::cerr << "MapViewOfFile() failed, name = " << fname
-                      << ", error = " << GetLastError() << std::endl;
-            exit(EXIT_FAILURE);
-        }
+            if (!*baseAddress)
+            {
+                std::cerr << "MapViewOfFile() failed, name = " << fname
+                          << ", error = " << GetLastError() << std::endl;
+                exit(EXIT_FAILURE);
+            }
 #endif
+        }
+
         uint8_t* data = (uint8_t*)*baseAddress;
 
         constexpr uint8_t Magics[][4] = { { 0xD7, 0x66, 0x0C, 0xA5 },
@@ -285,6 +364,9 @@ public:
     }
 
     static void unmap(void* baseAddress, uint64_t mapping) {
+
+        if (internal4Men)
+            return;
 
 #ifndef _WIN32
         munmap(baseAddress, mapping);
@@ -478,12 +560,22 @@ void TBTables::add(const std::vector<PieceType>& pieces) {
     for (PieceType pt : pieces)
         code += PieceToChar[pt];
 
-    TBFile file(code.insert(code.find('K', 1), "v") + ".rtbw"); // KRK -> KRvK
+    code.insert(code.find('K', 1), "v"); // KRK -> KRvK
 
-    if (!file.is_open()) // Only WDL file is checked
-        return;
+    if (internal4Men)
+    {
+        if (!get_4men(code + ".rtbw"))
+            return;
+    }
+    else
+    {
+        TBFile file(code + ".rtbw");
 
-    file.close();
+        if (!file.is_open()) // Only WDL file is checked
+            return;
+
+        file.close();
+    }
 
     MaxCardinality = std::max((int)pieces.size(), MaxCardinality);
 
@@ -1268,6 +1360,8 @@ void Tablebases::init(const std::string& paths) {
 
     if (paths.empty() || paths == "<empty>")
         return;
+
+    internal4Men = (paths == "<4-men>") && (const void*)gEmbedded4menData;
 
     // MapB1H1H7[] encodes a square below a1-h8 diagonal to 0..27
     int code = 0;

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -75,7 +75,7 @@ void init(OptionsMap& o) {
   o["UCI_LimitStrength"]     << Option(false);
   o["UCI_Elo"]               << Option(1350, 1350, 2850);
   o["UCI_ShowWDL"]           << Option(false);
-  o["SyzygyPath"]            << Option("<empty>", on_tb_path);
+  o["SyzygyPath"]            << Option("<4-men>", on_tb_path);
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(7, 0, 7);


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/5f4dddfaba100690c5cc5db4
LLR: 2.93 (-2.94,2.94) {-0.25,1.25}
Total: 24736 W: 2852 L: 2677 D: 19207
Ptnml(0-2): 105, 1998, 8023, 2101, 141 

LTC: https://tests.stockfishchess.org/tests/view/5f4e1e10ba100690c5cc5dcd
LLR: 2.94 (-2.94,2.94) {0.25,1.25}
Total: 47688 W: 2607 L: 2411 D: 42670
Ptnml(0-2): 34, 1935, 19717, 2117, 41 

bench: 3505347

I wrote this patch(w/o DTZ) a long time ago but never opened a PR because of the increased size of the binary.  With the NNUE net now being embedded the delta is less significant going from 22MB to 26MB (without DTZ it would go to 23MB).  The elo increase isn't very large but there are other considerations as well.

- The TB code will now get test coverage on fishtest
- The bench now incorporates TB
- Profile(PGO) binaries will have optimized TB code
- Perfect out of the box 3 & 4 men play (especially many mobile users never install any TB)
- Unlike the nets the TB data does not change so it won't cause the repository to grow or have to be updated

Comments welcome below.  Thank you.
Edit:
Some comments so far: https://github.com/mstembera/Stockfish/commit/44d04bf7010d619fca930b2f1b5834d8c4cc21ad
Also credit and thanks to @snicolet who originated the idea https://groups.google.com/d/msg/fishcooking/y0bQIdqy2n4/5u6jsrK7BQAJ