### PR TITLE
Remove coordination between searching threads

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -102,49 +102,6 @@ namespace {
     Move best = MOVE_NONE;
   };
 
-  // Breadcrumbs are used to mark nodes as being searched by a given thread
-  struct Breadcrumb {
-    std::atomic<Thread*> thread;
-    std::atomic<Key> key;
-  };
-  std::array<Breadcrumb, 1024> breadcrumbs;
-
-  // ThreadHolding structure keeps track of which thread left breadcrumbs at the given
-  // node for potential reductions. A free node will be marked upon entering the moves
-  // loop by the constructor, and unmarked upon leaving that loop by the destructor.
-  struct ThreadHolding {
-    explicit ThreadHolding(Thread* thisThread, Key posKey, int ply) {
-       location = ply < 8 ? &breadcrumbs[posKey & (breadcrumbs.size() - 1)] : nullptr;
-       otherThread = false;
-       owning = false;
-       if (location)
-       {
-          // See if another already marked this location, if not, mark it ourselves
-          Thread* tmp = (*location).thread.load(std::memory_order_relaxed);
-          if (tmp == nullptr)
-          {
-              (*location).thread.store(thisThread, std::memory_order_relaxed);
-              (*location).key.store(posKey, std::memory_order_relaxed);
-              owning = true;
-          }
-          else if (   tmp != thisThread
-                   && (*location).key.load(std::memory_order_relaxed) == posKey)
-              otherThread = true;
-       }
-    }
-
-    ~ThreadHolding() {
-       if (owning) // Free the marked location
-           (*location).thread.store(nullptr, std::memory_order_relaxed);
-    }
-
-    bool marked() { return otherThread; }
-
-    private:
-    Breadcrumb* location;
-    bool otherThread, owning;
-  };
-
   template <NodeType NT>
   Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, bool cutNode);
 
@@ -1013,9 +970,6 @@ moves_loop: // When in check, search starts from here
                          && (tte->bound() & BOUND_UPPER)
                          && tte->depth() >= depth;
 
-    // Mark this node as being searched
-    ThreadHolding th(thisThread, posKey, ss->ply);
-
     // Step 12. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
     while ((move = mp.next_move(moveCountPruning)) != MOVE_NONE)
@@ -1189,10 +1143,6 @@ moves_loop: // When in check, search starts from here
           // Decrease reduction if the ttHit running average is large
           if (thisThread->ttHitAverage > 537 * TtHitAverageResolution * TtHitAverageWindow / 1024)
               r--;
-
-          // Increase reduction if other threads are searching this position
-          if (th.marked())
-              r++;
 
           // Decrease reduction if position is or has been on the PV
           // and node is not likely to fail low. (~10 Elo)


### PR DESCRIPTION
In summary, this revert #2204, as it seems not to bring any strength anymore, so it's no long needed.

STC (5+0.05 @ 8 threads):
LLR: 2.96 (-2.94,2.94) <-2.50,0.50>
Total: 105728 W: 6406 L: 6393 D: 92929
Ptnml(0-2): 154, 5479, 41599, 5464, 168
https://tests.stockfishchess.org/tests/view/6096994095e7f1852abd3154

LTC (20+0.2 @ 8 threads):
LLR: 2.96 (-2.94,2.94) <-2.50,0.50>
Total: 26336 W: 774 L: 712 D: 24850
Ptnml(0-2): 9, 641, 11810, 695, 13
https://tests.stockfishchess.org/tests/view/6097c62995e7f1852abd31e8

No functional change.