### PR TITLE
[WIP] Optimistic Net

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -36,7 +36,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-cb26f10b1fd9.nnue"
+  #define EvalFileDefaultName   "nn-1918a67ad406.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
A contempt effect can be achieved by altering the net bias of the output layer. Changing from -154 to 33 gains about 8 Elo against weaker opponents. The addition of the net bias is the last operation before the appropriate scaling to give the NNUE evaluation. So by changing this to a positive number, the evaluation will be highly optimistic and leads to better play against weaker opponents.

The net bias naturally increased for the net patches that altered the output layer but recently decreased with the cb26 net:
Sergio 0374 net bias = **-162**
Vondele 04a8 net bias = **-156**
SFisGOD baeb net bias = **-154**
Fisherman cb26 net bias = **-158**

Base Test (net bias -154)
ELO: 120.37 +-2.2 (95%) LOS: 100.0%
Total: 40000 W: 15421 L: 2092 D: 22487
Ptnml(0-2): 62, 1093, 7122, 8900, 2823
https://tests.stockfishchess.org/tests/view/5f9ae5236a2c112b60691c78

Cnet (net bias -138)
ELO: 123.50 +-2.2 (95%) LOS: 100.0%
Total: 40000 W: 15788 L: 2140 D: 22072
Ptnml(0-2): 60, 1140, 6953, 8786, 3061
https://tests.stockfishchess.org/tests/view/5f9ae7526a2c112b60691c7b

Cnet2 (net bias -100)
ELO: 124.12 +-2.2 (95%) LOS: 100.0%
Total: 40000 W: 15787 L: 2076 D: 22137
Ptnml(0-2): 59, 1084, 7013, 8775, 3069
https://tests.stockfishchess.org/tests/view/5f9b43136a2c112b60691c9f

Cnet3m2 (net bias -66)
ELO: 121.10 +-2.2 (95%) LOS: 100.0%
Total: 40000 W: 15609 L: 2205 D: 22186
Ptnml(0-2): 72, 1167, 6924, 8959, 2878
https://tests.stockfishchess.org/tests/view/5f9fc900bca9bf35bae7f6f2

Cnet3m1 (net bias -33)
ELO: 124.16 +-2.2 (95%) LOS: 100.0%
Total: 40000 W: 15807 L: 2092 D: 22101
Ptnml(0-2): 49, 1112, 7008, 8737, 3094
https://tests.stockfishchess.org/tests/view/5f9fc6f5bca9bf35bae7f6f0

Cnet3 (net bias 0)
ELO: 126.20 +-2.2 (95%) LOS: 100.0%
Total: 40000 W: 15961 L: 2039 D: 22000
Ptnml(0-2): 60, 1100, 6926, 8686, 3228
https://tests.stockfishchess.org/tests/view/5f9f86a6bca9bf35bae7f6bf

Cnet3p1 (net bias 33)
ELO: 128.03 +-2.3 (95%) LOS: 100.0%
Total: 40000 W: 16186 L: 2079 D: 21735
Ptnml(0-2): 51, 1112, 6882, 8589, 3366
https://tests.stockfishchess.org/tests/view/5f9fccfbbca9bf35bae7f6f5

Cnet4 (net bias 75)
ELO: 126.97 +-2.2 (95%) LOS: 100.0%
Total: 40000 W: 16124 L: 2124 D: 21752
Ptnml(0-2): 52, 1135, 6803, 8781, 3229
https://tests.stockfishchess.org/tests/view/5f9f8a26bca9bf35bae7f6c1

Cnet5 (net bias 158)
ELO: 120.41 +-2.2 (95%) LOS: 100.0%
Total: 40000 W: 15458 L: 2125 D: 22417
Ptnml(0-2): 49, 1133, 7169, 8734, 2915
https://tests.stockfishchess.org/tests/view/5f9f8bdfbca9bf35bae7f6c3

Cnet3 failed non-regression against master of the base test
LLR: -2.93 (-2.94,2.94) {-1.25,0.25}
Total: 22856 W: 2259 L: 2428 D: 18169
Ptnml(0-2): 124, 1893, 7549, 1752, 110
https://tests.stockfishchess.org/tests/view/5f9fb6f1bca9bf35bae7f6e6

Cnet2 passed STC non-regression against master of the base test
LLR: 2.96 (-2.94,2.94) {-1.25,0.25}
Total: 67072 W: 7032 L: 6990 D: 53050
Ptnml(0-2): 347, 5396, 21985, 5484, 324
https://tests.stockfishchess.org/tests/view/5fa0995abca9bf35bae7f768

Cnet2 passed LTC non-regression against master of the base test
LLR: 2.93 (-2.94,2.94) {-0.75,0.25}
Total: 140120 W: 6648 L: 6657 D: 126815
Ptnml(0-2): 125, 5857, 58071, 5916, 91
https://tests.stockfishchess.org/tests/view/5fa10f4fbca9bf35bae7f7c5

Cnet3p1 failed LTC non-regression against master of the base test
LLR: -2.93 (-2.94,2.94) {-0.75,0.25}
Total: 25696 W: 1216 L: 1331 D: 23149
Ptnml(0-2): 27, 1173, 10559, 1066, 23
https://tests.stockfishchess.org/tests/view/5fa21829bca9bf35bae7f840

Bench: 4105221