### PR TITLE
Time-management fix in MultiPV mode.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1315,8 +1315,10 @@ moves_loop: // When in check, search starts here
                   rm.pv.push_back(*m);
 
               // We record how often the best move has been changed in each
-              // iteration. This information is used for time management and LMR
-              if (moveCount > 1)
+              // iteration. This information is used for time management and LMR.
+              // Note: in MultiPV mode we must take care to only do this for the
+              // first PV line.
+              if (moveCount > 1 && !thisThread->pvIdx)
                   ++thisThread->bestMoveChanges;
           }
           else


### PR DESCRIPTION
When playing games in MultiPV mode we must take care to only track the best move changing for the first PV line.
Otherwise, SF will spend most of its time for the initial moves after the book exit.

This has been observed and reported on discord, but can also be seen in games
played in Stefan Pohl's MultiPV experiment.

Tested with MultiPV=4.

STC https://tests.stockfishchess.org/tests/view/615c24b59d256038a969b990
LLR: 2.95 (-2.94,2.94) <-0.50,2.50>
Total: 1744 W: 694 L: 447 D: 603
Ptnml(0-2): 32, 125, 358, 278, 79 

LTC: https://tests.stockfishchess.org/tests/view/615c31769d256038a969b993
LLR: 2.94 (-2.94,2.94) <0.50,3.50>
Total: 2048 W: 723 L: 525 D: 800
Ptnml(0-2): 10, 158, 511, 314, 31 

Bench: 5714575