### PR TITLE
Allow for first three moves always a two plies deeper LMR search.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1210,11 +1210,11 @@ moves_loop: // When in check, search starts here
           // In general we want to cap the LMR depth search at newDepth. But if reductions
           // are really negative and movecount is low, we allow this move to be searched
           // deeper than the first move (this may lead to hidden double extensions).
-          int deeper =   r >= -1                   ? 0
-                       : moveCount <= 3 && r <= -3 ? 2
-                       : moveCount <= 5            ? 1
-                       : PvNode && depth > 6       ? 1
-                       :                             0;
+          int deeper =   r >= -1             ? 0
+                       : moveCount <= 3      ? 2
+                       : moveCount <= 5      ? 1
+                       : PvNode && depth > 6 ? 1
+                       :                       0;
 
           Depth d = std::clamp(newDepth - r, 1, newDepth + deeper);
 


### PR DESCRIPTION
STC:
LLR: 2.96 (-2.94,2.94) <-2.50,0.50>
Total: 206096 W: 51966 L: 52093 D: 102037
Ptnml(0-2): 664, 23817, 54293, 23530, 744
https://tests.stockfishchess.org/tests/view/616f197d40f619782fd4f75a

LTC:
LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 62384 W: 15567 L: 15492 D: 31325
Ptnml(0-2): 40, 6633, 17777, 6696, 46
https://tests.stockfishchess.org/tests/view/616ffa1b4f0b65a0e231e682

Bench: 6154836