### PR TITLE
Pre-initialize ss->ply over the whole stack.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -268,6 +268,9 @@ void Thread::search() {
   for (int i = 7; i > 0; i--)
       (ss-i)->continuationHistory = &this->continuationHistory[0][0][NO_PIECE][0]; // Use as a sentinel
 
+  for (int i = 1; i <= MAX_PLY; ++i)
+      (ss+i)->ply = i;
+
   ss->pv = pv;
 
   bestValue = delta = alpha = -VALUE_INFINITE;
@@ -607,7 +610,6 @@ namespace {
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
-    (ss+1)->ply = ss->ply + 1;
     (ss+1)->ttPv = false;
     (ss+1)->excludedMove = bestMove = MOVE_NONE;
     (ss+2)->killers[0] = (ss+2)->killers[1] = MOVE_NONE;
@@ -1375,7 +1377,6 @@ moves_loop: // When in check, search starts from here
     }
 
     Thread* thisThread = pos.this_thread();
-    (ss+1)->ply = ss->ply + 1;
     bestMove = MOVE_NONE;
     ss->inCheck = pos.checkers();
     moveCount = 0;


### PR DESCRIPTION
There is no need to re-assign the same value(s) over and over again
while searching. Probably a tiny speedup on longer searches.

Tested for no regression.
STC
LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 25784 W: 2205 L: 2101 D: 21478
Ptnml(0-2): 62, 1660, 9368, 1716, 86 
https://tests.stockfishchess.org/tests/view/60b516c6457376eb8bca9dfa

LTC
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 26200 W: 944 L: 878 D: 24378
Ptnml(0-2): 12, 732, 11545, 800, 11 
https://tests.stockfishchess.org/tests/view/60b53652457376eb8bca9e0e

No functional change.