### PR TITLE
Faster reduction in search.cpp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -73,7 +73,7 @@ namespace {
 
   Depth reduction(bool i, Depth d, int mn) {
     int r = Reductions[d] * Reductions[mn];
-    return ((503 + r + (( ~i && r > 915) << 10)) >> 10);
+    return ((503 + r + (( !i && r > 915) << 10)) >> 10);
   }
 
   constexpr int futility_move_count(bool improving, Depth depth) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -73,7 +73,7 @@ namespace {
 
   Depth reduction(bool i, Depth d, int mn) {
     int r = Reductions[d] * Reductions[mn];
-    return (r + 503) / 1024 + (!i && r > 915);
+    return ((503 + r + (( ~i && r > 915) << 10)) >> 10);
   }
 
   constexpr int futility_move_count(bool improving, Depth depth) {


### PR DESCRIPTION
when -O3 is used this change is 5 instructions long vs the original 12 instruction operation.