### PR TITLE
Unify naming convention of the nnue parts to match the rest of stockfish.

### DIFF
--- a/src/nnue/architectures/halfkp_256x2-32-32.h
+++ b/src/nnue/architectures/halfkp_256x2-32-32.h
@@ -32,15 +32,15 @@ namespace Stockfish::Eval::NNUE {
 
 // Input features used in evaluation function
 using RawFeatures = Features::FeatureSet<
-    Features::HalfKP<Features::Side::kFriend>>;
+    Features::HalfKP<Features::Side::Friend>>;
 
 // Number of input feature dimensions after conversion
-constexpr IndexType kTransformedFeatureDimensions = 256;
+constexpr IndexType TransformedFeatureDimensions = 256;
 
 namespace Layers {
 
 // Define network structure
-using InputLayer = InputSlice<kTransformedFeatureDimensions * 2>;
+using InputLayer = InputSlice<TransformedFeatureDimensions * 2>;
 using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
 using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
 using OutputLayer = AffineTransform<HiddenLayer2, 1>;

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -32,7 +32,7 @@
 namespace Stockfish::Eval::NNUE {
 
   // Input feature converter
-  LargePagePtr<FeatureTransformer> feature_transformer;
+  LargePagePtr<FeatureTransformer> featureTransformer;
 
   // Evaluation function
   AlignedPtr<Network> network;
@@ -44,14 +44,14 @@ namespace Stockfish::Eval::NNUE {
 
   // Initialize the evaluation function parameters
   template <typename T>
-  void Initialize(AlignedPtr<T>& pointer) {
+  void initialize(AlignedPtr<T>& pointer) {
 
     pointer.reset(reinterpret_cast<T*>(std_aligned_alloc(alignof(T), sizeof(T))));
     std::memset(pointer.get(), 0, sizeof(T));
   }
 
   template <typename T>
-  void Initialize(LargePagePtr<T>& pointer) {
+  void initialize(LargePagePtr<T>& pointer) {
 
     static_assert(alignof(T) <= 4096, "aligned_large_pages_alloc() may fail for such a big alignment requirement of T");
     pointer.reset(reinterpret_cast<T*>(aligned_large_pages_alloc(sizeof(T))));
@@ -60,46 +60,46 @@ namespace Stockfish::Eval::NNUE {
 
   // Read evaluation function parameters
   template <typename T>
-  bool ReadParameters(std::istream& stream, T& reference) {
+  bool read_parameters(std::istream& stream, T& reference) {
 
     std::uint32_t header;
     header = read_little_endian<std::uint32_t>(stream);
-    if (!stream || header != T::GetHashValue()) return false;
-    return reference.ReadParameters(stream);
+    if (!stream || header != T::get_hash_value()) return false;
+    return reference.read_parameters(stream);
   }
 
   }  // namespace Detail
 
   // Initialize the evaluation function parameters
-  void Initialize() {
+  void initialize() {
 
-    Detail::Initialize(feature_transformer);
-    Detail::Initialize(network);
+    Detail::initialize(featureTransformer);
+    Detail::initialize(network);
   }
 
   // Read network header
-  bool ReadHeader(std::istream& stream, std::uint32_t* hash_value, std::string* architecture)
+  bool read_header(std::istream& stream, std::uint32_t* hashValue, std::string* architecture)
   {
     std::uint32_t version, size;
 
     version     = read_little_endian<std::uint32_t>(stream);
-    *hash_value = read_little_endian<std::uint32_t>(stream);
+    *hashValue = read_little_endian<std::uint32_t>(stream);
     size        = read_little_endian<std::uint32_t>(stream);
-    if (!stream || version != kVersion) return false;
+    if (!stream || version != Version) return false;
     architecture->resize(size);
     stream.read(&(*architecture)[0], size);
     return !stream.fail();
   }
 
   // Read network parameters
-  bool ReadParameters(std::istream& stream) {
+  bool read_parameters(std::istream& stream) {
 
-    std::uint32_t hash_value;
+    std::uint32_t hashValue;
     std::string architecture;
-    if (!ReadHeader(stream, &hash_value, &architecture)) return false;
-    if (hash_value != kHashValue) return false;
-    if (!Detail::ReadParameters(stream, *feature_transformer)) return false;
-    if (!Detail::ReadParameters(stream, *network)) return false;
+    if (!read_header(stream, &hashValue, &architecture)) return false;
+    if (hashValue != HashValue) return false;
+    if (!Detail::read_parameters(stream, *featureTransformer)) return false;
+    if (!Detail::read_parameters(stream, *network)) return false;
     return stream && stream.peek() == std::ios::traits_type::eof();
   }
 
@@ -109,36 +109,36 @@ namespace Stockfish::Eval::NNUE {
     // We manually align the arrays on the stack because with gcc < 9.3
     // overaligning stack variables with alignas() doesn't work correctly.
 
-    constexpr uint64_t alignment = kCacheLineSize;
+    constexpr uint64_t alignment = CacheLineSize;
 
 #if defined(ALIGNAS_ON_STACK_VARIABLES_BROKEN)
-    TransformedFeatureType transformed_features_unaligned[
-      FeatureTransformer::kBufferSize + alignment / sizeof(TransformedFeatureType)];
-    char buffer_unaligned[Network::kBufferSize + alignment];
+    TransformedFeatureType transformedFeaturesUnaligned[
+      FeatureTransformer::BufferSize + alignment / sizeof(TransformedFeatureType)];
+    char bufferUnaligned[Network::BufferSize + alignment];
 
-    auto* transformed_features = align_ptr_up<alignment>(&transformed_features_unaligned[0]);
-    auto* buffer = align_ptr_up<alignment>(&buffer_unaligned[0]);
+    auto* transformedFeatures = align_ptr_up<alignment>(&transformedFeaturesUnaligned[0]);
+    auto* buffer = align_ptr_up<alignment>(&bufferUnaligned[0]);
 #else
     alignas(alignment)
-      TransformedFeatureType transformed_features[FeatureTransformer::kBufferSize];
-    alignas(alignment) char buffer[Network::kBufferSize];
+      TransformedFeatureType transformedFeatures[FeatureTransformer::BufferSize];
+    alignas(alignment) char buffer[Network::BufferSize];
 #endif
 
-    ASSERT_ALIGNED(transformed_features, alignment);
+    ASSERT_ALIGNED(transformedFeatures, alignment);
     ASSERT_ALIGNED(buffer, alignment);
 
-    feature_transformer->Transform(pos, transformed_features);
-    const auto output = network->Propagate(transformed_features, buffer);
+    featureTransformer->transform(pos, transformedFeatures);
+    const auto output = network->propagate(transformedFeatures, buffer);
 
-    return static_cast<Value>(output[0] / FV_SCALE);
+    return static_cast<Value>(output[0] / OutputScale);
   }
 
   // Load eval, from a file stream or a memory stream
   bool load_eval(std::string name, std::istream& stream) {
 
-    Initialize();
+    initialize();
     fileName = name;
-    return ReadParameters(stream);
+    return read_parameters(stream);
   }
 
 } // namespace Stockfish::Eval::NNUE

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -28,8 +28,8 @@
 namespace Stockfish::Eval::NNUE {
 
   // Hash value of evaluation function structure
-  constexpr std::uint32_t kHashValue =
-      FeatureTransformer::GetHashValue() ^ Network::GetHashValue();
+  constexpr std::uint32_t HashValue =
+      FeatureTransformer::get_hash_value() ^ Network::get_hash_value();
 
   // Deleter for automating release of memory area
   template <typename T>

--- a/src/nnue/features/feature_set.h
+++ b/src/nnue/features/feature_set.h
@@ -36,7 +36,7 @@ namespace Stockfish::Eval::NNUE::Features {
       return value == First || CompileTimeList<T, Remaining...>::Contains(value);
     }
     static constexpr std::array<T, sizeof...(Remaining) + 1>
-        kValues = {{First, Remaining...}};
+        Values = {{First, Remaining...}};
   };
 
   // Base class of feature set
@@ -51,16 +51,16 @@ namespace Stockfish::Eval::NNUE::Features {
 
    public:
     // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t kHashValue = FeatureType::kHashValue;
+    static constexpr std::uint32_t HashValue = FeatureType::HashValue;
     // Number of feature dimensions
-    static constexpr IndexType kDimensions = FeatureType::kDimensions;
+    static constexpr IndexType Dimensions = FeatureType::Dimensions;
     // Maximum number of simultaneously active features
-    static constexpr IndexType kMaxActiveDimensions =
-        FeatureType::kMaxActiveDimensions;
+    static constexpr IndexType MaxActiveDimensions =
+        FeatureType::MaxActiveDimensions;
     // Trigger for full calculation instead of difference calculation
     using SortedTriggerSet =
-        CompileTimeList<TriggerEvent, FeatureType::kRefreshTrigger>;
-    static constexpr auto kRefreshTriggers = SortedTriggerSet::kValues;
+        CompileTimeList<TriggerEvent, FeatureType::RefreshTrigger>;
+    static constexpr auto RefreshTriggers = SortedTriggerSet::Values;
 
   };
 

--- a/src/nnue/features/features_common.h
+++ b/src/nnue/features/features_common.h
@@ -33,11 +33,11 @@ namespace Stockfish::Eval::NNUE::Features {
 
   // Trigger to perform full calculations instead of difference only
   enum class TriggerEvent {
-    kFriendKingMoved // calculate full evaluation when own king moves
+    FriendKingMoved // calculate full evaluation when own king moves
   };
 
   enum class Side {
-    kFriend // side to move
+    Friend // side to move
   };
 
 }  // namespace Stockfish::Eval::NNUE::Features

--- a/src/nnue/features/half_kp.cpp
+++ b/src/nnue/features/half_kp.cpp
@@ -30,12 +30,12 @@ namespace Stockfish::Eval::NNUE::Features {
 
   // Index of a feature for a given king position and another piece on some square
   inline IndexType make_index(Color perspective, Square s, Piece pc, Square ksq) {
-    return IndexType(orient(perspective, s) + kpp_board_index[perspective][pc] + PS_END * ksq);
+    return IndexType(orient(perspective, s) + PieceSquareIndex[perspective][pc] + PS_NB * ksq);
   }
 
   // Get a list of indices for active features
   template <Side AssociatedKing>
-  void HalfKP<AssociatedKing>::AppendActiveIndices(
+  void HalfKP<AssociatedKing>::append_active_indices(
       const Position& pos, Color perspective, IndexList* active) {
 
     Square ksq = orient(perspective, pos.square<KING>(perspective));
@@ -48,7 +48,7 @@ namespace Stockfish::Eval::NNUE::Features {
   }
 
 
-  // AppendChangedIndices() : get a list of indices for recently changed features
+  // append_changed_indices() : get a list of indices for recently changed features
 
   // IMPORTANT: The `pos` in this function is pretty much useless as it
   // is not always the position the features are updated to. The feature
@@ -67,7 +67,7 @@ namespace Stockfish::Eval::NNUE::Features {
   // the current leaf position (the position after the move).
 
   template <Side AssociatedKing>
-  void HalfKP<AssociatedKing>::AppendChangedIndices(
+  void HalfKP<AssociatedKing>::append_changed_indices(
       const Position& pos, const DirtyPiece& dp, Color perspective,
       IndexList* removed, IndexList* added) {
 
@@ -82,6 +82,6 @@ namespace Stockfish::Eval::NNUE::Features {
     }
   }
 
-  template class HalfKP<Side::kFriend>;
+  template class HalfKP<Side::Friend>;
 
 }  // namespace Stockfish::Eval::NNUE::Features

--- a/src/nnue/features/half_kp.h
+++ b/src/nnue/features/half_kp.h
@@ -33,25 +33,25 @@ namespace Stockfish::Eval::NNUE::Features {
 
    public:
     // Feature name
-    static constexpr const char* kName = "HalfKP(Friend)";
+    static constexpr const char* Name = "HalfKP(Friend)";
     // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t kHashValue =
-        0x5D69D5B9u ^ (AssociatedKing == Side::kFriend);
+    static constexpr std::uint32_t HashValue =
+        0x5D69D5B9u ^ (AssociatedKing == Side::Friend);
     // Number of feature dimensions
-    static constexpr IndexType kDimensions =
-        static_cast<IndexType>(SQUARE_NB) * static_cast<IndexType>(PS_END);
+    static constexpr IndexType Dimensions =
+        static_cast<IndexType>(SQUARE_NB) * static_cast<IndexType>(PS_NB);
     // Maximum number of simultaneously active features
-    static constexpr IndexType kMaxActiveDimensions = 30; // Kings don't count
+    static constexpr IndexType MaxActiveDimensions = 30; // Kings don't count
     // Trigger for full calculation instead of difference calculation
-    static constexpr TriggerEvent kRefreshTrigger = TriggerEvent::kFriendKingMoved;
+    static constexpr TriggerEvent RefreshTrigger = TriggerEvent::FriendKingMoved;
 
     // Get a list of indices for active features
-    static void AppendActiveIndices(const Position& pos, Color perspective,
-                                    IndexList* active);
+    static void append_active_indices(const Position& pos, Color perspective,
+                                      IndexList* active);
 
     // Get a list of indices for recently changed features
-    static void AppendChangedIndices(const Position& pos, const DirtyPiece& dp, Color perspective,
-                                     IndexList* removed, IndexList* added);
+    static void append_changed_indices(const Position& pos, const DirtyPiece& dp, Color perspective,
+                                       IndexList* removed, IndexList* added);
   };
 
 }  // namespace Stockfish::Eval::NNUE::Features

--- a/src/nnue/features/index_list.h
+++ b/src/nnue/features/index_list.h
@@ -56,7 +56,7 @@ namespace Stockfish::Eval::NNUE::Features {
 
   //Type of feature index list
   class IndexList
-      : public ValueList<IndexType, RawFeatures::kMaxActiveDimensions> {
+      : public ValueList<IndexType, RawFeatures::MaxActiveDimensions> {
   };
 
 }  // namespace Stockfish::Eval::NNUE::Features

--- a/src/nnue/layers/input_slice.h
+++ b/src/nnue/layers/input_slice.h
@@ -26,38 +26,38 @@
 namespace Stockfish::Eval::NNUE::Layers {
 
 // Input layer
-template <IndexType OutputDimensions, IndexType Offset = 0>
+template <IndexType OutDims, IndexType Offset = 0>
 class InputSlice {
  public:
   // Need to maintain alignment
-  static_assert(Offset % kMaxSimdWidth == 0, "");
+  static_assert(Offset % MaxSimdWidth == 0, "");
 
   // Output type
   using OutputType = TransformedFeatureType;
 
   // Output dimensionality
-  static constexpr IndexType kOutputDimensions = OutputDimensions;
+  static constexpr IndexType OutputDimensions = OutDims;
 
   // Size of forward propagation buffer used from the input layer to this layer
-  static constexpr std::size_t kBufferSize = 0;
+  static constexpr std::size_t BufferSize = 0;
 
   // Hash value embedded in the evaluation file
-  static constexpr std::uint32_t GetHashValue() {
-    std::uint32_t hash_value = 0xEC42E90Du;
-    hash_value ^= kOutputDimensions ^ (Offset << 10);
-    return hash_value;
+  static constexpr std::uint32_t get_hash_value() {
+    std::uint32_t hashValue = 0xEC42E90Du;
+    hashValue ^= OutputDimensions ^ (Offset << 10);
+    return hashValue;
   }
 
   // Read network parameters
-  bool ReadParameters(std::istream& /*stream*/) {
+  bool read_parameters(std::istream& /*stream*/) {
     return true;
   }
 
   // Forward propagation
-  const OutputType* Propagate(
-      const TransformedFeatureType* transformed_features,
+  const OutputType* propagate(
+      const TransformedFeatureType* transformedFeatures,
       char* /*buffer*/) const {
-    return transformed_features + Offset;
+    return transformedFeatures + Offset;
   }
 
  private:

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -29,9 +29,9 @@ namespace Stockfish::Eval::NNUE {
   enum AccumulatorState { EMPTY, COMPUTED, INIT };
 
   // Class that holds the result of affine transformation of input features
-  struct alignas(kCacheLineSize) Accumulator {
+  struct alignas(CacheLineSize) Accumulator {
     std::int16_t
-        accumulation[2][kRefreshTriggers.size()][kTransformedFeatureDimensions];
+        accumulation[2][RefreshTriggers.size()][TransformedFeatureDimensions];
     AccumulatorState state[2];
   };
 

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -26,12 +26,12 @@
 
 namespace Stockfish::Eval::NNUE {
 
-  static_assert(kTransformedFeatureDimensions % kMaxSimdWidth == 0, "");
-  static_assert(Network::kOutputDimensions == 1, "");
+  static_assert(TransformedFeatureDimensions % MaxSimdWidth == 0, "");
+  static_assert(Network::OutputDimensions == 1, "");
   static_assert(std::is_same<Network::OutputType, std::int32_t>::value, "");
 
   // Trigger for full calculation instead of difference calculation
-  constexpr auto kRefreshTriggers = RawFeatures::kRefreshTriggers;
+  constexpr auto RefreshTriggers = RawFeatures::RefreshTriggers;
 
 }  // namespace Stockfish::Eval::NNUE
 

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -46,30 +46,30 @@
 namespace Stockfish::Eval::NNUE {
 
   // Version of the evaluation file
-  constexpr std::uint32_t kVersion = 0x7AF32F16u;
+  constexpr std::uint32_t Version = 0x7AF32F16u;
 
   // Constant used in evaluation value calculation
-  constexpr int FV_SCALE = 16;
-  constexpr int kWeightScaleBits = 6;
+  constexpr int OutputScale = 16;
+  constexpr int WeightScaleBits = 6;
 
   // Size of cache line (in bytes)
-  constexpr std::size_t kCacheLineSize = 64;
+  constexpr std::size_t CacheLineSize = 64;
 
   // SIMD width (in bytes)
   #if defined(USE_AVX2)
-  constexpr std::size_t kSimdWidth = 32;
+  constexpr std::size_t SimdWidth = 32;
 
   #elif defined(USE_SSE2)
-  constexpr std::size_t kSimdWidth = 16;
+  constexpr std::size_t SimdWidth = 16;
 
   #elif defined(USE_MMX)
-  constexpr std::size_t kSimdWidth = 8;
+  constexpr std::size_t SimdWidth = 8;
 
   #elif defined(USE_NEON)
-  constexpr std::size_t kSimdWidth = 16;
+  constexpr std::size_t SimdWidth = 16;
   #endif
 
-  constexpr std::size_t kMaxSimdWidth = 32;
+  constexpr std::size_t MaxSimdWidth = 32;
 
   // unique number for each piece type on each square
   enum {
@@ -84,19 +84,16 @@ namespace Stockfish::Eval::NNUE {
     PS_B_ROOK   =  7 * SQUARE_NB + 1,
     PS_W_QUEEN  =  8 * SQUARE_NB + 1,
     PS_B_QUEEN  =  9 * SQUARE_NB + 1,
-    PS_W_KING   = 10 * SQUARE_NB + 1,
-    PS_END      = PS_W_KING, // pieces without kings (pawns included)
-    PS_B_KING   = 11 * SQUARE_NB + 1,
-    PS_END2     = 12 * SQUARE_NB + 1
+    PS_NB = 10 * SQUARE_NB + 1
   };
 
-  constexpr uint32_t kpp_board_index[COLOR_NB][PIECE_NB] = {
+  constexpr uint32_t PieceSquareIndex[COLOR_NB][PIECE_NB] = {
     // convention: W - us, B - them
     // viewed from other side, W and B are reversed
-    { PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_W_KING, PS_NONE,
-      PS_NONE, PS_B_PAWN, PS_B_KNIGHT, PS_B_BISHOP, PS_B_ROOK, PS_B_QUEEN, PS_B_KING, PS_NONE },
-    { PS_NONE, PS_B_PAWN, PS_B_KNIGHT, PS_B_BISHOP, PS_B_ROOK, PS_B_QUEEN, PS_B_KING, PS_NONE,
-      PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_W_KING, PS_NONE }
+    { PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_NONE, PS_NONE,
+      PS_NONE, PS_B_PAWN, PS_B_KNIGHT, PS_B_BISHOP, PS_B_ROOK, PS_B_QUEEN, PS_NONE, PS_NONE },
+    { PS_NONE, PS_B_PAWN, PS_B_KNIGHT, PS_B_BISHOP, PS_B_ROOK, PS_B_QUEEN, PS_NONE, PS_NONE,
+      PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_NONE, PS_NONE }
   };
 
   // Type of input feature after conversion
@@ -105,7 +102,7 @@ namespace Stockfish::Eval::NNUE {
 
   // Round n up to be a multiple of base
   template <typename IntType>
-  constexpr IntType CeilToMultiple(IntType n, IntType base) {
+  constexpr IntType ceil_to_multiple(IntType n, IntType base) {
       return (n + base - 1) / base * base;
   }
 

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -40,7 +40,7 @@ namespace Stockfish::Eval::NNUE {
   #define vec_store(a,b) _mm512_store_si512(a,b)
   #define vec_add_16(a,b) _mm512_add_epi16(a,b)
   #define vec_sub_16(a,b) _mm512_sub_epi16(a,b)
-  static constexpr IndexType kNumRegs = 8; // only 8 are needed
+  static constexpr IndexType NumRegs = 8; // only 8 are needed
 
   #elif USE_AVX2
   typedef __m256i vec_t;
@@ -48,7 +48,7 @@ namespace Stockfish::Eval::NNUE {
   #define vec_store(a,b) _mm256_store_si256(a,b)
   #define vec_add_16(a,b) _mm256_add_epi16(a,b)
   #define vec_sub_16(a,b) _mm256_sub_epi16(a,b)
-  static constexpr IndexType kNumRegs = 16;
+  static constexpr IndexType NumRegs = 16;
 
   #elif USE_SSE2
   typedef __m128i vec_t;
@@ -56,7 +56,7 @@ namespace Stockfish::Eval::NNUE {
   #define vec_store(a,b) *(a)=(b)
   #define vec_add_16(a,b) _mm_add_epi16(a,b)
   #define vec_sub_16(a,b) _mm_sub_epi16(a,b)
-  static constexpr IndexType kNumRegs = Is64Bit ? 16 : 8;
+  static constexpr IndexType NumRegs = Is64Bit ? 16 : 8;
 
   #elif USE_MMX
   typedef __m64 vec_t;
@@ -64,7 +64,7 @@ namespace Stockfish::Eval::NNUE {
   #define vec_store(a,b) *(a)=(b)
   #define vec_add_16(a,b) _mm_add_pi16(a,b)
   #define vec_sub_16(a,b) _mm_sub_pi16(a,b)
-  static constexpr IndexType kNumRegs = 8;
+  static constexpr IndexType NumRegs = 8;
 
   #elif USE_NEON
   typedef int16x8_t vec_t;
@@ -72,7 +72,7 @@ namespace Stockfish::Eval::NNUE {
   #define vec_store(a,b) *(a)=(b)
   #define vec_add_16(a,b) vaddq_s16(a,b)
   #define vec_sub_16(a,b) vsubq_s16(a,b)
-  static constexpr IndexType kNumRegs = 16;
+  static constexpr IndexType NumRegs = 16;
 
   #else
   #undef VECTOR
@@ -84,11 +84,11 @@ namespace Stockfish::Eval::NNUE {
 
    private:
     // Number of output dimensions for one side
-    static constexpr IndexType kHalfDimensions = kTransformedFeatureDimensions;
+    static constexpr IndexType HalfDimensions = TransformedFeatureDimensions;
 
     #ifdef VECTOR
-    static constexpr IndexType kTileHeight = kNumRegs * sizeof(vec_t) / 2;
-    static_assert(kHalfDimensions % kTileHeight == 0, "kTileHeight must divide kHalfDimensions");
+    static constexpr IndexType TileHeight = NumRegs * sizeof(vec_t) / 2;
+    static_assert(HalfDimensions % TileHeight == 0, "TileHeight must divide HalfDimensions");
     #endif
 
    public:
@@ -96,95 +96,92 @@ namespace Stockfish::Eval::NNUE {
     using OutputType = TransformedFeatureType;
 
     // Number of input/output dimensions
-    static constexpr IndexType kInputDimensions = RawFeatures::kDimensions;
-    static constexpr IndexType kOutputDimensions = kHalfDimensions * 2;
+    static constexpr IndexType InputDimensions = RawFeatures::Dimensions;
+    static constexpr IndexType OutputDimensions = HalfDimensions * 2;
 
     // Size of forward propagation buffer
-    static constexpr std::size_t kBufferSize =
-        kOutputDimensions * sizeof(OutputType);
+    static constexpr std::size_t BufferSize =
+        OutputDimensions * sizeof(OutputType);
 
     // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t GetHashValue() {
-
-      return RawFeatures::kHashValue ^ kOutputDimensions;
+    static constexpr std::uint32_t get_hash_value() {
+      return RawFeatures::HashValue ^ OutputDimensions;
     }
 
     // Read network parameters
-    bool ReadParameters(std::istream& stream) {
-
-      for (std::size_t i = 0; i < kHalfDimensions; ++i)
-        biases_[i] = read_little_endian<BiasType>(stream);
-      for (std::size_t i = 0; i < kHalfDimensions * kInputDimensions; ++i)
-        weights_[i] = read_little_endian<WeightType>(stream);
+    bool read_parameters(std::istream& stream) {
+      for (std::size_t i = 0; i < HalfDimensions; ++i)
+        biases[i] = read_little_endian<BiasType>(stream);
+      for (std::size_t i = 0; i < HalfDimensions * InputDimensions; ++i)
+        weights[i] = read_little_endian<WeightType>(stream);
       return !stream.fail();
     }
 
     // Convert input features
-    void Transform(const Position& pos, OutputType* output) const {
-
-      UpdateAccumulator(pos, WHITE);
-      UpdateAccumulator(pos, BLACK);
+    void transform(const Position& pos, OutputType* output) const {
+      update_accumulator(pos, WHITE);
+      update_accumulator(pos, BLACK);
 
       const auto& accumulation = pos.state()->accumulator.accumulation;
 
   #if defined(USE_AVX512)
-      constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth * 2);
-      static_assert(kHalfDimensions % (kSimdWidth * 2) == 0);
-      const __m512i kControl = _mm512_setr_epi64(0, 2, 4, 6, 1, 3, 5, 7);
-      const __m512i kZero = _mm512_setzero_si512();
+      constexpr IndexType NumChunks = HalfDimensions / (SimdWidth * 2);
+      static_assert(HalfDimensions % (SimdWidth * 2) == 0);
+      const __m512i Control = _mm512_setr_epi64(0, 2, 4, 6, 1, 3, 5, 7);
+      const __m512i Zero = _mm512_setzero_si512();
 
   #elif defined(USE_AVX2)
-      constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
-      constexpr int kControl = 0b11011000;
-      const __m256i kZero = _mm256_setzero_si256();
+      constexpr IndexType NumChunks = HalfDimensions / SimdWidth;
+      constexpr int Control = 0b11011000;
+      const __m256i Zero = _mm256_setzero_si256();
 
   #elif defined(USE_SSE2)
-      constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
+      constexpr IndexType NumChunks = HalfDimensions / SimdWidth;
 
   #ifdef USE_SSE41
-      const __m128i kZero = _mm_setzero_si128();
+      const __m128i Zero = _mm_setzero_si128();
   #else
       const __m128i k0x80s = _mm_set1_epi8(-128);
   #endif
 
   #elif defined(USE_MMX)
-      constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
+      constexpr IndexType NumChunks = HalfDimensions / SimdWidth;
       const __m64 k0x80s = _mm_set1_pi8(-128);
 
   #elif defined(USE_NEON)
-      constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
-      const int8x8_t kZero = {0};
+      constexpr IndexType NumChunks = HalfDimensions / (SimdWidth / 2);
+      const int8x8_t Zero = {0};
   #endif
 
       const Color perspectives[2] = {pos.side_to_move(), ~pos.side_to_move()};
       for (IndexType p = 0; p < 2; ++p) {
-        const IndexType offset = kHalfDimensions * p;
+        const IndexType offset = HalfDimensions * p;
 
   #if defined(USE_AVX512)
         auto out = reinterpret_cast<__m512i*>(&output[offset]);
-        for (IndexType j = 0; j < kNumChunks; ++j) {
+        for (IndexType j = 0; j < NumChunks; ++j) {
           __m512i sum0 = _mm512_load_si512(
               &reinterpret_cast<const __m512i*>(accumulation[perspectives[p]][0])[j * 2 + 0]);
           __m512i sum1 = _mm512_load_si512(
               &reinterpret_cast<const __m512i*>(accumulation[perspectives[p]][0])[j * 2 + 1]);
-          _mm512_store_si512(&out[j], _mm512_permutexvar_epi64(kControl,
-              _mm512_max_epi8(_mm512_packs_epi16(sum0, sum1), kZero)));
+          _mm512_store_si512(&out[j], _mm512_permutexvar_epi64(Control,
+              _mm512_max_epi8(_mm512_packs_epi16(sum0, sum1), Zero)));
         }
 
   #elif defined(USE_AVX2)
         auto out = reinterpret_cast<__m256i*>(&output[offset]);
-        for (IndexType j = 0; j < kNumChunks; ++j) {
+        for (IndexType j = 0; j < NumChunks; ++j) {
           __m256i sum0 = _mm256_load_si256(
               &reinterpret_cast<const __m256i*>(accumulation[perspectives[p]][0])[j * 2 + 0]);
           __m256i sum1 = _mm256_load_si256(
               &reinterpret_cast<const __m256i*>(accumulation[perspectives[p]][0])[j * 2 + 1]);
           _mm256_store_si256(&out[j], _mm256_permute4x64_epi64(_mm256_max_epi8(
-              _mm256_packs_epi16(sum0, sum1), kZero), kControl));
+              _mm256_packs_epi16(sum0, sum1), Zero), Control));
         }
 
   #elif defined(USE_SSE2)
         auto out = reinterpret_cast<__m128i*>(&output[offset]);
-        for (IndexType j = 0; j < kNumChunks; ++j) {
+        for (IndexType j = 0; j < NumChunks; ++j) {
           __m128i sum0 = _mm_load_si128(&reinterpret_cast<const __m128i*>(
               accumulation[perspectives[p]][0])[j * 2 + 0]);
           __m128i sum1 = _mm_load_si128(&reinterpret_cast<const __m128i*>(
@@ -194,7 +191,7 @@ namespace Stockfish::Eval::NNUE {
           _mm_store_si128(&out[j],
 
   #ifdef USE_SSE41
-              _mm_max_epi8(packedbytes, kZero)
+              _mm_max_epi8(packedbytes, Zero)
   #else
               _mm_subs_epi8(_mm_adds_epi8(packedbytes, k0x80s), k0x80s)
   #endif
@@ -204,7 +201,7 @@ namespace Stockfish::Eval::NNUE {
 
   #elif defined(USE_MMX)
         auto out = reinterpret_cast<__m64*>(&output[offset]);
-        for (IndexType j = 0; j < kNumChunks; ++j) {
+        for (IndexType j = 0; j < NumChunks; ++j) {
           __m64 sum0 = *(&reinterpret_cast<const __m64*>(
               accumulation[perspectives[p]][0])[j * 2 + 0]);
           __m64 sum1 = *(&reinterpret_cast<const __m64*>(
@@ -215,14 +212,14 @@ namespace Stockfish::Eval::NNUE {
 
   #elif defined(USE_NEON)
         const auto out = reinterpret_cast<int8x8_t*>(&output[offset]);
-        for (IndexType j = 0; j < kNumChunks; ++j) {
+        for (IndexType j = 0; j < NumChunks; ++j) {
           int16x8_t sum = reinterpret_cast<const int16x8_t*>(
               accumulation[perspectives[p]][0])[j];
-          out[j] = vmax_s8(vqmovn_s16(sum), kZero);
+          out[j] = vmax_s8(vqmovn_s16(sum), Zero);
         }
 
   #else
-        for (IndexType j = 0; j < kHalfDimensions; ++j) {
+        for (IndexType j = 0; j < HalfDimensions; ++j) {
           BiasType sum = accumulation[static_cast<int>(perspectives[p])][0][j];
           output[offset + j] = static_cast<OutputType>(
               std::max<int>(0, std::min<int>(127, sum)));
@@ -236,12 +233,12 @@ namespace Stockfish::Eval::NNUE {
     }
 
    private:
-    void UpdateAccumulator(const Position& pos, const Color c) const {
+    void update_accumulator(const Position& pos, const Color c) const {
 
   #ifdef VECTOR
       // Gcc-10.2 unnecessarily spills AVX2 registers if this array
       // is defined in the VECTOR code below, once in each branch
-      vec_t acc[kNumRegs];
+      vec_t acc[NumRegs];
   #endif
 
       // Look for a usable accumulator of an earlier position. We keep track
@@ -254,8 +251,8 @@ namespace Stockfish::Eval::NNUE {
         // The first condition tests whether an incremental update is
         // possible at all: if this side's king has moved, it is not possible.
         static_assert(std::is_same_v<RawFeatures::SortedTriggerSet,
-              Features::CompileTimeList<Features::TriggerEvent, Features::TriggerEvent::kFriendKingMoved>>,
-              "Current code assumes that only kFriendlyKingMoved refresh trigger is being used.");
+              Features::CompileTimeList<Features::TriggerEvent, Features::TriggerEvent::FriendKingMoved>>,
+              "Current code assumes that only FriendlyKingMoved refresh trigger is being used.");
         if (   dp.piece[0] == make_piece(c, KING)
             || (gain -= dp.dirty_num + 1) < 0)
           break;
@@ -273,13 +270,13 @@ namespace Stockfish::Eval::NNUE {
 
         // Gather all features to be updated. This code assumes HalfKP features
         // only and doesn't support refresh triggers.
-        static_assert(std::is_same_v<Features::FeatureSet<Features::HalfKP<Features::Side::kFriend>>,
+        static_assert(std::is_same_v<Features::FeatureSet<Features::HalfKP<Features::Side::Friend>>,
                                      RawFeatures>);
         Features::IndexList removed[2], added[2];
-        Features::HalfKP<Features::Side::kFriend>::AppendChangedIndices(pos,
+        Features::HalfKP<Features::Side::Friend>::append_changed_indices(pos,
             next->dirtyPiece, c, &removed[0], &added[0]);
         for (StateInfo *st2 = pos.state(); st2 != next; st2 = st2->previous)
-          Features::HalfKP<Features::Side::kFriend>::AppendChangedIndices(pos,
+          Features::HalfKP<Features::Side::Friend>::append_changed_indices(pos,
               st2->dirtyPiece, c, &removed[1], &added[1]);
 
         // Mark the accumulators as computed.
@@ -290,12 +287,12 @@ namespace Stockfish::Eval::NNUE {
         StateInfo *info[3] =
           { next, next == pos.state() ? nullptr : pos.state(), nullptr };
   #ifdef VECTOR
-        for (IndexType j = 0; j < kHalfDimensions / kTileHeight; ++j)
+        for (IndexType j = 0; j < HalfDimensions / TileHeight; ++j)
         {
           // Load accumulator
           auto accTile = reinterpret_cast<vec_t*>(
-            &st->accumulator.accumulation[c][0][j * kTileHeight]);
-          for (IndexType k = 0; k < kNumRegs; ++k)
+            &st->accumulator.accumulation[c][0][j * TileHeight]);
+          for (IndexType k = 0; k < NumRegs; ++k)
             acc[k] = vec_load(&accTile[k]);
 
           for (IndexType i = 0; info[i]; ++i)
@@ -303,25 +300,25 @@ namespace Stockfish::Eval::NNUE {
             // Difference calculation for the deactivated features
             for (const auto index : removed[i])
             {
-              const IndexType offset = kHalfDimensions * index + j * kTileHeight;
-              auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
-              for (IndexType k = 0; k < kNumRegs; ++k)
+              const IndexType offset = HalfDimensions * index + j * TileHeight;
+              auto column = reinterpret_cast<const vec_t*>(&weights[offset]);
+              for (IndexType k = 0; k < NumRegs; ++k)
                 acc[k] = vec_sub_16(acc[k], column[k]);
             }
 
             // Difference calculation for the activated features
             for (const auto index : added[i])
             {
-              const IndexType offset = kHalfDimensions * index + j * kTileHeight;
-              auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
-              for (IndexType k = 0; k < kNumRegs; ++k)
+              const IndexType offset = HalfDimensions * index + j * TileHeight;
+              auto column = reinterpret_cast<const vec_t*>(&weights[offset]);
+              for (IndexType k = 0; k < NumRegs; ++k)
                 acc[k] = vec_add_16(acc[k], column[k]);
             }
 
             // Store accumulator
             accTile = reinterpret_cast<vec_t*>(
-              &info[i]->accumulator.accumulation[c][0][j * kTileHeight]);
-            for (IndexType k = 0; k < kNumRegs; ++k)
+              &info[i]->accumulator.accumulation[c][0][j * TileHeight]);
+            for (IndexType k = 0; k < NumRegs; ++k)
               vec_store(&accTile[k], acc[k]);
           }
         }
@@ -331,25 +328,25 @@ namespace Stockfish::Eval::NNUE {
         {
           std::memcpy(info[i]->accumulator.accumulation[c][0],
               st->accumulator.accumulation[c][0],
-              kHalfDimensions * sizeof(BiasType));
+              HalfDimensions * sizeof(BiasType));
           st = info[i];
 
           // Difference calculation for the deactivated features
           for (const auto index : removed[i])
           {
-            const IndexType offset = kHalfDimensions * index;
+            const IndexType offset = HalfDimensions * index;
 
-            for (IndexType j = 0; j < kHalfDimensions; ++j)
-              st->accumulator.accumulation[c][0][j] -= weights_[offset + j];
+            for (IndexType j = 0; j < HalfDimensions; ++j)
+              st->accumulator.accumulation[c][0][j] -= weights[offset + j];
           }
 
           // Difference calculation for the activated features
           for (const auto index : added[i])
           {
-            const IndexType offset = kHalfDimensions * index;
+            const IndexType offset = HalfDimensions * index;
 
-            for (IndexType j = 0; j < kHalfDimensions; ++j)
-              st->accumulator.accumulation[c][0][j] += weights_[offset + j];
+            for (IndexType j = 0; j < HalfDimensions; ++j)
+              st->accumulator.accumulation[c][0][j] += weights[offset + j];
           }
         }
   #endif
@@ -360,41 +357,41 @@ namespace Stockfish::Eval::NNUE {
         auto& accumulator = pos.state()->accumulator;
         accumulator.state[c] = COMPUTED;
         Features::IndexList active;
-        Features::HalfKP<Features::Side::kFriend>::AppendActiveIndices(pos, c, &active);
+        Features::HalfKP<Features::Side::Friend>::append_active_indices(pos, c, &active);
 
   #ifdef VECTOR
-        for (IndexType j = 0; j < kHalfDimensions / kTileHeight; ++j)
+        for (IndexType j = 0; j < HalfDimensions / TileHeight; ++j)
         {
           auto biasesTile = reinterpret_cast<const vec_t*>(
-              &biases_[j * kTileHeight]);
-          for (IndexType k = 0; k < kNumRegs; ++k)
+              &biases[j * TileHeight]);
+          for (IndexType k = 0; k < NumRegs; ++k)
             acc[k] = biasesTile[k];
 
           for (const auto index : active)
           {
-            const IndexType offset = kHalfDimensions * index + j * kTileHeight;
-            auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
+            const IndexType offset = HalfDimensions * index + j * TileHeight;
+            auto column = reinterpret_cast<const vec_t*>(&weights[offset]);
 
-            for (unsigned k = 0; k < kNumRegs; ++k)
+            for (unsigned k = 0; k < NumRegs; ++k)
               acc[k] = vec_add_16(acc[k], column[k]);
           }
 
           auto accTile = reinterpret_cast<vec_t*>(
-              &accumulator.accumulation[c][0][j * kTileHeight]);
-          for (unsigned k = 0; k < kNumRegs; k++)
+              &accumulator.accumulation[c][0][j * TileHeight]);
+          for (unsigned k = 0; k < NumRegs; k++)
             vec_store(&accTile[k], acc[k]);
         }
 
   #else
-        std::memcpy(accumulator.accumulation[c][0], biases_,
-            kHalfDimensions * sizeof(BiasType));
+        std::memcpy(accumulator.accumulation[c][0], biases,
+            HalfDimensions * sizeof(BiasType));
 
         for (const auto index : active)
         {
-          const IndexType offset = kHalfDimensions * index;
+          const IndexType offset = HalfDimensions * index;
 
-          for (IndexType j = 0; j < kHalfDimensions; ++j)
-            accumulator.accumulation[c][0][j] += weights_[offset + j];
+          for (IndexType j = 0; j < HalfDimensions; ++j)
+            accumulator.accumulation[c][0][j] += weights[offset + j];
         }
   #endif
       }
@@ -407,9 +404,9 @@ namespace Stockfish::Eval::NNUE {
     using BiasType = std::int16_t;
     using WeightType = std::int16_t;
 
-    alignas(kCacheLineSize) BiasType biases_[kHalfDimensions];
-    alignas(kCacheLineSize)
-        WeightType weights_[kHalfDimensions * kInputDimensions];
+    alignas(CacheLineSize) BiasType biases[HalfDimensions];
+    alignas(CacheLineSize)
+        WeightType weights[HalfDimensions * InputDimensions];
   };
 
 }  // namespace Stockfish::Eval::NNUE

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -79,7 +79,7 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
       && !pos.can_castle(ANY_CASTLING))
   {
       StateInfo st;
-      ASSERT_ALIGNED(&st, Eval::NNUE::kCacheLineSize);
+      ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
 
       Position p;
       p.set(pos.fen(), pos.is_chess960(), &st, pos.this_thread());
@@ -1315,7 +1315,7 @@ bool Position::pos_is_ok() const {
               assert(0 && "pos_is_ok: Bitboards");
 
   StateInfo si = *st;
-  ASSERT_ALIGNED(&si, Eval::NNUE::kCacheLineSize);
+  ASSERT_ALIGNED(&si, Eval::NNUE::CacheLineSize);
 
   set_state(&si);
   if (std::memcmp(&si, st, sizeof(StateInfo)))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -165,7 +165,7 @@ namespace {
   uint64_t perft(Position& pos, Depth depth) {
 
     StateInfo st;
-    ASSERT_ALIGNED(&st, Eval::NNUE::kCacheLineSize);
+    ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
 
     uint64_t cnt, nodes = 0;
     const bool leaf = (depth == 2);
@@ -597,7 +597,7 @@ namespace {
 
     Move pv[MAX_PLY+1], capturesSearched[32], quietsSearched[64];
     StateInfo st;
-    ASSERT_ALIGNED(&st, Eval::NNUE::kCacheLineSize);
+    ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
 
     TTEntry* tte;
     Key posKey;
@@ -1458,7 +1458,7 @@ moves_loop: // When in check, search starts from here
 
     Move pv[MAX_PLY+1];
     StateInfo st;
-    ASSERT_ALIGNED(&st, Eval::NNUE::kCacheLineSize);
+    ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
 
     TTEntry* tte;
     Key posKey;
@@ -1964,7 +1964,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
 bool RootMove::extract_ponder_from_tt(Position& pos) {
 
     StateInfo st;
-    ASSERT_ALIGNED(&st, Eval::NNUE::kCacheLineSize);
+    ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
 
     bool ttHit;
 


### PR DESCRIPTION
I tried to push this once on the nodchip branch but it was half overwritten by a merge. I think this is a good time to attempt this (after that I want to remove some useless clutter that is not longer needed in the nnue implementation now). I understand that it's a lot of changes, but IMO it should be done at some point. Now there is nothing blocking us, the nodchip trainer is pretty dead and was already hard to merge. A new branch with tools for data generation and other stuff is already close to official-stockfish/master and should be easy to merge. I want to know what's the stance of others on this.