### PR TITLE
Prevent search explosion in data generation when search is bounded by node count.

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -34,7 +34,7 @@ ThreadPool Threads; // Global object
 /// Thread constructor launches the thread and waits until it goes to sleep
 /// in idle_loop(). Note that 'searching' and 'exit' should be already set.
 
-Thread::Thread(size_t n) : idx(n), stdThread(&Thread::idle_loop, this) {
+Thread::Thread(size_t n) : idx(n), stdThread(&Thread::idle_loop, this), maxNodes(0) {
 
   wait_for_search_finished();
   wait_for_worker_finished();

--- a/src/thread.h
+++ b/src/thread.h
@@ -92,6 +92,7 @@ public:
   int selDepth, nmpMinPly;
   Color nmpColor;
   std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;
+  uint64_t maxNodes;
 
   Position rootPos;
   StateInfo rootState;


### PR DESCRIPTION
Sometimes a depth takes extreme amount of time (in the order of x1000 or more) than the previous depth, which can cause the search bounded by nodes to go for a long time. Because of that we add an additional limit that's 10x higher and is checked within
the search function and can kill the search regardless of whether the full depth has been completed or not.