### PR TITLE
LMR tweak

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,6 +19,7 @@ Alain Savard (Rocky640)
 Alayan Feh (Alayan-stk-2)
 Alexander Kure
 Alexander Pagel (Lolligerhans)
+Alfredo Menezes (lonfom169)
 Ali AlZhrani (Cooffe)
 Andrew Grant (AndyGrant)
 Andrey Neporada (nepal)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1168,6 +1168,9 @@ moves_loop: // When in check, search starts from here
           // Decrease reduction if position is or has been on the PV (~10 Elo)
           if (ss->ttPv)
               r -= 2;
+              
+          if (!PvNode && depth > 10 && thisThread->bestMoveChanges <= 2)
+              r++;
 
           if (moveCountPruning && !formerPv)
               r++;


### PR DESCRIPTION
Increase reduction based on the number of best move changes.

Thanks to @Vizvezdenec for the `PvNode` idea and also to @vondele for this patch https://tests.stockfishchess.org/tests/view/5fa82d2867cbf42301d6a662 which gave me the light to try `!PvNode` instead.

Passed STC:
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 19120 W: 1998 L: 1839 D: 15283
Ptnml(0-2): 76, 1445, 6375, 1572, 92
https://tests.stockfishchess.org/tests/view/5fa8af3e67cbf42301d6a6c9

Passed LTC:
LLR: 2.94 (-2.94,2.94) {0.25,1.25}
Total: 75584 W: 3454 L: 3205 D: 68925
Ptnml(0-2): 54, 2832, 31771, 3081, 54
https://tests.stockfishchess.org/tests/view/5fa8cbce67cbf42301d6a6e0

Bench: 3595418