### PR TITLE
Simplify Null move search condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -825,7 +825,7 @@ namespace {
         && (ss-1)->statScore < 23767
         &&  eval >= beta
         &&  eval >= ss->staticEval
-        &&  ss->staticEval >= beta - 20 * depth - improvement / 15 + 168 * ss->ttPv + 177
+        &&  ss->staticEval >= beta - 20 * depth - improvement / 15 + 177
         && !excludedMove
         &&  pos.non_pawn_material(us)
         && (ss->ply >= thisThread->nmpMinPly || us != thisThread->nmpColor))


### PR DESCRIPTION
Remove `ss->ttPv` condition on null move search condition

STC:
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 80832 W: 20276 L: 20221 D: 40335
Ptnml(0-2): 267, 9335, 21168, 9368, 278
https://tests.stockfishchess.org/tests/view/616ed4a0942d40685e3237c6

LTC:
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 54184 W: 13464 L: 13377 D: 27343
Ptnml(0-2): 37, 5758, 15435, 5805, 57
https://tests.stockfishchess.org/tests/view/616ef71f40f619782fd4f72d

bench: 6201607