### PR TITLE
Tuning of a Null Move Parameter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,7 @@
 # List of authors for Stockfish
 
 # Founders of the Stockfish project and fishtest infrastructure
-Tord Romstad (romstad) 
+Tord Romstad (romstad)
 Marco Costalba (mcostalba)
 Joona Kiiski (zamar)
 Gary Linscott (glinscott)


### PR DESCRIPTION
After the recent simplification of this formula, I felt that the parameters can be tuned also, and thankfully here is an elo gaining patch:

STC:
LLR: 2.99 (-2.94,2.94) <-0.50,2.50>
Total: 78744 W: 19956 L: 19664 D: 39124
Ptnml(0-2): 259, 9005, 20573, 9255, 280
https://tests.stockfishchess.org/tests/view/6172017a38cb9784038af947

LTC:
LLR: 2.95 (-2.94,2.94) <0.50,3.50>
Total: 68528 W: 17309 L: 16964 D: 34255
Ptnml(0-2): 41, 7194, 19455, 7527, 47
https://tests.stockfishchess.org/tests/view/6172994d38cb9784038af983