### PR TITLE
Adjust ButterflyHistory decay parameter

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -86,7 +86,7 @@ enum StatsType { NoCaptures, Captures };
 /// unsuccessful during the current search, and is used for reduction and move
 /// ordering decisions. It uses 2 tables (one for each color) indexed by
 /// the move's from and to squares, see www.chessprogramming.org/Butterfly_Boards
-typedef Stats<int16_t, 13365, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)> ButterflyHistory;
+typedef Stats<int16_t, 14365, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)> ButterflyHistory;
 
 /// At higher depths LowPlyHistory records successful quiet moves near the root
 /// and quiet moves which are/were in the PV (ttPv). LowPlyHistory is populated during


### PR DESCRIPTION
passed STC:
LLR: 2.98 (-2.94,2.94) <-0.50,2.50>
Total: 26680 W: 6807 L: 6593 D: 13280
Ptnml(0-2): 73, 3007, 6989, 3175, 96
https://tests.stockfishchess.org/tests/view/6174094e6ce927be32558441

passed LTC:
LLR: 2.98 (-2.94,2.94) <0.50,3.50>
Total: 21104 W: 5403 L: 5185 D: 10516
Ptnml(0-2): 8, 2160, 6001, 2372, 11
https://tests.stockfishchess.org/tests/view/61744927351812fe5f969864

Bench: 6891812