### PR TITLE
Rethinking En Passant Evasion Capture

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -156,9 +156,9 @@ namespace {
         {
             assert(rank_of(pos.ep_square()) == relative_rank(Us, RANK_6));
 
-            // An en passant capture can be an evasion only if the checking piece
-            // is the double pushed pawn and so is in the target. Otherwise this
-            // is a discovery check and we are forced to do otherwise.
+            // An en passant capture cannot be an evasion if it is a discovery check
+            // and so the square the doubled-pushed pawn came from is in the target.
+            // Otherwise, the checking piece is the double-pushed pawn and it is pseudo-legal.
             if (Type == EVASIONS && (target & (pos.ep_square() + Up)))
                 return moveList;
 

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -159,7 +159,7 @@ namespace {
             // An en passant capture can be an evasion only if the checking piece
             // is the double pushed pawn and so is in the target. Otherwise this
             // is a discovery check and we are forced to do otherwise.
-            if (Type == EVASIONS && !(target & (pos.ep_square() - Up)))
+            if (Type == EVASIONS && (target & (pos.ep_square() + Up)))
                 return moveList;
 
             b1 = pawnsNotOn7 & pawn_attacks_bb(Them, pos.ep_square());

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -156,9 +156,7 @@ namespace {
         {
             assert(rank_of(pos.ep_square()) == relative_rank(Us, RANK_6));
 
-            // An en passant capture cannot be an evasion if it is a discovery check
-            // and so the square the doubled-pushed pawn came from is in the target.
-            // Otherwise, the checking piece is the double-pushed pawn and it is pseudo-legal.
+            // An en passant capture cannot resolve a discovered check.
             if (Type == EVASIONS && (target & (pos.ep_square() + Up)))
                 return moveList;
 


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/5ff890946019e097de3ef0a5
LLR: 2.93 (-2.94,2.94) {-1.25,0.25}
Total: 47912 W: 4327 L: 4285 D: 39300
Ptnml(0-2): 144, 3312, 17012, 3334, 154
bench: 4109336

Changing the way to check if En Passant Evasion Capture is pseudo-legal. No change on complexity, just checking if it is a discovery check instead of the checking piece is the double-pushed pawn.
The idea is to support a few more illegal fens without affecting legal fens. Solving issue #3270.