### PR TITLE
Birthday patch.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1234,7 +1234,7 @@ moves_loop: // When in check, search starts from here
 
               // Decrease/increase reduction for moves with a good/bad history (~30 Elo)
               // If we are not in check use statScore, if we are in check 
-              // use sum of main history and 1st countemove history with an offset
+              // use sum of main history and first continuation history with an offset
               if (ss->inCheck)
                   r -= (thisThread->mainHistory[us][from_to(move)] 
                      + (*contHist[0])[movedPiece][to_sq(move)] - 4333) / 16384;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1233,7 +1233,13 @@ moves_loop: // When in check, search starts from here
                   r++;
 
               // Decrease/increase reduction for moves with a good/bad history (~30 Elo)
-              r -= ss->statScore / 14884;
+              // If we are not in check use statScore, if we are in check 
+              // use sum of main history and 1st countemove history with an offset
+              if (ss->inCheck)
+                  r -= (thisThread->mainHistory[us][from_to(move)] 
+                     + (*contHist[0])[movedPiece][to_sq(move)] - 4333) / 16384;
+              else
+                  r -= ss->statScore / 14884;
           }
 
           Depth d = std::clamp(newDepth - r, 1, newDepth);


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/5ff87b2f6019e097de3ef09b
LLR: 2.93 (-2.94,2.94) {-0.25,1.25}
Total: 63992 W: 5887 L: 5678 D: 52427
Ptnml(0-2): 201, 4561, 22305, 4686, 243 
passed LTC
https://tests.stockfishchess.org/tests/view/5ff8b6206019e097de3ef0b2
LLR: 2.94 (-2.94,2.94) {0.25,1.25}
Total: 81216 W: 3127 L: 2880 D: 75209
Ptnml(0-2): 46, 2544, 35176, 2801, 41 
This patch separates stat based reductions for quiet moves in case of being in check and in case of not being in check.
We will be using sum of first continuation history and main history (similar to movepicker) instead of statScore for the first case.
bench 4395984