### PR TITLE
Skip move generation for illegal moves

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -565,7 +565,10 @@ bool Position::pseudo_legal(const Move m) const {
 
   // Use a slower but simpler function for uncommon cases
   if (type_of(m) != NORMAL)
-      return MoveList<LEGAL>(*this).contains(m);
+  {
+      return    (type_of(m) != EN_PASSANT || to == ep_square())
+             && MoveList<LEGAL>(*this).contains(m);
+  }
 
   // Is not a promotion, so promotion piece must be empty
   if (promotion_type(m) - KNIGHT != NO_PIECE_TYPE)


### PR DESCRIPTION
Possible alternative to #3304 with a likely speedup given the nature of en passant.  Tested using `bench-parallel.sh`:

```
$ time ./stockfish bench 16 1 13 default depth classical

For 10 iterations (positive 0.3% +/- 0.3% speedup at ply 13):

run     base    test    diff
  1  1080498  1087553  +7055
  2  926526  927950  +1424
  3  1101187  1099934  -1253
  4  1097186  1094699  -2487
  5  1068785  1075926  +7141
  6  759935  765474  +5539
  7  926171  929736  +3565
  8  864669  867464  +2795
  9  1094204  1097186  +2982
 10  1054553  1056629  +2076

base =     997371 +/- 78361
test =    1000255 +/- 77833
diff =       2883 +/- 2086
speedup = 0.002891

For 40 iterations (negative 0.0% +/- 0.0% speedup at ply 13):

base =     985978 +/- 23561
test =     985710 +/- 23809
diff =       -267 +/- 1608
speedup = -0.000272
```