### PR TITLE
Simplify Chess960 Castling legality check

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -533,11 +533,9 @@ bool Position::legal(Move m) const {
           if (attackers_to(s) & pieces(~us))
               return false;
 
-      // In case of Chess960, verify that when moving the castling rook we do
-      // not discover some hidden checker.
+      // In case of Chess960, verify if the Rook blocks some checks
       // For instance an enemy queen in SQ_A1 when castling rook is in SQ_B1.
-      return   !chess960
-            || !(attacks_bb<ROOK>(to, pieces() ^ to_sq(m)) & pieces(~us, ROOK, QUEEN));
+      return !chess960 || !(blockers_for_king(us) & to);
   }
 
   // If the moving piece is a king, check whether the destination square is

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -535,7 +535,7 @@ bool Position::legal(Move m) const {
 
       // In case of Chess960, verify if the Rook blocks some checks
       // For instance an enemy queen in SQ_A1 when castling rook is in SQ_B1.
-      return !chess960 || !(blockers_for_king(us) & to);
+      return !chess960 || !(blockers_for_king(us) & to_sq(m));
   }
 
   // If the moving piece is a king, check whether the destination square is


### PR DESCRIPTION
```
Build Tester: 1.4.7.0
Windows 10 (Version 10.0, Build 0, 64-bit Edition)
Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
SafeMode: No 
Running In VM: No 
HyperThreading Enabled: Yes
CPU Warmup: Yes
Command Line: bench 16 1 18 fens.txt
Tests per Build: 25
ANOVA: n/a

                Engine# (NPS)                           Speedup     Sp     Conf. 99.5%  S.S.
PR  (1.487.802,8   ) ---> master  (1.482.895,4   ) --->  0,331%  3.785,2      Yes       No 
```
It both simplify and slightly speed up the check of legality of castling on uncommon cases of Chess960.
Note: fens.txt contains 35 only Chess960 fens on the ninth turn.