### PR TITLE
Definition Tweak

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -790,7 +790,7 @@ namespace {
                 if (!(pos.pieces(Them) & bb))
                     unsafeSquares &= attackedBy[Them][ALL_PIECES] | pos.pieces(Them);
 
-                // If there are no enemy attacks on passed pawn span, assign a big bonus.
+                // If there are no enemy pieces or attacks on passed pawn span, assign a big bonus.
                 // Otherwise assign a smaller bonus if the path to queen is not attacked
                 // and even smaller bonus if it is attacked but block square is not.
                 int k = !unsafeSquares                    ? 35 :

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -237,11 +237,11 @@ namespace {
 
   // PassedRank[Rank] contains a bonus according to the rank of a passed pawn
   constexpr Score PassedRank[RANK_NB] = {
-    S(0, 0), S(9, 28), S(15, 31), S(17, 39), S(64, 70), S(171, 177), S(277, 260)
+    S(0, 0), S(7, 27), S(16, 32), S(17, 40), S(64, 71), S(170, 174), S(278, 262)
   };
 
   constexpr Score RookOnClosedFile = S(10, 5);
-  constexpr Score RookOnOpenFile[] = { S(19, 7), S(48, 27) };
+  constexpr Score RookOnOpenFile[] = { S(19, 6), S(47, 26) };
 
   // ThreatByMinor/ByRook[attacked PieceType] contains bonuses according to
   // which piece type attacks which one. Attacks on lesser pieces which are
@@ -788,7 +788,7 @@ namespace {
                 bb = forward_file_bb(Them, s) & pos.pieces(ROOK, QUEEN);
 
                 if (!(pos.pieces(Them) & bb))
-                    unsafeSquares &= attackedBy[Them][ALL_PIECES];
+                    unsafeSquares &= attackedBy[Them][ALL_PIECES] | pos.pieces(Them);
 
                 // If there are no enemy attacks on passed pawn span, assign a big bonus.
                 // Otherwise assign a smaller bonus if the path to queen is not attacked

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -37,10 +37,10 @@ namespace {
   constexpr Score WeakUnopposed = S(13, 25);
 
   // Bonus for blocked pawns at 5th or 6th rank
-  constexpr Score BlockedPawn[2] = { S(-13, -4), S(-5, 2) };
+  constexpr Score BlockedPawn[2] = { S(-15, -3), S(-6, 3) };
 
   constexpr Score BlockedStorm[RANK_NB] = {
-    S(0, 0), S(0, 0), S(76, 78), S(-10, 15), S(-7, 10), S(-4, 6), S(-1, 2)
+    S(0, 0), S(0, 0), S(75, 78), S(-8, 16), S(-6, 10), S(-6, 6), S(0, 2)
   };
 
   // Connected pawn bonus


### PR DESCRIPTION
The bonus 35 is now not given whenever there is an enemy piece in front of the pawn.

As coded it also excludes this bonus 35 if there is some enemy piece on some adjacent file in front of the pawn.
This might seems weird, but in most cases, this means that the piece is attacking the "squarestoqueen"
(in which case master was not giving this bonus 35 anyway, but sometimes a lesser bonus)

A future test will try to exclude such enemy pieces if attacked by a pawn.

The version which passed the tests is a version using the average values between the (Stc tuning + Ltc tuning + Original values).

P.s: I would like to give credit to Rocky for his constant help and also to unaic for trying this idea earlier, even though if I remember correctly, he also got it from Costalba.



Passed STC:
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 109472 W: 22097 L: 21673 D: 65702
Ptnml(0-2): 2111, 12800, 24482, 13240, 2103
https://tests.stockfishchess.org/tests/view/5fd8d3740c5870924361ffad

Passed LTC:
LLR: 2.95 (-2.94,2.94) {0.25,1.25}
Total: 39384 W: 5334 L: 4990 D: 29060
Ptnml(0-2): 279, 3648, 11535, 3910, 320
https://tests.stockfishchess.org/tests/view/5fd971ab0c5870924361fff0