### PR TITLE
Introduce extensions for captures and promotions.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1094,6 +1094,9 @@ moves_loop: // When in check, search starts here
                   return beta;
           }
       }
+      // Captures extension for PvNodes and cutNodes
+      else if (   (PvNode || cutNode) && captureOrPromotion && moveCount != 1)
+          extension = 1;
       else if (   givesCheck
                && depth > 6
                && abs(ss->staticEval) > Value(100))


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/6134abf325b9b35584838574
LLR: 2.95 (-2.94,2.94) <-0.50,2.50>
Total: 188920 W: 47754 L: 47304 D: 93862
Ptnml(0-2): 595, 21754, 49344, 22140, 627 
passed LTC
https://tests.stockfishchess.org/tests/view/613521de25b9b355848385d7
LLR: 2.93 (-2.94,2.94) <0.50,3.50>
Total: 8768 W: 2283 L: 2098 D: 4387
Ptnml(0-2): 7, 866, 2452, 1053, 6 
This patch introduces extension for captures and promotions.
Every capture or promotion that is not the first move in the list gets extended at PvNodes and cutNodes.
Special thanks to @locutus2 - all my previous attepmts that failed on this idea were done only for PvNodes - idea to include also cutNodes was based on his latest passed patch.