### PR TITLE
Laziness

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -24,11 +24,12 @@
 #include "types.h"
 
 class Position;
+enum Laziness { LAZY, CLASSICAL, NNUE_ONLY, HYBRID };
 
 namespace Eval {
 
-  std::string trace(const Position& pos);
-  Value evaluate(const Position& pos);
+  template<Laziness L> std::string trace(const Position& pos);
+  template<Laziness L> Value evaluate(const Position& pos);
 
   extern bool useNNUE;
   extern std::string eval_file_loaded;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -631,7 +631,7 @@ namespace {
         if (   Threads.stop.load(std::memory_order_relaxed)
             || pos.is_draw(ss->ply)
             || ss->ply >= MAX_PLY)
-            return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate(pos)
+          return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate<HYBRID>(pos)
                                                         : value_draw(pos.this_thread());
 
         // Step 3. Mate distance pruning. Even if we mate at the next move our score
@@ -790,7 +790,7 @@ namespace {
         // Never assume anything about values stored in TT
         ss->staticEval = eval = tte->eval();
         if (eval == VALUE_NONE)
-            ss->staticEval = eval = evaluate(pos);
+          ss->staticEval = eval = evaluate<HYBRID>(pos);
 
         // Randomize draw evaluation
         if (eval == VALUE_DRAW)
@@ -806,7 +806,7 @@ namespace {
         // In case of null move search use previous static eval with a different sign
         // and addition of two tempos
         if ((ss-1)->currentMove != MOVE_NULL)
-            ss->staticEval = eval = evaluate(pos);
+          ss->staticEval = eval = evaluate<HYBRID>(pos);
         else
             ss->staticEval = eval = -(ss-1)->staticEval + 2 * Tempo;
 
@@ -1451,7 +1451,7 @@ moves_loop: // When in check, search starts from here
     // Check for an immediate draw or maximum ply reached
     if (   pos.is_draw(ss->ply)
         || ss->ply >= MAX_PLY)
-        return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate(pos) : VALUE_DRAW;
+      return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate<HYBRID>(pos) : VALUE_DRAW;
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
@@ -1487,7 +1487,7 @@ moves_loop: // When in check, search starts from here
         {
             // Never assume anything about values stored in TT
             if ((ss->staticEval = bestValue = tte->eval()) == VALUE_NONE)
-                ss->staticEval = bestValue = evaluate(pos);
+              ss->staticEval = bestValue = evaluate<HYBRID>(pos);
 
             // Can ttValue be used as a better position evaluation?
             if (    ttValue != VALUE_NONE
@@ -1498,7 +1498,7 @@ moves_loop: // When in check, search starts from here
             // In case of null move search use previous static eval with a different sign
             // and addition of two tempos
             ss->staticEval = bestValue =
-            (ss-1)->currentMove != MOVE_NULL ? evaluate(pos)
+              (ss-1)->currentMove != MOVE_NULL ? evaluate<HYBRID>(pos)
                                              : -(ss-1)->staticEval + 2 * Tempo;
 
         // Stand pat. Return immediately if static value is at least beta

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -123,7 +123,8 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   for (int i = 0; i < ClusterSize; ++i)
       if (tte[i].key16 == key16 || !tte[i].depth8)
       {
-          tte[i].genBound8 = uint8_t(generation8 | (tte[i].genBound8 & 0x7)); // Refresh
+        tte[i].genBound8 =
+          uint8_t(generation8 | (tte[i].genBound8 & (GEN_DELTA - 1))); // Refresh
 
           return found = (bool)tte[i].depth8, &tte[i];
       }
@@ -131,12 +132,13 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   // Find an entry to be replaced according to the replacement strategy
   TTEntry* replace = tte;
   for (int i = 1; i < ClusterSize; ++i)
-      // Due to our packed storage format for generation and its cyclic
-      // nature we add 263 (256 is the modulus plus 7 to keep the unrelated
-      // lowest three bits from affecting the result) to calculate the entry
-      // age correctly even after generation8 overflows into the next cycle.
-      if (  replace->depth8 - ((263 + generation8 - replace->genBound8) & 0xF8)
-          >   tte[i].depth8 - ((263 + generation8 -   tte[i].genBound8) & 0xF8))
+      // Due to our packed storage format for generation and its
+      // cyclic nature we add CYCLE (256 is the modulus plus what's
+      // needed to keep the unrelated lowest n bits from affecting
+      // the result) to calculate the entry age correctly even after
+      // generation8 overflows into the next cycle.
+      if (  replace->depth8 - ((CYCLE + generation8 - replace->genBound8) & MASK)
+          >   tte[i].depth8 - ((CYCLE + generation8 -   tte[i].genBound8) & MASK))
           replace = &tte[i];
 
   return found = false, replace;
@@ -151,7 +153,7 @@ int TranspositionTable::hashfull() const {
   int cnt = 0;
   for (int i = 0; i < 1000; ++i)
       for (int j = 0; j < ClusterSize; ++j)
-          cnt += table[i].entry[j].depth8 && (table[i].entry[j].genBound8 & 0xF8) == generation8;
+          cnt += table[i].entry[j].depth8 && (table[i].entry[j].genBound8 & MASK) == generation8;
 
   return cnt / ClusterSize;
 }

--- a/src/tt.h
+++ b/src/tt.h
@@ -54,6 +54,10 @@ private:
   int16_t  eval16;
 };
 
+const unsigned GEN_BITS = 3;                // no. of bits used for other things
+const int CYCLE = 255 + (1 << GEN_BITS);    // cycle length
+const int MASK = (0xFF << GEN_BITS) & 0xFF; // mask to pull out generation #
+const int GEN_DELTA = (1 << GEN_BITS);      // increment for generation field
 
 /// A TranspositionTable is an array of Cluster, of size clusterCount. Each
 /// cluster consists of ClusterSize number of TTEntry. Each non-empty TTEntry
@@ -74,7 +78,7 @@ class TranspositionTable {
 
 public:
  ~TranspositionTable() { aligned_large_pages_free(table); }
-  void new_search() { generation8 += 8; } // Lower 3 bits are used by PV flag and Bound
+  void new_search() { generation8 += GEN_DELTA; } // Lower bits used by others
   TTEntry* probe(const Key key, bool& found) const;
   int hashfull() const;
   void resize(size_t mbSize);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -87,7 +87,7 @@ namespace {
 
     Eval::NNUE::verify();
 
-    sync_cout << "\n" << Eval::trace(p) << sync_endl;
+    sync_cout << "\n" << Eval::trace<HYBRID>(p) << sync_endl;
   }
 
 


### PR DESCRIPTION
This PR templatizes both evaluation() and value() so that a caller can specify how lazy (or not) the evaluation functions should be.   The idea is that certain calls (e.g., for pruning in qsearch) can probably be made less accurate in some situations, saving execution time.

One issue that will likely arise as the additional granularity is used is that the transposition table will need to record how lazy any particular evaluation was, so that lazy evaluations are not used in situations where more accurate values are desired.   This will involve using a bit or two in the TT to store this information, so this PR is likely to be dependent on #3310 in practice.

I am aware that the three PRs (this, #3310, #3313) involve a significant amount of code without any demonstrated performance improvement.  I believe, however, that they introduce a novel optiization metric that has not yet been considered.  It is for this reason that I am submitting the PRs "piecemeal" as the overall architecture is constructed.  I hope that each of the PRs is viewed as an improement in its own right, although perhaps only in terms of improving code readability.

STC
LLR: 2.95 (-2.94,2.94) {-1.25,0.25}
Total: 97880 W: 8747 L: 8776 D: 80357
Ptnml(0-2): 295, 6841, 34707, 6792, 305
https://tests.stockfishchess.org/html/live_elo.html?600843466019e097de3efbb4

LTC
LLR: 3.02 (-2.94,2.94) {-0.75,0.25}
Total: 53800 W: 2006 L: 1976 D: 49818
Ptnml(0-2): 22, 1656. 23513, 1688, 21
https://tests.stockfishchess.org/html/live_elo.html?6008cc32735dd7f0f0352977