### PR TITLE
Remove last captures extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1158,11 +1158,6 @@ moves_loop: // When in check, search starts from here
                && (pos.is_discovered_check_on_king(~us, move) || pos.see_ge(move)))
           extension = 1;
 
-      // Last captures extension
-      else if (   PieceValue[EG][pos.captured_piece()] > PawnValueEg
-               && pos.non_pawn_material() <= 2 * RookValueMg)
-          extension = 1;
-
       // Add extension to new depth
       newDepth += extension;
 


### PR DESCRIPTION
Passed STC
https://tests.stockfishchess.org/tests/view/607690f1814175337896068f
LLR: 2.95 (-2.94,2.94) {-1.00,0.20}
Total: 85024 W: 7754 L: 7707 D: 69563
Ptnml(0-2): 293, 5991, 29914, 6004, 310 
Passed LTC
https://tests.stockfishchess.org/tests/view/6076ccbe814175337896069e
LLR: 2.96 (-2.94,2.94) {-0.70,0.20}
Total: 39880 W: 1503 L: 1453 D: 36924
Ptnml(0-2): 17, 1281, 17293, 1333, 16 
This patch removes last captures extension. The main problem of current code in master is that it actually extends moves after capture instead of capture itself. This patch removes this logic alltogether.
bench 4202264