### PR TITLE
Merge static history into main history

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -54,9 +54,9 @@ namespace {
 /// ordering is at the current node.
 
 /// MovePicker constructor for the main search
-MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh, const ButterflyHistory* sh, const LowPlyHistory* lp,
+MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh, const LowPlyHistory* lp,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Move cm, const Move* killers, int pl)
-           : pos(p), mainHistory(mh), staticHistory(sh), lowPlyHistory(lp), captureHistory(cph), continuationHistory(ch),
+           : pos(p), mainHistory(mh), lowPlyHistory(lp), captureHistory(cph), continuationHistory(ch),
              ttMove(ttm), refutations{{killers[0], 0}, {killers[1], 0}, {cm, 0}}, depth(d), ply(pl) {
 
   assert(d > 0);
@@ -66,9 +66,9 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 }
 
 /// MovePicker constructor for quiescence search
-MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh, const ButterflyHistory* sh,
+MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Square rs)
-           : pos(p), mainHistory(mh), staticHistory(sh), captureHistory(cph), continuationHistory(ch), ttMove(ttm), recaptureSquare(rs), depth(d) {
+           : pos(p), mainHistory(mh), captureHistory(cph), continuationHistory(ch), ttMove(ttm), recaptureSquare(rs), depth(d) {
 
   assert(d <= 0);
 
@@ -105,7 +105,6 @@ void MovePicker::score() {
 
       else if (Type == QUIETS)
           m.value =      (*mainHistory)[pos.side_to_move()][from_to(m)]
-                   +     (*staticHistory)[pos.side_to_move()][from_to(m)]
                    + 2 * (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
                    + 2 * (*continuationHistory[1])[pos.moved_piece(m)][to_sq(m)]
                    + 2 * (*continuationHistory[3])[pos.moved_piece(m)][to_sq(m)]

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -123,12 +123,10 @@ public:
   MovePicker& operator=(const MovePicker&) = delete;
   MovePicker(const Position&, Move, Value, const CapturePieceToHistory*);
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*,
-                                           const ButterflyHistory*,
                                            const CapturePieceToHistory*,
                                            const PieceToHistory**,
                                            Square);
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*,
-                                           const ButterflyHistory*,
                                            const LowPlyHistory*,
                                            const CapturePieceToHistory*,
                                            const PieceToHistory**,
@@ -145,7 +143,6 @@ private:
 
   const Position& pos;
   const ButterflyHistory* mainHistory;
-  const ButterflyHistory* staticHistory;
   const LowPlyHistory* lowPlyHistory;
   const CapturePieceToHistory* captureHistory;
   const PieceToHistory** continuationHistory;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -721,7 +721,10 @@ namespace {
         // Partial workaround for the graph history interaction problem
         // For high rule50 counts don't produce transposition table cutoffs.
         if (pos.rule50_count() < 90)
+        {
+            ss->staticEval = tte->eval();
             return ttValue;
+        }
     }
 
     // Step 5. Tablebases probe
@@ -1354,7 +1357,7 @@ moves_loop: // When in check, search starts from here
 
           else if (!captureOrPromotion)
           {
-              if (depth < 6 && !givesCheck && !ss->inCheck)
+              if (depth < 6 && !givesCheck && !ss->inCheck && (ss+1)->staticEval != VALUE_NONE)
               {
                    int bonus = std::clamp(- depth * 2 * int((ss+1)->staticEval + ss->staticEval - 2 * Tempo), -1000, 1000);
                    thisThread->mainHistory[us][from_to(move)] << bonus;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1358,7 +1358,7 @@ moves_loop: // When in check, search starts from here
           if (captureOrPromotion && captureCount < 32)
               capturesSearched[captureCount++] = move;
 
-          if (quietCount < 64)
+          else if (quietCount < 64)
               quietsSearched[quietCount++] = move;
       }
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1358,7 +1358,7 @@ moves_loop: // When in check, search starts from here
           if (captureOrPromotion && captureCount < 32)
               capturesSearched[captureCount++] = move;
 
-          else if (quietCount < 64)
+          else if (!captureOrPromotion && quietCount < 64)
               quietsSearched[quietCount++] = move;
       }
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -815,15 +815,6 @@ namespace {
         tte->save(posKey, VALUE_NONE, ss->ttPv, BOUND_NONE, DEPTH_NONE, MOVE_NONE, eval);
     }
 
-    // Update static history for previous move
-    if (is_ok((ss-1)->currentMove) && !(ss-1)->inCheck && !priorCapture)
-    {
-        int bonus = ss->staticEval > -(ss-1)->staticEval + 2 * Tempo ? -stat_bonus(depth) :
-                    ss->staticEval < -(ss-1)->staticEval + 2 * Tempo ? stat_bonus(depth) :
-                    0;
-        thisThread->staticHistory[~us][from_to((ss-1)->currentMove)] << bonus;
-    }
-
     // Step 7. Razoring (~1 Elo)
     if (   !rootNode // The required rootNode PV handling is not available in qsearch
         &&  depth == 1
@@ -985,7 +976,6 @@ moves_loop: // When in check, search starts from here
     Move countermove = thisThread->counterMoves[pos.piece_on(prevSq)][prevSq];
 
     MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory,
-                                      &thisThread->staticHistory,
                                       &thisThread->lowPlyHistory,
                                       &captureHistory,
                                       contHist,
@@ -1362,8 +1352,16 @@ moves_loop: // When in check, search starts from here
           if (captureOrPromotion && captureCount < 32)
               capturesSearched[captureCount++] = move;
 
-          else if (!captureOrPromotion && quietCount < 64)
-              quietsSearched[quietCount++] = move;
+          else if (!captureOrPromotion)
+          {
+              if (depth < 6 && !givesCheck && !ss->inCheck)
+              {
+                   int bonus = std::clamp(- depth * 2 * int((ss+1)->staticEval + ss->staticEval - 2 * Tempo), -1000, 1000);
+                   thisThread->mainHistory[us][from_to(move)] << bonus;
+              }
+              if (quietCount < 64)
+                  quietsSearched[quietCount++] = move;
+          }
       }
     }
 
@@ -1536,7 +1534,6 @@ moves_loop: // When in check, search starts from here
     // queen and checking knight promotions, and other checks(only if depth >= DEPTH_QS_CHECKS)
     // will be generated.
     MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory,
-                                      &thisThread->staticHistory,
                                       &thisThread->captureHistory,
                                       contHist,
                                       to_sq((ss-1)->currentMove));

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -57,7 +57,6 @@ void Thread::clear() {
 
   counterMoves.fill(MOVE_NONE);
   mainHistory.fill(0);
-  staticHistory.fill(0);
   lowPlyHistory.fill(0);
   captureHistory.fill(0);
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -69,7 +69,6 @@ public:
   Depth rootDepth, completedDepth;
   CounterMoveHistory counterMoves;
   ButterflyHistory mainHistory;
-  ButterflyHistory staticHistory;
   LowPlyHistory lowPlyHistory;
   CapturePieceToHistory captureHistory;
   ContinuationHistory continuationHistory[2][2];


### PR DESCRIPTION
Merge static history into main history and modify the way the static diffs are used.
I believe static diff for better move ordering only works near the tips
of the searchtree, so this patch only writes   bonus/malus at low depths.

LTC:
LLR: 2.96 (-2.94,2.94) {-0.75,0.25}
Total: 14704 W: 597 L: 533 D: 13574
Ptnml(0-2): 4, 483, 6316, 543, 6
https://tests.stockfishchess.org/tests/view/5fd4bf741ac16912018884d3

STC:
LLR: 2.97 (-2.94,2.94) {-1.25,0.25}
Total: 27280 W: 2485 L: 2405 D: 22390
Ptnml(0-2): 86, 1963, 9484, 1999, 108
https://tests.stockfishchess.org/tests/view/5fd4a35f1ac16912018884b9

bench: 3993204