### PR TITLE
Simplify LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1206,16 +1206,11 @@ moves_loop: // When in check, search starts from here
               && thisThread->bestMoveChanges <= 2)
               r++;
 
-          // More reductions for late moves if position was not in previous PV
-          if (   moveCountPruning
-              && !formerPv)
-              r++;
-
           // Decrease reduction if opponent's move count is high (~5 Elo)
           if ((ss-1)->moveCount > 13)
               r--;
 
-          // Decrease reduction if ttMove has been singularly extended (~3 Elo)
+          // Decrease reduction if ttMove has been singularly extended (~1 Elo)
           if (singularQuietLMR)
               r--;
 
@@ -1228,7 +1223,7 @@ moves_loop: // When in check, search starts from here
           }
           else
           {
-              // Increase reduction if ttMove is a capture (~5 Elo)
+              // Increase reduction if ttMove is a capture (~3 Elo)
               if (ttCapture)
                   r++;
 
@@ -1238,13 +1233,6 @@ moves_loop: // When in check, search starts from here
               // Increase reduction for cut nodes (~10 Elo)
               if (cutNode)
                   r += 2;
-
-              // Decrease reduction for moves that escape a capture. Filter out
-              // castling moves, because they are coded as "king captures rook" and
-              // hence break reverse_move() (~2 Elo)
-              else if (    type_of(move) == NORMAL
-                       && !pos.see_ge(reverse_move(move)))
-                  r -= 2 + ss->ttPv - (type_of(movedPiece) == PAWN);
 
               ss->statScore =  thisThread->mainHistory[us][from_to(move)]
                              + (*contHist[0])[movedPiece][to_sq(move)]


### PR DESCRIPTION
Simplify LMR, as it seems not to bring any strength and thus is no longer needed.

Tests for updating elo estimates:
https://tests.stockfishchess.org/tests/view/6099ff123a33eb67a844f789
https://tests.stockfishchess.org/tests/view/60953e6695e7f1852abd305b

Individual simplification tests:
https://tests.stockfishchess.org/tests/view/6098cfc73a33eb67a844f6a1
https://tests.stockfishchess.org/tests/view/6095539495e7f1852abd308b

LTC:
LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 96984 W: 3624 L: 3608 D: 89752
Ptnml(0-2): 45, 3222, 41939, 3244, 42
https://tests.stockfishchess.org/tests/view/6099921a3a33eb67a844f74f

bench: 3836428
