### PR TITLE
Non functional simplification in Eval::evaluate

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1080,34 +1080,25 @@ make_v:
 Value Eval::evaluate(const Position& pos) {
 
   Value v;
+  
+  // If there is PSQ imbalance we use the classical eval, but we switch to
+  // NNUE eval faster when shuffling or with high material on the board
 
-  if (!useNNUE)
+  if (  !useNNUE 
+      || abs(eg_value(pos.psq_score())) * 5 
+      > (850 + pos.non_pawn_material() / 64) * (5 + pos.rule50_count()))
       v = Evaluation<NO_TRACE>(pos).value();
   else
   {
       // Scale and shift NNUE for compatibility with search and classical evaluation
-      auto  adjusted_NNUE = [&]()
-      {
-         int scale =   883
-                     + 32 * pos.count<PAWN>()
-                     + 32 * pos.non_pawn_material() / 1024;
+      int scale =   883
+                  + 32 * pos.count<PAWN>()
+                  + 32 * pos.non_pawn_material() / 1024;
 
-         Value nnue = NNUE::evaluate(pos, true) * scale / 1024;
+       v = NNUE::evaluate(pos, true) * scale /  1024;
 
-         if (pos.is_chess960())
-             nnue += fix_FRC(pos);
-
-         return nnue;
-      };
-
-      // If there is PSQ imbalance we use the classical eval, but we switch to
-      // NNUE eval faster when shuffling or if the material on the board is high.
-      int r50 = pos.rule50_count();
-      Value psq = Value(abs(eg_value(pos.psq_score())));
-      bool classical = psq * 5 > (850 + pos.non_pawn_material() / 64) * (5 + r50);
-
-      v = classical ? Evaluation<NO_TRACE>(pos).value()  // classical
-                    : adjusted_NNUE();                   // NNUE
+       if (pos.is_chess960())
+           v += fix_FRC(pos);
   }
 
   // Damp down the evaluation linearly when shuffling


### PR DESCRIPTION
The goal of this PR is to make the style in the function similar to the rest of the code. Non-functional change.