### PR TITLE
Tweak Score

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -106,8 +106,8 @@ void MovePicker::score() {
       else if (Type == QUIETS)
           m.value =      (*mainHistory)[pos.side_to_move()][from_to(m)]
                    + 2 * (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
-                   + 2 * (*continuationHistory[1])[pos.moved_piece(m)][to_sq(m)]
-                   + 2 * (*continuationHistory[3])[pos.moved_piece(m)][to_sq(m)]
+                   +     (*continuationHistory[1])[pos.moved_piece(m)][to_sq(m)]
+                   +     (*continuationHistory[3])[pos.moved_piece(m)][to_sq(m)]
                    +     (*continuationHistory[5])[pos.moved_piece(m)][to_sq(m)]
                    + (ply < MAX_LPH ? std::min(4, depth / 3) * (*lowPlyHistory)[ply][from_to(m)] : 0);
 
@@ -117,8 +117,8 @@ void MovePicker::score() {
               m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
                        - Value(type_of(pos.moved_piece(m)));
           else
-              m.value =  (*mainHistory)[pos.side_to_move()][from_to(m)]
-                       + (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
+              m.value =      (*mainHistory)[pos.side_to_move()][from_to(m)]
+                       + 2 * (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
                        - (1 << 28);
       }
 }


### PR DESCRIPTION
Tuning Score

Further Tuning (Current):
https://tests.stockfishchess.org/tests/view/6016c2db735dd7f0f0353162

Tuning:
https://tests.stockfishchess.org/tests/view/60136857735dd7f0f0352f6c

Passed STC:
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 32184 W: 2936 L: 2773 D: 26475
Ptnml(0-2): 115, 2196, 11328, 2317, 136
https://tests.stockfishchess.org/tests/view/60161ee1735dd7f0f03530f8

Passed LTC:
LLR: 2.93 (-2.94,2.94) {0.25,1.25}
Total: 33088 W: 1292 L: 1149 D: 30647
Ptnml(0-2): 14, 1030, 14318, 1163, 19
https://tests.stockfishchess.org/tests/view/60163146735dd7f0f03530ff