### PR TITLE
Better "make clean" for Windows in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -793,6 +793,9 @@ profileclean:
 	@rm -rf profdir
 	@rm -f bench.txt *.gcda *.gcno ./syzygy/*.gcda ./nnue/*.gcda ./nnue/features/*.gcda *.s
 	@rm -f stockfish.profdata *.profraw
+	@rm -f stockfish.exe.lto_wrapper_args
+	@rm -f stockfish.exe.ltrans.out
+	@rm -f ./-lstdc++.res
 
 default:
 	help


### PR DESCRIPTION
Make clean should be really clean on Windows.

Fixes issue https://github.com/official-stockfish/Stockfish/issues/3291
Closes https://github.com/official-stockfish/Stockfish/pull/3517

No functional change