### PR TITLE
Apply good/bad history reduction also when inCheck

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1172,8 +1172,7 @@ moves_loop: // When in check, search starts from here
                              - 4923;
 
               // Decrease/increase reduction for moves with a good/bad history (~30 Elo)
-              if (!ss->inCheck)
-                  r -= ss->statScore / 14721;
+              r -= ss->statScore / 14721;
           }
 
           // In general we want to cap the LMR depth search at newDepth. But if


### PR DESCRIPTION
passed STC:
https://tests.stockfishchess.org/tests/view/60f1b68dd1189bed71812d40
LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 53472 W: 4078 L: 4008 D: 45386
Ptnml(0-2): 127, 3297, 19795, 3413, 104

passed LTC:
https://tests.stockfishchess.org/tests/view/60f291e6d1189bed71812de3
LLR: 2.92 (-2.94,2.94) <-2.50,0.50>
Total: 89712 W: 2651 L: 2632 D: 84429
Ptnml(0-2): 60, 2261, 40188, 2294, 53

Main idea is that, in some cases, 'in check' situations are not so different from 'not in check' ones.
Trying to use piece count in order to select only a few 'in check' situations have failed LTC testing.
It could be interesting to apply one of those ideas in other parts of the search function.

Bench: 4962435