### PR TITLE
Tweak hybrid treshold.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1018,7 +1018,7 @@ Value Eval::evaluate(const Position& pos) {
   // Use classical eval if there is a large imbalance
   // If there is a moderate imbalance, use classical eval with probability (1/8),
   // as derived from the node counter.
-  bool useClassical = abs(eg_value(pos.psq_score())) * 16 > NNUEThreshold1 * (16 + pos.rule50_count());
+  bool useClassical = abs(eg_value(pos.psq_score())) * 16 > (NNUEThreshold1 + pos.non_pawn_material() / 64) * (16 + pos.rule50_count());
   bool classical = !Eval::useNNUE
                 ||  useClassical
                 || (abs(eg_value(pos.psq_score())) > PawnValueMg / 4 && !(pos.this_thread()->nodes & 0xB));


### PR DESCRIPTION
Increase the first hybrid threshold with more material.

STC:
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 24416 W: 3039 L: 2848 D: 18529
Ptnml(0-2): 135, 2136, 7503, 2271, 163
https://tests.stockfishchess.org/tests/view/5f6451efbb0cae038ca8f4dc

LTC;
LLR: 2.95 (-2.94,2.94) {0.25,1.25}
Total: 65016 W: 3702 L: 3455 D: 57859
Ptnml(0-2): 66, 2991, 26157, 3218, 76
https://tests.stockfishchess.org/tests/view/5f64b143bb0cae038ca8f51f

Bench: 3809395