### PR TITLE
Simplify NNUE / classical evaluation selection

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -218,7 +218,6 @@ namespace {
   constexpr Value LazyThreshold2    =  Value(1102);
   constexpr Value SpaceThreshold    = Value(11551);
   constexpr Value NNUEThreshold1    =   Value(800);
-  constexpr Value NNUEThreshold2    =   Value(176);
 
   // KingAttackWeights[PieceType] contains king attack weights by piece type
   constexpr int KingAttackWeights[PIECE_TYPE_NB] = { 0, 0, 81, 52, 44, 10 };
@@ -1127,29 +1126,14 @@ Value Eval::evaluate(const Position& pos) {
          return nnue;
       };
 
-      // If there is PSQ imbalance we use the classical eval. We also introduce
-      // a small probability of using the classical eval when PSQ imbalance is small.
+      // If there is PSQ imbalance we use the classical eval.
       Value psq = Value(abs(eg_value(pos.psq_score())));
       int   r50 = 16 + pos.rule50_count();
       bool  largePsq = psq * 16 > (NNUEThreshold1 + pos.non_pawn_material() / 64) * r50;
 
-      // Use classical evaluation for really low piece endgames.
-      // One critical case is the draw for bishop + A/H file pawn vs naked king.
-      bool lowPieceEndgame =   pos.non_pawn_material() == BishopValueMg
-                            || (pos.non_pawn_material() < 2 * RookValueMg && pos.count<PAWN>() < 2);
+      v = largePsq ? Evaluation<NO_TRACE>(pos).value()  // classical
+                   : adjusted_NNUE();                   // NNUE
 
-      v = largePsq || lowPieceEndgame ? Evaluation<NO_TRACE>(pos).value()  // classical
-                                      : adjusted_NNUE();                   // NNUE
-
-      // If the classical eval is small and imbalance large, use NNUE nevertheless.
-      // For the case of opposite colored bishops, switch to NNUE eval with small
-      // probability if the classical eval is less than the threshold.
-      if (    largePsq
-          && !lowPieceEndgame
-          && (   abs(v) * 16 < NNUEThreshold2 * r50
-              || (   pos.opposite_bishops()
-                  && abs(v) * 16 < (NNUEThreshold1 + pos.non_pawn_material() / 64) * r50)))
-          v = adjusted_NNUE();
   }
 
   // Damp down the evaluation linearly when shuffling


### PR DESCRIPTION
for the new network architecture these rules can be simplified,
closer to the original PSQT difference based again.

passed STC
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 22656 W: 1979 L: 1868 D: 18809
Ptnml(0-2): 70, 1496, 8087, 1603, 72
https://tests.stockfishchess.org/tests/view/60b24579db3c4776cb89d122

passed LTC
LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 30224 W: 1015 L: 953 D: 28256
Ptnml(0-2): 4, 860, 13330, 906, 12
https://tests.stockfishchess.org/tests/view/60b27613db3c4776cb89d145

Bench: 3937626