### PR TITLE
Simplify LMR multiThread condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1159,10 +1159,9 @@ moves_loop: // When in check, search starts here
       // cases where we extend a son if it has good chances to be "interesting".
       if (    depth >= 3
           &&  moveCount > 1 + 2 * rootNode
-          && (  !captureOrPromotion
-              || (cutNode && (ss-1)->moveCount > 1)
-              || !ss->ttPv)
-          && (!PvNode || ss->ply > 1 || thisThread->id() % 4 != 3))
+          && (   !ss->ttPv
+              || !captureOrPromotion
+              || (cutNode && (ss-1)->moveCount > 1)))
       {
           Depth r = reduction(improving, depth, moveCount, rangeReduction > 2);
 


### PR DESCRIPTION
Simplify LMR multiThread condition

STC:
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 110584 W: 27818 L: 27807 D: 54959
Ptnml(0-2): 156, 12089, 30791, 12100, 156
https://tests.stockfishchess.org/tests/view/6172ef436ce927be325583a9

LTC:
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 23632 W: 6025 L: 5903 D: 11704
Ptnml(0-2): 5, 2292, 7100, 2414, 5
https://tests.stockfishchess.org/tests/view/6173cf096ce927be32558412

No functional change in the single-threaded case