### PR TITLE
Use a separate net for endgame

### DIFF
--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -54,6 +54,8 @@ namespace Eval::NNUE {
   template <typename T>
   using LargePagePtr = std::unique_ptr<T, LargePageDeleter<T>>;
 
+  extern AlignedPtr<Network> network;
+
 }  // namespace Eval::NNUE
 
 #endif // #ifndef NNUE_EVALUATE_NNUE_H_INCLUDED

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -663,7 +663,7 @@ namespace Eval::NNUE::Layers {
       return output;
     }
 
-   private:
+   // private:
     using BiasType = OutputType;
     using WeightType = std::int8_t;
 


### PR DESCRIPTION
The output layer is the most influential layer of an NNUE net. By exploiting this fact, an endgame net can be introduced by just altering this layer and not change the other parts of the net. So instead of two entirely separate nets, we can save space by making the two nets share the input and hidden layers.

SPSA Tuning Run for Endgame Net:
https://tests.stockfishchess.org/tests/view/5fb98c0867cbf42301d6affe

The criteria for switching to an endgame output layer is when there are 8 non-pawn pieces. This switch happens regardless of the number of pawns.

STC:
LLR: 2.95 (-2.94,2.94) {-0.25,1.25}
Total: 49544 W: 9963 L: 9780 D: 29801
Ptnml(0-2): 9, 3922, 16730, 4099, 12
https://tests.stockfishchess.org/tests/view/5fbb706a67cbf42301d6b142

LTC:
LLR: 2.95 (-2.94,2.94) {0.25,1.25}
Total: 40928 W: 7853 L: 7640 D: 25435
Ptnml(0-2): 1, 2382, 15485, 2595, 1
https://tests.stockfishchess.org/tests/view/5fbba64b67cbf42301d6b163

A variant of this patch also passed STC and LTC so essentially, this idea passed 4 Elo-gaining SPRTs. The following variant uses the separate output layer if there are 6 non-pawn pieces left.

STC:
LLR: 2.95 (-2.94,2.94) {-0.25,1.25}
Total: 31688 W: 6325 L: 6171 D: 19192
Ptnml(0-2): 10, 2397, 10874, 2555, 8
https://tests.stockfishchess.org/tests/view/5fbb5e4467cbf42301d6b130

LTC:
LLR: 2.94 (-2.94,2.94) {0.25,1.25}
Total: 50000 W: 9496 L: 9262 D: 31242
Ptnml(0-2): 4, 2959, 18838, 3197, 2
https://tests.stockfishchess.org/tests/view/5fbb834867cbf42301d6b14b

This idea of using multiple nets is not new. It's been repeatedly suggested by countless people but many fail to find the right implementation.

Bench: 3754190