### PR TITLE
Extend quiet tt moves at PvNodes.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1149,6 +1149,13 @@ moves_loop: // When in check, search starts here
                && depth > 6
                && abs(ss->staticEval) > Value(100))
           extension = 1;
+    
+      // Quiet ttMove extensions
+      else if (   PvNode
+               && move == ttMove 
+               && move == ss->killers[0]
+               && (*contHist[0])[movedPiece][to_sq(move)] >= 10000)
+          extension = 1;
 
       // Add extension to new depth
       newDepth += extension;


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/614cca8e7bdc23e77ceb89f0
LLR: 2.96 (-2.94,2.94) <-0.50,2.50>
Total: 42944 W: 10932 L: 10695 D: 21317
Ptnml(0-2): 141, 4869, 11210, 5116, 136 
passed LTC
https://tests.stockfishchess.org/tests/view/614cf93d7bdc23e77ceb8a13
LLR: 2.93 (-2.94,2.94) <0.50,3.50>
Total: 156848 W: 39473 L: 38893 D: 78482
Ptnml(0-2): 125, 16327, 44913, 16961, 98 
Idea is to extend some quiet ttMoves if a lot of things indicate that it's going to be a good move.
1) move being a killer - so being the best move in nearby node;
2) reply continuation history is really good.
This is basically saying that move is good "in general" in this position and that it's a good reply to opponent move and that it was the best in this position somewhere in search - so extending it makes a lot of sense.
In general in past year we had a lot of extensions of different types, maybe there is smth more in it :)
bench 5714575