### PR TITLE
Add "silent" switch to the "go" command.

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -118,7 +118,7 @@ vector<string> setup_bench(const Position& current, istream& is) {
   string limitType = (is >> token) ? token : "depth";
   string evalType  = (is >> token) ? token : "mixed";
 
-  go = limitType == "eval" ? "eval" : "go " + limitType + " " + limit;
+  go = limitType == "eval" ? "eval" : "go " + limitType + " " + limit + " silent";
 
   if (fenFile == "default")
       fens = Defaults;

--- a/src/search.h
+++ b/src/search.h
@@ -88,6 +88,7 @@ struct LimitsType {
     time[WHITE] = time[BLACK] = inc[WHITE] = inc[BLACK] = npmsec = movetime = TimePoint(0);
     movestogo = depth = mate = perft = infinite = 0;
     nodes = 0;
+    silent = false;
   }
 
   bool use_time_management() const {
@@ -98,6 +99,7 @@ struct LimitsType {
   TimePoint time[COLOR_NB], inc[COLOR_NB], npmsec, movetime, startTime;
   int movestogo, depth, mate, perft, infinite;
   int64_t nodes;
+  bool silent;
 };
 
 extern LimitsType Limits;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -142,6 +142,7 @@ namespace {
         else if (token == "movetime")  is >> limits.movetime;
         else if (token == "mate")      is >> limits.mate;
         else if (token == "perft")     is >> limits.perft;
+        else if (token == "silent")    limits.silent = true;
         else if (token == "infinite")  limits.infinite = 1;
         else if (token == "ponder")    ponderMode = true;
 


### PR DESCRIPTION
If specified then most output will be supressed. "bestmove" line will not be supressed so it should still conform to the UCI protocol.

Used in bench,

Fixes #3344 