### PR TITLE
Tweak reduction formula.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -192,7 +192,7 @@ namespace {
 void Search::init() {
 
   for (int i = 1; i < MAX_MOVES; ++i)
-      Reductions[i] = int((22.0 + 2 * std::log(Threads.size())) * std::log(i));
+      Reductions[i] = int((22.0 + 2 * std::log(Threads.size())) * std::log(i + 0.25 * std::log(i)));
 }
 
 


### PR DESCRIPTION
Replace log(i) with log(i + 0.25 * log(i)). This increases especially for low values the reductions. But for bigger values there are nearly no changes.

STC:
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 49640 W: 5505 L: 5289 D: 38846
Ptnml(0-2): 270, 4074, 15924, 4274, 278
https://tests.stockfishchess.org/tests/view/5f71f04d3b22d6afa5069478

LTC:
LLR: 2.94 (-2.94,2.94) {0.25,1.25}
Total: 43856 W: 2209 L: 2021 D: 39626
Ptnml(0-2): 32, 1776, 18128, 1956, 36
https://tests.stockfishchess.org/tests/view/5f7232ee3b22d6afa50699a2

Bench: 3573163