### PR TITLE
Search simplification

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1557,7 +1557,6 @@ moves_loop: // When in check, search starts from here
 
       // Do not search moves with negative SEE values
       if (    bestValue > VALUE_TB_LOSS_IN_MAX_PLY
-          && !(givesCheck && pos.is_discovery_check_on_king(~pos.side_to_move(), move))
           && !pos.see_ge(move))
           continue;
 


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5fc2083942a050a89f02c8bb
LLR: 2.93 (-2.94,2.94) {-1.25,0.25}
Total: 23200 W: 2251 L: 2160 D: 18789
Ptnml(0-2): 86, 1726, 7895, 1797, 96

LTC https://tests.stockfishchess.org/tests/view/5fc22d7b42a050a89f02c8d0
LLR: 2.92 (-2.94,2.94) {-0.75,0.25}
Total: 15832 W: 653 L: 590 D: 14589
Ptnml(0-2): 7, 521, 6795, 588, 5

bench: 3929725

Simplify search.