### PR TITLE
Optimize and tidy up affine transform code.

### DIFF
--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -22,13 +22,357 @@
 #define NNUE_LAYERS_AFFINE_TRANSFORM_H_INCLUDED
 
 #include <iostream>
+#include <algorithm>
+#include <type_traits>
 #include "../nnue_common.h"
+#include "../../simd.h"
+
+/*
+  This file contains the definition for a fully connected layer (aka affine transform).
+  Two approaches are employed, depending on the sizes of the transform.
+
+  Approach 1:
+    - used when the PaddedInputDimensions >= 128
+    - uses AVX512 if possible
+    - processes inputs in batches of 2*InputSimdWidth
+      - so in batches of 128 for AVX512
+    - the weight blocks of size InputSimdWidth are transposed such that
+      access is sequential
+    - N columns of the weight matrix are processed a time, where N
+      depends on the architecture (the amount of registers)
+    - accumulate + hadd is used
+
+  Approach 2:
+    - used when the PaddedInputDimensions < 128
+    - does not use AVX512
+    - expected use-case is for when PaddedInputDimensions == 32 and InputDimensions <= 32.
+      - that's why AVX512 is hard to implement
+    - expected use-case is small layers
+      - not optimized as well as the approach 1
+    - inputs are processed in chunks of 4, weights are respectively transposed
+    - accumulation happens directly to int32s
+*/
 
 namespace Stockfish::Eval::NNUE::Layers {
 
-  // Affine transformation layer
+// Fallback implementation for older/other architectures.
+// Identical for both approaches. Requires the input to be padded to at least 16 values.
+#if !defined(USE_SSSE3)
+  template <IndexType InputDimensions, IndexType PaddedInputDimensions, IndexType OutputDimensions>
+  static void affine_transform_non_ssse3(std::int32_t* output, const std::int8_t* weights, const std::int32_t* biases, const std::uint8_t* input)
+  {
+# if defined(USE_SSE2)
+    // At least a multiple of 16, with SSE2.
+    static_assert(PaddedInputDimensions % 16 == 0);
+    constexpr IndexType NumChunks = PaddedInputDimensions / 16;
+    const __m128i Zeros = _mm_setzero_si128();
+    const auto inputVector = reinterpret_cast<const __m128i*>(input);
+
+# elif defined(USE_MMX)
+    static_assert(InputDimensions % 8 == 0);
+    constexpr IndexType NumChunks = InputDimensions / 8;
+    const __m64 Zeros = _mm_setzero_si64();
+    const auto inputVector = reinterpret_cast<const __m64*>(input);
+
+# elif defined(USE_NEON)
+    static_assert(PaddedInputDimensions % 16 == 0);
+    constexpr IndexType NumChunks = PaddedInputDimensions / 16;
+    const auto inputVector = reinterpret_cast<const int8x8_t*>(input);
+# endif
+
+    for (IndexType i = 0; i < OutputDimensions; ++i) {
+      const IndexType offset = i * PaddedInputDimensions;
+
+# if defined(USE_SSE2)
+      __m128i sumLo = _mm_cvtsi32_si128(biases[i]);
+      __m128i sumHi = Zeros;
+      const auto row = reinterpret_cast<const __m128i*>(&weights[offset]);
+      for (IndexType j = 0; j < NumChunks; ++j) {
+        __m128i row_j = _mm_load_si128(&row[j]);
+        __m128i input_j = _mm_load_si128(&inputVector[j]);
+        __m128i extendedRowLo = _mm_srai_epi16(_mm_unpacklo_epi8(row_j, row_j), 8);
+        __m128i extendedRowHi = _mm_srai_epi16(_mm_unpackhi_epi8(row_j, row_j), 8);
+        __m128i extendedInputLo = _mm_unpacklo_epi8(input_j, Zeros);
+        __m128i extendedInputHi = _mm_unpackhi_epi8(input_j, Zeros);
+        __m128i productLo = _mm_madd_epi16(extendedRowLo, extendedInputLo);
+        __m128i productHi = _mm_madd_epi16(extendedRowHi, extendedInputHi);
+        sumLo = _mm_add_epi32(sumLo, productLo);
+        sumHi = _mm_add_epi32(sumHi, productHi);
+      }
+      __m128i sum = _mm_add_epi32(sumLo, sumHi);
+      __m128i sumHigh_64 = _mm_shuffle_epi32(sum, _MM_SHUFFLE(1, 0, 3, 2));
+      sum = _mm_add_epi32(sum, sumHigh_64);
+      __m128i sum_second_32 = _mm_shufflelo_epi16(sum, _MM_SHUFFLE(1, 0, 3, 2));
+      sum = _mm_add_epi32(sum, sum_second_32);
+      output[i] = _mm_cvtsi128_si32(sum);
+
+# elif defined(USE_MMX)
+      __m64 sumLo = _mm_cvtsi32_si64(biases[i]);
+      __m64 sumHi = Zeros;
+      const auto row = reinterpret_cast<const __m64*>(&weights[offset]);
+      for (IndexType j = 0; j < NumChunks; ++j) {
+        __m64 row_j = row[j];
+        __m64 input_j = inputVector[j];
+        __m64 extendedRowLo = _mm_srai_pi16(_mm_unpacklo_pi8(row_j, row_j), 8);
+        __m64 extendedRowHi = _mm_srai_pi16(_mm_unpackhi_pi8(row_j, row_j), 8);
+        __m64 extendedInputLo = _mm_unpacklo_pi8(input_j, Zeros);
+        __m64 extendedInputHi = _mm_unpackhi_pi8(input_j, Zeros);
+        __m64 productLo = _mm_madd_pi16(extendedRowLo, extendedInputLo);
+        __m64 productHi = _mm_madd_pi16(extendedRowHi, extendedInputHi);
+        sumLo = _mm_add_pi32(sumLo, productLo);
+        sumHi = _mm_add_pi32(sumHi, productHi);
+      }
+      __m64 sum = _mm_add_pi32(sumLo, sumHi);
+      sum = _mm_add_pi32(sum, _mm_unpackhi_pi32(sum, sum));
+      output[i] = _mm_cvtsi64_si32(sum);
+
+# elif defined(USE_NEON)
+      int32x4_t sum = {biases[i]};
+      const auto row = reinterpret_cast<const int8x8_t*>(&weights[offset]);
+      for (IndexType j = 0; j < NumChunks; ++j) {
+        int16x8_t product = vmull_s8(inputVector[j * 2], row[j * 2]);
+        product = vmlal_s8(product, inputVector[j * 2 + 1], row[j * 2 + 1]);
+        sum = vpadalq_s16(sum, product);
+      }
+      output[i] = sum[0] + sum[1] + sum[2] + sum[3];
+
+# else
+      std::int32_t sum = biases[i];
+      for (IndexType j = 0; j < InputDimensions; ++j) {
+        sum += weights[offset + j] * input[j];
+      }
+      output[i] = sum;
+# endif
+    }
+
+# if defined(USE_MMX)
+    _mm_empty();
+# endif
+  }
+#endif
+
+  template <typename PreviousLayer, IndexType OutDims, typename Enabled = void>
+  class AffineTransform;
+
+  // A specialization for large inputs.
   template <typename PreviousLayer, IndexType OutDims>
-  class AffineTransform {
+  class AffineTransform<PreviousLayer, OutDims, std::enable_if_t<(PreviousLayer::OutputDimensions >= 2*64-1)>> {
+   public:
+    // Input/output type
+    using InputType = typename PreviousLayer::OutputType;
+    using OutputType = std::int32_t;
+    static_assert(std::is_same<InputType, std::uint8_t>::value, "");
+
+    // Number of input/output dimensions
+    static constexpr IndexType InputDimensions = PreviousLayer::OutputDimensions;
+    static constexpr IndexType OutputDimensions = OutDims;
+
+    static constexpr IndexType PaddedInputDimensions =
+      ceil_to_multiple<IndexType>(InputDimensions, MaxSimdWidth);
+
+    static_assert(PaddedInputDimensions >= 128, "Something went wrong. This specialization should not have been chosen.");
+
+#if defined (USE_AVX512)
+    static constexpr const IndexType InputSimdWidth = 64;
+    static constexpr const IndexType MaxNumOutputRegs = 16;
+#elif defined (USE_AVX2)
+    static constexpr const IndexType InputSimdWidth = 32;
+    static constexpr const IndexType MaxNumOutputRegs = 8;
+#elif defined (USE_SSSE3)
+    static constexpr const IndexType InputSimdWidth = 16;
+    static constexpr const IndexType MaxNumOutputRegs = 8;
+#else
+    // The fallback implementation will not have permuted weights.
+    // We define these to avoid a lot of ifdefs later.
+    static constexpr const IndexType InputSimdWidth = 1;
+    static constexpr const IndexType MaxNumOutputRegs = 1;
+#endif
+
+    // A big block is a region in the weight matrix of the size [PaddedInputDimensions, NumOutputRegs].
+    // A small block is a region of size [InputSimdWidth, 1]
+
+    static constexpr const IndexType NumOutputRegs = std::min(MaxNumOutputRegs, OutputDimensions);
+    static constexpr const IndexType SmallBlockSize = InputSimdWidth;
+    static constexpr const IndexType BigBlockSize = NumOutputRegs * PaddedInputDimensions;
+    static constexpr const IndexType NumSmallBlocksInBigBlock = BigBlockSize / SmallBlockSize;
+    static constexpr const IndexType NumSmallBlocksPerOutput = PaddedInputDimensions / SmallBlockSize;
+    static constexpr const IndexType NumBigBlocks = OutputDimensions / NumOutputRegs;
+
+    static_assert(OutputDimensions % NumOutputRegs == 0);
+
+    // Size of forward propagation buffer used in this layer
+    static constexpr std::size_t SelfBufferSize =
+      ceil_to_multiple(OutputDimensions * sizeof(OutputType), CacheLineSize);
+
+    // Size of the forward propagation buffer used from the input layer to this layer
+    static constexpr std::size_t BufferSize =
+      PreviousLayer::BufferSize + SelfBufferSize;
+
+    // Hash value embedded in the evaluation file
+    static constexpr std::uint32_t get_hash_value() {
+      std::uint32_t hashValue = 0xCC03DAE4u;
+      hashValue += OutputDimensions;
+      hashValue ^= PreviousLayer::get_hash_value() >> 1;
+      hashValue ^= PreviousLayer::get_hash_value() << 31;
+      return hashValue;
+    }
+
+    /*
+      Transposes the small blocks within a block.
+      Effectively means that weights can be traversed sequentially during inference.
+    */
+    static IndexType get_weight_index(IndexType i)
+    {
+      const IndexType smallBlock = (i / SmallBlockSize) % NumSmallBlocksInBigBlock;
+      const IndexType smallBlockCol = smallBlock / NumSmallBlocksPerOutput;
+      const IndexType smallBlockRow = smallBlock % NumSmallBlocksPerOutput;
+      const IndexType bigBlock   = i / BigBlockSize;
+      const IndexType rest       = i % SmallBlockSize;
+
+      const IndexType idx =
+          bigBlock * BigBlockSize
+        + smallBlockRow * SmallBlockSize * NumOutputRegs
+        + smallBlockCol * SmallBlockSize
+        + rest;
+
+      return idx;
+    }
+
+    // Read network parameters
+    bool read_parameters(std::istream& stream) {
+      if (!previousLayer.read_parameters(stream)) return false;
+      for (std::size_t i = 0; i < OutputDimensions; ++i)
+        biases[i] = read_little_endian<BiasType>(stream);
+
+      for (std::size_t i = 0; i < OutputDimensions * PaddedInputDimensions; ++i)
+        weights[get_weight_index(i)] = read_little_endian<WeightType>(stream);
+
+      return !stream.fail();
+    }
+
+    // Write network parameters
+    bool write_parameters(std::ostream& stream) const {
+      if (!previousLayer.write_parameters(stream)) return false;
+      for (std::size_t i = 0; i < OutputDimensions; ++i)
+          write_little_endian<BiasType>(stream, biases[i]);
+
+      for (std::size_t i = 0; i < OutputDimensions * PaddedInputDimensions; ++i)
+        write_little_endian<WeightType>(stream, weights[get_weight_index(i)]);
+
+      return !stream.fail();
+    }
+
+    // Forward propagation
+    const OutputType* propagate(
+        const TransformedFeatureType* transformedFeatures, char* buffer) const {
+      const auto input = previousLayer.propagate(
+        transformedFeatures, buffer + SelfBufferSize);
+      OutputType* output = reinterpret_cast<OutputType*>(buffer);
+
+#if defined (USE_AVX512)
+      using vec_t = __m512i;
+      #define vec_setzero _mm512_setzero_si512
+      #define vec_set_32 _mm512_set1_epi32
+      #define vec_add_dpbusd_32 Simd::m512_add_dpbusd_epi32
+      #define vec_add_dpbusd_32x2 Simd::m512_add_dpbusd_epi32x2
+      #define vec_hadd Simd::m512_hadd
+      #define vec_haddx4 Simd::m512_haddx4
+#elif defined (USE_AVX2)
+      using vec_t = __m256i;
+      #define vec_setzero _mm256_setzero_si256
+      #define vec_set_32 _mm256_set1_epi32
+      #define vec_add_dpbusd_32 Simd::m256_add_dpbusd_epi32
+      #define vec_add_dpbusd_32x2 Simd::m256_add_dpbusd_epi32x2
+      #define vec_hadd Simd::m256_hadd
+      #define vec_haddx4 Simd::m256_haddx4
+#elif defined (USE_SSSE3)
+      using vec_t = __m128i;
+      #define vec_setzero _mm_setzero_si128
+      #define vec_set_32 _mm_set1_epi32
+      #define vec_add_dpbusd_32 Simd::m128_add_dpbusd_epi32
+      #define vec_add_dpbusd_32x2 Simd::m128_add_dpbusd_epi32x2
+      #define vec_hadd Simd::m128_hadd
+      #define vec_haddx4 Simd::m128_haddx4
+#endif
+
+#if defined (USE_SSSE3)
+      const vec_t* invec = reinterpret_cast<const vec_t*>(input);
+
+
+      // Perform accumulation to registers for each big block
+      for (IndexType bigBlock = 0; bigBlock < NumBigBlocks; ++bigBlock)
+      {
+        vec_t acc[NumOutputRegs] = { vec_setzero() };
+
+        // Each big block has NumOutputRegs small blocks in each "row", one per register.
+        // We process two small blocks at a time to save on one addition without VNNI.
+        for (IndexType smallBlock = 0; smallBlock < NumSmallBlocksPerOutput; smallBlock += 2)
+        {
+          const vec_t* weightvec =
+            reinterpret_cast<const vec_t*>(
+                weights
+              + bigBlock * BigBlockSize
+              + smallBlock * SmallBlockSize * NumOutputRegs);
+
+          const vec_t in0 = invec[smallBlock + 0];
+          const vec_t in1 = invec[smallBlock + 1];
+
+          for (IndexType k = 0; k < NumOutputRegs; ++k)
+            vec_add_dpbusd_32x2(acc[k], in0, weightvec[k], in1, weightvec[k + NumOutputRegs]);
+        }
+
+        // Horizontally add all accumulators.
+        if constexpr (NumOutputRegs % 4 == 0)
+        {
+          __m128i* outputvec = reinterpret_cast<__m128i*>(output);
+          const __m128i* biasvec = reinterpret_cast<const __m128i*>(biases);
+
+          for (IndexType k = 0; k < NumOutputRegs; k += 4)
+          {
+            const IndexType idx = (bigBlock * NumOutputRegs + k) / 4;
+            outputvec[idx] = vec_haddx4(acc[k+0], acc[k+1], acc[k+2], acc[k+3], biasvec[idx]);
+          }
+        }
+        else
+        {
+          for (IndexType k = 0; k < NumOutputRegs; ++k)
+          {
+            const IndexType idx = (bigBlock * NumOutputRegs + k);
+            output[idx] = vec_hadd(acc[k], biases[idx]);
+          }
+        }
+      }
+
+# undef vec_setzero
+# undef vec_set_32
+# undef vec_add_dpbusd_32
+# undef vec_add_dpbusd_32x2
+# undef vec_hadd
+# undef vec_haddx4
+#else
+      // Use old implementation for the other architectures.
+      affine_transform_non_ssse3<
+        InputDimensions,
+        PaddedInputDimensions,
+        OutputDimensions>(output, weights, biases, input);
+
+#endif
+
+      return output;
+    }
+
+   private:
+    using BiasType = OutputType;
+    using WeightType = std::int8_t;
+
+    PreviousLayer previousLayer;
+
+    alignas(CacheLineSize) BiasType biases[OutputDimensions];
+    alignas(CacheLineSize) WeightType weights[OutputDimensions * PaddedInputDimensions];
+  };
+
+  template <typename PreviousLayer, IndexType OutDims>
+  class AffineTransform<PreviousLayer, OutDims, std::enable_if_t<(PreviousLayer::OutputDimensions < 2*64-1)>> {
    public:
     // Input/output type
     using InputType = typename PreviousLayer::OutputType;
@@ -41,24 +385,21 @@ namespace Stockfish::Eval::NNUE::Layers {
     static constexpr IndexType OutputDimensions = OutDims;
     static constexpr IndexType PaddedInputDimensions =
         ceil_to_multiple<IndexType>(InputDimensions, MaxSimdWidth);
-#if defined (USE_AVX512)
-    static constexpr const IndexType OutputSimdWidth = SimdWidth / 2;
-#elif defined (USE_SSSE3)
+
+    static_assert(PaddedInputDimensions < 128, "Something went wrong. This specialization should not have been chosen.");
+
+#if defined (USE_SSSE3)
     static constexpr const IndexType OutputSimdWidth = SimdWidth / 4;
-#endif
-#if defined (USE_AVX512)
-    static constexpr const IndexType InputSimdWidth = SimdWidth * 2;
-#elif defined (USE_SSSE3)
     static constexpr const IndexType InputSimdWidth = SimdWidth;
 #endif
 
     // Size of forward propagation buffer used in this layer
     static constexpr std::size_t SelfBufferSize =
-        ceil_to_multiple(OutputDimensions * sizeof(OutputType), CacheLineSize);
+      ceil_to_multiple(OutputDimensions * sizeof(OutputType), CacheLineSize);
 
     // Size of the forward propagation buffer used from the input layer to this layer
     static constexpr std::size_t BufferSize =
-        PreviousLayer::BufferSize + SelfBufferSize;
+      PreviousLayer::BufferSize + SelfBufferSize;
 
     // Hash value embedded in the evaluation file
     static constexpr std::uint32_t get_hash_value() {
@@ -69,30 +410,30 @@ namespace Stockfish::Eval::NNUE::Layers {
       return hashValue;
     }
 
+    static IndexType get_weight_index_scrambled(IndexType i)
+    {
+      return
+        (i / 4) % (PaddedInputDimensions / 4) * OutputDimensions * 4 +
+        i / PaddedInputDimensions * 4 +
+        i % 4;
+    }
+
+    static IndexType get_weight_index(IndexType i)
+    {
+#if defined (USE_SSSE3)
+      return get_weight_index_scrambled(i);
+#else
+      return i;
+#endif
+    }
+
     // Read network parameters
     bool read_parameters(std::istream& stream) {
       if (!previousLayer.read_parameters(stream)) return false;
       for (std::size_t i = 0; i < OutputDimensions; ++i)
         biases[i] = read_little_endian<BiasType>(stream);
       for (std::size_t i = 0; i < OutputDimensions * PaddedInputDimensions; ++i)
-#if !defined (USE_SSSE3)
-        weights[i] = read_little_endian<WeightType>(stream);
-#elif defined (USE_VNNI) || defined (USE_AVX512)
-        if constexpr (OutputDimensions <= 8 && OutputDimensions != 1)
-            weights[i] = read_little_endian<WeightType>(stream);
-        else
-            weights[
-              (i / 4) % (PaddedInputDimensions / 4) * OutputDimensions * 4 +
-              i / PaddedInputDimensions * 4 +
-              i % 4
-            ] = read_little_endian<WeightType>(stream);
-#else
-        weights[
-          (i / 4) % (PaddedInputDimensions / 4) * OutputDimensions * 4 +
-          i / PaddedInputDimensions * 4 +
-          i % 4
-        ] = read_little_endian<WeightType>(stream);
-#endif
+        weights[get_weight_index(i)] = read_little_endian<WeightType>(stream);
 
       return !stream.fail();
     }
@@ -101,24 +442,10 @@ namespace Stockfish::Eval::NNUE::Layers {
     bool write_parameters(std::ostream& stream) const {
       if (!previousLayer.write_parameters(stream)) return false;
       for (std::size_t i = 0; i < OutputDimensions; ++i)
-          write_little_endian<BiasType>(stream, biases[i]);
-#if !defined (USE_SSSE3)
-      for (std::size_t i = 0; i < OutputDimensions * PaddedInputDimensions; ++i)
-          write_little_endian<WeightType>(stream, weights[i]);
-#else
-      std::unique_ptr<WeightType[]> unscrambledWeights = std::make_unique<WeightType[]>(OutputDimensions * PaddedInputDimensions);
-      for (std::size_t i = 0; i < OutputDimensions * PaddedInputDimensions; ++i) {
-          unscrambledWeights[i] =
-              weights[
-                (i / 4) % (PaddedInputDimensions / 4) * OutputDimensions * 4 +
-                i / PaddedInputDimensions * 4 +
-                i % 4
-              ];
-      }
+        write_little_endian<BiasType>(stream, biases[i]);
 
       for (std::size_t i = 0; i < OutputDimensions * PaddedInputDimensions; ++i)
-          write_little_endian<WeightType>(stream, unscrambledWeights[i]);
-#endif
+        write_little_endian<WeightType>(stream, weights[get_weight_index(i)]);
 
       return !stream.fail();
     }
@@ -126,493 +453,87 @@ namespace Stockfish::Eval::NNUE::Layers {
     const OutputType* propagate(
         const TransformedFeatureType* transformedFeatures, char* buffer) const {
       const auto input = previousLayer.propagate(
-          transformedFeatures, buffer + SelfBufferSize);
+        transformedFeatures, buffer + SelfBufferSize);
+      const auto output = reinterpret_cast<OutputType*>(buffer);
 
-#if defined (USE_AVX512)
-
-      [[maybe_unused]] const __m512i Ones512 = _mm512_set1_epi16(1);
-
-      [[maybe_unused]] auto m512_hadd = [](__m512i sum, int bias) -> int {
-        return _mm512_reduce_add_epi32(sum) + bias;
-      };
-
-      [[maybe_unused]] auto m512_hadd128x16_interleave = [](
-        __m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3) -> __m512i {
-
-        __m512i sum01a = _mm512_unpacklo_epi32(sum0, sum1);
-        __m512i sum01b = _mm512_unpackhi_epi32(sum0, sum1);
-
-        __m512i sum23a = _mm512_unpacklo_epi32(sum2, sum3);
-        __m512i sum23b = _mm512_unpackhi_epi32(sum2, sum3);
-
-        __m512i sum01 = _mm512_add_epi32(sum01a, sum01b);
-        __m512i sum23 = _mm512_add_epi32(sum23a, sum23b);
-
-        __m512i sum0123a = _mm512_unpacklo_epi64(sum01, sum23);
-        __m512i sum0123b = _mm512_unpackhi_epi64(sum01, sum23);
-
-        return _mm512_add_epi32(sum0123a, sum0123b);
-      };
-
-      [[maybe_unused]] auto m512_haddx4 = [m512_hadd128x16_interleave](
-        __m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3, __m128i bias) -> __m128i {
-
-        __m512i sum = m512_hadd128x16_interleave(sum0, sum1, sum2, sum3);
-
-        __m256i sum256lo = _mm512_castsi512_si256(sum);
-        __m256i sum256hi = _mm512_extracti64x4_epi64(sum, 1);
-
-        sum256lo = _mm256_add_epi32(sum256lo, sum256hi);
-
-        __m128i sum128lo = _mm256_castsi256_si128(sum256lo);
-        __m128i sum128hi = _mm256_extracti128_si256(sum256lo, 1);
-
-        return _mm_add_epi32(_mm_add_epi32(sum128lo, sum128hi), bias);
-      };
-
-      [[maybe_unused]] auto m512_add_dpbusd_epi32 = [=](__m512i& acc, __m512i a, __m512i b) {
-#if defined (USE_VNNI)
-        acc = _mm512_dpbusd_epi32(acc, a, b);
-#else
-        __m512i product0 = _mm512_maddubs_epi16(a, b);
-        product0 = _mm512_madd_epi16(product0, Ones512);
-        acc = _mm512_add_epi32(acc, product0);
-#endif
-      };
-
-      [[maybe_unused]] auto m512_add_dpbusd_epi32x2 = [=](__m512i& acc, __m512i a0, __m512i b0, __m512i a1, __m512i b1) {
-#if defined (USE_VNNI)
-        acc = _mm512_dpbusd_epi32(acc, a0, b0);
-        acc = _mm512_dpbusd_epi32(acc, a1, b1);
-#else
-        __m512i product0 = _mm512_maddubs_epi16(a0, b0);
-        __m512i product1 = _mm512_maddubs_epi16(a1, b1);
-        product0 = _mm512_adds_epi16(product0, product1);
-        product0 = _mm512_madd_epi16(product0, Ones512);
-        acc = _mm512_add_epi32(acc, product0);
-#endif
-      };
-
-      [[maybe_unused]] auto m512_add_dpbusd_epi32x4 = [=](__m512i& acc, __m512i a0, __m512i b0, __m512i a1, __m512i b1,
-                                                                        __m512i a2, __m512i b2, __m512i a3, __m512i b3) {
-#if defined (USE_VNNI)
-        acc = _mm512_dpbusd_epi32(acc, a0, b0);
-        acc = _mm512_dpbusd_epi32(acc, a1, b1);
-        acc = _mm512_dpbusd_epi32(acc, a2, b2);
-        acc = _mm512_dpbusd_epi32(acc, a3, b3);
-#else
-        __m512i product0 = _mm512_maddubs_epi16(a0, b0);
-        __m512i product1 = _mm512_maddubs_epi16(a1, b1);
-        __m512i product2 = _mm512_maddubs_epi16(a2, b2);
-        __m512i product3 = _mm512_maddubs_epi16(a3, b3);
-        product0 = _mm512_adds_epi16(product0, product1);
-        product0 = _mm512_madd_epi16(product0, Ones512);
-        product2 = _mm512_adds_epi16(product2, product3);
-        product2 = _mm512_madd_epi16(product2, Ones512);
-        acc = _mm512_add_epi32(acc, _mm512_add_epi32(product0, product2));
-#endif
-      };
-
-#endif
 #if defined (USE_AVX2)
-
-      [[maybe_unused]] const __m256i Ones256 = _mm256_set1_epi16(1);
-
-      [[maybe_unused]] auto m256_hadd = [](__m256i sum, int bias) -> int {
-        __m128i sum128 = _mm_add_epi32(_mm256_castsi256_si128(sum), _mm256_extracti128_si256(sum, 1));
-        sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_BADC));
-        sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_CDAB));
-        return _mm_cvtsi128_si32(sum128) + bias;
-      };
-
-      [[maybe_unused]] auto m256_haddx4 = [](__m256i sum0, __m256i sum1, __m256i sum2, __m256i sum3, __m128i bias) -> __m128i {
-        sum0 = _mm256_hadd_epi32(sum0, sum1);
-        sum2 = _mm256_hadd_epi32(sum2, sum3);
-
-        sum0 = _mm256_hadd_epi32(sum0, sum2);
-
-        __m128i sum128lo = _mm256_castsi256_si128(sum0);
-        __m128i sum128hi = _mm256_extracti128_si256(sum0, 1);
-
-        return _mm_add_epi32(_mm_add_epi32(sum128lo, sum128hi), bias);
-      };
-
-      [[maybe_unused]] auto m256_add_dpbusd_epi32 = [=](__m256i& acc, __m256i a, __m256i b) {
-#if defined (USE_VNNI)
-        acc = _mm256_dpbusd_epi32(acc, a, b);
-#else
-        __m256i product0 = _mm256_maddubs_epi16(a, b);
-        product0 = _mm256_madd_epi16(product0, Ones256);
-        acc = _mm256_add_epi32(acc, product0);
-#endif
-      };
-
-      [[maybe_unused]] auto m256_add_dpbusd_epi32x2 = [=](__m256i& acc, __m256i a0, __m256i b0, __m256i a1, __m256i b1) {
-#if defined (USE_VNNI)
-        acc = _mm256_dpbusd_epi32(acc, a0, b0);
-        acc = _mm256_dpbusd_epi32(acc, a1, b1);
-#else
-        __m256i product0 = _mm256_maddubs_epi16(a0, b0);
-        __m256i product1 = _mm256_maddubs_epi16(a1, b1);
-        product0 = _mm256_adds_epi16(product0, product1);
-        product0 = _mm256_madd_epi16(product0, Ones256);
-        acc = _mm256_add_epi32(acc, product0);
-#endif
-      };
-
-      [[maybe_unused]] auto m256_add_dpbusd_epi32x4 = [=](__m256i& acc, __m256i a0, __m256i b0, __m256i a1, __m256i b1,
-                                                                        __m256i a2, __m256i b2, __m256i a3, __m256i b3) {
-#if defined (USE_VNNI)
-        acc = _mm256_dpbusd_epi32(acc, a0, b0);
-        acc = _mm256_dpbusd_epi32(acc, a1, b1);
-        acc = _mm256_dpbusd_epi32(acc, a2, b2);
-        acc = _mm256_dpbusd_epi32(acc, a3, b3);
-#else
-        __m256i product0 = _mm256_maddubs_epi16(a0, b0);
-        __m256i product1 = _mm256_maddubs_epi16(a1, b1);
-        __m256i product2 = _mm256_maddubs_epi16(a2, b2);
-        __m256i product3 = _mm256_maddubs_epi16(a3, b3);
-        product0 = _mm256_adds_epi16(product0, product1);
-        product0 = _mm256_madd_epi16(product0, Ones256);
-        product2 = _mm256_adds_epi16(product2, product3);
-        product2 = _mm256_madd_epi16(product2, Ones256);
-        acc = _mm256_add_epi32(acc, _mm256_add_epi32(product0, product2));
-#endif
-      };
-
-#endif
-#if defined (USE_SSSE3)
-
-      [[maybe_unused]] const __m128i Ones128 = _mm_set1_epi16(1);
-
-      [[maybe_unused]] auto m128_hadd = [](__m128i sum, int bias) -> int {
-        sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0x4E)); //_MM_PERM_BADC
-        sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0xB1)); //_MM_PERM_CDAB
-        return _mm_cvtsi128_si32(sum) + bias;
-      };
-
-      [[maybe_unused]] auto m128_haddx4 = [](__m128i sum0, __m128i sum1, __m128i sum2, __m128i sum3, __m128i bias) -> __m128i {
-        sum0 = _mm_hadd_epi32(sum0, sum1);
-        sum2 = _mm_hadd_epi32(sum2, sum3);
-        sum0 = _mm_hadd_epi32(sum0, sum2);
-        return _mm_add_epi32(sum0, bias);
-      };
-
-      [[maybe_unused]] auto m128_add_dpbusd_epi32 = [=](__m128i& acc, __m128i a, __m128i b) {
-        __m128i product0 = _mm_maddubs_epi16(a, b);
-        product0 = _mm_madd_epi16(product0, Ones128);
-        acc = _mm_add_epi32(acc, product0);
-      };
-
-      [[maybe_unused]] auto m128_add_dpbusd_epi32x2 = [=](__m128i& acc, __m128i a0, __m128i b0, __m128i a1, __m128i b1) {
-        __m128i product0 = _mm_maddubs_epi16(a0, b0);
-        __m128i product1 = _mm_maddubs_epi16(a1, b1);
-        product0 = _mm_adds_epi16(product0, product1);
-        product0 = _mm_madd_epi16(product0, Ones128);
-        acc = _mm_add_epi32(acc, product0);
-      };
-
-      [[maybe_unused]] auto m128_add_dpbusd_epi32x4 = [=](__m128i& acc, __m128i a0, __m128i b0, __m128i a1, __m128i b1,
-                                                                        __m128i a2, __m128i b2, __m128i a3, __m128i b3) {
-        __m128i product0 = _mm_maddubs_epi16(a0, b0);
-        __m128i product1 = _mm_maddubs_epi16(a1, b1);
-        __m128i product2 = _mm_maddubs_epi16(a2, b2);
-        __m128i product3 = _mm_maddubs_epi16(a3, b3);
-        product0 = _mm_adds_epi16(product0, product1);
-        product0 = _mm_madd_epi16(product0, Ones128);
-        product2 = _mm_adds_epi16(product2, product3);
-        product2 = _mm_madd_epi16(product2, Ones128);
-        acc = _mm_add_epi32(acc, _mm_add_epi32(product0, product2));
-      };
-
-#endif
-
-#if defined (USE_AVX512)
-      using vec_t = __m512i;
-      #define vec_setzero _mm512_setzero_si512
-      #define vec_set_32 _mm512_set1_epi32
-      [[maybe_unused]] auto& vec_add_dpbusd_32 = m512_add_dpbusd_epi32;
-      [[maybe_unused]] auto& vec_add_dpbusd_32x2 = m512_add_dpbusd_epi32x2;
-      [[maybe_unused]] auto& vec_add_dpbusd_32x4 = m512_add_dpbusd_epi32x4;
-      [[maybe_unused]] auto& vec_hadd = m512_hadd;
-      [[maybe_unused]] auto& vec_haddx4 = m512_haddx4;
-#elif defined (USE_AVX2)
       using vec_t = __m256i;
       #define vec_setzero _mm256_setzero_si256
       #define vec_set_32 _mm256_set1_epi32
