### PR TITLE
Search simplification

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1257,9 +1257,6 @@ moves_loop: // When in check, search starts from here
               int bonus = value > alpha ?  stat_bonus(newDepth)
                                         : -stat_bonus(newDepth);
 
-              if (move == ss->killers[0])
-                  bonus += bonus / 4;
-
               update_continuation_histories(ss, movedPiece, to_sq(move), bonus);
           }
       }


### PR DESCRIPTION
Remove bonus for killers.

Passed non-regression STC:
LLR: 2.94 (-2.94,2.94) {-1.25,0.25}
Total: 14712 W: 1416 L: 1315 D: 11981
Ptnml(0-2): 59, 1029, 5082, 1124, 62
https://tests.stockfishchess.org/tests/view/5fbfa31f67cbf42301d6b36e

Passed non-regression LTC:
LLR: 2.95 (-2.94,2.94) {-0.75,0.25}
Total: 27536 W: 1099 L: 1044 D: 25393
Ptnml(0-2): 11, 929, 11838, 974, 16
https://tests.stockfishchess.org/tests/view/5fbfac9167cbf42301d6b371

Bench: 4093050