### PR TITLE
King on File

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,7 @@
 # List of authors for Stockfish, as of August 4, 2020
 
 # Founders of the Stockfish project and fishtest infrastructure
-Tord Romstad (romstad)
+Tord Romstad (romstad).
 Marco Costalba (mcostalba)
 Joona Kiiski (zamar)
 Gary Linscott (glinscott)

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,7 @@
 # List of authors for Stockfish, as of August 4, 2020
 
 # Founders of the Stockfish project and fishtest infrastructure
-Tord Romstad (romstad).
+Tord Romstad (romstad)
 Marco Costalba (mcostalba)
 Joona Kiiski (zamar)
 Gary Linscott (glinscott)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -49,10 +49,10 @@ namespace {
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
-    { V(-5), V(79), V(92), V(61), V(43), V(13), V(23) },
-    { V(-43), V(66), V(38), V(-53), V(-27), V(-11), V(-59) },
-    { V(-10), V(83), V(28), V(-8), V(29), V(1), V(-40) },
-    { V(-45), V(-15), V(-27), V(-54), V(-47), V(-69), V(-167) }
+    { V(-5), V(82), V(92), V(54), V(36), V(22), V(28) },
+    { V(-44), V(63), V(33), V(-50), V(-30), V(-12), V(-62) },
+    { V(-11), V(77), V(22), V(-6), V(31), V(8), V(-45) },
+    { V(-39), V(-12), V(-29), V(-50), V(-43), V(-68), V(-164) }
   };
 
   // Danger of enemy pawns moving toward our king by [distance from edge][rank].
@@ -60,17 +60,17 @@ namespace {
   // is behind our king. Note that UnblockedStorm[0][1-2] accommodate opponent pawn
   // on edge, likely blocked by our king.
   constexpr Value UnblockedStorm[int(FILE_NB) / 2][RANK_NB] = {
-    { V(86), V(-294), V(-169), V(93), V(46), V(44), V(50) },
-    { V(44), V(-24), V(119), V(46), V(35), V(-11), V(19) },
-    { V(-12), V(54), V(173), V(35), V(-1), V(-24), V(-11) },
-    { V(-18), V(-19), V(99), V(6), V(17), V(-18), V(-23) }
+    { V(87), V(-288), V(-168), V(96), V(47), V(44), V(46) },
+    { V(42), V(-25), V(120), V(45), V(34), V(-9), V(24) },
+    { V(-8), V(51), V(167), V(35), V(-4), V(-16), V(-12) },
+    { V(-17), V(-13), V(100), V(4), V(9), V(-16), V(-31) }
   };
   
   // KingOnFile[open/semiopen] contains bonuses/penalties for king
   // when the king is in a semiopen or open file.
 
-  constexpr Score KingOnFile[2][2] = {{ S(-21,14), S(-5, 4)  },  //we have a pawn on file
-                                     {  S(  5,-2), S( 9, 1) }};  //we don't have a pawn on file
+  constexpr Score KingOnFile[2][2] = {{ S(-19,12), S(-6, 7)  },  //we have a pawn on file
+                                     {  S(  0, 2), S( 6,-5) }};  //we don't have a pawn on file
                                  //they have  ^        ^  they don't
 
   #undef S
@@ -243,6 +243,9 @@ Score Entry::evaluate_shelter(const Position& pos, Square ksq) const {
       else
           bonus -= make_score(UnblockedStorm[d][theirRank], 0);
   }
+  
+  // King On File
+  bonus -= KingOnFile[pos.is_on_semiopen_file(Us, ksq)][pos.is_on_semiopen_file(Them, ksq)];
 
   return bonus;
 }

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -49,9 +49,9 @@ namespace {
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
-    { V(-5), V(82), V(92), V(54), V(36), V(22), V(28) },
-    { V(-44), V(63), V(33), V(-50), V(-30), V(-12), V(-62) },
-    { V(-11), V(77), V(22), V(-6), V(31), V(8), V(-45) },
+    { V( -5), V( 82), V( 92), V( 54), V( 36), V( 22), V(  28) },
+    { V(-44), V( 63), V( 33), V(-50), V(-30), V(-12), V( -62) },
+    { V(-11), V( 77), V( 22), V( -6), V( 31), V(  8), V( -45) },
     { V(-39), V(-12), V(-29), V(-50), V(-43), V(-68), V(-164) }
   };
 