-      [[maybe_unused]] auto& vec_add_dpbusd_32 = m256_add_dpbusd_epi32;
-      [[maybe_unused]] auto& vec_add_dpbusd_32x2 = m256_add_dpbusd_epi32x2;
-      [[maybe_unused]] auto& vec_add_dpbusd_32x4 = m256_add_dpbusd_epi32x4;
-      [[maybe_unused]] auto& vec_hadd = m256_hadd;
-      [[maybe_unused]] auto& vec_haddx4 = m256_haddx4;
+      #define vec_add_dpbusd_32 Simd::m256_add_dpbusd_epi32
+      #define vec_add_dpbusd_32x2 Simd::m256_add_dpbusd_epi32x2
+      #define vec_add_dpbusd_32x4 Simd::m256_add_dpbusd_epi32x4
+      #define vec_hadd Simd::m256_hadd
+      #define vec_haddx4 Simd::m256_haddx4
 #elif defined (USE_SSSE3)
       using vec_t = __m128i;
       #define vec_setzero _mm_setzero_si128
       #define vec_set_32 _mm_set1_epi32
-      [[maybe_unused]] auto& vec_add_dpbusd_32 = m128_add_dpbusd_epi32;
-      [[maybe_unused]] auto& vec_add_dpbusd_32x2 = m128_add_dpbusd_epi32x2;
-      [[maybe_unused]] auto& vec_add_dpbusd_32x4 = m128_add_dpbusd_epi32x4;
-      [[maybe_unused]] auto& vec_hadd = m128_hadd;
-      [[maybe_unused]] auto& vec_haddx4 = m128_haddx4;
+      #define vec_add_dpbusd_32 Simd::m128_add_dpbusd_epi32
+      #define vec_add_dpbusd_32x2 Simd::m128_add_dpbusd_epi32x2
+      #define vec_add_dpbusd_32x4 Simd::m128_add_dpbusd_epi32x4
+      #define vec_hadd Simd::m128_hadd
+      #define vec_haddx4 Simd::m128_haddx4
 #endif
 
 #if defined (USE_SSSE3)
