### PR TITLE
Schedule threads fairly under valgrind

### DIFF
--- a/tests/instrumented.sh
+++ b/tests/instrumented.sh
@@ -20,7 +20,7 @@ case $1 in
   --valgrind-thread)
     echo "valgrind-thread testing started"
     prefix=''
-    exeprefix='valgrind --error-exitcode=42'
+    exeprefix='valgrind --fair-sched=try --error-exitcode=42'
     postfix='1>/dev/null'
     threads="2"
   ;;


### PR DESCRIPTION
fixes a rare case that can cause CI to fail when running multithreaded under valgrind.

No functional change.