### PR TITLE
Simplify Promotion Movegen

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1464,7 +1464,7 @@ moves_loop: // When in check, search starts from here
 
     // Initialize a MovePicker object for the current position, and prepare
     // to search the moves. Because the depth is <= 0 here, only captures,
-    // queen and checking knight promotions, and other checks(only if depth >= DEPTH_QS_CHECKS)
+    // queen promotions, and other checks(only if depth >= DEPTH_QS_CHECKS)
     // will be generated.
     MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory,
                                       &thisThread->captureHistory,


### PR DESCRIPTION
It removes Knight promotion checks from Captures. As a consequence, it also removes this underpromotion from qsearch.

STC:
LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 37776 W: 3113 L: 3023 D: 31640
Ptnml(0-2): 103, 2419, 13755, 2507, 104
https://tests.stockfishchess.org/tests/view/60be6a06457376eb8bcaa775

LTC:
LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 39760 W: 1257 L: 1203 D: 37300
Ptnml(0-2): 11, 1079, 17646, 1133, 11
https://tests.stockfishchess.org/tests/view/60beb972457376eb8bcaa7c5

bench: 5530620