### PR TITLE
Add Microsoft Visual C++ build support

### DIFF
--- a/src/msvc/get_default_eval_file.cmd
+++ b/src/msvc/get_default_eval_file.cmd
@@ -1,0 +1,32 @@
+:: This batch file will parse "evaluate.h" in the parent directory and download the default evaluation file specified in it.
+:: If called with a parameter, it will also copy the downloaded *.nnue file to the directory provided in the parameter.
+:: This could be the directory where stockfish.exe is located, so the default *.nnue is always loaded when stockfish is started.
+
+@echo off
+
+cd /D "%~dp0"
+set nnuefile=""
+
+for /f "tokens=1-3 delims= " %%a in (..\evaluate.h) do (
+    if "%%a"=="#define" (
+        if "%%b"=="EvalFileDefaultName" set nnuefile=%%c
+    )
+)
+
+:: Remove double quotes, if any.
+set nnuefile=%nnuefile:"=%
+
+if "%nnuefile%"=="" (
+    echo #define EvalFileDefaultName was not found in evaluate.h!
+) else (
+    if exist %nnuefile% (
+        echo Download of %nnuefile% skipped because the file already exists.
+    ) else (
+        echo Downloading https://tests.stockfishchess.org/api/nn/%nnuefile%...
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://tests.stockfishchess.org/api/nn/%nnuefile%', '%nnuefile%')"
+    )
+    if not "%~1"=="" (
+        echo Copying %nnuefile% to stockfish.exe directory...
+        copy /B /Y %nnuefile% %1
+    )
+)

--- a/src/msvc/stockfish.sln
+++ b/src/msvc/stockfish.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31410.357
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "stockfish", "stockfish.vcxproj", "{E5B3CC35-2723-4A39-8A5F-62C5ECFF7C90}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Windows 32 = Debug|Windows 32
+		Debug|Windows x64 for Haswell CPUs = Debug|Windows x64 for Haswell CPUs
+		Release|Windows 32 = Release|Windows 32
+		Release|Windows x64 for Haswell CPUs = Release|Windows x64 for Haswell CPUs
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E5B3CC35-2723-4A39-8A5F-62C5ECFF7C90}.Debug|Windows 32.ActiveCfg = Debug|Win32
+		{E5B3CC35-2723-4A39-8A5F-62C5ECFF7C90}.Debug|Windows 32.Build.0 = Debug|Win32
+		{E5B3CC35-2723-4A39-8A5F-62C5ECFF7C90}.Debug|Windows x64 for Haswell CPUs.ActiveCfg = Debug|x64
+		{E5B3CC35-2723-4A39-8A5F-62C5ECFF7C90}.Debug|Windows x64 for Haswell CPUs.Build.0 = Debug|x64
+		{E5B3CC35-2723-4A39-8A5F-62C5ECFF7C90}.Release|Windows 32.ActiveCfg = Release|Win32
+		{E5B3CC35-2723-4A39-8A5F-62C5ECFF7C90}.Release|Windows 32.Build.0 = Release|Win32
+		{E5B3CC35-2723-4A39-8A5F-62C5ECFF7C90}.Release|Windows x64 for Haswell CPUs.ActiveCfg = Release|x64
+		{E5B3CC35-2723-4A39-8A5F-62C5ECFF7C90}.Release|Windows x64 for Haswell CPUs.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0F72F623-25D3-4836-8FAE-2129204F9FEF}
+	EndGlobalSection
+EndGlobal

