### PR TITLE
Do more continuation history based pruning.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1025,7 +1025,7 @@ moves_loop: // When in check, search starts from here
           else
           {
               // Continuation history based pruning (~20 Elo)
-              if (   lmrDepth < 4
+              if (   lmrDepth < 5
                   && (*contHist[0])[movedPiece][to_sq(move)] < CounterMovePruneThreshold
                   && (*contHist[1])[movedPiece][to_sq(move)] < CounterMovePruneThreshold)
                   continue;


### PR DESCRIPTION
Passed LTC with STC bounds 
https://tests.stockfishchess.org/tests/view/60a027395085663412d090ce
LLR: 2.93 (-2.94,2.94) <-0.50,2.50>
Total: 175256 W: 6774 L: 6548 D: 161934
Ptnml(0-2): 91, 5808, 75604, 6034, 91 
Passed VLTC with LTC bounds
https://tests.stockfishchess.org/tests/view/60a2bccce229097940a037a7
LLR: 2.96 (-2.94,2.94) <0.50,3.50>
Total: 65736 W: 1224 L: 1092 D: 63420
Ptnml(0-2): 5, 1012, 30706, 1136, 9 
This patch increases lmrDepth threshold for continuation history based pruning in search. 
This part of code for a long time was known to be really TC sensitive - decreasing this threshold easily passed lower time controls but failed badly at LTC, on the other hand it increase was part of a tuning that resulted in being negative at STC but was +12 elo at 180+1.8.  
After recent simplification of special conditions that sometimes increase it from 4 to 5 it was logical to overall test at longer time controls if 5 is better than 4 with deeper searches.  
Since there is an obvious time control dependence next logical thing to try there would be to try and implement varying threshold for this heuristic based on rootDepth of current thread.
bench 4368054