### PR TITLE
Variable tempo for nnue depending on strength (thinking time and threads).

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -33,6 +33,7 @@
 #include "misc.h"
 #include "pawns.h"
 #include "thread.h"
+#include "timeman.h"
 #include "uci.h"
 #include "incbin/incbin.h"
 
@@ -1096,7 +1097,7 @@ Value Eval::evaluate(const Position& pos) {
                     + material / 32
                     - 4 * pos.rule50_count();
 
-         Value nnue = NNUE::evaluate(pos) * scale / 1024 + Tempo;
+         Value nnue = NNUE::evaluate(pos) * scale / 1024 + Time.tempoNNUE;
 
          if (pos.is_chess960())
              nnue += fix_FRC(pos);

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -94,6 +94,14 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
   optimumTime = TimePoint(optScale * timeLeft);
   maximumTime = TimePoint(std::min(0.8 * limits.time[us] - moveOverhead, maxScale * optimumTime));
 
+  if (Stockfish::Search::Limits.use_time_management())
+  {
+      int strength = std::log( std::max(1, int(optimumTime * Threads.size() / 10))) * 60;
+      tempoNNUE = std::clamp( (strength + 264) / 24, 18, 30);
+  }
+  else
+      tempoNNUE = 28; // default for no time given
+
   if (Options["Ponder"])
       optimumTime += optimumTime / 4;
 }

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -37,6 +37,7 @@ public:
                                      TimePoint(Threads.nodes_searched()) : now() - startTime; }
 
   int64_t availableNodes; // When in 'nodes as time' mode
+  int tempoNNUE;
 
 private:
   TimePoint startTime;


### PR DESCRIPTION
The original idea here was that NNUE is best with a slightly different tempo value to classical, since its style of play is slightly different. It turns out that the best tempo for NNUE varies with strength of play, so a formula is used which gives about 19 for STC and 24 for LTC.

STC  10+0.1 :
LLR: 2.94 (-2.94,2.94) {-0.20,1.10}
Total: 120816 W: 11155 L: 10861 D: 98800
Ptnml(0-2): 406, 8728, 41933, 8848, 493
https://tests.stockfishchess.org/tests/view/60735b3a8141753378960534

LTC 60+0.6 :
LLR: 2.94 (-2.94,2.94) {0.20,0.90}
Total: 35688 W: 1392 L: 1234 D: 33062
Ptnml(0-2): 23, 1079, 15473, 1255, 14
https://tests.stockfishchess.org/tests/view/6073ffbc814175337896057f

SMP LTC 20+0.2 th 8 :
LLR: 2.95 (-2.94,2.94) {-0.70,0.20}
Total: 11008 W: 317 L: 267 D: 10424
Ptnml(0-2): 2, 245, 4962, 291, 4
https://tests.stockfishchess.org/tests/view/60749ea881417533789605a4

Bench 4191632