### PR TITLE
Use more time if losing - how to progress?

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -507,10 +507,9 @@ void Thread::search() {
           && !mainThread->stopOnPonderhit)
       {
           double fallingEval = (318 + 6 * (mainThread->bestPreviousScore - bestValue)
-                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)
-                                    + std::clamp(int(-bestValue) - 100, 0, 200) / 4
-                               ) / 825.0;
-          fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
+                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)) / 825.0;
+          fallingEval =  std::clamp(fallingEval, 0.5, 1.5)
+                       + std::clamp(int(-bestValue) - 100, 0, 200) / 16;
 
           // If the bestMove is stable over several iterations, reduce time accordingly
           timeReduction = lastBestMoveDepth + 9 < completedDepth ? 1.92 : 0.95;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -189,8 +189,6 @@ namespace {
 
 } // namespace
 
-int A = 120, B = 120, C = 128;
-TUNE(A, B, C);
 
 /// Search::init() is called at startup to initialize various lookup tables
 
@@ -508,9 +506,9 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (318 + A * (mainThread->bestPreviousScore - bestValue) / 20
-                                    + B * (mainThread->iterValue[iterIdx] - bestValue) / 20
-                                    + std::clamp(int(-bestValue) - 100, 0, 200) * C / 512
+          double fallingEval = (318 + 4 * (mainThread->bestPreviousScore - bestValue)
+                                    + 4 * (mainThread->iterValue[iterIdx] - bestValue)
+                                    + std::clamp(int(-bestValue) - 100, 0, 200) / 4
                                ) / 825.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -189,6 +189,8 @@ namespace {
 
 } // namespace
 
+int A = 120, B = 120, C = 128, D = 100, E = 100;
+TUNE(A, B, C, D, E);
 
 /// Search::init() is called at startup to initialize various lookup tables
 
@@ -506,10 +508,10 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (3180 +  67 * (mainThread->bestPreviousScore - bestValue)
-                                     +  71 * (mainThread->iterValue[iterIdx] - bestValue)
-                                     + 450 * std::clamp(int(-bestValue) - 100, 0, 200) / 256
-                               ) / 8250.0;
+          double fallingEval = (318 + A * (mainThread->bestPreviousScore - bestValue) / 20
+                                    + B * (mainThread->iterValue[iterIdx] - bestValue) / 20
+                                    + std::clamp(int(-bestValue) - D, 0, 2 * E) * C / 512
+                               ) / 825.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 
           // If the bestMove is stable over several iterations, reduce time accordingly

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -507,10 +507,9 @@ void Thread::search() {
           && !mainThread->stopOnPonderhit)
       {
           double fallingEval = (318 + 6 * (mainThread->bestPreviousScore - bestValue)
-                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)
-                                    + std::clamp(int(-bestValue) - 100, 0, 200) / 8
-                               ) / 825.0;
-          fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
+                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)) / 825.0;
+          fallingEval =  std::clamp(fallingEval, 0.5, 1.5)
+                       + std::clamp(int(-bestValue) - 100, 0, 200) / 13200.0;
 
           // If the bestMove is stable over several iterations, reduce time accordingly
           timeReduction = lastBestMoveDepth + 9 < completedDepth ? 1.92 : 0.95;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -508,7 +508,7 @@ void Thread::search() {
       {
           double fallingEval = (3180 +  67 * (mainThread->bestPreviousScore - bestValue)
                                      +  71 * (mainThread->iterValue[iterIdx] - bestValue)
-                                     + 490 * std::clamp(int(-bestValue) - 100, 0, 200) / 256
+                                     + 410 * std::clamp(int(-bestValue) - 100, 0, 200) / 256
                                ) / 8250.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -507,9 +507,10 @@ void Thread::search() {
           && !mainThread->stopOnPonderhit)
       {
           double fallingEval = (318 + 6 * (mainThread->bestPreviousScore - bestValue)
-                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)) / 825.0;
-          fallingEval =  std::clamp(fallingEval, 0.5, 1.5)
-                       + std::clamp(int(-bestValue) - 100, 0, 200) / 13200.0;
+                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)
+                                    + std::clamp(int(-bestValue), 0, 200) / 4
+                               ) / 825.0;
+          fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 
           // If the bestMove is stable over several iterations, reduce time accordingly
           timeReduction = lastBestMoveDepth + 9 < completedDepth ? 1.92 : 0.95;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -189,7 +189,7 @@ namespace {
 
 } // namespace
 
