### PR TITLE
Range reductions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -193,6 +193,7 @@ Unai Corzo (unaiic)
 Uri Blass (uriblass)
 Vince Negri (cuddlestmonkey)
 zz4032
+Ofek Shochat (ghostway)
 
 
 # Additionally, we acknowledge the authors and maintainers of fishtest,

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -72,9 +72,9 @@ namespace {
   // Reductions lookup table, initialized at startup
   int Reductions[MAX_MOVES]; // [depth or moveNumber]
 
-  Depth reduction(bool i, Depth d, int mn) {
+  Depth reduction(bool i, Depth d, int mn, bool b) {
     int r = Reductions[d] * Reductions[mn];
-    return (r + 534) / 1024 + (!i && r > 904);
+    return (r + 534) / 1024 + (!i && r > 904) + b;
   }
 
   constexpr int futility_move_count(bool improving, Depth depth) {
@@ -918,6 +918,7 @@ moves_loop: // When in check, search starts here
 
     ttCapture = ttMove && pos.capture_or_promotion(ttMove);
 
+    bool b = false;
     // Step 11. A small Probcut idea, when we are in check
     probCutBeta = beta + 409;
     if (   ss->inCheck
@@ -1005,7 +1006,7 @@ moves_loop: // When in check, search starts here
           moveCountPruning = moveCount >= futility_move_count(improving, depth);
 
           // Reduced depth of the next LMR search
-          int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount), 0);
+          int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount, b), 0);
 
           if (   captureOrPromotion
               || givesCheck)
@@ -1140,7 +1141,7 @@ moves_loop: // When in check, search starts here
               || !ss->ttPv)
           && (!PvNode || ss->ply > 1 || thisThread->id() % 4 != 3))
       {
-          Depth r = reduction(improving, depth, moveCount);
+          Depth r = reduction(improving, depth, moveCount, b);
 
           if (PvNode)
               r--;
@@ -1227,6 +1228,9 @@ moves_loop: // When in check, search starts here
 
           value = -search<PV>(pos, ss+1, -beta, -alpha,
                               std::min(maxNextDepth, newDepth), false);
+          if (value > ss->staticEval) {
+              b = true;
+          }
       }
 
       // Step 18. Undo move

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1006,7 +1006,7 @@ moves_loop: // When in check, search starts here
           moveCountPruning = moveCount >= futility_move_count(improving, depth);
 
           // Reduced depth of the next LMR search
-          int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount, b > 1), 0);
+          int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount, b > 2), 0);
 
           if (   captureOrPromotion
               || givesCheck)
@@ -1141,7 +1141,7 @@ moves_loop: // When in check, search starts here
               || !ss->ttPv)
           && (!PvNode || ss->ply > 1 || thisThread->id() % 4 != 3))
       {
-          Depth r = reduction(improving, depth, moveCount, b > 1);
+          Depth r = reduction(improving, depth, moveCount, b > 2);
 
           if (PvNode)
               r--;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1236,6 +1236,8 @@ moves_loop: // When in check, search starts here
           Depth d = std::clamp(newDepth - r, 1, newDepth + deeper);
 
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, d, true);
+
+          // range reductions
           if (ss->staticEval - value < 30 && depth > 7) {
               b += 1;
           }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -955,7 +955,7 @@ moves_loop: // When in check, search starts here
 
     ttCapture = ttMove && pos.capture_or_promotion(ttMove);
 
-    int b = 0;
+    int rangeReduction = 0;
     // Step 11. A small Probcut idea, when we are in check
     probCutBeta = beta + 409;
     if (   ss->inCheck
@@ -1237,9 +1237,9 @@ moves_loop: // When in check, search starts here
 
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, d, true);
 
-          // range reductions
+          // Range reductions (~3 Elo)
           if (ss->staticEval - value < 30 && depth > 7) {
-              b += 1;
+              rangeReduction += 1;
           }
 
           // If the son is reduced and fails high it will be re-searched at full depth

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -69,9 +69,9 @@ namespace {
   // Reductions lookup table, initialized at startup
   int Reductions[MAX_MOVES]; // [depth or moveNumber]
 
-  Depth reduction(bool i, Depth d, int mn, bool b) {
+  Depth reduction(bool i, Depth d, int mn, bool rangeReduction) {
     int r = Reductions[d] * Reductions[mn];
-    return (r + 534) / 1024 + (!i && r > 904) + b;
+    return (r + 534) / 1024 + (!i && r > 904) + rangeReduction;
   }
 
   constexpr int futility_move_count(bool improving, Depth depth) {
@@ -1042,7 +1042,7 @@ moves_loop: // When in check, search starts here
           moveCountPruning = moveCount >= futility_move_count(improving, depth);
 
           // Reduced depth of the next LMR search
-          int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount, b > 2), 0);
+          int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount, rangeReduction > 2), 0);
 
           if (   captureOrPromotion
               || givesCheck)
@@ -1177,7 +1177,7 @@ moves_loop: // When in check, search starts here
               || !ss->ttPv)
           && (!PvNode || ss->ply > 1 || thisThread->id() % 4 != 3))
       {
-          Depth r = reduction(improving, depth, moveCount, b > 2);
+          Depth r = reduction(improving, depth, moveCount, rangeReduction > 2);
 
           if (PvNode)
               r--;


### PR DESCRIPTION
adding reductions for when the delta between the static eval and the child's eval is consistently low.

passed STC
https://tests.stockfishchess.org/html/live_elo.html?614d7b3c7bdc23e77ceb8a5d
LLR: 2.95 (-2.94,2.94) <-0.50,2.50>
Total: 88872 W: 22672 L: 22366 D: 43834
Ptnml(0-2): 343, 10150, 23117, 10510, 316

passed LTC
https://tests.stockfishchess.org/html/live_elo.html?614daf3e7bdc23e77ceb8a82
LLR: 2.93 (-2.94,2.94) <0.50,3.50>
Total: 24368 W: 6153 L: 5928 D: 12287
Ptnml(0-2): 13, 2503, 6937, 2708, 23

possible improvements:

1. including more kinds of nodes
2. different kind of scoring for every type of node (pv, nonpv)
3.  tuning for the threshold