### PR TITLE
Use classical eval for Bishop vs Pawns

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1112,7 +1112,8 @@ Value Eval::evaluate(const Position& pos) {
 
       // Use classical evaluation for really low piece endgames.
       // The most critical case is a bishop + A/H file pawn vs naked king draw.
-      bool strongClassical = pos.non_pawn_material() < 2 * RookValueMg && pos.count<PAWN>() < 2;
+      bool strongClassical = pos.non_pawn_material() == BishopValueMg || (
+							pos.non_pawn_material() < 2 * RookValueMg && pos.count<PAWN>() < 2);
 
       v = classical || strongClassical ? Evaluation<NO_TRACE>(pos).value() : adjusted_NNUE();
 


### PR DESCRIPTION
NNUE evaluation is incapable of recognizing trivially drawn bishop endgames (the wrong-colored rook pawn), which are in fact ubiquitous and stock standard in chess analysis. Switching off NNUE evaluation in KBPs vs KPs endgames is a measure that stops Stockfish from trading down to a drawn version of these endings when we presumably have advantage. The patch is able to edge over master in endgame positions.

STC:
LLR: 2.93 (-2.94,2.94) {-0.20,1.10}
Total: 33232 W: 6655 L: 6497 D: 20080
Ptnml(0-2): 4, 2342, 11769, 2494, 7
https://tests.stockfishchess.org/tests/view/6074a52981417533789605b8

LTC:
LLR: 2.93 (-2.94,2.94) {0.20,0.90}
Total: 159056 W: 29799 L: 29378 D: 99879
Ptnml(0-2): 7, 9004, 61085, 9425, 7
https://tests.stockfishchess.org/tests/view/6074c39a81417533789605ca

Bench: 4246038