### PR TITLE
Added Elbrus 2000 architecture

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -294,7 +294,7 @@ endif
 
 ifeq ($(findstring e2k,$(ARCH)),e2k)
 	arch = e2k
-	bits = 32
+	bits = 64
 	sse = yes
 	sse2 = yes
 
@@ -696,6 +696,8 @@ help:
 	@echo "armv7                   > ARMv7 32-bit"
 	@echo "armv7-neon              > ARMv7 32-bit with popcnt and neon"
 	@echo "armv8                   > ARMv8 64-bit with popcnt and neon"
+	@echo "e2k                     > Elbrus 2000"
+	@echo "e2k-v5                  > Elbrus 2000 Version 5 with SIMD 128 bit support"
 	@echo "apple-silicon           > Apple silicon ARM64"
 	@echo "general-64              > unspecified 64-bit"
 	@echo "general-32              > unspecified 32-bit"

--- a/src/Makefile
+++ b/src/Makefile
@@ -485,7 +485,7 @@ endif
 ### 3.3 Optimization
 ifeq ($(optimize),yes)
 
-	ifeq ($(ARCH),e2k)
+	ifeq ($(findstring e2k,$(ARCH)),e2k)
 		CXXFLAGS += -O4
 	else
 		CXXFLAGS += -O3

--- a/src/Makefile
+++ b/src/Makefile
@@ -97,6 +97,7 @@ ifeq ($(ARCH), $(filter $(ARCH), \
                  x86-64-vnni512 x86-64-vnni256 x86-64-avx512 x86-64-bmi2 x86-64-avx2 \
                  x86-64-sse41-popcnt x86-64-modern x86-64-ssse3 x86-64-sse3-popcnt \
                  x86-64 x86-32-sse41-popcnt x86-32-sse2 x86-32 ppc-64 ppc-32 \
+                 e2k e2k-v5 \
                  armv7 armv7-neon armv8 apple-silicon general-64 general-32))
    SUPPORTED_ARCH=true
 else
@@ -289,6 +290,19 @@ ifeq ($(ARCH),ppc-64)
 	arch = ppc64
 	popcnt = yes
 	prefetch = yes
+endif
+
+ifeq ($(findstring e2k,$(ARCH)),e2k)
+	arch = e2k
+	bits = 32
+	sse = yes
+	sse2 = yes
+
+ifeq ($(findstring -v5,$(ARCH)),-v5)
+	ssse3 = yes
+	sse41 = yes
+endif
+
 endif
 
 endif
@@ -829,6 +843,7 @@ config-sanity: net
 	@test "$(SUPPORTED_ARCH)" = "true"
 	@test "$(arch)" = "any" || test "$(arch)" = "x86_64" || test "$(arch)" = "i386" || \
 	 test "$(arch)" = "ppc64" || test "$(arch)" = "ppc" || \
+	 test "$(arch)" = "e2k" || test "$(arch)" = "e2k-v5" || \
 	 test "$(arch)" = "armv7" || test "$(arch)" = "armv8" || test "$(arch)" = "arm64"
 	@test "$(bits)" = "32" || test "$(bits)" = "64"
 	@test "$(prefetch)" = "yes" || test "$(prefetch)" = "no"

--- a/src/Makefile
+++ b/src/Makefile
@@ -297,9 +297,10 @@ ifeq ($(findstring e2k,$(ARCH)),e2k)
 	bits = 64
 	sse = yes
 	sse2 = yes
+	ssse3 = yes
+	popcnt = yes
 
 ifeq ($(findstring -v5,$(ARCH)),-v5)
-	ssse3 = yes
 	sse41 = yes
 endif
 
@@ -484,7 +485,11 @@ endif
 ### 3.3 Optimization
 ifeq ($(optimize),yes)
 
-	CXXFLAGS += -O3
+	ifeq ($(ARCH),e2k)
+		CXXFLAGS += -O4
+	else
+		CXXFLAGS += -O3
+	endif
 
 	ifeq ($(comp),gcc)
 		ifeq ($(OS), Android)

--- a/src/Makefile
+++ b/src/Makefile
@@ -97,7 +97,7 @@ ifeq ($(ARCH), $(filter $(ARCH), \
                  x86-64-vnni512 x86-64-vnni256 x86-64-avx512 x86-64-bmi2 x86-64-avx2 \
                  x86-64-sse41-popcnt x86-64-modern x86-64-ssse3 x86-64-sse3-popcnt \
                  x86-64 x86-32-sse41-popcnt x86-32-sse2 x86-32 ppc-64 ppc-32 \
-                 e2k e2k-v5 \
+                 e2k e2k-v3 e2k-v4 e2k-v5 e2k-v6 \
                  armv7 armv7-neon armv8 apple-silicon general-64 general-32))
    SUPPORTED_ARCH=true
 else
@@ -533,6 +533,23 @@ ifeq ($(popcnt),yes)
 	endif
 endif
 
+ifeq ($(findstring e2k,$(ARCH)),e2k)
+	ifeq ($(findstring -v3,$(ARCH)),-v3)
+		CXXFLAGS += -march=elbrus-v3
+	endif
+
+	ifeq ($(findstring -v4,$(ARCH)),-v4)
+		CXXFLAGS += -march=elbrus-v4
+	endif
+
+	ifeq ($(findstring -v5,$(ARCH)),-v5)
+		CXXFLAGS += -march=elbrus-v5
+	endif
+
+	ifeq ($(findstring -v6,$(ARCH)),-v6)
+		CXXFLAGS += -march=elbrus-v6
+	endif
+endif
 
 ifeq ($(avx2),yes)
 	CXXFLAGS += -DUSE_AVX2
