### PR TITLE
Merge all Movegen into one

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -63,8 +63,8 @@ namespace {
     Bitboard pawnsOn7    = pos.pieces(Us, PAWN) &  TRank7BB;
     Bitboard pawnsNotOn7 = pos.pieces(Us, PAWN) & ~TRank7BB;
 
-    Bitboard enemies = (Type == EVASIONS ? pos.checkers():
-                        Type == CAPTURES ? target : pos.pieces(Them));
+    Bitboard enemies = (Type == EVASIONS ? pos.checkers()
+                     :  Type == CAPTURES ? target : pos.pieces(Them));
 
     // Single and double pawn pushes, no promotions
     if (Type != CAPTURES)
@@ -175,19 +175,19 @@ namespace {
   }
 
 
-  template<PieceType Pt, bool Checks>
-  ExtMove* generate_moves(const Position& pos, ExtMove* moveList, Bitboard piecesToMove, Bitboard target) {
+  template<Color Us, PieceType Pt, bool Checks>
+  ExtMove* generate_moves(const Position& pos, ExtMove* moveList, Bitboard target) {
 
     static_assert(Pt != KING && Pt != PAWN, "Unsupported piece type in generate_moves()");
 
-    Bitboard bb = piecesToMove & pos.pieces(Pt);
+    Bitboard bb = pos.pieces(Us, Pt);
 
     while (bb)
     {
         Square from = pop_lsb(bb);
 
         Bitboard b = attacks_bb<Pt>(from, pos.pieces()) & target;
-        if constexpr (Checks)
+        if (Checks && (Pt == QUEEN || !(pos.blockers_for_king(~Us) & from)))
             b &= pos.check_squares(Pt);
 
         while (b)
@@ -204,42 +204,34 @@ namespace {
     static_assert(Type != LEGAL, "Unsupported type in generate_all()");
 
     constexpr bool Checks = Type == QUIET_CHECKS; // Reduce template instantiations
-    Bitboard target, piecesToMove = pos.pieces(Us);
+    const Square ksq = pos.square<KING>(Us);
+    Bitboard target;
+    
+    if (Type == EVASIONS && more_than_one(pos.checkers()))
+        goto kingMoves; // Double check, only a king move can save the day
 
-    if(Type == QUIET_CHECKS)
-        piecesToMove &= ~pos.blockers_for_king(~Us);
-
-    switch (Type)
-    {
-        case CAPTURES:
-            target =  pos.pieces(~Us);
-            break;
-        case QUIETS:
-        case QUIET_CHECKS:
-            target = ~pos.pieces();
-            break;
-        case EVASIONS:
-            target = between_bb(pos.square<KING>(Us), lsb(pos.checkers()));
-            break;
-        case NON_EVASIONS:
-            target = ~pos.pieces(Us);
-            break;
-    }
+    target = Type == EVASIONS     ?  between_bb(ksq, lsb(pos.checkers()))
+           : Type == NON_EVASIONS ? ~pos.pieces( Us)
+           : Type == CAPTURES     ?  pos.pieces(~Us)
+                                  : ~pos.pieces(   ); // QUIETS || QUIET_CHECKS
 
     moveList = generate_pawn_moves<Us, Type>(pos, moveList, target);
-    moveList = generate_moves<KNIGHT, Checks>(pos, moveList, piecesToMove, target);
-    moveList = generate_moves<BISHOP, Checks>(pos, moveList, piecesToMove, target);
-    moveList = generate_moves<  ROOK, Checks>(pos, moveList, piecesToMove, target);
-    moveList = generate_moves< QUEEN, Checks>(pos, moveList, piecesToMove, target);
+    moveList = generate_moves<Us, KNIGHT, Checks>(pos, moveList, target);
+    moveList = generate_moves<Us, BISHOP, Checks>(pos, moveList, target);
+    moveList = generate_moves<Us,   ROOK, Checks>(pos, moveList, target);
+    moveList = generate_moves<Us,  QUEEN, Checks>(pos, moveList, target);
 
-    if (Type != QUIET_CHECKS && Type != EVASIONS)
+kingMoves:
+    if (!Checks || pos.blockers_for_king(~Us) & ksq)
     {
-        Square ksq = pos.square<KING>(Us);
-        Bitboard b = attacks_bb<KING>(ksq) & target;
+        Bitboard b = attacks_bb<KING>(ksq) & (Type == EVASIONS ? ~pos.pieces(Us) : target);
+        if (Checks)
+            b &= ~attacks_bb<QUEEN>(pos.square<KING>(~Us));
+
         while (b)
             *moveList++ = make_move(ksq, pop_lsb(b));
 
-        if ((Type != CAPTURES) && pos.can_castle(Us & ANY_CASTLING))
+        if ((Type == QUIETS || Type == NON_EVASIONS) && pos.can_castle(Us & ANY_CASTLING))
             for (CastlingRights cr : { Us & KING_SIDE, Us & QUEEN_SIDE } )
                 if (!pos.castling_impeded(cr) && pos.can_castle(cr))
                     *moveList++ = make<CASTLING>(ksq, pos.castling_rook_square(cr));
@@ -253,6 +245,8 @@ namespace {
 
 /// <CAPTURES>     Generates all pseudo-legal captures plus queen and checking knight promotions
 /// <QUIETS>       Generates all pseudo-legal non-captures and underpromotions (except checking knight)
+/// <EVASIONS>     Generates all pseudo-legal check evasions when the side to move is in check
+/// <QUIET_CHECKS> Generates all pseudo-legal non-captures giving check, except castling
 /// <NON_EVASIONS> Generates all pseudo-legal captures and non-captures
 ///
 /// Returns a pointer to the end of the move list.
@@ -260,8 +254,8 @@ namespace {
 template<GenType Type>
 ExtMove* generate(const Position& pos, ExtMove* moveList) {
 
-  static_assert(Type == CAPTURES || Type == QUIETS || Type == NON_EVASIONS, "Unsupported type in generate()");
-  assert(!pos.checkers());
+  static_assert(Type != LEGAL, "Unsupported type in generate()");
+  assert((Type == EVASIONS) == (bool)pos.checkers());
 
   Color us = pos.side_to_move();
 
@@ -272,60 +266,9 @@ ExtMove* generate(const Position& pos, ExtMove* moveList) {
 // Explicit template instantiations
 template ExtMove* generate<CAPTURES>(const Position&, ExtMove*);
 template ExtMove* generate<QUIETS>(const Position&, ExtMove*);
+template ExtMove* generate<EVASIONS>(const Position&, ExtMove*);
+template ExtMove* generate<QUIET_CHECKS>(const Position&, ExtMove*);
 template ExtMove* generate<NON_EVASIONS>(const Position&, ExtMove*);
-
-
-/// generate<QUIET_CHECKS> generates all pseudo-legal non-captures giving check,
-/// except castling. Returns a pointer to the end of the move list.
-template<>
-ExtMove* generate<QUIET_CHECKS>(const Position& pos, ExtMove* moveList) {
-
-  assert(!pos.checkers());
-
-  Color us = pos.side_to_move();
-  Bitboard dc = pos.blockers_for_king(~us) & pos.pieces(us) & ~pos.pieces(PAWN);
-
-  while (dc)
-  {
-     Square from = pop_lsb(dc);
-     PieceType pt = type_of(pos.piece_on(from));
-
-     Bitboard b = attacks_bb(pt, from, pos.pieces()) & ~pos.pieces();
-
-     if (pt == KING)
-         b &= ~attacks_bb<QUEEN>(pos.square<KING>(~us));
-
-     while (b)
-         *moveList++ = make_move(from, pop_lsb(b));
-  }
-
-  return us == WHITE ? generate_all<WHITE, QUIET_CHECKS>(pos, moveList)
-                     : generate_all<BLACK, QUIET_CHECKS>(pos, moveList);
-}
-
-
-/// generate<EVASIONS> generates all pseudo-legal check evasions when the side
-/// to move is in check. Returns a pointer to the end of the move list.
-template<>
-ExtMove* generate<EVASIONS>(const Position& pos, ExtMove* moveList) {
-
-  assert(pos.checkers());
-
-  Color us = pos.side_to_move();
-  Square ksq = pos.square<KING>(us);
-
-  // Generate evasions for king
-  Bitboard b = attacks_bb<KING>(ksq) & ~pos.pieces(us);
-  while (b)
-      *moveList++ = make_move(ksq, pop_lsb(b));
-
-  if (more_than_one(pos.checkers()))
-      return moveList; // Double check, only a king move can save the day
-
-  // Generate blocking interpositions or captures of the checking piece
-  return us == WHITE ? generate_all<WHITE, EVASIONS>(pos, moveList)
-                     : generate_all<BLACK, EVASIONS>(pos, moveList);
-}
 
 
 /// generate<LEGAL> generates all the legal moves in the given position


### PR DESCRIPTION
Merging `generate<EVASIONS>` and `generate<QUIET_CHECKS>` into `generate_all()`.

This patch brings two changes in Movegen:

| Difference | Master | Patch | Sorted in movepick |
| --- | --- | --- | --- |
| EVASIONS | `KING` moves are generated first | `KING` moves are generated last | ✔️ |
| QUIET_CHECKS | Discovery checks are generated first | Discovery checks are generated among direct checks | ❌ |

Verified for correctness of `EVASIONS` by running perft:
```
./stockfish b3nch 16 1 6 default perft          (replace 3 by e in b3nch)
Nodes searched  : 71608931810
```

For verifying the correctness of `QUIET_CHECKS` , I changed the line: 
https://github.com/official-stockfish/Stockfish/blob/b862c8d4be2cf6245360a8072ab910a67eb5bc00/src/search.cpp#L170
to:
`uint64_t cnt, nodes = MoveList<QUIET_CHECKS>(pos).size();`

And tested again:
```
./stockfish b3nch 16 1 6 default perft         (replace 3 by e in b3nch)
Nodes searched  : 71653647410
```

Reference for Merging only `EVASIONS`: #3417 

STC:
LLR: 2.94 (-2.94,2.94) {-1.00,0.20}
Total: 161800 W: 14585 L: 14624 D: 132591
Ptnml(0-2): 577, 11681, 56451, 11586, 605
https://tests.stockfishchess.org/tests/view/606532732b2df919fd5f026d

LTC:
LLR: 2.98 (-2.94,2.94) {-0.70,0.20}
Total: 188504 W: 6906 L: 6961 D: 174637
Ptnml(0-2): 87, 6272, 81610, 6175, 108
https://tests.stockfishchess.org/tests/view/6065b0772b2df919fd5f02ae

bench: 4536129