### PR TITLE
Add penalty for doubled pawns in agile pawn structures

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -32,6 +32,7 @@ namespace {
   // Pawn penalties
   constexpr Score Backward      = S( 6, 23);
   constexpr Score Doubled       = S(13, 53);
+  constexpr Score DoubledEarly  = S(20, 10);
   constexpr Score Isolated      = S( 2, 15);
   constexpr Score WeakLever     = S( 5, 57);
   constexpr Score WeakUnopposed = S(16, 22);
@@ -86,6 +87,7 @@ namespace {
 
     constexpr Color     Them = ~Us;
     constexpr Direction Up   = pawn_push(Us);
+    constexpr Direction Down = -Up;
 
     Bitboard neighbours, stoppers, support, phalanx, opposed;
     Bitboard lever, leverPush, blocked;
@@ -122,6 +124,13 @@ namespace {
         neighbours = ourPawns   & adjacent_files_bb(s);
         phalanx    = neighbours & rank_bb(s);
         support    = neighbours & rank_bb(s - Up);
+
+        if (doubled)
+        {
+            // Additional doubled penalty if none of their pawns is fixed
+            if (!(ourPawns & shift<Down>(theirPawns | pawn_attacks_bb<Them>(theirPawns))))
+                score -= DoubledEarly;
+        }
 
         // A pawn is backward when it is behind all pawns of the same color on
         // the adjacent files and cannot safely advance.


### PR DESCRIPTION
### Cleanup
Like always, I did a slight cleanup for PR:
1. replaced `make_score` with `constexpr` paramter for easier tuning. Named it DoubledEarly because, like explained in the commit message, it uses an early-game-indicator. Future tweaks can show which name would really be appropriate.
2. Replaced the lenghty `score += Score * bool` construction with a not-as-lengthy `if (bool) Score +=`.

On my setup, the binary _does_ change from these adjustments. I can also use the exact tested version instead.

### Idea
The original idea was to penalize if only the doubled pawn formation is not facing their pawns. Any advancement or pawn break from them against our doubled pawns is discouraged: such breaks would allow us to un-double the pawns by simply taking at the first opportunity. It may be easier to pronounce the weakness of doubled pawns when given more chances to set up a favorable pawn structure against them.

The penalty is not yet tuned and no other tweaks were tried.

Generally, the current pawn scoring has some blind spots imposed by the concrete logic implemented. For example, if the doubled pawn in question is protected by our pawns, all existing doubled penalties are skipped.
This patch may only have been successful because it triggers penalties for doubled pawns in situations which the currently logic simply refuses to categorize as a weakness, and the constructed early-game-indicator may simply be predictive enough to identify these cases.

Funnily, I just forgot to restrict this idea to the current `file_bb()` for the test. The accidentally emerging notion of _all_ pawns being able to freely take at least one step w/o being blocked/captured (aka early-game-indicator) may be an interesting starting point for other tweaks as well.
Or subject to future simplification removing the blind spot instead.