### PR TITLE
50144f835024 2

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-33c9d39e5eb6.nnue"
+  #define EvalFileDefaultName   "nn-50144f835024.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
**Python Command**

c:\nnue>python train.py i:/bin/all.binpack i:/bin/all.binpack --gpus 1 --threads 4 --num-workers 30 --batch-size 16384  --progress_bar_refresh_rate 300 --smart-fen-skipping --random-fen-skipping 3 --features=HalfKAv2^  --lambda=1.0 --max_epochs=440 --seed %random%%random% --default_root_dir exp/run_8 --resume-from-model ./pt/nn-6ad41a9207d0.pt
`
all.binpack equaled 4 parts Wrong_NNUE_2.binpack https://drive.google.com/file/d/1seGNOqcVdvK_vPNq98j-zV3XPE5zWAeq/view?usp=sharing plus two parts of Training_Data.binpack https://drive.google.com/file/d/1RFkQES3DpsiJqsOtUshENtzPfFgUmEff/view?usp=sharing 
Each set was concatenated together - make one large Wrong_NNUE 2 binpack and one large Training_Data of approximate size.  They were then interleaved together.  The idea was to give Wrong_NNUE.binpack closer to equal weighting  with the Training _Data binpack .

nn-6ad41a9207d0.pt was derived from a net @Vondle ran which passed STC quicklly , but faltered in LTC. https://tests.stockfishchess.org/tests/view/60cba666457376eb8bcab443


**STC:** 
   LLR: 2.95 (-2.94,2.94) <-0.50,2.50>
   Total: 18792 W: 2068 L: 1889 D: 14835
   Ptnml(0-2): 82, 1480, 6117, 1611, 106
https://tests.stockfishchess.org/tests/view/60ccda8b457376eb8bcab568

**LTC:**   
LLR: 2.94 (-2.94,2.94) <0.50,3.50>
Total: 11376 W: 574 L: 454 D: 10348
Ptnml(0-2): 4, 412, 4747, 510, 15
https://tests.stockfishchess.org/tests/view/60ccf952457376eb8bcab58d

Bench: 4900906