### PR TITLE
Simplify away rootDepth in LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1157,7 +1157,6 @@ moves_loop: // When in check, search starts from here
 
           // Increase reduction at root and non-PV nodes when the best move does not change frequently
           if (   (rootNode || !PvNode)
-              && thisThread->rootDepth > 10
               && thisThread->bestMoveChanges <= 2)
               r++;
 


### PR DESCRIPTION
Simplify reduction when best move doesn't change frequently.

STC:
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 40400 W: 3468 L: 3377 D: 33555
Ptnml(0-2): 134, 2734, 14388, 2795, 149
https://tests.stockfishchess.org/tests/view/60c93e5a457376eb8bcab15f

LTC:
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 34200 W: 1190 L: 1128 D: 31882
Ptnml(0-2): 22, 998, 15001, 1054, 25
https://tests.stockfishchess.org/tests/view/60c96a1a457376eb8bcab180

bench: 5629669