### PR TITLE
Adjust TTdepth acceptance on early cutoff

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -673,7 +673,7 @@ namespace {
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode
         && ss->ttHit
-        && tte->depth() >= depth
+        && tte->depth() > depth
         && ttValue != VALUE_NONE // Possible in case of TT access race
         && (ttValue >= beta ? (tte->bound() & BOUND_LOWER)
                             : (tte->bound() & BOUND_UPPER)))


### PR DESCRIPTION
Increase ttdepth acceptance by 1 on early cutoff

STC:
LLR: 2.94 (-2.94,2.94) <-0.50,2.50>
Total: 63784 W: 16185 L: 15917 D: 31682
Ptnml(0-2): 231, 7309, 16531, 7603, 218
https://tests.stockfishchess.org/tests/view/616ed03a942d40685e3237c0

LTC:
LLR: 2.93 (-2.94,2.94) <0.50,3.50>
Total: 12728 W: 3268 L: 3072 D: 6388
Ptnml(0-2): 8, 1298, 3563, 1480, 15
https://tests.stockfishchess.org/tests/view/616ef156942d40685e32380a

bench: 6380807