### PR TITLE
Tweak capture LMR.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1172,7 +1172,7 @@ moves_loop: // When in check, search starts from here
               || moveCountPruning
               || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha
               || cutNode
-              || (!PvNode && !formerPv)
+              || (!PvNode && !formerPv && thisThread->captureHistory[movedPiece][to_sq(move)][type_of(pos.captured_piece())] < 4506)
               || thisThread->ttHitAverage < 432 * TtHitAverageResolution * TtHitAverageWindow / 1024))
       {
           Depth r = reduction(improving, depth, moveCount);


### PR DESCRIPTION
Apply the recently added LMR condition for captures at nodes which are not PV or former PV nodes only if capture history is not too good.

STC:
LLR: 2.96 (-2.94,2.94) {-0.25,1.25}
Total: 95296 W: 8917 L: 8660 D: 77719
Ptnml(0-2): 323, 6871, 33045, 7044, 365
https://tests.stockfishchess.org/tests/view/5feca7f46019e097de3ee9ae

LTC:
LLR: 2.95 (-2.94,2.94) {0.25,1.25}
Total: 29216 W: 1172 L: 1034 D: 27010
Ptnml(0-2): 11, 946, 12568, 1060, 23
https://tests.stockfishchess.org/tests/view/5fecf1786019e097de3ee9d5

Bench: 4006138