### PR TITLE
Fix discrepancy for ep square between set and move in the binpack lib.

### DIFF
--- a/src/extra/nnue_data_binpack_format.h
+++ b/src/extra/nnue_data_binpack_format.h
@@ -6078,18 +6078,14 @@ namespace chess
         // for double pushes move index differs by 16 or -16;
         if((movedPiece == PieceType::Pawn) & ((ordinal(move.to) ^ ordinal(move.from)) == 16))
         {
-            const Square potentialEpSquare = fromOrdinal<Square>((ordinal(move.to) + ordinal(move.from)) >> 1);
-            // Even though the move has not yet been made we can safely call
-            // this function and get the right result because the position of the
-            // pawn to be captured is not really relevant.
-            if (isEpPossible(potentialEpSquare, !m_sideToMove))
-            {
-                m_epSquare = potentialEpSquare;
-            }
+            m_epSquare = fromOrdinal<Square>((ordinal(move.to) + ordinal(move.from)) >> 1);
         }
 
         const Piece captured = BaseType::doMove(move);
         m_sideToMove = !m_sideToMove;
+
+        nullifyEpSquareIfNotPossible();
+
         return { move, captured, oldEpSquare, oldCastlingRights };
     }
 


### PR DESCRIPTION
Fixes reading 500M_t2_d8_p9.binpack from https://openchessdb.com/nnue.html. But it **might** break something else, as the encoding/decoding process is sensitive to such things, as proven once some time earlier where a fix needed to be reverted. However I'm hopeful that this time this issue is specific enough not to break correct encodings. But **please** if you can then run validation (rebase on top of #3497 )


raw from discord:

> [7:10 PM] Sopel: I found the issue that might be causing https://discord.com/channels/435943710472011776/733545871911813221/846424208053108748 but I'm unable to create a synthetic replication
> [7:11 PM] Sopel: basically, the binpack lib doesn't reset the epsquare after f7f5 in this 5kb1/5p2/2B3p1/1N1KP2p/3p1P2/2bP2P1/5r2/8 b - - 0 1 position, but it does reset it when passed the fen 5kb1/8/2B3p1/1N1KPp1p/3p1P2/2bP2P1/5r2/8 w - f6 0 50. Potentially creating a discrepancy based on whether the position was set directly or arrived at by a move
> [7:11 PM] Sopel: but I'm unable to create replication
> [7:12 PM] Sopel: I can fix it but I'm not sure it'll not break some existing data
> [7:12 PM] Sopel: will draft PR
> [7:13 PM] Sopel: I think it shouldn't but we never know, there was already one similar case
> [7:13 PM] Sopel: either way, now the error is corrected and the validation goes past
> [7:14 PM] Sopel: that means the position was written correctly, that is without the ep square, but when reading the binpack it arrives at it with a move, and doesn't remove the faux ep square
> [7:15 PM] Sopel: (which is weird, because stockfish doesn't remove it in this case too, and when converting PSV to a binpack entry it's not corrected, so it should be the other way around)

Needs to also be done in the nnue-pytorch trainer if merged.