### PR TITLE
Remove Stat Reset at beta cutoff bench: 3831936

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1273,7 +1273,6 @@ moves_loop: // When in check, search starts from here
               else
               {
                   assert(value >= beta); // Fail high
-                  ss->statScore = 0;
                   break;
               }
           }


### PR DESCRIPTION
Remove Stat Reset at beta cutoff

STC:
LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 63936 W: 5350 L: 5288 D: 53298
Ptnml(0-2): 184, 4295, 22954, 4345, 190
https://tests.stockfishchess.org/tests/view/60affb4c12066fd299795c64

LTC:
LLR: 2.96 (-2.94,2.94) <-2.50,0.50>
Total: 35856 W: 1201 L: 1142 D: 33513
Ptnml(0-2): 7, 1031, 15795, 1086, 9
https://tests.stockfishchess.org/tests/view/60affb4c12066fd299795c64

Bench:  3831936