### PR TITLE
Search::init simplification

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -152,7 +152,7 @@ namespace {
 void Search::init() {
 
   for (int i = 1; i < MAX_MOVES; ++i)
-      Reductions[i] = int((21.3 + std::log(Threads.size())) * std::log(i + 0.25 * std::log(i)));
+      Reductions[i] = int(21.3 * std::log(i + 0.25 * std::log(i)));
 }
 
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -152,7 +152,7 @@ namespace {
 void Search::init() {
 
   for (int i = 1; i < MAX_MOVES; ++i)
-      Reductions[i] = int((21.3 + 2 * std::log(Threads.size())) * std::log(i + 0.25 * std::log(i)));
+      Reductions[i] = int((21.3 + std::log(Threads.size())) * std::log(i + 0.25 * std::log(i)));
 }
 
 


### PR DESCRIPTION
Dependance on Threads.size() was removed.

STC:
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 17376 W: 1024 L: 929 D: 15423
Ptnml(0-2): 24, 781, 6989, 864, 30
https://tests.stockfishchess.org/tests/view/60ac110812066fd2997957dc

LTC:
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 145552 W: 3656 L: 3673 D: 138223
Ptnml(0-2): 37, 3351, 66014, 3340, 34
https://tests.stockfishchess.org/tests/view/60ac267412066fd299795825