### PR TITLE
check extension using a static evaluation

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1097,6 +1097,11 @@ moves_loop: // When in check, search starts from here
                   return beta;
           }
       }
+	  
+	  else if (givesCheck 
+			&& depth > 6
+			&& abs(ss->staticEval) > Value(100))
+          extension = 1;
 
       // Add extension to new depth
       newDepth += extension;


### PR DESCRIPTION
Check Extension using Static Evaluation:
stc:
LLR: 2.97 (-2.94,2.94) <-0.50,2.50>
Total: 87008 W: 7337 L: 7100 D: 72571
Ptnml(0-2): 264, 5737, 31270, 5964, 269
https://tests.stockfishchess.org/tests/view/60b1034787a1a67ae56c47b6

ltc:
LLR: 2.94 (-2.94,2.94) <0.50,3.50>
Total: 79320 W: 2629 L: 2432 D: 74259
Ptnml(0-2): 29, 2205, 35000, 2392, 34
https://tests.stockfishchess.org/tests/view/60b1ae0b87a1a67ae56c487c

Bench: 4447112