### PR TITLE
[RFC] Make UCI option handling more type-safe and the code cleaner.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -73,11 +73,11 @@ namespace Eval {
 
   void NNUE::init() {
 
-    useNNUE = Options["Use NNUE"];
+    useNNUE = UCI::Options.get_bool("Use NNUE");
     if (!useNNUE)
         return;
 
-    string eval_file = string(Options["EvalFile"]);
+    string eval_file = UCI::Options.get_string("EvalFile");
 
     #if defined(DEFAULT_NNUE_DIRECTORY)
     #define stringify2(x) #x
@@ -117,17 +117,14 @@ namespace Eval {
   /// NNUE::verify() verifies that the last net used was loaded successfully
   void NNUE::verify() {
 
-    string eval_file = string(Options["EvalFile"]);
+    string eval_file = UCI::Options.get_string("EvalFile");
 
     if (useNNUE && eval_file_loaded != eval_file)
     {
-        UCI::OptionsMap defaults;
-        UCI::init(defaults);
-
         string msg1 = "If the UCI option \"Use NNUE\" is set to true, network evaluation parameters compatible with the engine must be available.";
         string msg2 = "The option is set to true, but the network file " + eval_file + " was not loaded successfully.";
         string msg3 = "The UCI option EvalFile might need to specify the full path, including the directory name, to the network file.";
-        string msg4 = "The default net can be downloaded from: https://tests.stockfishchess.org/api/nn/" + string(defaults["EvalFile"]);
+        string msg4 = "The default net can be downloaded from: https://tests.stockfishchess.org/api/nn/" + std::string(EvalFileDefaultName);
         string msg5 = "The engine will be terminated now.";
 
         sync_cout << "info string ERROR: " << msg1 << sync_endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,14 +35,14 @@ int main(int argc, char* argv[]) {
   std::cout << engine_info() << std::endl;
 
   CommandLine::init(argc, argv);
-  UCI::init(Options);
+  UCI::init();
   Tune::init();
   PSQT::init();
   Bitboards::init();
   Position::init();
   Bitbases::init();
   Endgames::init();
-  Threads.set(size_t(Options["Threads"]));
+  Threads.set(UCI::Options.get_int("Threads"));
   Search::clear(); // After threads are up
   Eval::NNUE::init();
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1522,7 +1522,7 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
     // Check whether a position was repeated since the last zeroing move.
     bool rep = pos.has_repeated();
 
-    int dtz, bound = Options["Syzygy50MoveRule"] ? 900 : 1;
+    int dtz, bound = UCI::Options.get_bool("Syzygy50MoveRule") ? 900 : 1;
 
     // Probe and rank each move
     for (auto& m : rootMoves)
@@ -1596,7 +1596,7 @@ bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves) {
     StateInfo st;
     WDLScore wdl;
 
-    bool rule50 = Options["Syzygy50MoveRule"];
+    bool rule50 = UCI::Options.get_bool("Syzygy50MoveRule");
 
     // Probe and rank each move
     for (auto& m : rootMoves)

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -103,7 +103,7 @@ void Thread::idle_loop() {
   // some Windows NUMA hardware, for instance in fishtest. To make it simple,
   // just check if running threads are below a threshold, in this case all this
   // NUMA machinery is not needed.
-  if (Options["Threads"] > 8)
+  if (UCI::Options.get_int("Threads") > 8)
       WinProcGroup::bindThisThread(idx);
 
   while (true)
@@ -145,7 +145,7 @@ void ThreadPool::set(size_t requested) {
       clear();
 
       // Reallocate the hash with the new threadpool size
-      TT.resize(size_t(Options["Hash"]));
+      TT.resize(UCI::Options.get_int("Hash"));
 
       // Init thread number dependent search params.
       Search::init();

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -36,9 +36,9 @@ TimeManagement Time; // Our global time management object
 
 void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
 
-  TimePoint moveOverhead    = TimePoint(Options["Move Overhead"]);
-  TimePoint slowMover       = TimePoint(Options["Slow Mover"]);
-  TimePoint npmsec          = TimePoint(Options["nodestime"]);
+  TimePoint moveOverhead    = TimePoint(UCI::Options.get_int("Move Overhead"));
+  TimePoint slowMover       = TimePoint(UCI::Options.get_int("Slow Mover"));
+  TimePoint npmsec          = TimePoint(UCI::Options.get_int("nodestime"));
 
   // optScale is a percentage of available time to use for the current move.
   // maxScale is a multiplier applied to optimumTime.
@@ -94,7 +94,7 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
   optimumTime = TimePoint(optScale * timeLeft);
   maximumTime = TimePoint(std::min(0.8 * limits.time[us] - moveOverhead, maxScale * optimumTime));
 
-  if (Options["Ponder"])
+  if (UCI::Options.get_bool("Ponder"))
       optimumTime += optimumTime / 4;
 }
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -87,18 +87,19 @@ void TranspositionTable::clear() {
 
   std::vector<std::thread> threads;
 
-  for (size_t idx = 0; idx < Options["Threads"]; ++idx)
+  const size_t numThreads = UCI::Options.get_int("Threads");
+  for (size_t idx = 0; idx < numThreads; ++idx)
   {
-      threads.emplace_back([this, idx]() {
+      threads.emplace_back([this, idx, numThreads]() {
 
           // Thread binding gives faster search on systems with a first-touch policy
-          if (Options["Threads"] > 8)
+          if (numThreads > 8)
               WinProcGroup::bindThisThread(idx);
 
           // Each thread will zero its part of the hash table
-          const size_t stride = size_t(clusterCount / Options["Threads"]),
+          const size_t stride = size_t(clusterCount / numThreads),
                        start  = size_t(stride * idx),
-                       len    = idx != Options["Threads"] - 1 ?
+                       len    = idx != numThreads - 1 ?
                                 stride : clusterCount - start;
 
           std::memset(&table[start], 0, len * sizeof(Cluster));

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -66,8 +66,8 @@ static void make_option(const string& n, int v, const SetRange& r) {
   if (TuneResults.count(n))
       v = TuneResults[n];
 
-  Options[n] << UCI::Option(v, r(v).first, r(v).second, on_tune);
-  LastOption = &Options[n];
+  UCI::Options.add(n, UCI::Option::spin(v, r(v).first, r(v).second).on_change(on_tune));
+  LastOption = &UCI::Options.get(n);
 
   // Print formatted parameters, ready to be copy-pasted in Fishtest
   std::cout << n << ","
@@ -81,15 +81,15 @@ static void make_option(const string& n, int v, const SetRange& r) {
 template<> void Tune::Entry<int>::init_option() { make_option(name, value, range); }
 
 template<> void Tune::Entry<int>::read_option() {
-  if (Options.count(name))
-      value = int(Options[name]);
+  if (UCI::Options.exists(name))
+      value = UCI::Options.get_int(name);
 }
 
 template<> void Tune::Entry<Value>::init_option() { make_option(name, value, range); }
 
 template<> void Tune::Entry<Value>::read_option() {
-  if (Options.count(name))
-      value = Value(int(Options[name]));
+  if (UCI::Options.exists(name))
+      value = Value(UCI::Options.get_int(name));
 }
 
 template<> void Tune::Entry<Score>::init_option() {
@@ -98,11 +98,11 @@ template<> void Tune::Entry<Score>::init_option() {
 }
 
 template<> void Tune::Entry<Score>::read_option() {
-  if (Options.count("m" + name))
-      value = make_score(int(Options["m" + name]), eg_value(value));
+  if (UCI::Options.exists("m" + name))
+      value = make_score(UCI::Options.get_int("m" + name), eg_value(value));
 
-  if (Options.count("e" + name))
-      value = make_score(mg_value(value), int(Options["e" + name]));
+  if (UCI::Options.exists("e" + name))
+      value = make_score(mg_value(value), UCI::Options.get_int("e" + name));
 }
 
 // Instead of a variable here we have a PostUpdate function: just call it

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -68,7 +68,7 @@ namespace {
         return;
 
     states = StateListPtr(new std::deque<StateInfo>(1)); // Drop old and create a new one
-    pos.set(fen, Options["UCI_Chess960"], &states->back(), Threads.main());
+    pos.set(fen, UCI::Options.get_bool("UCI_Chess960"), &states->back(), Threads.main());
 
     // Parse move list (if any)
     while (is >> token && (m = UCI::to_move(pos, token)) != MOVE_NONE)
@@ -85,7 +85,7 @@ namespace {
 
     StateListPtr states(new std::deque<StateInfo>(1));
     Position p;
-    p.set(pos.fen(), Options["UCI_Chess960"], &states->back(), Threads.main());
+    p.set(pos.fen(), UCI::Options.get_bool("UCI_Chess960"), &states->back(), Threads.main());
 
     Eval::NNUE::verify();
 
@@ -110,8 +110,8 @@ namespace {
     while (is >> token)
         value += (value.empty() ? "" : " ") + token;
 
-    if (Options.count(name))
-        Options[name] = value;
+    if (UCI::Options.exists(name))
+        UCI::Options.set(name, value);
     else
         sync_cout << "No such option: " << name << sync_endl;
   }

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -20,6 +20,7 @@
 #include <cassert>
 #include <ostream>
 #include <sstream>
+#include <cmath>
 
 #include "evaluate.h"
 #include "misc.h"
@@ -33,18 +34,36 @@ using std::string;
 
 namespace Stockfish {
 
-UCI::OptionsMap Options; // Global object
-
 namespace UCI {
+
+OptionsMap Options; // Global object
 
 /// 'On change' actions, triggered by an option's value change
 void on_clear_hash(const Option&) { Search::clear(); }
-void on_hash_size(const Option& o) { TT.resize(size_t(o)); }
-void on_logger(const Option& o) { start_logger(o); }
-void on_threads(const Option& o) { Threads.set(size_t(o)); }
-void on_tb_path(const Option& o) { Tablebases::init(o); }
+void on_hash_size(const Option& o) { TT.resize(o.get_int()); }
+void on_logger(const Option& o) { start_logger(o.get_string()); }
+void on_threads(const Option& o) { Threads.set(o.get_int()); }
+void on_tb_path(const Option& o) { Tablebases::init(o.get_string()); }
 void on_use_NNUE(const Option& ) { Eval::NNUE::init(); }
 void on_eval_file(const Option& ) { Eval::NNUE::init(); }
+
+std::string option_type_to_string(OptionType t) {
+  switch (t) {
+    case OptionType::String:
+      return "string";
+    case OptionType::Button:
+      return "button";
+    case OptionType::Check:
+      return "check";
+    case OptionType::Spin:
+      return "spin";
+    case OptionType::Combo:
+      return "combo";
+  }
+
+  assert(false);
+  return "";
+}
 
 /// Our case insensitive less() function as required by UCI protocol
 bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const {
@@ -53,59 +72,24 @@ bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const 
          [](char c1, char c2) { return tolower(c1) < tolower(c2); });
 }
 
-
-/// UCI::init() initializes the UCI options to their hard-coded default values
-
-void init(OptionsMap& o) {
-
-  constexpr int MaxHashMB = Is64Bit ? 33554432 : 2048;
-
-  o["Debug Log File"]        << Option("", on_logger);
-  o["Threads"]               << Option(1, 1, 512, on_threads);
-  o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
-  o["Clear Hash"]            << Option(on_clear_hash);
-  o["Ponder"]                << Option(false);
-  o["MultiPV"]               << Option(1, 1, 500);
-  o["Skill Level"]           << Option(20, 0, 20);
-  o["Move Overhead"]         << Option(10, 0, 5000);
-  o["Slow Mover"]            << Option(100, 10, 1000);
-  o["nodestime"]             << Option(0, 0, 10000);
-  o["UCI_Chess960"]          << Option(false);
-  o["UCI_AnalyseMode"]       << Option(false);
-  o["UCI_LimitStrength"]     << Option(false);
-  o["UCI_Elo"]               << Option(1350, 1350, 2850);
-  o["UCI_ShowWDL"]           << Option(false);
-  o["SyzygyPath"]            << Option("<empty>", on_tb_path);
-  o["SyzygyProbeDepth"]      << Option(1, 1, 100);
-  o["Syzygy50MoveRule"]      << Option(true);
-  o["SyzygyProbeLimit"]      << Option(7, 0, 7);
-  o["Use NNUE"]              << Option(true, on_use_NNUE);
-  o["EvalFile"]              << Option(EvalFileDefaultName, on_eval_file);
-}
-
-
 /// operator<<() is used to print all the options default values in chronological
 /// insertion order (the idx field) and in the format defined by the UCI protocol.
 
 std::ostream& operator<<(std::ostream& os, const OptionsMap& om) {
 
-  for (size_t idx = 0; idx < om.size(); ++idx)
-      for (const auto& it : om)
-          if (it.second.idx == idx)
-          {
-              const Option& o = it.second;
-              os << "\noption name " << it.first << " type " << o.type;
+  for (auto&& iter : om.ordered) {
+      const std::string& name = iter->first;
+      const Option& o = iter->second;
+      os << "\noption name " << name << " type " << option_type_to_string(o.type);
 
-              if (o.type == "string" || o.type == "check" || o.type == "combo")
-                  os << " default " << o.defaultValue;
+      if (o.type == OptionType::String || o.type == OptionType::Check || o.type == OptionType::Combo)
+          os << " default " << o.defaultValue;
 
-              if (o.type == "spin")
-                  os << " default " << int(stof(o.defaultValue))
-                     << " min "     << o.min
-                     << " max "     << o.max;
-
-              break;
-          }
+      if (o.type == OptionType::Spin)
+          os << " default " << static_cast<int>(std::round(std::stod(o.defaultValue)))
+             << " min "     << o.min
+             << " max "     << o.max;
+  }
 
   return os;
 }
@@ -113,78 +97,184 @@ std::ostream& operator<<(std::ostream& os, const OptionsMap& om) {
 
 /// Option class constructors and conversion operators
 
-Option::Option(const char* v, OnChange f) : type("string"), min(0), max(0), on_change(f)
-{ defaultValue = currentValue = v; }
+Option::Option(OptionType t) :
+  type(t)
+{ }
 
-Option::Option(bool v, OnChange f) : type("check"), min(0), max(0), on_change(f)
-{ defaultValue = currentValue = (v ? "true" : "false"); }
-
-Option::Option(OnChange f) : type("button"), min(0), max(0), on_change(f)
-{}
-
-Option::Option(double v, int minv, int maxv, OnChange f) : type("spin"), min(minv), max(maxv), on_change(f)
-{ defaultValue = currentValue = std::to_string(v); }
-
-Option::Option(const char* v, const char* cur, OnChange f) : type("combo"), min(0), max(0), on_change(f)
-{ defaultValue = v; currentValue = cur; }
-
-Option::operator double() const {
-  assert(type == "check" || type == "spin");
-  return (type == "spin" ? stof(currentValue) : currentValue == "true");
+Option Option::string(const std::string& v) {
+  Option opt(OptionType::String);
+  opt.defaultValue = v;
+  opt.currentValue = v;
+  opt.allowEmpty = true;
+  return opt;
 }
 
-Option::operator std::string() const {
-  assert(type == "string");
+Option Option::button(OnChange ptr) {
+  Option opt(OptionType::Button);
+  opt.allowEmpty = true;
+  opt.onChange = ptr;
+  return opt;
+}
+
+Option Option::check(bool v) {
+  Option opt(OptionType::Check);
+  opt.defaultValue = (v ? "true" : "false");
+  opt.currentValue = opt.defaultValue;
+  opt.allowEmpty = false;
+  return opt;
+}
+
+Option Option::spin(int v, int min, int max) {
+  Option opt(OptionType::Spin);
+  opt.defaultValue = std::to_string(v);
+  opt.currentValue = opt.defaultValue;
+  opt.min = min;
+  opt.max = max;
+  opt.allowEmpty = false;
+  return opt;
+}
+
+Option Option::combo(const std::string& v, const std::string& allowedValues) {
+  Option opt(OptionType::Combo);
+  opt.defaultValue = v;
+  opt.currentValue = v;
+  opt.allowEmpty = false;
+  {
+      std::string token;
+      std::istringstream ss(allowedValues);
+      while (ss >> token)
+          if (token != "var")
+              opt.allowedComboValues.emplace(token);
+  }
+  return opt;
+}
+
+Option& Option::on_change(OnChange ptr) & {
+  onChange = ptr;
+  return *this;
+}
+
+Option&& Option::on_change(OnChange ptr) && {
+  onChange = ptr;
+  return std::move(*this);
+}
+
+Option& Option::allow_empty(bool allow) & {
+  allowEmpty = allow;
+  return *this;
+}
+
+Option&& Option::allow_empty(bool allow) && {
+  allowEmpty = allow;
+  return std::move(*this);
+}
+
+int Option::get_int() const {
+  assert(type == OptionType::Spin);
+  return static_cast<int>(std::round(std::stod(currentValue)));
+}
+
+double Option::get_double() const {
+  assert(type == OptionType::Spin);
+  return std::stod(currentValue);
+}
+
+std::string Option::get_string() const {
+  assert(type == OptionType::Combo || type == OptionType::String);
   return currentValue;
 }
 
-bool Option::operator==(const char* s) const {
-  assert(type == "combo");
-  return   !CaseInsensitiveLess()(currentValue, s)
-        && !CaseInsensitiveLess()(s, currentValue);
+bool Option::get_bool() const {
+  assert(type == OptionType::Check);
+  return currentValue == "true";
 }
 
-
-/// operator<<() inits options and assigns idx in the correct printing order
-
-void Option::operator<<(const Option& o) {
-
-  static size_t insert_order = 0;
-
-  *this = o;
-  idx = insert_order++;
+void OptionsMap::clear() {
+  unordered.clear();
+  ordered.clear();
 }
 
+bool OptionsMap::exists(const std::string& name) {
+  return unordered.count(name) != 0;
+}
+
+void OptionsMap::set(const std::string& name, const std::string& value) {
+  unordered.at(name) = value;
+}
+
+void OptionsMap::add(const std::string& name, Option&& option) {
+  auto [iter, inserted] = unordered.emplace(name, std::move(option));
+  ordered.emplace_back(iter);
+}
+
+const Option& OptionsMap::get(const std::string& name) {
+  return unordered.at(name);
+}
+
+int OptionsMap::get_int(const std::string& name) {
+  return get(name).get_int();
+}
+
+double OptionsMap::get_double(const std::string& name) {
+  return get(name).get_double();
+}
+
+std::string OptionsMap::get_string(const std::string& name) {
+  return get(name).get_string();
+}
+
+bool OptionsMap::get_bool(const std::string& name) {
+  return get(name).get_bool();
+}
+
+/// UCI::init() initializes the UCI options to their hard-coded default values
+
+void init() {
+
+  constexpr int MaxHashMB = Is64Bit ? 33554432 : 2048;
+
+  Options.clear();
+
+  Options.add("Debug Log File",    Option::string("").on_change(on_logger));
+  Options.add("Threads",           Option::spin(1, 1, 512).on_change(on_threads));
+  Options.add("Hash",              Option::spin(16, 1, MaxHashMB).on_change(on_hash_size));
+  Options.add("Clear Hash",        Option::button(on_clear_hash));
+  Options.add("Ponder",            Option::check(false));
+  Options.add("MultiPV",           Option::spin(1, 1, 500));
+  Options.add("Skill Level",       Option::spin(20, 0, 20));
+  Options.add("Move Overhead",     Option::spin(10, 0, 5000));
+  Options.add("Slow Mover",        Option::spin(100, 10, 1000));
+  Options.add("nodestime",         Option::spin(0, 0, 10000));
+  Options.add("UCI_Chess960",      Option::check(false));
+  Options.add("UCI_AnalyseMode",   Option::check(false));
+  Options.add("UCI_LimitStrength", Option::check(false));
+  Options.add("UCI_Elo",           Option::spin(1350, 1350, 2850));
+  Options.add("UCI_ShowWDL",       Option::check(false));
+  Options.add("SyzygyPath",        Option::string("<empty>").on_change(on_tb_path));
+  Options.add("SyzygyProbeDepth",  Option::spin(1, 1, 100));
+  Options.add("Syzygy50MoveRule",  Option::check(true));
+  Options.add("SyzygyProbeLimit",  Option::spin(7, 0, 7));
+  Options.add("Use NNUE",          Option::check(true).on_change(on_use_NNUE));
+  Options.add("EvalFile",          Option::string(EvalFileDefaultName).on_change(on_eval_file).allow_empty(false));
+}
 
 /// operator=() updates currentValue and triggers on_change() action. It's up to
 /// the GUI to check for option's limits, but we could receive the new value
 /// from the user by console window, so let's check the bounds anyway.
 
-Option& Option::operator=(const string& v) {
+Option& Option::operator=(const std::string& v) {
 
-  assert(!type.empty());
-
-  if (   (type != "button" && type != "string" && v.empty())
-      || (type == "check" && v != "true" && v != "false")
-      || (type == "spin" && (stof(v) < min || stof(v) > max)))
+  if (   (!allowEmpty && v.empty())
+      || (type == OptionType::Check && v != "true" && v != "false")
+      || (type == OptionType::Spin && (std::stod(v) < min || std::stod(v) > max))
+      || (type == OptionType::Combo && allowedComboValues.count(v) == 0))
       return *this;
 
-  if (type == "combo")
-  {
-      OptionsMap comboMap; // To have case insensitive compare
-      string token;
-      std::istringstream ss(defaultValue);
-      while (ss >> token)
-          comboMap[token] << Option();
-      if (!comboMap.count(v) || v == "var")
-          return *this;
-  }
-
-  if (type != "button")
+  if (type != OptionType::Button)
       currentValue = v;
 
-  if (on_change)
-      on_change(*this);
+  if (onChange)
+      onChange(*this);
 
   return *this;
 }


### PR DESCRIPTION
This patch cleans up the syntax and semantics of the code handling UCI options. The following changes have been done:

- add a proper `OptionsMap` class that holds both ordered an unordered options
  - prevents accidental O(n^2) when printing the options. If my understanding is correct this could be an issue with a lot of tunable parameters.
- the allowed combo values are parsed on option creation instead of each assignment
- the accessors are explicitly typed to prevent prevent ambiguity, casting, and to know the type on the caller side
- `Options` was moved to the `UCI` namespace
- `NNUE::verify` no longer uses a hacky way of getting the default nnue file name
- an `allowEmpty` field is added to each option, see https://github.com/official-stockfish/Stockfish/pull/3668
- chain syntax for initializing optional fields in the option (onChange, allowEmpty)
- named constructors for creating options
  - include the option type in the name, no need to do the mental work of resolving the overloads
- get rid of a stringly-typed option type in favor of a closed set of types (enum)
- correctly use `stod` instead of stof for reading `double` options
- round instead of truncate when reading `double` option values as `int`
- don't abuse `operator<<` for adding options to the `OptionsMap`

I want to get some feedback regarding this, which changes are good and which are bad in your eyes, and whether there's a chance of getting this merged. If this is to be merged we will need to test for non-regression on fishtest and also verify whether the tuning works correctly.