### PR TITLE
Reintroduce Check Extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1098,6 +1098,12 @@ moves_loop: // When in check, search starts from here
           }
       }
 
+      // Check extension (~3 Elo on endgame)
+      else if (    givesCheck
+               &&  pos.non_pawn_material() < 2 * BishopValueMg + 2 * RookValueMg
+               && (pos.blockers_for_king(~us) & from_sq(move) || pos.see_ge(move)))
+          extension = 1;
+
       // Add extension to new depth
       newDepth += extension;
 


### PR DESCRIPTION
Reintroduce Check extension.

---
Endgame book:
STC:
LLR: 2.94 (-2.94,2.94) <-0.50,2.50>
Total: 16808 W: 3424 L: 3271 D: 10113
Ptnml(0-2): 3, 1215, 5816, 1366, 4
https://tests.stockfishchess.org/tests/view/60a2cd88e229097940a03c61

LTC:
LLR: 2.93 (-2.94,2.94) <0.50,3.50>
Total: 14856 W: 2874 L: 2734 D: 9248
Ptnml(0-2): 0, 737, 5814, 877, 0
https://tests.stockfishchess.org/tests/view/60a2d13de229097940a03c67

---
Standard book: 

STC:
LLR: 2.94 (-2.94,2.94) <-0.50,2.50>
Total: 25768 W: 2455 L: 2285 D: 21028
Ptnml(0-2): 79, 1759, 9048, 1909, 89
https://tests.stockfishchess.org/tests/view/60a1e38c5085663412d092d7

LTC:
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 34656 W: 1252 L: 1191 D: 32213
Ptnml(0-2): 14, 1026, 15188, 1085, 15
https://tests.stockfishchess.org/tests/view/60a2d7e4e229097940a03c7e

bench: 5085031