### PR TITLE
Keep more pawns

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1091,8 +1091,8 @@ Value Eval::evaluate(const Position& pos) {
       // Scale and shift NNUE for compatibility with search and classical evaluation
       auto  adjusted_NNUE = [&]()
       {
-         int material = pos.non_pawn_material() + 2 * PawnValueMg * pos.count<PAWN>();
-         int scale =  641
+         int material = pos.non_pawn_material() + 4 * PawnValueMg * pos.count<PAWN>();
+         int scale =  580
                     + material / 32
                     - 4 * pos.rule50_count();
 


### PR DESCRIPTION
This patch increases the weight of pawns in the scale factor applied
to the output of the NNUE evaluation. This has the effect that Stockfish
will try a little bit harder to keep more pawns in position where the
engine has the advantage, and exchange more pawns in bad positions.

STC:
LLR: 2.93 (-2.94,2.94) {-0.20,1.10}
Total: 42552 W: 3858 L: 3668 D: 35026
Ptnml(0-2): 152, 2956, 14876, 3134, 158
https://tests.stockfishchess.org/tests/view/606a06dd2b2df919fd5f0504

LTC:
LLR: 2.95 (-2.94,2.94) {0.20,0.90}
Total: 44328 W: 1703 L: 1531 D: 41094
Ptnml(0-2): 20, 1373, 19207, 1543, 21
https://tests.stockfishchess.org/tests/view/606aa4ec2b2df919fd5f053e

Closes https://github.com/official-stockfish/Stockfish/pull/3420

Bench: 4310076