### PR TITLE
Make nnue code more idiomatic

### DIFF
--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -143,6 +143,7 @@ namespace Stockfish::Eval::NNUE {
     // overaligning stack variables with alignas() doesn't work correctly.
 
     constexpr uint64_t alignment = CacheLineSize;
+    int delta = 7;
 
 #if defined(ALIGNAS_ON_STACK_VARIABLES_BROKEN)
     TransformedFeatureType transformedFeaturesUnaligned[
@@ -162,20 +163,14 @@ namespace Stockfish::Eval::NNUE {
 
     const std::size_t bucket = (pos.count<ALL_PIECES>() - 1) / 4;
     const auto psqt = featureTransformer->transform(pos, transformedFeatures, bucket);
-    const auto output = network[bucket]->propagate(transformedFeatures, buffer);
+    const auto positional = network[bucket]->propagate(transformedFeatures, buffer)[0];
 
-    int materialist = psqt;
-    int positional  = output[0];
-
-    int delta_npm = abs(pos.non_pawn_material(WHITE) - pos.non_pawn_material(BLACK));
-    int entertainment = (adjusted && delta_npm <= RookValueMg - BishopValueMg ? 7 : 0);
-
-    int A = 128 - entertainment;
-    int B = 128 + entertainment;
-
-    int sum = (A * materialist + B * positional) / 128;
-
-    return static_cast<Value>( sum / OutputScale );
+    // Give more value to positional evaluation when material is balanced
+    if (   adjusted
+        && abs(pos.non_pawn_material(WHITE) - pos.non_pawn_material(BLACK)) <= RookValueMg - BishopValueMg)
+      return  static_cast<Value>(((128 - delta) * psqt + (128 + delta) * positional) / 128 / OutputScale);
+    else
+      return static_cast<Value>((psqt + positional) / OutputScale);
   }
 
   struct NnueEvalTrace {


### PR DESCRIPTION
Make the eval code in the evaluate_nnue.cpp more similar to the rest of the codebase:
- remove multiple variable assignment
- make if conditions explicit and indent on multiple lines

Tested on [STC](https://tests.stockfishchess.org/tests/view/616f250540f619782fd4f76d) for non-slowdown 

LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 59032 W: 14834 L: 14751 D: 29447
Ptnml(0-2): 176, 6310, 16459, 6397, 174 