### PR TITLE
Store the whole 64-bit zobrist key in the TT entries.

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -36,18 +36,18 @@ TranspositionTable TT; // Our global transposition table
 void TTEntry::save(Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev) {
 
   // Preserve any existing move for the same position
-  if (m || (uint16_t)k != key16)
+  if (m || k != key64)
       move16 = (uint16_t)m;
 
   // Overwrite less valuable entries (cheapest checks first)
   if (b == BOUND_EXACT
-      || (uint16_t)k != key16
+      || k != key64
       || d - DEPTH_OFFSET > depth8 - 4)
   {
       assert(d > DEPTH_OFFSET);
       assert(d < 256 + DEPTH_OFFSET);
 
-      key16     = (uint16_t)k;
+      key64     = k;
       depth8    = (uint8_t)(d - DEPTH_OFFSET);
       genBound8 = (uint8_t)(TT.generation8 | uint8_t(pv) << 2 | b);
       value16   = (int16_t)v;
@@ -120,10 +120,9 @@ void TranspositionTable::clear() {
 TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 
   TTEntry* const tte = first_entry(key);
-  const uint16_t key16 = (uint16_t)key;  // Use the low 16 bits as key inside the cluster
 
   for (int i = 0; i < ClusterSize; ++i)
-      if (tte[i].key16 == key16 || !tte[i].depth8)
+      if (tte[i].key64 == key || !tte[i].depth8)
       {
           tte[i].genBound8 = uint8_t(generation8 | (tte[i].genBound8 & (GENERATION_DELTA - 1))); // Refresh
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -24,9 +24,9 @@
 
 namespace Stockfish {
 
-/// TTEntry struct is the 10 bytes transposition table entry, defined as below:
+/// TTEntry struct is the 16 bytes transposition table entry, defined as below:
 ///
-/// key        16 bit
+/// key        64 bit
 /// depth       8 bit
 /// generation  5 bit
 /// pv node     1 bit
@@ -48,7 +48,7 @@ struct TTEntry {
 private:
   friend class TranspositionTable;
 
-  uint16_t key16;
+  uint64_t key64;
   uint8_t  depth8;
   uint8_t  genBound8;
   uint16_t move16;
@@ -65,11 +65,10 @@ private:
 
 class TranspositionTable {
 
-  static constexpr int ClusterSize = 3;
+  static constexpr int ClusterSize = 2;
 
   struct Cluster {
     TTEntry entry[ClusterSize];
-    char padding[2]; // Pad to 32 bytes
   };
 
   static_assert(sizeof(Cluster) == 32, "Unexpected Cluster size");


### PR DESCRIPTION
```
STC:
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 110168 W: 8932 L: 8923 D: 92313
Ptnml(0-2): 276, 7368, 39848, 7255, 337

LTC:
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 303408 W: 9194 L: 9322 D: 284892
Ptnml(0-2): 124, 8340, 134888, 8244, 108
```

Currently the position keys stored in TT entries are lossy, only 16 bits of the key is saved. The primary purpose is to fit the entry in 10 bytes (which gives 6 TT entries per cache line). This patch makes the whole 64 bit position key be stored for every TT entry, resulting in entries having 16 bytes (which gives 4 TT entries per cache line). While it reduces the TT capacity by 1/3rd it has a number of nice consequences:

1. The TT can be resized without losing the content. Currently it's not possible to recalculate the new position for an existing TT entry if the number of clusters changes, because the key information stored in the entries is incomplete. This means that the TT cannot be resized during analysis either way without having to repopulate it with search again.
2. It reduces the number of hash collisions during long searches. This was explored by skiminki to some extent in #2755. Some chosen statistics are shown below, with an assumption that the TT is full prior to starting the search or shortly after:
```
        | The expected number   | The expected number   |
        | of incorrect reads    | of hash collisions    |
        | in N reads.           | (pairs) among a set   |
        |                       | of N positions.       |
        | 2^-bits * N           | 2^-bits * (N choose 2)|
|-------|-----------------------|-----------------------|
| N     |  16 bits  |  64 bits  |  16 bits  |  64 bits  |
|-------|-----------|-----------|-----------|-----------|
| 1e9   |  1.5e4    |  0        |  7.6e12   |  0        |
| 1e10  |  1.5e5    |  0        |  7.6e14   |  2        |
| 1e11  |  1.5e6    |  0        |  7.6e16   |  271      |
| 1e12  |  1.5e7    |  0        |  7.6e18   |  27105    |
| 1e13  |  1.5e8    |  0        |  7.6e20   |  2710505  |
|-------|-----------|-----------|-----------|-----------|
```
3. This allows a potential TT persistence layer to save and load without TT size restrictions being imposed on the user. This is important because such a persisted TT may be shared among people and they will most likely use different TT sizes during analysis.
4. It allows the TT to function as a (first step of a) book builder, because the whole key that needs to be put into the book is retrievable. In particular a book format may be specified such that the zobrist key is encoded in the header, and such become a parameter of the book, which would create a possibility of dumping the TT contents as book entries. The need for specialized book building tools would then become restricted to advanced use.

Bench: whatever it ends up being after everything is merged