### PR TITLE
Fix static_assert.

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -210,6 +210,9 @@ namespace {
 
   template<Color Us, GenType Type>
   ExtMove* generate_all(const Position& pos, ExtMove* moveList) {
+
+    static_assert(Type != LEGAL, "Unsupported type in generate_all()");
+
     constexpr bool Checks = Type == QUIET_CHECKS; // Reduce template instantations
     Bitboard target;
 
@@ -231,8 +234,6 @@ namespace {
         case NON_EVASIONS:
             target = ~pos.pieces(Us);
             break;
-        default:
-            static_assert(true, "Unsupported type in generate_all()");
     }
 
     moveList = generate_pawn_moves<Us, Type>(pos, moveList, target);


### PR DESCRIPTION
`static_assert(true, ...)` is always a no-op, hence "useless" (or as useful as mere comments, if you prefer). 

Unfortunately, one cannot use `static_assert(false, ...)` either...
Fix this in line with other static_asserts in the same file.

No functional change.