### PR TITLE
Fix sometimes incorrect key for prefetches

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1013,9 +1013,9 @@ void Position::do_null_move(StateInfo& newSt) {
   }
 
   st->key ^= Zobrist::side;
-  prefetch(TT.first_entry(key()));
-
   ++st->rule50;
+  prefetch(TT.first_entry(key()));
+  
   st->pliesFromNull = 0;
 
   sideToMove = ~sideToMove;


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/61737b4f6ce927be32558401
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 138712 W: 34914 L: 34942 D: 68856
Ptnml(0-2): 421, 14817, 38894, 14817, 407 

Very minor bug fix since Position::key() depends on the 50 move rule counter.
Comments: https://github.com/mstembera/Stockfish/commit/cddde31eed505cdf0c4fc8ff96b89f6e39c797e1
No functional change
bench: 6689428

