### PR TITLE
remove magic numbers in TT bit management

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -113,6 +113,7 @@ Maciej Żenczykowski (zenczykowski)
 Malcolm Campbell (xoto10)
 Mark Tenzer (31m059)
 marotear
+Matt Ginsberg (mattginsberg)
 Matthew Lai (matthewlai)
 Matthew Sullivan (Matt14916)
 Maxim Molchanov (Maxim)

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -115,6 +115,9 @@ void TranspositionTable::clear() {
 /// minus 8 times its relative age. TTEntry t1 is considered more valuable than
 /// TTEntry t2 if its replace value is greater than that of t2.
 
+static constexpr int CYCLE = 255 + (1 << GEN_BITS);    // cycle length
+static constexpr int MASK = (0xFF << GEN_BITS) & 0xFF; // mask to pull out generation #
+
 TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 
   TTEntry* const tte = first_entry(key);
@@ -123,7 +126,8 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   for (int i = 0; i < ClusterSize; ++i)
       if (tte[i].key16 == key16 || !tte[i].depth8)
       {
-          tte[i].genBound8 = uint8_t(generation8 | (tte[i].genBound8 & 0x7)); // Refresh
+        tte[i].genBound8 =
+          uint8_t(generation8 | (tte[i].genBound8 & (GEN_DELTA - 1))); // Refresh
 
           return found = (bool)tte[i].depth8, &tte[i];
       }
@@ -131,12 +135,13 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
   // Find an entry to be replaced according to the replacement strategy
   TTEntry* replace = tte;
   for (int i = 1; i < ClusterSize; ++i)
-      // Due to our packed storage format for generation and its cyclic
-      // nature we add 263 (256 is the modulus plus 7 to keep the unrelated
-      // lowest three bits from affecting the result) to calculate the entry
-      // age correctly even after generation8 overflows into the next cycle.
-      if (  replace->depth8 - ((263 + generation8 - replace->genBound8) & 0xF8)
-          >   tte[i].depth8 - ((263 + generation8 -   tte[i].genBound8) & 0xF8))
+      // Due to our packed storage format for generation and its
+      // cyclic nature we add CYCLE (256 is the modulus plus what's
+      // needed to keep the unrelated lowest n bits from affecting
+      // the result) to calculate the entry age correctly even after
+      // generation8 overflows into the next cycle.
+      if (  replace->depth8 - ((CYCLE + generation8 - replace->genBound8) & MASK)
+          >   tte[i].depth8 - ((CYCLE + generation8 -   tte[i].genBound8) & MASK))
           replace = &tte[i];
 
   return found = false, replace;
@@ -151,7 +156,7 @@ int TranspositionTable::hashfull() const {
   int cnt = 0;
   for (int i = 0; i < 1000; ++i)
       for (int j = 0; j < ClusterSize; ++j)
-          cnt += table[i].entry[j].depth8 && (table[i].entry[j].genBound8 & 0xF8) == generation8;
+          cnt += table[i].entry[j].depth8 && (table[i].entry[j].genBound8 & MASK) == generation8;
 
   return cnt / ClusterSize;
 }

--- a/src/tt.h
+++ b/src/tt.h
@@ -54,6 +54,8 @@ private:
   int16_t  eval16;
 };
 
+const unsigned GEN_BITS = 3;                // no. of bits used for other things
+constexpr int GEN_DELTA = (1 << GEN_BITS);  // increment for generation field
 
 /// A TranspositionTable is an array of Cluster, of size clusterCount. Each
 /// cluster consists of ClusterSize number of TTEntry. Each non-empty TTEntry
@@ -74,7 +76,7 @@ class TranspositionTable {
 
 public:
  ~TranspositionTable() { aligned_large_pages_free(table); }
-  void new_search() { generation8 += 8; } // Lower 3 bits are used by PV flag and Bound
+  void new_search() { generation8 += GEN_DELTA; } // Lower bits used by others
   TTEntry* probe(const Key key, bool& found) const;
   int hashfull() const;
   void resize(size_t mbSize);


### PR DESCRIPTION
Should be no change to binary; just removed magic numbers in the bits reserved for generation in transpo tables.