### PR TITLE
Additional statistics for gather_statistics

### DIFF
--- a/docs/stats.md
+++ b/docs/stats.md
@@ -29,3 +29,9 @@ Any name that doesn't designate an argument name or is not an argument will be i
 `move`, `moved_piece_type` - the number of times a piece of each type was moved
 
 `piece_count` - the histogram of the number of pieces on the board
+
+`ply_discontinuities` - the number of times the ply jumped by a value different than 1 between two consecutive positions. Usually the number of games.
+
+`material_imbalance` - the histogram of imbalances, with values computed using "simple eval", that is pawn=1, bishop=knight=3, rook=5, queen=9
+
+`results` - the distribution of game results

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -35,3 +35,5 @@ Any name that doesn't designate an argument name or is not an argument will be i
 `material_imbalance` - the histogram of imbalances, with values computed using "simple eval", that is pawn=1, bishop=knight=3, rook=5, queen=9
 
 `results` - the distribution of game results
+
+`endgames_6man` - distribution of endgame configurations for <=6 pieces (including kings)

--- a/src/tools/stats.cpp
+++ b/src/tools/stats.cpp
@@ -869,7 +869,18 @@ namespace Stockfish::Tools::Stats
             StatisticOutput out;
             auto& header = out.emplace_node<StatisticOutputEntryHeader>("Number of \"simple eval\" imbalances for white's perspective:");
             const int key_length = get_num_base_10_digits(max_imbalance) + 1;
+            int min_non_zero = max_imbalance;
+            int max_non_zero = -max_imbalance;
             for (int i = -max_imbalance; i <= max_imbalance; ++i)
