### PR TITLE
Simplify away advanced pawn push.

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -128,7 +128,6 @@ public:
   bool capture(Move m) const;
   bool capture_or_promotion(Move m) const;
   bool gives_check(Move m) const;
-  bool advanced_pawn_push(Move m) const;
   Piece moved_piece(Move m) const;
   Piece captured_piece() const;
 
@@ -308,11 +307,6 @@ inline bool Position::is_discovered_check_on_king(Color c, Move m) const {
 
 inline bool Position::pawn_passed(Color c, Square s) const {
   return !(pieces(~c, PAWN) & passed_pawn_span(c, s));
-}
-
-inline bool Position::advanced_pawn_push(Move m) const {
-  return   type_of(moved_piece(m)) == PAWN
-        && relative_rank(sideToMove, to_sq(m)) > RANK_6;
 }
 
 inline int Position::pawns_on_same_color_squares(Color c, Square s) const {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1579,7 +1579,7 @@ moves_loop: // When in check, search starts from here
       if (    bestValue > VALUE_TB_LOSS_IN_MAX_PLY
           && !givesCheck
           &&  futilityBase > -VALUE_KNOWN_WIN
-          && !pos.advanced_pawn_push(move))
+          &&  type_of(move) != PROMOTION)
       {
 
           if (moveCount > 2)


### PR DESCRIPTION
Passed STC
https://tests.stockfishchess.org/tests/view/6048c5842433018de7a387e6
LLR: 2.93 (-2.94,2.94) {-1.25,0.25}
Total: 34424 W: 3081 L: 3015 D: 28328
Ptnml(0-2): 110, 2442, 12052, 2488, 120 
Passed LTC
https://tests.stockfishchess.org/tests/view/6048f7d22433018de7a387f0
LLR: 2.94 (-2.94,2.94) {-0.75,0.25}
Total: 142024 W: 5170 L: 5202 D: 131652
Ptnml(0-2): 50, 4678, 61613, 4596, 75 
Continuation of work by @Topologist .
Instead of using advanced pawn push in qsearch we can use a simple check if move is a promotion or no. This allows to simplify this method in position.h alltogether.
bench 4339126