### PR TITLE
Fix reset not being initialized on null moves leading to possible zeroing out of the accumulator.

### DIFF
--- a/src/nnue/features/feature_set.h
+++ b/src/nnue/features/feature_set.h
@@ -62,12 +62,12 @@ namespace Eval::NNUE::Features {
         IndexListType removed[2], IndexListType added[2], bool reset[2]) {
 
       const auto& dp = pos.state()->dirtyPiece;
-      if (dp.dirty_num == 0) return;
 
       for (Color perspective : { WHITE, BLACK }) {
         reset[perspective] = false;
         switch (trigger) {
           case TriggerEvent::kFriendKingMoved:
+            if (dp.dirty_num == 0) continue;
             reset[perspective] = dp.piece[0] == make_piece(perspective, KING);
             break;
           default:


### PR DESCRIPTION
This bug was found by noob. On null moves AppendChangedIndices would exit before setting `reset` and therefore leave it uninitialized. This in theory can cause `reset` to be true when no features are appended and in result clear the accumulator without adding weights for any feature.

Curiously doesn't have any impact on the execution.