-      const auto output = reinterpret_cast<OutputType*>(buffer);
       const auto inputVector = reinterpret_cast<const vec_t*>(input);
-#endif
 
-#if defined (USE_VNNI) || defined (USE_AVX512)
-
-      static_assert(OutputDimensions == 1 || OutputDimensions % 4 == 0);
-
-      // OutputDimensions is either 1 or a multiple of SimdWidth
-      // because then it is also an input dimension.
-      if constexpr (OutputDimensions <= 8 && OutputDimensions != 1)
-      {
-          constexpr IndexType NumChunks = PaddedInputDimensions / InputSimdWidth;
-
-          static_assert(NumChunks % 2 == 0);
-
-          const auto input_vec = reinterpret_cast<const vec_t*>(input);
-          const auto bias_vec = reinterpret_cast<const __m128i*>(biases);
-          auto out_vec = reinterpret_cast<__m128i*>(output);
-
-          vec_t regs[OutputDimensions];
-          for (IndexType k = 0; k < OutputDimensions; ++k)
-            regs[k] = vec_setzero();
-
-          for (IndexType i = 0; i < NumChunks / 2; ++i)
-          {
-              const vec_t in0 = input_vec[i * 2 + 0];
-              const vec_t in1 = input_vec[i * 2 + 1];
-              for (IndexType k = 0; k < OutputDimensions; ++k)
-              {
-                  const vec_t w0 = reinterpret_cast<const vec_t*>(&weights[k * PaddedInputDimensions])[i * 2 + 0];
-                  const vec_t w1 = reinterpret_cast<const vec_t*>(&weights[k * PaddedInputDimensions])[i * 2 + 1];
-                  vec_add_dpbusd_32(regs[k], in0, w0);
-                  vec_add_dpbusd_32(regs[k], in1, w1);
-              }
-          }
-
-          for (IndexType k = 0; k < OutputDimensions / 4; ++k)
-          {
-            out_vec[k] = vec_haddx4(
-              regs[k * 4 + 0],
-              regs[k * 4 + 1],
-              regs[k * 4 + 2],
-              regs[k * 4 + 3],
-              bias_vec[k]
-            );
-          }
-      }
-      else if constexpr (InputDimensions == 8)
-      {
-          const auto input32 = reinterpret_cast<const std::int32_t*>(input);
-          __m256i* outptr = reinterpret_cast<__m256i*>(output);
-          std::memcpy(output, biases, OutputDimensions * sizeof(OutputType));
-
-          const __m256i in0 = _mm256_set1_epi32(input32[0]);
-          const __m256i in1 = _mm256_set1_epi32(input32[1]);
-          const auto col0 = reinterpret_cast<const __m256i*>(&weights[0]);
-          const auto col1 = reinterpret_cast<const __m256i*>(&weights[OutputDimensions * 4]);
-          for (IndexType j = 0; j * 8 < OutputDimensions; ++j)
-              m256_add_dpbusd_epi32x2(outptr[j], in0, col0[j], in1, col1[j]);
-      }
-      else
-
-#elif defined (USE_SSSE3)
-
-      if constexpr (OutputDimensions % OutputSimdWidth == 0 && InputDimensions == 8)
-      {
-          const auto input32 = reinterpret_cast<const std::int32_t*>(input);
-          vec_t* outptr = reinterpret_cast<vec_t*>(output);
-          std::memcpy(output, biases, OutputDimensions * sizeof(OutputType));
-
-          const vec_t in0 = vec_set_32(input32[0]);
-          const vec_t in1 = vec_set_32(input32[1]);
-          const auto col0 = reinterpret_cast<const vec_t*>(&weights[0]);
-          const auto col1 = reinterpret_cast<const vec_t*>(&weights[OutputDimensions * 4]);
-          for (IndexType j = 0; j * OutputSimdWidth < OutputDimensions; ++j)
-              vec_add_dpbusd_32x2(outptr[j], in0, col0[j], in1, col1[j]);
-      }
-      else
-
-#endif
-
-#if defined (USE_SSSE3)
+      static_assert(InputDimensions % 8 == 0);
+      static_assert(OutputDimensions % OutputSimdWidth == 0 || OutputDimensions == 1);
 
       if constexpr (OutputDimensions % OutputSimdWidth == 0)
       {
-          static_assert(InputDimensions % 16 == 0);
+        constexpr IndexType NumChunks = InputDimensions / 4;
+        constexpr IndexType NumRegs = OutputDimensions / OutputSimdWidth;
 
-          constexpr IndexType NumChunks = InputDimensions / 4;
-          constexpr IndexType NumRegs = OutputDimensions / OutputSimdWidth;
+        const auto input32 = reinterpret_cast<const std::int32_t*>(input);
+        const vec_t* biasvec = reinterpret_cast<const vec_t*>(biases);
+        vec_t acc[NumRegs];
+        for (IndexType k = 0; k < NumRegs; ++k)
+          acc[k] = biasvec[k];
 
-          const auto input32 = reinterpret_cast<const std::int32_t*>(input);
-          const vec_t* biasvec = reinterpret_cast<const vec_t*>(biases);
-          vec_t outs[NumRegs];
+        for (IndexType i = 0; i < NumChunks; i += 2)
+        {
+          const vec_t in0 = vec_set_32(input32[i + 0]);
+          const vec_t in1 = vec_set_32(input32[i + 1]);
+          const auto col0 = reinterpret_cast<const vec_t*>(&weights[(i + 0) * OutputDimensions * 4]);
+          const auto col1 = reinterpret_cast<const vec_t*>(&weights[(i + 1) * OutputDimensions * 4]);
           for (IndexType k = 0; k < NumRegs; ++k)
-              outs[k] = biasvec[k];
+            vec_add_dpbusd_32x2(acc[k], in0, col0[k], in1, col1[k]);
+        }
 
-          for (IndexType i = 0; i < NumChunks; i += 4)
-          {
-              const vec_t in0 = vec_set_32(input32[i + 0]);
-              const vec_t in1 = vec_set_32(input32[i + 1]);
-              const vec_t in2 = vec_set_32(input32[i + 2]);
-              const vec_t in3 = vec_set_32(input32[i + 3]);
-              const auto col0 = reinterpret_cast<const vec_t*>(&weights[(i + 0) * OutputDimensions * 4]);
-              const auto col1 = reinterpret_cast<const vec_t*>(&weights[(i + 1) * OutputDimensions * 4]);
-              const auto col2 = reinterpret_cast<const vec_t*>(&weights[(i + 2) * OutputDimensions * 4]);
-              const auto col3 = reinterpret_cast<const vec_t*>(&weights[(i + 3) * OutputDimensions * 4]);
-              for (IndexType k = 0; k < NumRegs; ++k)
-                  vec_add_dpbusd_32x4(outs[k], in0, col0[k], in1, col1[k], in2, col2[k], in3, col3[k]);
-          }
-
-          vec_t* outptr = reinterpret_cast<vec_t*>(output);
-          for (IndexType k = 0; k < NumRegs; ++k)
-              outptr[k] = outs[k];
+        vec_t* outptr = reinterpret_cast<vec_t*>(output);
+        for (IndexType k = 0; k < NumRegs; ++k)
+          outptr[k] = acc[k];
       }
       else if constexpr (OutputDimensions == 1)
       {
-          static_assert(InputDimensions % 4 == 0);
+        constexpr IndexType NumChunks = PaddedInputDimensions / SimdWidth;
+        vec_t sum0 = vec_setzero();
+        const auto row0 = reinterpret_cast<const vec_t*>(&weights[0]);
 
-#if defined (USE_AVX512)
-          if constexpr (PaddedInputDimensions % (SimdWidth * 2) != 0)
-          {
-              constexpr IndexType NumChunks = PaddedInputDimensions / SimdWidth;
-              const auto inputVector256 = reinterpret_cast<const __m256i*>(input);
-
-              __m256i sum0 = _mm256_setzero_si256();
-              const auto row0 = reinterpret_cast<const __m256i*>(&weights[0]);
-
-              for (int j = 0; j < (int)NumChunks; ++j)
-              {
-                  const __m256i in = inputVector256[j];
-                  m256_add_dpbusd_epi32(sum0, in, row0[j]);
-              }
-              output[0] = m256_hadd(sum0, biases[0]);
-          }
-          else
-#endif
-          {
-#if defined (USE_AVX512)
-              constexpr IndexType NumChunks = PaddedInputDimensions / (SimdWidth * 2);
-#else
-              constexpr IndexType NumChunks = PaddedInputDimensions / SimdWidth;
-#endif
-              vec_t sum0 = vec_setzero();
-              const auto row0 = reinterpret_cast<const vec_t*>(&weights[0]);
-
-              for (int j = 0; j < (int)NumChunks; ++j)
-              {
-                  const vec_t in = inputVector[j];
-                  vec_add_dpbusd_32(sum0, in, row0[j]);
-              }
-              output[0] = vec_hadd(sum0, biases[0]);
-          }
+        for (int j = 0; j < (int)NumChunks; ++j)
+        {
+          const vec_t in = inputVector[j];
+          vec_add_dpbusd_32(sum0, in, row0[j]);
+        }
+        output[0] = vec_hadd(sum0, biases[0]);
       }
 
