### PR TITLE
Reduce amount of branching and work duplication in generate_moves.

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -180,17 +180,17 @@ namespace {
 
     Bitboard bb = piecesToMove & pos.pieces(Pt);
 
+    if (!bb)
+        return moveList;
+
+    [[maybe_unused]] const Bitboard checkSquares = pos.check_squares(Pt);
+
     while (bb) {
         Square from = pop_lsb(&bb);
 
-        if (Checks && (Pt == BISHOP || Pt == ROOK || Pt == QUEEN)
-            && !(attacks_bb<Pt>(from) & target & pos.check_squares(Pt)))
-            continue;
-
         Bitboard b = attacks_bb<Pt>(from, pos.pieces()) & target;
-
-        if (Checks)
-            b &= pos.check_squares(Pt);
+        if constexpr (Checks)
+            b &= checkSquares;
 
         while (b)
             *moveList++ = make_move(from, pop_lsb(&b));


### PR DESCRIPTION
This is inspired by previous changes by @BM123499.

This change simplifies control flow in the `generate_moves` function which ensures the compiler doesn't duplicate work due to possibly not resolving pureness of the function calls. Also the biggest change is the removal of the unnecessary condition checking for empty `b` in a convoluted way. The rationale for removal of this condition is that computing attacks_bb with occupancy is not much more costly than computing pseudo attacks and overall the condition (also being likely unpredictable) is a pessimisation.

Passed STC:
```
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 88040 W: 8172 L: 7931 D: 71937
Ptnml(0-2): 285, 6128, 30957, 6361, 289 
```
https://tests.stockfishchess.org/tests/view/5ffc28386019e097de3ef1c7

The test was performed against BM's branch that was merged into master. the only change for this PR is that I added `[[maybe_unused]]` as making sure the variable is not defined in some cases is not trivial.