### PR TITLE
Simplify futility pruning for captures

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1056,7 +1056,6 @@ moves_loop: // When in check, search starts from here
               if (   !givesCheck
                   && lmrDepth < 6
                   && !(PvNode && abs(bestValue) < 2)
-                  && PieceValue[MG][type_of(movedPiece)] >= PieceValue[MG][type_of(pos.piece_on(to_sq(move)))]
                   && !ss->inCheck
                   && ss->staticEval + 169 + 244 * lmrDepth
                      + PieceValue[MG][type_of(pos.piece_on(to_sq(move)))] <= alpha)


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f61f0e4b91f2ec371e429c2
LLR: 2.94 (-2.94,2.94) {-1.25,0.25}
Total: 75512 W: 8747 L: 8704 D: 58061
Ptnml(0-2): 440, 6589, 23683, 6576, 468

LTC https://tests.stockfishchess.org/tests/view/5f6215d3912c15f19854b801
LLR: 2.95 (-2.94,2.94) {-0.75,0.25}
Total: 92912 W: 5030 L: 4992 D: 82890
Ptnml(0-2): 88, 4363, 37532, 4369, 104

bench: 4063097

Simplify term from futility pruning for captures.