### PR TITLE
Fix for cygwin's environment build-profile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -878,13 +878,13 @@ clang-profile-use:
 
 gcc-profile-make:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-generate' \
+	EXTRACXXFLAGS='-fprofile-generate="./"' \
 	EXTRALDFLAGS='-lgcov' \
 	all
 
 gcc-profile-use:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-use -fno-peel-loops -fno-tracer' \
+	EXTRACXXFLAGS='-fprofile-use="./" -fno-peel-loops -fno-tracer' \
 	EXTRALDFLAGS='-lgcov' \
 	all
 


### PR DESCRIPTION
Little fix for cygwin. Now 'build-profile' contains zero errors.
Errors:
```
...
libgcov profiling error:/home/Open/stockfish/Stockfish/src/bitbase.gcda:overwriting an existing profile data with a different timestamp
...
bitbase.cpp:172:1: warning: ‘/home/Open/stockfish/Stockfish/src/bitbase.gcda’ profile count data file not found [-Wmissing-profile]
  172 | } // namespace Stockfish
...
```
It's general solution to set the path in -fprofile-*=path options, maybe should use -fprofile-prefix-path=path option