### PR TITLE
Prune more in endgames

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1026,7 +1026,6 @@ moves_loop: // When in check, search starts here
 
       // Step 13. Pruning at shallow depth (~200 Elo). Depth conditions are important for mate finding.
       if (  !rootNode
-          && pos.non_pawn_material(us)
           && bestValue > VALUE_TB_LOSS_IN_MAX_PLY)
       {
           // Skip quiet moves if movecount exceeds our FutilityMoveCount threshold


### PR DESCRIPTION
seemingly no need anymore to exclude pawn endgames from pruning.

passed STC:
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 30504 W: 7776 L: 7650 D: 15078
Ptnml(0-2): 98, 3302, 8339, 3402, 111
https://tests.stockfishchess.org/tests/view/61703f534f0b65a0e231e6c8

passed LTC:
LLR: 2.93 (-2.94,2.94) <-2.50,0.50>
Total: 141480 W: 35272 L: 35303 D: 70905
Ptnml(0-2): 107, 14348, 41848, 14343, 94
https://tests.stockfishchess.org/tests/view/617056ca4f0b65a0e231e6ea

Bench: 6662758