### PR TITLE
Simplify ProbCut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -847,7 +847,7 @@ namespace {
 
     probCutBeta = beta + 209 - 44 * improving;
 
-    // Step 9. ProbCut (~10 Elo)
+    // Step 9. ProbCut (~4 Elo)
     // If we have a good enough capture and a reduced search returns a value
     // much above beta, we can (almost) safely prune the previous move.
     if (   !PvNode
@@ -862,15 +862,6 @@ namespace {
              && ttValue != VALUE_NONE
              && ttValue < probCutBeta))
     {
-        // if ttMove is a capture and value from transposition table is good enough produce probCut
-        // cutoff without digging into actual probCut search
-        if (   ss->ttHit
-            && tte->depth() >= depth - 3
-            && ttValue != VALUE_NONE
-            && ttValue >= probCutBeta
-            && ttMove
-            && pos.capture_or_promotion(ttMove))
-            return probCutBeta;
 
         assert(probCutBeta < VALUE_INFINITE);
 


### PR DESCRIPTION
We simplify away early return in ProbCut, as it seems not to bring any strength anymore.

STC:
LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 42632 W: 3705 L: 3617 D: 35310
Ptnml(0-2): 123, 2947, 15110, 2991, 145
https://tests.stockfishchess.org/tests/view/609c49da7746e3dc74ffae02

LTC:
LLR: 2.96 (-2.94,2.94) <-2.50,0.50>
Total: 35384 W: 1314 L: 1251 D: 32819
Ptnml(0-2): 11, 1130, 15355, 1177, 19
https://tests.stockfishchess.org/tests/view/609c71467746e3dc74ffae47

---

While at it, we also update the Elo estimate of ProbCut
(see https://tests.stockfishchess.org/tests/view/609bfb597746e3dc74ffabe3).

bench: 3764662