### PR TITLE
Speed Up Perft Search

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -354,7 +354,7 @@ ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
   moveList = pos.checkers() ? generate<EVASIONS    >(pos, moveList)
                             : generate<NON_EVASIONS>(pos, moveList);
   while (cur != moveList)
-      if (   (pinned || from_sq(*cur) == ksq || type_of(*cur) == EN_PASSANT)
+      if (  ((pinned && pinned & from_sq(*cur)) || from_sq(*cur) == ksq || type_of(*cur) == EN_PASSANT)
           && !pos.legal(*cur))
           *cur = (--moveList)->move;
       else


### PR DESCRIPTION
```
Build Tester: 1.4.7.0
Windows 10 (Version 10.0, Build 0, 64-bit Edition)
Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
SafeMode: No 
Running In VM: No 
HyperThreading Enabled: Yes
CPU Warmup: Yes
Command Line: bench 16 1 5 default perft
Tests per Build: 50
ANOVA: n/a

                Engine# (NPS)                           Speedup     Sp     Conf. 99.5%  S.S.
PR  (244.683.834,0 ) ---> master  (237.791.195,1 ) --->  2,899%  510.406,1    Yes       No 
```

It speeds up `generate<LEGAL>`, I proposed a change (#3304) that will make `perft` the only place that will use it now. If that is not accepted, consider in using this PR for speed up in games.