### PR TITLE
Tweak extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1130,6 +1130,8 @@ moves_loop: // When in check, search starts from here
           {
               extension = 1;
               singularQuietLMR = !ttCapture;
+              if (!PvNode && value < singularBeta - 140)
+                  extension = 2;
           }
 
           // Multi-cut pruning


### PR DESCRIPTION
More extensions for non-PV nodes if value from singular extension search is significantly below singularBeta.

Passed STC:
LLR: 2.97 (-2.94,2.94) <-0.50,2.50>
Total: 25064 W: 2334 L: 2162 D: 20568
Ptnml(0-2): 82, 1720, 8768, 1868, 94
https://tests.stockfishchess.org/tests/view/6084ba7995e7f1852abd27e3

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,3.50>
Total: 67136 W: 2644 L: 2450 D: 62042
Ptnml(0-2): 46, 2134, 28990, 2376, 22
https://tests.stockfishchess.org/tests/view/6084d79195e7f1852abd27ee

Bench: 4075325