### PR TITLE
Update default net to nn-7b23f384897e.nnue (for snicolet only)

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -36,7 +36,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-c3ca321c51c9.nnue"
+  #define EvalFileDefaultName   "nn-7b23f384897e.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
About 5 Elo gained for SALC positions and passed non-regression using default book.

STC:
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 14768 W: 3089 L: 2826 D: 8853
Ptnml(0-2): 211, 1611, 3510, 1808, 244
https://tests.stockfishchess.org/tests/view/5fbb9b2c67cbf42301d6b15e

LTC:
LLR: 2.95 (-2.94,2.94) {0.25,1.25}
Total: 17432 W: 2463 L: 2197 D: 12772
Ptnml(0-2): 73, 1497, 5328, 1727, 91
https://tests.stockfishchess.org/tests/view/5fbbcd7267cbf42301d6b175

Non-regression LTC using default book
LLR: 2.98 (-2.94,2.94) {-0.75,0.25}
Total: 199736 W: 8431 L: 8491 D: 182814
Ptnml(0-2): 137, 7549, 84562, 7477, 143
https://tests.stockfishchess.org/tests/view/5fbc13f767cbf42301d6b1b5

Bench: 4087476