### PR TITLE
Simplify condition for assigning static-eval based bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -815,9 +815,10 @@ namespace {
         tte->save(posKey, VALUE_NONE, ss->ttPv, BOUND_NONE, DEPTH_NONE, MOVE_NONE, eval);
     }
 
-    if ((ss-1)->moveCount > 1 && is_ok((ss-1)->currentMove) && !(ss-1)->inCheck && !priorCapture && depth < 7)
+    // Use static evaluation difference to improve quiet move ordering
+    if (is_ok((ss-1)->currentMove) && !(ss-1)->inCheck && !priorCapture)
     {
-        int bonus = std::clamp(- (depth+1) * 2 * int((ss-1)->staticEval + ss->staticEval - 2 * Tempo), -1000, 1000);
+        int bonus = std::clamp(-depth * 4 * int((ss-1)->staticEval + ss->staticEval - 2 * Tempo), -1000, 1000);
         thisThread->mainHistory[~us][from_to((ss-1)->currentMove)] << bonus;
     }
 


### PR DESCRIPTION
Simplify condition for assigning static-eval based bonus for quiet move ordering and simplify bonus formula.

Due to clamping the bonus to relative low values the impact on high
depths is minimal, thus the restriction to low depths seems not necessary.
Also the condition of move count in previous node seems to be not determinant at all.

Passed STC:
LLR: 2.95 (-2.94,2.94) {-1.25,0.25}
Total: 14600 W: 1424 L: 1323 D: 11853
Ptnml(0-2): 55, 1033, 5020, 1140, 52
https://tests.stockfishchess.org/tests/view/5fd67b381ac16912018885ec

Passed LTC:
LLR: 2.95 (-2.94,2.94) {-0.75,0.25}
Total: 85008 W: 3218 L: 3206 D: 78584
Ptnml(0-2): 49, 2840, 36700, 2880, 35
https://tests.stockfishchess.org/tests/view/5fd6af041ac16912018885f8

bench:  3986846