### PR TITLE
Bishop Pawns based on Files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# List of authors for Stockfish, as of August 4, 2021
+# List of authors for Stockfish, as of August 4, 2020
 
 # Founders of the Stockfish project and fishtest infrastructure
 Tord Romstad (romstad)

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# List of authors for Stockfish, as of August 4, 2020
+# List of authors for Stockfish, as of August 4, 2021
 
 # Founders of the Stockfish project and fishtest infrastructure
 Tord Romstad (romstad)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -221,6 +221,11 @@ namespace {
       S( 74,147), S( 76,149), S( 90,153), S(104,169), S(105,171), S(106,171),
       S(112,178), S(114,185), S(114,187), S(119,221) }
   };
+  
+  // A description of BishopPawns[distance from edge] to be inserted here
+  constexpr Score BishopPawns[int(FILE_NB) / 2] = {
+    S(3, 8), S(3, 9), S(1, 8), S(3, 7)
+  };
 
   // KingProtector[knight/bishop] contains penalty for each distance unit to own king
   constexpr Score KingProtector[] = { S(8, 9), S(6, 9) };
@@ -252,7 +257,6 @@ namespace {
   // Assorted bonuses and penalties
   constexpr Score BadOutpost          = S( -7, 36);
   constexpr Score BishopOnKingRing    = S( 24,  0);
-  constexpr Score BishopPawns         = S(  3,  7);
   constexpr Score BishopXRayPawns     = S(  4,  5);
   constexpr Score CorneredBishop      = S( 50, 50);
   constexpr Score FlankAttacks        = S(  8,  0);
@@ -453,7 +457,7 @@ namespace {
                 // when the bishop is outside the pawn chain.
                 Bitboard blocked = pos.pieces(Us, PAWN) & shift<Down>(pos.pieces());
 
-                score -= BishopPawns * pos.pawns_on_same_color_squares(Us, s)
+                score -= BishopPawns[edge_distance(file_of(s))] * pos.pawns_on_same_color_squares(Us, s)
                                      * (!(attackedBy[Us][PAWN] & s) + popcount(blocked & CenterFiles));
 
                 // Penalty for all enemy pawns x-rayed


### PR DESCRIPTION
Upgrading Bishop pawns from a simple bonus to a bonus based on the position of the Bishop on the board based on files.

Passed STC:
https://tests.stockfishchess.org/tests/view/5f8cc8145a4eacb45305da3c
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 132544 W: 27795 L: 27328 D: 77421
Ptnml(0-2): 2756, 15558, 29272, 15835, 2851

Passed LTC:
https://tests.stockfishchess.org/tests/view/5f8df614bacb75a4f9a4721e
LLR: 2.94 (-2.94,2.94) {0.25,1.25}
Total: 169608 W: 23257 L: 22622 D: 123729
Ptnml(0-2): 1408, 16316, 48758, 16877, 1445