### PR TITLE
Increase reduction in case of stable best move.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1192,7 +1192,7 @@ moves_loop: // When in check, search starts from here
               r -= 2;
 
           // Increase reduction at root and non-PV nodes when the best move does not change frequently
-          if ((rootNode || !PvNode) && depth > 10 && thisThread->bestMoveChanges <= 2)
+          if ((rootNode || !PvNode) && thisThread->rootDepth > 10 && thisThread->bestMoveChanges <= 2)
               r++;
 
           // More reductions for late moves if position was not in previous PV


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5fd643271ac16912018885c5
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 13232 W: 1308 L: 1169 D: 10755
Ptnml(0-2): 39, 935, 4535, 1062, 45 
passed LTC
https://tests.stockfishchess.org/tests/view/5fd68db11ac16912018885f0
LLR: 2.96 (-2.94,2.94) {0.25,1.25}
Total: 14024 W: 565 L: 463 D: 12996
Ptnml(0-2): 3, 423, 6062, 517, 7 
Idea of this patch is pretty simple - we already do more reductions for non-PV and root nodes in case of stable best move for depth > 10.
This patch makes us do so if root depth if > 10 instead - which is logical since best move changes (thus instability of it) is counted at root, so it makes a lot of sence to use depth of the root.
bench 4607631