### PR TITLE
Double probability of using classical eval

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1015,10 +1015,13 @@ make_v:
 
 Value Eval::evaluate(const Position& pos) {
 
+  // Use classical eval if there is a large imbalance
+  // If there is a moderate imbalance, use classical eval with probability (1/8),
+  // as derived from the node counter.
   bool useClassical = abs(eg_value(pos.psq_score())) * 16 > NNUEThreshold1 * (16 + pos.rule50_count());
   bool classical = !Eval::useNNUE
                 ||  useClassical
-                || (abs(eg_value(pos.psq_score())) > PawnValueMg / 8 && !(pos.this_thread()->nodes & 0xF));
+                || (abs(eg_value(pos.psq_score())) > PawnValueMg / 4 && !(pos.this_thread()->nodes & 0xB));
   Value v = classical ? Evaluation<NO_TRACE>(pos).value()
                       : NNUE::evaluate(pos) * 5 / 4 + Tempo;
 


### PR DESCRIPTION
This patch doubles the moderate imbalance threshold and probability of using classical eval. 
So now if imbalance is greater than PawnValueMg / 4 then there is a 1/8 chance of using classical eval.

STC:
LLR: 2.93 (-2.94,2.94) {-0.25,1.25}
Total: 10984 W: 1303 L: 1140 D: 8541
Ptnml(0-2): 58, 867, 3489, 1010, 68
https://tests.stockfishchess.org/tests/view/5f554c9f97da2d5437d3813e

LTC:
LLR: 2.95 (-2.94,2.94) {0.25,1.25}
Total: 43064 W: 2476 L: 2276 D: 38312
Ptnml(0-2): 37, 1985, 17308, 2145, 57
https://tests.stockfishchess.org/tests/view/5f55690a00a0aa2ca79f0a43

Bench: 4161067