--- a/src/msvc/stockfish.vcxproj
+++ b/src/msvc/stockfish.vcxproj
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{e5b3cc35-2723-4a39-8a5f-62c5ecff7c90}</ProjectGuid>
+    <RootNamespace>stockfish</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;USE_MMX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <PostBuildEvent>
+      <Command>call get_default_eval_file.cmd $(OutDir)</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;USE_MMX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <PostBuildEvent>
+      <Command>call get_default_eval_file.cmd $(OutDir)</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;USE_PEXT;USE_AVX2;USE_SSE41;USE_SSSE3;USE_SSE2;USE_POPCNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <PostBuildEvent>
+      <Command>call get_default_eval_file.cmd $(OutDir)</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;USE_PEXT;USE_AVX2;USE_SSE41;USE_SSSE3;USE_SSE2;USE_POPCNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <PostBuildEvent>
+      <Command>call get_default_eval_file.cmd $(OutDir)</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\benchmark.cpp" />
+    <ClCompile Include="..\bitbase.cpp" />
+    <ClCompile Include="..\bitboard.cpp" />
+    <ClCompile Include="..\endgame.cpp" />
+    <ClCompile Include="..\evaluate.cpp" />
+    <ClCompile Include="..\main.cpp" />
+    <ClCompile Include="..\material.cpp" />
+    <ClCompile Include="..\misc.cpp" />
+    <ClCompile Include="..\movegen.cpp" />
+    <ClCompile Include="..\movepick.cpp" />
+    <ClCompile Include="..\nnue\evaluate_nnue.cpp" />
+    <ClCompile Include="..\nnue\features\half_ka_v2.cpp" />
+    <ClCompile Include="..\pawns.cpp" />
+    <ClCompile Include="..\position.cpp" />
+    <ClCompile Include="..\psqt.cpp" />
+    <ClCompile Include="..\search.cpp" />
+    <ClCompile Include="..\syzygy\tbprobe.cpp" />
+    <ClCompile Include="..\thread.cpp" />
+    <ClCompile Include="..\timeman.cpp" />
+    <ClCompile Include="..\tt.cpp" />
+    <ClCompile Include="..\tune.cpp" />
+    <ClCompile Include="..\uci.cpp" />
+    <ClCompile Include="..\ucioption.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\bitboard.h" />
+    <ClInclude Include="..\endgame.h" />
+    <ClInclude Include="..\evaluate.h" />
+    <ClInclude Include="..\incbin\incbin.h" />
+    <ClInclude Include="..\material.h" />
+    <ClInclude Include="..\misc.h" />
+    <ClInclude Include="..\movegen.h" />
+    <ClInclude Include="..\movepick.h" />
+    <ClInclude Include="..\nnue\evaluate_nnue.h" />
+    <ClInclude Include="..\nnue\features\half_ka_v2.h" />
+    <ClInclude Include="..\nnue\layers\affine_transform.h" />
+    <ClInclude Include="..\nnue\layers\clipped_relu.h" />
+    <ClInclude Include="..\nnue\layers\input_slice.h" />
+    <ClInclude Include="..\nnue\nnue_accumulator.h" />
+    <ClInclude Include="..\nnue\nnue_architecture.h" />
+    <ClInclude Include="..\nnue\nnue_common.h" />
+    <ClInclude Include="..\nnue\nnue_feature_transformer.h" />
+    <ClInclude Include="..\pawns.h" />
+    <ClInclude Include="..\position.h" />
+    <ClInclude Include="..\psqt.h" />
+    <ClInclude Include="..\search.h" />
+    <ClInclude Include="..\syzygy\tbprobe.h" />
+    <ClInclude Include="..\thread.h" />
+    <ClInclude Include="..\thread_win32_osx.h" />
+    <ClInclude Include="..\timeman.h" />
+    <ClInclude Include="..\tt.h" />
+    <ClInclude Include="..\tune.h" />
+    <ClInclude Include="..\types.h" />
+    <ClInclude Include="..\uci.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/msvc/stockfish.vcxproj
+++ b/src/msvc/stockfish.vcxproj
@@ -93,9 +93,9 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <PostBuildEvent>
+    <PreBuildEvent>
       <Command>call get_default_eval_file.cmd $(OutDir)</Command>
-    </PostBuildEvent>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -106,6 +106,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;USE_MMX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/Ob3 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -113,9 +114,9 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <PostBuildEvent>
+    <PreBuildEvent>
       <Command>call get_default_eval_file.cmd $(OutDir)</Command>
-    </PostBuildEvent>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -129,9 +130,9 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <PostBuildEvent>
+    <PreBuildEvent>
       <Command>call get_default_eval_file.cmd $(OutDir)</Command>
-    </PostBuildEvent>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -142,6 +143,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;USE_PEXT;USE_AVX2;USE_SSSE3;USE_SSE2;USE_POPCNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/Ob3 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -149,9 +151,9 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <PostBuildEvent>
+    <PreBuildEvent>
       <Command>call get_default_eval_file.cmd $(OutDir)</Command>
-    </PostBuildEvent>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\benchmark.cpp" />

--- a/src/msvc/stockfish.vcxproj
+++ b/src/msvc/stockfish.vcxproj
@@ -121,7 +121,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;USE_PEXT;USE_AVX2;USE_SSE41;USE_SSSE3;USE_SSE2;USE_POPCNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;USE_PEXT;USE_AVX2;USE_SSSE3;USE_SSE2;USE_POPCNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
@@ -139,7 +139,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;USE_PEXT;USE_AVX2;USE_SSE41;USE_SSSE3;USE_SSE2;USE_POPCNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;USE_PEXT;USE_AVX2;USE_SSSE3;USE_SSE2;USE_POPCNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>

--- a/src/msvc/stockfish.vcxproj
+++ b/src/msvc/stockfish.vcxproj
@@ -125,6 +125,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;USE_PEXT;USE_AVX2;USE_SSSE3;USE_SSE2;USE_POPCNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -144,6 +145,7 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalOptions>/Ob3 %(AdditionalOptions)</AdditionalOptions>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/msvc/stockfish.vcxproj
+++ b/src/msvc/stockfish.vcxproj
@@ -169,7 +169,7 @@
     <ClCompile Include="..\movegen.cpp" />
     <ClCompile Include="..\movepick.cpp" />
     <ClCompile Include="..\nnue\evaluate_nnue.cpp" />
-    <ClCompile Include="..\nnue\features\half_ka_v2.cpp" />
+    <ClCompile Include="..\nnue\features\half_ka_v2_hm.cpp" />
     <ClCompile Include="..\pawns.cpp" />
     <ClCompile Include="..\position.cpp" />
     <ClCompile Include="..\psqt.cpp" />
