### PR TITLE
Use "pedantic" flag also for mingw

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -368,7 +368,7 @@ ifeq ($(COMP),mingw)
 		CXX=g++
 	endif
 
-	CXXFLAGS += -Wextra -Wshadow
+	CXXFLAGS += -pedantic -Wextra -Wshadow
 	LDFLAGS += -static
 endif
 


### PR DESCRIPTION
This will avoid to run in fishtest a test where the linux machines exit from
the building process (wasting CPU) and only the windows machines run the test.
See:
https://tests.stockfishchess.org/tests/view/61122d732a8a49ac5be79996
https://github.com/SFisGOD/Stockfish/commit/4e422577d6ebd1f6ecf606189190b8f6fb03f6c9#comments

No functional change.