### PR TITLE
Remove castling extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1127,11 +1127,6 @@ moves_loop: // When in check, search starts from here
                && pos.non_pawn_material() <= 2 * RookValueMg)
           extension = 1;
 
-      // Castling extension
-      if (   type_of(move) == CASTLING
-          && popcount(pos.pieces(us) & ~pos.pieces(PAWN) & (to_sq(move) & KingSide ? KingSide : QueenSide)) <= 2)
-          extension = 1;
-
       // Late irreversible move extension
       if (   move == ttMove
           && pos.rule50_count() > 80


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f5fa5348fbc1c8a3f476eca
LLR: 2.94 (-2.94,2.94) {-1.25,0.25}
Total: 38520 W: 4713 L: 4610 D: 29197
Ptnml(0-2): 233, 3486, 11734, 3559, 248

LTC https://tests.stockfishchess.org/tests/view/5f62166a912c15f19854b806
LLR: 2.93 (-2.94,2.94) {-0.75,0.25}
Total: 48024 W: 2673 L: 2600 D: 42751
Ptnml(0-2): 64, 2247, 19316, 2322, 63

bench: 3818400

Remove castling extension. It was discussed here, after being rejected for being too premature: https://github.com/official-stockfish/Stockfish/pull/3018#issuecomment-691688516