### PR TITLE
Alternative Fix for 3523

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -251,8 +251,6 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
       set_castling_right(c, rsq);
   }
 
-  set_state(st);
-
   // 4. En passant square.
   // Ignore if square is invalid or not on side to move relative rank 6.
   bool enpassant = false;
@@ -260,28 +258,27 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
   if (   ((ss >> col) && (col >= 'a' && col <= 'h'))
       && ((ss >> row) && (row == (sideToMove == WHITE ? '6' : '3'))))
   {
+      assert(th != nullptr);
       st->epSquare = make_square(File(col - 'a'), Rank(row - '1'));
 
       // En passant square will be considered only if
       // a) side to move have a pawn threatening epSquare
       // b) there is an enemy pawn in front of epSquare
       // c) there is no piece on epSquare or behind epSquare
-      // d) enemy pawn didn't block a check of its own color by moving forward
       enpassant = pawn_attacks_bb(~sideToMove, st->epSquare) & pieces(sideToMove, PAWN)
                && (pieces(~sideToMove, PAWN) & (st->epSquare + pawn_push(~sideToMove)))
-               && !(pieces() & (st->epSquare | (st->epSquare + pawn_push(sideToMove))))
-               && (   file_of(square<KING>(sideToMove)) == file_of(st->epSquare)
-                   || !(blockers_for_king(sideToMove) & (st->epSquare + pawn_push(~sideToMove))));
+               && !(pieces() & (st->epSquare | (st->epSquare + pawn_push(sideToMove))));
   }
 
-  // It's necessary for st->previous to be intialized in this way because legality check relies on its existence
+  // It's necessary for st->previous to be intialized because legality check relies on its existence
   if (enpassant) {
-      st->previous = new StateInfo();
-      remove_piece(st->epSquare - pawn_push(sideToMove));
-      st->previous->checkersBB = attackers_to(square<KING>(~sideToMove)) & pieces(sideToMove);
-      st->previous->blockersForKing[WHITE] = slider_blockers(pieces(BLACK), square<KING>(WHITE), st->previous->pinners[BLACK]);
-      st->previous->blockersForKing[BLACK] = slider_blockers(pieces(WHITE), square<KING>(BLACK), st->previous->pinners[WHITE]);
-      put_piece(make_piece(~sideToMove, PAWN), st->epSquare - pawn_push(sideToMove));
+      move_piece(st->epSquare - pawn_push(sideToMove), st->epSquare + pawn_push(sideToMove));
+      sideToMove = ~sideToMove;
+      th->sentinelState.epSquare = SQ_NONE;
+      th->sentinelState.castlingRights = st->castlingRights;
+      set_state(st->previous = &th->sentinelState);
+      sideToMove = ~sideToMove;
+      move_piece(st->epSquare + pawn_push(sideToMove), st->epSquare - pawn_push(sideToMove));
   }
   else
       st->epSquare = SQ_NONE;
@@ -295,6 +292,7 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
 
   chess960 = isChess960;
   thisThread = th;
+  set_state(st);
   st->accumulator.state[WHITE] = Eval::NNUE::INIT;
   st->accumulator.state[BLACK] = Eval::NNUE::INIT;
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -66,7 +66,7 @@ public:
   std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;
 
   Position rootPos;
-  StateInfo rootState;
+  StateInfo rootState, sentinelState;
   Search::RootMoves rootMoves;
   Depth rootDepth, completedDepth;
   CounterMoveHistory counterMoves;


### PR DESCRIPTION
This is an alternative to fix the leak introduced in #3330. 
By using a sentinel in Thread, it fixs the leak.

Note that when `th == nullptr` is only true when setting endgame material key and the pieces are only placed on 2nd and 7th rank, so it's impossible to set a en passant under these conditions.

Also note that it adds an `assert`, but it's goal is to warn unlikely future sets that doesn't use threads. (note that, by not using thread in a position, it can't use `do_move()`)

base non-regression STC:
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 26848 W: 2274 L: 2171 D: 22403
Ptnml(0-2): 75, 1699, 9787, 1774, 89
https://tests.stockfishchess.org/tests/view/60ba1a69457376eb8bcaa2e6

patch non-regression STC:
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 89688 W: 7595 L: 7562 D: 74531
Ptnml(0-2): 255, 6023, 32262, 6042, 262
https://tests.stockfishchess.org/tests/view/60ba4e52457376eb8bcaa30a

No functional change