### PR TITLE
Prevent search explosion in data generation when search is bounded by node count.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -577,6 +577,7 @@ namespace {
     {
         // Step 2. Check for aborted search and immediate draw
         if (   Threads.stop.load(std::memory_order_relaxed)
+            || (Limits.nodesThisThread && thisThread->nodes.load(std::memory_order_relaxed) >= Limits.nodesThisThread)
             || pos.is_draw(ss->ply)
             || ss->ply >= MAX_PLY)
             return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate(pos)
@@ -2061,6 +2062,13 @@ namespace Search
 
   ValueAndPV search(Position& pos, int depth_, size_t multiPV /* = 1 */, uint64_t nodesLimit /* = 0 */)
   {
+    // Sometimes a depth takes extreme amount of time (in the order of x1000 or more)
+    // than the previous depth, which can cause the search bounded by nodes to go for a long time.
+    // Because of that we add an additional limit that's 10x higher and is checked within
+    // the search function and can kill the search regardless of whether the full depth
+    // has been completed or not.
+    constexpr uint64_t nodesOversearchFactor = 10;
+
     std::vector<Move> pvs;
 
     Depth depth = depth_;
@@ -2101,6 +2109,11 @@ namespace Search
     Value delta = -VALUE_INFINITE;
     Value bestValue = -VALUE_INFINITE;
 
+    if (nodesLimit != 0)
+    {
+      Limits.nodesThisThread = nodesLimit * nodesOversearchFactor;
+    }
+
     while ((rootDepth += 1) <= depth
       // exit this loop even if the node limit is exceeded
       // The number of search nodes is passed in the argument of this function.
@@ -2140,6 +2153,11 @@ namespace Search
         {
           Depth adjustedDepth = std::max(1, rootDepth);
           bestValue = Stockfish::search<Root>(pos, ss, alpha, beta, adjustedDepth, false);
+
+          if (Limits.nodesThisThread && th->nodes.load(std::memory_order_relaxed) >= Limits.nodesThisThread)
+          {
+            break;
+          }
 
           stable_sort(rootMoves.begin() + pvIdx, rootMoves.end());
           //my_stable_sort(pos.this_thread()->thread_id(),&rootMoves[0] + pvIdx, rootMoves.size() - pvIdx);
@@ -2186,6 +2204,8 @@ namespace Search
 
     // Considering multiPV, the score of rootMoves[0] is returned as bestValue.
     bestValue = rootMoves[0].score;
+
+    Limits.nodesThisThread = 0;
 
     return ValueAndPV(bestValue, pvs);
   }

--- a/src/search.h
+++ b/src/search.h
@@ -92,6 +92,7 @@ struct LimitsType {
     time[WHITE] = time[BLACK] = inc[WHITE] = inc[BLACK] = npmsec = movetime = TimePoint(0);
     movestogo = depth = mate = perft = infinite = 0;
     nodes = 0;
+    nodesThisThread = 0;
     silent = false;
   }
 
@@ -103,6 +104,7 @@ struct LimitsType {
   TimePoint time[COLOR_NB], inc[COLOR_NB], npmsec, movetime, startTime;
   int movestogo, depth, mate, perft, infinite;
   int64_t nodes;
+  uint64_t nodesThisThread;
   // Silent mode that does not output to the screen (for continuous self-play in process)
   // Do not output PV at this time.
   bool silent;

--- a/src/tools/training_data_generator.cpp
+++ b/src/tools/training_data_generator.cpp
@@ -224,6 +224,7 @@ namespace Stockfish::Tools
 
         // If you use this, it will be compared with the accumulated nodes of each thread. Therefore, do not use it.
         limits.nodes = 0;
+        limits.nodesThisThread = 0;
 
         // depth is also processed by the one passed as an argument of Tools::search().
         limits.depth = 0;


### PR DESCRIPTION
Sometimes a depth takes extreme amount of time (in the order of x1000 or more) than the previous depth, which can cause the search bounded by nodes to go for a long time. Because of that we add an additional limit that's 10x higher and is checked within
the search function and can kill the search regardless of whether the full depth has been completed or not.