### PR TITLE
RookOnQueenFile Removal

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,7 +7,7 @@ Joona Kiiski (zamar)
 Gary Linscott (glinscott)
 
 # Authors and inventors of NNUE, training, NNUE port
-Yu Nasu (ynasu87)
+Yu Nasu (ynasu87)hi
 Motohiro Isozaki (yaneurao)
 Hisayori Noda (nodchip)
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -7,7 +7,7 @@ Joona Kiiski (zamar)
 Gary Linscott (glinscott)
 
 # Authors and inventors of NNUE, training, NNUE port
-Yu Nasu (ynasu87)hi
+Yu Nasu (ynasu87)
 Motohiro Isozaki (yaneurao)
 Hisayori Noda (nodchip)
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -265,7 +265,7 @@ namespace {
   constexpr Score ReachableOutpost    = S( 31, 22);
   constexpr Score RestrictedPiece     = S(  7,  7);
   constexpr Score RookOnKingRing      = S( 16,  0);
-  constexpr Score RookOnQueenFile     = S(  6, 11);
+  // constexpr Score RookOnQueenFile     = S(  6, 11);
   constexpr Score SliderOnQueen       = S( 60, 18);
   constexpr Score ThreatByKing        = S( 24, 89);
   constexpr Score ThreatByPawnPush    = S( 48, 39);
@@ -482,8 +482,8 @@ namespace {
         if (Pt == ROOK)
         {
             // Bonus for rook on the same file as a queen
-            if (file_bb(s) & pos.pieces(QUEEN))
-                score += RookOnQueenFile;
+            // if (file_bb(s) & pos.pieces(QUEEN))
+            //     score += RookOnQueenFile;
 
             // Bonus for rook on an open or semi-open file
             if (pos.is_on_semiopen_file(Us, s))


### PR DESCRIPTION
Removing Rook On Queen File looks beneficial, and it might even bring some ELO.
I will try to reintroduce it with a different method later on.

Passed STC:
https://tests.stockfishchess.org/tests/view/5f7cea204389873867eb10cb
LLR: 2.94 (-2.94,2.94) {-1.25,0.25}
Total: 18624 W: 3800 L: 3568 D: 11256
Ptnml(0-2): 308, 2131, 4257, 2253, 363

Passed LTC:
https://tests.stockfishchess.org/tests/view/5f7d76a4e936c6892bf50598
LLR: 2.95 (-2.94,2.94) {-0.75,0.25}
Total: 117864 W: 15515 L: 15340 D: 87009
Ptnml(0-2): 926, 11127, 34671, 11262, 946