### PR TITLE
Simplify away late irreversible move extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1142,12 +1142,6 @@ moves_loop: // When in check, search starts from here
                && pos.non_pawn_material() <= 2 * RookValueMg)
           extension = 1;
 
-      // Late irreversible move extension
-      if (   move == ttMove
-          && pos.rule50_count() > 80
-          && (captureOrPromotion || type_of(movedPiece) == PAWN))
-          extension = 2;
-
       // Add extension to new depth
       newDepth += extension;
 


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5fe75c5c3932f79192d398ca
LLR: 2.93 (-2.94,2.94) {-1.25,0.25}
Total: 196192 W: 18111 L: 18278 D: 159803
Ptnml(0-2): 681, 14097, 68652, 14040, 626

LTC https://tests.stockfishchess.org/tests/view/5fe875e23932f79192d39952
LLR: 2.96 (-2.94,2.94) {-0.75,0.25}
Total: 28080 W: 1105 L: 1053 D: 25922
Ptnml(0-2): 13, 904, 12158, 948, 17

bench: 4075243

Late irreversible move extension seems to be useless. Some ELO estimation: https://tests.stockfishchess.org/tests/view/5fe72efb3932f79192d39889