### PR TITLE
add macOS and windows to CI

### DIFF
--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -25,28 +25,87 @@ jobs:
               os: ubuntu-20.04,
               compiler: g++,
               comp: gcc,
-              run_expensive_tests: true
+              run_expensive_tests: true,
+              run_32bit_tests: true,
+              run_64bit_tests: true,
+              shell: 'bash {0}'
             }
           - {
               name: "Ubuntu 20.04 Clang",
               os: ubuntu-20.04,
               compiler: clang++,
               comp: clang,
-              run_expensive_tests: false
+              run_expensive_tests: false,
+              run_32bit_tests: true,
+              run_64bit_tests: true,
+              shell: 'bash {0}'
+            }
+          - {
+              name: "MacOS 10.15 Apple Clang",
+              os: macos-10.15,
+              compiler: clang++,
+              comp: clang,
+              run_expensive_tests: false,
+              run_32bit_tests: false,
+              run_64bit_tests: true,
+              shell: 'bash {0}'
+            }
+          - {
+              name: "MacOS 10.15 GCC 10",
+              os: macos-10.15,
+              compiler: g++-10,
+              comp: gcc,
+              run_expensive_tests: false,
+              run_32bit_tests: false,
+              run_64bit_tests: true,
+              shell: 'bash {0}'
+            }
+          - {
+              name: "Windows 2019 Mingw-w64 GCC x86_64",
+              os: windows-2019,
+              compiler: g++,
+              comp: gcc,
+              run_expensive_tests: false,
+              run_32bit_tests: false,
+              run_64bit_tests: true,
+              msys_sys: 'mingw64',
+              msys_env: 'x86_64',
+              shell: 'msys2 {0}'
+            }
+          - {
+              name: "Windows 2019 Mingw-w64 GCC i686",
+              os: windows-2019,
+              compiler: g++,
+              comp: gcc,
+              run_expensive_tests: false,
+              run_32bit_tests: true,
+              run_64bit_tests: false,
+              msys_sys: 'mingw32',
+              msys_env: 'i686',
+              shell: 'msys2 {0}'
             }
 
     defaults:
       run:
         working-directory: src
+        shell: ${{ matrix.config.shell }}
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: Download required packages
+      - name: Download required linux packages
+        if: runner.os == 'Linux'
         run: |
           sudo apt update
           sudo apt install expect valgrind g++-multilib
+
+      - name: Setup msys and install required packages
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.config.msys_sys}}
+          install: mingw-w64-${{matrix.config.msys_env}}-gcc make git expect
 
       - name: Download the used network from the fishtest framework
         run: |
@@ -68,6 +127,7 @@ jobs:
       # x86-32 tests
 
       - name: Test debug x86-32 build
+        if: ${{ matrix.config.run_32bit_tests }}
         run: |
           export CXXFLAGS="-Werror -D_GLIBCXX_DEBUG"
           make clean
@@ -75,24 +135,28 @@ jobs:
           ../tests/signature.sh $benchref
 
       - name: Test x86-32 build
+        if: ${{ matrix.config.run_32bit_tests }}
         run: |
           make clean
           make -j2 ARCH=x86-32 build
           ../tests/signature.sh $benchref
 
       - name: Test x86-32-sse41-popcnt build
+        if: ${{ matrix.config.run_32bit_tests }}
         run: |
           make clean
           make -j2 ARCH=x86-32-sse41-popcnt build
           ../tests/signature.sh $benchref
 
       - name: Test x86-32-sse2 build
+        if: ${{ matrix.config.run_32bit_tests }}
         run: |
           make clean
           make -j2 ARCH=x86-32-sse2 build
           ../tests/signature.sh $benchref
 
       - name: Test general-32 build
+        if: ${{ matrix.config.run_32bit_tests }}
         run: |
           make clean
           make -j2 ARCH=general-32 build
@@ -101,6 +165,7 @@ jobs:
       # x86-64 tests
 
       - name: Test debug x86-64-modern build
+        if: ${{ matrix.config.run_64bit_tests }}
         run: |
           export CXXFLAGS="-Werror -D_GLIBCXX_DEBUG"
           make clean
@@ -108,30 +173,35 @@ jobs:
           ../tests/signature.sh $benchref
 
       - name: Test x86-64-modern build
+        if: ${{ matrix.config.run_64bit_tests }}
         run: |
           make clean
           make -j2 ARCH=x86-64-modern build
           ../tests/signature.sh $benchref
 
       - name: Test x86-64-ssse3 build
