### PR TITLE
Allow more thinking time when only one legal move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -519,7 +519,7 @@ void Thread::search() {
           }
           double bestMoveInstability = 1 + 2 * totBestMoveChanges / Threads.size();
 
-          double totalTime = rootMoves.size() == 1 ? 0 :
+          double totalTime = rootMoves.size() == 1 ? Time.optimum() * 0.001 :
                              Time.optimum() * fallingEval * reduction * bestMoveInstability;
 
           // Stop the search if we have exceeded the totalTime, at least 1ms search
@@ -529,13 +529,6 @@ void Thread::search() {
               // keep pondering until the GUI sends "ponderhit" or "stop".
               if (mainThread->ponder)
                   mainThread->stopOnPonderhit = true;
-              // If there is only one legal move, use previous score instead
-              // of depth 1 score
-              else if (rootMoves.size() == 1)
-              {
-                  Threads.stop = true;
-                  rootMoves[0].score = rootMoves[0].previousScore;
-              }
               else
                   Threads.stop = true;
           }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -519,6 +519,7 @@ void Thread::search() {
           }
           double bestMoveInstability = 1 + 2 * totBestMoveChanges / Threads.size();
 
+          // Spend a little amount of time to give reasonable evals when there is only one legal move
           double totalTime = rootMoves.size() == 1 ? Time.optimum() * 0.001 :
                              Time.optimum() * fallingEval * reduction * bestMoveInstability;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -529,6 +529,8 @@ void Thread::search() {
               // keep pondering until the GUI sends "ponderhit" or "stop".
               if (mainThread->ponder)
                   mainThread->stopOnPonderhit = true;
+              // If there is only one legal move, use previous score instead
+              // of depth 1 score
               else if (rootMoves.size() == 1)
               {
                   Threads.stop = true;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -529,6 +529,11 @@ void Thread::search() {
               // keep pondering until the GUI sends "ponderhit" or "stop".
               if (mainThread->ponder)
                   mainThread->stopOnPonderhit = true;
+              else if (rootMoves.size() == 1)
+              {
+                  Threads.stop = true;
+                  rootMoves[0].score = rootMoves[0].previousScore;
+              }
               else
                   Threads.stop = true;
           }


### PR DESCRIPTION
Allow Stockfish to spend more time in order to give a reasonable evaluation when there is only one legal move. With a little bit of search time, the evaluation is better than the current allowed 1 millisecond search. This solves the eval issue in moves 38-39 of TCEC S19 Superfinal (https://tcec-chess.com/#div=sf&game=96&season=19)

Passed STC Non-regression
LLR: 2.95 (-2.94,2.94) {-1.25,0.25}
Total: 122168 W: 12615 L: 12661 D: 96892
Ptnml(0-2): 522, 9551, 40987, 9499, 525
https://tests.stockfishchess.org/tests/view/5f89d247eae8a6e60644d6d4

No functional change