### PR TITLE
Try new strategy to limit double extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1069,10 +1069,10 @@ moves_loop: // When in check, search starts here
               extension = 1;
               singularQuietLMR = !ttCapture;
 
-              // Avoid search explosion by limiting the number of double extensions to at most 3
+              // Avoid search explosion by limiting the number of double extensions
               if (   !PvNode
-                  && value < singularBeta - 93
-                  && ss->doubleExtensions < 3)
+                  && value < singularBeta - 51 - 50*std::min(1,ss->doubleExtensions)
+                  && ss->doubleExtensions <= 5)
               {
                   extension = 2;
                   doubleExtension = true;


### PR DESCRIPTION
The idea of this change is to be more flexible with double extensions
and to use a dynamic limit instead of a fixed one. For sure further
tuning of this is possible.
Note: As viz pointed out it should probably be refactored by changing
std::min(1,ss->doubleExtensions) to i.e. "bool(ss->doubleExtensions)".

Passed STC
https://tests.stockfishchess.org/tests/view/61446a0826348c8594273220
LLR: 2.93 (-2.94,2.94) <-0.50,2.50>
Total: 25232 W: 6460 L: 6250 D: 12522
Ptnml(0-2): 85, 2830, 6580, 3032, 89

Passed LTC
https://tests.stockfishchess.org/tests/view/6144805a26348c8594273225
LLR: 2.94 (-2.94,2.94) <0.50,3.50>
Total: 23384 W: 6043 L: 5821 D: 11520
Ptnml(0-2): 16, 2377, 6681, 2605, 13

Bench 6217697