### PR TITLE
Change advanced pawn threshold

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -129,6 +129,7 @@ public:
   bool capture_or_promotion(Move m) const;
   bool gives_check(Move m) const;
   bool advanced_pawn_push(Move m) const;
+  bool passed_pawn_push(Move m) const;
   Piece moved_piece(Move m) const;
   Piece captured_piece() const;
 
@@ -313,6 +314,12 @@ inline bool Position::pawn_passed(Color c, Square s) const {
 inline bool Position::advanced_pawn_push(Move m) const {
   return   type_of(moved_piece(m)) == PAWN
         && relative_rank(sideToMove, to_sq(m)) > RANK_5;
+}
+
+inline bool Position::passed_pawn_push(Move m) const {
+    return   advanced_pawn_push(m)
+        && pawn_passed(sideToMove, from_sq(m));
+
 }
 
 inline int Position::pawns_on_same_color_squares(Color c, Square s) const {

--- a/src/position.h
+++ b/src/position.h
@@ -318,7 +318,7 @@ inline bool Position::advanced_pawn_push(Move m) const {
 
 inline bool Position::passed_pawn_push(Move m) const {
     return   advanced_pawn_push(m)
-        && pawn_passed(sideToMove, from_sq(m));
+        && pawn_passed(sideToMove, to_sq(m));
 
 }
 

--- a/src/position.h
+++ b/src/position.h
@@ -128,8 +128,7 @@ public:
   bool capture(Move m) const;
   bool capture_or_promotion(Move m) const;
   bool gives_check(Move m) const;
-  bool advanced_pawn_push(Move m) const;
-  bool passed_pawn_push(Move m) const;
+  bool advanced_pawn_push(Move m, Rank thresh = RANK_5) const;
   Piece moved_piece(Move m) const;
   Piece captured_piece() const;
 
@@ -311,15 +310,9 @@ inline bool Position::pawn_passed(Color c, Square s) const {
   return !(pieces(~c, PAWN) & passed_pawn_span(c, s));
 }
 
-inline bool Position::advanced_pawn_push(Move m) const {
+inline bool Position::advanced_pawn_push(Move m, Rank thresh) const {
   return   type_of(moved_piece(m)) == PAWN
-        && relative_rank(sideToMove, to_sq(m)) > RANK_5;
-}
-
-inline bool Position::passed_pawn_push(Move m) const {
-    return   advanced_pawn_push(m)
-        && pawn_passed(sideToMove, to_sq(m));
-
+        && relative_rank(sideToMove, to_sq(m)) > thresh;
 }
 
 inline int Position::pawns_on_same_color_squares(Color c, Square s) const {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1162,6 +1162,7 @@ moves_loop: // When in check, search starts from here
                && pos.non_pawn_material() <= 2 * RookValueMg)
           extension = 1;
 
+
       // Add extension to new depth
       newDepth += extension;
 
@@ -1579,9 +1580,9 @@ moves_loop: // When in check, search starts from here
       if (    bestValue > VALUE_TB_LOSS_IN_MAX_PLY
           && !givesCheck
           &&  futilityBase > -VALUE_KNOWN_WIN
-          && !pos.advanced_pawn_push(move))
+          && !pos.passed_pawn_push(move))
       {
-          assert(type_of(move) != EN_PASSANT); // Due to !pos.advanced_pawn_push
+          assert(type_of(move) != EN_PASSANT); // Due to !pos.passed_pawn_push
 
           // moveCount pruning
           if (moveCount > 2)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1580,9 +1580,9 @@ moves_loop: // When in check, search starts from here
       if (    bestValue > VALUE_TB_LOSS_IN_MAX_PLY
           && !givesCheck
           &&  futilityBase > -VALUE_KNOWN_WIN
-          && !pos.passed_pawn_push(move))
+          && !pos.advanced_pawn_push(move, RANK_6))
       {
-          assert(type_of(move) != EN_PASSANT); // Due to !pos.passed_pawn_push
+          assert(type_of(move) != EN_PASSANT); // Due to !pos.advanced_pawn_push
 
           // moveCount pruning
           if (moveCount > 2)


### PR DESCRIPTION
A pawn push is now considered to be "advanced" if the relative destination rank is >6 (previously it was >5).
This affects the search heuristic.

STC:
LLR: 2.97 (-2.94,2.94) {-0.25,1.25}
Total: 46744 W: 4224 L: 4040 D: 38480
Ptnml(0-2): 165, 3206, 16451, 3380, 170
https://tests.stockfishchess.org/tests/view/604746082433018de7a3872e

LTC:
LLR: 2.94 (-2.94,2.94) {0.25,1.25}
Total: 107840 W: 4198 L: 3892 D: 99750
Ptnml(0-2): 58, 3472, 46557, 3772, 61
https://tests.stockfishchess.org/tests/view/60475eae2433018de7a38737

Bench:
4796780
