### PR TITLE
Fix usage of sync_endl instead of endl causing UB mutex unlock.

### DIFF
--- a/src/tools/training_data_generator.cpp
+++ b/src/tools/training_data_generator.cpp
@@ -715,9 +715,9 @@ namespace Stockfish::Tools
         const auto now_time = now();
 
         out
-            << endl
+            << '\n'
             << 0 << " sfens, "
-            << "at " << now_string() << sync_endl;
+            << "at " << now_string() << endl;
 
         last_stats_report_time = now_time;
 
@@ -730,10 +730,10 @@ namespace Stockfish::Tools
         const TimePoint elapsed = now_time - last_stats_report_time + 1;
 
         out
-            << endl
+            << '\n'
             << done << " sfens, "
             << new_done * 1000 / elapsed << " sfens/second, "
-            << "at " << now_string() << sync_endl;
+            << "at " << now_string() << endl;
 
         last_stats_report_time = now_time;
 


### PR DESCRIPTION
```
WARNING: ThreadSanitizer: unlock of an unlocked mutex (or by a wrong thread) (pid=82492)
    #0 pthread_mutex_unlock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4179 (libtsan.so.0+0x3aadc)
    #1 __gthread_mutex_unlock /usr/include/x86_64-linux-gnu/c++/9/bits/gthr-default.h:779 (stockfish+0x3483e)
    #2 std::mutex::unlock() /usr/include/c++/9/bits/std_mutex.h:118 (stockfish+0x34901)
    #3 Stockfish::operator<<(std::ostream&, Stockfish::SyncCout) /home/vondele/chess/vondele/Stockfish/src/misc.cpp:312 (stockfish+0x33b53)
    #4 void Stockfish::SynchronizedRegionLogger::write<Stockfish::SyncCout>(unsigned long, Stockfish::SyncCout const&) misc.h:289 (stockfish+0xb319b)
    #5 Stockfish::SynchronizedRegionLogger::Region& Stockfish::SynchronizedRegionLogger::Region::operator<< <Stockfish::SyncCout>(Stockfish::SyncCout const&) misc.h:218 (stockfish+0xb31e3)
    #6 Stockfish::Tools::TrainingDataGenerator::initial_report() tools/training_data_generator.cpp:725 (stockfish+0xa5d46)
    #7 Stockfish::Tools::TrainingDataGenerator::generate(unsigned long, unsigned long) tools/training_data_generator.cpp:236 (stockfish+0xa60ec)
    #8 Stockfish::Tools::generate_training_data(std::__cxx11::basic_istringstream<char, std::char_traits<char>, std::allocator<char> >&) tools/training_data_generator.cpp:940 (stockfish+0xa726f)
    #9 Stockfish::UCI::loop(int, char**) /home/vondele/chess/vondele/Stockfish/src/uci.cpp:363 (stockfish+0x7222d)
    #10 main /home/vondele/chess/vondele/Stockfish/src/main.cpp:51 (stockfish+0x31480)

  Location is global 'Stockfish::operator<<(std::ostream&, Stockfish::SyncCout)::m' of size 40 at 0x55e981edb520 (stockfish+0x000002f6d520)

  Mutex M113 (0x55e981edb520) created at:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4165 (libtsan.so.0+0x526fc)
    #1 __gthread_mutex_lock /usr/include/x86_64-linux-gnu/c++/9/bits/gthr-default.h:749 (stockfish+0x34806)
    #2 std::mutex::lock() /usr/include/c++/9/bits/std_mutex.h:100 (stockfish+0x348d5)
    #3 Stockfish::operator<<(std::ostream&, Stockfish::SyncCout) /home/vondele/chess/vondele/Stockfish/src/misc.cpp:309 (stockfish+0x33b45)
    #4 Stockfish::Eval::NNUE::verify() /home/vondele/chess/vondele/Stockfish/src/evaluate.cpp:157 (stockfish+0x2e2ac)
    #5 Stockfish::Tools::generate_training_data(std::__cxx11::basic_istringstream<char, std::char_traits<char>, std::allocator<char> >&) tools/training_data_generator.cpp:935 (stockfish+0xa721a)
    #6 Stockfish::UCI::loop(int, char**) /home/vondele/chess/vondele/Stockfish/src/uci.cpp:363 (stockfish+0x7222d)
    #7 main /home/vondele/chess/vondele/Stockfish/src/main.cpp:51 (stockfish+0x31480)

SUMMARY: ThreadSanitizer: unlock of an unlocked mutex (or by a wrong thread) /usr/include/x86_64-linux-gnu/c++/9/bits/gthr-default.h:779 in __gthread_mutex_unlock
```

The reporting code was erroneusly using `sync_endl`, which was not correctly paired with `sync_cout`, causing unlocking an unlocked mutex, potentially leading to wrong behaviour elsewhere.