### PR TITLE
Thread based reduction tweak.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1185,7 +1185,8 @@ moves_loop: // When in check, search starts from here
               || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha
               || cutNode
               || (!PvNode && !formerPv && captureHistory[movedPiece][to_sq(move)][type_of(pos.captured_piece())] < 3678)
-              || thisThread->ttHitAverage < 432 * TtHitAverageResolution * TtHitAverageWindow / 1024))
+              || thisThread->ttHitAverage < 432 * TtHitAverageResolution * TtHitAverageWindow / 1024)
+          && (!PvNode || ss->ply > 1 || thisThread->id() % 4 != 3))
       {
           Depth r = reduction(improving, depth, moveCount);
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -55,6 +55,7 @@ public:
   void idle_loop();
   void start_searching();
   void wait_for_search_finished();
+  int id() const { return idx; }
 
   Pawns::Table pawnsTable;
   Material::Table materialTable;


### PR DESCRIPTION
For PV nodes at the first two plies no reductions are done for each fourth thread.

STC (8 threads):
LLR: 2.94 (-2.94,2.94) <-0.50,2.50>
Total: 53992 W: 3334 L: 3167 D: 47491
Ptnml(0-2): 64, 2713, 21285, 2860, 74
https://tests.stockfishchess.org/tests/view/6083b2d695e7f1852abd277a

LTC (8 threads):
LLR: 2.93 (-2.94,2.94) <0.50,3.50>
Total: 64888 W: 1888 L: 1725 D: 61275
Ptnml(0-2): 14, 1556, 29146, 1709, 19
https://tests.stockfishchess.org/tests/view/6084249595e7f1852abd2795

No functional change (for one thread)