### PR TITLE
nn-8e47cf062333 as new default

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-7e66505906a6.nnue"
+  #define EvalFileDefaultName   "nn-8e47cf062333.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
This net is the result of 200 epochs training on thoroughly shuffled T60 and T74 data kindly provided by borg (T = test no. x, data is a result of Leela selfplay, different tests have differently sized nets). 
The data is available at vondele's google drive: https://drive.google.com/drive/folders/1mftuzYdl9o6tBaceR3d_VBQIrgKJsFpl

The Leela data comes in small chunks of .binpack files. To shuffle them, I simply used a small python script to randomly rename the files. To get them into a single file I used `cat` (available on windows via msys2). As validation data I picked a file of T60 data. 

Unlike the previous run, it doesn't have adjusted scaling; not because I didn't want to, but because I forgot. However, it randomly skips 40% more positions than previous run.

This is the exact training command: `python train.py --smart-fen-skipping --random-fen-skipping 14 --batch-size 16384 --threads 4 --num-workers 4 --gpus 1 trainingdata\training_data.binpack validationdata\val.binpack`

The loss was very spiky and decreased slower than it does usually. 
The loss curves look like this (training loss): 
![2021-06-14 09_04_51-TensorBoard — Mozilla Firefox](https://user-images.githubusercontent.com/26392242/121853033-a5c06980-ccf0-11eb-87f6-27d9c5be98b2.png)
and this (validation loss):
![2021-06-14 09_05_35-TensorBoard — Mozilla Firefox](https://user-images.githubusercontent.com/26392242/121853039-a8bb5a00-ccf0-11eb-89f1-93e166d3a657.png)



I will further investigate T74 data.

I hope the 2 10k tests (didn't expect such a performance) cover the lack of a STC SPRT test.

10k STC result: https://tests.stockfishchess.org/tests/view/60c67e50457376eb8bcaae70
ELO: 3.61 +-3.3 (95%) LOS: 98.4%
Total: 10000 W: 1241 L: 1137 D: 7622
Ptnml(0-2): 68, 841, 3086, 929, 76

10k LTC result: https://tests.stockfishchess.org/tests/view/60c69deb457376eb8bcaae98
ELO: 2.71 +-2.4 (95%) LOS: 98.8%
Total: 10000 W: 659 L: 581 D: 8760
Ptnml(0-2): 22, 485, 3900, 579, 14

Passed LTC sub 10k games: https://tests.stockfishchess.org/html/live_elo.html?60c6d41c457376eb8bcaaecf
LLR: 2.93 (-2.94,2.94) <0.50,3.50>
Total: 9648 W: 685 L: 545 D: 8418
Ptnml(0-2): 22, 448, 3740, 596, 18

Bench: 4877339