### PR TITLE
Don't decrease reduction at PV nodes that are likely to fail low.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1025,6 +1025,14 @@ moves_loop: // When in check, search starts from here
       movedPiece = pos.moved_piece(move);
       givesCheck = pos.gives_check(move);
 
+      // Indicate PvNodes that will probably fail low if node was searched with non-PV search 
+      // at depth equal or greater to current depth and result of this search was far below alpha
+      bool likelyFailLow =    PvNode 
+                           && ttMove 
+                           && (tte->bound() & BOUND_UPPER) 
+                           && ttValue < alpha + 200 + 100 * depth 
+                           && tte->depth() >= depth;
+
       // Calculate new depth for this move
       newDepth = depth - 1;
 
@@ -1172,8 +1180,9 @@ moves_loop: // When in check, search starts from here
           if (th.marked())
               r++;
 
-          // Decrease reduction if position is or has been on the PV (~10 Elo)
-          if (ss->ttPv)
+          // Decrease reduction if position is or has been on the PV 
+          // and node is not likely to fail low (~10 Elo)
+          if (ss->ttPv && !likelyFailLow)
               r -= 2;
 
           // Increase reduction at root and non-PV nodes when the best move does not change frequently


### PR DESCRIPTION
Passed STC
https://tests.stockfishchess.org/tests/view/6023a5fa7f517a561bc49638
LLR: 2.95 (-2.94,2.94) {-0.25,1.25}
Total: 70288 W: 6443 L: 6223 D: 57622
Ptnml(0-2): 239, 5022, 24436, 5174, 273 
passed LTC
https://tests.stockfishchess.org/tests/view/6023f2617f517a561bc49661
LLR: 2.94 (-2.94,2.94) {0.25,1.25}
Total: 105656 W: 4048 L: 3748 D: 97860
Ptnml(0-2): 67, 3312, 45761, 3630, 58 
Idea of this patch can be described as following - if PvNode was researched in non-pv search and value this search got was much lower than alpha we can assume that this PvNode is likely gonna fail low so we can reduce more at it.
bench 3766422