### PR TITLE
Smooth improving. bench 4666087

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -590,7 +590,7 @@ namespace {
     bool captureOrPromotion, doFullDepthSearch, moveCountPruning,
          ttCapture, singularQuietLMR, noLMRExtension;
     Piece movedPiece;
-    int moveCount, captureCount, quietCount, bestMoveCount;
+    int moveCount, captureCount, quietCount, bestMoveCount, howImproving;
 
     // Step 1. Initialize node
     ss->inCheck        = pos.checkers();
@@ -766,6 +766,7 @@ namespace {
         // Skip early pruning when in check
         ss->staticEval = eval = VALUE_NONE;
         improving = false;
+        howImproving = 0;
         goto moves_loop;
     }
     else if (ss->ttHit)
@@ -808,9 +809,11 @@ namespace {
     // We define position as improving if static evaluation of position is better
     // Than the previous static evaluation at our turn
     // In case of us being in check at our previous move we look at move prior to it
-    improving =  (ss-2)->staticEval == VALUE_NONE
-               ? ss->staticEval > (ss-4)->staticEval || (ss-4)->staticEval == VALUE_NONE
-               : ss->staticEval > (ss-2)->staticEval;
+    howImproving =  (ss-2)->staticEval == VALUE_NONE ? (ss-4)->staticEval == VALUE_NONE ? 200
+               : ss->staticEval - (ss-4)->staticEval
+               : ss->staticEval - (ss-2)->staticEval;
+
+    improving = howImproving > 0;
 
     // Step 7. Futility pruning: child node (~50 Elo).
     // The depth condition is important for mate finding.
@@ -826,7 +829,7 @@ namespace {
         && (ss-1)->statScore < 23767
         &&  eval >= beta
         &&  eval >= ss->staticEval
-        &&  ss->staticEval >= beta - 20 * depth - 22 * improving + 168 * ss->ttPv + 177
+        &&  ss->staticEval >= beta - 20 * depth - howImproving / 15 + 168 * ss->ttPv + 177
         && !excludedMove
         &&  pos.non_pawn_material(us)
         && (ss->ply >= thisThread->nmpMinPly || us != thisThread->nmpColor))


### PR DESCRIPTION
Smooth dependency on improving margin in null move search.

[STC](https://tests.stockfishchess.org/tests/view/61689b8a1e5f6627cc1c0fdc)
LLR: 2.93 (-2.94,2.94) <-0.50,2.50>
Total: 17384 W: 4468 L: 4272 D: 8644
Ptnml(0-2): 42, 1919, 4592, 2079, 60 

[LTC](https://tests.stockfishchess.org/tests/view/6168a12c1e5f6627cc1c0fe3)
LLR: 2.94 (-2.94,2.94) <0.50,3.50>
Total: 45648 W: 11525 L: 11243 D: 22880
Ptnml(0-2): 26, 4731, 13036, 4997, 34 