### PR TITLE
SEE: simplify stm variable initialization

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1081,7 +1081,7 @@ bool Position::see_ge(Move m, Value threshold) const {
       return true;
 
   Bitboard occupied = pieces() ^ from ^ to;
-  Color stm = color_of(piece_on(from));
+  Color stm = sideToMove;
   Bitboard attackers = attackers_to(to, occupied);
   Bitboard stmAttackers, bb;
   int res = 1;


### PR DESCRIPTION
As suggested by Xoto (on PR #3485) opening a separate PR for proposing/discussing this.

Pull #3458 removed the only usage of pos.see_ge() moving pieces that don't belong to the side to move, 
so in the current master the stm variable initialization is unnecessarily complicated.

N.B: see_ge is on the 'hot path' so also in past we committed even small micro-optimizations.

no functional change
bench: 4687476