### PR TITLE
Revert July 13 futility pruning patches as it hinders mate finding abilities

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -781,6 +781,7 @@ namespace {
 
     // Step 7. Futility pruning: child node (~50 Elo)
     if (   !PvNode
+        &&  depth < 9
         &&  eval - futility_margin(depth, improving) >= beta
         &&  eval < VALUE_KNOWN_WIN) // Do not return unproven wins
         return eval;
@@ -1022,7 +1023,8 @@ moves_loop: // When in check, search starts here
                   continue;
 
               // Futility pruning: parent node (~5 Elo)
-              if (   !ss->inCheck
+              if (   lmrDepth < 7
+                  && !ss->inCheck
                   && ss->staticEval + 174 + 157 * lmrDepth <= alpha)
                   continue;
 


### PR DESCRIPTION
Creating this pull request as per discussion with @SFisGOD.
This patch reverts futility pruning patches which were merged on July 13, 2021. They were found to hurt stockfish's ability to find quicker mating lines.

Fixes #3627 

Bench: 4875824