### PR TITLE
Add more output to endgame stats.

### DIFF
--- a/src/tools/stats.cpp
+++ b/src/tools/stats.cpp
@@ -980,7 +980,7 @@ namespace Stockfish::Tools::Stats
             reset();
         }
 
-        void on_entry(const Position& pos, const Move&, const PackedSfenValue&) override
+        void on_entry(const Position& pos, const Move&, const PackedSfenValue& psv) override
         {
             const int piece_count = pos.count<ALL_PIECES>();
             if (piece_count > MaxManCount)
@@ -989,12 +989,29 @@ namespace Stockfish::Tools::Stats
             }
 
             const auto index = get_material_key_for_position(pos);
-            m_counts[index] += 1;
+            auto& entry = m_entries[index];
+            entry.count += 1;
+            if (psv.game_result == 0)
+            {
+                entry.draws += 1;
+            }
+            else
+            {
+                const Color winner_side = psv.game_result == 1 ? pos.side_to_move() : ~pos.side_to_move();
+                if (winner_side == WHITE)
+                {
+                    entry.white_wins += 1;
+                }
+                else
+                {
+                    entry.black_wins += 1;
+                }
+            }
         }
 
         void reset() override
         {
-            m_counts.clear();
+            m_entries.clear();
         }
 
         [[nodiscard]] const std::string& get_name() const override
@@ -1005,25 +1022,49 @@ namespace Stockfish::Tools::Stats
         [[nodiscard]] StatisticOutput get_output() const override
         {
             StatisticOutput out;
-            auto& header = out.emplace_node<StatisticOutputEntryHeader>("Distribution of endgame configurations:");
-            std::vector<std::pair<MaterialKey, std::uint64_t>> flattened(m_counts.begin(), m_counts.end());
-            std::sort(flattened.begin(), flattened.end(), [](const auto& lhs, const auto& rhs) { return lhs.second > rhs.second; });
-            for (auto&& [index, count] : flattened)
+            auto& header = out.emplace_node<StatisticOutputEntryHeader>("Distribution of endgame configurations (count W D L Perf%):");
+            std::vector<std::pair<MaterialKey, Entry>> flattened(m_entries.begin(), m_entries.end());
+            std::sort(flattened.begin(), flattened.end(), [](const auto& lhs, const auto& rhs) { return lhs.second.count > rhs.second.count; });
+            for (auto&& [index, entry] : flattened)
             {
-                header.emplace_child<StatisticOutputEntryValue<std::uint64_t>>(
+                header.emplace_child<StatisticOutputEntryValue<std::string>>(
                     get_padded_name_by_material_key(index),
-                    count
+                    entry.to_string()
                 );
             }
             return out;
         }
 
     private:
+        struct Entry
+        {
+            std::uint64_t count = 0;
+            std::uint64_t white_wins = 0;
+            std::uint64_t black_wins = 0;
+            std::uint64_t draws = 0;
+
+            [[nodiscard]] std::string to_string() const
+            {
+                constexpr int wide_column_width = 9;
+                constexpr int narrow_column_width = 4;
+
+                const float perf =
+                      (white_wins + draws / 2.0f)
+                    / (white_wins + black_wins + draws);
+
+                return
+                      left_pad_to_length(std::to_string(count), ' ', wide_column_width) + ' '
+                    + left_pad_to_length(std::to_string(white_wins), ' ', wide_column_width) + ' '
+                    + left_pad_to_length(std::to_string(draws), ' ', wide_column_width) + ' '
+                    + left_pad_to_length(std::to_string(black_wins), ' ', wide_column_width) + ' '
+                    + left_pad_to_length(std::to_string(static_cast<int>(perf * 100.0f + 0.5f)), ' ', narrow_column_width) + '%';
+            }
+        };
         // can support up to 17 pieces.
         // it's basically the material string encoded as a number in base 8
         // encoding is from the least significant digit to most significant
         // v=1, P=2, N=3, B=4, R=5, Q=6, K=7. 0 indicates end
-        std::map<MaterialKey, std::uint64_t> m_counts;
+        std::map<MaterialKey, Entry> m_entries;
 
         [[nodiscard]] MaterialKey get_material_key_for_position(const Position& pos) const
         {
@@ -1053,6 +1094,7 @@ namespace Stockfish::Tools::Stats
         [[nodiscard]] std::string get_padded_name_by_material_key(MaterialKey index) const
         {
             std::string sides[COLOR_NB];
+            int material[COLOR_NB] = { 0, 0 };
             Color side = WHITE;
 
             while (index != 0)
@@ -1064,18 +1106,23 @@ namespace Stockfish::Tools::Stats
                         break;
                     case 2:
                         sides[side] += 'P';
+                        material[side] += 1;
                         break;
                     case 3:
                         sides[side] += 'N';
+                        material[side] += 3;
                         break;
                     case 4:
                         sides[side] += 'B';
+                        material[side] += 3;
                         break;
                     case 5:
                         sides[side] += 'R';
+                        material[side] += 5;
                         break;
                     case 6:
                         sides[side] += 'Q';
+                        material[side] += 9;
                         break;
                     case 7:
                         sides[side] += 'K';
@@ -1086,10 +1133,19 @@ namespace Stockfish::Tools::Stats
                 index >>= 3;
             }
 
+            const int imbalance = material[WHITE] - material[BLACK];
+            const std::string imbalance_str =
+                  std::string(imbalance > 0 ? "+" : "") // force + sign for positive values
+                + std::string(imbalance == 0 ? " " : "") // pad 0
+                + std::to_string(imbalance);
+
             return
                   right_pad_to_length(sides[WHITE], ' ', MaxManCount-1)
                 + 'v'
-                + right_pad_to_length(sides[BLACK], ' ', MaxManCount-1);
+                + right_pad_to_length(sides[BLACK], ' ', MaxManCount-1)
+                + " ("
+                + right_pad_to_length(imbalance_str, ' ', 3)
+                + ')';
         }
     };
 


