### PR TITLE
~4% AVX2 and SSSE3 speedup

### DIFF
--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -232,9 +232,14 @@ namespace Eval::NNUE::Layers {
 #else
         __m256i product0 = _mm256_maddubs_epi16(a0, b0);
         __m256i product1 = _mm256_maddubs_epi16(a1, b1);
-        product0 = _mm256_adds_epi16(product0, product1);
+#if defined (ALLOW_SATURATE)
+        product1 = _mm256_adds_epi16(product0, product1);
+#else
         product0 = _mm256_madd_epi16(product0, kOnes256);
         acc = _mm256_add_epi32(acc, product0);
+#endif
+        product1 = _mm256_madd_epi16(product1, kOnes256);
+        acc = _mm256_add_epi32(acc, product1);
 #endif
       };
 
@@ -268,9 +273,14 @@ namespace Eval::NNUE::Layers {
       [[maybe_unused]] auto m128_add_dpbusd_epi32x2 = [=](__m128i& acc, __m128i a0, __m128i b0, __m128i a1, __m128i b1) {
         __m128i product0 = _mm_maddubs_epi16(a0, b0);
         __m128i product1 = _mm_maddubs_epi16(a1, b1);
-        product0 = _mm_adds_epi16(product0, product1);
+#if defined (ALLOW_SATURATE)
+        product1 = _mm_adds_epi16(product0, product1);
+#else
         product0 = _mm_madd_epi16(product0, kOnes128);
         acc = _mm_add_epi32(acc, product0);
+#endif
+        product1 = _mm_madd_epi16(product1, kOnes128);
+        acc = _mm_add_epi32(acc, product1);
       };
 
 #endif

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -225,6 +225,19 @@ namespace Eval::NNUE::Layers {
 #endif
       };
 
+      [[maybe_unused]] auto m256_add_dpbusd_epi32x2 = [=](__m256i& acc, __m256i a0, __m256i b0, __m256i a1, __m256i b1) {
+#if defined (USE_VNNI)
+        acc = _mm256_dpbusd_epi32(acc, a0, b0);
+        acc = _mm256_dpbusd_epi32(acc, a1, b1);
+#else
+        __m256i product0 = _mm256_maddubs_epi16(a0, b0);
+        __m256i product1 = _mm256_maddubs_epi16(a1, b1);
+        product0 = _mm256_adds_epi16(product0, product1);
+        product0 = _mm256_madd_epi16(product0, kOnes256);
+        acc = _mm256_add_epi32(acc, product0);
+#endif
+      };
+
 #endif
 
 #if defined (USE_SSSE3)
@@ -248,6 +261,14 @@ namespace Eval::NNUE::Layers {
 
       [[maybe_unused]] auto m128_add_dpbusd_epi32 = [=](__m128i& acc, __m128i a, __m128i b) {
         __m128i product0 = _mm_maddubs_epi16(a, b);
+        product0 = _mm_madd_epi16(product0, kOnes128);
+        acc = _mm_add_epi32(acc, product0);
+      };
+
+      [[maybe_unused]] auto m128_add_dpbusd_epi32x2 = [=](__m128i& acc, __m128i a0, __m128i b0, __m128i a1, __m128i b1) {
+        __m128i product0 = _mm_maddubs_epi16(a0, b0);
+        __m128i product1 = _mm_maddubs_epi16(a1, b1);
+        product0 = _mm_adds_epi16(product0, product1);
         product0 = _mm_madd_epi16(product0, kOnes128);
         acc = _mm_add_epi32(acc, product0);
       };
@@ -461,14 +482,24 @@ namespace Eval::NNUE::Layers {
           const auto row2 = reinterpret_cast<const __m256i*>(&weights_[offset2]);
           const auto row3 = reinterpret_cast<const __m256i*>(&weights_[offset3]);
 
-          for (IndexType j = 0; j < kNumChunks; ++j)
+          for (int j = 0; j < (int)kNumChunks - 1; j += 2)
           {
-            const __m256i in = input_vector[j];
+              const __m256i in0 = input_vector[j];
+              const __m256i in1 = input_vector[j + 1];
 
-            m256_add_dpbusd_epi32(sum0, in, row0[j]);
-            m256_add_dpbusd_epi32(sum1, in, row1[j]);
-            m256_add_dpbusd_epi32(sum2, in, row2[j]);
-            m256_add_dpbusd_epi32(sum3, in, row3[j]);
+              m256_add_dpbusd_epi32x2(sum0, in0, row0[j], in1, row0[j + 1]);
+              m256_add_dpbusd_epi32x2(sum1, in0, row1[j], in1, row1[j + 1]);
+              m256_add_dpbusd_epi32x2(sum2, in0, row2[j], in1, row2[j + 1]);
+              m256_add_dpbusd_epi32x2(sum3, in0, row3[j], in1, row3[j + 1]);
+          }
+          if constexpr (kNumChunks & 0x1)
+          {
+              const __m256i in = input_vector[kNumChunks - 1];
+
+              m256_add_dpbusd_epi32(sum0, in, row0[kNumChunks - 1]);
+              m256_add_dpbusd_epi32(sum1, in, row1[kNumChunks - 1]);
+              m256_add_dpbusd_epi32(sum2, in, row2[kNumChunks - 1]);
+              m256_add_dpbusd_epi32(sum3, in, row3[kNumChunks - 1]);
           }
 
           *outptr = m256_haddx4(sum0, sum1, sum2, sum3, bias);
@@ -527,14 +558,24 @@ namespace Eval::NNUE::Layers {
           const auto row2 = reinterpret_cast<const __m128i*>(&weights_[offset2]);
           const auto row3 = reinterpret_cast<const __m128i*>(&weights_[offset3]);
 
-          for (int j = 0; j < (int)kNumChunks; j += 1)
+          for (int j = 0; j < (int)kNumChunks - 1; j += 2)
           {
-            const __m128i in = input_vector[j];
+            const __m128i in0 = input_vector[j];
+            const __m128i in1 = input_vector[j + 1];
 
-            m128_add_dpbusd_epi32(sum0, in, row0[j]);
-            m128_add_dpbusd_epi32(sum1, in, row1[j]);
-            m128_add_dpbusd_epi32(sum2, in, row2[j]);
-            m128_add_dpbusd_epi32(sum3, in, row3[j]);
+            m128_add_dpbusd_epi32x2(sum0, in0, row0[j], in1, row0[j + 1]);
+            m128_add_dpbusd_epi32x2(sum1, in0, row1[j], in1, row1[j + 1]);
+            m128_add_dpbusd_epi32x2(sum2, in0, row2[j], in1, row2[j + 1]);
+            m128_add_dpbusd_epi32x2(sum3, in0, row3[j], in1, row3[j + 1]);
+          }
+          if constexpr (kNumChunks & 0x1)
+          {
+            const __m128i in = input_vector[kNumChunks - 1];
+
+            m128_add_dpbusd_epi32(sum0, in, row0[kNumChunks - 1]);
+            m128_add_dpbusd_epi32(sum1, in, row1[kNumChunks - 1]);
+            m128_add_dpbusd_epi32(sum2, in, row2[kNumChunks - 1]);
+            m128_add_dpbusd_epi32(sum3, in, row3[kNumChunks - 1]);
           }
 
           *outptr = m128_haddx4(sum0, sum1, sum2, sum3, bias);


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/5fa86c4367cbf42301d6a69a
LLR: 2.97 (-2.94,2.94) {-0.25,1.25}
Total: 8960 W: 970 L: 830 D: 7160
Ptnml(0-2): 27, 637, 3025, 751, 40 

Improves throughput by summing 2 intermediate dot products using 16 bit addition before upconverting to 32 bit.
Theoretically this could saturate but I have found no such cases in practice.  In a version 
https://tests.stockfishchess.org/tests/view/5fa7ea9967cbf42301d6a62f
which sums 4 such intermediate results in even more places thus increasing any chances of saturation it still doesn't happen.
Verifying nnue bench up to depth 35 "stockfish.exe bench 1024 1 35 default depth nnue 1>nul" produces the same 5014079061 for all versions.  For comparison hard TT collisions happen 1 in 65K times.  Saturation is also less deleterious than a collision because by saturating(not overflowing) the result becomes merely inaccurate but not random.
(I would prefer to deal w/ AVX512 in a follow up PR because it is a bit more complicated and we will need to collect bench measurements since fishtest doesn't have enough capable machines.)

No functional change
bench: 3578092