+# undef vec_setzero
+# undef vec_set_32
+# undef vec_add_dpbusd_32
+# undef vec_add_dpbusd_32x2
+# undef vec_add_dpbusd_32x4
+# undef vec_hadd
+# undef vec_haddx4
 #else
-
-// Use old implementation for the other architectures.
-
-      auto output = reinterpret_cast<OutputType*>(buffer);
-
-#if defined(USE_SSE2)
-      // At least a multiple of 16, with SSE2.
-      static_assert(PaddedInputDimensions % SimdWidth == 0);
-      constexpr IndexType NumChunks = PaddedInputDimensions / SimdWidth;
-      const __m128i Zeros = _mm_setzero_si128();
-      const auto inputVector = reinterpret_cast<const __m128i*>(input);
-
-#elif defined(USE_MMX)
-      static_assert(InputDimensions % SimdWidth == 0);
-      constexpr IndexType NumChunks = InputDimensions / SimdWidth;
-      const __m64 Zeros = _mm_setzero_si64();
-      const auto inputVector = reinterpret_cast<const __m64*>(input);
-
-#elif defined(USE_NEON)
-      static_assert(PaddedInputDimensions % SimdWidth == 0);
-      constexpr IndexType NumChunks = PaddedInputDimensions / SimdWidth;
-      const auto inputVector = reinterpret_cast<const int8x8_t*>(input);
-#endif
-
-      for (IndexType i = 0; i < OutputDimensions; ++i) {
-        const IndexType offset = i * PaddedInputDimensions;
-
-#if defined(USE_SSE2)
-        __m128i sumLo = _mm_cvtsi32_si128(biases[i]);
-        __m128i sumHi = Zeros;
-        const auto row = reinterpret_cast<const __m128i*>(&weights[offset]);
-        for (IndexType j = 0; j < NumChunks; ++j) {
-          __m128i row_j = _mm_load_si128(&row[j]);
-          __m128i input_j = _mm_load_si128(&inputVector[j]);
-          __m128i extendedRowLo = _mm_srai_epi16(_mm_unpacklo_epi8(row_j, row_j), 8);
-          __m128i extendedRowHi = _mm_srai_epi16(_mm_unpackhi_epi8(row_j, row_j), 8);
-          __m128i extendedInputLo = _mm_unpacklo_epi8(input_j, Zeros);
-          __m128i extendedInputHi = _mm_unpackhi_epi8(input_j, Zeros);
-          __m128i productLo = _mm_madd_epi16(extendedRowLo, extendedInputLo);
-          __m128i productHi = _mm_madd_epi16(extendedRowHi, extendedInputHi);
-          sumLo = _mm_add_epi32(sumLo, productLo);
-          sumHi = _mm_add_epi32(sumHi, productHi);
-        }
-        __m128i sum = _mm_add_epi32(sumLo, sumHi);
-        __m128i sumHigh_64 = _mm_shuffle_epi32(sum, _MM_SHUFFLE(1, 0, 3, 2));
-        sum = _mm_add_epi32(sum, sumHigh_64);
-        __m128i sum_second_32 = _mm_shufflelo_epi16(sum, _MM_SHUFFLE(1, 0, 3, 2));
-        sum = _mm_add_epi32(sum, sum_second_32);
-        output[i] = _mm_cvtsi128_si32(sum);
-
-#elif defined(USE_MMX)
-        __m64 sumLo = _mm_cvtsi32_si64(biases[i]);
-        __m64 sumHi = Zeros;
-        const auto row = reinterpret_cast<const __m64*>(&weights[offset]);
-        for (IndexType j = 0; j < NumChunks; ++j) {
-          __m64 row_j = row[j];
-          __m64 input_j = inputVector[j];
-          __m64 extendedRowLo = _mm_srai_pi16(_mm_unpacklo_pi8(row_j, row_j), 8);
-          __m64 extendedRowHi = _mm_srai_pi16(_mm_unpackhi_pi8(row_j, row_j), 8);
-          __m64 extendedInputLo = _mm_unpacklo_pi8(input_j, Zeros);
-          __m64 extendedInputHi = _mm_unpackhi_pi8(input_j, Zeros);
-          __m64 productLo = _mm_madd_pi16(extendedRowLo, extendedInputLo);
-          __m64 productHi = _mm_madd_pi16(extendedRowHi, extendedInputHi);
-          sumLo = _mm_add_pi32(sumLo, productLo);
-          sumHi = _mm_add_pi32(sumHi, productHi);
-        }
-        __m64 sum = _mm_add_pi32(sumLo, sumHi);
-        sum = _mm_add_pi32(sum, _mm_unpackhi_pi32(sum, sum));
-        output[i] = _mm_cvtsi64_si32(sum);
-
-#elif defined(USE_NEON)
-        int32x4_t sum = {biases[i]};
-        const auto row = reinterpret_cast<const int8x8_t*>(&weights[offset]);
-        for (IndexType j = 0; j < NumChunks; ++j) {
-          int16x8_t product = vmull_s8(inputVector[j * 2], row[j * 2]);
-          product = vmlal_s8(product, inputVector[j * 2 + 1], row[j * 2 + 1]);
-          sum = vpadalq_s16(sum, product);
-        }
-        output[i] = sum[0] + sum[1] + sum[2] + sum[3];
-
-#else
-        OutputType sum = biases[i];
-        for (IndexType j = 0; j < InputDimensions; ++j) {
-          sum += weights[offset + j] * input[j];
-        }
-        output[i] = sum;
-#endif
-
-      }
-#if defined(USE_MMX)
-      _mm_empty();
-#endif
-
-#endif
-
-#if (!defined (USE_SSSE3) && defined (USE_SSE2)) || defined (USE_NEON)
-      static_assert(SimdWidth <= 16, "Otherwise we run outside of the padding for the output.");
-      if constexpr (SimdWidth > OutputDimensions && OutputDimensions != 1)
-          for (IndexType i = OutputDimensions; i < SimdWidth; ++i)
-            output[i] = 0;
+      // Use old implementation for the other architectures.
+      affine_transform_non_ssse3<
+        InputDimensions,
+        PaddedInputDimensions,
+        OutputDimensions>(output, weights, biases, input);
 #endif
 
       return output;

