### PR TITLE
Simplify Reduction on Null Move Search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -810,7 +810,7 @@ namespace {
         assert(eval - beta >= 0);
 
         // Null move dynamic reduction based on depth and value
-        Depth R = (1090 + 81 * depth) / 256 + std::min(int(eval - beta) / 205, 3);
+        Depth R = (1090 + 81 * depth + int(eval - beta)) / 256;
 
         ss->currentMove = MOVE_NULL;
         ss->continuationHistory = &thisThread->continuationHistory[0][0][NO_PIECE][0];


### PR DESCRIPTION
This patch simplifies reduction on null move search

STC:
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 162736 W: 13604 L: 13655 D: 135477
Ptnml(0-2): 513, 11075, 58192, 11126, 462
https://tests.stockfishchess.org/tests/view/60b7e014457376eb8bcaa119

LTC:
LLR: 3.21 (-2.94,2.94) <-2.50,0.50>
Total: 280512 W: 9390 L: 9500 D: 261622
Ptnml(0-2): 102, 8578, 123003, 8474, 99
https://tests.stockfishchess.org/tests/view/60b8c60d457376eb8bcaa1a7

bench: 3883393