### PR TITLE
Simplify King Evasion

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -313,17 +313,9 @@ ExtMove* generate<EVASIONS>(const Position& pos, ExtMove* moveList) {
 
   Color us = pos.side_to_move();
   Square ksq = pos.square<KING>(us);
-  Bitboard sliderAttacks = 0;
-  Bitboard sliders = pos.checkers() & ~pos.pieces(KNIGHT, PAWN);
 
-  // Find all the squares attacked by slider checkers. We will remove them from
-  // the king evasions in order to skip known illegal moves, which avoids any
-  // useless legality checks later on.
-  while (sliders)
-      sliderAttacks |= line_bb(ksq, pop_lsb(sliders)) & ~pos.checkers();
-
-  // Generate evasions for king, capture and non capture moves
-  Bitboard b = attacks_bb<KING>(ksq) & ~pos.pieces(us) & ~sliderAttacks;
+  // Generate evasions for king
+  Bitboard b = attacks_bb<KING>(ksq) & ~pos.pieces(us);
   while (b)
       *moveList++ = make_move(ksq, pop_lsb(b));
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -544,7 +544,7 @@ bool Position::legal(Move m) const {
   // If the moving piece is a king, check whether the destination square is
   // attacked by the opponent.
   if (type_of(piece_on(from)) == KING)
-      return !(attackers_to(to) & pieces(~us));
+      return !(attackers_to(to, pieces() ^ from) & pieces(~us));
 
   // A non-king move is legal if and only if it is not pinned or it
   // is moving along the ray towards or away from the king.


### PR DESCRIPTION
Simplify away the removal of some illegal `KING`-evasion moves on movegen.
Trivia: it solves #3171 . 

Verified for correctness by running perft on the following positions:

```
stockfish

bench 16 1 6 default perft

Nodes searched  : 71608931810

position fen 4rrk1/1p1nq3/p7/2p1P1pp/3P2bp/3Q1Bn1/PPPB4/1K2R1NR w - - 40 21
go perft 6

Nodes searched: 6136386434
```

STC:
LLR: 2.94 (-2.94,2.94) {-1.00,0.20}
Total: 16072 W: 1473 L: 1349 D: 13250
Ptnml(0-2): 57, 1047, 5710, 1159, 63
https://tests.stockfishchess.org/tests/view/60629e7ef183b42957b423b1

LTC:
LLR: 2.94 (-2.94,2.94) {-0.70,0.20}
Total: 59064 W: 2214 L: 2177 D: 54673
Ptnml(0-2): 26, 1944, 25556, 1979, 27
https://tests.stockfishchess.org/tests/view/6062dce4f183b42957b423de

No functional Change