### PR TITLE
Scale factor tweak

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -910,7 +910,9 @@ namespace {
             sf = 37 + 3 * (pos.count<QUEEN>(WHITE) == 1 ? pos.count<BISHOP>(BLACK) + pos.count<KNIGHT>(BLACK)
                                                         : pos.count<BISHOP>(WHITE) + pos.count<KNIGHT>(WHITE));
         else
-            sf = std::min(sf, 36 + 7 * pos.count<PAWN>(strongSide));
+            sf = std::min(sf, 36 + 7 * pos.count<PAWN>(strongSide)) - 4 * !pawnsOnBothFlanks;
+      
+        sf -= 4 * !pawnsOnBothFlanks;
     }
 
     // Interpolate between the middlegame and (scaled by 'sf') endgame score


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f8080575b3847b5d41f9134
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 250960 W: 49779 L: 49168 D: 152013
Ptnml(0-2): 4224, 28822, 58802, 29383, 4249

LTC https://tests.stockfishchess.org/tests/view/5f832f498ea73fb8ddf83ddb
LLR: 2.95 (-2.94,2.94) {0.25,1.25}
Total: 88584 W: 11827 L: 11388 D: 65369
Ptnml(0-2): 585, 8079, 26578, 8412, 638

bench: 3896634

Add !pawnsOnBothFlanks heuristic to scale factor.