### PR TITLE
Simplify usage of LMR for captures.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1121,11 +1121,8 @@ moves_loop: // When in check, search starts from here
       if (    depth >= 3
           &&  moveCount > 1 + 2 * rootNode
           && (  !captureOrPromotion
-              || moveCountPruning
-              || ss->staticEval + PieceValue[EG][pos.captured_piece()] <= alpha
               || cutNode
-              || (!PvNode && !formerPv && captureHistory[movedPiece][to_sq(move)][type_of(pos.captured_piece())] < 3678)
-              || thisThread->ttHitAverage < 432 * TtHitAverageResolution * TtHitAverageWindow / 1024)
+              || (!PvNode && !formerPv))
           && (!PvNode || ss->ply > 1 || thisThread->id() % 4 != 3))
       {
           Depth r = reduction(improving, depth, moveCount);


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/60a40117ce8ea25a3ef03ca7
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 58976 W: 4875 L: 4807 D: 49294
Ptnml(0-2): 176, 3897, 21270, 3973, 172 
passed LTC
https://tests.stockfishchess.org/tests/view/60a43ff8ce8ea25a3ef03d18
LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 65272 W: 2203 L: 2165 D: 60904
Ptnml(0-2): 28, 1936, 28668, 1978, 26 
This patch simplifies a lot of "enablers" for LMR when move is a capture or promotion.
After it we will have only 2 conditions - if node is a cutNode or if it's an allNode that was not in PV, so all captures or promotions wouldn't go thru LMR at any PVnodes.
bench 4590550