### PR TITLE
Limit double Extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -611,6 +611,7 @@ namespace {
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
     (ss+1)->ttPv = false;
+    ss->doubleExt      = (ss-1)->doubleExt;
     (ss+1)->excludedMove = bestMove = MOVE_NONE;
     (ss+2)->killers[0] = (ss+2)->killers[1] = MOVE_NONE;
     Square prevSq = to_sq((ss-1)->currentMove);
@@ -1074,7 +1075,8 @@ moves_loop: // When in check, search starts from here
           {
               extension = 1;
               singularQuietLMR = !ttCapture;
-              if (!PvNode && value < singularBeta - 93)
+              // avoid search explosion by limiting the number of double extensions to at most 3.
+              if (!PvNode && value < singularBeta - 93 && ss->doubleExt < 3)
                   extension = 2;
           }
 
@@ -1104,6 +1106,7 @@ moves_loop: // When in check, search starts from here
           extension = 1;
 
       // Add extension to new depth
+      ss->doubleExt      = (ss-1)->doubleExt + (extension == 2);
       newDepth += extension;
 
       // Speculative prefetch as early as possible

--- a/src/search.h
+++ b/src/search.h
@@ -52,6 +52,7 @@ struct Stack {
   bool inCheck;
   bool ttPv;
   bool ttHit;
+  int doubleExt;
 };
 
 


### PR DESCRIPTION
double extensions can lead to search explosions, for specific positions.
Currently, however, this double extensions is worth about 10Elo and can't be removed.
This patch instead limits the number of double extensions given to a maximum of 3.

This fixes https://github.com/official-stockfish/Stockfish/issues/3532
where the following testcase was shown to be problematic:

```
uci
setoption name Hash value 4
setoption name Contempt value 0
ucinewgame
position fen 8/Pk6/8/1p6/8/P1K5/8/6B1 w - - 37 130
go depth 20
```

passed STC:
https://tests.stockfishchess.org/tests/view/60c13161457376eb8bcaaa0f
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 73256 W: 6114 L: 6062 D: 61080
Ptnml(0-2): 222, 4912, 26306, 4968, 220

passed LTC:
https://tests.stockfishchess.org/tests/view/60c196fb457376eb8bcaaa6b
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 166440 W: 5559 L: 5594 D: 155287
Ptnml(0-2): 106, 4921, 73197, 4894, 102

Bench: 5067605