### PR TITLE
New default net nn-3b20abec10c1.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-33c9d39e5eb6.nnue"
+  #define EvalFileDefaultName   "nn-3b20abec10c1.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
This net was created by @pleomati, who manually edited with an hex editor 10 values randomly chosen in the LCSFNet10 net (nn-6ad41a9207d0.nnue) to create this one. The LCSFNet10 net was trained by Joost VandeVondele from a dataset combining Stockfish games and Leela games (16x10^9 positions from SF self-play at depth 9, and 6.3x10^9 positions from Leela games, so overall 72% of Stockfish positions and 28% of Leela positions).

STC 10+0.1 :
LLR: 2.94 (-2.94,2.94) <-0.50,2.50>
Total: 50888 W: 5881 L: 5654 D: 39353
Ptnml(0-2): 281, 4290, 16085, 4497, 291
https://tests.stockfishchess.org/tests/view/60cbfa68457376eb8bcab49a

LTC 60+0.6 :
LLR: 2.94 (-2.94,2.94) <0.50,3.50>
Total: 25480 W: 1498 L: 1338 D: 22644
Ptnml(0-2): 36, 1155, 10193, 1325, 31
https://tests.stockfishchess.org/tests/view/60cc4af8457376eb8bcab4d4

Bench: 4904930 