### PR TITLE
Tweak the formulas for unsafeSquares

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -791,12 +791,14 @@ namespace {
                     unsafeSquares &= attackedBy[Them][ALL_PIECES] | pos.pieces(Them);
 
                 // If there are no enemy pieces or attacks on passed pawn span, assign a big bonus.
+                // Or if there is some, but they are all attacked by our pawns, assign a bit smaller bonus.
                 // Otherwise assign a smaller bonus if the path to queen is not attacked
                 // and even smaller bonus if it is attacked but block square is not.
-                int k = !unsafeSquares                    ? 35 :
-                        !(unsafeSquares & squaresToQueen) ? 20 :
-                        !(unsafeSquares & blockSq)        ?  9 :
-                                                             0 ;
+                
+                int k = !unsafeSquares                    ? 36 :
+                !(unsafeSquares & ~attackedBy[Us][PAWN])  ? 30 :
+                        !(unsafeSquares & squaresToQueen) ? 17 :
+                        !(unsafeSquares & blockSq)        ?  7 :
 
                 // Assign a larger bonus if the block square is defended
                 if ((pos.pieces(Us) & bb) || (attackedBy[Us][ALL_PIECES] & blockSq))

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -799,6 +799,7 @@ namespace {
                 !(unsafeSquares & ~attackedBy[Us][PAWN])  ? 30 :
                         !(unsafeSquares & squaresToQueen) ? 17 :
                         !(unsafeSquares & blockSq)        ?  7 :
+                                                             0 ;
 
                 // Assign a larger bonus if the block square is defended
                 if ((pos.pieces(Us) & bb) || (attackedBy[Us][ALL_PIECES] & blockSq))


### PR DESCRIPTION
Follow-up to recent #3266

We give more bonus for a special case If there are some enemy squares occupied or attacked by the enemy on the passed pawn span, but if they are all attacked by our pawn, use new intermediate factor  30.

The main credit goes to Rocky for the idea, and to me for the tuning and tests.

Passed STC:
LLR: 2.95 (-2.94,2.94) {-0.25,1.25}
Total: 96464 W: 19233 L: 18834 D: 58397
Ptnml(0-2): 1683, 11327, 21950, 11452, 1820
https://tests.stockfishchess.org/tests/view/5fdd21ab3932f79192d39357

Passed LTC:
LLR: 2.94 (-2.94,2.94) {0.25,1.25}
Total: 81320 W: 10784 L: 10352 D: 60184
Ptnml(0-2): 602, 7524, 24044, 7820, 670
https://tests.stockfishchess.org/tests/view/5fddec983932f79192d393a4