### PR TITLE
Possible fix for CCCC slowdown

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -123,7 +123,8 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   for (int i = 0; i < ClusterSize; ++i)
       if (tte[i].key16 == key16 || !tte[i].depth8)
       {
-          tte[i].genBound8 = uint8_t(generation8 | (tte[i].genBound8 & 0x7)); // Refresh
+          if ((tte[i].genBound8 & 0xF8) != generation8 && tte[i].depth8)
+              tte[i].genBound8 = uint8_t(generation8 | (tte[i].genBound8 & 0x7)); // Refresh
 
           return found = (bool)tte[i].depth8, &tte[i];
       }


### PR DESCRIPTION
Don't unnecessarily refresh TT entries to lower memory bandwidth.
No functional change
bench: 4109336