### PR TITLE
Add "max_time_*" options to "generate_training_data" tool.

### DIFF
--- a/docs/generate_training_data.md
+++ b/docs/generate_training_data.md
@@ -22,7 +22,9 @@ Currently the following options are available:
 
 `nodes` - the number of nodes to use for evaluation of each position. This number is multiplied by the number of PVs of the current search. This does NOT override the `depth` and `depth2` options. If specified then whichever of depth or nodes limit is reached first applies.
 
-`count` - the number of training data entries to generate. 1 entry == 1 position. Default: 8000000000 (8B).
+`count` - the number of training data entries to generate. 1 entry == 1 position. If both `count` and `max_time_*` are specified the data generation process will end when any of conditions is fullfilled. Default: 8000000000 (8B).
+
+`max_time_seconds`, `max_time_minutes`, `max_time_hours` - specifies the maximum runtime for the data generation. The data generation will NOT be interrupted while a self-play game is in progress. If both `count` and `max_time_*` are specified the data generation process will end when any of conditions is fullfilled. Default: \~250 years.
 
 `output_file_name` - the name of the file to output to. If the extension is not present or doesn't match the selected training data format the right extension will be appened. Default: generated_kifu
 


### PR DESCRIPTION
Requested by @vondele.

`max_time_seconds`, `max_time_minutes`, `max_time_hours` - specifies the maximum runtime for the data generation. The data generation will NOT be interrupted while a self-play game is in progress. If both `count` and `max_time_*` are specified the data generation process will end when any of conditions is fullfilled. Default: \~250 years.

Example use:
```
c:\dev\stockfish-master\src>stockfish.exe
Stockfish 140921 by the Stockfish developers (see AUTHORS file)
generate_training_data count 10000000 max_time_seconds 1
INFO: Executing generate_training_data command
INFO: Parameters:
  - search_depth_min       = 3
  - search_depth_max       = 3
  - nodes                  = 0
  - count                  = 10000000
  - max_time_seconds       = 1
  - eval_limit             = 3000
  - num threads (UCI)      = 1
  - random_move_min_ply    = 1
  - random_move_max_ply    = 24
  - random_move_count      = 5
  - random_move_like_apery = 0
  - random_multi_pv        = 0
  - random_multi_pv_diff   = 32000
  - random_multi_pv_depth  = 3
  - write_min_ply          = 16
  - write_max_ply          = 400
  - book                   =
  - output_file_name       = training_data
  - save_every             = 18446744073709551615
  - random_file_name       = 0
  - write_drawn_games      = 1
  - draw by low score      = 1
  - draw by insuff. mat.   = 1
info string NNUE evaluation using nn-e8321e467bf6.nnue enabled
INFO (sfen_writer): Creating new data file at training_data
PRNG::seed = 6dc6f498ba0dbe05

0 sfens, at Tue Sep 14 14:47:06 2021

1546 sfens, 1539 sfens/second, at Tue Sep 14 14:47:07 2021

INFO: generate_training_data finished.
generate_training_data count 10000000 max_time_seconds 10
INFO: Executing generate_training_data command
INFO: Parameters:
  - search_depth_min       = 3
  - search_depth_max       = 3
  - nodes                  = 0
  - count                  = 10000000
  - max_time_seconds       = 10
  - eval_limit             = 3000
  - num threads (UCI)      = 1
  - random_move_min_ply    = 1
  - random_move_max_ply    = 24
  - random_move_count      = 5
  - random_move_like_apery = 0
  - random_multi_pv        = 0
  - random_multi_pv_diff   = 32000
  - random_multi_pv_depth  = 3
  - write_min_ply          = 16
  - write_max_ply          = 400
  - book                   =
  - output_file_name       = training_data
  - save_every             = 18446744073709551615
  - random_file_name       = 0
  - write_drawn_games      = 1
  - draw by low score      = 1
  - draw by insuff. mat.   = 1
info string NNUE evaluation using nn-e8321e467bf6.nnue enabled
INFO (sfen_writer): Creating new data file at training_data
PRNG::seed = 9e2e89a9d0194fc8

0 sfens, at Tue Sep 14 14:47:12 2021
...
15178 sfens, 1516 sfens/second, at Tue Sep 14 14:47:22 2021

INFO: generate_training_data finished.
```