### PR TITLE
Remove ensure_quiet parameter from generate_training_data.

### DIFF
--- a/docs/generate_training_data.md
+++ b/docs/generate_training_data.md
@@ -60,6 +60,4 @@ Currently the following options are available:
 
 `data_format` - format of the training data to use. Either `bin` or `binpack`. Default: `binpack`.
 
-`ensure_quiet` - this is a flag option. When specified the positions will be from the qsearch leaf.
-
 `seed` - seed for the PRNG. Can be either a number or a string. If it's a string then its hash will be used. If not specified then the current time will be used.


### PR DESCRIPTION
Up to the maintainer to approve, but personally I think this option has not been relevant for a long time and only complicates the code.