### PR TITLE
allow hash=0 to disable TT

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -34,6 +34,7 @@ TranspositionTable TT; // Our global transposition table
 /// overwriting an old position. Update is not atomic and can be racy.
 
 void TTEntry::save(Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev) {
+  if (TT.clusterCount == 0) return;
 
   // Preserve any existing move for the same position
   if (m || (uint16_t)k != key16)

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -64,7 +64,7 @@ void init(OptionsMap& o) {
   o["Contempt"]              << Option(24, -100, 100);
   o["Analysis Contempt"]     << Option("Both var Off var White var Black var Both", "Both");
   o["Threads"]               << Option(1, 1, 512, on_threads);
-  o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
+  o["Hash"]                  << Option(16, 0, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);


### PR DESCRIPTION
useful for debugging search changes.  In all honesty, I can't tell if there is any impact to performance because of the single new line of code in TTEntry::save.  Should be a single instruction, I would think.  Two runs at LTC produced:

LLR: 2.93 (-2.94,2.94) {-0.75,0.25}
Total: 103520 W: 3794 L: 3802 D: 95924
Ptnml(0-2): 43, 3199, 45297, 3165, 56 

LLR: -2.92 (-2.94,2.94) {-0.75,0.25} 	          
Total: 15000 W: 539 L: 620 D: 13841 	          
Ptnml(0-2): 13, 519, 6507, 458, 3 

If there *is* an effect, I would expect it to be way smaller than either of these.  Note that TTEntry::probe does *not* need modification because it will return found=false and then save won't do anything because of the new line of code.


