### PR TITLE
Compact position structures

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -38,7 +38,6 @@ namespace Stockfish {
 /// board (by calling Position::do_move), a StateInfo object must be passed.
 
 struct StateInfo {
-
   // Copied when making a move
   Key    pawnKey;
   Key    materialKey;
@@ -51,11 +50,11 @@ struct StateInfo {
   // Not copied when making a move (will be recomputed anyhow)
   Key        key;
   Bitboard   checkersBB;
-  Piece      capturedPiece;
   StateInfo* previous;
   Bitboard   blockersForKing[COLOR_NB];
   Bitboard   pinners[COLOR_NB];
   Bitboard   checkSquares[PIECE_TYPE_NB];
+  Piece      capturedPiece;
   int        repetition;
 
   // Used by NNUE
@@ -192,11 +191,11 @@ private:
   int castlingRightsMask[SQUARE_NB];
   Square castlingRookSquare[CASTLING_RIGHT_NB];
   Bitboard castlingPath[CASTLING_RIGHT_NB];
+  Thread* thisThread;
+  StateInfo* st;
   int gamePly;
   Color sideToMove;
   Score psq;
-  Thread* thisThread;
-  StateInfo* st;
   bool chess960;
 };
 


### PR DESCRIPTION
Reorder position structures data members to reduce padding.

Passed STC:
https://tests.stockfishchess.org/tests/view/60a8011fce8ea25a3ef04069
 LLR: 2.94 (-2.94,2.94) <-0.50,2.50>
Total: 14120 W: 1214 L: 1067 D: 11839
Ptnml(0-2): 26, 857, 5161, 976, 40 

No LTC needed (see comment).

No functional change.