@@ -60,10 +60,10 @@ namespace {
   // is behind our king. Note that UnblockedStorm[0][1-2] accommodate opponent pawn
   // on edge, likely blocked by our king.
   constexpr Value UnblockedStorm[int(FILE_NB) / 2][RANK_NB] = {
-    { V(87), V(-288), V(-168), V(96), V(47), V(44), V(46) },
-    { V(42), V(-25), V(120), V(45), V(34), V(-9), V(24) },
-    { V(-8), V(51), V(167), V(35), V(-4), V(-16), V(-12) },
-    { V(-17), V(-13), V(100), V(4), V(9), V(-16), V(-31) }
+    { V( 87), V(-288), V(-168), V( 96), V( 47), V( 44), V( 46) },
+    { V( 42), V( -25), V( 120), V( 45), V( 34), V( -9), V( 24) },
+    { V( -8), V(  51), V( 167), V( 35), V( -4), V(-16), V(-12) },
+    { V(-17), V( -13), V( 100), V(  4), V(  9), V(-16), V(-31) }
   };
   
   // KingOnFile[open/semiopen] contains bonuses/penalties for king

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -49,10 +49,10 @@ namespace {
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
   constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
-    { V( -6), V( 81), V( 93), V( 58), V( 39), V( 18), V(  25) },
-    { V(-43), V( 61), V( 35), V(-49), V(-29), V(-11), V( -63) },
-    { V(-10), V( 75), V( 23), V( -2), V( 32), V(  3), V( -45) },
-    { V(-39), V(-13), V(-29), V(-52), V(-48), V(-67), V(-166) }
+    { V(-5), V(79), V(92), V(61), V(43), V(13), V(23) },
+    { V(-43), V(66), V(38), V(-53), V(-27), V(-11), V(-59) },
+    { V(-10), V(83), V(28), V(-8), V(29), V(1), V(-40) },
+    { V(-45), V(-15), V(-27), V(-54), V(-47), V(-69), V(-167) }
   };
 
   // Danger of enemy pawns moving toward our king by [distance from edge][rank].
@@ -60,11 +60,18 @@ namespace {
   // is behind our king. Note that UnblockedStorm[0][1-2] accommodate opponent pawn
   // on edge, likely blocked by our king.
   constexpr Value UnblockedStorm[int(FILE_NB) / 2][RANK_NB] = {
-    { V( 85), V(-289), V(-166), V(97), V(50), V( 45), V( 50) },
-    { V( 46), V( -25), V( 122), V(45), V(37), V(-10), V( 20) },
-    { V( -6), V(  51), V( 168), V(34), V(-2), V(-22), V(-14) },
-    { V(-15), V( -11), V( 101), V( 4), V(11), V(-15), V(-29) }
+    { V(86), V(-294), V(-169), V(93), V(46), V(44), V(50) },
+    { V(44), V(-24), V(119), V(46), V(35), V(-11), V(19) },
+    { V(-12), V(54), V(173), V(35), V(-1), V(-24), V(-11) },
+    { V(-18), V(-19), V(99), V(6), V(17), V(-18), V(-23) }
   };
+  
+  // KingOnFile[open/semiopen] contains bonuses/penalties for king
+  // when the king is in a semiopen or open file.
+
+  constexpr Score KingOnFile[2][2] = {{ S(-21,14), S(-5, 4)  },  //we have a pawn on file
+                                     {  S(  5,-2), S( 9, 1) }};  //we don't have a pawn on file
+                                 //they have  ^        ^  they don't
 
   #undef S
   #undef V


### PR DESCRIPTION
Introducing King On File

this new concept calculates bonuses/penalties for the king when the king is in a semiopen or open file.

Passed STC:
LLR: 2.95 (-2.94,2.94) {-0.25,1.25}
Total: 44904 W: 9365 L: 9028 D: 26511
Ptnml(0-2): 857, 5309, 9841, 5530, 915
https://tests.stockfishchess.org/tests/view/5fa343625d72639a7acef72b

Passed LTC:
LLR: 2.94 (-2.94,2.94) {0.25,1.25}
Total: 60552 W: 8449 L: 8051 D: 44052
Ptnml(0-2): 466, 5772, 17481, 6012, 545
https://tests.stockfishchess.org/tests/view/5fa40e365d72639a7acef79e