### PR TITLE
Generalize debugging functions with 512 counters

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -277,22 +277,32 @@ std::string compiler_info() {
 }
 
 
-/// Debug functions used mainly to collect run-time statistics
-static std::atomic<int64_t> hits[2], means[2];
+/// Debug functions used mainly to collect run-time statistics.
+/// Use the versions with a integer argument n to get up to 512 counters.
 
-void dbg_hit_on(bool b) { ++hits[0]; if (b) ++hits[1]; }
-void dbg_hit_on(bool c, bool b) { if (c) dbg_hit_on(b); }
-void dbg_mean_of(int v) { ++means[0]; means[1] += v; }
+const int MAX_DEBUG = 512;
+static std::atomic<int64_t> hits[MAX_DEBUG][2]  = {{ 0 }};
+static std::atomic<int64_t> means[MAX_DEBUG][2] = {{ 0 }};
+
+void dbg_hit_on(bool b,         int n)  { ++hits[n][0]; if (b) ++hits[n][1]; }
+void dbg_hit_on(bool c, bool b, int n)  { if (c) dbg_hit_on(b, n); }
+void dbg_mean_of(int v,         int n)  { ++means[n][0]; means[n][1] += v; }
+
+void dbg_hit_on(bool b)                 { dbg_hit_on(b, 0); }
+void dbg_hit_on(bool c, bool b)         { dbg_hit_on(c, b, 0); }
+void dbg_mean_of(int v)                 { dbg_mean_of(v, 0); }
 
 void dbg_print() {
 
-  if (hits[0])
-      cerr << "Total " << hits[0] << " Hits " << hits[1]
-           << " hit rate (%) " << 100 * hits[1] / hits[0] << endl;
+  for (int n = 0 ; n < MAX_DEBUG ; ++n)
+   	  if (hits[n][0])
+          cerr << "[" << n << "] Total " << hits[n][0] << " Hits " << hits[n][1]
+               << "  hit rate (%) " << 100 * hits[n][1] / hits[n][0] << endl;
 
-  if (means[0])
-      cerr << "Total " << means[0] << " Mean "
-           << (double)means[1] / means[0] << endl;
+  for (int n = 0 ; n < MAX_DEBUG ; ++n)
+      if (means[n][0])
+          cerr << "[" << n << "] Total " << means[n][0] << " Mean "
+               << (double)means[n][1] / means[n][0] << endl;
 }
 
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -283,21 +283,33 @@ std::string compiler_info() {
 const int MAX_DEBUG = 512;
 static std::atomic<int64_t> hits[MAX_DEBUG][2]  = {{ 0 }};
 static std::atomic<int64_t> means[MAX_DEBUG][2] = {{ 0 }};
+static std::string          name[MAX_DEBUG]     = {{ "" }};
+
+int dbg_find(string s) { for (int n = MAX_DEBUG - 1; n >= 0; n--)
+                           if (name[n] == s || name[n] == "")
+                              return name[n] = s, n;
+                         return 0; }
 
 void dbg_hit_on(bool b,         int n)  { ++hits[n][0]; if (b) ++hits[n][1]; }
 void dbg_hit_on(bool c, bool b, int n)  { if (c) dbg_hit_on(b, n); }
 void dbg_mean_of(int v,         int n)  { ++means[n][0]; means[n][1] += v; }
 
+void dbg_hit_on(bool b,         string s)  { dbg_hit_on(b,    dbg_find(s)); }
+void dbg_hit_on(bool c, bool b, string s)  { dbg_hit_on(b, c, dbg_find(s)); }
+void dbg_mean_of(int v,         string s)  { dbg_mean_of(v,   dbg_find(s)); }
+
 void dbg_print() {
+
+  auto dbg_name = [&](int n) { return name[n] != "" ? name[n] : to_string(n); };
 
   for (int n = 0 ; n < MAX_DEBUG ; ++n)
    	  if (hits[n][0])
-          cerr << "[" << n << "] Total " << hits[n][0] << " Hits " << hits[n][1]
+          cerr << "[" << dbg_name(n) << "] Total " << hits[n][0] << " Hits " << hits[n][1]
                << "  hit rate (%) " << 100 * hits[n][1] / hits[n][0] << endl;
 
   for (int n = 0 ; n < MAX_DEBUG ; ++n)
       if (means[n][0])
-          cerr << "[" << n << "] Total " << means[n][0] << " Mean "
+          cerr << "[" << dbg_name(n) << "] Total " << means[n][0] << " Mean "
                << (double)means[n][1] / means[n][0] << endl;
 }
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -288,10 +288,6 @@ void dbg_hit_on(bool b,         int n)  { ++hits[n][0]; if (b) ++hits[n][1]; }
 void dbg_hit_on(bool c, bool b, int n)  { if (c) dbg_hit_on(b, n); }
 void dbg_mean_of(int v,         int n)  { ++means[n][0]; means[n][1] += v; }
 
-void dbg_hit_on(bool b)                 { dbg_hit_on(b, 0); }
-void dbg_hit_on(bool c, bool b)         { dbg_hit_on(c, b, 0); }
-void dbg_mean_of(int v)                 { dbg_mean_of(v, 0); }
-
 void dbg_print() {
 
   for (int n = 0 ; n < MAX_DEBUG ; ++n)

--- a/src/misc.h
+++ b/src/misc.h
@@ -43,6 +43,9 @@ void aligned_large_pages_free(void* mem); // nop if mem == nullptr
 void dbg_hit_on(bool b,         int n = 0);
 void dbg_hit_on(bool c, bool b, int n = 0);
 void dbg_mean_of(int v,         int n = 0);
+void dbg_hit_on(bool b,         std::string s);
+void dbg_hit_on(bool c, bool b, std::string s);
+void dbg_mean_of(int v,         std::string s);
 void dbg_print();
 
 typedef std::chrono::milliseconds::rep TimePoint; // A value in milliseconds

--- a/src/misc.h
+++ b/src/misc.h
@@ -39,12 +39,10 @@ void std_aligned_free(void* ptr);
 void* aligned_large_pages_alloc(size_t size); // memory aligned by page size, min alignment: 4096 bytes
 void aligned_large_pages_free(void* mem); // nop if mem == nullptr
 
-void dbg_hit_on(bool b);
-void dbg_hit_on(bool c, bool b);
-void dbg_mean_of(int v);
-void dbg_hit_on(bool b, int n);
-void dbg_hit_on(bool c, bool b, int n);
-void dbg_mean_of(int v, int n);
+
+void dbg_hit_on(bool b,         int n = 0);
+void dbg_hit_on(bool c, bool b, int n = 0);
+void dbg_mean_of(int v,         int n = 0);
 void dbg_print();
 
 typedef std::chrono::milliseconds::rep TimePoint; // A value in milliseconds

--- a/src/misc.h
+++ b/src/misc.h
@@ -42,6 +42,9 @@ void aligned_large_pages_free(void* mem); // nop if mem == nullptr
 void dbg_hit_on(bool b);
 void dbg_hit_on(bool c, bool b);
 void dbg_mean_of(int v);
+void dbg_hit_on(bool b, int n);
+void dbg_hit_on(bool c, bool b, int n);
+void dbg_mean_of(int v, int n);
 void dbg_print();
 
 typedef std::chrono::milliseconds::rep TimePoint; // A value in milliseconds


### PR DESCRIPTION
Generalize dbg_hit() and dbg_mean_of() to allow statistics for 512 different levels.

For instance, using dbg_mean_of(value, depth) instead of dbg_mean_of(value),
we can now get distinct statistics for each depth during the search. Another
example to get the average value of NNUE eval bucket by bucket for our new net:

```
dbg_mean_of( abs(sum/OutputScale), bucket);

[0] Total 1487 Mean 1175.51
[1] Total 95558 Mean 303.013
[2] Total 30585 Mean 438.34
[3] Total 47250 Mean 534.691
[4] Total 76898 Mean 380.318
[5] Total 176846 Mean 380.57
[6] Total 154532 Mean 257.359
[7] Total 2489 Mean 341.965
```

It would be cool to write a small python script to catch the output of this patch
and draw nice histograms or nice curves automatically after a simple "bench" command,
for instance.

closes https://github.com/official-stockfish/Stockfish/pull/3504

No functional change