### PR TITLE
Compute fluentStructure indicator outside of loop

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -83,11 +83,10 @@ namespace {
   /// be re-used even when the pieces have moved.
 
   template<Color Us>
-  Score evaluate(const Position& pos, Pawns::Entry* e) {
+  Score evaluate(const Position& pos, Pawns::Entry* e, const bool fluentStructure) {
 
     constexpr Color     Them = ~Us;
     constexpr Direction Up   = pawn_push(Us);
-    constexpr Direction Down = -Up;
 
     Bitboard neighbours, stoppers, support, phalanx, opposed;
     Bitboard lever, leverPush, blocked;
@@ -127,8 +126,8 @@ namespace {
 
         if (doubled)
         {
-            // Additional doubled penalty if none of their pawns is fixed
-            if (!(ourPawns & shift<Down>(theirPawns | pawn_attacks_bb<Them>(theirPawns))))
+            // Additional doubled penalty if no pawns are fixed
+            if (fluentStructure)
                 score -= DoubledEarly;
         }
 
@@ -212,10 +211,14 @@ Entry* probe(const Position& pos) {
   if (e->key == key)
       return e;
 
+  const Bitboard whitePawns = pos.pieces(WHITE, PAWN);
+  const Bitboard blackPawns = pos.pieces(BLACK, PAWN);
+  const bool fluentStructure = !(whitePawns & shift<SOUTH>(blackPawns | pawn_attacks_bb<BLACK>(blackPawns)));
+
   e->key = key;
   e->blockedCount = 0;
-  e->scores[WHITE] = evaluate<WHITE>(pos, e);
-  e->scores[BLACK] = evaluate<BLACK>(pos, e);
+  e->scores[WHITE] = evaluate<WHITE>(pos, e, fluentStructure);
+  e->scores[BLACK] = evaluate<BLACK>(pos, e, fluentStructure);
 
   return e;
 }


### PR DESCRIPTION
This makes it simpler to use the indicator for other bonuses.

STC
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 79672 W: 15788 L: 15427 D: 48457
Ptnml(0-2): 1255, 9136, 18771, 9341, 1333
https://tests.stockfishchess.org/tests/view/6003fa9e6019e097de3ef949

No functional change

---

- STC only, because non-functional. If needed, [LTC](https://tests.stockfishchess.org/tests/view/6004258d6019e097de3ef973) is prepared in queue (set prio=0 to run).
- Using identifier `fluentStructure` but open for suggestions.