### PR TITLE
Simplify singularQuietLMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1196,7 +1196,7 @@ moves_loop: // When in check, search starts from here
 
           // Decrease reduction if ttMove has been singularly extended (~3 Elo)
           if (singularQuietLMR)
-              r -= 1 + formerPv;
+              r--;
 
           if (!captureOrPromotion)
           {


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f4cb922ba100690c5cc5d35
LLR: 2.96 (-2.94,2.94) {-1.25,0.25}
Total: 113672 W: 12347 L: 12368 D: 88957
Ptnml(0-2): 566, 9537, 36699, 9420, 614

LTC https://tests.stockfishchess.org/tests/view/5f4e8474ba100690c5cc5e12
LLR: 2.93 (-2.94,2.94) {-0.75,0.25}
Total: 43032 W: 2298 L: 2227 D: 38507
Ptnml(0-2): 45, 1940, 17475, 2011, 45

bench: 3890143

Simplify singularQuietLMR.