--- a/src/simd.h
+++ b/src/simd.h
@@ -125,8 +125,8 @@ namespace Stockfish::Simd {
       asm(
           "vpmaddwd    %[tmp], %[ones], %[tmp]\n\t"
           "vpaddd      %[acc], %[tmp], %[acc]\n\t"
-          : [acc]"+v"(acc)
-          : [tmp]"v"(tmp), [ones]"v"(_mm512_set1_epi16(1))
+          : [acc]"+v"(acc), [tmp]"+&v"(tmp)
+          : [ones]"v"(_mm512_set1_epi16(1))
       );
 #   else
       __m512i product0 = _mm512_maddubs_epi16(a, b);
@@ -161,8 +161,8 @@ namespace Stockfish::Simd {
           "vpaddsw     %[tmp0], %[tmp1], %[tmp0]\n\t"
           "vpmaddwd    %[tmp0], %[ones], %[tmp0]\n\t"
           "vpaddd      %[acc], %[tmp0], %[acc]\n\t"
-          : [acc]"+v"(acc)
-          : [tmp0]"v"(tmp0), [tmp1]"v"(tmp1), [ones]"v"(_mm512_set1_epi16(1))
+          : [acc]"+v"(acc), [tmp0]"+&v"(tmp0)
+          : [tmp1]"v"(tmp1), [ones]"v"(_mm512_set1_epi16(1))
       );
 #   else
       __m512i product0 = _mm512_maddubs_epi16(a0, b0);
@@ -221,8 +221,8 @@ namespace Stockfish::Simd {
       asm(
           "vpmaddwd    %[tmp], %[ones], %[tmp]\n\t"
           "vpaddd      %[acc], %[tmp], %[acc]\n\t"
-          : [acc]"+v"(acc)
-          : [tmp]"v"(tmp), [ones]"v"(_mm256_set1_epi16(1))
+          : [acc]"+v"(acc), [tmp]"+&v"(tmp)
+          : [ones]"v"(_mm256_set1_epi16(1))
       );
 #   else
       __m256i product0 = _mm256_maddubs_epi16(a, b);
@@ -257,8 +257,8 @@ namespace Stockfish::Simd {
           "vpaddsw     %[tmp0], %[tmp1], %[tmp0]\n\t"
           "vpmaddwd    %[tmp0], %[ones], %[tmp0]\n\t"
           "vpaddd      %[acc], %[tmp0], %[acc]\n\t"
-          : [acc]"+v"(acc)
-          : [tmp0]"v"(tmp0), [tmp1]"v"(tmp1), [ones]"v"(_mm256_set1_epi16(1))
+          : [acc]"+v"(acc), [tmp0]"+&v"(tmp0)
+          : [tmp1]"v"(tmp1), [ones]"v"(_mm256_set1_epi16(1))
       );
 #   else
       __m256i product0 = _mm256_maddubs_epi16(a0, b0);
@@ -300,8 +300,8 @@ namespace Stockfish::Simd {
       asm(
           "pmaddwd    %[ones], %[tmp]\n\t"
           "paddd      %[tmp], %[acc]\n\t"
-          : [acc]"+v"(acc)
-          : [tmp]"v"(tmp), [ones]"v"(_mm_set1_epi16(1))
+          : [acc]"+v"(acc), [tmp]"+&v"(tmp)
+          : [ones]"v"(_mm_set1_epi16(1))
       );
 #   else
       __m128i product0 = _mm_maddubs_epi16(a, b);
@@ -322,8 +322,8 @@ namespace Stockfish::Simd {
           "paddsw     %[tmp1], %[tmp0]\n\t"
           "pmaddwd    %[ones], %[tmp0]\n\t"
           "paddd      %[tmp0], %[acc]\n\t"
-          : [acc]"+v"(acc)
-          : [tmp0]"v"(tmp0), [tmp1]"v"(tmp1), [ones]"v"(_mm_set1_epi16(1))
+          : [acc]"+v"(acc), [tmp0]"+&v"(tmp0)
+          : [tmp1]"v"(tmp1), [ones]"v"(_mm_set1_epi16(1))
       );
 #   else
       __m128i product0 = _mm_maddubs_epi16(a0, b0);

--- a/src/simd.h
+++ b/src/simd.h
@@ -1,0 +1,341 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2021 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef STOCKFISH_SIMD_H_INCLUDED
+#define STOCKFISH_SIMD_H_INCLUDED
+
+#if defined(USE_AVX2)
+# include <immintrin.h>
+
+#elif defined(USE_SSE41)
+# include <smmintrin.h>
+
+#elif defined(USE_SSSE3)
+# include <tmmintrin.h>
+
+#elif defined(USE_SSE2)
+# include <emmintrin.h>
+
+#elif defined(USE_MMX)
+# include <mmintrin.h>
+
+#elif defined(USE_NEON)
+# include <arm_neon.h>
+#endif
+
+// The inline asm is only safe for GCC, where it is necessary to get good codegen.
+// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101693
+// Clang does fine without it.
+// Play around here: https://godbolt.org/z/7EWqrYq51
+#if (defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER))
+#define USE_INLINE_ASM
+#endif
+
+namespace Stockfish::Simd {
+
+#if defined (USE_AVX512)
+
+    [[maybe_unused]] static int m512_hadd(__m512i sum, int bias) {
+      return _mm512_reduce_add_epi32(sum) + bias;
+    }
+
+    /*
+      Parameters:
+        sum0 = [zmm0.i128[0], zmm0.i128[1], zmm0.i128[2], zmm0.i128[3]]
+        sum1 = [zmm1.i128[0], zmm1.i128[1], zmm1.i128[2], zmm1.i128[3]]
+        sum2 = [zmm2.i128[0], zmm2.i128[1], zmm2.i128[2], zmm2.i128[3]]
+        sum3 = [zmm3.i128[0], zmm3.i128[1], zmm3.i128[2], zmm3.i128[3]]
+
+      Returns:
+        ret = [
+          reduce_add_epi32(zmm0.i128[0]), reduce_add_epi32(zmm1.i128[0]), reduce_add_epi32(zmm2.i128[0]), reduce_add_epi32(zmm3.i128[0]),
+          reduce_add_epi32(zmm0.i128[1]), reduce_add_epi32(zmm1.i128[1]), reduce_add_epi32(zmm2.i128[1]), reduce_add_epi32(zmm3.i128[1]),
+          reduce_add_epi32(zmm0.i128[2]), reduce_add_epi32(zmm1.i128[2]), reduce_add_epi32(zmm2.i128[2]), reduce_add_epi32(zmm3.i128[2]),
+          reduce_add_epi32(zmm0.i128[3]), reduce_add_epi32(zmm1.i128[3]), reduce_add_epi32(zmm2.i128[3]), reduce_add_epi32(zmm3.i128[3])
+        ]
+    */
+    [[maybe_unused]] static __m512i m512_hadd128x16_interleave(
+        __m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3) {
+
+      __m512i sum01a = _mm512_unpacklo_epi32(sum0, sum1);
+      __m512i sum01b = _mm512_unpackhi_epi32(sum0, sum1);
+
+      __m512i sum23a = _mm512_unpacklo_epi32(sum2, sum3);
+      __m512i sum23b = _mm512_unpackhi_epi32(sum2, sum3);
+
+      __m512i sum01 = _mm512_add_epi32(sum01a, sum01b);
+      __m512i sum23 = _mm512_add_epi32(sum23a, sum23b);
+
+      __m512i sum0123a = _mm512_unpacklo_epi64(sum01, sum23);
+      __m512i sum0123b = _mm512_unpackhi_epi64(sum01, sum23);
+
+      return _mm512_add_epi32(sum0123a, sum0123b);
+    }
+
+    [[maybe_unused]] static __m128i m512_haddx4(
+        __m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3,
+        __m128i bias) {
+
+      __m512i sum = m512_hadd128x16_interleave(sum0, sum1, sum2, sum3);
+
+      __m256i sum256lo = _mm512_castsi512_si256(sum);
+      __m256i sum256hi = _mm512_extracti64x4_epi64(sum, 1);
+
+      sum256lo = _mm256_add_epi32(sum256lo, sum256hi);
+
+      __m128i sum128lo = _mm256_castsi256_si128(sum256lo);
+      __m128i sum128hi = _mm256_extracti128_si256(sum256lo, 1);
+
+      return _mm_add_epi32(_mm_add_epi32(sum128lo, sum128hi), bias);
+    }
+
+    [[maybe_unused]] static void m512_add_dpbusd_epi32(
+        __m512i& acc,
+        __m512i a,
+        __m512i b) {
+
+# if defined (USE_VNNI)
+#   if defined (USE_INLINE_ASM)
+      asm(
+        "vpdpbusd %[b], %[a], %[acc]\n\t"
+        : [acc]"+v"(acc)
+        : [a]"v"(a), [b]"vm"(b)
+      );
+#   else
+      acc = _mm512_dpbusd_epi32(acc, a, b);
+#   endif
+# else
+#   if defined (USE_INLINE_ASM)
+      __m512i tmp = _mm512_maddubs_epi16(a, b);
+      asm(
+          "vpmaddwd    %[tmp], %[ones], %[tmp]\n\t"
+          "vpaddd      %[acc], %[tmp], %[acc]\n\t"
+          : [acc]"+v"(acc)
+          : [tmp]"v"(tmp), [ones]"v"(_mm512_set1_epi16(1))
+      );
+#   else
+      __m512i product0 = _mm512_maddubs_epi16(a, b);
+      product0 = _mm512_madd_epi16(product0, _mm512_set1_epi16(1));
+      acc = _mm512_add_epi32(acc, product0);
+#   endif
+# endif
+    }
+
+    [[maybe_unused]] static void m512_add_dpbusd_epi32x2(
+        __m512i& acc,
+        __m512i a0, __m512i b0,
+        __m512i a1, __m512i b1) {
+
+# if defined (USE_VNNI)
+#   if defined (USE_INLINE_ASM)
+      asm(
+        "vpdpbusd %[b0], %[a0], %[acc]\n\t"
+        "vpdpbusd %[b1], %[a1], %[acc]\n\t"
+        : [acc]"+v"(acc)
+        : [a0]"v"(a0), [b0]"vm"(b0), [a1]"v"(a1), [b1]"vm"(b1)
+      );
+#   else
+      acc = _mm512_dpbusd_epi32(acc, a0, b0);
+      acc = _mm512_dpbusd_epi32(acc, a1, b1);
+#   endif
+# else
+#   if defined (USE_INLINE_ASM)
+      __m512i tmp0 = _mm512_maddubs_epi16(a0, b0);
+      __m512i tmp1 = _mm512_maddubs_epi16(a1, b1);
+      asm(
+          "vpaddsw     %[tmp0], %[tmp1], %[tmp0]\n\t"
+          "vpmaddwd    %[tmp0], %[ones], %[tmp0]\n\t"
+          "vpaddd      %[acc], %[tmp0], %[acc]\n\t"
+          : [acc]"+v"(acc)
+          : [tmp0]"v"(tmp0), [tmp1]"v"(tmp1), [ones]"v"(_mm512_set1_epi16(1))
+      );
+#   else
+      __m512i product0 = _mm512_maddubs_epi16(a0, b0);
+      __m512i product1 = _mm512_maddubs_epi16(a1, b1);
+      product0 = _mm512_adds_epi16(product0, product1);
+      product0 = _mm512_madd_epi16(product0, _mm512_set1_epi16(1));
+      acc = _mm512_add_epi32(acc, product0);
+#   endif
+# endif
+    }
+
+#endif
+
+#if defined (USE_AVX2)
+
+    [[maybe_unused]] static int m256_hadd(__m256i sum, int bias) {
+      __m128i sum128 = _mm_add_epi32(_mm256_castsi256_si128(sum), _mm256_extracti128_si256(sum, 1));
+      sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_BADC));
+      sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_CDAB));
+      return _mm_cvtsi128_si32(sum128) + bias;
+    }
+
+    [[maybe_unused]] static __m128i m256_haddx4(
+        __m256i sum0, __m256i sum1, __m256i sum2, __m256i sum3,
+        __m128i bias) {
+
+      sum0 = _mm256_hadd_epi32(sum0, sum1);
+      sum2 = _mm256_hadd_epi32(sum2, sum3);
+
+      sum0 = _mm256_hadd_epi32(sum0, sum2);
+
+      __m128i sum128lo = _mm256_castsi256_si128(sum0);
+      __m128i sum128hi = _mm256_extracti128_si256(sum0, 1);
+
+      return _mm_add_epi32(_mm_add_epi32(sum128lo, sum128hi), bias);
+    }
+
+    [[maybe_unused]] static void m256_add_dpbusd_epi32(
+        __m256i& acc,
+        __m256i a,
+        __m256i b) {
+
+# if defined (USE_VNNI)
+#   if defined (USE_INLINE_ASM)
+      asm(
+        "vpdpbusd %[b], %[a], %[acc]\n\t"
+        : [acc]"+v"(acc)
+        : [a]"v"(a), [b]"vm"(b)
+      );
+#   else
+      acc = _mm256_dpbusd_epi32(acc, a, b);
+#   endif
+# else
+#   if defined (USE_INLINE_ASM)
+      __m256i tmp = _mm256_maddubs_epi16(a, b);
+      asm(
+          "vpmaddwd    %[tmp], %[ones], %[tmp]\n\t"
+          "vpaddd      %[acc], %[tmp], %[acc]\n\t"
+          : [acc]"+v"(acc)
+          : [tmp]"v"(tmp), [ones]"v"(_mm256_set1_epi16(1))
+      );
+#   else
+      __m256i product0 = _mm256_maddubs_epi16(a, b);
+      product0 = _mm256_madd_epi16(product0, _mm256_set1_epi16(1));
+      acc = _mm256_add_epi32(acc, product0);
+#   endif
+# endif
+    }
+
+    [[maybe_unused]] static void m256_add_dpbusd_epi32x2(
+        __m256i& acc,
+        __m256i a0, __m256i b0,
+        __m256i a1, __m256i b1) {
+
+# if defined (USE_VNNI)
+#   if defined (USE_INLINE_ASM)
+      asm(
+        "vpdpbusd %[b0], %[a0], %[acc]\n\t"
+        "vpdpbusd %[b1], %[a1], %[acc]\n\t"
+        : [acc]"+v"(acc)
+        : [a0]"v"(a0), [b0]"vm"(b0), [a1]"v"(a1), [b1]"vm"(b1)
+      );
+#   else
+      acc = _mm256_dpbusd_epi32(acc, a0, b0);
+      acc = _mm256_dpbusd_epi32(acc, a1, b1);
+#   endif
+# else
+#   if defined (USE_INLINE_ASM)
+      __m256i tmp0 = _mm256_maddubs_epi16(a0, b0);
+      __m256i tmp1 = _mm256_maddubs_epi16(a1, b1);
+      asm(
+          "vpaddsw     %[tmp0], %[tmp1], %[tmp0]\n\t"
+          "vpmaddwd    %[tmp0], %[ones], %[tmp0]\n\t"
+          "vpaddd      %[acc], %[tmp0], %[acc]\n\t"
+          : [acc]"+v"(acc)
+          : [tmp0]"v"(tmp0), [tmp1]"v"(tmp1), [ones]"v"(_mm256_set1_epi16(1))
+      );
+#   else
+      __m256i product0 = _mm256_maddubs_epi16(a0, b0);
+      __m256i product1 = _mm256_maddubs_epi16(a1, b1);
+      product0 = _mm256_adds_epi16(product0, product1);
+      product0 = _mm256_madd_epi16(product0, _mm256_set1_epi16(1));
+      acc = _mm256_add_epi32(acc, product0);
+#   endif
+# endif
+    }
+
+#endif
+
+#if defined (USE_SSSE3)
+
+    [[maybe_unused]] static int m128_hadd(__m128i sum, int bias) {
+      sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0x4E)); //_MM_PERM_BADC
+      sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0xB1)); //_MM_PERM_CDAB
+      return _mm_cvtsi128_si32(sum) + bias;
+    }
+
+    [[maybe_unused]] static __m128i m128_haddx4(
+        __m128i sum0, __m128i sum1, __m128i sum2, __m128i sum3,
+        __m128i bias) {
+
+      sum0 = _mm_hadd_epi32(sum0, sum1);
+      sum2 = _mm_hadd_epi32(sum2, sum3);
+      sum0 = _mm_hadd_epi32(sum0, sum2);
+      return _mm_add_epi32(sum0, bias);
+    }
+
+    [[maybe_unused]] static void m128_add_dpbusd_epi32(
+        __m128i& acc,
+        __m128i a,
+        __m128i b) {
+
+#   if defined (USE_INLINE_ASM)
+      __m128i tmp = _mm_maddubs_epi16(a, b);
+      asm(
+          "pmaddwd    %[ones], %[tmp]\n\t"
+          "paddd      %[tmp], %[acc]\n\t"
+          : [acc]"+v"(acc)
+          : [tmp]"v"(tmp), [ones]"v"(_mm_set1_epi16(1))
+      );
+#   else
+      __m128i product0 = _mm_maddubs_epi16(a, b);
+      product0 = _mm_madd_epi16(product0, _mm_set1_epi16(1));
+      acc = _mm_add_epi32(acc, product0);
+#   endif
+    }
+
+    [[maybe_unused]] static void m128_add_dpbusd_epi32x2(
+        __m128i& acc,
+        __m128i a0, __m128i b0,
+        __m128i a1, __m128i b1) {
+
+#   if defined (USE_INLINE_ASM)
+      __m128i tmp0 = _mm_maddubs_epi16(a0, b0);
+      __m128i tmp1 = _mm_maddubs_epi16(a1, b1);
+      asm(
+          "paddsw     %[tmp1], %[tmp0]\n\t"
+          "pmaddwd    %[ones], %[tmp0]\n\t"
+          "paddd      %[tmp0], %[acc]\n\t"
+          : [acc]"+v"(acc)
+          : [tmp0]"v"(tmp0), [tmp1]"v"(tmp1), [ones]"v"(_mm_set1_epi16(1))
+      );
+#   else
+      __m128i product0 = _mm_maddubs_epi16(a0, b0);
+      __m128i product1 = _mm_maddubs_epi16(a1, b1);
+      product0 = _mm_adds_epi16(product0, product1);
+      product0 = _mm_madd_epi16(product0, _mm_set1_epi16(1));
+      acc = _mm_add_epi32(acc, product0);
+#   endif
+    }
+
+#endif
+
+}
+
+#endif // STOCKFISH_SIMD_H_INCLUDED


