### PR TITLE
Reduce in LMR reduction on PvNode

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1132,6 +1132,9 @@ moves_loop: // When in check, search starts from here
       {
           Depth r = reduction(improving, depth, moveCount);
 
+          if (PvNode)
+              r--;
+
           // Decrease reduction if the ttHit running average is large (~0 Elo)
           if (thisThread->ttHitAverage > 537 * TtHitAverageResolution * TtHitAverageWindow / 1024)
               r--;


### PR DESCRIPTION
This patch reduces reduction in LMR by 1 on PvNode.

STC:
LLR: 2.93 (-2.94,2.94) <-0.50,2.50>
Total: 266080 W: 22438 L: 21996 D: 221646
Ptnml(0-2): 774, 17874, 95376, 18168, 848
https://tests.stockfishchess.org/tests/view/60bc0661457376eb8bcaa4bb

LTC:
LLR: 2.93 (-2.94,2.94) <0.50,3.50>
Total: 20144 W: 698 L: 587 D: 18859
Ptnml(0-2): 2, 529, 8906, 626, 9
https://tests.stockfishchess.org/tests/view/60bcc3f2457376eb8bcaa58d

bench: 5173012