### PR TITLE
Simplify probCutCount away

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -893,19 +893,16 @@ namespace {
         assert(probCutBeta < VALUE_INFINITE);
 
         MovePicker mp(pos, ttMove, probCutBeta - ss->staticEval, &captureHistory);
-        int probCutCount = 0;
         bool ttPv = ss->ttPv;
         ss->ttPv = false;
 
-        while (   (move = mp.next_move()) != MOVE_NONE
-               && probCutCount < 2 + 2 * cutNode)
+        while (   (move = mp.next_move()) != MOVE_NONE)
             if (move != excludedMove && pos.legal(move))
             {
                 assert(pos.capture_or_promotion(move));
                 assert(depth >= 5);
 
                 captureOrPromotion = true;
-                probCutCount++;
 
                 ss->currentMove = move;
                 ss->continuationHistory = &thisThread->continuationHistory[ss->inCheck]


### PR DESCRIPTION
Simplify away the limitation in number of moves in probCut

STC
LLR: 2.96 (-2.94,2.94) <-2.50,0.50>
Total: 286768 W: 71888 L: 72133 D: 142747
Ptnml(0-2): 983, 33084, 75471, 32887, 959
https://tests.stockfishchess.org/tests/view/616c9b9b90e1312a3cd0ef0a

LTC:
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 69312 W: 17243 L: 17176 D: 34893
Ptnml(0-2): 42, 7452, 19614, 7493, 55
https://tests.stockfishchess.org/tests/view/616cebbf4f95b438f7a85f93

bench: 4980084