### PR TITLE
Switch to NNUE eval probabilistically

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1035,7 +1035,9 @@ Value Eval::evaluate(const Position& pos) {
       // if the classical eval is small and imbalance large, use NNUE nevertheless.
       if (   largePsq
           && (abs(v) * 16 < NNUEThreshold2 * r50
-          || (pos.opposite_bishops() && abs(v) * 16 < 2 * PawnValueEg * r50)))
+          || (   pos.opposite_bishops() 
+              && abs(v) * 16 < NNUEThreshold1 * r50
+              && !(pos.this_thread()->nodes & 0x3))))
           v = adjusted_NNUE();
   }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1021,10 +1021,10 @@ Value Eval::evaluate(const Position& pos) {
       v = Evaluation<NO_TRACE>(pos).value();
   else
   {
-      // scale and shift NNUE for compatibility with search and classical evaluation
+      // Scale and shift NNUE for compatibility with search and classical evaluation
       auto  adjusted_NNUE = [&](){ return NNUE::evaluate(pos) * 5 / 4 + Tempo; };
 
-      // if there is PSQ imbalance use classical eval, with small probability if it is small
+      // If there is PSQ imbalance use classical eval, with small probability if it is small
       Value psq = Value(abs(eg_value(pos.psq_score())));
       int   r50 = 16 + pos.rule50_count();
       bool  largePsq = psq * 16 > (NNUEThreshold1 + pos.non_pawn_material() / 64) * r50;
@@ -1032,7 +1032,9 @@ Value Eval::evaluate(const Position& pos) {
 
       v = classical ? Evaluation<NO_TRACE>(pos).value() : adjusted_NNUE();
 
-      // if the classical eval is small and imbalance large, use NNUE nevertheless.
+      // If the classical eval is small and imbalance large, use NNUE nevertheless.
+      // For opposite colored bishops and the classical eval is struggling to win,
+      // switch to NNUE with small probability.
       if (   largePsq
           && (abs(v) * 16 < NNUEThreshold2 * r50
           || (   pos.opposite_bishops() 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1033,8 +1033,8 @@ Value Eval::evaluate(const Position& pos) {
       v = classical ? Evaluation<NO_TRACE>(pos).value() : adjusted_NNUE();
 
       // If the classical eval is small and imbalance large, use NNUE nevertheless.
-      // For opposite colored bishops and the classical eval is struggling to win,
-      // switch to NNUE with small probability.
+      // For the case of opposite colored bishops, switch to NNUE eval with
+      // small probability if the classical eval is less than the threshold.
       if (   largePsq
           && (abs(v) * 16 < NNUEThreshold2 * r50
           || (   pos.opposite_bishops() 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1034,7 +1034,8 @@ Value Eval::evaluate(const Position& pos) {
 
       // if the classical eval is small and imbalance large, use NNUE nevertheless.
       if (   largePsq
-          && abs(v) * 16 < NNUEThreshold2 * r50)
+          && (abs(v) * 16 < NNUEThreshold2 * r50
+          || (pos.opposite_bishops() && abs(v) * 16 < 2 * PawnValueEg * r50)))
           v = adjusted_NNUE();
   }
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1036,8 +1036,8 @@ Value Eval::evaluate(const Position& pos) {
       if (   largePsq
           && (abs(v) * 16 < NNUEThreshold2 * r50
           || (   pos.opposite_bishops() 
-              && abs(v) * 16 < NNUEThreshold1 * r50
-              && !(pos.this_thread()->nodes & 0x3))))
+              && abs(v) * 16 < (NNUEThreshold1 + pos.non_pawn_material() / 64) * r50
+              && !(pos.this_thread()->nodes & 0xB))))
           v = adjusted_NNUE();
   }
 


### PR DESCRIPTION
Introduce a small chance of switching to NNUE if PSQ imbalance is large but we have opposite colored bishops and the classical eval is struggling to win.

STC:
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 25304 W: 3179 L: 2983 D: 19142
Ptnml(0-2): 172, 2171, 7781, 2345, 183
https://tests.stockfishchess.org/tests/view/5f6b14dec7759d4ee307cfe3

LTC:
LLR: 2.94 (-2.94,2.94) {0.25,1.25}
Total: 84680 W: 4846 L: 4556 D: 75278
Ptnml(0-2): 89, 3933, 34011, 4213, 94
https://tests.stockfishchess.org/tests/view/5f6b3fb6c7759d4ee307cff9

Bench: 3865413