-int A = 120, B = 120, C = 128, D = 100, E = 100;
+int A = 124, B = 164, C = 60, D = 100, E = 100;
 TUNE(A, B, C, D, E);
 
 /// Search::init() is called at startup to initialize various lookup tables

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -509,7 +509,7 @@ void Thread::search() {
           double fallingEval = (318 + 6 * (mainThread->bestPreviousScore - bestValue)
                                     + 6 * (mainThread->iterValue[iterIdx] - bestValue)) / 825.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5)
-                       + std::clamp(int(-bestValue) - 100, 0, 200) / 3300.0;
+                       + std::clamp(int(-bestValue) - 100, 0, 200) / 13200.0;
 
           // If the bestMove is stable over several iterations, reduce time accordingly
           timeReduction = lastBestMoveDepth + 9 < completedDepth ? 1.92 : 0.95;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -507,9 +507,10 @@ void Thread::search() {
           && !mainThread->stopOnPonderhit)
       {
           double fallingEval = (318 + 6 * (mainThread->bestPreviousScore - bestValue)
-                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)) / 825.0;
-          fallingEval =  std::clamp(fallingEval, 0.5, 1.5)
-                       + std::clamp(int(-bestValue) - 100, 0, 200) / 13200.0;
+                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)
+                                    + std::clamp(int(-bestValue) - 100, 0, 200) / 8
+                               ) / 825.0;
+          fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 
           // If the bestMove is stable over several iterations, reduce time accordingly
           timeReduction = lastBestMoveDepth + 9 < completedDepth ? 1.92 : 0.95;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -506,9 +506,9 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (3180 +  74 * (mainThread->bestPreviousScore - bestValue)
-                                     +  96 * (mainThread->iterValue[iterIdx] - bestValue)
-                                     + 316 * std::clamp(int(-bestValue) - 117, 0, 232) / 256
+          double fallingEval = (3180 +  62 * (mainThread->bestPreviousScore - bestValue)
+                                     +  63 * (mainThread->iterValue[iterIdx] - bestValue)
+                                     + 228 * std::clamp(int(-bestValue) - 75, 0, 228) / 256
                                ) / 8250.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -506,8 +506,8 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (318 + 4 * (mainThread->bestPreviousScore - bestValue)
-                                    + 4 * (mainThread->iterValue[iterIdx] - bestValue)
+          double fallingEval = (318 + 2 * (mainThread->bestPreviousScore - bestValue)
+                                    + 2 * (mainThread->iterValue[iterIdx] - bestValue)
                                     + std::clamp(int(-bestValue) - 100, 0, 200) / 2
                                ) / 825.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -189,8 +189,6 @@ namespace {
 
 } // namespace
 
-int A = 124, B = 164, C = 60, D = 100, E = 100;
-TUNE(A, B, C, D, E);
 
 /// Search::init() is called at startup to initialize various lookup tables
 
@@ -508,10 +506,10 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (318 + A * (mainThread->bestPreviousScore - bestValue) / 20
-                                    + B * (mainThread->iterValue[iterIdx] - bestValue) / 20
-                                    + std::clamp(int(-bestValue) - D, 0, 2 * E) * C / 512
-                               ) / 825.0;
+          double fallingEval = (3180 +  64 * (mainThread->bestPreviousScore - bestValue)
+                                     +  79 * (mainThread->iterValue[iterIdx] - bestValue)
+                                     + 325 * std::clamp(int(-bestValue) - 100, 0, 200) / 256
+                               ) / 8250.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 
           // If the bestMove is stable over several iterations, reduce time accordingly

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -506,9 +506,9 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (3180 +  62 * (mainThread->bestPreviousScore - bestValue)
-                                     +  63 * (mainThread->iterValue[iterIdx] - bestValue)
-                                     + 228 * std::clamp(int(-bestValue) - 75, 0, 228) / 256
+          double fallingEval = (3180 +  89 * (mainThread->bestPreviousScore - bestValue)
+                                     +  87 * (mainThread->iterValue[iterIdx] - bestValue)
+                                     + 367 * std::clamp(int(-bestValue) - 111, 0, 307) / 256
                                ) / 8250.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -506,9 +506,9 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (3180 +  64 * (mainThread->bestPreviousScore - bestValue)
-                                     +  79 * (mainThread->iterValue[iterIdx] - bestValue)
-                                     + 325 * std::clamp(int(-bestValue) - 100, 0, 200) / 256
+          double fallingEval = (3180 +  62 * (mainThread->bestPreviousScore - bestValue)
+                                     +  70 * (mainThread->iterValue[iterIdx] - bestValue)
+                                     + 490 * std::clamp(int(-bestValue) - 100, 0, 200) / 256
                                ) / 8250.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -506,9 +506,9 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (3180 +  62 * (mainThread->bestPreviousScore - bestValue)
-                                     +  70 * (mainThread->iterValue[iterIdx] - bestValue)
-                                     + 490 * std::clamp(int(-bestValue) - 100, 0, 200) / 256
+          double fallingEval = (3180 +  67 * (mainThread->bestPreviousScore - bestValue)
+                                     +  71 * (mainThread->iterValue[iterIdx] - bestValue)
+                                     + 450 * std::clamp(int(-bestValue) - 80, 0, 200) / 256
                                ) / 8250.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -507,9 +507,10 @@ void Thread::search() {
           && !mainThread->stopOnPonderhit)
       {
           double fallingEval = (318 + 6 * (mainThread->bestPreviousScore - bestValue)
-                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)) / 825.0;
-          fallingEval =  std::clamp(fallingEval, 0.5, 1.5)
-                       + std::clamp(int(-bestValue) - 100, 0, 200) / 4;
+                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)
+                                    + std::clamp(int(-bestValue) - 100, 0, 200) / 4
+                               ) / 825.0;
+          fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 
           // If the bestMove is stable over several iterations, reduce time accordingly
           timeReduction = lastBestMoveDepth + 9 < completedDepth ? 1.92 : 0.95;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -506,9 +506,9 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (318 + 6 * (mainThread->bestPreviousScore - bestValue)
-                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)
-                                    + std::clamp(int(-bestValue) - 200, 0, 200) / 4
+          double fallingEval = (318 + 4 * (mainThread->bestPreviousScore - bestValue)
+                                    + 4 * (mainThread->iterValue[iterIdx] - bestValue)
+                                    + std::clamp(int(-bestValue) - 100, 0, 200) / 2
                                ) / 825.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -509,7 +509,7 @@ void Thread::search() {
           double fallingEval = (318 + 6 * (mainThread->bestPreviousScore - bestValue)
                                     + 6 * (mainThread->iterValue[iterIdx] - bestValue)) / 825.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5)
-                       + std::clamp(int(-bestValue) - 100, 0, 200) / 16;
+                       + std::clamp(int(-bestValue) - 100, 0, 200) / 3300.0;
 
           // If the bestMove is stable over several iterations, reduce time accordingly
           timeReduction = lastBestMoveDepth + 9 < completedDepth ? 1.92 : 0.95;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -506,9 +506,9 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (3180 +  89 * (mainThread->bestPreviousScore - bestValue)
-                                     +  87 * (mainThread->iterValue[iterIdx] - bestValue)
-                                     + 400 * std::clamp(int(-bestValue) - 105, 0, 320) / 256
+          double fallingEval = (3180 + 104 * (mainThread->bestPreviousScore - bestValue)
+                                     + 111 * (mainThread->iterValue[iterIdx] - bestValue)
+                                     + 405 * std::clamp(int(-bestValue) - 113, 0, 333) / 256
                                ) / 8250.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -508,7 +508,7 @@ void Thread::search() {
       {
           double fallingEval = (3180 +  67 * (mainThread->bestPreviousScore - bestValue)
                                      +  71 * (mainThread->iterValue[iterIdx] - bestValue)
-                                     + 450 * std::clamp(int(-bestValue) - 80, 0, 200) / 256
+                                     + 490 * std::clamp(int(-bestValue) - 100, 0, 200) / 256
                                ) / 8250.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -506,9 +506,9 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (3180 +  67 * (mainThread->bestPreviousScore - bestValue)
-                                     +  71 * (mainThread->iterValue[iterIdx] - bestValue)
-                                     + 410 * std::clamp(int(-bestValue) - 100, 0, 200) / 256
+          double fallingEval = (3180 +  74 * (mainThread->bestPreviousScore - bestValue)
+                                     +  96 * (mainThread->iterValue[iterIdx] - bestValue)
+                                     + 316 * std::clamp(int(-bestValue) - 117, 0, 232) / 256
                                ) / 8250.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -508,7 +508,7 @@ void Thread::search() {
       {
           double fallingEval = (3180 +  89 * (mainThread->bestPreviousScore - bestValue)
                                      +  87 * (mainThread->iterValue[iterIdx] - bestValue)
-                                     + 367 * std::clamp(int(-bestValue) - 111, 0, 307) / 256
+                                     + 400 * std::clamp(int(-bestValue) - 105, 0, 320) / 256
                                ) / 8250.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -508,7 +508,7 @@ void Thread::search() {
       {
           double fallingEval = (318 + 6 * (mainThread->bestPreviousScore - bestValue)
                                     + 6 * (mainThread->iterValue[iterIdx] - bestValue)
-                                    + std::clamp(int(-bestValue), 0, 200) / 4
+                                    + std::clamp(int(-bestValue) - 200, 0, 200) / 4
                                ) / 825.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -506,10 +506,10 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (318 + 4 * (mainThread->bestPreviousScore - bestValue)
-                                    + 4 * (mainThread->iterValue[iterIdx] - bestValue)
-                                    + std::clamp(int(-bestValue) - 100, 0, 200) / 4
-                               ) / 825.0;
+          double fallingEval = (3180 +  67 * (mainThread->bestPreviousScore - bestValue)
+                                     +  71 * (mainThread->iterValue[iterIdx] - bestValue)
+                                     + 450 * std::clamp(int(-bestValue) - 100, 0, 200) / 256
+                               ) / 8250.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 
           // If the bestMove is stable over several iterations, reduce time accordingly

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -509,7 +509,7 @@ void Thread::search() {
           double fallingEval = (318 + 6 * (mainThread->bestPreviousScore - bestValue)
                                     + 6 * (mainThread->iterValue[iterIdx] - bestValue)) / 825.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5)
-                       + std::clamp(int(-bestValue) - 100, 0, 200);
+                       + std::clamp(int(-bestValue) - 100, 0, 200) / 4;
 
           // If the bestMove is stable over several iterations, reduce time accordingly
           timeReduction = lastBestMoveDepth + 9 < completedDepth ? 1.92 : 0.95;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -189,6 +189,8 @@ namespace {
 
 } // namespace
 
+int A = 120, B = 120, C = 128;
+TUNE(A, B, C);
 
 /// Search::init() is called at startup to initialize various lookup tables
 
@@ -506,9 +508,9 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (318 + 2 * (mainThread->bestPreviousScore - bestValue)
-                                    + 2 * (mainThread->iterValue[iterIdx] - bestValue)
-                                    + std::clamp(int(-bestValue) - 100, 0, 200) / 2
+          double fallingEval = (318 + A * (mainThread->bestPreviousScore - bestValue) / 20
+                                    + B * (mainThread->iterValue[iterIdx] - bestValue) / 20
+                                    + std::clamp(int(-bestValue) - 100, 0, 200) * C / 512
                                ) / 825.0;
           fallingEval =  std::clamp(fallingEval, 0.5, 1.5);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -507,7 +507,9 @@ void Thread::search() {
           && !mainThread->stopOnPonderhit)
       {
           double fallingEval = (318 + 6 * (mainThread->bestPreviousScore - bestValue)
-                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)) / 825.0;
+                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)
+                                    + std::clamp(int(-bestValue) - 100, 0, 200))
+                               / 825.0;
           fallingEval = std::clamp(fallingEval, 0.5, 1.5);
 
           // If the bestMove is stable over several iterations, reduce time accordingly

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -507,10 +507,9 @@ void Thread::search() {
           && !mainThread->stopOnPonderhit)
       {
           double fallingEval = (318 + 6 * (mainThread->bestPreviousScore - bestValue)
-                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)
-                                    + std::clamp(int(-bestValue) - 100, 0, 200))
-                               / 825.0;
-          fallingEval = std::clamp(fallingEval, 0.5, 1.5);
+                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)) / 825.0;
+          fallingEval =  std::clamp(fallingEval, 0.5, 1.5)
+                       + std::clamp(int(-bestValue) - 100, 0, 200);
 
           // If the bestMove is stable over several iterations, reduce time accordingly
           timeReduction = lastBestMoveDepth + 9 < completedDepth ? 1.92 : 0.95;


### PR DESCRIPTION
It appears that stockfish could sometimes benefit from moving slower when in tricky positions - moving too quickly and making a fatal mistake seems like a bad idea. This idea was tuned at LTC and the following initial test at LTC has passed:

Initial LTC:
LLR: 2.94 (-2.94,2.94) <0.50,3.50>
Total: 61480 W: 2426 L: 2243 D: 56811
Ptnml(0-2): 31, 1930, 26628, 2127, 24
https://tests.stockfishchess.org/tests/view/6083d4e295e7f1852abd2786

How should we progress from here?

I can run STC, but based on earlier tests I suspect that will fail, it seems to need either the longer tc with higher quality games or the specific tc it was tuned at (no idea which part is the significant one).

[ Obviously this branch is messy at the moment, but I see no point in tidying it up yet, just creating the PR to get discussion / direction from maintainers ]

Edit: Also thanks to @QuackQuackBlah for doing the first ltc tune :-) I was thinking of doing that after trying at 20+0.2 but it's possible I would have given up without trying ltc