### PR TITLE
Probabilistic usage of subsequent buckets

### DIFF
--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -157,7 +157,11 @@ namespace Stockfish::Eval::NNUE {
     ASSERT_ALIGNED(transformedFeatures, alignment);
     ASSERT_ALIGNED(buffer, alignment);
 
-    const std::size_t bucket = (pos.count<ALL_PIECES>() - 1) / 4;
+    std::size_t bucket = (pos.count<ALL_PIECES>() - 1) / 4;
+
+    if (bucket >= 5 && !(pos.key() & 0xB))
+        bucket = bucket - 1;
+
     const auto psqt = featureTransformer->transform(pos, transformedFeatures, bucket);
     const auto output = network[bucket]->propagate(transformedFeatures, buffer);
 


### PR DESCRIPTION
After conducting a series of experimental tests, it seems that using a subsequent bucket to have a second opinion on the evaluation of a position can be beneficial. However, the precise condition when to call is challenging to find and maybe there is even no such condition, so we just do it probabilistically. This patch also serves to smooth the transition between buckets since the current implementation is quite drastic in changing buckets at the boundary piece counts.

STC:
LLR: 2.96 (-2.94,2.94) <-0.50,2.50>
Total: 56064 W: 4950 L: 4744 D: 46370
Ptnml(0-2): 185, 3831, 19794, 4037, 185
https://tests.stockfishchess.org/tests/view/60c74bbd457376eb8bcaaf4c

LTC:
LLR: 2.97 (-2.94,2.94) <0.50,3.50>
Total: 60648 W: 2104 L: 1929 D: 56615
Ptnml(0-2): 25, 1739, 26629, 1898, 33
https://tests.stockfishchess.org/tests/view/60c7b780457376eb8bcaafb1

Bench: 4971722