### PR TITLE
Always re-enable NNUE after "bench".

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -164,5 +164,7 @@ vector<string> setup_bench(const Position& current, istream& is) {
           ++posCounter;
       }
 
+  list.emplace_back("setoption name Use NNUE value true");
+
   return list;
 }


### PR DESCRIPTION
Restore the default NNUE setting (enabled) after a bench command.
This also makes the resulting program settings independent of the
number of FENs that are being benched.

Fixes issue #3112.

No functional change.