### PR TITLE
Remove eval grain from classical evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1027,10 +1027,7 @@ make_v:
         Trace::add(PAWN, pe->pawn_score(WHITE), pe->pawn_score(BLACK));
         Trace::add(MOBILITY, mobility[WHITE], mobility[BLACK]);
     }
-
-    // Evaluation grain
-    v = (v / 16) * 16;
-
+    
     // Side to move point of view
     v = (pos.side_to_move() == WHITE ? v : -v);
 


### PR DESCRIPTION
Trying to add evaluation grain to nnue failed. This lead me to test whether it is still needed in the "classical" evaluation.
The removal passed both STC and LTC with non-regression bounds.

STC: 
LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 25144 W: 6441 L: 6305 D: 12398
Ptnml(0-2): 73, 2868, 6587, 2938, 106
https://tests.stockfishchess.org/tests/view/61241b355318138ee12047da

LTC:
LLR: 2.96 (-2.94,2.94) <-2.50,0.50>
Total: 56744 W: 14384 L: 14299 D: 28061
Ptnml(0-2): 38, 6136, 15947, 6205, 46
https://tests.stockfishchess.org/tests/view/6124735e5318138ee120481a

bench: 5046349