### PR TITLE
Increase reductions with the number of threads

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -192,7 +192,7 @@ namespace {
 void Search::init() {
 
   for (int i = 1; i < MAX_MOVES; ++i)
-      Reductions[i] = int((22.0 + std::log(Threads.size())) * std::log(i));
+      Reductions[i] = int((22.0 + 2 * std::log(Threads.size())) * std::log(i));
 }
 
 


### PR DESCRIPTION
Passed STC with 8 threads:
LLR: 2.92 (-2.94,2.94) {-0.25,1.25}
Total: 13520 W: 1135 L: 1012 D: 11373
Ptnml(0-2): 39, 815, 4929, 938, 39
https://tests.stockfishchess.org/tests/view/5f68e274ded68c240be73f41

Passed LTC with 8 threads:
LLR: 2.96 (-2.94,2.94) {0.25,1.25}
Total: 48384 W: 2183 L: 1994 D: 44207
Ptnml(0-2): 28, 1777, 20402, 1948, 37
https://tests.stockfishchess.org/tests/view/5f68f068ded68c240be747e9

closes https://github.com/official-stockfish/Stockfish/pull/3142

No functional change (for one thread)