### PR TITLE
Use incremental updates more

### DIFF
--- a/src/nnue/features/half_kp.cpp
+++ b/src/nnue/features/half_kp.cpp
@@ -52,11 +52,10 @@ namespace Eval::NNUE::Features {
   // Get a list of indices for recently changed features
   template <Side AssociatedKing>
   void HalfKP<AssociatedKing>::AppendChangedIndices(
-      const Position& pos, Color perspective,
+      const Position& pos, const DirtyPiece& dp, Color perspective,
       IndexList* removed, IndexList* added) {
 
     Square ksq = orient(perspective, pos.square<KING>(perspective));
-    const auto& dp = pos.state()->dirtyPiece;
     for (int i = 0; i < dp.dirty_num; ++i) {
       Piece pc = dp.piece[i];
       if (type_of(pc) == KING) continue;

--- a/src/nnue/features/half_kp.h
+++ b/src/nnue/features/half_kp.h
@@ -50,7 +50,7 @@ namespace Eval::NNUE::Features {
                                     IndexList* active);
 
     // Get a list of indices for recently changed features
-    static void AppendChangedIndices(const Position& pos, Color perspective,
+    static void AppendChangedIndices(const Position& pos, const DirtyPiece& dp, Color perspective,
                                      IndexList* removed, IndexList* added);
 
    private:


### PR DESCRIPTION
Use incremental updates for accumulators for up to 2 plies.

While cleaning up code, I found that https://github.com/official-stockfish/Stockfish/blob/1dbd2a1ad548b3ca676f7da949e1a998c64b836b/src/nnue/nnue_feature_transformer.h#L292 is a clear mistake for not using a reference, fix is included in this patch along with fixing of https://github.com/official-stockfish/Stockfish/pull/3149.

Passed STC:
LLR: 2.95 (-2.94,2.94) {-0.25,1.25}
Total: 21752 W: 2583 L: 2403 D: 16766
Ptnml(0-2): 128, 1761, 6923, 1931, 133
https://tests.stockfishchess.org/tests/view/5f7150cf3b22d6afa5069412

This PR only differs by adding asserts() as requested.

--------------------------------------------------------------------------------------------

https://tests.stockfishchess.org/tests/view/5f70e5d43b22d6afa50693da

This test is inferior due to full copy of previous accumulators and dirtyPiece, also has more LOC, however it measures gains from the described incremental update behavior alone.

https://tests.stockfishchess.org/tests/view/5f71844b3b22d6afa5069422

This test is inferior due to compiler unable to optimize lambda function well.

No functional change.