### PR TITLE
Replace distanceFromPv with a better logic.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -618,7 +618,6 @@ namespace {
     moveCount          = captureCount = quietCount = ss->moveCount = 0;
     bestValue          = -VALUE_INFINITE;
     maxValue           = VALUE_INFINITE;
-    ss->distanceFromPv = (PvNode ? 0 : ss->distanceFromPv);
 
     // Check for the available remaining time
     if (thisThread == Threads.main())
@@ -1180,8 +1179,6 @@ moves_loop: // When in check, search starts from here
       // Step 15. Make the move
       pos.do_move(move, st, givesCheck);
 
-      (ss+1)->distanceFromPv = ss->distanceFromPv + moveCount - 1;
-
       // Step 16. Late moves reduction / extension (LMR, ~200 Elo)
       // We use various heuristics for the sons of a node after the first son has
       // been searched. In general we would like to reduce them, but there are many
@@ -1280,10 +1277,10 @@ moves_loop: // When in check, search starts from here
                   r -= ss->statScore / 14790;
           }
 
-          // In general we want to cap the LMR depth search at newDepth. But for nodes
-          // close to the principal variation the cap is at (newDepth + 1), which will
-          // allow these nodes to be searched deeper than the pv (up to 4 plies deeper).
-          Depth d = std::clamp(newDepth - r, 1, newDepth + ((ss+1)->distanceFromPv <= 4));
+          // In general we want to cap the LMR depth search at newDepth.
+          // But if reductions are really negative and movecount is low we allow this 
+          // moves to be searched deeper than the first move.
+          Depth d = std::clamp(newDepth - r, 1, newDepth + (r < -1 && moveCount <= 5));
 
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, d, true);
 

--- a/src/search.h
+++ b/src/search.h
@@ -49,7 +49,6 @@ struct Stack {
   Value staticEval;
   int statScore;
   int moveCount;
-  int distanceFromPv;
   bool inCheck;
   bool ttPv;
   bool ttHit;


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/6069c9d02b2df919fd5f04d2
LLR: 2.95 (-2.94,2.94) {-0.20,1.10}
Total: 153008 W: 13913 L: 13579 D: 125516
Ptnml(0-2): 547, 10811, 53470, 11113, 563 
passed LTC
https://tests.stockfishchess.org/tests/view/606a99fd2b2df919fd5f0532
LLR: 2.94 (-2.94,2.94) {0.20,0.90}
Total: 101920 W: 3964 L: 3699 D: 94257
Ptnml(0-2): 55, 3279, 44019, 3560, 47 
This patch removes recently introduced distanceFromPv logic and replaces it with following logic : if reductions of moves with low movecount is really negative we search them deeper than the first move.
bench 4191632