### PR TITLE
Imbalance Tables Tweak

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,7 +58,7 @@ Fabian Beuke (madnight)
 Fabian Fichter (ianfab)
 Fanael Linithien (Fanael)
 fanon
-Fauzi Akram Dabat (FauziAkram)
+Fauzi Akram Dabat (FauziAkram) IS THE BEST!
 Felix Wittmann
 gamander
 Gary Heckman (gheckman)

--- a/AUTHORS
+++ b/AUTHORS
@@ -58,7 +58,7 @@ Fabian Beuke (madnight)
 Fabian Fichter (ianfab)
 Fanael Linithien (Fanael)
 fanon
-Fauzi Akram Dabat (FauziAkram) IS THE BEST!
+Fauzi Akram Dabat (FauziAkram)
 Felix Wittmann
 gamander
 Gary Heckman (gheckman)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -594,7 +594,7 @@ namespace {
     int kingFlankDefense = popcount(b3);
 
     kingDanger +=        kingAttackersCount[Them] * kingAttackersWeight[Them] // (~10 Elo)
-                 + 185 * popcount(kingRing[Us] & weak)                        // (~15 Elo)
+                 + 183 * popcount(kingRing[Us] & weak)                        // (~15 Elo)
                  + 148 * popcount(unsafeChecks)                               // (~4 Elo)
                  +  98 * popcount(pos.blockers_for_king(Us))                  // (~2 Elo)
                  +  69 * kingAttacksCount[Them]                               // (~0.5 Elo)

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -25,30 +25,36 @@
 using namespace std;
 
 namespace {
+  #define S(mg, eg) make_score(mg, eg)
 
   // Polynomial material imbalance parameters
 
-  constexpr int QuadraticOurs[][PIECE_TYPE_NB] = {
+  Score QuadraticOurs[][PIECE_TYPE_NB] = {
     //            OUR PIECES
     // pair pawn knight bishop rook queen
-    {1438                               }, // Bishop pair
-    {  40,   38                         }, // Pawn
-    {  32,  255, -62                    }, // Knight      OUR PIECES
-    {   0,  104,   4,    0              }, // Bishop
-    { -26,   -2,  47,   105,  -208      }, // Rook
-    {-189,   24, 117,   133,  -134, -6  }  // Queen
+    {S(1438, 1438)                                                                  }, // Bishop pair
+    {S(  40,   40), S( 38,  38)                                                     }, // Pawn
+    {S(  32,   32), S(255, 255), S(-62, -62)                                        }, // Knight      OUR PIECES
+    {S(   0,    0), S(104, 104), S(  4,   4), S(  0,   0)                           }, // Bishop
+    {S( -26,  -26), S( -2,  -2), S( 47,  47), S(105, 105), S(-208, -208)            }, // Rook
+    {S(-189, -189), S( 24,  24), S(117, 117), S(133, 133), S(-134, -134), S(-6, -6) }  // Queen
   };
 
-  constexpr int QuadraticTheirs[][PIECE_TYPE_NB] = {
+  Score QuadraticTheirs[][PIECE_TYPE_NB] = {
     //           THEIR PIECES
     // pair pawn knight bishop rook queen
-    {                                   }, // Bishop pair
-    {  36,                              }, // Pawn
-    {   9,   63,                        }, // Knight      OUR PIECES
-    {  59,   65,  42,                   }, // Bishop
-    {  46,   39,  24,   -24,            }, // Rook
-    {  97,  100, -42,   137,  268,      }  // Queen
+    {                                                                               }, // Bishop pair
+    {S(  36,  36)                                                                   }, // Pawn
+    {S(   9,   9), S( 63,  63)                                                      }, // Knight      OUR PIECES
+    {S(  59,  59), S( 65,  65), S( 42,  42)                                         }, // Bishop
+    {S(  46,  46), S( 39,  39), S( 24,  24), S(-24, -24)                            }, // Rook
+    {S(  97,  97), S(100, 100), S(-42, -42), S(137, 137), S(268, 268)               }  // Queen
   };
+  
+  TUNE(SetRange(-500, 2000), QuadraticOurs);
+  TUNE(SetRange(-100, 400), QuadraticTheirs);
+  
+  #undef S
 
   // Endgame evaluation and scaling functions are accessed directly and not through
   // the function maps because they correspond to more than one material hash key.
@@ -82,11 +88,11 @@ namespace {
   /// piece type for both colors.
 
   template<Color Us>
-  int imbalance(const int pieceCount[][PIECE_TYPE_NB]) {
-
+  Score imbalance(const int pieceCount[][PIECE_TYPE_NB]) {
+  
     constexpr Color Them = ~Us;
 
-    int bonus = 0;
+    Score bonus = SCORE_ZERO;
 
     // Second-degree polynomial material imbalance, by Tord Romstad
     for (int pt1 = NO_PIECE_TYPE; pt1 <= QUEEN; ++pt1)
@@ -213,7 +219,7 @@ Entry* probe(const Position& pos) {
   { pos.count<BISHOP>(BLACK) > 1, pos.count<PAWN>(BLACK), pos.count<KNIGHT>(BLACK),
     pos.count<BISHOP>(BLACK)    , pos.count<ROOK>(BLACK), pos.count<QUEEN >(BLACK) } };
 
-  e->value = int16_t((imbalance<WHITE>(pieceCount) - imbalance<BLACK>(pieceCount)) / 16);
+  e->score = (imbalance<WHITE>(pieceCount) - imbalance<BLACK>(pieceCount)) / 16;
   return e;
 }
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -29,30 +29,28 @@ namespace {
 
   // Polynomial material imbalance parameters
 
-  Score QuadraticOurs[][PIECE_TYPE_NB] = {
+  constexpr Score QuadraticOurs[][PIECE_TYPE_NB] = {
     //            OUR PIECES
     // pair pawn knight bishop rook queen
-    {S(1434, 1477)                                                                  }, // Bishop pair
-    {S( 100,   31), S( 38,  40)                                                     }, // Pawn
-    {S(  59,   64), S(248, 196), S(-51, -60)                                        }, // Knight      OUR PIECES
-    {S(   0,    0), S(122, 133), S( 10,  28), S(  0,   0)                           }, // Bishop
-    {S( -61,  -64), S( -5,   3), S(100,  78), S(133, 121), S(-247, -240)            }, // Rook
-    {S(-213, -212), S( 36,  14), S(154, 143), S(158,  98), S(-155, -170), S(-8,-30) }  // Queen
+    {S(1487, 1567)                                                                  }, // Bishop pair
+    {S( 108,   37), S( 38,  42)                                                     }, // Pawn
+    {S(  64,   56), S(258, 206), S(-50, -60)                                        }, // Knight      OUR PIECES
+    {S(   0,    0), S(125, 142), S( 11,  32), S(  0,   0)                           }, // Bishop
+    {S( -60,  -62), S( -6,   3), S(109,  82), S(128, 123), S(-232, -250)            }, // Rook
+    {S(-217, -212), S( 33,  16), S(143, 146), S(151,  91), S(-146, -181), S(-7,-29) }  // Queen
   };
 
-  Score QuadraticTheirs[][PIECE_TYPE_NB] = {
+  constexpr Score QuadraticTheirs[][PIECE_TYPE_NB] = {
     //           THEIR PIECES
     // pair pawn knight bishop rook queen
     {                                                                               }, // Bishop pair
-    {S(  34,  30)                                                                   }, // Pawn
-    {S(  45,  18), S(110,  86)                                                      }, // Knight      OUR PIECES
-    {S(  75,  36), S( 58,  43), S( 59,  15)                                         }, // Bishop
-    {S(  27,  36), S(  4,  22), S( 38,  38), S(-11,  -1)                            }, // Rook
-    {S(  97,  92), S( 97, 166), S(-56, -90), S(104, 179), S(277, 227)               }  // Queen
+    {S(  33,  29)                                                                   }, // Pawn
+    {S(  49,  19), S(113,  82)                                                      }, // Knight      OUR PIECES
+    {S(  74,  40), S( 55,  44), S( 64,  11)                                         }, // Bishop
+    {S(  30,  35), S(  5,  20), S( 37,  37), S(-11,  -2)                            }, // Rook
+    {S(  96,  94), S( 92, 173), S(-59, -90), S(105, 193), S(301, 245)               }  // Queen
   };
   
-  TUNE(SetRange(-500, 2000), QuadraticOurs);
-  TUNE(SetRange(-100, 400), QuadraticTheirs);
   
   #undef S
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -32,23 +32,23 @@ namespace {
   Score QuadraticOurs[][PIECE_TYPE_NB] = {
     //            OUR PIECES
     // pair pawn knight bishop rook queen
-    {S(1438, 1438)                                                                  }, // Bishop pair
-    {S(  40,   40), S( 38,  38)                                                     }, // Pawn
-    {S(  32,   32), S(255, 255), S(-62, -62)                                        }, // Knight      OUR PIECES
-    {S(   0,    0), S(104, 104), S(  4,   4), S(  0,   0)                           }, // Bishop
-    {S( -26,  -26), S( -2,  -2), S( 47,  47), S(105, 105), S(-208, -208)            }, // Rook
-    {S(-189, -189), S( 24,  24), S(117, 117), S(133, 133), S(-134, -134), S(-6, -6) }  // Queen
+    {S(1434, 1477)                                                                  }, // Bishop pair
+    {S( 100,   31), S( 38,  40)                                                     }, // Pawn
+    {S(  59,   64), S(248, 196), S(-51, -60)                                        }, // Knight      OUR PIECES
+    {S(   0,    0), S(122, 133), S( 10,  28), S(  0,   0)                           }, // Bishop
+    {S( -61,  -64), S( -5,   3), S(100,  78), S(133, 121), S(-247, -240)            }, // Rook
+    {S(-213, -212), S( 36,  14), S(154, 143), S(158,  98), S(-155, -170), S(-8,-30) }  // Queen
   };
 
   Score QuadraticTheirs[][PIECE_TYPE_NB] = {
     //           THEIR PIECES
     // pair pawn knight bishop rook queen
     {                                                                               }, // Bishop pair
-    {S(  36,  36)                                                                   }, // Pawn
-    {S(   9,   9), S( 63,  63)                                                      }, // Knight      OUR PIECES
-    {S(  59,  59), S( 65,  65), S( 42,  42)                                         }, // Bishop
-    {S(  46,  46), S( 39,  39), S( 24,  24), S(-24, -24)                            }, // Rook
-    {S(  97,  97), S(100, 100), S(-42, -42), S(137, 137), S(268, 268)               }  // Queen
+    {S(  34,  30)                                                                   }, // Pawn
+    {S(  45,  18), S(110,  86)                                                      }, // Knight      OUR PIECES
+    {S(  75,  36), S( 58,  43), S( 59,  15)                                         }, // Bishop
+    {S(  27,  36), S(  4,  22), S( 38,  38), S(-11,  -1)                            }, // Rook
+    {S(  97,  92), S( 97, 166), S(-56, -90), S(104, 179), S(277, 227)               }  // Queen
   };
   
   TUNE(SetRange(-500, 2000), QuadraticOurs);

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -32,23 +32,23 @@ namespace {
   constexpr Score QuadraticOurs[][PIECE_TYPE_NB] = {
     //            OUR PIECES
     // pair pawn knight bishop rook queen
-    {S(1458, 1539)                                                                  }, // Bishop pair
-    {S( 106,   33), S( 38,  41)                                                     }, // Pawn
-    {S(  61,   59), S(254, 201), S(-51, -60)                                        }, // Knight      OUR PIECES
-    {S(   0,    0), S(123, 140), S( 10,  31), S(  0,   0)                           }, // Bishop
-    {S( -60,  -64), S( -6,   3), S(105,  81), S(129, 121), S(-237, -247)            }, // Rook
-    {S(-215, -211), S( 34,  15), S(145, 146), S(155,  95), S(-149, -177), S(-8,-29) }  // Queen
+    {S(1434, 1477)                                                                  }, // Bishop pair
+    {S( 100,   31), S( 38,  40)                                                     }, // Pawn
+    {S(  59,   64), S(248, 196), S(-51, -60)                                        }, // Knight      OUR PIECES
+    {S(   0,    0), S(122, 133), S( 10,  28), S(  0,   0)                           }, // Bishop
+    {S( -61,  -64), S( -5,   3), S(100,  78), S(133, 121), S(-247, -240)            }, // Rook
+    {S(-213, -212), S( 36,  14), S(154, 143), S(158,  98), S(-155, -170), S(-8,-30) }  // Queen
   };
 
   constexpr Score QuadraticTheirs[][PIECE_TYPE_NB] = {
     //           THEIR PIECES
     // pair pawn knight bishop rook queen
     {                                                                               }, // Bishop pair
-    {S(  33,  30)                                                                   }, // Pawn
-    {S(  48,  18), S(110,  83)                                                      }, // Knight      OUR PIECES
-    {S(  74,  39), S( 56,  44), S( 62,  12)                                         }, // Bishop
-    {S(  28,  35), S(  5,  21), S( 37,  38), S(-11,  -2)                            }, // Rook
-    {S(  96,  94), S( 94, 171), S(-58, -91), S(107, 192), S(293, 237)               }  // Queen
+    {S(  34,  30)                                                                   }, // Pawn
+    {S(  45,  18), S(110,  86)                                                      }, // Knight      OUR PIECES
+    {S(  75,  36), S( 58,  43), S( 59,  15)                                         }, // Bishop
+    {S(  27,  36), S(  4,  22), S( 38,  38), S(-11,  -1)                            }, // Rook
+    {S(  97,  92), S( 97, 166), S(-56, -90), S(104, 179), S(277, 227)               }  // Queen
   };
   
   

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -32,23 +32,23 @@ namespace {
   constexpr Score QuadraticOurs[][PIECE_TYPE_NB] = {
     //            OUR PIECES
     // pair pawn knight bishop rook queen
-    {S(1434, 1477)                                                                  }, // Bishop pair
-    {S( 100,   31), S( 38,  40)                                                     }, // Pawn
-    {S(  59,   64), S(248, 196), S(-51, -60)                                        }, // Knight      OUR PIECES
-    {S(   0,    0), S(122, 133), S( 10,  28), S(  0,   0)                           }, // Bishop
-    {S( -61,  -64), S( -5,   3), S(100,  78), S(133, 121), S(-247, -240)            }, // Rook
-    {S(-213, -212), S( 36,  14), S(154, 143), S(158,  98), S(-155, -170), S(-8,-30) }  // Queen
+    {S(1472, 1566)                                                                  }, // Bishop pair
+    {S( 112,   37), S( 38,  42)                                                     }, // Pawn
+    {S(  64,   55), S(256, 204), S(-49, -60)                                        }, // Knight      OUR PIECES
+    {S(   0,    0), S(127, 138), S( 10,  33), S(  0,   0)                           }, // Bishop
+    {S( -60,  -62), S( -6,   2), S(111,  79), S(131, 123), S(-233, -238)            }, // Rook
+    {S(-219, -221), S( 33,  16), S(149, 151), S(158,  95), S(-140, -179), S(-8,-28) }  // Queen
   };
 
   constexpr Score QuadraticTheirs[][PIECE_TYPE_NB] = {
     //           THEIR PIECES
     // pair pawn knight bishop rook queen
     {                                                                               }, // Bishop pair
-    {S(  34,  30)                                                                   }, // Pawn
-    {S(  45,  18), S(110,  86)                                                      }, // Knight      OUR PIECES
-    {S(  75,  36), S( 58,  43), S( 59,  15)                                         }, // Bishop
-    {S(  27,  36), S(  4,  22), S( 38,  38), S(-11,  -1)                            }, // Rook
-    {S(  97,  92), S( 97, 166), S(-56, -90), S(104, 179), S(277, 227)               }  // Queen
+    {S(  33,  29)                                                                   }, // Pawn
+    {S(  48,  19), S(116,  82)                                                      }, // Knight      OUR PIECES
+    {S(  74,  41), S( 56,  44), S( 64,  10)                                         }, // Bishop
+    {S(  30,  36), S(  5,  21), S( 36,  37), S(-12,  -1)                            }, // Rook
+    {S(  95,  93), S( 85, 178), S(-59, -91), S(109, 189), S(299, 249)               }  // Queen
   };
   
   

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -32,23 +32,23 @@ namespace {
   constexpr Score QuadraticOurs[][PIECE_TYPE_NB] = {
     //            OUR PIECES
     // pair pawn knight bishop rook queen
-    {S(1405, 1487)                                                                  }, // Bishop pair
-    {S( 103,   28), S( 38,  38)                                                     }, // Pawn
-    {S(  55,   65), S(246, 191), S(-51, -62)                                        }, // Knight      OUR PIECES
-    {S(   0,    0), S(121, 136), S( 10,  28), S(  0,   0)                           }, // Bishop
-    {S( -61,  -65), S( -5,   3), S( 99,  79), S(132, 117), S(-247, -247)            }, // Rook
-    {S(-212, -207), S( 37,  13), S(150, 144), S(160, 101), S(-155, -172), S(-9,-31) }  // Queen
+    {S(1458, 1539)                                                                  }, // Bishop pair
+    {S( 106,   33), S( 38,  41)                                                     }, // Pawn
+    {S(  61,   59), S(254, 201), S(-51, -60)                                        }, // Knight      OUR PIECES
+    {S(   0,    0), S(123, 140), S( 10,  31), S(  0,   0)                           }, // Bishop
+    {S( -60,  -64), S( -6,   3), S(105,  81), S(129, 121), S(-237, -247)            }, // Rook
+    {S(-215, -211), S( 34,  15), S(145, 146), S(155,  95), S(-149, -177), S(-8,-29) }  // Queen
   };
 
   constexpr Score QuadraticTheirs[][PIECE_TYPE_NB] = {
     //           THEIR PIECES
     // pair pawn knight bishop rook queen
     {                                                                               }, // Bishop pair
-    {S(  35,  30)                                                                   }, // Pawn
-    {S(  45,  18), S(104,  86)                                                      }, // Knight      OUR PIECES
-    {S(  75,  35), S( 59,  44), S( 60,  15)                                         }, // Bishop
-    {S(  25,  35), S(  6,  22), S( 37,  40), S(-12,  -1)                            }, // Rook
-    {S(  97,  94), S( 96, 167), S(-57, -90), S(111, 190), S(279, 219)               }  // Queen
+    {S(  33,  30)                                                                   }, // Pawn
+    {S(  48,  18), S(110,  83)                                                      }, // Knight      OUR PIECES
+    {S(  74,  39), S( 56,  44), S( 62,  12)                                         }, // Bishop
+    {S(  28,  35), S(  5,  21), S( 37,  38), S(-11,  -2)                            }, // Rook
+    {S(  96,  94), S( 94, 171), S(-58, -91), S(107, 192), S(293, 237)               }  // Queen
   };
   
   

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -32,23 +32,23 @@ namespace {
   constexpr Score QuadraticOurs[][PIECE_TYPE_NB] = {
     //            OUR PIECES
     // pair pawn knight bishop rook queen
-    {S(1487, 1567)                                                                  }, // Bishop pair
-    {S( 108,   37), S( 38,  42)                                                     }, // Pawn
-    {S(  64,   56), S(258, 206), S(-50, -60)                                        }, // Knight      OUR PIECES
-    {S(   0,    0), S(125, 142), S( 11,  32), S(  0,   0)                           }, // Bishop
-    {S( -60,  -62), S( -6,   3), S(109,  82), S(128, 123), S(-232, -250)            }, // Rook
-    {S(-217, -212), S( 33,  16), S(143, 146), S(151,  91), S(-146, -181), S(-7,-29) }  // Queen
+    {S(1405, 1487)                                                                  }, // Bishop pair
+    {S( 103,   28), S( 38,  38)                                                     }, // Pawn
+    {S(  55,   65), S(246, 191), S(-51, -62)                                        }, // Knight      OUR PIECES
+    {S(   0,    0), S(121, 136), S( 10,  28), S(  0,   0)                           }, // Bishop
+    {S( -61,  -65), S( -5,   3), S( 99,  79), S(132, 117), S(-247, -247)            }, // Rook
+    {S(-212, -207), S( 37,  13), S(150, 144), S(160, 101), S(-155, -172), S(-9,-31) }  // Queen
   };
 
   constexpr Score QuadraticTheirs[][PIECE_TYPE_NB] = {
     //           THEIR PIECES
     // pair pawn knight bishop rook queen
     {                                                                               }, // Bishop pair
-    {S(  33,  29)                                                                   }, // Pawn
-    {S(  49,  19), S(113,  82)                                                      }, // Knight      OUR PIECES
-    {S(  74,  40), S( 55,  44), S( 64,  11)                                         }, // Bishop
-    {S(  30,  35), S(  5,  20), S( 37,  37), S(-11,  -2)                            }, // Rook
-    {S(  96,  94), S( 92, 173), S(-59, -90), S(105, 193), S(301, 245)               }  // Queen
+    {S(  35,  30)                                                                   }, // Pawn
+    {S(  45,  18), S(104,  86)                                                      }, // Knight      OUR PIECES
+    {S(  75,  35), S( 59,  44), S( 60,  15)                                         }, // Bishop
+    {S(  25,  35), S(  6,  22), S( 37,  40), S(-12,  -1)                            }, // Rook
+    {S(  97,  94), S( 96, 167), S(-57, -90), S(111, 190), S(279, 219)               }  // Queen
   };
   
   

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -32,23 +32,23 @@ namespace {
   constexpr Score QuadraticOurs[][PIECE_TYPE_NB] = {
     //            OUR PIECES
     // pair pawn knight bishop rook queen
-    {S(1472, 1566)                                                                  }, // Bishop pair
-    {S( 112,   37), S( 38,  42)                                                     }, // Pawn
-    {S(  64,   55), S(256, 204), S(-49, -60)                                        }, // Knight      OUR PIECES
-    {S(   0,    0), S(127, 138), S( 10,  33), S(  0,   0)                           }, // Bishop
-    {S( -60,  -62), S( -6,   2), S(111,  79), S(131, 123), S(-233, -238)            }, // Rook
-    {S(-219, -221), S( 33,  16), S(149, 151), S(158,  95), S(-140, -179), S(-8,-28) }  // Queen
+    {S(1419, 1455)                                                                  }, // Bishop pair
+    {S( 101,   28), S( 37,  39)                                                     }, // Pawn
+    {S(  57,   64), S(249, 187), S(-49, -62)                                        }, // Knight      OUR PIECES
+    {S(   0,    0), S(118, 137), S( 10,  27), S(  0,   0)                           }, // Bishop
+    {S( -63,  -68), S( -5,   3), S(100,  81), S(132, 118), S(-246, -244)            }, // Rook
+    {S(-210, -211), S( 37,  14), S(147, 141), S(161, 105), S(-158, -174), S(-9,-31) }  // Queen
   };
 
   constexpr Score QuadraticTheirs[][PIECE_TYPE_NB] = {
     //           THEIR PIECES
     // pair pawn knight bishop rook queen
     {                                                                               }, // Bishop pair
-    {S(  33,  29)                                                                   }, // Pawn
-    {S(  48,  19), S(116,  82)                                                      }, // Knight      OUR PIECES
-    {S(  74,  41), S( 56,  44), S( 64,  10)                                         }, // Bishop
-    {S(  30,  36), S(  5,  21), S( 36,  37), S(-12,  -1)                            }, // Rook
-    {S(  95,  93), S( 85, 178), S(-59, -91), S(109, 189), S(299, 249)               }  // Queen
+    {S(  33,  30)                                                                   }, // Pawn
+    {S(  46,  18), S(106,  84)                                                      }, // Knight      OUR PIECES
+    {S(  75,  35), S( 59,  44), S( 60,  15)                                         }, // Bishop
+    {S(  26,  35), S(  6,  22), S( 38,  39), S(-12,  -2)                            }, // Rook
+    {S(  97,  93), S(100, 163), S(-58, -91), S(112, 192), S(276, 225)               }  // Queen
   };
   
   

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -32,12 +32,12 @@ namespace {
   constexpr Score QuadraticOurs[][PIECE_TYPE_NB] = {
     //            OUR PIECES
     // pair pawn knight bishop rook queen
-    {S(1419, 1455)                                                                  }, // Bishop pair
-    {S( 101,   28), S( 37,  39)                                                     }, // Pawn
-    {S(  57,   64), S(249, 187), S(-49, -62)                                        }, // Knight      OUR PIECES
-    {S(   0,    0), S(118, 137), S( 10,  27), S(  0,   0)                           }, // Bishop
-    {S( -63,  -68), S( -5,   3), S(100,  81), S(132, 118), S(-246, -244)            }, // Rook
-    {S(-210, -211), S( 37,  14), S(147, 141), S(161, 105), S(-158, -174), S(-9,-31) }  // Queen
+    {S(1446, 1511)                                                                  }, // Bishop pair
+    {S( 106,   32), S( 37,  41)                                                     }, // Pawn
+    {S(  61,   59), S(253, 196), S(-49, -61)                                        }, // Knight      OUR PIECES
+    {S(   0,    0), S(122, 138), S( 10,  30), S(  0,   0)                           }, // Bishop
+    {S( -61,  -65), S( -5,   2), S(106,  80), S(131, 120), S(-239, -241)            }, // Rook
+    {S(-215, -216), S( 35,  15), S(148, 146), S(160, 100), S(-149, -177), S(-8,-30) }  // Queen
   };
 
   constexpr Score QuadraticTheirs[][PIECE_TYPE_NB] = {
@@ -45,10 +45,10 @@ namespace {
     // pair pawn knight bishop rook queen
     {                                                                               }, // Bishop pair
     {S(  33,  30)                                                                   }, // Pawn
-    {S(  46,  18), S(106,  84)                                                      }, // Knight      OUR PIECES
-    {S(  75,  35), S( 59,  44), S( 60,  15)                                         }, // Bishop
-    {S(  26,  35), S(  6,  22), S( 38,  39), S(-12,  -2)                            }, // Rook
-    {S(  97,  93), S(100, 163), S(-58, -91), S(112, 192), S(276, 225)               }  // Queen
+    {S(  47,  19), S(111,  83)                                                      }, // Knight      OUR PIECES
+    {S(  75,  38), S( 57,  44), S( 62,  13)                                         }, // Bishop
+    {S(  28,  36), S(  5,  21), S( 37,  38), S(-12,  -2)                            }, // Rook
+    {S(  96,  93), S( 93, 170), S(-58, -91), S(111, 190), S(287, 237)               }  // Queen
   };
   
   

--- a/src/material.h
+++ b/src/material.h
@@ -58,7 +58,7 @@ struct Entry {
   const EndgameBase<ScaleFactor>* scalingFunction[COLOR_NB]; // Could be one for each
                                                              // side (e.g. KPKP, KBPsK)
   Score score;
-  Phase gamePhase;
+  int16_t gamePhase;
   uint8_t factor[COLOR_NB];
 };
 

--- a/src/material.h
+++ b/src/material.h
@@ -37,7 +37,7 @@ namespace Material {
 
 struct Entry {
 
-  Score imbalance() const { return make_score(value, value); }
+  Score imbalance() const { return score; }
   Phase game_phase() const { return gamePhase; }
   bool specialized_eval_exists() const { return evaluationFunction != nullptr; }
   Value evaluate(const Position& pos) const { return (*evaluationFunction)(pos); }
@@ -57,9 +57,9 @@ struct Entry {
   const EndgameBase<Value>* evaluationFunction;
   const EndgameBase<ScaleFactor>* scalingFunction[COLOR_NB]; // Could be one for each
                                                              // side (e.g. KPKP, KBPsK)
-  int16_t value;
-  uint8_t factor[COLOR_NB];
+  Score score;
   Phase gamePhase;
+  uint8_t factor[COLOR_NB];
 };
 
 typedef HashTable<Entry, 8192> Table;

--- a/src/material.h
+++ b/src/material.h
@@ -38,7 +38,7 @@ namespace Material {
 struct Entry {
 
   Score imbalance() const { return score; }
-  Phase game_phase() const { return gamePhase; }
+  Phase game_phase() const { return (Phase)gamePhase; }
   bool specialized_eval_exists() const { return evaluationFunction != nullptr; }
   Value evaluate(const Position& pos) const { return (*evaluationFunction)(pos); }
 


### PR DESCRIPTION
Imbalance tables tweaked to contain MiddleGame and Endgame values, instead of a single value.

The idea started from Fisherman, which requested my help to tune the values back in June/July, so I tuned the values back then, and we were able to accomplish good results, but not enough to pass both STC and LTC tests.

So after the recent changes, I decided to give it another shot, and I am glad that it was a successful attempt.

A special thanks goes also to mstembera, which notified me a simple way to let the patch perform a little better.

Passed STC:
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 60640 W: 12087 L: 11741 D: 36812
Ptnml(0-2): 1067, 7046, 13774, 7340, 1093
https://tests.stockfishchess.org/tests/view/5fc92cd542a050a89f02ccc5

Yellow LTC (+0.55 ELO):
LLR: -2.96 (-2.94,2.94) {0.25,1.25}
Total: 246680 W: 32369 L: 32096 D: 182215
Ptnml(0-2): 1928, 23294, 72592, 23629, 1897
https://tests.stockfishchess.org/tests/view/5fc981bd42a050a89f02ccf5