### PR TITLE
Introduce probCut for check evasions.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1003,7 +1003,6 @@ moves_loop: // When in check, search starts from here
 
     value = bestValue;
     singularQuietLMR = moveCountPruning = false;
-    ttCapture = ttMove && pos.capture_or_promotion(ttMove);
 
     // Mark this node as being searched
     ThreadHolding th(thisThread, posKey, ss->ply);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -969,6 +969,24 @@ namespace {
 
 moves_loop: // When in check, search starts from here
 
+     ttCapture = ttMove && pos.capture_or_promotion(ttMove);
+     probCutBeta = beta + 400;
+ 
+     // Step 11. Probcut if we are in check.
+     // If transposition table move is a capture and value produced by it if much above beta
+     // produce a cutoff in the same way as we do in probCut.
+     // This can only happen if we are in check since if we were not in check we would've already
+     // produced a probCut cutoff.
+     if (    ss->inCheck
+          && !PvNode
+          && depth >= 4
+          && ttCapture
+          && (tte->bound() & BOUND_LOWER)
+          && tte->depth() >= depth - 3
+          && ttValue != VALUE_NONE
+          && ttValue >= probCutBeta)
+          return probCutBeta;
+
     const PieceToHistory* contHist[] = { (ss-1)->continuationHistory, (ss-2)->continuationHistory,
                                           nullptr                   , (ss-4)->continuationHistory,
                                           nullptr                   , (ss-6)->continuationHistory };
@@ -990,7 +1008,7 @@ moves_loop: // When in check, search starts from here
     // Mark this node as being searched
     ThreadHolding th(thisThread, posKey, ss->ply);
 
-    // Step 11. Loop through all pseudo-legal moves until no moves remain
+    // Step 12. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
     while ((move = mp.next_move(moveCountPruning)) != MOVE_NONE)
     {
@@ -1036,7 +1054,7 @@ moves_loop: // When in check, search starts from here
       // Calculate new depth for this move
       newDepth = depth - 1;
 
-      // Step 12. Pruning at shallow depth (~200 Elo)
+      // Step 13. Pruning at shallow depth (~200 Elo)
       if (  !rootNode
           && pos.non_pawn_material(us)
           && bestValue > VALUE_TB_LOSS_IN_MAX_PLY)
@@ -1084,7 +1102,7 @@ moves_loop: // When in check, search starts from here
           }
       }
 
-      // Step 13. Extensions (~75 Elo)
+      // Step 14. Extensions (~75 Elo)
 
       // Singular extension search (~70 Elo). If all moves but one fail low on a
       // search of (alpha-s, beta-s), and just one fails high on (alpha, beta),
@@ -1156,10 +1174,10 @@ moves_loop: // When in check, search starts from here
                                                                 [movedPiece]
                                                                 [to_sq(move)];
 
-      // Step 14. Make the move
+      // Step 15. Make the move
       pos.do_move(move, st, givesCheck);
 
-      // Step 15. Reduced depth search (LMR, ~200 Elo). If the move fails high it will be
+      // Step 16. Reduced depth search (LMR, ~200 Elo). If the move fails high it will be
       // re-searched at full depth.
       if (    depth >= 3
           &&  moveCount > 1 + 2 * rootNode
@@ -1266,7 +1284,7 @@ moves_loop: // When in check, search starts from here
           didLMR = false;
       }
 
-      // Step 16. Full depth search when LMR is skipped or fails high
+      // Step 17. Full depth search when LMR is skipped or fails high
       if (doFullDepthSearch)
       {
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, newDepth, !cutNode);
@@ -1293,12 +1311,12 @@ moves_loop: // When in check, search starts from here
                               std::min(maxNextDepth, newDepth), false);
       }
 
-      // Step 17. Undo move
+      // Step 18. Undo move
       pos.undo_move(move);
 
       assert(value > -VALUE_INFINITE && value < VALUE_INFINITE);
 
-      // Step 18. Check for a new best move
+      // Step 19. Check for a new best move
       // Finished searching the move. If a stop occurred, the return value of
       // the search cannot be trusted, and we return immediately without
       // updating best move, PV and TT.
@@ -1375,7 +1393,7 @@ moves_loop: // When in check, search starts from here
         return VALUE_DRAW;
     */
 
-    // Step 19. Check for mate and stalemate
+    // Step 20. Check for mate and stalemate
     // All legal moves have been searched and if there are no legal moves, it
     // must be a mate or a stalemate. If we are in a singular extension search then
     // return a fail low score.

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -984,7 +984,9 @@ moves_loop: // When in check, search starts from here
           && (tte->bound() & BOUND_LOWER)
           && tte->depth() >= depth - 3
           && ttValue != VALUE_NONE
-          && ttValue >= probCutBeta)
+          && ttValue >= probCutBeta
+          && abs(ttValue) <= VALUE_KNOWN_WIN
+          && abs(beta) <= VALUE_KNOWN_WIN)
           return probCutBeta;
 
     const PieceToHistory* contHist[] = { (ss-1)->continuationHistory, (ss-2)->continuationHistory,


### PR DESCRIPTION
Passed STC 
https://tests.stockfishchess.org/tests/view/602cd1087f517a561bc49bda
LLR: 2.94 (-2.94,2.94) {-0.25,1.25}
Total: 33440 W: 3056 L: 2891 D: 27493
Ptnml(0-2): 110, 2338, 11672, 2477, 123 
Passed LTC
https://tests.stockfishchess.org/tests/view/602ceea57f517a561bc49bf0
LLR: 2.98 (-2.94,2.94) {0.25,1.25}
Total: 10072 W: 401 L: 309 D: 9362
Ptnml(0-2): 2, 288, 4365, 378, 3 
Idea of this patch can be described as following : 
if we are in check and transposition table move is a capture that returns value far above beta we can assume that opponent just blundered and return transposition table value (similar to probCut logic but with different threshold).
bench 3632557