### PR TITLE
Simplify check extension

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -115,7 +115,6 @@ public:
   Bitboard blockers_for_king(Color c) const;
   Bitboard check_squares(PieceType pt) const;
   Bitboard pinners(Color c) const;
-  bool is_discovered_check_on_king(Color c, Move m) const;
 
   // Attacks to/from a given square
   Bitboard attackers_to(Square s) const;
@@ -299,10 +298,6 @@ inline Bitboard Position::pinners(Color c) const {
 
 inline Bitboard Position::check_squares(PieceType pt) const {
   return st->checkSquares[pt];
-}
-
-inline bool Position::is_discovered_check_on_king(Color c, Move m) const {
-  return st->blockersForKing[c] & from_sq(m);
 }
 
 inline bool Position::pawn_passed(Color c, Square s) const {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1155,11 +1155,6 @@ moves_loop: // When in check, search starts from here
           }
       }
 
-      // Check extension (~2 Elo)
-      else if (    givesCheck
-               && (pos.is_discovered_check_on_king(~us, move) || pos.see_ge(move)))
-          extension = 1;
-
       // Add extension to new depth
       newDepth += extension;
 


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/608c18e995e7f1852abd2b81
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 54544 W: 4891 L: 4815 D: 44838
Ptnml(0-2): 186, 3889, 19081, 3895, 221

LTC https://tests.stockfishchess.org/tests/view/608c6ab195e7f1852abd2bc6
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 51008 W: 1845 L: 1794 D: 47369
Ptnml(0-2): 31, 1591, 22206, 1648, 28

bench: 3993071

Simplify check extension, as it seems not to bring any strength and thus is no longer needed.