### PR TITLE
Genbits

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -123,7 +123,8 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   for (int i = 0; i < ClusterSize; ++i)
       if (tte[i].key16 == key16 || !tte[i].depth8)
       {
-          tte[i].genBound8 = uint8_t(generation8 | (tte[i].genBound8 & 0x7)); // Refresh
+        tte[i].genBound8 =
+          uint8_t(generation8 | (tte[i].genBound8 & (GEN_DELTA - 1))); // Refresh
 
           return found = (bool)tte[i].depth8, &tte[i];
       }

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -115,6 +115,9 @@ void TranspositionTable::clear() {
 /// minus 8 times its relative age. TTEntry t1 is considered more valuable than
 /// TTEntry t2 if its replace value is greater than that of t2.
 
+static constexpr int CYCLE = 255 + (1 << GEN_BITS);    // cycle length
+static constexpr int MASK = (0xFF << GEN_BITS) & 0xFF; // mask to pull out generation #
+
 TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 
   TTEntry* const tte = first_entry(key);

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -132,12 +132,13 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   // Find an entry to be replaced according to the replacement strategy
   TTEntry* replace = tte;
   for (int i = 1; i < ClusterSize; ++i)
-      // Due to our packed storage format for generation and its cyclic
-      // nature we add 263 (256 is the modulus plus 7 to keep the unrelated
-      // lowest three bits from affecting the result) to calculate the entry
-      // age correctly even after generation8 overflows into the next cycle.
-      if (  replace->depth8 - ((263 + generation8 - replace->genBound8) & 0xF8)
-          >   tte[i].depth8 - ((263 + generation8 -   tte[i].genBound8) & 0xF8))
+      // Due to our packed storage format for generation and its
+      // cyclic nature we add CYCLE (256 is the modulus plus what's
+      // needed to keep the unrelated lowest n bits from affecting
+      // the result) to calculate the entry age correctly even after
+      // generation8 overflows into the next cycle.
+      if (  replace->depth8 - ((CYCLE + generation8 - replace->genBound8) & MASK)
+          >   tte[i].depth8 - ((CYCLE + generation8 -   tte[i].genBound8) & MASK))
           replace = &tte[i];
 
   return found = false, replace;
@@ -152,7 +153,7 @@ int TranspositionTable::hashfull() const {
   int cnt = 0;
   for (int i = 0; i < 1000; ++i)
       for (int j = 0; j < ClusterSize; ++j)
-          cnt += table[i].entry[j].depth8 && (table[i].entry[j].genBound8 & 0xF8) == generation8;
+          cnt += table[i].entry[j].depth8 && (table[i].entry[j].genBound8 & MASK) == generation8;
 
   return cnt / ClusterSize;
 }

--- a/src/tt.h
+++ b/src/tt.h
@@ -55,9 +55,7 @@ private:
 };
 
 const unsigned GEN_BITS = 3;                // no. of bits used for other things
-const int CYCLE = 255 + (1 << GEN_BITS);    // cycle length
-const int MASK = (0xFF << GEN_BITS) & 0xFF; // mask to pull out generation #
-const int GEN_DELTA = (1 << GEN_BITS);      // increment for generation field
+constexpr int GEN_DELTA = (1 << GEN_BITS);  // increment for generation field
 
 /// A TranspositionTable is an array of Cluster, of size clusterCount. Each
 /// cluster consists of ClusterSize number of TTEntry. Each non-empty TTEntry

--- a/src/tt.h
+++ b/src/tt.h
@@ -54,6 +54,10 @@ private:
   int16_t  eval16;
 };
 
+const unsigned GEN_BITS = 3;                // no. of bits used for other things
+const int CYCLE = 255 + (1 << GEN_BITS);    // cycle length
+const int MASK = (0xFF << GEN_BITS) & 0xFF; // mask to pull out generation #
+const int GEN_DELTA = (1 << GEN_BITS);      // increment for generation field
 
 /// A TranspositionTable is an array of Cluster, of size clusterCount. Each
 /// cluster consists of ClusterSize number of TTEntry. Each non-empty TTEntry
@@ -74,7 +78,7 @@ class TranspositionTable {
 
 public:
  ~TranspositionTable() { aligned_large_pages_free(table); }
-  void new_search() { generation8 += 8; } // Lower 3 bits are used by PV flag and Bound
+  void new_search() { generation8 += GEN_DELTA; } // Lower bits used by others
   TTEntry* probe(const Key key, bool& found) const;
   int hashfull() const;
   void resize(size_t mbSize);


### PR DESCRIPTION
Added a few constants to make it easy to "borrow" a bit or two from the generation in the transposition table.  Said bits could be used (for example) to record the source of a value (NNUE vs Classical).  Current settings don't touch the number of bits so performance should be unchanged.

LLR: 2.94 (-2.94,2.94) {-0.75,0.25}
Total: 26632 W: 1005 L: 959 D: 24668
Ptnml(0-2): 14, 775, 11686, 833, 8
https://tests.stockfishchess.org/html/live_elo.html?600774896019e097de3efb4a