### PR TITLE
Add additional checks for en-passant possiblity when fixing the erroneus ep flag from a fen.

### DIFF
--- a/src/extra/nnue_data_binpack_format.h
+++ b/src/extra/nnue_data_binpack_format.h
@@ -6116,6 +6116,26 @@ namespace chess
 
     [[nodiscard]] inline bool Position::isEpPossibleColdPath(Square epSquare, Bitboard pawnsAttackingEpSquare, Color sideToMove) const
     {
+        if (pieceAt(epSquare) != Piece::none())
+        {
+            return false;
+        }
+
+        const auto forward =
+            sideToMove == chess::Color::White
+            ? FlatSquareOffset(0, 1)
+            : FlatSquareOffset(0, -1);
+
+        if (pieceAt(epSquare + forward) != Piece::none())
+        {
+            return false;
+        }
+
+        if (pieceAt(epSquare + -forward) != Piece(PieceType::Pawn, !sideToMove))
+        {
+            return false;
+        }
+
         // only set m_epSquare when it matters, ie. when
         // the opposite side can actually capture
         for (Square sq : pawnsAttackingEpSquare)


### PR DESCRIPTION
This is a reapplication of https://github.com/nodchip/Stockfish/pull/316, but now it seems that it works, because the previous patch made the side to move consistent (as it's used in this additional checks). Still, better test this on some large amount of data before merging.