### PR TITLE
Decrease depth for cutnodes with no tt move.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -903,11 +903,16 @@ namespace {
          ss->ttPv = ttPv;
     }
 
-    // Step 10. If the position is not in TT, decrease depth by 2
+    // Step 10. If the position is not in TT, decrease depth by 2 or 1 depending on node type
     if (   PvNode
         && depth >= 6
         && !ttMove)
         depth -= 2;
+
+    if (   cutNode
+        && depth >= 9
+        && !ttMove)
+        depth--;
 
 moves_loop: // When in check, search starts here
 


### PR DESCRIPTION
Passed STC
https://tests.stockfishchess.org/tests/view/613abf5a689039fce12e1155
LLR: 2.94 (-2.94,2.94) <-0.50,2.50>
Total: 90336 W: 23108 L: 22804 D: 44424
Ptnml(0-2): 286, 10316, 23642, 10656, 268 
Passed LTC
https://tests.stockfishchess.org/tests/view/613ae330689039fce12e1172
LLR: 2.94 (-2.94,2.94) <0.50,3.50>
Total: 37736 W: 9607 L: 9346 D: 18783
Ptnml(0-2): 21, 3917, 10730, 4180, 20 
By analogy to existing logic of decreasing depth for PvNodes w/o tt move do the same for cutNodes.
bench 5891181