### PR TITLE
Enable New Pass Manager for Clang.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -479,6 +479,10 @@ ifeq ($(optimize),yes)
 			CXXFLAGS += -mdynamic-no-pic
 		endif
 	endif
+
+	ifeq ($(comp),clang)
+		CXXFLAGS += -fexperimental-new-pass-manager
+	endif
 endif
 
 ### 3.4 Bits


### PR DESCRIPTION
Clang has a new optimization pass manager activated by
-fexperimental-new-pass-manager. It's been in development
for several years, and by now generally performing better
than the default. It is planned to be the new default in
Clang 13, but even versions before that perform better with it,
and it's stable enough that major software like Firefox has
been using it already:
https://bugzilla.mozilla.org/show_bug.cgi?id=1619461

It's about 1% speedup for Stockfish.

Result of 100 runs
==================
base (...fish_clang12) =    1946851  +/- 3717
test (./stockfish    ) =    1967276  +/- 3408
diff                   =     +20425  +/- 2438

speedup        = +0.0105
P(speedup > 0) =  1.0000

CPU: 4 x Intel(R) Xeon(R) CPU E3-1240 v3 @ 3.40GHz
Hyperthreading: on

Thanks to David Major for making me aware of this part
of LLVM development.