### PR TITLE
Simplify LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1140,12 +1140,12 @@ moves_loop: // When in check, search starts from here
       {
           Depth r = reduction(improving, depth, moveCount);
 
-          // Decrease reduction if the ttHit running average is large
+          // Decrease reduction if the ttHit running average is large (~0 Elo)
           if (thisThread->ttHitAverage > 537 * TtHitAverageResolution * TtHitAverageWindow / 1024)
               r--;
 
           // Decrease reduction if position is or has been on the PV
-          // and node is not likely to fail low. (~10 Elo)
+          // and node is not likely to fail low. (~3 Elo)
           if (   ss->ttPv
               && !likelyFailLow)
               r -= 2;
@@ -1171,9 +1171,10 @@ moves_loop: // When in check, search starts from here
                   r++;
 
               // Increase reduction at root if failing high
-              r += rootNode ? thisThread->failedHighCnt * thisThread->failedHighCnt * moveCount / 512 : 0;
+              if (rootNode)
+                  r += thisThread->failedHighCnt * thisThread->failedHighCnt * moveCount / 512;
 
-              // Increase reduction for cut nodes (~10 Elo)
+              // Increase reduction for cut nodes (~3 Elo)
               if (cutNode)
                   r += 2;
 
@@ -1183,20 +1184,8 @@ moves_loop: // When in check, search starts from here
                              + (*contHist[3])[movedPiece][to_sq(move)]
                              - 4741;
 
-              // Decrease/increase reduction by comparing opponent's stat score (~10 Elo)
-              if (ss->statScore >= -89 && (ss-1)->statScore < -116)
-                  r--;
-
-              else if ((ss-1)->statScore >= -112 && ss->statScore < -100)
-                  r++;
-
               // Decrease/increase reduction for moves with a good/bad history (~30 Elo)
-              // If we are not in check use statScore, but if we are in check we use
-              // the sum of main history and first continuation history with an offset.
-              if (ss->inCheck)
-                  r -= (thisThread->mainHistory[us][from_to(move)]
-                     + (*contHist[0])[movedPiece][to_sq(move)] - 3833) / 16384;
-              else
+              if (!ss->inCheck)
                   r -= ss->statScore / 14790;
           }
 


### PR DESCRIPTION
We simplify parts of LMR, as it seems not to bring any strength anymore.

---

Individual Tests:
https://tests.stockfishchess.org/tests/view/609d1cc15085663412d0856a
https://tests.stockfishchess.org/tests/view/609cb0cc7746e3dc74ffae8d
https://tests.stockfishchess.org/tests/view/609d1c9f5085663412d08568

---

LTC:
LLR: 2.97 (-2.94,2.94) <-2.50,0.50>
Total: 84184 W: 3093 L: 3066 D: 78025
Ptnml(0-2): 47, 2755, 36458, 2788, 44
https://tests.stockfishchess.org/tests/view/609d84615085663412d08e2f

---

While at it, we also update the Elo estimate of the previous rule in LMR, see:
https://tests.stockfishchess.org/tests/view/609a933c3a33eb67a844f7ca
https://tests.stockfishchess.org/tests/view/609a959c3a33eb67a844f7d5
https://tests.stockfishchess.org/tests/view/609afff73a33eb67a844f870

---

bench: 4022442