### PR TITLE
Rework between_bb() into ray_bb() + prefab results

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -28,6 +28,7 @@ uint8_t PopCnt16[1 << 16];
 uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 Bitboard SquareBB[SQUARE_NB];
+Bitboard RayBB[SQUARE_NB][SQUARE_NB];
 Bitboard LineBB[SQUARE_NB][SQUARE_NB];
 Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 Bitboard PawnAttacks[COLOR_NB][SQUARE_NB];
@@ -106,9 +107,14 @@ void Bitboards::init() {
       PseudoAttacks[QUEEN][s1] |= PseudoAttacks[  ROOK][s1] = attacks_bb<  ROOK>(s1, 0);
 
       for (PieceType pt : { BISHOP, ROOK })
-          for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2)
+          for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2){
               if (PseudoAttacks[pt][s1] & s2)
                   LineBB[s1][s2] = (attacks_bb(pt, s1, 0) & attacks_bb(pt, s2, 0)) | s1 | s2;
+
+              RayBB[s1][s2] = LineBB[s1][s2] & ((AllSquares << s1) ^ (AllSquares << s2));
+              RayBB[s1][s2] &= RayBB[s1][s2] - 1;
+              RayBB[s1][s2] |= s2;
+          }
   }
 }
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -218,7 +218,7 @@ inline Bitboard line_bb(Square s1, Square s2) {
 
 /// ray_bb() returns a bitboard representing squares that are linearly
 /// between the two given squares (excluding first given square and including last square).
-/// If both square are not in a file/rank/diagonal, we return square_bb(s2).
+/// If both square are not align in a file/rank/diagonal, we return square_bb(s2).
 /// For instance, ray_bb(SQ_C4, SQ_F7) will return a bitboard with squares D5, E6 and F7.
 
 inline Bitboard ray_bb(Square ksq, Square checkersq){

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -75,6 +75,7 @@ extern uint8_t PopCnt16[1 << 16];
 extern uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];
+extern Bitboard RayBB[SQUARE_NB][SQUARE_NB];
 extern Bitboard LineBB[SQUARE_NB][SQUARE_NB];
 extern Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 extern Bitboard PawnAttacks[COLOR_NB][SQUARE_NB];
@@ -215,14 +216,13 @@ inline Bitboard line_bb(Square s1, Square s2) {
 }
 
 
-/// between_bb() returns a bitboard representing squares that are linearly
-/// between the two given squares (excluding the given squares). If the given
-/// squares are not on a same file/rank/diagonal, we return 0. For instance,
-/// between_bb(SQ_C4, SQ_F7) will return a bitboard with squares D5 and E6.
-
-inline Bitboard between_bb(Square s1, Square s2) {
-  Bitboard b = line_bb(s1, s2) & ((AllSquares << s1) ^ (AllSquares << s2));
-  return b & (b - 1); //exclude lsb
+/// ray_bb() returns a bitboard representing squares that are linearly
+/// between the two given squares (including last given square and excluding first).
+/// If the given squares are not on a same file/rank/diagonal, we return 0. For instance,
+/// ray_bb(SQ_C4, SQ_F7) will return a bitboard with squares D5, E6 and F7.
+inline Bitboard ray_bb(Square ksq, Square checkersq){
+  assert(is_ok(ksq) && is_ok(checkersq));
+  return RayBB[ksq][checkersq];
 }
 
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -217,9 +217,9 @@ inline Bitboard line_bb(Square s1, Square s2) {
 
 
 /// ray_bb() returns a bitboard representing squares that are linearly
-/// between the two given squares (including last given square and excluding first).
-/// If the given squares are not on a same file/rank/diagonal, we return 0. For instance,
-/// ray_bb(SQ_C4, SQ_F7) will return a bitboard with squares D5, E6 and F7.
+/// between the two given squares (excluding first given square and including last square).
+/// If both square are not in a file/rank/diagonal, we return square_bb(s2).
+/// For instance, ray_bb(SQ_C4, SQ_F7) will return a bitboard with squares D5, E6 and F7.
 
 inline Bitboard ray_bb(Square ksq, Square checkersq){
   assert(is_ok(ksq) && is_ok(checkersq));

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -220,6 +220,7 @@ inline Bitboard line_bb(Square s1, Square s2) {
 /// between the two given squares (including last given square and excluding first).
 /// If the given squares are not on a same file/rank/diagonal, we return 0. For instance,
 /// ray_bb(SQ_C4, SQ_F7) will return a bitboard with squares D5, E6 and F7.
+
 inline Bitboard ray_bb(Square ksq, Square checkersq){
   assert(is_ok(ksq) && is_ok(checkersq));
   return RayBB[ksq][checkersq];

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -223,7 +223,7 @@ namespace {
             target = ~pos.pieces();
             break;
         case EVASIONS:
-            target = between_bb(pos.square<KING>(Us), lsb(pos.checkers())) | pos.checkers();
+            target = ray_bb(pos.square<KING>(Us), lsb(pos.checkers()));
             break;
         case NON_EVASIONS:
             target = ~pos.pieces(Us);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -320,7 +320,7 @@ void Position::set_castling_right(Color c, Square rfrom) {
   Square kto = relative_square(c, cr & KING_SIDE ? SQ_G1 : SQ_C1);
   Square rto = relative_square(c, cr & KING_SIDE ? SQ_F1 : SQ_D1);
 
-  castlingPath[cr] =   (between_bb(rfrom, rto) | between_bb(kfrom, kto) | rto | kto)
+  castlingPath[cr] =   (ray_bb(rfrom, rto) | ray_bb(kfrom, kto))
                     & ~(kfrom | rfrom);
 }
 
@@ -477,7 +477,7 @@ Bitboard Position::slider_blockers(Bitboard sliders, Square s, Bitboard& pinners
   while (snipers)
   {
     Square sniperSq = pop_lsb(&snipers);
-    Bitboard b = between_bb(s, sniperSq) & occupancy;
+    Bitboard b = ray_bb(s, sniperSq) & occupancy;
 
     if (b && !more_than_one(b))
     {
@@ -614,7 +614,7 @@ bool Position::pseudo_legal(const Move m) const {
               return false;
 
           // Our move must be a blocking evasion or a capture of the checking piece
-          if (!((between_bb(lsb(checkers()), square<KING>(us)) | checkers()) & to))
+          if (!(ray_bb(square<KING>(us), lsb(checkers())) & to))
               return false;
       }
       // In case of king moves under check we have to remove king so as to catch
@@ -1218,7 +1218,7 @@ bool Position::has_game_cycle(int ply) const {
           Square s1 = from_sq(move);
           Square s2 = to_sq(move);
 
-          if (!(between_bb(s1, s2) & pieces()))
+          if (!((ray_bb(s1, s2) ^ s2) & pieces()))
           {
               if (ply > i)
                   return true;


### PR DESCRIPTION
In all times (except in `has_game_cycle()`) `between_bb()` uses or is indifferent if the one of the given square is added. And has shown in [here](https://tests.stockfishchess.org/tests/view/604d09f72433018de7a389fb) that using prefab results can speed up. So combining both, I reworked `between_bb()` into `ray_bb()`, that uses prefab results and includes the last parameter square.

```
Build Tester: 1.4.7.0
Windows 10 (Version 10.0, Build 0, 64-bit Edition)
Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
SafeMode: No 
Running In VM: No 
HyperThreading Enabled: Yes
CPU Warmup: Yes
Command Line: bench 16 1 5 default perft
Tests per Build: 10
ANOVA: n/a

                Engine# (NPS)                               Speedup     Sp     Conf. 99.5%  S.S.
patch  (102.715.251,9 ) ---> master  (98.242.950,2  ) --->  4,552%  2.105.495,3    Yes       No
```

Passed STC:
LLR: 2.96 (-2.94,2.94) {-0.25,1.25}
Total: 18736 W: 1746 L: 1607 D: 15383
Ptnml(0-2): 61, 1226, 6644, 1387, 50
https://tests.stockfishchess.org/tests/view/60428c84ddcba5f0627bb6e4

Yellow LTC:
LTC:
LLR: -3.00 (-2.94,2.94) {0.25,1.25}
Total: 39144 W: 1431 L: 1413 D: 36300
Ptnml(0-2): 13, 1176, 17184, 1178, 21
https://tests.stockfishchess.org/tests/view/605128702433018de7a38ca1

No functional change