### PR TITLE
Disable ThinLTO when using Clang.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -588,7 +588,7 @@ endif
 ifeq ($(optimize),yes)
 ifeq ($(debug), no)
 	ifeq ($(comp),clang)
-		CXXFLAGS += -flto=thin
+		CXXFLAGS += -flto
 		ifneq ($(findstring MINGW,$(KERNEL)),)
 			CXXFLAGS += -fuse-ld=lld
 		else ifneq ($(findstring MSYS,$(KERNEL)),)
@@ -608,7 +608,7 @@ ifeq ($(debug), no)
 			LDFLAGS += -save-temps
 		endif
 	else
-		CXXFLAGS += -flto=thin
+		CXXFLAGS += -flto
 		LDFLAGS += $(CXXFLAGS)
 	endif
 


### PR DESCRIPTION
The default Clang configuration uses ThinLTO instead of the standard
LTO. When published, benchmarks already showed this to be inferior for
chess engines:
http://blog.llvm.org/2016/06/thinlto-scalable-and-incremental-lto.html

Benchmarking with current Clang 12 shows that the above result still holds
and ThinLTO is a pessimization, see issue #3341.

The commit that added ThinLTO did not contain any benchmarking. While
ThinLTO may compile faster, that's not a worthwhile tradeoff for a chess
engine. With ThinLTO disabled, Clang 12 will outperform GCC 9 and 10 for
some architectures, e.g. Intel Haswell.