### PR TITLE
Add an UCI level command "export_embedded_net".

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -47,7 +47,9 @@
 // Note that this does not work in Microsoft Visual Studio.
 #if !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
   INCBIN(EmbeddedNNUE, EvalFileDefaultName);
+  constexpr bool             gHasEmbeddedNet = true;
 #else
+  constexpr bool             gHasEmbeddedNet = false;
   const unsigned char        gEmbeddedNNUEData[1] = {0x0};
   const unsigned char *const gEmbeddedNNUEEnd = &gEmbeddedNNUEData[1];
   const unsigned int         gEmbeddedNNUESize = 1;
@@ -112,6 +114,15 @@ namespace Eval {
                     eval_file_loaded = eval_file;
             }
         }
+  }
+
+  void NNUE::export_embedded_net() {
+    if constexpr (gHasEmbeddedNet) {
+      ofstream stream(EvalFileDefaultName, std::ios_base::binary);
+      stream.write(reinterpret_cast<const char*>(gEmbeddedNNUEData), gEmbeddedNNUESize);
+    } else {
+      sync_cout << "No embedded network file." << sync_endl;
+    }
   }
 
   /// NNUE::verify() verifies that the last net used was loaded successfully

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -45,6 +45,7 @@ namespace Eval {
     Value evaluate(const Position& pos);
     bool load_eval(std::string name, std::istream& stream);
     void init();
+    void export_embedded_net();
     void verify();
 
   } // namespace NNUE

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -277,6 +277,7 @@ void UCI::loop(int argc, char* argv[]) {
       else if (token == "d")        sync_cout << pos << sync_endl;
       else if (token == "eval")     trace_eval(pos);
       else if (token == "compiler") sync_cout << compiler_info() << sync_endl;
+      else if (token == "export_embedded_net") Eval::NNUE::export_embedded_net();
       else if (!token.empty() && token[0] != '#')
           sync_cout << "Unknown command: " << cmd << sync_endl;
 


### PR DESCRIPTION
This command writes the embedded net to the file `EvalFileDefaultName`. If there is no embedded net the command does nothing.

Closes #3453 