### PR TITLE
More enhancements for the `eval` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,14 @@ For developers the following non-standard commands might be of interest, mainly 
     Display the current position, with ascii art and fen.
 
   * #### eval
-    Return the evaluation of the current position.
+    Display a detailed evaluation of the current position.
+      > Specific classical evaluation terms
+      > Estimated value of each piece on the board, from the NNUE evaluation.
+        It is computed by removing the piece from the board and comparing
+        the evaluation before and after. Each square displays both
+        the material (PSQT) and the positional (layers) parts, along with the total.
+      > NNUE evaluation given by each subnetwork. Material, positional, total.
+      > Total evaluation for classical, pure NNUE, adjusted NNUE, and the actual value used.
 
   * #### export_net [filename]
     Exports the currently loaded network to a file.

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1172,17 +1172,21 @@ std::string Eval::trace(Position& pos) {
   ss << std::showpoint << std::showpos << std::fixed << std::setprecision(2) << std::setw(15);
 
   v = pos.side_to_move() == WHITE ? v : -v;
-  ss << "\nClassical evaluation   " << to_cp(v) << " (white side)\n";
+  ss << "\nClassical evaluation       " << to_cp(v) << " (white side)\n";
   if (Eval::useNNUE)
   {
       v = NNUE::evaluate(pos, false);
       v = pos.side_to_move() == WHITE ? v : -v;
-      ss << "NNUE evaluation        " << to_cp(v) << " (white side)\n";
+      ss << "NNUE evaluation            " << to_cp(v) << " (white side)\n";
+
+      v = NNUE::evaluate(pos, true);
+      v = pos.side_to_move() == WHITE ? v : -v;
+      ss << "NNUE evaluation (adjusted) " << to_cp(v) << " (white side)\n";
   }
 
   v = evaluate(pos);
   v = pos.side_to_move() == WHITE ? v : -v;
-  ss << "Final evaluation       " << to_cp(v) << " (white side)";
+  ss << "Final evaluation           " << to_cp(v) << " (white side)";
   if (Eval::useNNUE)
      ss << " [with scaled NNUE, hybrid, ...]";
   ss << "\n";


### PR DESCRIPTION
- make everything be from white point of view
- include adjusted NNUE output
- show parts of the evaluation in each square
- improve readme

Example:
```
./stockfish
Stockfish 220621 by the Stockfish developers (see AUTHORS file)
position fen 3Qb1k1/1r2ppb1/pN1n2q1/Pp1Pp1Pr/4P2p/4BP2/4B1R1/1R5K b - - 11 40
eval
info string NNUE evaluation using nn-190f102a22c3.nnue enabled

 Contributing terms for the classical eval:
+------------+-------------+-------------+-------------+
|    Term    |    White    |    Black    |    Total    |
|            |   MG    EG  |   MG    EG  |   MG    EG  |
+------------+-------------+-------------+-------------+
|   Material |  ----  ---- |  ----  ---- | -0.73 -1.55 |
|  Imbalance |  ----  ---- |  ----  ---- | -0.21 -0.17 |
|      Pawns |  0.35 -0.00 |  0.19 -0.26 |  0.16  0.25 |
|    Knights |  0.04 -0.08 |  0.12 -0.01 | -0.08 -0.07 |
|    Bishops | -0.34 -0.87 | -0.17 -0.61 | -0.17 -0.26 |
|      Rooks |  0.12  0.00 |  0.08  0.00 |  0.04  0.00 |
|     Queens |  0.00  0.00 | -0.27 -0.07 |  0.27  0.07 |
|   Mobility |  0.84  1.76 |  0.01  0.66 |  0.83  1.10 |
|King safety | -0.99 -0.17 | -0.72 -0.10 | -0.27 -0.07 |
|    Threats |  0.27  0.27 |  0.73  0.86 | -0.46 -0.59 |
|     Passed |  0.00  0.00 |  0.79  0.82 | -0.79 -0.82 |
|      Space |  0.61  0.00 |  0.24  0.00 |  0.37  0.00 |
|   Winnable |  ----  ---- |  ----  ---- |  0.00 -0.03 |
+------------+-------------+-------------+-------------+
|      Total |  ----  ---- |  ----  ---- | -1.03 -2.14 |
+------------+-------------+-------------+-------------+

 NNUE derived piece values (white side) [order: material, positional, total]:
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |   Q   |   b   |       |   k   |       |
|       |       |       | +11.1 | -3.59 |       |       |       |
|       |       |       | +0.37 | +1.92 |       |       |       |
|       |       |       | +11.5 | -1.66 |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |   r   |       |       |   p   |   p   |   b   |       |
|       | -4.71 |       |       | -0.83 | -0.95 | -3.67 |       |
|       | +1.62 |       |       | -0.16 | -0.21 | +0.80 |       |
|       | -3.09 |       |       | -1.00 | -1.17 | -2.87 |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   p   |   N   |       |   n   |       |       |   q   |       |
| -0.72 | +3.29 |       | -3.45 |       |       | -11.4 |       |
| -1.10 | +0.03 |       | -0.70 |       |       | +8.57 |       |
| -1.82 | +3.32 |       | -4.15 |       |       | -2.92 |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   P   |   p   |       |   P   |   p   |       |   P   |   r   |
| +0.55 | -0.84 |       | +0.57 | -0.85 |       | +0.60 | -4.77 |
| +0.54 | -0.15 |       | -0.22 | +1.11 |       | -0.36 | +1.67 |
| +1.10 | -1.00 |       | +0.35 | +0.25 |       | +0.23 | -3.09 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |   P   |       |       |   p   |
|       |       |       |       | +0.59 |       |       | -0.78 |
|       |       |       |       | +1.61 |       |       | +1.93 |
|       |       |       |       | +2.20 |       |       | +1.14 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |   B   |   P   |       |       |
|       |       |       |       | +3.36 | +0.53 |       |       |
|       |       |       |       | +0.54 | +0.99 |       |       |
|       |       |       |       | +3.90 | +1.52 |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |   B   |       |   R   |       |
|       |       |       |       | +3.34 |       | +4.60 |       |
|       |       |       |       | +0.60 |       | +0.42 |       |
|       |       |       |       | +3.94 |       | +5.02 |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |   R   |       |       |       |       |       |   K   |
|       | +4.48 |       |       |       |       |       |       |
|       | -0.70 |       |       |       |       |       |       |
|       | +3.77 |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+

 NNUE network contributions (white side)
+------------+------------+------------+------------+
|   Bucket   |  Material  | Positional |   Total    |
|            |   (PSQT)   |  (Layers)  |            |
+------------+------------+------------+------------+
|  0         |  -  0.68   |  +  0.59   |  -  0.09   |
|  1         |  -  0.18   |  +  1.56   |  +  1.37   |
|  2         |  -  0.47   |  +  1.75   |  +  1.28   |
|  3         |  -  0.56   |  +  1.96   |  +  1.39   |
|  4         |  -  0.46   |  +  1.85   |  +  1.38   |
|  5         |  -  0.36   |  +  2.11   |  +  1.75   |
|  6         |  -  0.50   |  +  2.05   |  +  1.55   | <-- this bucket is used
|  7         |  -  1.87   |  +  1.77   |  -  0.09   |
+------------+------------+------------+------------+


Classical evaluation       -1.00 (white side)
NNUE evaluation            +1.55 (white side)
NNUE evaluation (adjusted) +1.69 (white side)
Final evaluation           +2.53 (white side) [with scaled NNUE, hybrid, ...]
```