### PR TITLE
CMH Pruning Tweak - bench:  5848718

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1018,7 +1018,7 @@ moves_loop: // When in check, search starts from here
               // Continuation history based pruning (~20 Elo)
               if (   lmrDepth < 5
                   && (*contHist[0])[movedPiece][to_sq(move)] < (depth == 1 ? 0 : -stat_bonus(depth-1))
-                  && (*contHist[1])[movedPiece][to_sq(move)] < < (depth == 1 ? 0 : -stat_bonus(depth-1)))
+                  && (*contHist[1])[movedPiece][to_sq(move)] < (depth == 1 ? 0 : -stat_bonus(depth-1)))
                   continue;
 
               // Futility pruning: parent node (~5 Elo)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -907,7 +907,7 @@ namespace {
         && !ttMove)
         depth -= 2;
 
-moves_loop: // When in check, search starts from here
+moves_loop: // When in check, search starts here
 
     ttCapture = ttMove && pos.capture_or_promotion(ttMove);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1017,8 +1017,8 @@ moves_loop: // When in check, search starts from here
           {
               // Continuation history based pruning (~20 Elo)
               if (   lmrDepth < 5
-                  && (*contHist[0])[movedPiece][to_sq(move)] < CounterMovePruneThreshold
-                  && (*contHist[1])[movedPiece][to_sq(move)] < CounterMovePruneThreshold)
+                  && (*contHist[0])[movedPiece][to_sq(move)] < (depth == 1 ? 0 : -stat_bonus(depth-1))
+                  && (*contHist[1])[movedPiece][to_sq(move)] < < (depth == 1 ? 0 : -stat_bonus(depth-1)))
                   continue;
 
               // Futility pruning: parent node (~5 Elo)


### PR DESCRIPTION
CMH Pruning Tweak

STC:
LLR: 2.94 (-2.94,2.94) <-0.50,2.50>
Total: 35512 W: 2718 L: 2552 D: 30242
Ptnml(0-2): 66, 2138, 13194, 2280, 78
https://tests.stockfishchess.org/tests/view/6104442fafad2da4f4ae3b94

LTC:
LLR: 2.96 (-2.94,2.94) <0.50,3.50>
Total: 36536 W: 1150 L: 1019 D: 34367
Ptnml(0-2): 10, 920, 16278, 1049, 11
https://tests.stockfishchess.org/tests/view/6104b033afad2da4f4ae3bbc

Bench:  5848718