### PR TITLE
Correct Outflanking calculations in classical eval

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -871,7 +871,8 @@ namespace {
                             && (pos.pieces(PAWN) & KingSide);
 
     bool almostUnwinnable =   outflanking < 0
-                           && !pawnsOnBothFlanks;
+                           && !pawnsOnBothFlanks
+                           && rank_of(pos.square<KING>(WHITE)) < rank_of(pos.square<KING>(BLACK));
 
     bool infiltration =   rank_of(pos.square<KING>(WHITE)) > RANK_4
                        || rank_of(pos.square<KING>(BLACK)) < RANK_5;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -865,7 +865,7 @@ namespace {
   Value Evaluation<T>::winnable(Score score) const {
 
     int outflanking =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
-                     + int(rank_of(pos.square<KING>(WHITE)) - rank_of(pos.square<KING>(BLACK)));
+                    + int(rank_of(pos.square<KING>(WHITE)) - rank_of(pos.square<KING>(BLACK)));
 
     bool pawnsOnBothFlanks =   (pos.pieces(PAWN) & QueenSide)
                             && (pos.pieces(PAWN) & KingSide);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -865,14 +865,13 @@ namespace {
   Value Evaluation<T>::winnable(Score score) const {
 
     int outflanking =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
-                     - distance<Rank>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
+                     + int(rank_of(pos.square<KING>(WHITE)) - rank_of(pos.square<KING>(BLACK)));
 
     bool pawnsOnBothFlanks =   (pos.pieces(PAWN) & QueenSide)
                             && (pos.pieces(PAWN) & KingSide);
 
     bool almostUnwinnable =   outflanking < 0
-                           && !pawnsOnBothFlanks
-                           && rank_of(pos.square<KING>(WHITE)) < rank_of(pos.square<KING>(BLACK));
+                           && !pawnsOnBothFlanks;
 
     bool infiltration =   rank_of(pos.square<KING>(WHITE)) > RANK_4
                        || rank_of(pos.square<KING>(BLACK)) < RANK_5;


### PR DESCRIPTION
Take signed value of rank difference between kings squares instead absolute value in outflanking calculation. This change correct evaluation of endgames with one king invading opponent last ranks.

Passed STC:
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 122240 W: 24326 L: 23896 D: 74018
Ptnml(0-2): 2101, 14139, 28236, 14517, 2127 
https://tests.stockfishchess.org/tests/view/5fdfc33a3932f79192d394b8

Passed LTC:
LLR: 2.97 (-2.94,2.94) {0.25,1.25}
Total: 157416 W: 20870 L: 20292 D: 116254
Ptnml(0-2): 973, 13954, 48333, 14418, 1030 
https://tests.stockfishchess.org/tests/view/5fe07a453932f79192d39502

Bench: 4001413