### PR TITLE
Simplify LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1156,7 +1156,7 @@ moves_loop: // When in check, search starts from here
               && thisThread->bestMoveChanges <= 2)
               r++;
 
-          // Decrease reduction if opponent's move count is high (~5 Elo)
+          // Decrease reduction if opponent's move count is high (~1 Elo)
           if ((ss-1)->moveCount > 13)
               r--;
 
@@ -1164,14 +1164,7 @@ moves_loop: // When in check, search starts from here
           if (singularQuietLMR)
               r--;
 
-          if (captureOrPromotion)
-          {
-              // Increase reduction for non-checking captures likely to be bad
-              if (   !givesCheck
-                  && ss->staticEval + PieceValue[EG][pos.captured_piece()] + 210 * depth <= alpha)
-                  r++;
-          }
-          else
+          if (!captureOrPromotion)
           {
               // Increase reduction if ttMove is a capture (~3 Elo)
               if (ttCapture)


### PR DESCRIPTION
Simplify LMR as it seems not to bring any strength and thus is no longer needed..

elo estimative test:
https://tests.stockfishchess.org/tests/view/609af2a63a33eb67a844f867

STC:
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 55256 W: 4972 L: 4897 D: 45387
Ptnml(0-2): 177, 3976, 19234, 4077, 164
https://tests.stockfishchess.org/tests/view/609adf3b3a33eb67a844f842

LTC:
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 10344 W: 437 L: 353 D: 9554
Ptnml(0-2): 1, 322, 4449, 392, 8
https://tests.stockfishchess.org/tests/view/609b3dfa3a33eb67a844f88e

bench: 3840688