### PR TITLE
Increase TTdepth acceptance only on half Threads

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -673,7 +673,7 @@ namespace {
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode
         && ss->ttHit
-        && tte->depth() > depth
+        && tte->depth() > depth - (thisThread->id() % 2 == 1)
         && ttValue != VALUE_NONE // Possible in case of TT access race
         && (ttValue >= beta ? (tte->bound() & BOUND_LOWER)
                             : (tte->bound() & BOUND_UPPER)))


### PR DESCRIPTION
Increase TTdepth acceptance only on half Threads

STC:
LLR: 2.96 (-2.94,2.94) <-0.50,2.50>
Total: 19272 W: 4956 L: 4766 D: 9550
Ptnml(0-2): 25, 1989, 5423, 2169, 30
https://tests.stockfishchess.org/tests/view/6172be6238cb9784038af9a7

LTC:
LLR: 2.93 (-2.94,2.94) <0.50,3.50>
Total: 23688 W: 6111 L: 5897 D: 11680
Ptnml(0-2): 2, 2275, 7081, 2479, 7
https://tests.stockfishchess.org/tests/view/6172e32938cb9784038af9c7

Non-functional on single-thread