### PR TITLE
Introducing lsb_bb()

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -417,6 +417,7 @@ inline Square msb(Bitboard b) {
 /// lsb_bb() finds the least significant bit and it return on its position in a non-zero bitboard
 
 inline Bitboard lsb_bb(Bitboard b) {
+  assert(b);
   return b & -b;
 }
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -414,6 +414,11 @@ inline Square msb(Bitboard b) {
 
 #endif
 
+/// lsb_bb() finds the least significant bit and it return on its position in a non-zero bitboard
+
+inline Bitboard lsb_bb(Bitboard b) {
+  return b & -b;
+}
 
 /// pop_lsb() finds and clears the least significant bit in a non-zero bitboard
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1109,7 +1109,7 @@ bool Position::see_ge(Move m, Value threshold) const {
           if ((swap = PawnValueMg - swap) < res)
               break;
 
-          occupied ^= lsb(bb);
+          occupied ^= lsb_bb(bb);
           attackers |= attacks_bb<BISHOP>(to, occupied) & pieces(BISHOP, QUEEN);
       }
 
@@ -1118,7 +1118,7 @@ bool Position::see_ge(Move m, Value threshold) const {
           if ((swap = KnightValueMg - swap) < res)
               break;
 
-          occupied ^= lsb(bb);
+          occupied ^= lsb_bb(bb);
       }
 
       else if ((bb = stmAttackers & pieces(BISHOP)))
@@ -1126,7 +1126,7 @@ bool Position::see_ge(Move m, Value threshold) const {
           if ((swap = BishopValueMg - swap) < res)
               break;
 
-          occupied ^= lsb(bb);
+          occupied ^= lsb_bb(bb);
           attackers |= attacks_bb<BISHOP>(to, occupied) & pieces(BISHOP, QUEEN);
       }
 
@@ -1135,7 +1135,7 @@ bool Position::see_ge(Move m, Value threshold) const {
           if ((swap = RookValueMg - swap) < res)
               break;
 
-          occupied ^= lsb(bb);
+          occupied ^= lsb_bb(bb);
           attackers |= attacks_bb<ROOK>(to, occupied) & pieces(ROOK, QUEEN);
       }
 
@@ -1144,7 +1144,7 @@ bool Position::see_ge(Move m, Value threshold) const {
           if ((swap = QueenValueMg - swap) < res)
               break;
 
-          occupied ^= lsb(bb);
+          occupied ^= lsb_bb(bb);
           attackers |=  (attacks_bb<BISHOP>(to, occupied) & pieces(BISHOP, QUEEN))
                       | (attacks_bb<ROOK  >(to, occupied) & pieces(ROOK  , QUEEN));
       }


### PR DESCRIPTION
Introducing `lsb_bb`. It's a function that return a value equal `square_bb(lsb(bb))`, but it uses fewer instruction. It should speed up more on older processors like [armv7-a Clang](https://godbolt.org/z/Kh8qfG).

Passed STC:
LLR: 2.93 (-2.94,2.94) {-0.25,1.25}
Total: 213200 W: 19171 L: 18753 D: 175276
Ptnml(0-2): 680, 14513, 75831, 14861, 715
https://tests.stockfishchess.org/tests/view/604bc7632433018de7a38982

No functional change