### PR TITLE
Nnue1

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -36,7 +36,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-62ef826d1a6d.nnue"
+  #define EvalFileDefaultName   "nn-0e698aa9eb8b.nnue"
 
   namespace NNUE {
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -62,7 +62,7 @@ void init(OptionsMap& o) {
   o["Contempt"]              << Option(24, -100, 100);
   o["Analysis Contempt"]     << Option("Both var Off var White var Black var Both", "Both");
   o["Threads"]               << Option(1, 1, 512, on_threads);
-  o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
+  o["Hash"]                  << Option(86, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -62,7 +62,7 @@ void init(OptionsMap& o) {
   o["Contempt"]              << Option(24, -100, 100);
   o["Analysis Contempt"]     << Option("Both var Off var White var Black var Both", "Both");
   o["Threads"]               << Option(1, 1, 512, on_threads);
-  o["Hash"]                  << Option(86, 1, MaxHashMB, on_hash_size);
+  o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);


### PR DESCRIPTION
This is a pull request with a new net. The tests can be found here:

https://tests.stockfishchess.org/html/live_elo.html?603898727f517a561bc4a3ed //STC Test (+4,5 ELO)
https://tests.stockfishchess.org/html/live_elo.html?603529b87f517a561bc4a177 //LTC Test (+0,4 ELO)

I found that a bit more hash improves the strength of this net by a lot, so I changed the default hash to the test conditions (the now default is 86 MB, a value that all of todays computers should do...)

The LTC test has been made without increased Hash.

The net was trained based on the old net by a total of 1B training positions, where about 50M positions were opening moves from ply 4 to ply 14. That means that this net is a bit more opening specialized. All of the positions were depth 5. So a bigger advantage is made by shorter time controls, because (logically) with depth 1 an evaluation depth of 5 is immediatly reached, but also at long analysis time, the evaluation depth is a bit increased.

The net is just like the size before.

WHAT'S THE NEXT CHALLENGE?
Well, I think that the maximum strength of this net size hasn't been reached even closely. My opinion is that we are in a local minimum. My next project will be to train a complete new net just with data generated by the new net, if this one is the new one or not.

I would be proud if this change will be taken over by the official stockfish team. This are my two cents and a big thank you to the whole stockfish developer team for developing this engine. I want to apologize because I made the LTC test before the STC test, but I don't have much experience with fishtest before.

Best regards,
MiauiKatze alias Raberger Raphael from Austria