### PR TITLE
Trace for NNUE eval.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1150,7 +1150,7 @@ Value Eval::evaluate(const Position& pos) {
 /// descriptions and values of each evaluation term. Useful for debugging.
 /// Trace scores are from white's point of view
 
-std::string Eval::trace(const Position& pos) {
+std::string Eval::trace(Position& pos) {
 
   if (pos.checkers())
       return "Final evaluation: none (in check)";
@@ -1187,6 +1187,11 @@ std::string Eval::trace(const Position& pos) {
      << "       Total | " << Term(TOTAL);
 
   v = pos.side_to_move() == WHITE ? v : -v;
+
+  if (Eval::useNNUE)
+  {
+      ss << '\n' << NNUE::trace(pos) << '\n';
+  }
 
   ss << "\nClassical evaluation: " << to_cp(v) << " (white side)\n";
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -30,7 +30,7 @@ class Position;
 
 namespace Eval {
 
-  std::string trace(const Position& pos);
+  std::string trace(Position& pos);
   Value evaluate(const Position& pos);
 
   extern bool useNNUE;
@@ -43,6 +43,7 @@ namespace Eval {
 
   namespace NNUE {
 
+    std::string trace(Position& pos);
     Value evaluate(const Position& pos, bool adjusted = false);
     bool load_eval(std::string name, std::istream& stream);
     bool save_eval(std::ostream& stream);

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -20,6 +20,8 @@
 
 #include <iostream>
 #include <set>
+#include <sstream>
+#include <iomanip>
 
 #include "../evaluate.h"
 #include "../position.h"
@@ -173,6 +175,185 @@ namespace Stockfish::Eval::NNUE {
     int sum = (A * materialist + B * positional) / 128;
 
     return static_cast<Value>( sum / OutputScale );
+  }
+
+  struct NnueEvalTrace {
+    static_assert(LayerStacks == PSQTBuckets);
+
+    Value psqt[LayerStacks];
+    Value positional[LayerStacks];
+    std::size_t correctBucket;
+  };
+
+  static NnueEvalTrace trace_evaluate(const Position& pos) {
+
+    // We manually align the arrays on the stack because with gcc < 9.3
+    // overaligning stack variables with alignas() doesn't work correctly.
+
+    constexpr uint64_t alignment = CacheLineSize;
+
+#if defined(ALIGNAS_ON_STACK_VARIABLES_BROKEN)
+    TransformedFeatureType transformedFeaturesUnaligned[
+      FeatureTransformer::BufferSize + alignment / sizeof(TransformedFeatureType)];
+    char bufferUnaligned[Network::BufferSize + alignment];
+
+    auto* transformedFeatures = align_ptr_up<alignment>(&transformedFeaturesUnaligned[0]);
+    auto* buffer = align_ptr_up<alignment>(&bufferUnaligned[0]);
+#else
+    alignas(alignment)
+      TransformedFeatureType transformedFeatures[FeatureTransformer::BufferSize];
+    alignas(alignment) char buffer[Network::BufferSize];
+#endif
+
+    ASSERT_ALIGNED(transformedFeatures, alignment);
+    ASSERT_ALIGNED(buffer, alignment);
+
+    NnueEvalTrace t{};
+    t.correctBucket = (pos.count<ALL_PIECES>() - 1) / 4;
+    for (std::size_t bucket = 0; bucket < LayerStacks; ++bucket) {
+      const auto psqt = featureTransformer->transform(pos, transformedFeatures, bucket);
+      const auto output = network[bucket]->propagate(transformedFeatures, buffer);
+
+      int materialist = psqt;
+      int positional  = output[0];
+
+      t.psqt[bucket] = static_cast<Value>( materialist / OutputScale );
+      t.positional[bucket] = static_cast<Value>( positional / OutputScale );
+    }
+
+    return t;
+  }
+
+  static const std::string PieceToChar(" PNBRQK  pnbrqk");
+
+  // Requires the buffer to have capacity for at least 5 values
+  static void format_cp_compact(Value v, char* buffer) {
+    buffer[0] = (v < 0 ? '-' : v > 0 ? '+' : ' ');
+    int cp = (int)(std::abs((float)v / PawnValueEg * 100.0f + 0.5f));
+    if (cp >= 10000) {
+      buffer[1] = '0' + cp / 10000; cp %= 10000;
+      buffer[2] = '0' + cp / 1000; cp %= 1000;
+      buffer[3] = '0' + cp / 100; cp %= 100;
+      buffer[4] = ' ';
+    }
+    else if (cp >= 1000) {
+      buffer[1] = '0' + cp / 1000; cp %= 1000;
+      buffer[2] = '0' + cp / 100; cp %= 100;
+      buffer[3] = '.';
+      buffer[4] = '0' + cp / 10;
+    }
+    else {
+      buffer[1] = '0' + cp / 100; cp %= 100;
+      buffer[2] = '.';
+      buffer[3] = '0' + cp / 10; cp %= 10;
+      buffer[4] = '0' + cp / 1;
+    }
+  }
+
+  // Requires the buffer to have capacity for at least 7 values
+  static void format_cp_aligned_dot(Value v, char* buffer) {
+    buffer[0] = (v < 0 ? '-' : v > 0 ? '+' : ' ');
+    int cp = (int)(std::abs((float)v / PawnValueEg * 100.0f + 0.5f));
+    if (cp >= 10000) {
+      buffer[1] = '0' + cp / 10000; cp %= 10000;
+      buffer[2] = '0' + cp / 1000; cp %= 1000;
+      buffer[3] = '0' + cp / 100; cp %= 100;
+      buffer[4] = '.';
+      buffer[5] = '0' + cp / 10; cp %= 10;
+      buffer[6] = '0' + cp;
+    }
+    else if (cp >= 1000) {
+      buffer[1] = ' ';
+      buffer[2] = '0' + cp / 1000; cp %= 1000;
+      buffer[3] = '0' + cp / 100; cp %= 100;
+      buffer[4] = '.';
+      buffer[5] = '0' + cp / 10;
+      buffer[6] = '0' + cp;
+    }
+    else {
+      buffer[1] = ' ';
+      buffer[2] = ' ';
+      buffer[3] = '0' + cp / 100; cp %= 100;
+      buffer[4] = '.';
+      buffer[5] = '0' + cp / 10; cp %= 10;
+      buffer[6] = '0' + cp / 1;
+    }
+  }
+
+  std::string trace(Position& pos) {
+    std::stringstream ss;
+
+    char board[3*8+1][8*8+2];
+    std::memset(board, ' ', sizeof(board));
+    for (int row = 0; row < 3*8+1; ++row) board[row][8*8+1] = '\0';
+    auto placeSquare = [&board](File file, Rank rank, Piece pc, Value value) {
+      const int x = ((int)file) * 8;
+      const int y = (7 - (int)rank) * 3;
+      for (int i = 1; i < 8; ++i) board[y][x+i] = board[y+3][x+i] = '-';
+      for (int i = 1; i < 3; ++i) board[y+i][x] = board[y+i][x+8] = '|';
+      board[y][x] = board[y][x+8] = board[y+3][x+8] = board[y+3][x] = '+';
+      if (pc != NO_PIECE)
+        board[y+1][x+4] = PieceToChar[pc];
+      if (value != VALUE_NONE) {
+        format_cp_compact(value, &board[y+2][x+2]);
+      }
+    };
+
+    Value baseValue = evaluate(pos, false);
+    baseValue = pos.side_to_move() == WHITE ? baseValue : -baseValue;
+    for (File f = FILE_A; f <= FILE_H; ++f) {
+      for (Rank r = RANK_1; r <= RANK_8; ++r) {
+        Square sq = make_square(f, r);
+        Piece pc = pos.piece_on(sq);
+        Value v = VALUE_NONE;
+        if (pc != NO_PIECE && type_of(pc) != KING) {
+          auto st = pos.state();
+
+          pos.remove_piece(sq);
+          st->accumulator.computed[WHITE] = false;
+          st->accumulator.computed[BLACK] = false;
+
+          Value eval = evaluate(pos, false);
+          eval = pos.side_to_move() == WHITE ? eval : -eval;
+          v = baseValue - eval;
+
+          pos.put_piece(pc, sq);
+          st->accumulator.computed[WHITE] = false;
+          st->accumulator.computed[BLACK] = false;
+        }
+        placeSquare(f, r, pc, v);
+      }
+    }
+
+    for (int row = 0; row < 3*8+1; ++row) {
+      ss << board[row] << '\n';
+    }
+
+    ss << '\n';
+
+    auto t = trace_evaluate(pos);
+    ss << "+------------+------------+------------+------------+\n";
+    ss << "|   Bucket   |  Material  | Positional |   Total    |\n";
+    ss << "|            |   (PSQT)   |  (Layers)  |            |\n";
+    ss << "+------------+------------+------------+------------+\n";
+    for (std::size_t bucket = 0; bucket < LayerStacks; ++bucket) {
+      char buffer[3][8];
+      std::memset(buffer, '\0', sizeof(buffer));
+      format_cp_aligned_dot(t.psqt[bucket], buffer[0]);
+      format_cp_aligned_dot(t.positional[bucket], buffer[1]);
+      format_cp_aligned_dot(t.psqt[bucket] + t.positional[bucket], buffer[2]);
+      ss << "|  " << bucket << "        "
+         << " |  " << buffer[0] << "  "
+         << " |  " << buffer[1] << "  "
+         << " |  " << buffer[2] << "  "
+         << " |";
+      if (bucket == t.correctBucket)
+        ss << " <-- this bucket is used";
+      ss << '\n';
+    }
+    ss << "+------------+------------+------------+------------+\n";
+
+    return ss.str();
   }
 
   // Load eval, from a file stream or a memory stream

--- a/src/position.h
+++ b/src/position.h
@@ -171,6 +171,9 @@ public:
   // Used by NNUE
   StateInfo* state() const;
 
+  void put_piece(Piece pc, Square s);
+  void remove_piece(Square s);
+
 private:
   // Initialization helpers (used while setting up a position)
   void set_castling_right(Color c, Square rfrom);
@@ -178,8 +181,6 @@ private:
   void set_check_info(StateInfo* si) const;
 
   // Other helpers
-  void put_piece(Piece pc, Square s);
-  void remove_piece(Square s);
   void move_piece(Square from, Square to);
   template<bool Do>
   void do_castling(Color us, Square from, Square& to, Square& rfrom, Square& rto);
@@ -386,7 +387,7 @@ inline void Position::remove_piece(Square s) {
   byTypeBB[ALL_PIECES] ^= s;
   byTypeBB[type_of(pc)] ^= s;
   byColorBB[color_of(pc)] ^= s;
-  /* board[s] = NO_PIECE;  Not needed, overwritten by the capturing one */
+  board[s] = NO_PIECE;
   pieceCount[pc]--;
   pieceCount[make_piece(color_of(pc), ALL_PIECES)]--;
   psq -= PSQT::psq[pc][s];


### PR DESCRIPTION
Some WIP, want to know if it's desired to have.

This patch adds some more output to the `eval` command. It adds a board display with estimated piece values (remove piece, eval, put piece), and split psqt+position eval for each bucket. Example:

```
Stockfish 170621 by the Stockfish developers (see AUTHORS file)
eval
info string NNUE evaluation using nn-33c9d39e5eb6.nnue enabled

     Term    |    White    |    Black    |    Total
             |   MG    EG  |   MG    EG  |   MG    EG
 ------------+-------------+-------------+------------
    Material |  ----  ---- |  ----  ---- |  0.00  0.00
   Imbalance |  ----  ---- |  ----  ---- |  0.00  0.00
       Pawns |  0.38 -0.08 |  0.38 -0.08 |  0.00  0.00
     Knights | -0.02 -0.19 | -0.02 -0.19 |  0.00  0.00
     Bishops |  0.01 -0.41 |  0.01 -0.41 |  0.00  0.00
       Rooks | -0.26 -0.06 | -0.26 -0.06 |  0.00  0.00
      Queens |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
    Mobility | -0.88 -1.15 | -0.88 -1.15 |  0.00  0.00
 King safety |  0.91 -0.10 |  0.91 -0.10 |  0.00  0.00
     Threats |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
      Passed |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
       Space |  0.40  0.00 |  0.40  0.00 |  0.00  0.00
    Winnable |  ----  ---- |  ----  ---- |  0.00  0.00
 ------------+-------------+-------------+------------
       Total |  ----  ---- |  ----  ---- |  0.00  0.00

+-------+-------+-------+-------+-------+-------+-------+-------+
|   r   |   n   |   b   |   q   |   k   |   b   |   n   |   r   |
| -7.83 | -7.63 | -7.68 | -13.6 |       | -8.06 | -7.71 | -8.25 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   p   |   p   |   p   |   p   |   p   |   p   |   p   |   p   |
| -1.04 | -1.35 | -1.50 | -1.48 | -1.57 | -1.91 | -1.79 | -1.00 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   P   |   P   |   P   |   P   |   P   |   P   |   P   |   P   |
| +0.89 | +1.22 | +1.28 | +1.26 | +1.37 | +1.73 | +1.64 | +0.71 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   R   |   N   |   B   |   Q   |   K   |   B   |   N   |   R   |
| +7.44 | +6.86 | +7.09 | +11.7 |       | +7.16 | +6.55 | +7.69 |
+-------+-------+-------+-------+-------+-------+-------+-------+

     | Bckt  | PSQT  |  LS   | Total |
     |     0 |  0.00 | -0.89 | -0.89 |
     |     1 |  0.00 | +0.36 | +0.36 |
     |     2 |  0.00 | +0.20 | +0.20 |
     |     3 |  0.00 | +0.21 | +0.21 |
     |     4 |  0.00 | +0.17 | +0.17 |
     |     5 |  0.00 | +0.11 | +0.11 |
     |     6 |  0.00 | +0.17 | +0.17 |
 --> |     7 |  0.00 | +0.16 | +0.16 |


Classical evaluation: 0.00 (white side)

NNUE evaluation:      0.17 (white side)

Final evaluation:     0.31 (white side)

position fen r1bqkbnr/ppp2ppp/2np4/4p3/4P3/3B1N2/PPPP1PPP/RNBQ1RK1 b kq - 3 4
eval
info string NNUE evaluation using nn-33c9d39e5eb6.nnue enabled

     Term    |    White    |    Black    |    Total
             |   MG    EG  |   MG    EG  |   MG    EG
 ------------+-------------+-------------+------------
    Material |  ----  ---- |  ----  ---- |  0.80  0.00
   Imbalance |  ----  ---- |  ----  ---- |  0.00  0.00
       Pawns |  0.34 -0.07 |  0.59 -0.02 | -0.25 -0.05
     Knights | -0.18 -0.29 | -0.07 -0.16 | -0.12 -0.13
     Bishops | -0.46 -1.39 | -0.14 -1.02 | -0.32 -0.37
       Rooks |  0.03 -0.02 | -0.19 -0.06 |  0.22  0.04
      Queens |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
    Mobility | -0.11 -0.14 |  0.08  0.21 | -0.19 -0.36
 King safety |  0.61 -0.10 |  0.68 -0.10 | -0.08  0.00
     Threats |  0.13  0.13 |  0.17  0.17 | -0.03 -0.03
      Passed |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
       Space |  0.54  0.00 |  0.61  0.00 | -0.07  0.00
    Winnable |  ----  ---- |  ----  ---- |  0.00 -0.28
 ------------+-------------+-------------+------------
       Total |  ----  ---- |  ----  ---- | -0.03 -1.17

+-------+-------+-------+-------+-------+-------+-------+-------+
|   r   |       |   b   |   q   |   k   |   b   |   n   |   r   |
| +6.80 |       | +7.01 | +12.4 |       | +6.66 | +6.14 | +6.97 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   p   |   p   |   p   |       |       |   p   |   p   |   p   |
| +0.82 | +1.33 | +1.29 |       |       | +1.16 | +0.94 | +0.37 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |   n   |   p   |       |       |       |       |
|       |       | +6.92 | +1.08 |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |   p   |       |       |       |
|       |       |       |       | +1.89 |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |   P   |       |       |       |
|       |       |       |       | -1.78 |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |   B   |       |   N   |       |       |
|       |       |       | -8.12 |       | -7.93 |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   P   |   P   |   P   |   P   |       |   P   |   P   |   P   |
| -0.81 | -1.22 | -1.32 | -1.01 |       | -1.34 | -2.96 | -1.54 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   R   |   N   |   B   |   Q   |       |   R   |   K   |       |
| -7.93 | -7.07 | -7.69 | -13.4 |       | -8.18 |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+

     | Bckt  | PSQT  |  LS   | Total |
     |     0 | +0.23 | -0.08 | +0.14 |
     |     1 | -0.08 | +0.35 | +0.26 |
     |     2 | -0.33 | +0.32 | -0.00 |
     |     3 | -0.39 | +0.27 | -0.12 |
     |     4 | -0.28 | +0.45 | +0.16 |
     |     5 | -0.14 | +0.32 | +0.17 |
     |     6 | -0.12 | +0.18 | +0.05 |
 --> |     7 | -0.13 | +0.14 | +0.00 |


Classical evaluation: 0.00 (white side)

NNUE evaluation:      -0.00 (white side)

Final evaluation:     -0.03 (white side)

position fen 8/3k4/5P2/5K2/8/8/8/8 w - - 0 1
eval
info string NNUE evaluation using nn-33c9d39e5eb6.nnue enabled

     Term    |    White    |    Black    |    Total
             |   MG    EG  |   MG    EG  |   MG    EG
 ------------+-------------+-------------+------------
    Material |  ----  ---- |  ----  ---- |  0.00  0.00
   Imbalance |  ----  ---- |  ----  ---- |  0.00  0.00
       Pawns |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
     Knights |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
     Bishops |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
       Rooks |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
      Queens |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
    Mobility |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
 King safety |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
     Threats |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
      Passed |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
       Space |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
    Winnable |  ----  ---- |  ----  ---- |  0.00  0.00
 ------------+-------------+-------------+------------
       Total |  ----  ---- |  ----  ---- |  0.00  0.00

+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |   k   |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |   P   |       |       |
|       |       |       |       |       | +11.6 |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |   K   |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+

     | Bckt  | PSQT  |  LS   | Total |
 --> |     0 | +0.93 | +10.7 | +11.6 |
     |     1 | +0.19 | +7.96 | +8.15 |
     |     2 | +0.74 | +4.76 | +5.51 |
     |     3 | +1.07 | +2.92 | +4.00 |
     |     4 | +1.11 | +0.78 | +1.90 |
     |     5 | +0.31 | +2.25 | +2.57 |
     |     6 | +0.16 | +3.75 | +3.91 |
     |     7 | +0.38 | +3.11 | +3.50 |


Classical evaluation: 49.10 (white side)

NNUE evaluation:      11.70 (white side)

Final evaluation:     11.12 (white side)

position fen 8/5k2/5P2/5K2/8/8/8/8 w - - 0 1
eval
info string NNUE evaluation using nn-33c9d39e5eb6.nnue enabled

     Term    |    White    |    Black    |    Total
             |   MG    EG  |   MG    EG  |   MG    EG
 ------------+-------------+-------------+------------
    Material |  ----  ---- |  ----  ---- |  0.00  0.00
   Imbalance |  ----  ---- |  ----  ---- |  0.00  0.00
       Pawns |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
     Knights |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
     Bishops |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
       Rooks |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
      Queens |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
    Mobility |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
 King safety |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
     Threats |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
      Passed |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
       Space |  0.00  0.00 |  0.00  0.00 |  0.00  0.00
    Winnable |  ----  ---- |  ----  ---- |  0.00  0.00
 ------------+-------------+-------------+------------
       Total |  ----  ---- |  ----  ---- |  0.00  0.00

+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |   k   |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |   P   |       |       |
|       |       |       |       |       | -0.14 |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |   K   |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+

     | Bckt  | PSQT  |  LS   | Total |
 --> |     0 | +0.92 | -0.93 | -0.00 |
     |     1 | +0.13 | +1.41 | +1.54 |
     |     2 | +0.60 | +0.58 | +1.18 |
     |     3 | +0.84 | -0.71 | +0.13 |
     |     4 | +0.84 | -0.62 | +0.21 |
     |     5 | +0.24 | +0.16 | +0.40 |
     |     6 | +0.09 | +2.50 | +2.60 |
     |     7 | +0.33 | +1.37 | +1.70 |


Classical evaluation: 0.00 (white side)

NNUE evaluation:      -0.01 (white side)

Final evaluation:     -0.10 (white side)
```