### PR TITLE
Speed Up on Generate Pawn Moves ?

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -57,7 +57,6 @@ namespace {
     constexpr Direction UpRight  = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
     constexpr Direction UpLeft   = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
 
-    const Square ksq = pos.square<KING>(Them);
     Bitboard emptySquares;
 
     Bitboard pawnsOn7    = pos.pieces(Us, PAWN) &  TRank7BB;
@@ -82,6 +81,8 @@ namespace {
 
         if (Type == QUIET_CHECKS)
         {
+            const Square ksq = pos.square<KING>(Them);
+
             b1 &= pawn_attacks_bb(Them, ksq);
             b2 &= pawn_attacks_bb(Them, ksq);
 
@@ -114,8 +115,10 @@ namespace {
     }
 
     // Promotions and underpromotions
-    if (pawnsOn7)
+    if (Type != QUIET_CHECKS && pawnsOn7)
     {
+        const Square ksq = pos.square<KING>(Them);
+
         if (Type == CAPTURES)
             emptySquares = ~pos.pieces();
 


### PR DESCRIPTION
As I said on discord and [here](https://github.com/BM123499/Stockfish/compare/f3b296c2e2...a65d2a5310) I can't find myself to measure its improvement with enough confidence. But the following tests shows evidences of speed up.

Passed STC:
LLR: 2.92 (-2.94,2.94) {-0.25,1.25}
Total: 288328 W: 25649 L: 25124 D: 237555
Ptnml(0-2): 895, 19588, 102675, 20109, 897
https://tests.stockfishchess.org/tests/view/60502e812433018de7a38bda

Yellow LTC:
LLR: -2.97 (-2.94,2.94) {0.25,1.25}
Total: 39792 W: 1435 L: 1414 D: 36943
Ptnml(0-2): 11, 1183, 17498, 1182, 22
https://tests.stockfishchess.org/tests/view/6050a4e92433018de7a38c36

No functional change