### PR TITLE
Fix wrong state init

### DIFF
--- a/src/tools/sfen_packer.cpp
+++ b/src/tools/sfen_packer.cpp
@@ -260,6 +260,8 @@ namespace Stockfish::Tools {
 
         pos.clear();
         std::memset(si, 0, sizeof(StateInfo));
+        si->accumulator.state[WHITE] = Eval::NNUE::INIT;
+        si->accumulator.state[BLACK] = Eval::NNUE::INIT;
         pos.st = si;
 
         // Active color


### PR DESCRIPTION
This fixes a crash in `transform nudged_static`. The issue is that `set_from_packed_sfen` was using zero initialization for StateInfo, but a patch some time ago changed the default value for accumulator state from 0 to 2