@@ -701,8 +718,11 @@ help:
 	@echo "armv7                   > ARMv7 32-bit"
 	@echo "armv7-neon              > ARMv7 32-bit with popcnt and neon"
 	@echo "armv8                   > ARMv8 64-bit with popcnt and neon"
-	@echo "e2k                     > Elbrus 2000"
-	@echo "e2k-v5                  > Elbrus 2000 Version 5 with SIMD 128 bit support"
+	@echo "e2k                     > Elbrus 2000 generic"
+	@echo "e2k-v3                  > Elbrus 2000 version 3"
+	@echo "e2k-v4                  > Elbrus 2000 version 4"
+	@echo "e2k-v5                  > Elbrus 2000 version 5"
+	@echo "e2k-v6                  > Elbrus 2000 version 6"
 	@echo "apple-silicon           > Apple silicon ARM64"
 	@echo "general-64              > unspecified 64-bit"
 	@echo "general-32              > unspecified 32-bit"
@@ -850,7 +870,7 @@ config-sanity: net
 	@test "$(SUPPORTED_ARCH)" = "true"
 	@test "$(arch)" = "any" || test "$(arch)" = "x86_64" || test "$(arch)" = "i386" || \
 	 test "$(arch)" = "ppc64" || test "$(arch)" = "ppc" || \
-	 test "$(arch)" = "e2k" || test "$(arch)" = "e2k-v5" || \
+	 test "$(arch)" = "e2k" || test "$(arch)" = "e2k-v3" || test "$(arch)" = "e2k-v4" || test "$(arch)" = "e2k-v5" || test "$(arch)" = "e2k-v6" || \
 	 test "$(arch)" = "armv7" || test "$(arch)" = "armv8" || test "$(arch)" = "arm64"
 	@test "$(bits)" = "32" || test "$(bits)" = "64"
 	@test "$(prefetch)" = "yes" || test "$(prefetch)" = "no"

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -51,7 +51,7 @@ typedef bool(*fun3_t)(HANDLE, CONST GROUP_AFFINITY*, PGROUP_AFFINITY);
 #include <sys/mman.h>
 #endif
 
-#if defined(__APPLE__) || defined(__ANDROID__) || defined(__OpenBSD__) || (defined(__GLIBCXX__) && !defined(_GLIBCXX_HAVE_ALIGNED_ALLOC) && !defined(_WIN32))
+#if defined(__APPLE__) || defined(__ANDROID__) || defined(__OpenBSD__) || (defined(__GLIBCXX__) && !defined(_GLIBCXX_HAVE_ALIGNED_ALLOC) && !defined(_WIN32)) || (defined(__LCC__) && !defined(_WIN32))
 #define POSIXALIGNEDALLOC
 #include <stdlib.h>
 #endif
@@ -195,6 +195,8 @@ std::string compiler_info() {
   #elif __GNUC__
      compiler += "g++ (GNUC) ";
      compiler += make_version_string(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+  #elif __LCC__ && !defined(_WIN32)
+     compiler += "Elbrus C Compiler";
   #else
      compiler += "Unknown compiler ";
      compiler += "(unknown version)";


### PR DESCRIPTION
e2k (Elbrus 2000) - this is VLIW/EPIC architecture, like Intel Itanium (IA-64) architecture.
Architecture has half native / half software support of most Intel/AMD SIMD (e.g. MMX/SSE/SSE2/SSE3/SSSE3/SSE4.1/SSE4.2/AES/AVX/AVX2 & 3DNow!/SSE4a/XOP/FMA4) via intrinsics.

https://en.wikipedia.org/wiki/Elbrus_2000

Cpu Info (Elbrus 8CB):

```
processor       : 0
vendor_id       : E8C
cpu family      : 4
model           : 9
model name      : E8C2
revision        : 2
cpu MHz         : 1549.910240
cache0          : level=1 type=Instruction scope=Private size=128K line_size=256 associativity=4
cache1          : level=1 type=Data scope=Private size=64K line_size=32 associativity=4
cache2          : level=2 type=Unified scope=Private size=512K line_size=64 associativity=4
cache3          : level=3 type=Unified scope=Private size=16384K line_size=64 associativity=16
bogomips        : 3100.46

..


processor       : 7
vendor_id       : E8C
cpu family      : 4
model           : 9
model name      : E8C2
revision        : 2
cpu MHz         : 1549.910240
cache0          : level=1 type=Instruction scope=Private size=128K line_size=256 associativity=4
cache1          : level=1 type=Data scope=Private size=64K line_size=32 associativity=4
cache2          : level=2 type=Unified scope=Private size=512K line_size=64 associativity=4
cache3          : level=3 type=Unified scope=Private size=16384K line_size=64 associativity=16
bogomips        : 3099.84
```

Compiler: Elbrus C Compiler (in code: __LCC__) (own MCST's compiler with GCC compatibility, not Little C Compiler)

Architecture name: E2k (in code: __e2k__)

Architecture versions: elbrus-v2 (generic), elbrus-v3 (e2k-v3), elbrus-v4 (e2k-v4), elbrus-v5 (e2k-v5), elbrus-v6 (e2k-v6)
