### PR TITLE
Add net as dependency of config

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -711,7 +711,7 @@ endif
         config-sanity icc-profile-use icc-profile-make gcc-profile-use gcc-profile-make \
         clang-profile-use clang-profile-make
 
-build: config-sanity net
+build: net config-sanity
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) all
 
 profile-build: net config-sanity objclean profileclean
@@ -784,7 +784,7 @@ default:
 
 all: $(EXE) .depend
 
-config-sanity:
+config-sanity: net
 	@echo ""
 	@echo "Config:"
 	@echo "debug: '$(debug)'"


### PR DESCRIPTION
cleaner output and error message if the server is down and the net is not available.

No functional change