### PR TITLE
Simplify reduction for consecutive fails

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -377,7 +377,7 @@ void Thread::search() {
           // Start with a small aspiration window and, in the case of a fail
           // high/low, re-search with a bigger window until we don't fail
           // high/low anymore.
-          failedHighCnt = 0;
+          int failedHighCnt = 0;
           while (true)
           {
               Depth adjustedDepth = std::max(1, rootDepth - failedHighCnt - searchAgainCounter);
@@ -1156,10 +1156,6 @@ moves_loop: // When in check, search starts from here
               // Increase reduction if ttMove is a capture (~3 Elo)
               if (ttCapture)
                   r++;
-
-              // Increase reduction at root if failing high
-              if (rootNode)
-                  r += thisThread->failedHighCnt * thisThread->failedHighCnt * moveCount / 512;
 
               // Increase reduction for cut nodes (~3 Elo)
               if (cutNode)

--- a/src/thread.h
+++ b/src/thread.h
@@ -75,7 +75,6 @@ public:
   CapturePieceToHistory captureHistory;
   ContinuationHistory continuationHistory[2][2];
   Score contempt;
-  int failedHighCnt;
 };
 
 


### PR DESCRIPTION
This revert #3184.

---
Before new net architecture:

STC:
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 226336 W: 20373 L: 20500 D: 185463
Ptnml(0-2): 755, 16087, 79595, 15992, 739
https://tests.stockfishchess.org/tests/view/609dec205085663412d08e9d

LTC:
LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 67432 W: 2411 L: 2375 D: 62646
Ptnml(0-2): 33, 1944, 29714, 2004, 21
https://tests.stockfishchess.org/tests/view/609ee30f5085663412d08fc3

---
After new net architecture:

STC:
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 141752 W: 11591 L: 11617 D: 118544
Ptnml(0-2): 387, 9231, 51674, 9189, 395
https://tests.stockfishchess.org/tests/view/60a4320ace8ea25a3ef03cfd

LTC:
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 294072 W: 9825 L: 9950 D: 274297
Ptnml(0-2): 121, 8610, 129681, 8521, 103
https://tests.stockfishchess.org/tests/view/60a51b5ece8ea25a3ef03dcd

---

bench: 3752892