### PR DESCRIPTION
The new network caused some issues initially due to the very narrow neuron set between the first two FC layers. Necessary changes were hacked together to make it work. This patch is a mature approach to make the affine transform code faster, more readable, and easier to maintain should the layer sizes change again. The following changes were made:

- ClippedReLU always produces a multiple of 32 outputs. This is about as good of a solution for AffineTransform's SIMD requirements as it can get without a bigger rewrite.
- All self-contained simd helpers are moved to a separate file (simd.h). Inline asm is utilized to work around GCC's issues with code generation and register assignment. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101693, https://godbolt.org/z/da76fY1n7
- AffineTransform has 2 specializations. While it's more lines of code due to the boilerplate, the logic in both is significantly reduced, as these two are impossible to nicely combine into one.
    - The first specialization is for cases when there's >=128 inputs. It uses a different approach to perform the affine transform and can make full use of AVX512 without any edge cases. Furthermore, it has higher theoretical throughput because less loads are needed in the hot path, requiring only a fixed amount of instructions for horizontal additions at the end, which are amortized by the large number of inputs.
    - The second specialization is made to handle smaller layers where performance is still necessary but edge cases need to be handled. AVX512 implementation for this was ommited by mistake, a remnant from the temporary implementation for the new... This could be easily reintroduced if needed. A slightly more detailed description of both implementations is in the code.

