### PR TITLE
Fix StateInfo leak

### DIFF
--- a/src/endgame.h
+++ b/src/endgame.h
@@ -109,9 +109,9 @@ namespace Endgames {
   template<EndgameCode E, typename T = eg_type<E>>
   void add(const std::string& code) {
 
-    StateInfo st;
-    map<T>()[Position().set(code, WHITE, &st).material_key()] = Ptr<T>(new Endgame<E>(WHITE));
-    map<T>()[Position().set(code, BLACK, &st).material_key()] = Ptr<T>(new Endgame<E>(BLACK));
+    StateInfo st[2];
+    map<T>()[Position().set(code, WHITE, &st[0], &st[1]).material_key()] = Ptr<T>(new Endgame<E>(WHITE));
+    map<T>()[Position().set(code, BLACK, &st[0], &st[1]).material_key()] = Ptr<T>(new Endgame<E>(BLACK));
   }
 
   template<typename T>

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -277,6 +277,7 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, St
 
   // It's necessary for st->previous to be intialized in this way because legality check relies on its existence
   if (enpassant) {
+      std::memset(ep, 0, sizeof(StateInfo));
       st->previous = ep;
       remove_piece(st->epSquare - pawn_push(sideToMove));
       st->previous->checkersBB = attackers_to(square<KING>(~sideToMove)) & pieces(sideToMove);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -276,7 +276,8 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
 
   // It's necessary for st->previous to be intialized in this way because legality check relies on its existence
   if (enpassant) {
-      st->previous = sentinel();
+      assert(th != nullptr);
+      st->previous = &th->sentinelState;
       remove_piece(st->epSquare - pawn_push(sideToMove));
       st->previous->checkersBB = attackers_to(square<KING>(~sideToMove)) & pieces(sideToMove);
       st->previous->blockersForKing[WHITE] = slider_blockers(pieces(BLACK), square<KING>(WHITE), st->previous->pinners[BLACK]);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -276,7 +276,7 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
 
   // It's necessary for st->previous to be intialized in this way because legality check relies on its existence
   if (enpassant) {
-      st->previous = new StateInfo();
+      st->previous = sentinel();
       remove_piece(st->epSquare - pawn_push(sideToMove));
       st->previous->checkersBB = attackers_to(square<KING>(~sideToMove)) & pieces(sideToMove);
       st->previous->blockersForKing[WHITE] = slider_blockers(pieces(BLACK), square<KING>(WHITE), st->previous->pinners[BLACK]);

--- a/src/position.h
+++ b/src/position.h
@@ -184,6 +184,8 @@ private:
   template<bool Do>
   void do_castling(Color us, Square from, Square& to, Square& rfrom, Square& rto);
 
+  static StateInfo* sentinel();
+
   // Data members
   Piece board[SQUARE_NB];
   Bitboard byTypeBB[PIECE_TYPE_NB];
@@ -412,6 +414,13 @@ inline StateInfo* Position::state() const {
 
   return st;
 }
+
+inline StateInfo* Position::sentinel() {
+
+    static StateInfo singleton;
+    return &singleton;
+}
+
 
 } // namespace Stockfish
 

--- a/src/position.h
+++ b/src/position.h
@@ -86,8 +86,8 @@ public:
   Position& operator=(const Position&) = delete;
 
   // FEN string input/output
-  Position& set(const std::string& fenStr, bool isChess960, StateInfo* si, Thread* th);
-  Position& set(const std::string& code, Color c, StateInfo* si);
+  Position& set(const std::string& fenStr, bool isChess960, StateInfo* si, StateInfo* ep, Thread* th);
+  Position& set(const std::string& code, Color c, StateInfo* si, StateInfo* ep);
   std::string fen() const;
 
   // Position representation
@@ -183,8 +183,6 @@ private:
   void move_piece(Square from, Square to);
   template<bool Do>
   void do_castling(Color us, Square from, Square& to, Square& rfrom, Square& rto);
-
-  static StateInfo* sentinel();
 
   // Data members
   Piece board[SQUARE_NB];
@@ -414,13 +412,6 @@ inline StateInfo* Position::state() const {
 
   return st;
 }
-
-inline StateInfo* Position::sentinel() {
-
-    static StateInfo singleton;
-    return &singleton;
-}
-
 
 } // namespace Stockfish
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -364,10 +364,10 @@ struct TBTable {
 template<>
 TBTable<WDL>::TBTable(const std::string& code) : TBTable() {
 
-    StateInfo st;
+    StateInfo st[2];
     Position pos;
 
-    key = pos.set(code, WHITE, &st).material_key();
+    key = pos.set(code, WHITE, &st[0], &st[1]).material_key();
     pieceCount = pos.count<ALL_PIECES>();
     hasPawns = pos.pieces(PAWN);
 
@@ -386,7 +386,7 @@ TBTable<WDL>::TBTable(const std::string& code) : TBTable() {
     pawnCount[0] = pos.count<PAWN>(c ? WHITE : BLACK);
     pawnCount[1] = pos.count<PAWN>(c ? BLACK : WHITE);
 
-    key2 = pos.set(code, BLACK, &st).material_key();
+    key2 = pos.set(code, BLACK, &st[0], &st[1]).material_key();
 }
 
 template<>

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -205,7 +205,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
       th->nodes = th->tbHits = th->nmpMinPly = th->bestMoveChanges = 0;
       th->rootDepth = th->completedDepth = 0;
       th->rootMoves = rootMoves;
-      th->rootPos.set(pos.fen(), pos.is_chess960(), &th->rootState, th);
+      th->rootPos.set(pos.fen(), pos.is_chess960(), &th->rootState, &th->sentinelState, th);
       th->rootState = setupStates->back();
   }
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -66,7 +66,7 @@ public:
   std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;
 
   Position rootPos;
-  StateInfo rootState;
+  StateInfo rootState, sentinelState;
   Search::RootMoves rootMoves;
   Depth rootDepth, completedDepth;
   CounterMoveHistory counterMoves;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -67,8 +67,8 @@ namespace {
     else
         return;
 
-    states = StateListPtr(new std::deque<StateInfo>(1)); // Drop old and create a new one
-    pos.set(fen, Options["UCI_Chess960"], &states->back(), Threads.main());
+    states = StateListPtr(new std::deque<StateInfo>(2)); // Drop old and create a new one
+    pos.set(fen, Options["UCI_Chess960"], &states->back(), &states->front(), Threads.main());
 
     // Parse move list (if any)
     while (is >> token && (m = UCI::to_move(pos, token)) != MOVE_NONE)
@@ -83,9 +83,9 @@ namespace {
 
   void trace_eval(Position& pos) {
 
-    StateListPtr states(new std::deque<StateInfo>(1));
+    StateListPtr states(new std::deque<StateInfo>(2));
     Position p;
-    p.set(pos.fen(), Options["UCI_Chess960"], &states->back(), Threads.main());
+    p.set(pos.fen(), Options["UCI_Chess960"], &states->back(), &states->front(), Threads.main());
 
     Eval::NNUE::verify();
 
@@ -232,9 +232,9 @@ void UCI::loop(int argc, char* argv[]) {
 
   Position pos;
   string token, cmd;
-  StateListPtr states(new std::deque<StateInfo>(1));
+  StateListPtr states(new std::deque<StateInfo>(2));
 
-  pos.set(StartFEN, false, &states->back(), Threads.main());
+  pos.set(StartFEN, false, &states->back(), &states->front(), Threads.main());
 
   for (int i = 1; i < argc; ++i)
       cmd += std::string(argv[i]) + " ";


### PR DESCRIPTION
Fix the StateInfo memory leak reported by the address sanitizer:


> ==473916==ERROR: LeakSanitizer: detected memory leaks
> 
> Direct leak of 2432 byte(s) in 1 object(s) allocated from:
>     #0 0x7f55e13c0067 in operator new(unsigned long, std::align_val_t) (/lib64/libasan.so.6+0xad067)
>     #1 0x469426 in Stockfish::Position::set(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, Stockfish::StateInfo*, Stockfish::Thread*) /home/gv/prog/workspace/Stockfish/src/position.cpp:279
>     #2 0x4a5a37 in Stockfish::ThreadPool::start_thinking(Stockfish::Position&, std::unique_ptr<std::deque<Stockfish::StateInfo, std::allocator<Stockfish::StateInfo> >, std::default_delete<std::deque<Stockfish::StateInfo, std::allocator<Stockfish::StateInfo> > > >&, Stockfish::Search::LimitsType const&, bool) /home/gv/prog/workspace/Stockfish/src/thread.cpp:208
>     #3 0x4bad5c in go /home/gv/prog/workspace/Stockfish/src/uci.cpp:150
>     #4 0x4bb2f6 in bench /home/gv/prog/workspace/Stockfish/src/uci.cpp:178
>     #5 0x4bc43a in Stockfish::UCI::loop(int, char**) /home/gv/prog/workspace/Stockfish/src/uci.cpp:276
>     #6 0x44c2d6 in main /home/gv/prog/workspace/Stockfish/src/main.cpp:49
>     #7 0x7f55e0e051e1 in __libc_start_main (/lib64/libc.so.6+0x281e1)> 
> 
> SUMMARY: AddressSanitizer: 2432 byte(s) leaked in 1 allocation(s).

No functional change.