@@ -192,7 +192,7 @@
     <ClInclude Include="..\movegen.h" />
     <ClInclude Include="..\movepick.h" />
     <ClInclude Include="..\nnue\evaluate_nnue.h" />
-    <ClInclude Include="..\nnue\features\half_ka_v2.h" />
+    <ClInclude Include="..\nnue\features\half_ka_v2_hm.h" />
     <ClInclude Include="..\nnue\layers\affine_transform.h" />
     <ClInclude Include="..\nnue\layers\clipped_relu.h" />
     <ClInclude Include="..\nnue\layers\input_slice.h" />

--- a/src/msvc/stockfish.vcxproj.filters
+++ b/src/msvc/stockfish.vcxproj.filters
@@ -1,0 +1,173 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\benchmark.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\bitbase.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\bitboard.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\endgame.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\evaluate.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\material.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\misc.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\movegen.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\movepick.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pawns.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\position.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\psqt.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\search.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\thread.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\timeman.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tt.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tune.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\uci.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ucioption.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\nnue\evaluate_nnue.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\nnue\features\half_ka_v2.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\syzygy\tbprobe.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\bitboard.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\endgame.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\evaluate.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\material.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\misc.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\movegen.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\movepick.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\pawns.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\position.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\psqt.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\search.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\thread.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\thread_win32_osx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\timeman.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tt.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tune.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\types.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\uci.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\incbin\incbin.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\nnue\evaluate_nnue.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\nnue\nnue_accumulator.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\nnue\nnue_architecture.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\nnue\nnue_common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\nnue\nnue_feature_transformer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\nnue\features\half_ka_v2.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\nnue\layers\affine_transform.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\nnue\layers\clipped_relu.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\nnue\layers\input_slice.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\syzygy\tbprobe.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/src/msvc/stockfish.vcxproj.filters
+++ b/src/msvc/stockfish.vcxproj.filters
@@ -74,7 +74,7 @@
     <ClCompile Include="..\nnue\evaluate_nnue.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\nnue\features\half_ka_v2.cpp">
+    <ClCompile Include="..\nnue\features\half_ka_v2_hm.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\syzygy\tbprobe.cpp">
@@ -154,7 +154,7 @@
     <ClInclude Include="..\nnue\nnue_feature_transformer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\nnue\features\half_ka_v2.h">
+    <ClInclude Include="..\nnue\features\half_ka_v2_hm.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\nnue\layers\affine_transform.h">

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -266,7 +266,7 @@ namespace Stockfish::Eval::NNUE {
     buffer[0] = (v < 0 ? '-' : v > 0 ? '+' : ' ');
 
     double cp = 1.0 * std::abs(int(v)) / PawnValueEg;
-    sprintf(&buffer[1], "%6.2f", cp);
+    snprintf(&buffer[1], 7, "%6.2f", cp);
   }
 
 

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -123,8 +123,10 @@ namespace Stockfish::Eval::NNUE {
       // We use __m* types as template arguments, which causes GCC to emit warnings
       // about losing some attribute information. This is irrelevant to us as we
       // only take their size, so the following pragma are harmless.
+  #ifdef __GNUC__
       #pragma GCC diagnostic push
       #pragma GCC diagnostic ignored "-Wignored-attributes"
+  #endif
 
       template <typename SIMDRegisterType,
                 typename LaneType,
@@ -157,7 +159,9 @@ namespace Stockfish::Eval::NNUE {
       static constexpr int NumRegs     = BestRegisterCount<vec_t, WeightType, TransformedFeatureDimensions, NumRegistersSIMD>();
       static constexpr int NumPsqtRegs = BestRegisterCount<psqt_vec_t, PSQTWeightType, PSQTBuckets, NumRegistersSIMD>();
 
+  #ifdef __GNUC__
       #pragma GCC diagnostic pop
+  #endif
 
   #endif
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1021,8 +1021,7 @@ moves_loop: // When in check, search starts from here
                   continue;
 
               // Futility pruning: parent node (~5 Elo)
-              if (   lmrDepth < 7
-                  && !ss->inCheck
+              if (   !ss->inCheck
                   && ss->staticEval + 174 + 157 * lmrDepth <= alpha
                   &&  (*contHist[0])[movedPiece][to_sq(move)]
                     + (*contHist[1])[movedPiece][to_sq(move)]

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -760,6 +760,7 @@ namespace {
             ss->staticEval = eval = -(ss-1)->staticEval;
 
         // Save static evaluation into transposition table
+        if(!excludedMove)
         tte->save(posKey, VALUE_NONE, ss->ttPv, BOUND_NONE, DEPTH_NONE, MOVE_NONE, eval);
     }
 


### PR DESCRIPTION
Add full Microsoft Visual C++ 2019 support. It will build either "Windows x64 for Haswell CPUs" (the most go-to x64 version) or the old-fashioned "Windows 32 (x86)" configurations from Stockfish master with all necessary flags automatically. In addition, the correct NNUE evaluation file is automatically downloaded into the working directory of the built executable as a post-build step.