### PR TITLE
Simplify reduced depth search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1151,7 +1151,7 @@ moves_loop: // When in check, search starts from here
       // Step 16. Reduced depth search (LMR, ~200 Elo). If the move fails high it will be
       // re-searched at full depth.
       if (    depth >= 3
-          &&  moveCount > 1 + 2 * rootNode + 2 * (PvNode && abs(bestValue) < 2)
+          &&  moveCount > 1 + 2 * rootNode
           && (  !captureOrPromotion
               || moveCountPruning
               || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f64c72fbb0cae038ca8f531
LLR: 2.94 (-2.94,2.94) {-1.25,0.25}
Total: 28320 W: 3475 L: 3359 D: 21486
Ptnml(0-2): 170, 2485, 8773, 2523, 209

LTC https://tests.stockfishchess.org/tests/view/5f650cfabb0cae038ca8f585
LLR: 2.95 (-2.94,2.94) {-0.75,0.25}
Total: 58392 W: 3354 L: 3285 D: 51753
Ptnml(0-2): 74, 2826, 23336, 2877, 83

bench: 4201295

Simplification in reduced depth search.