Overall it should be a minor speedup (or at least neutral) with AVX2/BMI2 targets. The biggest gains are expected with SSSE3, AVX512, VNNI256, VNNI512 targets. The VNNI targets have particularily been impacted, due to a bug in GCC linked above.

Example hot path comparison with x86-64-vnni256 target (GCC 10.1 in MSYS2):
master:
```
XDIS 14003bd80: DATAXFER  AVX        C5FD6F09                 vmovdqa ymm1, ymmword ptr [rcx]
XDIS 14003bd84: DATAXFER  AVX        C5FD6F4120               vmovdqa ymm0, ymmword ptr [rcx+0x20]
XDIS 14003bd89: BINARY    BASE       4883C140                 add rcx, 0x40
XDIS 14003bd8d: BINARY    BASE       4883C040                 add rax, 0x40
XDIS 14003bd91: AVX512    AVX512EVEX 62F2752850583E           vpdpbusd ymm3, ymm1, ymmword ptr [rax+0x7c0]
XDIS 14003bd98: AVX512    AVX512EVEX 62E275285080C01F0000     vpdpbusd ymm16, ymm1, ymmword ptr [rax+0x1fc0]
XDIS 14003bda2: AVX512    AVX512EVEX 62E275285088C0270000     vpdpbusd ymm17, ymm1, ymmword ptr [rax+0x27c0]
XDIS 14003bdac: AVX512    AVX512EVEX 62E275285090C02F0000     vpdpbusd ymm18, ymm1, ymmword ptr [rax+0x2fc0]
XDIS 14003bdb6: AVX512    AVX512EVEX 62E275285098C0370000     vpdpbusd ymm19, ymm1, ymmword ptr [rax+0x37c0]
XDIS 14003bdc0: AVX512    AVX512EVEX 62F275285050FE           vpdpbusd ymm2, ymm1, ymmword ptr [rax-0x40]
XDIS 14003bdc7: AVX512    AVX512EVEX 62F2752850607E           vpdpbusd ymm4, ymm1, ymmword ptr [rax+0xfc0]
XDIS 14003bdce: DATAXFER  AVX        C5FD6FFB                 vmovdqa ymm7, ymm3
XDIS 14003bdd2: AVX512    AVX512EVEX 62F2752850A8C0170000     vpdpbusd ymm5, ymm1, ymmword ptr [rax+0x17c0]
XDIS 14003bddc: DATAXFER  AVX512EVEX 62317D286FD0             vmovdqa32 ymm10, ymm16
XDIS 14003bde2: AVX512    AVX512EVEX 62F27D2850783F           vpdpbusd ymm7, ymm0, ymmword ptr [rax+0x7e0]
XDIS 14003bde9: DATAXFER  AVX512EVEX 62317D286FD9             vmovdqa32 ymm11, ymm17
XDIS 14003bdef: AVX512    AVX512EVEX 62727D285090E01F0000     vpdpbusd ymm10, ymm0, ymmword ptr [rax+0x1fe0]
XDIS 14003bdf9: DATAXFER  AVX512EVEX 62317D286FE2             vmovdqa32 ymm12, ymm18
XDIS 14003bdff: AVX512    AVX512EVEX 62727D285098E0270000     vpdpbusd ymm11, ymm0, ymmword ptr [rax+0x27e0]
XDIS 14003be09: DATAXFER  AVX512EVEX 62B17D286FCB             vmovdqa32 ymm1, ymm19
XDIS 14003be0f: AVX512    AVX512EVEX 62F27D285050FF           vpdpbusd ymm2, ymm0, ymmword ptr [rax-0x20]
XDIS 14003be16: AVX512    AVX512EVEX 62F27D2850607F           vpdpbusd ymm4, ymm0, ymmword ptr [rax+0xfe0]
XDIS 14003be1d: AVX512    AVX512EVEX 62F27D2850A8E0170000     vpdpbusd ymm5, ymm0, ymmword ptr [rax+0x17e0]
XDIS 14003be27: AVX512    AVX512EVEX 62727D2850A0E02F0000     vpdpbusd ymm12, ymm0, ymmword ptr [rax+0x2fe0]
XDIS 14003be31: DATAXFER  AVX        C5FD6FDF                 vmovdqa ymm3, ymm7
XDIS 14003be35: AVX512    AVX512EVEX 62F27D285088E0370000     vpdpbusd ymm1, ymm0, ymmword ptr [rax+0x37e0]
XDIS 14003be3f: DATAXFER  AVX512EVEX 62C1FD286FC2             vmovdqa64 ymm16, ymm10
XDIS 14003be45: DATAXFER  AVX512EVEX 62C1FD286FCB             vmovdqa64 ymm17, ymm11
XDIS 14003be4b: DATAXFER  AVX        C5FD6FF2                 vmovdqa ymm6, ymm2
XDIS 14003be4f: DATAXFER  AVX        C57D6FC4                 vmovdqa ymm8, ymm4
XDIS 14003be53: DATAXFER  AVX        C57D6FCD                 vmovdqa ymm9, ymm5
XDIS 14003be57: DATAXFER  AVX512EVEX 62C1FD286FD4             vmovdqa64 ymm18, ymm12
XDIS 14003be5d: DATAXFER  AVX512EVEX 62E1FD286FD9             vmovdqa64 ymm19, ymm1
XDIS 14003be63: BINARY    BASE       4839D1                   cmp rcx, rdx
XDIS 14003be66: COND_BR   BASE       0F8514FFFFFF             jnz 0x14003bd80
```

patch:
```
XDIS 14003bc88: DATAXFER  AVX        C5FD6F01                 vmovdqa ymm0, ymmword ptr [rcx]
XDIS 14003bc8c: DATAXFER  AVX        C5FD6F4920               vmovdqa ymm1, ymmword ptr [rcx+0x20]
XDIS 14003bc91: BINARY    BASE       4883C140                 add rcx, 0x40
XDIS 14003bc95: AVX512    AVX512EVEX 62F27D285018             vpdpbusd ymm3, ymm0, ymmword ptr [rax]
XDIS 14003bc9b: AVX512    AVX512EVEX 62F27528505808           vpdpbusd ymm3, ymm1, ymmword ptr [rax+0x100]
XDIS 14003bca2: AVX512    AVX512EVEX 62E27D28505801           vpdpbusd ymm19, ymm0, ymmword ptr [rax+0x20]
XDIS 14003bca9: AVX512    AVX512EVEX 62E27528505809           vpdpbusd ymm19, ymm1, ymmword ptr [rax+0x120]
XDIS 14003bcb0: AVX512    AVX512EVEX 62F27D28506802           vpdpbusd ymm5, ymm0, ymmword ptr [rax+0x40]
XDIS 14003bcb7: AVX512    AVX512EVEX 62F2752850680A           vpdpbusd ymm5, ymm1, ymmword ptr [rax+0x140]
XDIS 14003bcbe: AVX512    AVX512EVEX 62E27D28505003           vpdpbusd ymm18, ymm0, ymmword ptr [rax+0x60]
XDIS 14003bcc5: AVX512    AVX512EVEX 62E2752850500B           vpdpbusd ymm18, ymm1, ymmword ptr [rax+0x160]
XDIS 14003bccc: AVX512    AVX512EVEX 62F27D28505004           vpdpbusd ymm2, ymm0, ymmword ptr [rax+0x80]
XDIS 14003bcd3: AVX512    AVX512EVEX 62F2752850500C           vpdpbusd ymm2, ymm1, ymmword ptr [rax+0x180]
XDIS 14003bcda: AVX512    AVX512EVEX 62E27D28504805           vpdpbusd ymm17, ymm0, ymmword ptr [rax+0xa0]
XDIS 14003bce1: AVX512    AVX512EVEX 62E2752850480D           vpdpbusd ymm17, ymm1, ymmword ptr [rax+0x1a0]
XDIS 14003bce8: AVX512    AVX512EVEX 62F27D28506006           vpdpbusd ymm4, ymm0, ymmword ptr [rax+0xc0]
XDIS 14003bcef: AVX512    AVX512EVEX 62F2752850600E           vpdpbusd ymm4, ymm1, ymmword ptr [rax+0x1c0]
XDIS 14003bcf6: AVX512    AVX512EVEX 62E27D28504007           vpdpbusd ymm16, ymm0, ymmword ptr [rax+0xe0]
XDIS 14003bcfd: AVX512    AVX512EVEX 62E2752850400F           vpdpbusd ymm16, ymm1, ymmword ptr [rax+0x1e0]
XDIS 14003bd04: BINARY    BASE       480500020000             add rax, 0x200
XDIS 14003bd0a: BINARY    BASE       4839CA                   cmp rdx, rcx
XDIS 14003bd0d: COND_BR   BASE       0F8575FFFFFF             jnz 0x14003bc88
```

