### PR TITLE
Do not try to use large pages on 32 bit Windows.

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -360,7 +360,7 @@ void std_aligned_free(void* ptr) {
 /// aligned_large_pages_alloc() will return suitably aligned memory, if possible using large pages.
 
 #if defined(_WIN32)
-
+#if defined(_WIN64)
 static void* aligned_large_pages_alloc_win(size_t allocSize) {
 
   HANDLE hProcessToken { };
@@ -405,15 +405,20 @@ static void* aligned_large_pages_alloc_win(size_t allocSize) {
 
   return mem;
 }
+#endif
 
 void* aligned_large_pages_alloc(size_t allocSize) {
 
+#if defined(_WIN64)
   // Try to allocate large pages
   void* mem = aligned_large_pages_alloc_win(allocSize);
 
   // Fall back to regular, page aligned, allocation if necessary
   if (!mem)
       mem = VirtualAlloc(NULL, allocSize, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+#else
+  void* mem = VirtualAlloc(NULL, allocSize, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+#endif
 
   return mem;
 }


### PR DESCRIPTION
We override API availability when including headers for Windows APIs.
This patch disables the functions related to large pages on all 32-bit Windows targets because on those platforms, using large pages requires a different mechanism(AWE) and the API we currently use is not available under XP.
Fixes https://github.com/official-stockfish/Stockfish/issues/3379.

No functional change.