### PR TITLE
Remove obsolote architecture support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,7 +61,6 @@ Ernesto Gatti
 Linmiao Xu (linrock)
 Fabian Beuke (madnight)
 Fabian Fichter (ianfab)
-Fanael Linithien (Fanael)
 fanon
 Fauzi Akram Dabat (FauziAkram)
 Felix Wittmann

--- a/src/Makefile
+++ b/src/Makefile
@@ -73,8 +73,6 @@ endif
 # popcnt = yes/no     --- -DUSE_POPCNT     --- Use popcnt asm-instruction
 # pext = yes/no       --- -DUSE_PEXT       --- Use pext x86_64 asm-instruction
 # sse = yes/no        --- -msse            --- Use Intel Streaming SIMD Extensions
-# mmx = yes/no        --- -mmmx            --- Use Intel MMX instructions
-# sse2 = yes/no       --- -msse2           --- Use Intel Streaming SIMD Extensions 2
 # ssse3 = yes/no      --- -mssse3          --- Use Intel Supplemental Streaming SIMD Extensions 3
 # sse41 = yes/no      --- -msse4.1         --- Use Intel Streaming SIMD Extensions 4.1
 # avx2 = yes/no       --- -mavx2           --- Use Intel Advanced Vector Extensions 2
@@ -102,7 +100,7 @@ endif
 ifeq ($(ARCH), $(filter $(ARCH), \
                  x86-64-vnni512 x86-64-vnni256 x86-64-avx512 x86-64-bmi2 x86-64-avx2 \
                  x86-64-sse41-popcnt x86-64-modern x86-64-ssse3 x86-64-sse3-popcnt \
-                 x86-64 x86-32-sse41-popcnt x86-32-sse2 x86-32 ppc-64 ppc-32 e2k \
+                 x86-64 x86-32-sse41-popcnt x86-32 ppc-64 ppc-32 e2k \
                  armv7 armv7-neon armv8 apple-silicon general-64 general-32))
    SUPPORTED_ARCH=true
 else
@@ -117,8 +115,6 @@ prefetch = no
 popcnt = no
 pext = no
 sse = no
-mmx = no
-sse2 = no
 ssse3 = no
 sse41 = no
 avx2 = no
@@ -138,11 +134,9 @@ ifeq ($(findstring x86-32,$(ARCH)),x86-32)
 	arch = i386
 	bits = 32
 	sse = yes
-	mmx = yes
 else
 	arch = x86_64
 	sse = yes
-	sse2 = yes
 endif
 
 ifeq ($(findstring -sse,$(ARCH)),-sse)
@@ -153,24 +147,13 @@ ifeq ($(findstring -popcnt,$(ARCH)),-popcnt)
 	popcnt = yes
 endif
 
-ifeq ($(findstring -mmx,$(ARCH)),-mmx)
-	mmx = yes
-endif
-
-ifeq ($(findstring -sse2,$(ARCH)),-sse2)
-	sse = yes
-	sse2 = yes
-endif
-
 ifeq ($(findstring -ssse3,$(ARCH)),-ssse3)
 	sse = yes
-	sse2 = yes
 	ssse3 = yes
 endif
 
 ifeq ($(findstring -sse41,$(ARCH)),-sse41)
 	sse = yes
-	sse2 = yes
 	ssse3 = yes
 	sse41 = yes
 endif
@@ -178,7 +161,6 @@ endif
 ifeq ($(findstring -modern,$(ARCH)),-modern)
 	popcnt = yes
 	sse = yes
-	sse2 = yes
 	ssse3 = yes
 	sse41 = yes
 endif
@@ -186,7 +168,6 @@ endif
 ifeq ($(findstring -avx2,$(ARCH)),-avx2)
 	popcnt = yes
 	sse = yes
-	sse2 = yes
 	ssse3 = yes
 	sse41 = yes
 	avx2 = yes
@@ -195,7 +176,6 @@ endif
 ifeq ($(findstring -bmi2,$(ARCH)),-bmi2)
 	popcnt = yes
 	sse = yes
-	sse2 = yes
 	ssse3 = yes
 	sse41 = yes
 	avx2 = yes
@@ -205,7 +185,6 @@ endif
 ifeq ($(findstring -avx512,$(ARCH)),-avx512)
 	popcnt = yes
 	sse = yes
-	sse2 = yes
 	ssse3 = yes
 	sse41 = yes
 	avx2 = yes
@@ -216,7 +195,6 @@ endif
 ifeq ($(findstring -vnni256,$(ARCH)),-vnni256)
 	popcnt = yes
 	sse = yes
-	sse2 = yes
 	ssse3 = yes
 	sse41 = yes
 	avx2 = yes
@@ -227,7 +205,6 @@ endif
 ifeq ($(findstring -vnni512,$(ARCH)),-vnni512)
 	popcnt = yes
 	sse = yes
-	sse2 = yes
 	ssse3 = yes
 	sse41 = yes
 	avx2 = yes
@@ -299,10 +276,8 @@ endif
 
 ifeq ($(findstring e2k,$(ARCH)),e2k)
 	arch = e2k
-	mmx = yes
 	bits = 64
 	sse = yes
-	sse2 = yes
 	ssse3 = yes
 	sse41 = yes
 	popcnt = yes
@@ -573,20 +548,6 @@ ifeq ($(ssse3),yes)
 	endif
 endif
 
-ifeq ($(sse2),yes)
-	CXXFLAGS += -DUSE_SSE2
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
-		CXXFLAGS += -msse2
-	endif
-endif
-
-ifeq ($(mmx),yes)
-	CXXFLAGS += -DUSE_MMX
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
-		CXXFLAGS += -mmmx
-	endif
-endif
-
 ifeq ($(neon),yes)
 	CXXFLAGS += -DUSE_NEON
 	ifeq ($(KERNEL),Linux)
