### PR TITLE
Simd traits

### DIFF
--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -24,6 +24,10 @@
 #include <iostream>
 #include "../nnue_common.h"
 
+#if defined (USE_SSSE3)
+#  define SCRAMBLED_AFFINE_TRANSFORM
+#endif
+
 namespace Stockfish::Eval::NNUE::Layers {
 
   // Affine transformation layer
@@ -35,16 +39,20 @@ namespace Stockfish::Eval::NNUE::Layers {
     using OutputType = std::int32_t;
     static_assert(std::is_same<InputType, std::uint8_t>::value, "");
 
+    static constexpr IndexType SerializedWeightPadding = 32;
+
     // Number of input/output dimensions
     static constexpr IndexType InputDimensions =
         PreviousLayer::OutputDimensions;
     static constexpr IndexType OutputDimensions = OutDims;
     static constexpr IndexType PaddedInputDimensions =
-        ceil_to_multiple<IndexType>(InputDimensions, MaxSimdWidth);
-#if defined (USE_AVX512)
-    static constexpr const IndexType OutputSimdWidth = SimdWidth / 2;
-#elif defined (USE_SSSE3)
-    static constexpr const IndexType OutputSimdWidth = SimdWidth / 4;
+        ceil_to_multiple<IndexType>(InputDimensions, SerializedWeightPadding);
+
+#if defined(SIMD_AVAILABLE)
+    static constexpr const auto UsedArch = Simd::BestAvailableArch;
+    static constexpr const IndexType InputSimdWidth = Simd::Traits<UsedArch>::template NumLanes<InputType>;
+    static constexpr const IndexType OutputSimdWidth = Simd::Traits<UsedArch>::template NumLanes<OutputType>;
+    using SimdVecType = typename Simd::Traits<UsedArch>::template Type<InputType>;
 #endif
 
     // Size of forward propagation buffer used in this layer
@@ -70,7 +78,7 @@ namespace Stockfish::Eval::NNUE::Layers {
       for (std::size_t i = 0; i < OutputDimensions; ++i)
         biases[i] = read_little_endian<BiasType>(stream);
       for (std::size_t i = 0; i < OutputDimensions * PaddedInputDimensions; ++i)
-#if !defined (USE_SSSE3)
+#if !defined (SCRAMBLED_AFFINE_TRANSFORM)
         weights[i] = read_little_endian<WeightType>(stream);
 #else
         weights[
@@ -88,7 +96,7 @@ namespace Stockfish::Eval::NNUE::Layers {
       if (!previousLayer.write_parameters(stream)) return false;
       for (std::size_t i = 0; i < OutputDimensions; ++i)
           write_little_endian<BiasType>(stream, biases[i]);
-#if !defined (USE_SSSE3)
+#if !defined (SCRAMBLED_AFFINE_TRANSFORM)
       for (std::size_t i = 0; i < OutputDimensions * PaddedInputDimensions; ++i)
           write_little_endian<WeightType>(stream, weights[i]);
 #else
@@ -112,244 +120,152 @@ namespace Stockfish::Eval::NNUE::Layers {
     // Forward propagation
     const OutputType* propagate(
         const TransformedFeatureType* transformedFeatures, char* buffer) const {
+
       const auto input = previousLayer.propagate(
           transformedFeatures, buffer + SelfBufferSize);
 
-#if defined (USE_AVX512)
+      auto output = reinterpret_cast<OutputType*>(buffer);
 
-      [[maybe_unused]] const __m512i Ones512 = _mm512_set1_epi16(1);
+#if defined (SCRAMBLED_AFFINE_TRANSFORM)
 
-      [[maybe_unused]] auto m512_hadd = [](__m512i sum, int bias) -> int {
-        return _mm512_reduce_add_epi32(sum) + bias;
-      };
+#  if defined (USE_AVX512)
+      static_assert(UsedArch == Simd::Arch::AVX512 || UsedArch == Simd::Arch::VNNI512);
 
-      [[maybe_unused]] auto m512_add_dpbusd_epi32 = [=](__m512i& acc, __m512i a, __m512i b) {
-#if defined (USE_VNNI)
-        acc = _mm512_dpbusd_epi32(acc, a, b);
-#else
-        __m512i product0 = _mm512_maddubs_epi16(a, b);
-        product0 = _mm512_madd_epi16(product0, Ones512);
-        acc = _mm512_add_epi32(acc, product0);
-#endif
-      };
+      [[maybe_unused]] const __m512i Ones = _mm512_set1_epi16(1);
 
-      [[maybe_unused]] auto m512_add_dpbusd_epi32x4 = [=](__m512i& acc, __m512i a0, __m512i b0, __m512i a1, __m512i b1,
-                                                                        __m512i a2, __m512i b2, __m512i a3, __m512i b3) {
-#if defined (USE_VNNI)
+      [[maybe_unused]] const auto vec_add_dpbusd_epi32x4 = [=](__m512i& acc, __m512i a0, __m512i b0, __m512i a1, __m512i b1,
+                                                                      __m512i a2, __m512i b2, __m512i a3, __m512i b3) {
+#    if defined (USE_VNNI)
         acc = _mm512_dpbusd_epi32(acc, a0, b0);
         acc = _mm512_dpbusd_epi32(acc, a1, b1);
         acc = _mm512_dpbusd_epi32(acc, a2, b2);
         acc = _mm512_dpbusd_epi32(acc, a3, b3);
-#else
+#    else
         __m512i product0 = _mm512_maddubs_epi16(a0, b0);
         __m512i product1 = _mm512_maddubs_epi16(a1, b1);
         __m512i product2 = _mm512_maddubs_epi16(a2, b2);
         __m512i product3 = _mm512_maddubs_epi16(a3, b3);
         product0 = _mm512_adds_epi16(product0, product1);
-        product0 = _mm512_madd_epi16(product0, Ones512);
+        product0 = _mm512_madd_epi16(product0, Ones);
         product2 = _mm512_adds_epi16(product2, product3);
-        product2 = _mm512_madd_epi16(product2, Ones512);
+        product2 = _mm512_madd_epi16(product2, Ones);
         acc = _mm512_add_epi32(acc, _mm512_add_epi32(product0, product2));
-#endif
+#    endif
       };
 
-#endif
-#if defined (USE_AVX2)
+#  elif defined (USE_AVX2)
+      static_assert(UsedArch == Simd::Arch::AVX2 || UsedArch == Simd::Arch::VNNI256);
 
-      [[maybe_unused]] const __m256i Ones256 = _mm256_set1_epi16(1);
+      [[maybe_unused]] const __m256i Ones = _mm256_set1_epi16(1);
 
-      [[maybe_unused]] auto m256_hadd = [](__m256i sum, int bias) -> int {
-        __m128i sum128 = _mm_add_epi32(_mm256_castsi256_si128(sum), _mm256_extracti128_si256(sum, 1));
-        sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_BADC));
-        sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_CDAB));
-        return _mm_cvtsi128_si32(sum128) + bias;
-      };
-
-      [[maybe_unused]] auto m256_add_dpbusd_epi32 = [=](__m256i& acc, __m256i a, __m256i b) {
-#if defined (USE_VNNI)
-        acc = _mm256_dpbusd_epi32(acc, a, b);
-#else
-        __m256i product0 = _mm256_maddubs_epi16(a, b);
-        product0 = _mm256_madd_epi16(product0, Ones256);
-        acc = _mm256_add_epi32(acc, product0);
-#endif
-      };
-
-      [[maybe_unused]] auto m256_add_dpbusd_epi32x4 = [=](__m256i& acc, __m256i a0, __m256i b0, __m256i a1, __m256i b1,
+      [[maybe_unused]] const auto vec_add_dpbusd_epi32x4 = [=](__m256i& acc, __m256i a0, __m256i b0, __m256i a1, __m256i b1,
                                                                         __m256i a2, __m256i b2, __m256i a3, __m256i b3) {
-#if defined (USE_VNNI)
+#    if defined (USE_VNNI)
         acc = _mm256_dpbusd_epi32(acc, a0, b0);
         acc = _mm256_dpbusd_epi32(acc, a1, b1);
         acc = _mm256_dpbusd_epi32(acc, a2, b2);
         acc = _mm256_dpbusd_epi32(acc, a3, b3);
-#else
+#    else
         __m256i product0 = _mm256_maddubs_epi16(a0, b0);
         __m256i product1 = _mm256_maddubs_epi16(a1, b1);
         __m256i product2 = _mm256_maddubs_epi16(a2, b2);
         __m256i product3 = _mm256_maddubs_epi16(a3, b3);
         product0 = _mm256_adds_epi16(product0, product1);
-        product0 = _mm256_madd_epi16(product0, Ones256);
+        product0 = _mm256_madd_epi16(product0, Ones);
         product2 = _mm256_adds_epi16(product2, product3);
-        product2 = _mm256_madd_epi16(product2, Ones256);
+        product2 = _mm256_madd_epi16(product2, Ones);
         acc = _mm256_add_epi32(acc, _mm256_add_epi32(product0, product2));
-#endif
+#    endif
       };
 
-#endif
-#if defined (USE_SSSE3)
+#  elif defined (USE_SSSE3)
+      static_assert(UsedArch == Simd::Arch::SSSE3 || UsedArch == Simd::Arch::SSE41);
 
-      [[maybe_unused]] const __m128i Ones128 = _mm_set1_epi16(1);
+      [[maybe_unused]] const __m128i Ones = _mm_set1_epi16(1);
 
-      [[maybe_unused]] auto m128_hadd = [](__m128i sum, int bias) -> int {
-        sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0x4E)); //_MM_PERM_BADC
-        sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0xB1)); //_MM_PERM_CDAB
-        return _mm_cvtsi128_si32(sum) + bias;
-      };
-
-      [[maybe_unused]] auto m128_add_dpbusd_epi32 = [=](__m128i& acc, __m128i a, __m128i b) {
-        __m128i product0 = _mm_maddubs_epi16(a, b);
-        product0 = _mm_madd_epi16(product0, Ones128);
-        acc = _mm_add_epi32(acc, product0);
-      };
-
-      [[maybe_unused]] auto m128_add_dpbusd_epi32x4 = [=](__m128i& acc, __m128i a0, __m128i b0, __m128i a1, __m128i b1,
+      [[maybe_unused]] const auto vec_add_dpbusd_epi32x4 = [=](__m128i& acc, __m128i a0, __m128i b0, __m128i a1, __m128i b1,
                                                                         __m128i a2, __m128i b2, __m128i a3, __m128i b3) {
         __m128i product0 = _mm_maddubs_epi16(a0, b0);
         __m128i product1 = _mm_maddubs_epi16(a1, b1);
         __m128i product2 = _mm_maddubs_epi16(a2, b2);
         __m128i product3 = _mm_maddubs_epi16(a3, b3);
         product0 = _mm_adds_epi16(product0, product1);
-        product0 = _mm_madd_epi16(product0, Ones128);
+        product0 = _mm_madd_epi16(product0, Ones);
         product2 = _mm_adds_epi16(product2, product3);
-        product2 = _mm_madd_epi16(product2, Ones128);
+        product2 = _mm_madd_epi16(product2, Ones);
         acc = _mm_add_epi32(acc, _mm_add_epi32(product0, product2));
       };
 
-#endif
+#  endif
 
-#if defined (USE_AVX512)
-      using vec_t = __m512i;
-      #define vec_setzero _mm512_setzero_si512
-      #define vec_set_32 _mm512_set1_epi32
-      auto& vec_add_dpbusd_32 = m512_add_dpbusd_epi32;
-      auto& vec_add_dpbusd_32x4 = m512_add_dpbusd_epi32x4;
-      auto& vec_hadd = m512_hadd;
-#elif defined (USE_AVX2)
-      using vec_t = __m256i;
-      #define vec_setzero _mm256_setzero_si256
-      #define vec_set_32 _mm256_set1_epi32
-      auto& vec_add_dpbusd_32 = m256_add_dpbusd_epi32;
-      auto& vec_add_dpbusd_32x4 = m256_add_dpbusd_epi32x4;
-      auto& vec_hadd = m256_hadd;
-#elif defined (USE_SSSE3)
-      using vec_t = __m128i;
-      #define vec_setzero _mm_setzero_si128
-      #define vec_set_32 _mm_set1_epi32
-      auto& vec_add_dpbusd_32 = m128_add_dpbusd_epi32;
-      auto& vec_add_dpbusd_32x4 = m128_add_dpbusd_epi32x4;
-      auto& vec_hadd = m128_hadd;
-#endif
-
-#if defined (USE_SSSE3)
       // Different layout, we process 4 inputs at a time, always.
       static_assert(InputDimensions % 4 == 0);
-
-      const auto output = reinterpret_cast<OutputType*>(buffer);
-      const auto inputVector = reinterpret_cast<const vec_t*>(input);
-
       static_assert(OutputDimensions % OutputSimdWidth == 0 || OutputDimensions == 1);
 
-      // OutputDimensions is either 1 or a multiple of SimdWidth
-      // because then it is also an input dimension.
+      // OutputDimensions is either 1 or a multiple of OutputSimdWidth
+      // because for each output there is an input of the same dimensionality later.
       if constexpr (OutputDimensions % OutputSimdWidth == 0)
       {
+          constexpr auto vec_set_32 = Simd::Traits<UsedArch>::template Broadcast<std::uint32_t>;
+
           constexpr IndexType NumChunks = InputDimensions / 4;
 
           const auto input32 = reinterpret_cast<const std::int32_t*>(input);
-          vec_t* outptr = reinterpret_cast<vec_t*>(output);
+          SimdVecType* outptr = reinterpret_cast<SimdVecType*>(output);
           std::memcpy(output, biases, OutputDimensions * sizeof(OutputType));
 
           for (int i = 0; i < (int)NumChunks - 3; i += 4)
           {
-              const vec_t in0 = vec_set_32(input32[i + 0]);
-              const vec_t in1 = vec_set_32(input32[i + 1]);
-              const vec_t in2 = vec_set_32(input32[i + 2]);
-              const vec_t in3 = vec_set_32(input32[i + 3]);
-              const auto col0 = reinterpret_cast<const vec_t*>(&weights[(i + 0) * OutputDimensions * 4]);
-              const auto col1 = reinterpret_cast<const vec_t*>(&weights[(i + 1) * OutputDimensions * 4]);
-              const auto col2 = reinterpret_cast<const vec_t*>(&weights[(i + 2) * OutputDimensions * 4]);
-              const auto col3 = reinterpret_cast<const vec_t*>(&weights[(i + 3) * OutputDimensions * 4]);
+              const SimdVecType in0 = vec_set_32(input32[i + 0]);
+              const SimdVecType in1 = vec_set_32(input32[i + 1]);
+              const SimdVecType in2 = vec_set_32(input32[i + 2]);
+              const SimdVecType in3 = vec_set_32(input32[i + 3]);
+              const auto col0 = reinterpret_cast<const SimdVecType*>(&weights[(i + 0) * OutputDimensions * 4]);
+              const auto col1 = reinterpret_cast<const SimdVecType*>(&weights[(i + 1) * OutputDimensions * 4]);
+              const auto col2 = reinterpret_cast<const SimdVecType*>(&weights[(i + 2) * OutputDimensions * 4]);
+              const auto col3 = reinterpret_cast<const SimdVecType*>(&weights[(i + 3) * OutputDimensions * 4]);
               for (int j = 0; j * OutputSimdWidth < OutputDimensions; ++j)
-                  vec_add_dpbusd_32x4(outptr[j], in0, col0[j], in1, col1[j], in2, col2[j], in3, col3[j]);
+                  vec_add_dpbusd_epi32x4(outptr[j], in0, col0[j], in1, col1[j], in2, col2[j], in3, col3[j]);
           }
       }
       else if constexpr (OutputDimensions == 1)
       {
-#if defined (USE_AVX512)
-          if constexpr (PaddedInputDimensions % (SimdWidth * 2) != 0)
-          {
-              constexpr IndexType NumChunks = PaddedInputDimensions / SimdWidth;
-              const auto inputVector256 = reinterpret_cast<const __m256i*>(input);
-
-              __m256i sum0 = _mm256_setzero_si256();
-              const auto row0 = reinterpret_cast<const __m256i*>(&weights[0]);
-
-              for (int j = 0; j < (int)NumChunks; ++j)
-              {
-                  const __m256i in = inputVector256[j];
-                  m256_add_dpbusd_epi32(sum0, in, row0[j]);
-              }
-              output[0] = m256_hadd(sum0, biases[0]);
-          }
-          else
-#endif
-          {
-#if defined (USE_AVX512)
-              constexpr IndexType NumChunks = PaddedInputDimensions / (SimdWidth * 2);
-#else
-              constexpr IndexType NumChunks = PaddedInputDimensions / SimdWidth;
-#endif
-              vec_t sum0 = vec_setzero();
-              const auto row0 = reinterpret_cast<const vec_t*>(&weights[0]);
-
-              for (int j = 0; j < (int)NumChunks; ++j)
-              {
-                  const vec_t in = inputVector[j];
-                  vec_add_dpbusd_32(sum0, in, row0[j]);
-              }
-              output[0] = vec_hadd(sum0, biases[0]);
-          }
+          OutputType sum = biases[0];
+          for (IndexType j = 0; j < InputDimensions; ++j)
+              sum += weights[j] * input[j];
+          output[0] = sum;
       }
 
 #else
 
 // Use old implementation for the other architectures.
 
-      auto output = reinterpret_cast<OutputType*>(buffer);
-
-#if defined(USE_SSE2)
+#  if defined(USE_SSE2)
       // At least a multiple of 16, with SSE2.
-      static_assert(InputDimensions % SimdWidth == 0);
-      constexpr IndexType NumChunks = InputDimensions / SimdWidth;
+      static_assert(UsedArch == Simd::Arch::SSE2);
+      static_assert(InputDimensions % InputSimdWidth == 0);
+      constexpr IndexType NumChunks = InputDimensions / InputSimdWidth;
       const __m128i Zeros = _mm_setzero_si128();
       const auto inputVector = reinterpret_cast<const __m128i*>(input);
 
-#elif defined(USE_MMX)
-      static_assert(InputDimensions % SimdWidth == 0);
-      constexpr IndexType NumChunks = InputDimensions / SimdWidth;
+#  elif defined(USE_MMX)
+      static_assert(UsedArch == Simd::Arch::MMX);
+      static_assert(InputDimensions % InputSimdWidth == 0);
+      constexpr IndexType NumChunks = InputDimensions / InputSimdWidth;
       const __m64 Zeros = _mm_setzero_si64();
       const auto inputVector = reinterpret_cast<const __m64*>(input);
 
-#elif defined(USE_NEON)
-      static_assert(InputDimensions % SimdWidth == 0);
-      constexpr IndexType NumChunks = InputDimensions / SimdWidth;
+#  elif defined(USE_NEON)
+      static_assert(UsedArch == Simd::Arch::NEON);
+      static_assert(InputDimensions % InputSimdWidth == 0);
+      constexpr IndexType NumChunks = InputDimensions / InputSimdWidth;
       const auto inputVector = reinterpret_cast<const int8x8_t*>(input);
-#endif
+#  endif
 
       for (IndexType i = 0; i < OutputDimensions; ++i) {
         const IndexType offset = i * PaddedInputDimensions;
 
-#if defined(USE_SSE2)
+#  if defined(USE_SSE2)
         __m128i sumLo = _mm_cvtsi32_si128(biases[i]);
         __m128i sumHi = Zeros;
         const auto row = reinterpret_cast<const __m128i*>(&weights[offset]);
@@ -372,7 +288,7 @@ namespace Stockfish::Eval::NNUE::Layers {
         sum = _mm_add_epi32(sum, sum_second_32);
         output[i] = _mm_cvtsi128_si32(sum);
 
-#elif defined(USE_MMX)
+#  elif defined(USE_MMX)
         __m64 sumLo = _mm_cvtsi32_si64(biases[i]);
         __m64 sumHi = Zeros;
         const auto row = reinterpret_cast<const __m64*>(&weights[offset]);
@@ -392,7 +308,7 @@ namespace Stockfish::Eval::NNUE::Layers {
         sum = _mm_add_pi32(sum, _mm_unpackhi_pi32(sum, sum));
         output[i] = _mm_cvtsi64_si32(sum);
 
-#elif defined(USE_NEON)
+#  elif defined(USE_NEON)
         int32x4_t sum = {biases[i]};
         const auto row = reinterpret_cast<const int8x8_t*>(&weights[offset]);
         for (IndexType j = 0; j < NumChunks; ++j) {
@@ -402,18 +318,18 @@ namespace Stockfish::Eval::NNUE::Layers {
         }
         output[i] = sum[0] + sum[1] + sum[2] + sum[3];
 
-#else
+#  else
         OutputType sum = biases[i];
         for (IndexType j = 0; j < InputDimensions; ++j) {
           sum += weights[offset + j] * input[j];
         }
         output[i] = sum;
-#endif
+#  endif
 
       }
-#if defined(USE_MMX)
+#  if defined(USE_MMX)
       _mm_empty();
-#endif
+#  endif
 
 #endif
 

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -72,6 +72,7 @@ namespace Stockfish::Eval::NNUE::Layers {
       const auto output = reinterpret_cast<OutputType*>(buffer);
 
   #if defined(USE_AVX2)
+      constexpr auto SimdWidth = Simd::Traits<Simd::Arch::AVX2>::template NumLanes<InputType>;
       if constexpr (InputDimensions % SimdWidth == 0) {
         constexpr IndexType NumChunks = InputDimensions / SimdWidth;
         const __m256i Zero = _mm256_setzero_si256();
@@ -110,6 +111,7 @@ namespace Stockfish::Eval::NNUE::Layers {
         : InputDimensions / (SimdWidth / 2) * (SimdWidth / 2);
 
   #elif defined(USE_SSE2)
+      constexpr auto SimdWidth = Simd::Traits<Simd::Arch::SSE2>::template NumLanes<InputType>;
       constexpr IndexType NumChunks = InputDimensions / SimdWidth;
 
   #ifdef USE_SSE41
@@ -141,6 +143,7 @@ namespace Stockfish::Eval::NNUE::Layers {
       constexpr IndexType Start = NumChunks * SimdWidth;
 
   #elif defined(USE_MMX)
+      constexpr auto SimdWidth = Simd::Traits<Simd::Arch::MMX>::template NumLanes<InputType>;
       constexpr IndexType NumChunks = InputDimensions / SimdWidth;
       const __m64 k0x80s = _mm_set1_pi8(-128);
       const auto in = reinterpret_cast<const __m64*>(input);
@@ -159,6 +162,7 @@ namespace Stockfish::Eval::NNUE::Layers {
       constexpr IndexType Start = NumChunks * SimdWidth;
 
   #elif defined(USE_NEON)
+      constexpr auto SimdWidth = Simd::Traits<Simd::Arch::NEON>::template NumLanes<InputType>;
       constexpr IndexType NumChunks = InputDimensions / (SimdWidth / 2);
       const int8x8_t Zero = {0};
       const auto in = reinterpret_cast<const int32x4_t*>(input);

--- a/src/nnue/layers/input_slice.h
+++ b/src/nnue/layers/input_slice.h
@@ -29,8 +29,8 @@ namespace Stockfish::Eval::NNUE::Layers {
 template <IndexType OutDims, IndexType Offset = 0>
 class InputSlice {
  public:
-  // Need to maintain alignment
-  static_assert(Offset % MaxSimdWidth == 0, "");
+  static constexpr IndexType RequiredAlignment = 32;
+  static_assert(Offset % RequiredAlignment == 0, "");
 
   // Output type
   using OutputType = TransformedFeatureType;

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -51,7 +51,6 @@ namespace Stockfish::Eval::NNUE {
 
   using Network = Layers::OutputLayer;
 
-  static_assert(TransformedFeatureDimensions % MaxSimdWidth == 0, "");
   static_assert(Network::OutputDimensions == 1, "");
   static_assert(std::is_same<Network::OutputType, std::int32_t>::value, "");
 

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -25,25 +25,7 @@
 #include <iostream>
 
 #include "../misc.h"  // for IsLittleEndian
-
-#if defined(USE_AVX2)
-#include <immintrin.h>
-
-#elif defined(USE_SSE41)
-#include <smmintrin.h>
-
-#elif defined(USE_SSSE3)
-#include <tmmintrin.h>
-
-#elif defined(USE_SSE2)
-#include <emmintrin.h>
-
-#elif defined(USE_MMX)
-#include <mmintrin.h>
-
-#elif defined(USE_NEON)
-#include <arm_neon.h>
-#endif
+#include "../simd.h"
 
 namespace Stockfish::Eval::NNUE {
 
@@ -56,22 +38,6 @@ namespace Stockfish::Eval::NNUE {
 
   // Size of cache line (in bytes)
   constexpr std::size_t CacheLineSize = 64;
-
-  // SIMD width (in bytes)
-  #if defined(USE_AVX2)
-  constexpr std::size_t SimdWidth = 32;
-
-  #elif defined(USE_SSE2)
-  constexpr std::size_t SimdWidth = 16;
-
-  #elif defined(USE_MMX)
-  constexpr std::size_t SimdWidth = 8;
-
-  #elif defined(USE_NEON)
-  constexpr std::size_t SimdWidth = 16;
-  #endif
-
-  constexpr std::size_t MaxSimdWidth = 32;
 
   // Type of input feature after conversion
   using TransformedFeatureType = std::uint8_t;

--- a/src/simd.h
+++ b/src/simd.h
@@ -1,0 +1,774 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2021 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SIMD_H_INCLUDED
+#define SIMD_H_INCLUDED
+
+#if defined(USE_AVX2)
+#  include <immintrin.h>
+#  define SIMD_AVAILABLE
+#endif
+
+#if defined(USE_SSE41)
+#  include <smmintrin.h>
+#  define SIMD_AVAILABLE
+#endif
+
+#if defined(USE_SSSE3)
+#  include <tmmintrin.h>
+#  define SIMD_AVAILABLE
+#endif
+
+#if defined(USE_SSE2)
+#  include <emmintrin.h>
+#  define SIMD_AVAILABLE
+#endif
+
+#if defined(USE_MMX)
+#  include <mmintrin.h>
+#  define SIMD_AVAILABLE
+#endif
+
+#if defined(USE_NEON)
+#  include <arm_neon.h>
+#  define SIMD_AVAILABLE
+#endif
+
+#include <cstdint>
+#include <type_traits>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+
+namespace Stockfish::Simd {
+
+  enum struct Arch {
+    None,
+    MMX,
+    SSE2,
+    SSSE3,
+    SSE41,
+    AVX2,
+    VNNI256,
+    AVX512,
+    VNNI512,
+    NEON
+  };
+
+  namespace Detail {
+
+    template <typename T, typename... Us>
+    constexpr bool isTypeAnyOf() {
+      return (std::is_same_v<T, Us> || ...);
+    }
+
+#if defined(AVX512)
+    constexpr std::size_t NumSimdRegistersX86 = 32;
+#elif defined(IS_64BIT)
+    constexpr std::size_t NumSimdRegistersX86 = 16;
+#else
+    constexpr std::size_t NumSimdRegistersX86 = 8;
+#endif
+
+    template <Arch ArchV, typename LaneT> struct TypeDef {};
+
+    template <Arch ArchV> struct NumRegistersDef { static constexpr std::size_t Value = 0; };
+
+    template <Arch ArchV> struct NumBytesDef {};
+
+    template <Arch ArchV, typename LaneT>
+    struct NumLanesDef {
+      using SimdT = typename TypeDef<ArchV, LaneT>::Type;
+
+      static constexpr std::size_t Value = sizeof(SimdT) / sizeof(LaneT);
+    };
+
+    template <Arch ArchV, typename LaneT> struct LoadAlignedDef {};
+    template <Arch ArchV, typename LaneT> struct StoreAlignedDef {};
+    template <Arch ArchV, typename LaneT> struct AddDef {};
+    template <Arch ArchV, typename LaneT> struct SubDef {};
+    template <Arch ArchV, typename LaneT> struct ZerosDef {};
+    template <Arch ArchV, typename LaneT> struct BroadcastDef {};
+
+#if defined(USE_MMX)
+
+    template <> struct TypeDef<Arch::MMX, std::uint8_t > { using Type = __m64; };
+    template <> struct TypeDef<Arch::MMX, std:: int8_t > { using Type = __m64; };
+    template <> struct TypeDef<Arch::MMX, std::uint16_t> { using Type = __m64; };
+    template <> struct TypeDef<Arch::MMX, std:: int16_t> { using Type = __m64; };
+    template <> struct TypeDef<Arch::MMX, std::uint32_t> { using Type = __m64; };
+    template <> struct TypeDef<Arch::MMX, std:: int32_t> { using Type = __m64; };
+
+    template <> struct NumRegistersDef<Arch::MMX> { static constexpr std::size_t Value = 8; };
+
+    template <> struct NumBytesDef<Arch::MMX> { static constexpr std::size_t Value = 8; };
+
+    template <typename LaneT>
+    struct LoadAlignedDef<Arch::MMX, LaneT> {
+      using SimdT = typename TypeDef<Arch::MMX, LaneT>::Type;
+
+      static constexpr auto Value = [](const SimdT* v) {
+        return *v;
+      };
+    };
+
+    template <typename LaneT>
+    struct StoreAlignedDef<Arch::MMX, LaneT> {
+      using SimdT = typename TypeDef<Arch::MMX, LaneT>::Type;
+
+      static constexpr auto Value = [](SimdT* lhs, SimdT rhs) {
+        return (*lhs) = rhs;
+      };
+    };
+
+    template <typename LaneT>
+    struct AddDef<Arch::MMX, LaneT> {
+      using SimdT = typename TypeDef<Arch::MMX, LaneT>::Type;
+
+      static constexpr auto Value = [](SimdT lhs, SimdT rhs) {
+        if constexpr (sizeof(LaneT) == 1)
+          return _mm_add_pi8(lhs, rhs);
+        else if constexpr (sizeof(LaneT) == 2)
+          return _mm_add_pi16(lhs, rhs);
+        else
+          return _mm_add_pi32(lhs, rhs);
+      };
+    };
+
+    template <typename LaneT>
+    struct SubDef<Arch::MMX, LaneT> {
+      using SimdT = typename TypeDef<Arch::MMX, LaneT>::Type;
+
+      static constexpr auto Value = [](SimdT lhs, SimdT rhs) {
+        if constexpr (sizeof(LaneT) == 1)
+          return _mm_sub_pi8(lhs, rhs);
+        else if constexpr (sizeof(LaneT) == 2)
+          return _mm_sub_pi16(lhs, rhs);
+        else
+          return _mm_sub_pi32(lhs, rhs);
+      };
+    };
+
+    template <typename LaneT>
+    struct ZerosDef<Arch::MMX, LaneT> {
+      using SimdT = typename TypeDef<Arch::MMX, LaneT>::Type;
+
+      static constexpr auto Value = []() {
+        return _mm_setzero_si64();
+      };
+    };
+
+#endif
+
+#if defined(USE_SSE2)
+
+    template <> struct TypeDef<Arch::SSE2, std::uint8_t > { using Type = __m128i; };
+    template <> struct TypeDef<Arch::SSE2, std:: int8_t > { using Type = __m128i; };
+    template <> struct TypeDef<Arch::SSE2, std::uint16_t> { using Type = __m128i; };
+    template <> struct TypeDef<Arch::SSE2, std:: int16_t> { using Type = __m128i; };
+    template <> struct TypeDef<Arch::SSE2, std::uint32_t> { using Type = __m128i; };
+    template <> struct TypeDef<Arch::SSE2, std:: int32_t> { using Type = __m128i; };
+    template <> struct TypeDef<Arch::SSE2, std::uint64_t> { using Type = __m128i; };
+    template <> struct TypeDef<Arch::SSE2, std:: int64_t> { using Type = __m128i; };
+    template <> struct TypeDef<Arch::SSE2,         float> { using Type = __m128;  };
+    template <> struct TypeDef<Arch::SSE2,        double> { using Type = __m128;  };
+
+    template <> struct NumRegistersDef<Arch::SSE2> { static constexpr std::size_t Value = NumSimdRegistersX86; };
+
+    template <> struct NumBytesDef<Arch::SSE2> { static constexpr std::size_t Value = 16; };
+
+    template <typename LaneT>
+    struct LoadAlignedDef<Arch::SSE2, LaneT> {
+      using SimdT = typename TypeDef<Arch::SSE2, LaneT>::Type;
+
+      static constexpr auto Value = [](const SimdT* v) {
+        return *v;
+      };
+    };
+
+    template <typename LaneT>
+    struct StoreAlignedDef<Arch::SSE2, LaneT> {
+      using SimdT = typename TypeDef<Arch::SSE2, LaneT>::Type;
+
+      static constexpr auto Value = [](SimdT* lhs, SimdT rhs) {
+        return (*lhs) = rhs;
+      };
+    };
+
+    template <typename LaneT>
+    struct AddDef<Arch::SSE2, LaneT> {
+      using SimdT = typename TypeDef<Arch::SSE2, LaneT>::Type;
+
+      static constexpr auto Value = [](SimdT lhs, SimdT rhs) {
+        if constexpr (std::is_floating_point_v<LaneT>) {
+          if constexpr (sizeof(LaneT) == 4)
+            return _mm_add_ps(lhs, rhs);
+          else
+            return _mm_add_pd(lhs, rhs);
+        } else {
+          if constexpr (sizeof(LaneT) == 1)
+            return _mm_add_epi8(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 2)
+            return _mm_add_epi16(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 4)
+            return _mm_add_epi32(lhs, rhs);
+          else
+            return _mm_add_epi64(lhs, rhs);
+        }
+      };
+    };
+
+    template <typename LaneT>
+    struct SubDef<Arch::SSE2, LaneT> {
+      using SimdT = typename TypeDef<Arch::SSE2, LaneT>::Type;
+
+      static constexpr auto Value = [](SimdT lhs, SimdT rhs) {
+        if constexpr (std::is_floating_point_v<LaneT>) {
+          if constexpr (sizeof(LaneT) == 4)
+            return _mm_sub_ps(lhs, rhs);
+          else
+            return _mm_sub_pd(lhs, rhs);
+        } else {
+          if constexpr (sizeof(LaneT) == 1)
+            return _mm_sub_epi8(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 2)
+            return _mm_sub_epi16(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 4)
+            return _mm_sub_epi32(lhs, rhs);
+          else
+            return _mm_sub_epi64(lhs, rhs);
+        }
+      };
+    };
+
+    template <typename LaneT>
+    struct ZerosDef<Arch::SSE2, LaneT> {
+      using SimdT = typename TypeDef<Arch::SSE2, LaneT>::Type;
+
+      static constexpr auto Value = []() {
+        return _mm_setzero_si128();
+      };
+    };
+
+    template <typename LaneT>
+    struct BroadcastDef<Arch::SSE2, LaneT> {
+      using SimdT = typename TypeDef<Arch::SSE2, LaneT>::Type;
+
+      static constexpr auto Value = [](LaneT value) {
+        if constexpr (std::is_floating_point_v<LaneT>) {
+          if constexpr (sizeof(LaneT) == 4)
+            return _mm_set1_ps(value);
+          else
+            return _mm_set1_pd(value);
+        } else {
+          if constexpr (sizeof(LaneT) == 1)
+            return _mm_set1_epi8(value);
+          else if constexpr (sizeof(LaneT) == 2)
+            return _mm_set1_epi16(value);
+          else if constexpr (sizeof(LaneT) == 4)
+            return _mm_set1_epi32(value);
+          else
+            return _mm_set1_epi64(value);
+        }
+      };
+    };
+
+# if defined(USE_SSSE3)
+
+    template <typename LaneT> struct TypeDef<Arch::SSSE3, LaneT> : TypeDef<Arch::SSE2, LaneT> {};
+    template <> struct NumRegistersDef<Arch::SSSE3> : NumRegistersDef<Arch::SSE2> {};
+    template <> struct NumBytesDef<Arch::SSSE3> : NumBytesDef<Arch::SSE2> {};
+    template <typename LaneT> struct LoadAlignedDef<Arch::SSSE3, LaneT> : LoadAlignedDef<Arch::SSE2, LaneT> {};
+    template <typename LaneT> struct StoreAlignedDef<Arch::SSSE3, LaneT> : StoreAlignedDef<Arch::SSE2, LaneT> {};
+    template <typename LaneT> struct AddDef<Arch::SSSE3, LaneT> : AddDef<Arch::SSE2, LaneT> {};
+    template <typename LaneT> struct SubDef<Arch::SSSE3, LaneT> : SubDef<Arch::SSE2, LaneT> {};
+    template <typename LaneT> struct ZerosDef<Arch::SSSE3, LaneT> : ZerosDef<Arch::SSE2, LaneT> {};
+    template <typename LaneT> struct BroadcastDef<Arch::SSSE3, LaneT> : BroadcastDef<Arch::SSE2, LaneT> {};
+# endif
+
+# if defined(USE_SSE41)
+
+    template <typename LaneT> struct TypeDef<Arch::SSE41, LaneT> : TypeDef<Arch::SSSE3, LaneT> {};
+    template <> struct NumRegistersDef<Arch::SSE41> : NumRegistersDef<Arch::SSSE3> {};
+    template <> struct NumBytesDef<Arch::SSE41> : NumBytesDef<Arch::SSSE3> {};
+    template <typename LaneT> struct LoadAlignedDef<Arch::SSE41, LaneT> : LoadAlignedDef<Arch::SSSE3, LaneT> {};
+    template <typename LaneT> struct StoreAlignedDef<Arch::SSE41, LaneT> : StoreAlignedDef<Arch::SSSE3, LaneT> {};
+    template <typename LaneT> struct AddDef<Arch::SSE41, LaneT> : AddDef<Arch::SSSE3, LaneT> {};
+    template <typename LaneT> struct SubDef<Arch::SSE41, LaneT> : SubDef<Arch::SSSE3, LaneT> {};
+    template <typename LaneT> struct ZerosDef<Arch::SSE41, LaneT> : ZerosDef<Arch::SSSE3, LaneT> {};
+    template <typename LaneT> struct BroadcastDef<Arch::SSE41, LaneT> : BroadcastDef<Arch::SSSE3, LaneT> {};
+# endif
+
+#endif
+
+#if defined(USE_AVX2)
+
+    template <> struct TypeDef<Arch::AVX2, std::uint8_t > { using Type = __m256i; };
+    template <> struct TypeDef<Arch::AVX2, std:: int8_t > { using Type = __m256i; };
+    template <> struct TypeDef<Arch::AVX2, std::uint16_t> { using Type = __m256i; };
+    template <> struct TypeDef<Arch::AVX2, std:: int16_t> { using Type = __m256i; };
+    template <> struct TypeDef<Arch::AVX2, std::uint32_t> { using Type = __m256i; };
+    template <> struct TypeDef<Arch::AVX2, std:: int32_t> { using Type = __m256i; };
+    template <> struct TypeDef<Arch::AVX2, std::uint64_t> { using Type = __m256i; };
+    template <> struct TypeDef<Arch::AVX2, std:: int64_t> { using Type = __m256i; };
+    template <> struct TypeDef<Arch::AVX2,         float> { using Type = __m256;  };
+    template <> struct TypeDef<Arch::AVX2,        double> { using Type = __m256;  };
+
+    template <> struct NumRegistersDef<Arch::AVX2> { static constexpr std::size_t Value = NumSimdRegistersX86; };
+
+    template <> struct NumBytesDef<Arch::AVX2> { static constexpr std::size_t Value = 32; };
+
+    template <typename LaneT>
+    struct LoadAlignedDef<Arch::AVX2, LaneT> {
+      using SimdT = typename TypeDef<Arch::AVX2, LaneT>::Type;
+
+      static constexpr auto Value = [](const SimdT* v) {
+        return *v;
+      };
+    };
+
+    template <typename LaneT>
+    struct StoreAlignedDef<Arch::AVX2, LaneT> {
+      using SimdT = typename TypeDef<Arch::AVX2, LaneT>::Type;
+
+      static constexpr auto Value = [](SimdT* lhs, SimdT rhs) {
+        return (*lhs) = rhs;
+      };
+    };
+
+    template <typename LaneT>
+    struct AddDef<Arch::AVX2, LaneT> {
+      using SimdT = typename TypeDef<Arch::AVX2, LaneT>::Type;
+
+      static constexpr auto Value = [](SimdT lhs, SimdT rhs) {
+        if constexpr (std::is_floating_point_v<LaneT>) {
+          if constexpr (sizeof(LaneT) == 4)
+            return _mm256_add_ps(lhs, rhs);
+          else
+            return _mm256_add_pd(lhs, rhs);
+        } else {
+          if constexpr (sizeof(LaneT) == 1)
+            return _mm256_add_epi8(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 2)
+            return _mm256_add_epi16(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 4)
+            return _mm256_add_epi32(lhs, rhs);
+          else
+            return _mm256_add_epi64(lhs, rhs);
+        }
+      };
+    };
+
+    template <typename LaneT>
+    struct SubDef<Arch::AVX2, LaneT> {
+      using SimdT = typename TypeDef<Arch::AVX2, LaneT>::Type;
+
+      static constexpr auto Value = [](SimdT lhs, SimdT rhs) {
+        if constexpr (std::is_floating_point_v<LaneT>) {
+          if constexpr (sizeof(LaneT) == 4)
+            return _mm256_sub_ps(lhs, rhs);
+          else
+            return _mm256_sub_pd(lhs, rhs);
+        } else {
+          if constexpr (sizeof(LaneT) == 1)
+            return _mm256_sub_epi8(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 2)
+            return _mm256_sub_epi16(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 4)
+            return _mm256_sub_epi32(lhs, rhs);
+          else
+            return _mm256_sub_epi64(lhs, rhs);
+        }
+      };
+    };
+
+    template <typename LaneT>
+    struct ZerosDef<Arch::AVX2, LaneT> {
+      using SimdT = typename TypeDef<Arch::AVX2, LaneT>::Type;
+
+      static constexpr auto Value = []() {
+        return _mm256_setzero_si256();
+      };
+    };
+
+    template <typename LaneT>
+    struct BroadcastDef<Arch::AVX2, LaneT> {
+      using SimdT = typename TypeDef<Arch::AVX2, LaneT>::Type;
+
+      static constexpr auto Value = [](LaneT value) {
+        if constexpr (std::is_floating_point_v<LaneT>) {
+          if constexpr (sizeof(LaneT) == 4)
+            return _mm256_set1_ps(value);
+          else
+            return _mm256_set1_pd(value);
+        } else {
+          if constexpr (sizeof(LaneT) == 1)
+            return _mm256_set1_epi8(value);
+          else if constexpr (sizeof(LaneT) == 2)
+            return _mm256_set1_epi16(value);
+          else if constexpr (sizeof(LaneT) == 4)
+            return _mm256_set1_epi32(value);
+          else
+            return _mm256_set1_epi64(value);
+        }
+      };
+    };
+
+# if defined(USE_VNNI)
+
+    template <typename LaneT> struct TypeDef<Arch::VNNI256, LaneT> : TypeDef<Arch::AVX2, LaneT> {};
+    template <> struct NumRegistersDef<Arch::VNNI256> : NumRegistersDef<Arch::AVX2> {};
+    template <> struct NumBytesDef<Arch::VNNI256> : NumBytesDef<Arch::AVX2> {};
+    template <typename LaneT> struct LoadAlignedDef<Arch::VNNI256, LaneT> : LoadAlignedDef<Arch::AVX2, LaneT> {};
+    template <typename LaneT> struct StoreAlignedDef<Arch::VNNI256, LaneT> : StoreAlignedDef<Arch::AVX2, LaneT> {};
+    template <typename LaneT> struct AddDef<Arch::VNNI256, LaneT> : AddDef<Arch::AVX2, LaneT> {};
+    template <typename LaneT> struct SubDef<Arch::VNNI256, LaneT> : SubDef<Arch::AVX2, LaneT> {};
+    template <typename LaneT> struct ZerosDef<Arch::VNNI256, LaneT> : ZerosDef<Arch::AVX2, LaneT> {};
+    template <typename LaneT> struct BroadcastDef<Arch::VNNI256, LaneT> : BroadcastDef<Arch::AVX2, LaneT> {};
+# endif
+
+#endif
+
+#if defined(USE_AVX512)
+
+    template <> struct TypeDef<Arch::AVX512, std::uint8_t > { using Type = __m512i; };
+    template <> struct TypeDef<Arch::AVX512, std:: int8_t > { using Type = __m512i; };
+    template <> struct TypeDef<Arch::AVX512, std::uint16_t> { using Type = __m512i; };
+    template <> struct TypeDef<Arch::AVX512, std:: int16_t> { using Type = __m512i; };
+    template <> struct TypeDef<Arch::AVX512, std::uint32_t> { using Type = __m512i; };
+    template <> struct TypeDef<Arch::AVX512, std:: int32_t> { using Type = __m512i; };
+    template <> struct TypeDef<Arch::AVX512, std::uint64_t> { using Type = __m512i; };
+    template <> struct TypeDef<Arch::AVX512, std:: int64_t> { using Type = __m512i; };
+    template <> struct TypeDef<Arch::AVX512,         float> { using Type = __m512;  };
+    template <> struct TypeDef<Arch::AVX512,        double> { using Type = __m512;  };
+
+    template <> struct NumRegistersDef<Arch::AVX512> { static constexpr std::size_t Value = NumSimdRegistersX86; };
+
+    template <> struct NumBytesDef<Arch::AVX512> { static constexpr std::size_t Value = 64; };
+
+    template <typename LaneT>
+    struct LoadAlignedDef<Arch::AVX512, LaneT> {
+      using SimdT = typename TypeDef<Arch::AVX512, LaneT>::Type;
+
+      static constexpr auto Value = [](const SimdT* v) {
+        return *v;
+      };
+    };
+
+    template <typename LaneT>
+    struct StoreAlignedDef<Arch::AVX512, LaneT> {
+      using SimdT = typename TypeDef<Arch::AVX512, LaneT>::Type;
+
+      static constexpr auto Value = [](SimdT* lhs, SimdT rhs) {
+        return (*lhs) = rhs;
+      };
+    };
+
+    template <typename LaneT>
+    struct AddDef<Arch::AVX512, LaneT> {
+      using SimdT = typename TypeDef<Arch::AVX512, LaneT>::Type;
+
+      static constexpr auto Value = [](SimdT lhs, SimdT rhs) {
+        if constexpr (std::is_floating_point_v<LaneT>) {
+          if constexpr (sizeof(LaneT) == 4)
+            return _mm512_add_ps(lhs, rhs);
+          else
+            return _mm512_add_pd(lhs, rhs);
+        } else {
+          if constexpr (sizeof(LaneT) == 1)
+            return _mm512_add_epi8(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 2)
+            return _mm512_add_epi16(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 4)
+            return _mm512_add_epi32(lhs, rhs);
+          else
+            return _mm512_add_epi64(lhs, rhs);
+        }
+      };
+    };
+
+    template <typename LaneT>
+    struct SubDef<Arch::AVX512, LaneT> {
+      using SimdT = typename TypeDef<Arch::AVX512, LaneT>::Type;
+
+      static constexpr auto Value = [](SimdT lhs, SimdT rhs) {
+        if constexpr (std::is_floating_point_v<LaneT>) {
+          if constexpr (sizeof(LaneT) == 4)
+            return _mm512_sub_ps(lhs, rhs);
+          else
+            return _mm512_sub_pd(lhs, rhs);
+        } else {
+          if constexpr (sizeof(LaneT) == 1)
+            return _mm512_sub_epi8(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 2)
+            return _mm512_sub_epi16(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 4)
+            return _mm512_sub_epi32(lhs, rhs);
+          else
+            return _mm512_sub_epi64(lhs, rhs);
+        }
+      };
+    };
+
+    template <typename LaneT>
+    struct ZerosDef<Arch::AVX512, LaneT> {
+      using SimdT = typename TypeDef<Arch::AVX512, LaneT>::Type;
+
+      static constexpr auto Value = []() {
+        return _mm512_setzero_si512();
+      };
+    };
+
+    template <typename LaneT>
+    struct BroadcastDef<Arch::AVX512, LaneT> {
+      using SimdT = typename TypeDef<Arch::AVX512, LaneT>::Type;
+
+      static constexpr auto Value = [](LaneT value) {
+        if constexpr (std::is_floating_point_v<LaneT>) {
+          if constexpr (sizeof(LaneT) == 4)
+            return _mm512_set1_ps(value);
+          else
+            return _mm512_set1_pd(value);
+        } else {
+          if constexpr (sizeof(LaneT) == 1)
+            return _mm512_set1_epi8(value);
+          else if constexpr (sizeof(LaneT) == 2)
+            return _mm512_set1_epi16(value);
+          else if constexpr (sizeof(LaneT) == 4)
+            return _mm512_set1_epi32(value);
+          else
+            return _mm512_set1_epi64(value);
+        }
+      };
+    };
+
+# if defined(USE_VNNI)
+
+    template <typename LaneT> struct TypeDef<Arch::VNNI512, LaneT> : TypeDef<Arch::AVX512, LaneT> {};
+    template <> struct NumRegistersDef<Arch::VNNI512> : NumRegistersDef<Arch::AVX512> {};
+    template <> struct NumBytesDef<Arch::VNNI512> : NumBytesDef<Arch::AVX512> {};
+    template <typename LaneT> struct LoadAlignedDef<Arch::VNNI512, LaneT> : LoadAlignedDef<Arch::AVX512, LaneT> {};
+    template <typename LaneT> struct StoreAlignedDef<Arch::VNNI512, LaneT> : StoreAlignedDef<Arch::AVX512, LaneT> {};
+    template <typename LaneT> struct AddDef<Arch::VNNI512, LaneT> : AddDef<Arch::AVX512, LaneT> {};
+    template <typename LaneT> struct SubDef<Arch::VNNI512, LaneT> : SubDef<Arch::AVX512, LaneT> {};
+    template <typename LaneT> struct ZerosDef<Arch::VNNI512, LaneT> : ZerosDef<Arch::AVX512, LaneT> {};
+    template <typename LaneT> struct BroadcastDef<Arch::VNNI512, LaneT> : BroadcastDef<Arch::AVX512, LaneT> {};
+# endif
+
+#endif
+
+#if defined(USE_NEON)
+
+    template <> struct TypeDef<Arch::NEON, std::uint8_t > { using Type =  uint8x16_t; };
+    template <> struct TypeDef<Arch::NEON, std:: int8_t > { using Type =   int8x16_t; };
+    template <> struct TypeDef<Arch::NEON, std::uint16_t> { using Type =  uint16x8_t; };
+    template <> struct TypeDef<Arch::NEON, std:: int16_t> { using Type =   int16x8_t; };
+    template <> struct TypeDef<Arch::NEON, std::uint32_t> { using Type =  uint32x4_t; };
+    template <> struct TypeDef<Arch::NEON, std:: int32_t> { using Type =   int32x4_t; };
+    template <> struct TypeDef<Arch::NEON, std::uint64_t> { using Type =  uint64x2_t; };
+    template <> struct TypeDef<Arch::NEON, std:: int64_t> { using Type =   int64x2_t; };
+    template <> struct TypeDef<Arch::NEON,         float> { using Type = float32x4_t; };
+    template <> struct TypeDef<Arch::NEON,        double> { using Type = float64x2_t; };
+
+    template <> struct NumRegistersDef<Arch::NEON> { static constexpr std::size_t Value = 16; };
+
+    template <> struct NumBytesDef<Arch::NEON> { static constexpr std::size_t Value = 16; };
+
+    template <typename LaneT>
+    struct LoadAlignedDef<Arch::NEON, LaneT> {
+      using SimdT = typename TypeDef<Arch::NEON, LaneT>::Type;
+
+      static constexpr auto Value = [](const SimdT* v) {
+        return *v;
+      };
+    };
+
+    template <typename LaneT>
+    struct StoreAlignedDef<Arch::NEON, LaneT> {
+      using SimdT = typename TypeDef<Arch::NEON, LaneT>::Type;
+
+      static constexpr auto Value = [](SimdT* lhs, SimdT rhs) {
+        return (*lhs) = rhs;
+      };
+    };
+
+    template <typename LaneT>
+    struct AddDef<Arch::NEON, LaneT> {
+      using SimdT = typename TypeDef<Arch::NEON, LaneT>::Type;
+
+      static constexpr auto Value = [](SimdT lhs, SimdT rhs) {
+        if constexpr (std::is_floating_point_v<LaneT>) {
+          if constexpr (sizeof(LaneT) == 4)
+            return vaddq_f32(lhs, rhs);
+          else
+            return vaddq_f64(lhs, rhs);
+        } else {
+          if constexpr (sizeof(LaneT) == 1)
+            return vaddq_s8(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 2)
+            return vaddq_s16(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 4)
+            return vaddq_s32(lhs, rhs);
+          else
+            return vaddq_s64(lhs, rhs);
+        }
+      };
+    };
+
+    template <typename LaneT>
+    struct SubDef<Arch::NEON, LaneT> {
+      using SimdT = typename TypeDef<Arch::NEON, LaneT>::Type;
+
+      static constexpr auto Value = [](SimdT lhs, SimdT rhs) {
+        if constexpr (std::is_floating_point_v<LaneT>) {
+          if constexpr (sizeof(LaneT) == 4)
+            return vsubq_f32(lhs, rhs);
+          else
+            return vsubq_f64(lhs, rhs);
+        } else {
+          if constexpr (sizeof(LaneT) == 1)
+            return vsubq_s8(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 2)
+            return vsubq_s16(lhs, rhs);
+          else if constexpr (sizeof(LaneT) == 4)
+            return vsubq_s32(lhs, rhs);
+          else
+            return vsubq_s64(lhs, rhs);
+        }
+      };
+    };
+
+    template <typename LaneT>
+    struct ZerosDef<Arch::NEON, LaneT> {
+      using SimdT = typename TypeDef<Arch::NEON, LaneT>::Type;
+
+      static constexpr auto Value = []() {
+        return SimdT{0};
+      };
+    };
+
+#endif
+
+  }
+
+  template <Arch ArchV>
+  struct Traits {
+    template <typename LaneT>
+    using Type = typename Detail::TypeDef<ArchV, LaneT>::Type;
+
+    static constexpr std::size_t NumRegisters = Detail::NumRegistersDef<ArchV>::Value;
+
+    static constexpr std::size_t NumBytes = Detail::NumBytesDef<ArchV>::Value;
+
+    template <typename LaneT>
+    static constexpr std::size_t NumLanes = Detail::NumLanesDef<ArchV, LaneT>::Value;
+
+    template <typename LaneT>
+    static constexpr auto LoadAligned = Detail::LoadAlignedDef<ArchV, LaneT>::Value;
+
+    template <typename LaneT>
+    static constexpr auto StoreAligned = Detail::StoreAlignedDef<ArchV, LaneT>::Value;
+
+    template <typename LaneT>
+    static constexpr auto Add = Detail::AddDef<ArchV, LaneT>::Value;
+
+    template <typename LaneT>
+    static constexpr auto Sub = Detail::SubDef<ArchV, LaneT>::Value;
+
+    template <typename LaneT>
+    static constexpr auto Zeros = Detail::ZerosDef<ArchV, LaneT>::Value;
+
+    template <typename LaneT>
+    static constexpr auto Broadcast = Detail::BroadcastDef<ArchV, LaneT>::Value;
+  };
+
+static constexpr Arch AvailableArchs[] = {
+
+#if defined (USE_AVX512) && defined (USE_VNNI)
+  Arch::VNNI512,
+#endif
+
+#if defined (USE_AVX512)
+  Arch::AVX512,
+#endif
+
+#if defined (USE_AVX2) && defined (USE_VNNI)
+  Arch::VNNI256,
+#endif
+
+#if defined (USE_AVX2)
+  Arch::AVX2,
+#endif
+
+#if defined (USE_SSE41)
+  Arch::SSE41,
+#endif
+
+#if defined (USE_SSSE3)
+  Arch::SSSE3,
+#endif
+
+#if defined (USE_SSE2)
+  Arch::SSE2,
+#endif
+
+#if defined (USE_MMX)
+  Arch::MMX,
+#endif
+
+#if defined (USE_NEON)
+  Arch::NEON,
+#endif
+
+  Arch::None
+
+};
+
+  static constexpr Arch BestAvailableArch = AvailableArchs[0];
+
+  namespace Detail {
+    template <Arch ArchV>
+    static constexpr inline bool GetIsArchAvailable() {
+      for (auto arch : AvailableArchs)
+        if (arch == ArchV)
+          return true;
+      return false;
+    }
+  }
+
+  template <Arch ArchV>
+  static constexpr bool IsArchAvailable = Detail::GetIsArchAvailable<ArchV>();
+
+  namespace Detail {
+    template <Arch... Archs>
+    static constexpr inline Arch GetBestAvailableArchFromSubset() {
+      for (auto arch : AvailableArchs)
+        if (((Archs == arch) || ...))
+          return arch;
+      return Arch::None;
+    }
+  }
+
+  template <Arch... Archs>
+  static constexpr Arch BestAvailableArchFromSubset = Detail::GetBestAvailableArchFromSubset<Archs...>();
+
+}
+
+#pragma GCC diagnostic pop
+
+#endif


### PR DESCRIPTION
An attempt to have more structure, correctness, readability, and genericity to the manually vectorized code. I'd expect this to be much more useful [in the future] if the vectorized code was similar, but different register widths require different algorithms for what we have now. With that said though there were still places where the newly introduced simd traits applied nicely. Now the `SimdWidth` and `MaxSimdWidth`, which were poorly named and were carrying hidden semantics, are gone and replaced with explicit  lane counts, queried in a type safe way. Also some common operations were encapsulated in a generic way, mostly visible in the vectorized FT code. The binaries are almost identical.

I'm open to suggestions on how to improve it. I'd like if this patch is not judged by the number of lines added.

Non-regression running here: https://tests.stockfishchess.org/tests/view/60c64e11457376eb8bcaae49, but there will be small changes from that.