### PR TITLE
Edge pawn

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -30,11 +30,11 @@ namespace {
   #define S(mg, eg) make_score(mg, eg)
 
   // Pawn penalties
-  constexpr Score Backward      = S( 8, 25);
-  constexpr Score Doubled       = S(10, 55);
-  constexpr Score Isolated      = S( 3, 15);
-  constexpr Score WeakLever     = S( 3, 55);
-  constexpr Score WeakUnopposed = S(13, 25);
+  constexpr Score Backward      = S( 6, 23);
+  constexpr Score Doubled       = S(13, 53);
+  constexpr Score Isolated      = S( 2, 15);
+  constexpr Score WeakLever     = S( 5, 57);
+  constexpr Score WeakUnopposed = S(16, 22);
 
   // Bonus for blocked pawns at 5th or 6th rank
   constexpr Score BlockedPawn[2] = { S(-15, -3), S(-6, 3) };
@@ -69,8 +69,8 @@ namespace {
 
   // KingOnFile[semi-open Us][semi-open Them] contains bonuses/penalties
   // for king when the king is on a semi-open or open file.
-  constexpr Score KingOnFile[2][2] = {{ S(-19,12), S(-6, 7)  },
-                                     {  S(  0, 2), S( 6,-5) }};
+  constexpr Score KingOnFile[2][2] = {{ S(-21,10), S(-7, 1)  },
+                                     {  S(  0,-3), S( 9,-4) }};
 
   #undef S
   #undef V
@@ -172,7 +172,7 @@ namespace {
 
         else if (backward)
             score -=  Backward
-                    + WeakUnopposed * !opposed;
+                    + WeakUnopposed * !opposed * bool(~(FileABB | FileHBB) & s);
 
         if (!support)
             score -=  Doubled * doubled

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -167,7 +167,7 @@ namespace {
                 score -= Doubled;
             else
                 score -=  Isolated
-                        + WeakUnopposed * !opposed;
+                        + WeakUnopposed * !opposed * bool(~(FileABB | FileHBB) & s);
         }
 
         else if (backward)

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -167,12 +167,12 @@ namespace {
                 score -= Doubled;
             else
                 score -=  Isolated
-                        + WeakUnopposed * !opposed * bool(~(FileABB | FileHBB) & s);
+                        + WeakUnopposed * !opposed;
         }
 
         else if (backward)
             score -=  Backward
-                    + WeakUnopposed * !opposed;
+                    + WeakUnopposed * !opposed * bool(~(FileABB | FileHBB) & s);
 
         if (!support)
             score -=  Doubled * doubled

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -172,7 +172,7 @@ namespace {
 
         else if (backward)
             score -=  Backward
-                    + WeakUnopposed * !opposed * bool(~(FileABB | FileHBB) & s);
+                    + WeakUnopposed * !opposed;
 
         if (!support)
             score -=  Doubled * doubled


### PR DESCRIPTION
We can close this one now, as a new PR has been created.

Do not give the WeakUnopposed penalty for backwards on file A or H

The original idea comes from Lolligerhans, and a series of tunings and tests done by Fauzi.

Passed STC:
LLR: 2.96 (-2.94,2.94) {-0.25,1.25}
Total: 140864 W: 28127 L: 27660 D: 85077
Ptnml(0-2): 2529, 16660, 31735, 16831, 2677
https://tests.stockfishchess.org/tests/view/5fe39dec3932f79192d39673

Passed LTC:
LLR: 2.95 (-2.94,2.94) {0.25,1.25}
Total: 67568 W: 8993 L: 8590 D: 49985
Ptnml(0-2): 523, 6176, 19983, 6579, 523
https://tests.stockfishchess.org/tests/view/5fe3dd1b3932f79192d39693
Bench: 3799573