### PR TITLE
Simplify away extra conditions in countermoves based pruning.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1035,7 +1035,7 @@ moves_loop: // When in check, search starts from here
           else
           {
               // Countermoves based pruning (~20 Elo)
-              if (   lmrDepth < 4 + ((ss-1)->statScore > 0 || (ss-1)->moveCount == 1)
+              if (   lmrDepth < 4
                   && (*contHist[0])[movedPiece][to_sq(move)] < CounterMovePruneThreshold
                   && (*contHist[1])[movedPiece][to_sq(move)] < CounterMovePruneThreshold)
                   continue;


### PR DESCRIPTION
passed STC 
https://tests.stockfishchess.org/tests/view/609e81f35085663412d08f31
LLR: 2.96 (-2.94,2.94) <-2.50,0.50>
Total: 28488 W: 2487 L: 2382 D: 23619
Ptnml(0-2): 87, 1919, 10123, 2032, 83 
passed LTC
https://tests.stockfishchess.org/tests/view/609e9c085085663412d08f59
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 33176 W: 1219 L: 1155 D: 30802
Ptnml(0-2): 13, 1036, 14423, 1106, 10 
This conditions (both of them) were introduced quite a long time ago via speculative LTCs and seem to no longer bring any benefit.
bench 4524255