### PR TITLE
Simplify ttHitAverage away

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -332,7 +332,6 @@ void Thread::search() {
 
   multiPV = std::min(multiPV, rootMoves.size());
 
-  ttHitAverage.set(50, 100);                  // initialize the running average at 50%
   doubleExtensionAverage[WHITE].set(0, 100);  // initialize the running average at 0%
   doubleExtensionAverage[BLACK].set(0, 100);  // initialize the running average at 0%
 
@@ -669,9 +668,6 @@ namespace {
         && !priorCapture
         && is_ok((ss-1)->currentMove))
         thisThread->lowPlyHistory[ss->ply - 1][from_to((ss-1)->currentMove)] << stat_bonus(depth - 5);
-
-    // running average of ttHit
-    thisThread->ttHitAverage.update(ss->ttHit);
 
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode
@@ -1180,10 +1176,6 @@ moves_loop: // When in check, search starts here
           // Decrease reduction if on the PV (~2 Elo)
           if (   PvNode
               && bestMoveCount <= 3)
-              r--;
-
-          // Decrease reduction if the ttHit running average is large (~0 Elo)
-          if (thisThread->ttHitAverage.is_greater(537, 1024))
               r--;
 
           // Decrease reduction if position is or has been on the PV

--- a/src/thread.h
+++ b/src/thread.h
@@ -60,7 +60,6 @@ public:
   Pawns::Table pawnsTable;
   Material::Table materialTable;
   size_t pvIdx, pvLast;
-  RunningAverage ttHitAverage;
   RunningAverage doubleExtensionAverage[COLOR_NB];
   uint64_t nodesLastExplosive;
   uint64_t nodesLastNormal;


### PR DESCRIPTION
Simplify ttHitAverage away, introduced in [here](https://github.com/BM123499/Stockfish/commit/fe124896b241b4791454fd151da10101ad48f6d7)

Few tweaks have been tried to keep the code, but they all failed:
https://tests.stockfishchess.org/tests/view/61656f7683dd501a05b0b292
https://tests.stockfishchess.org/tests/view/6165c0ca83dd501a05b0b2ca
https://tests.stockfishchess.org/tests/view/6165bf9683dd501a05b0b2c8
https://tests.stockfishchess.org/tests/view/6165719483dd501a05b0b29b
https://tests.stockfishchess.org/tests/view/6166c7fd83dd501a05b0b353
https://tests.stockfishchess.org/tests/view/6166c63b83dd501a05b0b350

STC:
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 58504 W: 14781 L: 14694 D: 29029
Ptnml(0-2): 175, 6718, 15426, 6711, 222
https://tests.stockfishchess.org/tests/view/6165112c83dd501a05b0b257

LTC:
LLR: 2.96 (-2.94,2.94) <-2.50,0.50>
Total: 33480 W: 8448 L: 8332 D: 16700
Ptnml(0-2): 21, 3569, 9447, 3679, 24
https://tests.stockfishchess.org/tests/view/61656fcf83dd501a05b0b294

bench: 4540339