### PR TITLE
Simplify away futility pruning for captures

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1049,15 +1049,6 @@ moves_loop: // When in check, search starts from here
                   && captureHistory[movedPiece][to_sq(move)][type_of(pos.piece_on(to_sq(move)))] < 0)
                   continue;
 
-              // Futility pruning for captures
-              if (   !givesCheck
-                  && lmrDepth < 6
-                  && !(PvNode && abs(bestValue) < 2)
-                  && !ss->inCheck
-                  && ss->staticEval + 169 + 244 * lmrDepth
-                     + PieceValue[MG][type_of(pos.piece_on(to_sq(move)))] <= alpha)
-                  continue;
-
               // See based pruning
               if (!pos.see_ge(move, Value(-221) * depth)) // (~25 Elo)
                   continue;


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f749bfed930428c36d34c56
LLR: 2.94 (-2.94,2.94) {-1.25,0.25}
Total: 38064 W: 4011 L: 3929 D: 30124
Ptnml(0-2): 192, 3004, 12567, 3068, 201

LTC https://tests.stockfishchess.org/tests/view/5f74d99bf18675b1ce2f7412
LLR: 2.94 (-2.94,2.94) {-0.75,0.25}
Total: 184984 W: 8567 L: 8610 D: 167807
Ptnml(0-2): 146, 7593, 77058, 7548, 147

bench: 3890648

Remove futility pruning for captures.