### PR TITLE
Increase default slow mover value to 115

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -68,7 +68,7 @@ void init(OptionsMap& o) {
   o["MultiPV"]               << Option(1, 1, 500);
   o["Skill Level"]           << Option(20, 0, 20);
   o["Move Overhead"]         << Option(10, 0, 5000);
-  o["Slow Mover"]            << Option(100, 10, 1000);
+  o["Slow Mover"]            << Option(115, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
   o["UCI_Chess960"]          << Option(false);
   o["UCI_AnalyseMode"]       << Option(false);


### PR DESCRIPTION
Passed STC
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 37496 W: 4595 L: 4387 D: 28514
Ptnml(0-2): 222, 3216, 11696, 3360, 254

Passed LTC
LLR: 2.94 (-2.94,2.94) {0.25,1.25}
Total: 176736 W: 10020 L: 9531 D: 157185
Ptnml(0-2): 209, 8195, 71097, 8632, 235

Increase default slow mover value to 115, idea was first to test with increased contempt but more slowmover too (for less draw rate and hopefully more wins), but as suggested by vondele, to test slowmover only.

bench:4222126