### PR TITLE
Update default net to nn-7756374aaed3.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-8a08400ed089.nnue"
+  #define EvalFileDefaultName   "nn-7756374aaed3.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
trained with pytorch using the master branch and recommended settings,
same data set as previously used:

python train.py ../../all_d9_fishd9_d8_d10_shuffle.binpack ../../all_d9_fishd9_d8_d10_shuffle.binpack \
        --gpus 1 --threads 2 --num-workers 2 --batch-size 16384 --progress_bar_refresh_rate 300 \
        --smart-fen-skipping --random-fen-skipping 3 --features=HalfKAv2^   --lambda=1.0 \
        --max_epochs=400 --seed $RANDOM --default_root_dir exp/run_8

passed STC:
LLR: 2.93 (-2.94,2.94) <-0.50,2.50>
Total: 21424 W: 2078 L: 1907 D: 17439
Ptnml(0-2): 80, 1512, 7385, 1627, 108
https://tests.stockfishchess.org/tests/view/60a6c749ce8ea25a3ef03f4d

passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,3.50>
Total: 67912 W: 2851 L: 2648 D: 62413
Ptnml(0-2): 40, 2348, 28984, 2537, 47
https://tests.stockfishchess.org/tests/view/60a722ecce8ea25a3ef03fb9

Bench: 3779522