### PR TITLE
Make lazy threshold for the feature transformer PSQT a parameter.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -214,11 +214,12 @@ using namespace Trace;
 namespace {
 
   // Threshold for lazy and space evaluation
-  constexpr Value LazyThreshold1 =  Value(1565);
-  constexpr Value LazyThreshold2 =  Value(1102);
-  constexpr Value SpaceThreshold = Value(11551);
-  constexpr Value NNUEThreshold1 =   Value(682);
-  constexpr Value NNUEThreshold2 =   Value(176);
+  constexpr Value LazyThreshold1    =  Value(1565);
+  constexpr Value LazyThreshold2    =  Value(1102);
+  constexpr Value LazyThresholdNNUE =  Value(1400);
+  constexpr Value SpaceThreshold    = Value(11551);
+  constexpr Value NNUEThreshold1    =   Value(682);
+  constexpr Value NNUEThreshold2    =   Value(176);
 
   // KingAttackWeights[PieceType] contains king attack weights by piece type
   constexpr int KingAttackWeights[PIECE_TYPE_NB] = { 0, 0, 81, 52, 44, 10 };
@@ -1119,7 +1120,7 @@ Value Eval::evaluate(const Position& pos) {
 
          int scale = 903 + 28 * pos.count<PAWN>() + 28 * pos.non_pawn_material() / 1024;
 
-         Value nnue = NNUE::evaluate(pos, true) * scale / 1024;
+         Value nnue = NNUE::evaluate(pos, true, LazyThresholdNNUE) * scale / 1024;
 
          if (pos.is_chess960())
              nnue += fix_FRC(pos);

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -43,7 +43,7 @@ namespace Eval {
 
   namespace NNUE {
 
-    Value evaluate(const Position& pos, bool adjusted = false);
+    Value evaluate(const Position& pos, bool adjusted = false, Value lazyThreshold = VALUE_INFINITE);
     bool load_eval(std::string name, std::istream& stream);
     bool save_eval(std::ostream& stream);
     void init();

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -134,7 +134,7 @@ namespace Stockfish::Eval::NNUE {
   }
 
   // Evaluation function. Perform differential calculation.
-  Value evaluate(const Position& pos, bool adjusted) {
+  Value evaluate(const Position& pos, bool adjusted, Value lazyThreshold) {
 
     // We manually align the arrays on the stack because with gcc < 9.3
     // overaligning stack variables with alignas() doesn't work correctly.
@@ -158,7 +158,7 @@ namespace Stockfish::Eval::NNUE {
     ASSERT_ALIGNED(buffer, alignment);
 
     const std::size_t bucket = (pos.count<ALL_PIECES>() - 1) / 4;
-    const auto [psqt, lazy] = featureTransformer->transform(pos, transformedFeatures, bucket);
+    const auto [psqt, lazy] = featureTransformer->transform(pos, transformedFeatures, bucket, lazyThreshold);
 
     if (lazy)
       return static_cast<Value>(psqt / OutputScale);

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -124,8 +124,6 @@ namespace Stockfish::Eval::NNUE {
     // Number of output dimensions for one side
     static constexpr IndexType HalfDimensions = TransformedFeatureDimensions;
 
-    static constexpr int LazyThreshold = 1400;
-
     #ifdef VECTOR
     static constexpr IndexType TileHeight = NumRegs * sizeof(vec_t) / 2;
     static constexpr IndexType PsqtTileHeight = NumPsqtRegs * sizeof(psqt_vec_t) / 4;
@@ -171,7 +169,7 @@ namespace Stockfish::Eval::NNUE {
     }
 
     // Convert input features
-    std::pair<std::int32_t, bool> transform(const Position& pos, OutputType* output, int bucket) const {
+    std::pair<std::int32_t, bool> transform(const Position& pos, OutputType* output, int bucket, Value lazyThreshold) const {
       update_accumulator(pos, WHITE);
       update_accumulator(pos, BLACK);
 
@@ -184,7 +182,7 @@ namespace Stockfish::Eval::NNUE {
           - psqtAccumulation[static_cast<int>(perspectives[1])][bucket]
         ) / 2;
 
-      if (abs(psqt) > LazyThreshold * OutputScale)
+      if (abs(psqt) > (int)lazyThreshold * OutputScale)
         return { psqt, true };
 
   #if defined(USE_AVX512)


### PR DESCRIPTION
Definition of the lazy threshold moved to evaluate.cpp where all other are. Lazy threshold only used for real play, not used for "eval" call, preserving the purity of NNUE evaluation.

This is non-functional. If any tests are needed please tell me.