### PR TITLE
Tighter TT packing (6.7% more entries)

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1017,7 +1017,7 @@ void Position::do_null_move(StateInfo& newSt) {
   }
 
   st->key ^= Zobrist::side;
-  prefetch(TT.first_entry(st->key));
+  TT.prefetch(st->key);
 
   ++st->rule50;
   st->pliesFromNull = 0;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1152,7 +1152,7 @@ moves_loop: // When in check, search starts from here
       newDepth += extension;
 
       // Speculative prefetch as early as possible
-      prefetch(TT.first_entry(pos.key_after(move)));
+      TT.prefetch(pos.key_after(move));
 
       // Update the current move (this must be done after singular extension search)
       ss->currentMove = move;
@@ -1580,7 +1580,7 @@ moves_loop: // When in check, search starts from here
           continue;
 
       // Speculative prefetch as early as possible
-      prefetch(TT.first_entry(pos.key_after(move)));
+      TT.prefetch(pos.key_after(move));
 
       // Check for legality just before making the move
       if (!pos.legal(move))

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -69,8 +69,7 @@ void TranspositionTable::resize(size_t mbSize) {
 
   aligned_large_pages_free(table);
 
-  // + 2 temporarily adds padding for verifying no bench change
-  clusterCount = mbSize * 1024 * 1024 / (sizeof(Cluster) + ClusterSize * sizeof(EntryKey) + 2);
+  clusterCount = mbSize * 1024 * 1024 / (sizeof(Cluster) + ClusterSize * sizeof(EntryKey));
 
   table = static_cast<Cluster*>(aligned_large_pages_alloc(
                                 clusterCount * (sizeof(Cluster) + ClusterSize * sizeof(EntryKey))));

--- a/src/tt.h
+++ b/src/tt.h
@@ -63,13 +63,13 @@ private:
 
 class TranspositionTable {
 
-  static constexpr int ClusterSize = 3;
+  static constexpr int ClusterSize = 4;
 
   struct Cluster {
     TTEntry entry[ClusterSize];
   };
 
-  static_assert(sizeof(Cluster) == 24, "Unexpected Cluster size"); // temporary change
+  static_assert(sizeof(Cluster) == 32, "Unexpected Cluster size");
 
 public:
  ~TranspositionTable() { aligned_large_pages_free(table); }


### PR DESCRIPTION
Let's see if tighter TT packing is worth separating the entry keys.

I'll submit to fishtest after CI passes.

***

Ideally, depth8 and genBound8 would be also moved from TTEntry to EntryKey so that TranspositionTable::probe() needs to access only one data structure. However, that would once again leave the cluster size with odd non-power-of-2 size and it would be a more intrusive change. So, let's try this approach first.