### PR TITLE
Remove formerPV variable.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -561,7 +561,7 @@ namespace {
     Move ttMove, move, excludedMove, bestMove;
     Depth extension, newDepth;
     Value bestValue, value, ttValue, eval, maxValue, probCutBeta;
-    bool formerPv, givesCheck, improving, didLMR, priorCapture;
+    bool givesCheck, improving, didLMR, priorCapture;
     bool captureOrPromotion, doFullDepthSearch, moveCountPruning,
          ttCapture, singularQuietLMR;
     Piece movedPiece;
@@ -632,7 +632,6 @@ namespace {
             : ss->ttHit    ? tte->move() : MOVE_NONE;
     if (!excludedMove)
         ss->ttPv = PvNode || (ss->ttHit && tte->is_pv());
-    formerPv = ss->ttPv && !PvNode;
 
     // Update low ply history for previous move if we are near root and position is or has been in PV
     if (   ss->ttPv
@@ -1062,8 +1061,8 @@ moves_loop: // When in check, search starts from here
           && (tte->bound() & BOUND_LOWER)
           &&  tte->depth() >= depth - 3)
       {
-          Value singularBeta = ttValue - ((formerPv + 4) * depth) / 2;
-          Depth singularDepth = (depth - 1 + 3 * formerPv) / 2;
+          Value singularBeta = ttValue - 2 * depth;
+          Depth singularDepth = (depth - 1) / 2;
 
           ss->excludedMove = move;
           value = search<NonPV>(pos, ss, singularBeta - 1, singularBeta, singularDepth, cutNode);
@@ -1126,7 +1125,7 @@ moves_loop: // When in check, search starts from here
           &&  moveCount > 1 + 2 * rootNode
           && (  !captureOrPromotion
               || (cutNode && (ss-1)->moveCount > 1)
-              || (!PvNode && !formerPv))
+              || !ss->ttPv)
           && (!PvNode || ss->ply > 1 || thisThread->id() % 4 != 3))
       {
           Depth r = reduction(improving, depth, moveCount);


### PR DESCRIPTION
STC:
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 75672 W: 6546 L: 6496 D: 62630
Ptnml(0-2): 238, 5274, 26761, 5326, 237
https://tests.stockfishchess.org/tests/view/60b349c0ec0c03148cbed055

LTC:
LLR: 2.98 (-2.94,2.94) <-2.50,0.50>
Total: 137816 W: 4676 L: 4689 D: 128451
Ptnml(0-2): 52, 4237, 60354, 4202, 63
https://tests.stockfishchess.org/tests/view/60b38970ec0c03148cbed075

Bench: 4892288