### PR TITLE
Do not use lazy evaluation inside NNUE

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -43,7 +43,7 @@ namespace Eval {
 
   namespace NNUE {
 
-    Value evaluate(const Position& pos, bool adjusted = false, Value lazyThreshold = VALUE_INFINITE);
+    Value evaluate(const Position& pos, bool adjusted = false);
     bool load_eval(std::string name, std::istream& stream);
     bool save_eval(std::ostream& stream);
     void init();

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -169,7 +169,7 @@ namespace Stockfish::Eval::NNUE {
     }
 
     // Convert input features
-    std::pair<std::int32_t, bool> transform(const Position& pos, OutputType* output, int bucket, Value lazyThreshold) const {
+    std::int32_t transform(const Position& pos, OutputType* output, int bucket) const {
       update_accumulator(pos, WHITE);
       update_accumulator(pos, BLACK);
 
@@ -181,9 +181,6 @@ namespace Stockfish::Eval::NNUE {
             psqtAccumulation[static_cast<int>(perspectives[0])][bucket]
           - psqtAccumulation[static_cast<int>(perspectives[1])][bucket]
         ) / 2;
-
-      if (abs(psqt) > (int)lazyThreshold * OutputScale)
-        return { psqt, true };
 
   #if defined(USE_AVX512)
       constexpr IndexType NumChunks = HalfDimensions / (SimdWidth * 2);
@@ -291,7 +288,7 @@ namespace Stockfish::Eval::NNUE {
       _mm_empty();
   #endif
 
-      return { psqt, false };
+      return psqt;
     }
 
    private:


### PR DESCRIPTION
This simplification patch implements two changes:

1. it simplifies away the so-called "lazy" path in the NNUE evaluation internals,
   where we trusted the psqt head alone to avoid the costly "positional" head in
   some cases;
2. it raises a little bit the NNUEThreshold1 in evaluate.cpp (from 682 to 800),
   which increases the limit where we switched from NNUE eval to Classical eval.

Both effects increase the number of positional evaluations done by our new net
architecture, but the results of our tests below seem to indicate that the loss
of speed will be compensated by the gain of eval quality.

STC:
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 26280 W: 2244 L: 2137 D: 21899
Ptnml(0-2): 72, 1755, 9405, 1810, 98
https://tests.stockfishchess.org/tests/view/60ae73f112066fd299795a51

LTC:
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 20592 W: 750 L: 677 D: 19165
Ptnml(0-2): 9, 614, 8980, 681, 12
https://tests.stockfishchess.org/tests/view/60ae88e812066fd299795a82

closes https://github.com/official-stockfish/Stockfish/pull/3503

Bench: 3817907