### PR TITLE
Simplify Reductions Initialization

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -152,7 +152,7 @@ namespace {
 void Search::init() {
 
   for (int i = 1; i < MAX_MOVES; ++i)
-      Reductions[i] = int(21.3 * std::log(i + 0.25 * std::log(i)));
+      Reductions[i] = int(21.9 * std::log(i));
 }
 
 


### PR DESCRIPTION
This patch simplifies Reductions initialization.

STC:
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 45032 W: 3600 L: 3518 D: 37914
Ptnml(0-2): 111, 2893, 16435, 2957, 120
https://tests.stockfishchess.org/tests/view/60d2655d40925195e7a6c527

LTC:
LLR: 3.00 (-2.94,2.94) <-2.50,0.50>
Total: 25728 W: 786 L: 722 D: 24220
Ptnml(0-2): 5, 650, 11494, 706, 9
https://tests.stockfishchess.org/tests/view/60d2b14240925195e7a6c577

bench: 4602977