### PR DESCRIPTION
Example output:
```
Distribution of endgame configurations (count W D L Perf%):
    KPR  vKPR   ( 0 ):     23303       559     22082       662   50%
    KR   vKPR   (-1 ):     15468        50     11756      3662   38%
    KPR  vKR    (+1 ):     14026      3059     10926        41   61%
    KR   vKPPR  (-2 ):     11269        56      5967      5246   27%
    KPPR vKR    (+2 ):     10521      4435      6042        44   71%
    KPP  vKPP   ( 0 ):      6964      1287      4222      1455   49%
    KPNR vKR    (+4 ):      5234      3308      1926         0   82%
    KP   vKPP   (-1 ):      4686        88      1230      3368   15%
    KR   vKPNR  (-4 ):      4525         0      2088      2437   23%
    KPP  vKP    (+1 ):      4177      2766      1335        76   82%
    KPN  vKPN   ( 0 ):      4115        57      3975        83   50%
    KP   vKP    ( 0 ):      3516        87      3320       109   50%
    KR   vKPBR  (-4 ):      3321         0      1532      1789   23%
    KPBR vKR    (+4 ):      3257      1750      1507         0   77%
    KN   vKP    (+2 ):      3130         0      3112        18   50%
    KR   vKBR   (-3 ):      3077         0      2988        89   49%
    KPN  vKP    (+3 ):      3043      2088       945        10   84%
    KBR  vKPR   (+2 ):      2939         8      2930         1   50%
    KP   vKN    (-2 ):      2876        19      2857         0   50%
    KB   vKPB   (-1 ):      2749         0      2511       238   46%
    KPB  vKB    (+1 ):      2694       288      2406         0   55%
    KNR  vKPR   (+2 ):      2642        23      2609        10   50%
    KR   vKR    ( 0 ):      2618         0      2618         0   50%
    KP   vKPN   (-3 ):      2530         5       838      1687   17%
    KB   vKP    (+2 ):      2482         0      2459        23   50%
    KN   vKPN   (-1 ):      2435         0      2261       174   46%
    KPN  vKN    (+1 ):      2419       233      2186         0   55%
    KPRR vKR    (+6 ):      2411      2239       172         0   96%
    KP   vKPPP  (-2 ):      2381         6       154      2221    3%
    KR   vKPRR  (-6 ):      2340         0       168      2172    4%
    KPR  vKBR   (-2 ):      2323         4      2312         7   50%
    KPR  vKNR   (-2 ):      2301        10      2285         6   50%
    KP   vKB    (-2 ):      2208        45      2163         0   51%
    KP   vKPPN  (-4 ):      2187         3       152      2032    4%
    KPPN vKP    (+4 ):      2184      2024       159         1   96%
    KP   vK     (+1 ):      2173         0      2173         0   50%
    KPR  vKPP   (+4 ):      2117      1776       308        33   91%
    KPPP vKP    (+2 ):      2114      1939       153        22   95%
    KR   vKP    (+4 ):      2092       572      1513         7   64%
    KP   vKR    (-4 ):      2086         2      1682       402   40%
    KPB  vKPB   ( 0 ):      2046        41      1950        55   50%
    K    vKP    (-1 ):      2040         0      2040         0   50%
[...]
```