### PR TITLE
Clean Up Castling in gives_check

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -663,19 +663,15 @@ bool Position::gives_check(Move m) const {
       return  (attacks_bb<  ROOK>(square<KING>(~sideToMove), b) & pieces(sideToMove, QUEEN, ROOK))
             | (attacks_bb<BISHOP>(square<KING>(~sideToMove), b) & pieces(sideToMove, QUEEN, BISHOP));
   }
-  case CASTLING:
+  default: //CASTLING
   {
-      Square kfrom = from;
-      Square rfrom = to; // Castling is encoded as 'king captures the rook'
-      Square kto = relative_square(sideToMove, rfrom > kfrom ? SQ_G1 : SQ_C1);
-      Square rto = relative_square(sideToMove, rfrom > kfrom ? SQ_F1 : SQ_D1);
+      // Castling is encoded as 'king captures the rook'
+      Square ksq = square<KING>(~sideToMove);
+      Square rto = relative_square(sideToMove, to > from ? SQ_F1 : SQ_D1);
 
-      return   (attacks_bb<ROOK>(rto) & square<KING>(~sideToMove))
-            && (attacks_bb<ROOK>(rto, (pieces() ^ kfrom ^ rfrom) | rto | kto) & square<KING>(~sideToMove));
+      return   (attacks_bb<ROOK>(rto) & ksq)
+            && (attacks_bb<ROOK>(rto, pieces() ^ from ^ to) & ksq);
   }
-  default:
-      assert(false);
-      return false;
   }
 }
 


### PR DESCRIPTION
There is no need to add `rto` or `kto` on the Bitboard which represents the pieces.

STC:
LLR: 2.93 (-2.94,2.94) {-1.25,0.25}
Total: 57064 W: 5096 L: 5067 D: 46901
Ptnml(0-2): 202, 3862, 20355, 3931, 182
https://tests.stockfishchess.org/tests/view/6005ea2c6019e097de3efa55

LTC:
LLR: 2.92 (-2.94,2.94) {-0.75,0.25}
Total: 30088 W: 1094 L: 1052 D: 27942
Ptnml(0-2): 10, 882, 13217, 926, 9
https://tests.stockfishchess.org/tests/view/6006115a6019e097de3efa6e