+            {
+                if (m_num_imbalances[i + max_imbalance] != 0)
+                {
+                    min_non_zero = std::min(min_non_zero, i);
+                    max_non_zero = std::max(max_non_zero, i);
+                }
+            }
+
+            for (int i = min_non_zero; i <= max_non_zero; ++i)
             {
                 header.emplace_child<StatisticOutputEntryValue<std::uint64_t>>(
                     left_pad_to_length(std::to_string(i), ' ', key_length),


### PR DESCRIPTION
`ply_discontinuities` - the number of times the ply jumped by a value different than 1 between two consecutive positions. Usually the number of games.

`material_imbalance` - the histogram of imbalances, with values computed using "simple eval", that is pawn=1, bishop=knight=3, rook=5, queen=9

`results` - the distribution of game results

`endgames_6man` - distribution of endgame configurations for <=6 pieces (including kings)

Sample output:
```
Stockfish 190521 by the Stockfish developers (see AUTHORS file)
gather_statistics all input_file C:\dev\nnue-pytorch\10m_d3_2.binpack max_count 10000000
Processed 1000000 positions.
Processed 2000000 positions.
Processed 3000000 positions.
Processed 4000000 positions.
Processed 5000000 positions.
Processed 6000000 positions.
Processed 7000000 positions.
Processed 8000000 positions.
Processed 9000000 positions.
Processed 10000000 positions.
Finished gathering statistics.

Results:

Number of positions: 10000000
King square distribution:
    White king squares:
             721     1408     1391     1269     1424     1589     1609      833
            2611     6643     6131     6458     6766     6945     7486     3247
            4959    16849    17332    20064    18072    20194    19806     7744
            8468    24427    39831    36933    41545    43151    31225    13373
           11495    33273    54809    66765    77101    86526    58415    26904
           20332    68784   122806   171355   221573   242111   173653    60653
           44380   114571   199865   248949   397713   425915   456614   213295
           36510   235783   398598   195900  2022562   439891  2401570   250825

    Black king squares:
           33564   229227   396036   209821  2090492   445881  2279424   265564
           40702   121552   195472   253862   408809   421354   465925   213624
           21295    74001   119214   169002   207688   245068   174078    63601
           12435    34903    56936    67857    77301    84005    58992    26633
            8655    25407    40364    39580    40855    43956    30578    13755
            5587    18387    17790    20534    20148    19492    18563     7525
            3242     8154     7118     6776     7116     7959     7787     3511
            1028     2028     1717     1809     1662     1904     1764      931

Move from square distribution:
    White move from squares:
          21117   13547   15898   16186   12445   10100    8593   14048
          36587   41415   44936   29079   23910   30876   23390   22454
          34077   29830   46156   43684   39996   30457   24126   27290
          42644   84735   58205   77135   97565   47025   71450   42197
          70665   57763  110688  128432  112192  104167   60621   63007
          59450   73136  146359  110100  132917  194341   77462   56982
          87385  106994  101014  157062  167120  141892  136513  103366
         125553  114375  173768  200229  202770  212413  134536   79899

    Black move from squares:
         124118  135296  178283  201858  208855  220920  143591   82772
          88694  112135  110066  167479  177184  144204  140280  105339
          61095   73791  149426  108076  136927  194064   76993   59192
          73068   60282  104599  125329  102838   99426   60124   62042
          42775   91654   60860   76446   89256   47062   68575   41258
          34866   32275   46766   43083   35156   29375   22481   25887
          35442   41697   40763   29460   23232   28429   22506   21015
          21464   14572   16626   17068   13240   10876    9010   14155

Move to square distribution:
    White move to squares:
          31240   20985   27591   37143   22220   20727   13221   20171
          47485   54471   60633   54745   42239   48754   35505   31462
          49740   47721   83128   75979   75255   67168   43148   41951
          62044  110599   89741  127325  146979   78781   97406   64452
          89839   89465  126871  133065  149323  130970   92598   85384
          71785   87446  145654  126677  137799  180080  107104   75880
          20392   44086   79475  151945  147784   79919   74316   32691
          49931   68014   96965  123125  103211   83664   59111   89746

    Black move to squares:
          48323   66961   90442  119799  102061   87438   62464   94057
          20659   48859   75459  162156  154489   82814   78454   34791
          73192   90502  162671  129022  144730  187468  107730   80013
          93714   93448  129753  149186  155749  128804   93119   84564
          63406  117469   90927  125641  138503   78063   94400   63266
          50552   50983   87197   74060   64681   64050   40422   39643
          46414   55191   55892   56457   40191   44292   33749   29413
          31717   22033   28595   38220   22989   20946   13443   19980

Number of moves by type:
    Total: 10000000
    Normal: 9806248
    Capture: 2643363
    Promotion: 38945
    Castling: 149338
    En-passant: 5469
Number of moves by piece type:
    Pawn: 2198501
    Knight: 1411232
    Bishop: 1417243
    Rook: 2080562
    Queen: 1084443
    King: 1808019
Number of ply discontinuities (usually games): 151592
Number of "simple eval" imbalances for white's perspective:
     -34: 2
     -33: 0
     -32: 5
     -31: 8
     -30: 19
     -29: 55
     -28: 81
     -27: 142
     -26: 219
     -25: 344
     -24: 543
     -23: 825
     -22: 1256
     -21: 1741
     -20: 2542
     -19: 4051
     -18: 5477
     -17: 8581
     -16: 12577
     -15: 19321
     -14: 31222
     -13: 47127
     -12: 71906
     -11: 110872
     -10: 165712
      -9: 221284
      -8: 234293
      -7: 271970
      -6: 312138
      -5: 413840
      -4: 536525
      -3: 607106
      -2: 507962
      -1: 742232
       0: 1147540
       1: 718884
       2: 522414
       3: 625110
       4: 535262
       5: 427057
       6: 331870
       7: 296459
       8: 267285
       9: 248468
      10: 184615
      11: 124376
      12: 83018
      13: 54262
      14: 36124
      15: 23046
      16: 14338
      17: 9232
      18: 6129
      19: 4002
      20: 2717
      21: 1888
      22: 1362
      23: 920
      24: 587
      25: 370
      26: 241
      27: 183
      28: 108
      29: 63
      30: 40
      31: 27
      32: 13
      33: 5
      34: 3
      35: 4
Distribution of results:
    White wins: 3862758
    Black wins: 3546262
    Draws: 2590980
    Side to move wins: 3700903
    Side to move loses: 3708117
Number of positions by piece count:
    32: 37937
    31: 81314
    30: 249973
    29: 324560
    28: 442822
    27: 452983
    26: 474594
    25: 468433
    24: 467204
    23: 461787
    22: 455872
    21: 451156
    20: 444015
    19: 443190
    18: 439225
    17: 442227
    16: 435355
    15: 441142
    14: 424101
    13: 431445
    12: 399408
    11: 398084
    10: 347176
    9: 321293
    8: 239580
    7: 193705
    6: 123070
    5: 68349
    4: 35813
    3: 4187
    2: 0
    1: 0
    0: 0
Distribution of endgame configurations:
    KR   vKR   : 9012
    KPPR vKR   : 8878
    KR   vKPPR : 7276
    KPR  vKPR  : 7188
    KPPP vKP   : 6459
    KP   vKPPP : 6188
    KR   vKPR  : 5978
    KPR  vKR   : 5803
    KPNR vKR   : 3361
    KP   vKPP  : 3241
    KPP  vKP   : 3122
    KPBR vKR   : 2869
    KR   vKPNR : 2824
    KPP  vKPP  : 2613
    KP   vKPPN : 2593
    KR   vKPBR : 2553
    KPPN vKP   : 2433
    KP   vKP   : 2416
    K    vKPP  : 2382
    KPP  vK    : 2272
    K    vKP   : 2176
    KPPB vKP   : 2143
    KP   vKPN  : 2061
    KP   vKPPB : 2014
    KPPN vK    : 1931
    KPR  vKPP  : 1884
    KPN  vKP   : 1876
    KP   vK    : 1874
    K    vKPPN : 1747
    KPR  vKP   : 1716
    KPQ  vKP   : 1715
    KPP  vKPR  : 1712
    KPPR vKP   : 1682
    K    vKPPB : 1640
    KPN  vK    : 1638
    KPB  vK    : 1584
    KPN  vKPN  : 1574
    K    vKPB  : 1551
    K    vKPN  : 1531
    KR   vKPP  : 1512
    KP   vKPQ  : 1468
    KP   vKPR  : 1363
    KPPB vK    : 1348
    KP   vKPPR : 1342
    KP   vKPB  : 1314
    KPB  vKP   : 1294
    KQ   vKP   : 1236
    KPP  vKPQ  : 1232
    KPQ  vKPP  : 1197
    KP   vKQ   : 1129
    KPN  vKPP  : 1110
    K    vKPPPB: 1099
    KPP  vKPN  : 1095
    KPRR vKR   : 1076
    KPP  vKR   : 1056
    KB   vKPPR : 1029
    K    vKPPPN: 1002
    KR   vKBR  : 999
    KN   vKPN  : 975
    KPB  vKPP  : 972
    KPR  vKPQ  : 968
    KPP  vKPB  : 941
    KPPPNvK    : 941
    KP   vKPPQ : 941
    KPPQ vKP   : 932
    KP   vKN   : 923
    KPP  vKQ   : 920
    KN   vKPPR : 919
    KPPR vKB   : 911
    KN   vKP   : 872
    KP   vKB   : 872
    K    vKPPP : 865
    KBR  vKR   : 855
    KPPPBvK    : 845
    KQ   vKPP  : 821
    KPPP vK    : 804
    KB   vKR   : 798
    KB   vKP   : 766
    KNR  vKR   : 766
    KPB  vKPB  : 758
    KR   vKNR  : 727
    KR   vKP   : 724
    KPPR vKN   : 709
    KPR  vKB   : 671
    KBR  vKPR  : 671
    KPR  vKN   : 669
    KPR  vKBR  : 666
    KN   vKPR  : 664
    KPR  vKNR  : 663
    KPN  vKPR  : 660
    KPN  vKN   : 651
    KB   vKPR  : 643
    KR   vKPRR : 635
    KPN  vKPB  : 631
    KNR  vKPR  : 625
    KR   vKB   : 609
    KPR  vKPN  : 606
    KRR  vKR   : 604
    KPPN vKR   : 589
    KR   vKRR  : 586
    KP   vKR   : 581
    KQ   vKB   : 580
    KPNR vKP   : 564
    KPQ  vKPR  : 561
    KR   vKN   : 555
    KB   vKPP  : 553
    KPB  vKPR  : 532
    KPN  vKPQ  : 527
    KR   vKPQ  : 510
    KQ   vKPQ  : 509
    KN   vKPP  : 506
    KPPQ vKR   : 486
    KPP  vKB   : 474
    KRR  vKPR  : 474
    KN   vKPPN : 472
    KN   vKR   : 452
    KPQ  vKR   : 449
    KP   vKPNR : 447
    KQ   vKQ   : 443
    KPR  vKQ   : 442
    KQ   vKPR  : 440
    KPPP vKR   : 438
    KR   vKPB  : 431
    KPP  vKN   : 424
    KR   vKPPP : 423
    KPB  vKR   : 413
    KP   vKPNB : 405
    KQ   vKR   : 403
    KPR  vKPB  : 402
    KQ   vKPPR : 398
    KN   vKNR  : 396
    KQ   vKPN  : 394
    KR   vKPPB : 391
    KR   vKPN  : 389
    KPQ  vKPQ  : 386
    KB   vKQ   : 382
    KPN  vKB   : 373
    KPB  vKPQ  : 372
    KR   vKPPN : 372
    KPB  vKB   : 365
    KPBR vKP   : 365
    KPB  vKPN  : 364
    KB   vKB   : 362
    KB   vKPPB : 360
    KPPN vKN   : 357
    K    vKPPPP: 355
    KPQ  vKPB  : 353
    KPQ  vKPN  : 350
    KR   vKPPQ : 348
    KPPQ vKB   : 347
    KPB  vKQ   : 344
    KPN  vKR   : 342
    KR   vKQ   : 342
    KN   vKN   : 341
    KPPB vKR   : 334
    KPNR vKN   : 329
    KB   vKPQ  : 323
    KPPB vKN   : 319
    KPQ  vKQ   : 317
    KP   vKNR  : 316
    KNR  vKN   : 313
    KB   vKPPQ : 311
    KPNB vKP   : 308
    KP   vKPBR : 307
    KPPB vKB   : 301
    KNR  vKPN  : 301
    KPQ  vKB   : 299
    KBR  vKB   : 286
    KPPQ vKN   : 273
    KPPPPvK    : 273
    KB   vKPB  : 270
    KNR  vKNR  : 269
    KN   vKPB  : 268
    KPPR vKQ   : 261
    KQ   vKPB  : 259
    KPR  vKRR  : 256
    KB   vKPN  : 251
    KPN  vKNR  : 250
    KB   vKPPP : 246
    KQ   vKPPQ : 233
    KPPP vKB   : 231
    KN   vKPNB : 231
    K    vKPPBB: 228
    KNR  vKP   : 225
    KPB  vKN   : 223
    KPQ  vKN   : 220
    KN   vKPPB : 218
    KN   vKPPQ : 214
    KPPP vKQ   : 214
    KPNR vKB   : 212
    KQ   vKN   : 211
    KR   vKPNB : 210
    KPPP vKN   : 208
    KPP  vKBR  : 208
    KNR  vKB   : 204
    KN   vKQ   : 204
    KPPB vKQ   : 204
    KRQ  vKPR  : 202
    KB   vKPBR : 201
    KP   vKNB  : 201
    KQ   vKPPP : 201
    KPBR vKB   : 200
    KN   vKBR  : 200
    KB   vKPPN : 197
    KBQ  vKPP  : 196
    KNR  vKPP  : 195
    KN   vKPQ  : 195
    KPNB vKN   : 194
    KQ   vKPPB : 191
    KQ   vKPPN : 188
    KBR  vKPB  : 186
    KN   vKPPP : 183
    KNBR vKR   : 180
    KBR  vKPP  : 180
    KB   vKBR  : 177
    KPPQ vKQ   : 173
    KRQ  vKPP  : 171
    KNQ  vKPP  : 169
    KPPBBvK    : 166
    KN   vKPNR : 164
    KPPN vKB   : 163
    KPRQ vKR   : 162
    KP   vKBR  : 160
    KQ   vKPBQ : 159
    KPNQ vKR   : 156
    KBB  vK    : 156
    KPBR vKN   : 155
    KPNB vKR   : 155
    KB   vKN   : 153
    KPN  vKQ   : 153
    KRQ  vKR   : 151
    KN   vKPBR : 148
    KPP  vKNQ  : 148
    KPNQ vKP   : 147
    KR   vKRQ  : 143
    KPR  vKRQ  : 142
    KN   vKB   : 141
    KR   vKPBQ : 141
    KBR  vKP   : 141
    K    vKPBB : 135
    KQ   vKBQ  : 135
    KPBQ vKP   : 132
    KR   vKPNQ : 129
    KPQ  vKRQ  : 128
    KPNB vKQ   : 127
    KPP  vKRQ  : 125
    KP   vKPNQ : 124
    KPNN vKN   : 123
    KPBQ vKR   : 121
    KPP  vKNR  : 117
    KBR  vKN   : 116
    KBR  vKNR  : 114
    KPNB vKB   : 113
    KBQ  vKP   : 111
    KNQ  vKPR  : 111
    KB   vKPNB : 109
    KNR  vKPB  : 108
    KP   vKPNN : 108
    KQ   vKPBR : 108
    KPNQ vKQ   : 103
    KBQ  vKQ   : 101
    KNB  vKP   : 101
    KPBB vK    : 101
    KQ   vKPNB : 101
    KNR  vKPQ  : 100
    KPB  vKNR  : 94
    K    vKBB  : 93
    KPB  vKBR  : 92
    KNB  vKPN  : 91
    KR   vKNBR : 90
    KB   vKNN  : 88
    KR   vKPRQ : 87
    KPPN vKQ   : 87
    KP   vKPBQ : 86
    KPBQ vKQ   : 85
    KPNR vKQ   : 84
    KP   vKPBB : 84
    KPP  vKNB  : 84
    KNQ  vKP   : 82
    KPR  vKNB  : 81
    KPN  vKBQ  : 80
    KR   vKNB  : 79
    KQ   vKNB  : 78
    KNB  vKPP  : 78
    KP   vKBQ  : 77
    KPQ  vKBQ  : 76
    KNRQ vKR   : 76
    KQ   vKNQ  : 75
    KPP  vKBQ  : 74
    KBB  vKP   : 74
    KQ   vKBR  : 71
    KN   vKNBR : 70
    KNN  vKPR  : 69
    KBRQ vKR   : 69
    KR   vKBRQ : 68
    KPPR vK    : 67
    KPP  vKRR  : 67
    KBR  vKPN  : 66
    KR   vK    : 66
    KPN  vKBR  : 65
    KNR  vKBR  : 65
    KP   vKBB  : 63
    KPNN vKB   : 62
    KBQ  vKR   : 62
    KBB  vKPR  : 61
    KBRR vKR   : 61
    KNB  vKQ   : 60
    KR   vKNRQ : 60
    KR   vKBRR : 60
    KBR  vKBR  : 59
    KP   vKNQ  : 59
    KNR  vKQ   : 58
    KBR  vKPQ  : 57
    KPBR vKQ   : 57
    KNQ  vKPB  : 57
    K    vKPPR : 56
    KN   vKPNQ : 56
    KPBB vKP   : 55
    KB   vKPNR : 54
    KNB  vKPQ  : 53
    KPRR vKP   : 53
    KNN  vKB   : 52
    KPNN vKP   : 52
    KBQ  vKPQ  : 51
    KPB  vKBQ  : 50
    KN   vKPNN : 50
    KR   vKNQ  : 50
    KBQ  vKPR  : 49
    KPQ  vKRR  : 49
    KB   vKPNQ : 49
    KPR  vKNQ  : 49
    KRR  vKRR  : 47
    K    vKR   : 47
    KRR  vKPP  : 47
    KRR  vKPN  : 47
    KPB  vKNQ  : 46
    KNB  vKN   : 46
    KPP  vKBB  : 46
    KN   vKBQ  : 45
    KR   vKPBB : 45
    KNQ  vKR   : 45
    KN   vKPRR : 45
    KPBQ vKN   : 44
    KQ   vKRR  : 44
    KB   vKBB  : 44
    KPN  vKNQ  : 43
    KNN  vKPN  : 42
    KB   vKPBQ : 41
    KPQ  vKNR  : 41
    KBB  vKPP  : 41
    KNQ  vKPN  : 40
    KQ   vKRQ  : 39
    KPBB vKR   : 39
    KPNQ vKN   : 38
    KN   vKNN  : 38
    KRR  vKPQ  : 37
    KRQ  vKPN  : 36
    K    vKPR  : 36
    KPBB vKB   : 36
    KPR  vK    : 36
    KNBR vKN   : 35
    KBQ  vKB   : 35
    KB   vKNR  : 34
    KP   vKNN  : 34
    KQ   vKNBR : 33
    KNRR vKR   : 33
    KRQ  vKPQ  : 33
    KRQ  vKPB  : 33
    KNQ  vKRQ  : 33
    KP   vKPRR : 32
    KNB  vKPR  : 32
    KBBQ vKQ   : 32
    KN   vKNNB : 32
    KPBB vKN   : 31
    KBBQ vKR   : 31
    KNB  vKPB  : 30
    KPNN vKR   : 30
    KRR  vKN   : 29
    KPB  vKBB  : 29
    KN   vKPBQ : 28
    KR   vKBQ  : 28
    KNN  vKPB  : 27
    KPB  vKNB  : 27
    KBQ  vKBQ  : 26
    KPN  vKNB  : 26
    KPRQ vKN   : 25
    KPQ  vKBR  : 25
    KN   vKNQ  : 25
    KNN  vKP   : 25
    KPN  vKRR  : 25
    KPP  vKNN  : 24
    KB   vKRR  : 24
    KQ   vKPNQ : 24
    KBQ  vKPB  : 23
    KPPNRvK    : 23
    KPRQ vKQ   : 22
    K    vKPPNR: 22
    K    vKPPQ : 22
    KQ   vKPNR : 22
    KPPQ vK    : 22
    KRR  vKPB  : 22
    KPR  vKBQ  : 21
    KQ   vKPRQ : 21
    KPRR vKN   : 21
    KNN  vKPQ  : 21
    KPNQ vKB   : 21
    KPQ  vKNB  : 20
    KN   vKNB  : 20
    KBB  vKPQ  : 20
    KNQ  vKB   : 20
    KPN  vKNN  : 20
    KBB  vKR   : 20
    KNN  vKPP  : 20
    K    vKPPPR: 20
    KPR  vKNN  : 20
    KPB  vKRQ  : 19
    KPPNNvK    : 19
    KBBR vKR   : 18
    KPQ  vKNN  : 18
    KB   vKBQ  : 18
    KRQ  vKP   : 17
    KBRQ vKQ   : 16
    KB   vKNB  : 16
    KNQ  vKN   : 16
    KPBQ vKB   : 16
    K    vKPPBR: 16
    KQQ  vKBQ  : 16
    K    vKQ   : 15
    KRR  vKB   : 15
    KPNR vK    : 14
    KNQ  vKQ   : 14
    KB   vKBBR : 14
    KR   vKNBQ : 14
    KB   vKNQ  : 14
    KN   vKBBQ : 14
    KQQ  vKPR  : 13
    KBR  vKQ   : 13
    KNB  vKRQ  : 13
    KQQ  vKQ   : 13
    KPPPRvK    : 13
    KRR  vKNR  : 13
    KNR  vKRR  : 12
    KNN  vKNB  : 12
    KPR  vKQQ  : 12
    KBR  vKBB  : 12
    K    vKPNR : 12
    KN   vKPRQ : 12
    KBQ  vKN   : 12
    KPRR vKB   : 12
    KRR  vKBR  : 12
    KNB  vKNR  : 12
    KNBB vKP   : 12
    KPBR vK    : 12
    KR   vKNRR : 11
    KR   vKNBB : 11
    KQ   vKPBB : 11
    KP   vKRQ  : 11
    KP   vKRR  : 10
    KBQ  vKPN  : 10
    KQ   vKBB  : 10
    KB   vKPRQ : 10
    KNQ  vKBB  : 10
    KBB  vKRQ  : 10
    KBR  vKRR  : 10
    KNBR vKP   : 10
    KBR  vKBQ  : 10
    KPPBRvK    : 10
    KPN  vKRQ  : 9
    KQ   vK    : 9
    KP   vKNBR : 9
    KNR  vKNB  : 9
    KR   vKNNR : 9
    KN   vKPBB : 9
    KNB  vKB   : 9
    KNB  vKR   : 8
    KNQ  vKPQ  : 8
    KPB  vKRR  : 8
    K    vKPQ  : 8
    KQ   vKNR  : 8
    KNQQ vKQ   : 8
    KRQ  vKNB  : 7
    KPRQ vKP   : 7
    KBQ  vKRQ  : 7
    KQQ  vKNB  : 7
    KRQ  vKRQ  : 7
    KRRQ vKR   : 7
    KNBQ vKN   : 7
    KQQ  vKNQ  : 6
    KRR  vKP   : 6
    KQ   vKQQ  : 6
    KPNN vKQ   : 6
    KQQ  vKPB  : 6
    KR   vKPQQ : 6
    KRQ  vKB   : 6
    KPR  vKBB  : 6
    KNBQ vKR   : 6
    KPB  vKNN  : 6
    K    vKPBR : 6
    KNR  vKBQ  : 5
    KN   vKRR  : 5
    KNN  vKQ   : 5
    KPNB vK    : 5
    K    vKPPPQ: 5
    K    vKPNB : 5
    KNRQ vKQ   : 5
    KPPPQvK    : 4
    KQ   vKNRQ : 4
    KPQ  vK    : 4
    KQQ  vKPN  : 4
    KBB  vKQQ  : 4
    KNR  vK    : 4
    KR   vKRRQ : 4
    KRQ  vKNR  : 4
    KB   vKPRR : 4
    KP   vKNNB : 4
    K    vKPPNB: 4
    KP   vKPRQ : 4
    KPPNBvK    : 4
    KP   vKBBQ : 3
    KBR  vKNB  : 3
    KB   vKPBB : 3
    KNBR vKB   : 3
    KPRQ vKB   : 3
    KPN  vKQQ  : 3
    KNRR vKP   : 3
    K    vKNR  : 3
    KQQ  vKPP  : 3
    KPNN vK    : 3
    KRQ  vKBQ  : 3
    KN   vKNRR : 3
    KNB  vKRR  : 3
    KN   vKNRQ : 2
    KP   vKNRQ : 2
    KNR  vKRQ  : 2
    KPPNQvK    : 2
    KBB  vKPN  : 2
    KBRQ vKN   : 2
    KBB  vKPB  : 2
    KNRQ vKN   : 2
    KB   vKRQ  : 2
    KN   vKRQ  : 2
    KNBQ vKB   : 2
    KNNR vKP   : 2
    KP   vKBBR : 2
    KRQ  vKN   : 2
    K    vKPPNN: 2
    KNQ  vKBR  : 2
    KBRQ vKP   : 2
    KNBQ vKP   : 2
    K    vKBR  : 2
    KPQ  vKNQ  : 2
    KNR  vKNQ  : 2
    KN   vKNNQ : 2
    KBBQ vKP   : 2
    KNB  vK    : 2
    KBRR vKP   : 2
    KP   vKBRR : 2
    KRQ  vKBR  : 2
    KRRR vKP   : 1
    KNNB vKP   : 1
    KPBQ vK    : 1
    KBBR vKP   : 1
    KPBB vKQ   : 1
    K    vKPNQ : 1
    KPNQ vK    : 1
    KP   vKQQ  : 1
    K    vKPBQ : 1
    KPP  vKQQ  : 1
    KNN  vKR   : 1
    KQQ  vKB   : 1
    KNN  vKN   : 1
    KQ   vKNN  : 1
    KR   vKNN  : 1
    KBR  vK    : 1
    KPNBBvK    : 1
    KNN  vK    : 1
    K    vKBQ  : 1
    K    vKNB  : 1
    KNQ  vKNR  : 1
    KP   vKNBQ : 1
    K    vKPPBQ: 1
    K    vKPPNQ: 1
    KBQQ vKR   : 1
    KPQQ vKR   : 1
    KNNQ vKR   : 1
    KQ   vKPRR : 1
    KNB  vKBR  : 1
    KN   vKBBR : 1
    KP   vKBRQ : 1
    KN   vKBRQ : 1
    KB   vKBRQ : 1
    KNRQ vKP   : 1
    KP   vKNNR : 1
    KBBQ vKB   : 1
    KNRR vKB   : 1
    KBQ  vKNB  : 1
    KRR  vKNB  : 1
    KBR  vKRQ  : 1
    KNNQ vKN   : 1
    KNN  vKNN  : 1
    KQ   vKPNN : 1
    KN   vKNBQ : 1
    KPB  vKQQ  : 1
    KPQ  vKQQ  : 1
```