### PR TITLE
Allow using Intel SDE for PGO builds.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,11 @@ PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds
-PGOBENCH = ./$(EXE) bench
+ifeq ($(SDE_PATH),)
+	PGOBENCH = ./$(EXE) bench
+else
+	PGOBENCH = $(SDE_PATH) -- $(EXE) bench
+endif
 
 ### Source and object files
 SRCS = benchmark.cpp bitbase.cpp bitboard.cpp endgame.cpp evaluate.cpp main.cpp \


### PR DESCRIPTION
A new optional makefile argument `SDE_PATH`. If not empty it must contain the path to sde.exe https://software.intel.com/content/www/us/en/develop/articles/intel-software-development-emulator.html.

This allows producing PGO builds for architectures not supported by the machine running the compiler.

It should not interfere with the data being collected for PGO but some verification is welcome.

This is the first step towards a better and more automated way of producing binary releases.