### PR TITLE
Increase reduction in case of multiple moves exceeding alpha.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -994,6 +994,8 @@ moves_loop: // When in check, search starts here
                          && (tte->bound() & BOUND_UPPER)
                          && tte->depth() >= depth;
 
+    int bestMoveCount = 0;
+
     // Step 12. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
     while ((move = mp.next_move(moveCountPruning)) != MOVE_NONE)
@@ -1187,7 +1189,7 @@ moves_loop: // When in check, search starts here
           Depth r = reduction(improving, depth, moveCount, rangeReduction > 2);
 
           // Decrease reduction if on the PV (~1 Elo)
-          if (PvNode)
+          if (PvNode && bestMoveCount <= 3)
               r--;
 
           // Decrease reduction if the ttHit running average is large (~0 Elo)
@@ -1340,7 +1342,10 @@ moves_loop: // When in check, search starts here
                   update_pv(ss->pv, move, (ss+1)->pv);
 
               if (PvNode && value < beta) // Update alpha! Always alpha < beta
+              {
                   alpha = value;
+                  bestMoveCount++;
+              }
               else
               {
                   assert(value >= beta); // Fail high


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/615f614783dd501a05b0aee2
LLR: 2.94 (-2.94,2.94) <-0.50,2.50>
Total: 141816 W: 36056 L: 35686 D: 70074
Ptnml(0-2): 499, 15131, 39273, 15511, 494 
passed LTC
https://tests.stockfishchess.org/tests/view/615fdff683dd501a05b0af35
LLR: 2.94 (-2.94,2.94) <0.50,3.50>
Total: 68536 W: 17221 L: 16891 D: 34424
Ptnml(0-2): 38, 6573, 20725, 6885, 47 
Idea of this patch is the following - in case we already have 4 moves that exceeded alpha in current position probability of finding 5th should be reasonably low.
Number 4 is completely arbitrary - there could and probably should be some tweaks, both in tweaking best move count threshold for more reductions and tweaking how they work - for example making more reductions with best move count linearly.
bench 6131513