### PR TITLE
Simplify Movegen

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -63,7 +63,7 @@ namespace {
     Bitboard pawnsOn7    = pos.pieces(Us, PAWN) &  TRank7BB;
     Bitboard pawnsNotOn7 = pos.pieces(Us, PAWN) & ~TRank7BB;
 
-    Bitboard enemies = (Type == EVASIONS ? pos.pieces(Them) & target:
+    Bitboard enemies = (Type == EVASIONS ? pos.checkers():
                         Type == CAPTURES ? target : pos.pieces(Them));
 
     // Single and double pawn pushes, no promotions

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -182,17 +182,12 @@ namespace {
 
     Bitboard bb = piecesToMove & pos.pieces(Pt);
 
-    if (!bb)
-        return moveList;
-
-    [[maybe_unused]] const Bitboard checkSquares = pos.check_squares(Pt);
-
     while (bb) {
         Square from = pop_lsb(&bb);
 
         Bitboard b = attacks_bb<Pt>(from, pos.pieces()) & target;
         if constexpr (Checks)
-            b &= checkSquares;
+            b &= pos.check_squares(Pt);
 
         while (b)
             *moveList++ = make_move(from, pop_lsb(&b));


### PR DESCRIPTION
On patch 1, I rewrote the patch #3300 that Sopel made, so it's more reader-friendly.
On patch 2, it's a small simplification. And I also believe it's more easy to understand what the value stands for.

---
Patch 1:

STC:
LLR: 2.95 (-2.94,2.94) {-1.25,0.25}
Total: 29792 W: 2611 L: 2545 D: 24636
Ptnml(0-2): 94, 1982, 10659, 2086, 75
https://tests.stockfishchess.org/tests/view/604fe5b62433018de7a38ba8

LTC:
LLR: 2.92 (-2.94,2.94) {-0.75,0.25}
Total: 22040 W: 826 L: 777 D: 20437
Ptnml(0-2): 8, 646, 9664, 693, 9
https://tests.stockfishchess.org/tests/view/604fec892433018de7a38bac

---
Patch 2:

STC:
LLR: 2.97 (-2.94,2.94) {-1.25,0.25}
Total: 39352 W: 3551 L: 3493 D: 32308
Ptnml(0-2): 143, 2695, 13928, 2781, 129
https://tests.stockfishchess.org/tests/view/6050007a2433018de7a38bbb

LTC:
LLR: 2.96 (-2.94,2.94) {-0.75,0.25}
Total: 44944 W: 1629 L: 1596 D: 41719
Ptnml(0-2): 22, 1319, 19762, 1342, 27
https://tests.stockfishchess.org/tests/view/60500e892433018de7a38bc4

No functional change