### PR TITLE
Do more reductions for late quiet moves in case of consecutive fail highs. 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -417,7 +417,7 @@ void Thread::search() {
           // Start with a small aspiration window and, in the case of a fail
           // high/low, re-search with a bigger window until we don't fail
           // high/low anymore.
-          int failedHighCnt = 0;
+          failedHighCnt = 0;
           while (true)
           {
               Depth adjustedDepth = std::max(1, rootDepth - failedHighCnt - searchAgainCounter);
@@ -1176,6 +1176,9 @@ moves_loop: // When in check, search starts from here
               // Increase reduction if ttMove is a capture (~5 Elo)
               if (ttCapture)
                   r++;
+
+              // Increase reduction at root for late moves in case of consecutive fail highs
+              r += rootNode ? thisThread->failedHighCnt * thisThread->failedHighCnt * moveCount / 512 : 0;
 
               // Increase reduction for cut nodes (~10 Elo)
               if (cutNode)

--- a/src/thread.h
+++ b/src/thread.h
@@ -73,6 +73,7 @@ public:
   CapturePieceToHistory captureHistory;
   ContinuationHistory continuationHistory[2][2];
   Score contempt;
+  int failedHighCnt;
 };
 
 


### PR DESCRIPTION
passed STC
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 53392 W: 5681 L: 5474 D: 42237
Ptnml(0-2): 214, 4104, 17894, 4229, 255
https://tests.stockfishchess.org/tests/view/5f88501adcdad978fe8c527e
passed LTC
LLR: 2.94 (-2.94,2.94) {0.25,1.25}
Total: 59136 W: 2773 L: 2564 D: 53799
Ptnml(0-2): 30, 2117, 25078, 2300, 43
https://tests.stockfishchess.org/tests/view/5f884dbfdcdad978fe8c527a
Idea of this patch based on the fact that having a lot of consecutive fail highs is not really that common thing. So in this case we probably a) have moves already sorted reasonably well; b) late quiet moves will have a lot of problems in trying to beat result that is already really good (since we did beat our previous betas quite a lot times).
So it makes sence to reduce them more in LMR to not waste time on smth that probably isn't good anyway.
bench 3761499