### PR TITLE
New net cb26f10b1fd9

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -36,7 +36,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-2eb2e0707c2b.nnue"
+  #define EvalFileDefaultName   "nn-cb26f10b1fd9.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5f9c7bbc6a2c112b60691d4d
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 53712 W: 5776 L: 5561 D: 42375
Ptnml(0-2): 253, 4282, 17604, 4431, 286 

LTC https://tests.stockfishchess.org/tests/view/5f9d01f06a2c112b60691d87
LLR: 2.97 (-2.94,2.94) {0.25,1.25}
Total: 80184 W: 4007 L: 3739 D: 72438
Ptnml(0-2): 58, 3302, 33130, 3518, 84 

Result of https://tests.stockfishchess.org/tests/view/5f9a06796a2c112b60691c0f tuning.

bench: 3517795