Comparison for x86-64-modern:
(here the difference is harder to spot because in the patch 2x more work is done in each loop iteration. Notably it doesn't use the shuffles, which are slow, with everything else being about the same.)
master:
```
XDIS 14003b4e0: DATAXFER  SSE2       660F6E3A                 movd xmm7, dword ptr [rdx]
XDIS 14003b4e4: DATAXFER  SSE2       660F6E7204               movd xmm6, dword ptr [rdx+0x4]
XDIS 14003b4e9: BINARY    BASE       4883C210                 add rdx, 0x10
XDIS 14003b4ed: SSE       SSE2       660F70CF00               pshufd xmm1, xmm7, 0x0
XDIS 14003b4f2: SSE       SSE2       660F70FE00               pshufd xmm7, xmm6, 0x0
XDIS 14003b4f7: DATAXFER  SSE2       660F6E72F8               movd xmm6, dword ptr [rdx-0x8]
XDIS 14003b4fc: DATAXFER  SSE2       660F6FD9                 movdqa xmm3, xmm1
XDIS 14003b500: DATAXFER  SSE2       66440F6FD7               movdqa xmm10, xmm7
XDIS 14003b505: SSE       SSSE3      660F380418               pmaddubsw xmm3, xmmword ptr [rax]
XDIS 14003b50a: SSE       SSE2       660F70D600               pshufd xmm2, xmm6, 0x0
XDIS 14003b50f: DATAXFER  SSE2       660F6E72FC               movd xmm6, dword ptr [rdx-0x4]
XDIS 14003b514: SSE       SSSE3      66440F38045020           pmaddubsw xmm10, xmmword ptr [rax+0x20]
XDIS 14003b51b: SSE       SSSE3      660F38044810             pmaddubsw xmm1, xmmword ptr [rax+0x10]
XDIS 14003b521: SSE       SSSE3      660F38047830             pmaddubsw xmm7, xmmword ptr [rax+0x30]
XDIS 14003b527: DATAXFER  SSE2       66440F6FC2               movdqa xmm8, xmm2
XDIS 14003b52c: SSE       SSE2       660F70F600               pshufd xmm6, xmm6, 0x0
XDIS 14003b531: SSE       SSSE3      660F38045050             pmaddubsw xmm2, xmmword ptr [rax+0x50]
XDIS 14003b537: SSE       SSE2       66410FEDDA               paddsw xmm3, xmm10
XDIS 14003b53c: SSE       SSSE3      66440F38044040           pmaddubsw xmm8, xmmword ptr [rax+0x40]
XDIS 14003b543: DATAXFER  SSE2       66440F6FCE               movdqa xmm9, xmm6
XDIS 14003b548: SSE       SSSE3      660F38047070             pmaddubsw xmm6, xmmword ptr [rax+0x70]
XDIS 14003b54e: SSE       SSSE3      66440F38044860           pmaddubsw xmm9, xmmword ptr [rax+0x60]
XDIS 14003b555: SSE       SSE2       660FEDCF                 paddsw xmm1, xmm7
XDIS 14003b559: BINARY    BASE       4883E880                 sub rax, 0xffffffffffffff80
XDIS 14003b55d: SSE       SSE2       660FEDD6                 paddsw xmm2, xmm6
XDIS 14003b561: SSE       SSE2       660FF5D8                 pmaddwd xmm3, xmm0
XDIS 14003b565: SSE       SSE2       66450FEDC1               paddsw xmm8, xmm9
XDIS 14003b56a: SSE       SSE2       660FF5C8                 pmaddwd xmm1, xmm0
XDIS 14003b56e: SSE       SSE2       66440FF5C0               pmaddwd xmm8, xmm0
XDIS 14003b573: SSE       SSE2       660FF5D0                 pmaddwd xmm2, xmm0
XDIS 14003b577: SSE       SSE2       66410FFED8               paddd xmm3, xmm8
XDIS 14003b57c: SSE       SSE2       660FFECA                 paddd xmm1, xmm2
XDIS 14003b580: SSE       SSE2       660FFEDD                 paddd xmm3, xmm5
XDIS 14003b584: SSE       SSE2       660FFECC                 paddd xmm1, xmm4
XDIS 14003b588: DATAXFER  SSE2       660F6FEB                 movdqa xmm5, xmm3
XDIS 14003b58c: DATAXFER  SSE2       660F6FE1                 movdqa xmm4, xmm1
XDIS 14003b590: BINARY    BASE       4839D1                   cmp rcx, rdx
XDIS 14003b593: COND_BR   BASE       0F8547FFFFFF             jnz 0x14003b4e0
```

patch:
```
XDIS 14003b220: DATAXFER  SSE2       660F6F01                 movdqa xmm0, xmmword ptr [rcx]
XDIS 14003b224: DATAXFER  SSE2       660F6F4910               movdqa xmm1, xmmword ptr [rcx+0x10]
XDIS 14003b229: BINARY    BASE       4883C120                 add rcx, 0x20
XDIS 14003b22d: DATAXFER  SSE2       66440F6FD8               movdqa xmm11, xmm0
XDIS 14003b232: DATAXFER  SSE2       66440F6FE1               movdqa xmm12, xmm1
XDIS 14003b237: SSE       SSSE3      66440F380418             pmaddubsw xmm11, xmmword ptr [rax]
XDIS 14003b23d: SSE       SSSE3      66440F3804A080000000     pmaddubsw xmm12, xmmword ptr [rax+0x80]
XDIS 14003b247: SSE       SSE2       66450FEDDC               paddsw xmm11, xmm12
XDIS 14003b24c: SSE       SSE2       66440FF5DA               pmaddwd xmm11, xmm2
XDIS 14003b251: SSE       SSE2       66410FFEFB               paddd xmm7, xmm11
XDIS 14003b256: DATAXFER  SSE2       66440F6FD8               movdqa xmm11, xmm0
XDIS 14003b25b: DATAXFER  SSE2       66440F6FE1               movdqa xmm12, xmm1
XDIS 14003b260: SSE       SSSE3      66440F38045810           pmaddubsw xmm11, xmmword ptr [rax+0x10]
XDIS 14003b267: SSE       SSSE3      66440F3804A090000000     pmaddubsw xmm12, xmmword ptr [rax+0x90]
XDIS 14003b271: SSE       SSE2       66450FEDDC               paddsw xmm11, xmm12
XDIS 14003b276: SSE       SSE2       66440FF5DA               pmaddwd xmm11, xmm2
XDIS 14003b27b: SSE       SSE2       66450FFED3               paddd xmm10, xmm11
XDIS 14003b280: DATAXFER  SSE2       66440F6FD8               movdqa xmm11, xmm0
XDIS 14003b285: DATAXFER  SSE2       66440F6FE1               movdqa xmm12, xmm1
XDIS 14003b28a: SSE       SSSE3      66440F38045820           pmaddubsw xmm11, xmmword ptr [rax+0x20]
XDIS 14003b291: SSE       SSSE3      66440F3804A0A0000000     pmaddubsw xmm12, xmmword ptr [rax+0xa0]
XDIS 14003b29b: SSE       SSE2       66450FEDDC               paddsw xmm11, xmm12
XDIS 14003b2a0: SSE       SSE2       66440FF5DA               pmaddwd xmm11, xmm2
XDIS 14003b2a5: SSE       SSE2       66450FFEC3               paddd xmm8, xmm11
XDIS 14003b2aa: DATAXFER  SSE2       66440F6FD8               movdqa xmm11, xmm0
XDIS 14003b2af: DATAXFER  SSE2       66440F6FE1               movdqa xmm12, xmm1
XDIS 14003b2b4: SSE       SSSE3      66440F38045830           pmaddubsw xmm11, xmmword ptr [rax+0x30]
XDIS 14003b2bb: SSE       SSSE3      66440F3804A0B0000000     pmaddubsw xmm12, xmmword ptr [rax+0xb0]
XDIS 14003b2c5: SSE       SSE2       66450FEDDC               paddsw xmm11, xmm12
XDIS 14003b2ca: SSE       SSE2       66440FF5DA               pmaddwd xmm11, xmm2
XDIS 14003b2cf: SSE       SSE2       66450FFECB               paddd xmm9, xmm11
XDIS 14003b2d4: DATAXFER  SSE2       66440F6FD8               movdqa xmm11, xmm0
XDIS 14003b2d9: DATAXFER  SSE2       66440F6FE1               movdqa xmm12, xmm1
XDIS 14003b2de: SSE       SSSE3      66440F38045840           pmaddubsw xmm11, xmmword ptr [rax+0x40]
XDIS 14003b2e5: SSE       SSSE3      66440F3804A0C0000000     pmaddubsw xmm12, xmmword ptr [rax+0xc0]
XDIS 14003b2ef: SSE       SSE2       66450FEDDC               paddsw xmm11, xmm12
XDIS 14003b2f4: SSE       SSE2       66440FF5DA               pmaddwd xmm11, xmm2
XDIS 14003b2f9: SSE       SSE2       66410FFEF3               paddd xmm6, xmm11
XDIS 14003b2fe: DATAXFER  SSE2       66440F6FD8               movdqa xmm11, xmm0
XDIS 14003b303: DATAXFER  SSE2       66440F6FE1               movdqa xmm12, xmm1
XDIS 14003b308: SSE       SSSE3      66440F38045850           pmaddubsw xmm11, xmmword ptr [rax+0x50]
XDIS 14003b30f: SSE       SSSE3      66440F3804A0D0000000     pmaddubsw xmm12, xmmword ptr [rax+0xd0]
XDIS 14003b319: SSE       SSE2       66450FEDDC               paddsw xmm11, xmm12
XDIS 14003b31e: SSE       SSE2       66440FF5DA               pmaddwd xmm11, xmm2
XDIS 14003b323: SSE       SSE2       66410FFEEB               paddd xmm5, xmm11
XDIS 14003b328: DATAXFER  SSE2       66440F6FD8               movdqa xmm11, xmm0
XDIS 14003b32d: DATAXFER  SSE2       66440F6FE1               movdqa xmm12, xmm1
XDIS 14003b332: SSE       SSSE3      66440F38045860           pmaddubsw xmm11, xmmword ptr [rax+0x60]
XDIS 14003b339: SSE       SSSE3      66440F3804A0E0000000     pmaddubsw xmm12, xmmword ptr [rax+0xe0]
XDIS 14003b343: SSE       SSSE3      660F38044070             pmaddubsw xmm0, xmmword ptr [rax+0x70]
XDIS 14003b349: SSE       SSE2       66450FEDDC               paddsw xmm11, xmm12
XDIS 14003b34e: SSE       SSE2       66440FF5DA               pmaddwd xmm11, xmm2
XDIS 14003b353: SSE       SSE2       66410FFEE3               paddd xmm4, xmm11
XDIS 14003b358: SSE       SSSE3      660F380488F0000000       pmaddubsw xmm1, xmmword ptr [rax+0xf0]
XDIS 14003b361: BINARY    BASE       480500010000             add rax, 0x100
XDIS 14003b367: SSE       SSE2       660FEDC1                 paddsw xmm0, xmm1
XDIS 14003b36b: SSE       SSE2       660FF5C2                 pmaddwd xmm0, xmm2
XDIS 14003b36f: SSE       SSE2       660FFED8                 paddd xmm3, xmm0
XDIS 14003b373: BINARY    BASE       4839D1                   cmp rcx, rdx
XDIS 14003b376: COND_BR   BASE       0F85A4FEFFFF             jnz 0x14003b220
```

Bench of x86-64-modern target on my i7-920:
```
run       base       test     diff
  1     647015     662153   +15138
  2     623499     643276   +19777
  3     641628     652663   +11035
  4     640316     652238   +11922
  5     639743     671114   +31371
  6     646014     659538   +13524
  7     616516     647350   +30834
  8     640398     663469   +23071
  9     640562     670754   +30192
 10     649616     659712   +10096

Result of  10 runs
==================
base (...tockfish.exe) =     638531  +/- 6469
test (...una/tuna.exe) =     658227  +/- 5756
diff                   =     +19696  +/- 5334

speedup        = +0.0308
P(speedup > 0) =  1.0000
```

VNNI and AVX512 benchmarks are welcome.

```
STC:
LLR: 2.96 (-2.94,2.94) <-0.50,2.50>
Total: 51520 W: 4074 L: 3888 D: 43558
Ptnml(0-2): 111, 3136, 19097, 3288, 128
```

No functional changes.