### PR TITLE
Use Bitboard over Square in movegen

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -221,11 +221,8 @@ namespace {
             target = ~pos.pieces();
             break;
         case EVASIONS:
-        {
-            Square checksq = lsb(pos.checkers());
-            target = between_bb(pos.square<KING>(Us), checksq) | checksq;
+            target = between_bb(pos.square<KING>(Us), lsb(pos.checkers())) | pos.checkers();
             break;
-        }
         case NON_EVASIONS:
             target = ~pos.pieces(Us);
             break;


### PR DESCRIPTION
It uses `pos.checkers()` on `target` when movegen is the type of `EVASION`. It simplify the code. And it's also expected a slightly speed up, because `Bitboard` is more direct when doing bitwise.

Passed STC:
LLR: 2.93 (-2.94,2.94) {-1.25,0.25}
Total: 28176 W: 2506 L: 2437 D: 23233
Ptnml(0-2): 80, 1904, 10063, 1949, 92
https://tests.stockfishchess.org/tests/view/60421d18ddcba5f0627bb6a9

Passed LTC:
LLR: 2.93 (-2.94,2.94) {-0.75,0.25}
Total: 9704 W: 402 L: 341 D: 8961
Ptnml(0-2): 3, 279, 4230, 334, 6
https://tests.stockfishchess.org/tests/view/60422823ddcba5f0627bb6ae

Non-functional change