### PR TITLE
Remove Condition from Generate_Move Loop

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,6 +33,7 @@ Bill Henry (VoyagerOne)
 Bojun Guo (noobpwnftw, Nooby)
 braich
 Brian Sheppard (SapphireBrand, briansheppard-toast)
+Bruno de Melo Costa (BM123499)
 Bryan Cross (crossbr)
 candirufish
 Chess13234

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -182,18 +182,15 @@ namespace {
 
     Bitboard bb = pos.pieces(Us, Pt);
 
+    if(Checks)
+        bb &= ~pos.blockers_for_king(~Us);
+
     while (bb) {
         Square from = pop_lsb(&bb);
 
-        if (Checks)
-        {
-            if (    (Pt == BISHOP || Pt == ROOK || Pt == QUEEN)
-                && !(attacks_bb<Pt>(from) & target & pos.check_squares(Pt)))
-                continue;
-
-            if (pos.blockers_for_king(~Us) & from)
-                continue;
-        }
+        if (Checks && (Pt == BISHOP || Pt == ROOK || Pt == QUEEN)
+            && !(attacks_bb<Pt>(from) & target & pos.check_squares(Pt)))
+            continue;
 
         Bitboard b = attacks_bb<Pt>(from, pos.pieces()) & target;
 

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -175,15 +175,12 @@ namespace {
   }
 
 
-  template<Color Us, PieceType Pt, bool Checks>
-  ExtMove* generate_moves(const Position& pos, ExtMove* moveList, Bitboard target) {
+  template<PieceType Pt, bool Checks>
+  ExtMove* generate_moves(const Position& pos, ExtMove* moveList, Bitboard piecesToMove, Bitboard target) {
 
     static_assert(Pt != KING && Pt != PAWN, "Unsupported piece type in generate_moves()");
 
-    Bitboard bb = pos.pieces(Us, Pt);
-
-    if(Checks)
-        bb &= ~pos.blockers_for_king(~Us);
+    Bitboard bb = piecesToMove & pos.pieces(Pt);
 
     while (bb) {
         Square from = pop_lsb(&bb);
@@ -208,7 +205,10 @@ namespace {
   template<Color Us, GenType Type>
   ExtMove* generate_all(const Position& pos, ExtMove* moveList) {
     constexpr bool Checks = Type == QUIET_CHECKS; // Reduce template instantations
-    Bitboard target;
+    Bitboard target, piecesToMove = pos.pieces(Us);
+
+    if(Type == QUIET_CHECKS)
+        piecesToMove &= ~pos.blockers_for_king(~Us);
 
     switch (Type)
     {
@@ -233,10 +233,10 @@ namespace {
     }
 
     moveList = generate_pawn_moves<Us, Type>(pos, moveList, target);
-    moveList = generate_moves<Us, KNIGHT, Checks>(pos, moveList, target);
-    moveList = generate_moves<Us, BISHOP, Checks>(pos, moveList, target);
-    moveList = generate_moves<Us,   ROOK, Checks>(pos, moveList, target);
-    moveList = generate_moves<Us,  QUEEN, Checks>(pos, moveList, target);
+    moveList = generate_moves<KNIGHT, Checks>(pos, moveList, piecesToMove, target);
+    moveList = generate_moves<BISHOP, Checks>(pos, moveList, piecesToMove, target);
+    moveList = generate_moves<  ROOK, Checks>(pos, moveList, piecesToMove, target);
+    moveList = generate_moves< QUEEN, Checks>(pos, moveList, piecesToMove, target);
 
     if (Type != QUIET_CHECKS && Type != EVASIONS)
     {


### PR DESCRIPTION
First of all, all data I'm speaking is based on what I gathered and may be wrong. It was also gathered by using `bench 1024 1 26`.
Pieces in this contest will refer only to Knight, Bishop, Rook and Queen.

- About 12.4% of generate_moves calls was about QUIET_CHECK.
- There are, on average, 3.93 pieces of player of the turn color when generate_moves<QUIET_CHECK> is called.
- 0.053% of those pieces are in blockers_for_king(~Us)
- 3.67% of generate_moves<QUIET_CHECK> has no piece (of the player of the turn).
- 9% of generate_moves<QUIET_CHECK> has exactly one piece (of the player of the turn).

To be honest, I don't know why QUIET_CHECK don't generate discovered checks, but it seems it's better to handle blockers_for_king(~Us) outside loops (and even better if used just once).
If someone test those data as well, I would be grateful.

Passed STC:
LLR: 2.96 (-2.94,2.94) {-0.25,1.25}
Total: 22184 W: 2063 L: 1919 D: 18202
Ptnml(0-2): 63, 1485, 7855, 1623, 66
https://tests.stockfishchess.org/tests/view/5ffbee2f6019e097de3ef18d

bench: 4109336
Non-functional change