### PR TITLE
No special treatment of an only-move.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -519,8 +519,7 @@ void Thread::search() {
           }
           double bestMoveInstability = 1 + 2 * totBestMoveChanges / Threads.size();
 
-          double totalTime = rootMoves.size() == 1 ? 0 :
-                             Time.optimum() * fallingEval * reduction * bestMoveInstability;
+          double totalTime = Time.optimum() * fallingEval * reduction * bestMoveInstability;
 
           // Stop the search if we have exceeded the totalTime, at least 1ms search
           if (Time.elapsed() > totalTime)


### PR DESCRIPTION
remove the special case of a single legal move from time management. It doesn't bring Elo (even might be slightly weaker), and leads to score artefacts.

The reason why it might be slightly stronger is unclear, probably related to updating the TT and more order heuristics. I.e. the time spent is used to update the 'knowledge' in TT and heuristic and bring it up-to-date with the position.

passed STC:
LLR: 2.93 (-2.94,2.94) {-1.25,0.25}
Total: 22472 W: 2458 L: 2357 D: 17657
Ptnml(0-2): 106, 1733, 7453, 1842, 102
https://tests.stockfishchess.org/tests/view/5f926cbc81eda81bd78cb6df

passed LTC:
LLR: 2.94 (-2.94,2.94) {-0.75,0.25}
Total: 37880 W: 1736 L: 1682 D: 34462
Ptnml(0-2): 22, 1392, 16057, 1448, 21
https://tests.stockfishchess.org/tests/view/5f92a26081eda81bd78cb6fe

Bench: 3943959