### PR TITLE
Even more double extend search via LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1211,8 +1211,7 @@ moves_loop: // When in check, search starts here
           // are really negative and movecount is low, we allow this move to be searched
           // deeper than the first move (this may lead to hidden double extensions).
           int deeper =   r >= -1             ? 0
-                       : moveCount <= 3      ? 2
-                       : moveCount <= 5      ? 1
+                       : moveCount <= 5      ? 2
                        : PvNode && depth > 6 ? 1
                        :                       0;
 


### PR DESCRIPTION
Allow now for the first five moves a two plies deeper LMR search.

STC:
LLR: 2.96 (-2.94,2.94) <-2.50,0.50>
Total: 99608 W: 25143 L: 25115 D: 49350
Ptnml(0-2): 291, 11444, 26328, 11428, 313
https://tests.stockfishchess.org/tests/view/61718c9438cb9784038af8d7

LTC:
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 52064 W: 13234 L: 13145 D: 25685
Ptnml(0-2): 35, 5431, 15014, 5514, 38
https://tests.stockfishchess.org/tests/view/6171e13e38cb9784038af928

Bench: 7222293