### PR TITLE
Introduce attackedBy3 bitboard

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -310,6 +310,9 @@ namespace {
     // attackedBy2[color] are the squares attacked by at least 2 units of a given
     // color, including x-rays. But diagonal x-rays through pawns are not computed.
     Bitboard attackedBy2[COLOR_NB];
+
+    // attackedBy3[color] are the squares attacked by at least 3 units of a given
+    // color, including x-rays. But diagonal x-rays through pawns are not computed.
     Bitboard attackedBy3[COLOR_NB];
 
     // kingRing[color] are the squares adjacent to the king plus some other


### PR DESCRIPTION
Classical evaluation : this patch introduce and use attackedBy3 bitboard. The use is quiet similar to attackedBy2 bitboard but other uses can be developed in the future.

STC : 
LLR: 2.95 (-2.94,2.94) {-0.25,1.25}
Total: 30616 W: 6260 L: 5955 D: 18401
Ptnml(0-2): 539, 3481, 7020, 3672, 596 
https://tests.stockfishchess.org/tests/view/5f674a053e38315b2559ae87

LTC : (positive LLR after 800k games)
LLR: 0.45 (-2.94,2.94) {0.25,1.25}
Total: 800000 W: 107344 L: 105577 D: 587079
Ptnml(0-2): 6411, 76451, 232649, 77938, 6551 
https://tests.stockfishchess.org/tests/view/5f679bfbded68c240be70890

bench 3791487
