### PR TITLE
do_null() bugfix

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -999,6 +999,7 @@ void Position::do_null_move(StateInfo& newSt) {
   if (Eval::useNNUE)
   {
       std::memcpy(&newSt, st, sizeof(StateInfo));
+      newSt.dirtyPiece.dirty_num = 0;
   }
   else
       std::memcpy(&newSt, st, offsetof(StateInfo, accumulator));


### PR DESCRIPTION
This is related to #3149 

The NNUE code assumes that dirty_num == 0 after a null move, but do_null() currently just copies the information from the parent node's DirtyPiece struct into the current node's DirtyPiece struct and does not reset dirty_num.

This bug is currently triggered only very rarely because nnue_evaluate() is usually not called after a null move (instead, the previous eval is used with changed sign and Tempo correction). When this optimisation in search() is disabled, setting dirty_num to 0 indeed gives a difference bench count.

https://tests.stockfishchess.org/tests/view/5f8b4e973ff8113cab8a57ef
LLR: 2.96 (-2.94,2.94) {-1.25,0.25}
Total: 91664 W: 9534 L: 9536 D: 72594
Ptnml(0-2): 438, 6980, 30952, 7070, 392