### PR TITLE
Simplify search explosion detection.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -92,8 +92,7 @@ namespace {
   ExplosionState search_explosion(Thread* thisThread) {
 
     uint64_t nodesNow = thisThread->nodes;
-    bool explosive =    thisThread->doubleExtensionAverage[WHITE].is_greater(2, 100)
-                     || thisThread->doubleExtensionAverage[BLACK].is_greater(2, 100);
+    bool explosive = thisThread->doubleExtensionAverage.is_greater(1, 100);
 
     if (explosive)
        thisThread->nodesLastExplosive = nodesNow;
@@ -332,8 +331,7 @@ void Thread::search() {
 
   multiPV = std::min(multiPV, rootMoves.size());
 
-  doubleExtensionAverage[WHITE].set(0, 100);  // initialize the running average at 0%
-  doubleExtensionAverage[BLACK].set(0, 100);  // initialize the running average at 0%
+  doubleExtensionAverage.set(0, 100);  // initialize the running average at 0%
 
   nodesLastExplosive = nodes;
   nodesLastNormal    = nodes;
@@ -639,7 +637,7 @@ namespace {
     Square prevSq        = to_sq((ss-1)->currentMove);
 
     // Update the running average statistics for double extensions
-    thisThread->doubleExtensionAverage[us].update(ss->depth > (ss-1)->depth);
+    thisThread->doubleExtensionAverage.update(ss->depth > (ss-1)->depth);
 
     // Initialize statScore to zero for the grandchildren of the current position.
     // So statScore is shared between all grandchildren and only the first grandchild

--- a/src/thread.h
+++ b/src/thread.h
@@ -60,7 +60,7 @@ public:
   Pawns::Table pawnsTable;
   Material::Table materialTable;
   size_t pvIdx, pvLast;
-  RunningAverage doubleExtensionAverage[COLOR_NB];
+  RunningAverage doubleExtensionAverage;
   uint64_t nodesLastExplosive;
   uint64_t nodesLastNormal;
   std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;


### PR DESCRIPTION
Use one running average for both sides together. For compensation the explosive threshold is decreased from 2% to 1%.

I checked also the position from the original search explosion commit
https://github.com/official-stockfish/Stockfish/commit/73018a03375b4b72ee482eb5a4a2152d7e4f0aac
up to depth 55 on my 1000 position bench in comparison to master with following commands:

./stockfish
ucinewgame
position fen 8/Pk6/8/1p6/8/P1K5/8/6B1 w - - 37 130
go infinite

searched nodes
master:  22245463
PR:        25683826

So only a moderate 15% node count increase occurs.

STC:
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 14712 W: 3777 L: 3632 D: 7303
Ptnml(0-2): 36, 1505, 4140, 1628, 47
https://tests.stockfishchess.org/tests/view/616db7204f95b438f7a8607c

LTC:
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 32664 W: 8187 L: 8077 D: 16400
Ptnml(0-2): 17, 3114, 9965, 3214, 22
https://tests.stockfishchess.org/tests/view/616eab99942d40685e323779

Bench: 5005810