### PR TITLE
Increase reduction at root when the best move does not change frequently

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -85,7 +85,7 @@ Jekaa
 Jerry Donald Watson (jerrydonaldwatson)
 jjoshua2
 Jonathan Calovski (Mysseno)
-Jonathan Dumale (SFisGOD)
+Jonathan Buladas Dumale (SFisGOD)
 Joost VandeVondele (vondele)
 Jörg Oster (joergoster)
 Joseph Ellis (jhellis3)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1169,6 +1169,9 @@ moves_loop: // When in check, search starts from here
           if (ss->ttPv)
               r -= 2;
 
+          if (!PvNode && depth > 10 && thisThread->bestMoveChanges <= 2)
+              r++;
+
           if (moveCountPruning && !formerPv)
               r++;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1161,7 +1161,7 @@ moves_loop: // When in check, search starts from here
           if (thisThread->ttHitAverage > 509 * TtHitAverageResolution * TtHitAverageWindow / 1024)
               r--;
 
-          // Reduction if other threads are searching this position
+          // Increase reduction if other threads are searching this position
           if (th.marked())
               r++;
 
@@ -1169,6 +1169,7 @@ moves_loop: // When in check, search starts from here
           if (ss->ttPv)
               r -= 2;
 
+          // Increase reduction at root and non-PV nodes when the best move does not change frequently
           if (!(PvNode && !rootNode) && depth > 10 && thisThread->bestMoveChanges <= 2)
               r++;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1169,7 +1169,7 @@ moves_loop: // When in check, search starts from here
           if (ss->ttPv)
               r -= 2;
 
-          if (!PvNode && depth > 10 && thisThread->bestMoveChanges <= 2)
+          if (!(PvNode && !rootNode) && depth > 10 && thisThread->bestMoveChanges <= 2)
               r++;
 
           if (moveCountPruning && !formerPv)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1170,7 +1170,7 @@ moves_loop: // When in check, search starts from here
               r -= 2;
 
           // Increase reduction at root and non-PV nodes when the best move does not change frequently
-          if (!(PvNode && !rootNode) && depth > 10 && thisThread->bestMoveChanges <= 2)
+          if ((rootNode || !PvNode) && depth > 10 && thisThread->bestMoveChanges <= 2)
               r++;
 
           if (moveCountPruning && !formerPv)


### PR DESCRIPTION
STC:
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 51320 W: 5159 L: 4956 D: 41205
Ptnml(0-2): 215, 3897, 17242, 4082, 224
https://tests.stockfishchess.org/tests/view/5faa072367cbf42301d6a767

LTC:
LLR: 2.98 (-2.94,2.94) {0.25,1.25}
Total: 15952 W: 762 L: 642 D: 14548
Ptnml(0-2): 8, 561, 6725, 667, 15
https://tests.stockfishchess.org/tests/view/5faa4c3567cbf42301d6a794

Bench: 3954692