### PR TITLE
Increase reductions with thread count.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -173,7 +173,7 @@ namespace {
 void Search::init() {
 
   for (int i = 1; i < MAX_MOVES; ++i)
-      Reductions[i] = int(21.9 * std::log(i));
+      Reductions[i] = int((21.9 + std::log(Threads.size()) / 2) * std::log(i));
 }
 
 


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/615750702d02f48db3961b00
LLR: 2.96 (-2.94,2.94) <-0.50,2.50>
Total: 39736 W: 10205 L: 9986 D: 19545
Ptnml(0-2): 45, 4254, 11064, 4447, 58 
passed LTC
https://tests.stockfishchess.org/tests/view/6157d8935488e26ea5eace7f
LLR: 2.97 (-2.94,2.94) <0.50,3.50>
Total: 60352 W: 15530 L: 15218 D: 29604
Ptnml(0-2): 24, 5900, 18016, 6212, 24 
Respin of SMP idea that was simplified away recently. Basically doing more reductions with thread count since Lazy SMP naturally widens search.
With drawish book it got simplified away but with less drawish book it again gains elo, maybe trying to reinstall other ideas that were simplified away previously can be beneficial.
bench 5714575