### PR TITLE
Prune illegal moves in qsearch earlier

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1472,6 +1472,10 @@ moves_loop: // When in check, search starts from here
     {
       assert(is_ok(move));
 
+      // Check for legality
+      if (!pos.legal(move))
+          continue;
+
       givesCheck = pos.gives_check(move);
       captureOrPromotion = pos.capture_or_promotion(move);
 
@@ -1509,13 +1513,6 @@ moves_loop: // When in check, search starts from here
 
       // Speculative prefetch as early as possible
       prefetch(TT.first_entry(pos.key_after(move)));
-
-      // Check for legality just before making the move
-      if (!pos.legal(move))
-      {
-          moveCount--;
-          continue;
-      }
 
       ss->currentMove = move;
       ss->continuationHistory = &thisThread->continuationHistory[ss->inCheck]


### PR DESCRIPTION
passed STC with elo-gaining bounds
https://tests.stockfishchess.org/tests/view/60f20aefd1189bed71812da0
LLR: 2.94 (-2.94,2.94) <-0.50,2.50>
Total: 61512 W: 4688 L: 4492 D: 52332
Ptnml(0-2): 139, 3730, 22848, 3874, 165 
The same version functionally but with moving condition ever earlier passed LTC with simplification bounds.
https://tests.stockfishchess.org/tests/view/60f292cad1189bed71812de9
LLR: 2.98 (-2.94,2.94) <-2.50,0.50>
Total: 60944 W: 1724 L: 1685 D: 57535
Ptnml(0-2): 11, 1556, 27298, 1597, 10 
Main idea is that illegal moves influencing search or qsearch obviously can't be any sort of good.
The only reason why initially legality checks for search and qsearch were done after they actually can influence some heuristics is because legality check is expensive computationally.
Eventually in search it was moved to the place where it makes sure that illegal moves can't influence search.
This patch shows that the same can be done for qsearch + it passed STC with elo-gaining bounds + it removes 3 lines of code because you no longer need to increment/decrement movecount on illegal moves.
bench 4709569