### PR TITLE
split aspiration search into own function

### DIFF
--- a/src/thread.h
+++ b/src/thread.h
@@ -39,6 +39,8 @@ namespace Stockfish {
 /// pointer to an entry its life time is unlimited and we don't have
 /// to care about someone changing the entry under our feet.
 
+struct MainThread;
+
 class Thread {
 
   std::mutex mutex;
@@ -51,6 +53,8 @@ public:
   explicit Thread(size_t);
   virtual ~Thread();
   virtual void search();
+  Value aspiration_search(size_t multiPV, int ct, int searchAgainCounter,
+                          MainThread *mainThread, Search::Stack *ss);
   void clear();
   void idle_loop();
   void start_searching();


### PR DESCRIPTION
This is a nonfunctional change intended to improve code clarity by breaking aspiration search into a separate function.  It passed both STC and LTC with simplification bounds:

https://tests.stockfishchess.org/html/live_elo.html?60c595ce457376eb8bcaad77

https://tests.stockfishchess.org/html/live_elo.html?60c545d2457376eb8bcaad42

At the request of one of the project maintainers, I ran it at LTC with normal bounds, and it appears that it will show a small ELO pickup but will probably fail to meet the requirement for a non-simplification change:

https://tests.stockfishchess.org/html/live_elo.html?60c60972457376eb8bcaade8