### PR TITLE
Use a reasonable default value for the "Threads" UCI option

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -60,11 +60,13 @@ bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const 
 void init(OptionsMap& o) {
 
   constexpr int MaxHashMB = Is64Bit ? 33554432 : 2048;
-  const auto HardwareConcurrency = std::thread::hardware_concurrency();
+  const auto hc = std::thread::hardware_concurrency();
+  const float HardwareConcurrency = (hc > 0) ? hc : 1;
+  const float HashSizeMB = 16 * HardwareConcurrency;
 
   o["Debug Log File"]        << Option("", on_logger);
-  o["Threads"]               << Option(HardwareConcurrency > 0 ? HardwareConcurrency : 1, 1, 512, on_threads);
-  o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
+  o["Threads"]               << Option(HardwareConcurrency, 1, 512, on_threads);
+  o["Hash"]                  << Option(HashSizeMB, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -20,6 +20,7 @@
 #include <cassert>
 #include <ostream>
 #include <sstream>
+#include <thread>
 
 #include "evaluate.h"
 #include "misc.h"
@@ -59,9 +60,10 @@ bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const 
 void init(OptionsMap& o) {
 
   constexpr int MaxHashMB = Is64Bit ? 33554432 : 2048;
+  const auto HardwareConcurrency = std::thread::hardware_concurrency();
 
   o["Debug Log File"]        << Option("", on_logger);
-  o["Threads"]               << Option(1, 1, 512, on_threads);
+  o["Threads"]               << Option(HardwareConcurrency > 0 ? HardwareConcurrency : 1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(false);

--- a/tests/reprosearch.sh
+++ b/tests/reprosearch.sh
@@ -21,6 +21,7 @@ cat << EOF > repeat.exp
  send "uci\n"
  expect "uciok"
 
+ send "setoption name Threads value 1\n"
  send "ucinewgame\n"
  send "position startpos\n"
  send "go nodes \$nodes\n"


### PR DESCRIPTION
In many cases, an uninitiated user running Stockfish with the current hard-coded "Threads" default value of "1" will only get a fraction of what his system with x cores could potentially do. But the user or his GUI program usually also have no idea what would be the reasonable default for the important UCI option "Threads" on his system.

So I propose this simple, but in most cases very effective C++11 compatible change (all platforms) for the default value of the "Threads" option. Of course GUI can still set the value to any other value. It's just about the sensible default.