@@ -689,10 +650,9 @@ help:
 	@echo "x86-64-modern           > common modern CPU, currently x86-64-sse41-popcnt"
 	@echo "x86-64-ssse3            > x86 64-bit with ssse3 support"
 	@echo "x86-64-sse3-popcnt      > x86 64-bit with sse3 and popcnt support"
-	@echo "x86-64                  > x86 64-bit generic (with sse2 support)"
+	@echo "x86-64                  > x86 64-bit generic"
 	@echo "x86-32-sse41-popcnt     > x86 32-bit with sse41 and popcnt support"
-	@echo "x86-32-sse2             > x86 32-bit with sse2 support"
-	@echo "x86-32                  > x86 32-bit generic (with mmx and sse support)"
+	@echo "x86-32                  > x86 32-bit generic (with sse support)"
 	@echo "ppc-64                  > PPC 64-bit"
 	@echo "ppc-32                  > PPC 32-bit"
 	@echo "armv7                   > ARMv7 32-bit"
@@ -826,8 +786,6 @@ config-sanity: net
 	@echo "popcnt: '$(popcnt)'"
 	@echo "pext: '$(pext)'"
 	@echo "sse: '$(sse)'"
-	@echo "mmx: '$(mmx)'"
-	@echo "sse2: '$(sse2)'"
 	@echo "ssse3: '$(ssse3)'"
 	@echo "sse41: '$(sse41)'"
 	@echo "avx2: '$(avx2)'"
@@ -854,8 +812,6 @@ config-sanity: net
 	@test "$(popcnt)" = "yes" || test "$(popcnt)" = "no"
 	@test "$(pext)" = "yes" || test "$(pext)" = "no"
 	@test "$(sse)" = "yes" || test "$(sse)" = "no"
-	@test "$(mmx)" = "yes" || test "$(mmx)" = "no"
-	@test "$(sse2)" = "yes" || test "$(sse2)" = "no"
 	@test "$(ssse3)" = "yes" || test "$(ssse3)" = "no"
 	@test "$(sse41)" = "yes" || test "$(sse41)" = "no"
 	@test "$(avx2)" = "yes" || test "$(avx2)" = "no"

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -250,13 +250,7 @@ std::string compiler_info() {
   #if defined(USE_SSSE3)
     compiler += " SSSE3";
   #endif
-  #if defined(USE_SSE2)
-    compiler += " SSE2";
-  #endif
   compiler += (HasPopCnt ? " POPCNT" : "");
-  #if defined(USE_MMX)
-    compiler += " MMX";
-  #endif
   #if defined(USE_NEON)
     compiler += " NEON";
   #endif

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -109,7 +109,7 @@ namespace Stockfish::Eval::NNUE::Layers {
         ? InputDimensions / SimdWidth * SimdWidth
         : InputDimensions / (SimdWidth / 2) * (SimdWidth / 2);
 
-  #elif defined(USE_SSE2)
+  #elif defined(USE_SSSE3)
       constexpr IndexType NumChunks = InputDimensions / SimdWidth;
 
   #ifdef USE_SSE41
@@ -138,24 +138,6 @@ namespace Stockfish::Eval::NNUE::Layers {
 
         );
       }
-      constexpr IndexType Start = NumChunks * SimdWidth;
-
-  #elif defined(USE_MMX)
-      constexpr IndexType NumChunks = InputDimensions / SimdWidth;
-      const __m64 k0x80s = _mm_set1_pi8(-128);
-      const auto in = reinterpret_cast<const __m64*>(input);
-      const auto out = reinterpret_cast<__m64*>(output);
-      for (IndexType i = 0; i < NumChunks; ++i) {
-        const __m64 words0 = _mm_srai_pi16(
-            _mm_packs_pi32(in[i * 4 + 0], in[i * 4 + 1]),
-            WeightScaleBits);
-        const __m64 words1 = _mm_srai_pi16(
-            _mm_packs_pi32(in[i * 4 + 2], in[i * 4 + 3]),
-            WeightScaleBits);
-        const __m64 packedbytes = _mm_packs_pi16(words0, words1);
-        out[i] = _mm_subs_pi8(_mm_adds_pi8(packedbytes, k0x80s), k0x80s);
-      }
-      _mm_empty();
       constexpr IndexType Start = NumChunks * SimdWidth;
 
   #elif defined(USE_NEON)

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -35,12 +35,6 @@
 #elif defined(USE_SSSE3)
 #include <tmmintrin.h>
 
-#elif defined(USE_SSE2)
-#include <emmintrin.h>
-
-#elif defined(USE_MMX)
-#include <mmintrin.h>
-
 #elif defined(USE_NEON)
 #include <arm_neon.h>
 #endif
@@ -61,11 +55,8 @@ namespace Stockfish::Eval::NNUE {
   #if defined(USE_AVX2)
   constexpr std::size_t SimdWidth = 32;
 
-  #elif defined(USE_SSE2)
+  #elif defined(USE_SSSE3)
   constexpr std::size_t SimdWidth = 16;
-
-  #elif defined(USE_MMX)
-  constexpr std::size_t SimdWidth = 8;
 
   #elif defined(USE_NEON)
   constexpr std::size_t SimdWidth = 16;


### PR DESCRIPTION
This reverts the following commits:
21df37d7fd4dcc9b4a9c319382cc43685c0259c8
c7f0a768cb9d5972861baae0f215d69f9e86a626
038487f95499665bf86ca5343d7a83f970d4b06e

They were never tested on fishtest and as such should've never been merged in the first place.

The hardware the removed codepaths support is long obsolete, so approximately nobody should be affected.