### PR TITLE
Allow shallow depth pruning at root

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -992,9 +992,7 @@ moves_loop: // When in check, search starts here
       newDepth = depth - 1;
 
       // Step 13. Pruning at shallow depth (~200 Elo). Depth conditions are important for mate finding.
-      if (  !rootNode
-          && !(ss->ply == 1 && depth < 10)
-          && pos.non_pawn_material(us)
+      if (   pos.non_pawn_material(us)
           && bestValue > VALUE_TB_LOSS_IN_MAX_PLY)
       {
           // Skip quiet moves if movecount exceeds our FutilityMoveCount threshold

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -993,6 +993,7 @@ moves_loop: // When in check, search starts here
 
       // Step 13. Pruning at shallow depth (~200 Elo). Depth conditions are important for mate finding.
       if (  !rootNode
+          && !(ss->ply == 1 && depth < 9)
           && pos.non_pawn_material(us)
           && bestValue > VALUE_TB_LOSS_IN_MAX_PLY)
       {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -992,7 +992,8 @@ moves_loop: // When in check, search starts here
       newDepth = depth - 1;
 
       // Step 13. Pruning at shallow depth (~200 Elo). Depth conditions are important for mate finding.
-      if (  !rootNode\
+      if (  !rootNode
+          && !(ss->ply == 1 && depth < 10)
           && pos.non_pawn_material(us)
           && bestValue > VALUE_TB_LOSS_IN_MAX_PLY)
       {


### PR DESCRIPTION
Passed STC
https://tests.stockfishchess.org/tests/view/61183df84977aa1525c9c6e3
LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 70464 W: 5300 L: 5248 D: 59916
Ptnml(0-2): 185, 4340, 26120, 4412, 175
Passed LTC
https://tests.stockfishchess.org/tests/view/61187da14977aa1525c9c701
LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 20568 W: 633 L: 567 D: 19368
Ptnml(0-2): 5, 512, 9190, 566, 11
This patch allows shallow depth pruning at rootNode where it previously wasn't allowed.
The reason to allow it mostly because it actually takes effect to depths <= 10 or so
which is reached pretty fast anyway. Removes 1 line of code and maybe can lead to further improvements.
bench 5394404