+        if: ${{ matrix.config.run_64bit_tests }}
         run: |
           make clean
           make -j2 ARCH=x86-64-ssse3 build
           ../tests/signature.sh $benchref
 
       - name: Test x86-64-sse3-popcnt build
+        if: ${{ matrix.config.run_64bit_tests }}
         run: |
           make clean
           make -j2 ARCH=x86-64-sse3-popcnt build
           ../tests/signature.sh $benchref
 
       - name: Test x86-64 build
+        if: ${{ matrix.config.run_64bit_tests }}
         run: |
           make clean
           make -j2 ARCH=x86-64 build
           ../tests/signature.sh $benchref
 
       - name: Test general-64 build
+        if: matrix.config.run_64bit_tests
         run: |
           make clean
           make -j2 ARCH=general-64 build
@@ -140,26 +210,31 @@ jobs:
       # x86-64 with newer extensions tests
 
       - name: Compile x86-64-avx2 build
+        if: ${{ matrix.config.run_64bit_tests }}
         run: |
           make clean
           make -j2 ARCH=x86-64-avx2 build
 
       - name: Compile x86-64-bmi2 build
+        if: ${{ matrix.config.run_64bit_tests }}
         run: |
           make clean
           make -j2 ARCH=x86-64-bmi2 build
 
       - name: Compile x86-64-avx512 build
+        if: ${{ matrix.config.run_64bit_tests }}
         run: |
           make clean
           make -j2 ARCH=x86-64-avx512 build
 
       - name: Compile x86-64-vnni512 build
+        if: ${{ matrix.config.run_64bit_tests }}
         run: |
           make clean
           make -j2 ARCH=x86-64-vnni512 build
 
       - name: Compile x86-64-vnni256 build
+        if: ${{ matrix.config.run_64bit_tests }}
         run: |
           make clean
           make -j2 ARCH=x86-64-vnni256 build
@@ -167,6 +242,7 @@ jobs:
       # Other tests
 
       - name: Check perft and search reproducibility
+        if: ${{ matrix.config.run_64bit_tests }}
         run: |
           make clean
           make -j2 ARCH=x86-64-modern build

--- a/src/Makefile
+++ b/src/Makefile
@@ -256,12 +256,6 @@ endif
 
 ifeq ($(ARCH),general-64)
 	arch = any
-	# avoid apple clang error: "invalid arch name '-arch any'"
-	ifeq ($(KERNEL),Darwin)
-		arch = x86_64
-		sse = yes
-		sse2 = yes
-	endif
 endif
 
 ifeq ($(ARCH),armv7)
@@ -411,8 +405,12 @@ ifeq ($(COMP),clang)
 endif
 
 ifeq ($(KERNEL),Darwin)
-	CXXFLAGS += -arch $(arch) -mmacosx-version-min=10.14
-	LDFLAGS += -arch $(arch) -mmacosx-version-min=10.14
+	CXXFLAGS += -mmacosx-version-min=10.14
+	LDFLAGS += -mmacosx-version-min=10.14
+	ifneq ($(arch),any)
+		CXXFLAGS += -arch $(arch)
+		LDFLAGS += -arch $(arch)
+	endif
 	XCRUN = xcrun
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -256,6 +256,12 @@ endif
 
 ifeq ($(ARCH),general-64)
 	arch = any
+	# avoid apple clang error: "invalid arch name '-arch any'"
+	ifeq ($(KERNEL),Darwin)
+		arch = x86_64
+		sse = yes
+		sse2 = yes
+	endif
 endif
 
 ifeq ($(ARCH),armv7)

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -378,6 +378,7 @@ void std_aligned_free(void* ptr) {
 static void* aligned_large_pages_alloc_windows(size_t allocSize) {
 
   #if !defined(_WIN64)
+    (void)allocSize; // suppress unused-parameter compiler warning
     return nullptr;
   #else
 


### PR DESCRIPTION
- macOS
  - system clang
  - gcc
- windows / msys2
  - mingw 64-bit gcc
  - mingw 32-bit gcc
- minor code fixes to get new CI jobs to pass
  - suppress unused-parameter warning on 32-bit windows
  - Makefile
    - on macos use 'x86-64' in place of 'any' for arch
    - avoids clang compiler error: "invalid arch name '-arch any'"

resolves #2958