### PR TITLE
LMR Simplification bench:  4221376

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1168,13 +1168,6 @@ moves_loop: // When in check, search starts from here
       {
           Depth r = reduction(improving, depth, moveCount);
 
-          // Decrease reduction at non-check cut nodes for second move at low depths
-          if (   cutNode
-              && depth <= 10
-              && moveCount <= 2
-              && !ss->inCheck)
-              r--;
-
           // Decrease reduction if the ttHit running average is large
           if (thisThread->ttHitAverage > 509 * TtHitAverageResolution * TtHitAverageWindow / 1024)
               r--;


### PR DESCRIPTION
LMR Simplification

STC:
LLR: 2.95 (-2.94,2.94) {-1.25,0.25}
Total: 61712 W: 6594 L: 6543 D: 48575
Ptnml(0-2): 293, 5085, 20082, 5070, 326
https://tests.stockfishchess.org/tests/view/5f5007d6ba100690c5cc5ea9

LTC:
LLR: 2.94 (-2.94,2.94) {-0.75,0.25}
Total: 57544 W: 2983 L: 2925 D: 51636
Ptnml(0-2): 47, 2568, 23495, 2604, 58
https://tests.stockfishchess.org/tests/view/5f50c597ba100690c5cc5ef7

Bench:  4221376
