### PR TITLE
Do not skip non-recapture ttMove when in check

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -74,8 +74,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 
   stage = (pos.checkers() ? EVASION_TT : QSEARCH_TT) +
           (   !ttm
-           || !(   pos.checkers()
-                || depth > DEPTH_QS_RECAPTURES || to_sq(ttm) == recaptureSquare)
+           || !(pos.checkers() || depth > DEPTH_QS_RECAPTURES || to_sq(ttm) == recaptureSquare)
            || !pos.pseudo_legal(ttm));
 }
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -73,8 +73,10 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
   assert(d <= 0);
 
   stage = (pos.checkers() ? EVASION_TT : QSEARCH_TT) +
-           !(ttm && (depth > DEPTH_QS_RECAPTURES || to_sq(ttm) == recaptureSquare)
-                 && pos.pseudo_legal(ttm));
+          (   !ttm
+           || !(   pos.checkers()
+                || depth > DEPTH_QS_RECAPTURES || to_sq(ttm) == recaptureSquare)
+           || !pos.pseudo_legal(ttm));
 }
 
 /// MovePicker constructor for ProbCut: we generate captures with SEE greater

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -73,9 +73,9 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
   assert(d <= 0);
 
   stage = (pos.checkers() ? EVASION_TT : QSEARCH_TT) +
-          (   !ttm
-           || !(pos.checkers() || depth > DEPTH_QS_RECAPTURES || to_sq(ttm) == recaptureSquare)
-           || !pos.pseudo_legal(ttm));
+          !(   ttm
+            && (pos.checkers() || depth > DEPTH_QS_RECAPTURES || to_sq(ttm) == recaptureSquare)
+            && pos.pseudo_legal(ttm));
 }
 
 /// MovePicker constructor for ProbCut: we generate captures with SEE greater


### PR DESCRIPTION
The qsearch() MovePicker incorrectly skips a non-recapture ttMove when in check (if depth <= DEPTH_QS_RECAPTURES). This is clearly not intended and can cause qsearch() to return a mate score when there is no mate. (Incorrect mate scores reported to the user should be extremely rare though, if possible at all.)

The bug seems to have been present in hidden form since this patch:
https://github.com/official-stockfish/Stockfish/commit/cad300cfab869a4e8dcc6b286f9b2e60d2827bed
Hidden, because the skipped ttMove would still be played when it was generated.

The bug was "activated" by this patch (and detected by @joergoster in #3171 and #3198):
https://github.com/official-stockfish/Stockfish/commit/6596f0eac0c1d25a12bfd923907bfc78beedbc90

This PR fixes the bug by not skipping the non-recapture ttMove when in check.

Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/5f9867ea6a2c112b60691b10
LLR: 2.98 (-2.94,2.94) {-1.25,0.25}
Total: 27112 W: 2943 L: 2842 D: 21327
Ptnml(0-2): 127, 2170, 8878, 2237, 144 

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/5f9967326a2c112b60691bb0
LLR: 2.99 (-2.94,2.94) {-0.75,0.25}
Total: 18392 W: 807 L: 738 D: 16847
Ptnml(0-2): 9, 655, 7802, 718, 12 

Bench: 3870606