### PR TITLE
Modify draw_value() to return -3..0.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -88,7 +88,7 @@ namespace {
 
   // Add a small random component to draw evaluations to avoid 3-fold blindness
   Value value_draw(Thread* thisThread) {
-    return VALUE_DRAW + Value(2 * (thisThread->nodes & 1) - 1);
+    return VALUE_DRAW - Value((thisThread->nodes & 3));
   }
 
   // Skill structure is used to implement strength limit

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -88,7 +88,7 @@ namespace {
 
   // Add a small random component to draw evaluations to avoid 3-fold blindness
   Value value_draw(Thread* thisThread) {
-    return VALUE_DRAW - Value((thisThread->nodes & 3));
+    return VALUE_DRAW - int((thisThread->nodes & 3));
   }
 
   // Skill structure is used to implement strength limit


### PR DESCRIPTION
Simplify draw_value() to remove 2 operations and also return slightly lower values. This may give a slightly reduced draw ratio compared to master which could be desirable.

STC 10+0.1 :
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 82280 W: 6288 L: 6248 D: 69744
Ptnml(0-2): 214, 5167, 30331, 5221, 207
https://tests.stockfishchess.org/tests/view/60ea1bfad1189bed718127b7

LTC 60+0.6 :
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 116736 W: 3505 L: 3504 D: 109727
Ptnml(0-2): 110, 2940, 52245, 2985, 88

Bench 5206684