### PR TITLE
Randomly use classical eval

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1015,12 +1015,16 @@ make_v:
 
 Value Eval::evaluate(const Position& pos) {
 
+  bool useClassical = abs(eg_value(pos.psq_score())) * 16 > NNUEThreshold1 * (16 + pos.rule50_count());
   bool classical = !Eval::useNNUE
-                ||  abs(eg_value(pos.psq_score())) * 16 > NNUEThreshold1 * (16 + pos.rule50_count());
+                ||  useClassical
+                || (abs(eg_value(pos.psq_score())) > PawnValueMg / 8 && !(pos.this_thread()->nodes & 0xF));
   Value v = classical ? Evaluation<NO_TRACE>(pos).value()
                       : NNUE::evaluate(pos) * 5 / 4 + Tempo;
 
-  if (classical && Eval::useNNUE && abs(v) * 16 < NNUEThreshold2 * (16 + pos.rule50_count()))
+  if (   useClassical 
+      && Eval::useNNUE 
+      && abs(v) * 16 < NNUEThreshold2 * (16 + pos.rule50_count()))
       v = NNUE::evaluate(pos) * 5 / 4 + Tempo;
 
   // Damp down the evaluation linearly when shuffling


### PR DESCRIPTION
If there is a slight to moderate imbalance, use classical eval randomly for 1/16 or around 6.3% of the time.

STC:
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 32320 W: 3562 L: 3377 D: 25381
Ptnml(0-2): 144, 2609, 10478, 2776, 153
https://tests.stockfishchess.org/tests/view/5f520615ba100690c5cc5f80

LTC:
LLR: 2.95 (-2.94,2.94) {0.25,1.25}
Total: 21032 W: 1116 L: 974 D: 18942
Ptnml(0-2): 20, 837, 8664, 971, 24
https://tests.stockfishchess.org/tests/view/5f522eaaba100690c5cc5f8c

Bench: 3696738