### PR TITLE
Spend less time if we have found a TB win

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -521,7 +521,7 @@ void Thread::search() {
 
           // Spend less time if we have found a known win
           double totalTime =  rootMoves.size() == 1 ? 0
-                            : (abs(rootMoves[0].score) > VALUE_KNOWN_WIN || rootMoves[0].tbScore) ? Time.optimum() * 0.1
+                            : rootMoves[0].tbScore ? Time.optimum() * 0.1
                             : Time.optimum() * fallingEval * reduction * bestMoveInstability;
 
           // Stop the search if we have exceeded the totalTime, at least 1ms search

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -521,7 +521,7 @@ void Thread::search() {
 
           // Spend less time if we have found a known win
           double totalTime =  rootMoves.size() == 1 ? 0
-                            : rootMoves[0].tbScore ? Time.optimum() * 0.1
+                            : bestValue >= VALUE_TB_WIN_IN_MAX_PLY ? Time.optimum() * 0.2
                             : Time.optimum() * fallingEval * reduction * bestMoveInstability;
 
           // Stop the search if we have exceeded the totalTime, at least 1ms search

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -519,8 +519,10 @@ void Thread::search() {
           }
           double bestMoveInstability = 1 + 2 * totBestMoveChanges / Threads.size();
 
-          double totalTime = rootMoves.size() == 1 ? 0 :
-                             Time.optimum() * fallingEval * reduction * bestMoveInstability;
+          // Spend less time if we have found a known win
+          double totalTime =  rootMoves.size() == 1 ? 0
+                            : (abs(rootMoves[0].score) > VALUE_KNOWN_WIN || rootMoves[0].tbScore) ? Time.optimum() * 0.1
+                            : Time.optimum() * fallingEval * reduction * bestMoveInstability;
 
           // Stop the search if we have exceeded the totalTime, at least 1ms search
           if (Time.elapsed() > totalTime)


### PR DESCRIPTION
There is no need to spend lots of time if we have found a TB win so we reduce the allowable total time to 20% of optimum time.

Bench: 3834252