### PR TITLE
Fix uninitialized ss->ply in data generator

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1978,6 +1978,9 @@ namespace Search
       for (int i = 7; i > 0; i--)
           (ss - i)->continuationHistory = &th->continuationHistory[0][0][NO_PIECE][0]; // Use as a sentinel
 
+      for (int i = 0; i <= MAX_PLY + 2; ++i)
+          (ss + i)->ply = i;
+
       // set rootMoves
       auto& rootMoves = th->rootMoves;
 


### PR DESCRIPTION
https://github.com/official-stockfish/Stockfish/commit/9fd5b44d60c53357bb76d4c51f20d3d5aa31ebe3 changed how ss->ply is assigned and the change was not ported to the data generator back then.