### PR TITLE
Make extra time for bestMoveInstability dependent on rootdepth.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -480,8 +480,8 @@ void Thread::search() {
               totBestMoveChanges += th->bestMoveChanges;
               th->bestMoveChanges = 0;
           }
-          double bestMoveInstability = 1 + 2 * totBestMoveChanges / Threads.size();
-
+          double bestMoveInstability = 1.073 + std::max(1.0, 2.25 - 9.9 / rootDepth)
+                                              * totBestMoveChanges / Threads.size();
           double totalTime = Time.optimum() * fallingEval * reduction * bestMoveInstability;
 
           // Cap used time in case of a single legal move for a better viewer experience in tournaments


### PR DESCRIPTION
This change allocates more base time to moves and makes the additional time added for best move instability dependent on rootdepth.

STC 10+0.1 :
LLR: 2.94 (-2.94,2.94) <-0.50,2.50>
Total: 19432 W: 1711 L: 1553 D: 16168
Ptnml(0-2): 47, 1250, 6989, 1358, 72
https://tests.stockfishchess.org/tests/view/60b8cd41457376eb8bcaa1ad

LTC 60+0.6 :
LLR: 2.93 (-2.94,2.94) <0.50,3.50>
Total: 22480 W: 810 L: 693 D: 20977
Ptnml(0-2): 9, 603, 9902, 714, 12
https://tests.stockfishchess.org/tests/view/60b8e5bf457376eb8bcaa1e6

Bench 4364128