### PR TITLE
Perft with time consume and speed

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -217,8 +217,13 @@ void MainThread::search() {
 
   if (Limits.perft)
   {
+      auto elapsed = now();      
       nodes = perft<true>(rootPos, Limits.perft);
-      sync_cout << "\nNodes searched: " << nodes << "\n" << sync_endl;
+      elapsed = now() - elapsed;
+      sync_cout << "\nNodes searched: " << nodes
+                << "\nTime (ms)     : " << elapsed
+                << "\nNodes/second  : " << nodes * 1000 / (elapsed + 1)
+                << sync_endl;
       return;
   }
 


### PR DESCRIPTION
I m aware the Perft function of SF is used quite popularly. Programmers use it to verify their work on make/moves/generators. Even, in theory, it’s not a good/perfect way but they usually use it as a benchmark to compare between engines and/or hardware.

This PR helps those people by showing time consuming and speed of Perft computing. Note that due to using Perft’s bulk counting (nodes are counted without making/unmaking) the speed maybe not full meaning but still useful to compare in some situations.

The Perft now shows as below:

```
go perft 5
a2a3: 181046
b2b3: 215255
c2c3: 222861
d2d3: 328511
e2e3: 402988
f2f3: 178889
g2g3: 217210
h2h3: 181044
a2a4: 217832
b2b4: 216145
c2c4: 240082
d2d4: 361790
e2e4: 405385
f2f4: 198473
g2g4: 214048
h2h4: 218829
b1a3: 198572
b1c3: 234656
g1f3: 233491
g1h3: 198502

Nodes searched: 4865609
Time (ms)     : 229
Nodes/second  : 21154821
```
