### PR TITLE
no cut node reduction for killer moves. bench: 5343478

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1157,8 +1157,8 @@ moves_loop: // When in check, search starts from here
               r--;
 
           // Increase reduction for cut nodes (~3 Elo)
-          if (cutNode)
-              r += 1 + !captureOrPromotion;
+          if (cutNode && move != ss->killers[0])
+              r += 2;
 
           if (!captureOrPromotion)
           {


### PR DESCRIPTION
stc:
LLR: 2.95 (-2.94,2.94) <-0.50,2.50>
Total: 44344 W: 3474 L: 3294 D: 37576
Ptnml(0-2): 117, 2710, 16338, 2890, 117

https://tests.stockfishchess.org/tests/view/60d8ea673beab81350ac9eb8

ltc:
LLR: 2.93 (-2.94,2.94) <0.50,3.50>
Total: 82600 W: 2638 L: 2441 D: 77521
Ptnml(0-2): 38, 2147, 36749, 2312, 54

https://tests.stockfishchess.org/tests/view/60d9048f3beab81350ac9eed

bench 5343478