### PR TITLE
Allow passing RTLIB=compiler-rt to avoid linking in libatomic even on Linux

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -386,7 +386,9 @@ ifeq ($(COMP),clang)
 	ifneq ($(KERNEL),Darwin)
 	ifneq ($(KERNEL),OpenBSD)
 	ifneq ($(KERNEL),FreeBSD)
+	ifneq ($(RTLIB),compiler-rt)
 		LDFLAGS += -latomic
+	endif
 	endif
 	endif
 	endif


### PR DESCRIPTION
Not all linux users will have libatomic installed. When using clang as the system compiler with compiler-rt as the default runtime library instead of libgcc, atomic builtins may be provided by compiler-rt.

This change allows such users to pass RTLIB=compiler-rt to make sure the build doesn't error out on the missing (unnecessary) libatomic. Needless to say, this commit doesn't change anything if said flag isn't passed