### PR TITLE
Do more LMR for captures.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1172,6 +1172,7 @@ moves_loop: // When in check, search starts from here
               || moveCountPruning
               || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha
               || cutNode
+              || (!PvNode && !formerPv)
               || thisThread->ttHitAverage < 432 * TtHitAverageResolution * TtHitAverageWindow / 1024))
       {
           Depth r = reduction(improving, depth, moveCount);


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5fe50b9d3932f79192d3973c
LLR: 2.95 (-2.94,2.94) {-0.25,1.25}
Total: 83128 W: 7606 L: 7368 D: 68154
Ptnml(0-2): 292, 5905, 28939, 6129, 299 
passed LTC
https://tests.stockfishchess.org/tests/view/5fe552e43932f79192d39744
LLR: 2.92 (-2.94,2.94) {0.25,1.25}
Total: 13968 W: 568 L: 466 D: 12934
Ptnml(0-2): 5, 418, 6043, 506, 12 
This patch enables LMR for all captures at allNodes that were not in PV.
Currently we do LMR for all captures at cutNodes so this is an expansion of this logic - now we do LMR for all captures almost at all non-pv nodes, excluding only allNodes that were in PV.
bench 4194835