### PR TITLE
Remove all 'exit' stmts, use 'throw exception' instead

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -315,7 +315,7 @@ endif
 ### ==========================================================================
 
 ### 3.1 Selecting compiler (default = gcc)
-CXXFLAGS += -Wall -Wcast-qual -fno-exceptions -std=c++17 $(EXTRACXXFLAGS)
+CXXFLAGS += -Wall -Wcast-qual -fexceptions -std=c++17 $(EXTRACXXFLAGS)
 DEPENDFLAGS += -std=c++17
 LDFLAGS += $(EXTRALDFLAGS)
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -135,8 +135,7 @@ vector<string> setup_bench(const Position& current, istream& is) {
 
       if (!file.is_open())
       {
-          cerr << "Unable to open file " << fenFile << endl;
-          exit(EXIT_FAILURE);
+          throw std::runtime_error("Unable to open file " + fenFile);
       }
 
       while (getline(file, fen))

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -125,20 +125,13 @@ namespace Eval {
 
     if (useNNUE && currentEvalFileName != eval_file)
     {
-
-        string msg1 = "If the UCI option \"Use NNUE\" is set to true, network evaluation parameters compatible with the engine must be available.";
-        string msg2 = "The option is set to true, but the network file " + eval_file + " was not loaded successfully.";
-        string msg3 = "The UCI option EvalFile might need to specify the full path, including the directory name, to the network file.";
-        string msg4 = "The default net can be downloaded from: https://tests.stockfishchess.org/api/nn/" + std::string(EvalFileDefaultName);
-        string msg5 = "The engine will be terminated now.";
-
-        sync_cout << "info string ERROR: " << msg1 << sync_endl;
-        sync_cout << "info string ERROR: " << msg2 << sync_endl;
-        sync_cout << "info string ERROR: " << msg3 << sync_endl;
-        sync_cout << "info string ERROR: " << msg4 << sync_endl;
-        sync_cout << "info string ERROR: " << msg5 << sync_endl;
-
-        exit(EXIT_FAILURE);
+        std::stringstream stream;
+        stream
+            << "info string ERROR: If the UCI option \"Use NNUE\" is set to true, network evaluation parameters compatible with the engine must be available." << std::endl
+            << "info string ERROR: The option is set to true, but the network file " + eval_file + " was not loaded successfully." << std::endl
+            << "info string ERROR: The UCI option EvalFile might need to specify the full path, including the directory name, to the network file." << std::endl
+            << "info string ERROR: The default net can be downloaded from: https://tests.stockfishchess.org/api/nn/" + std::string(EvalFileDefaultName);
+        throw std::runtime_error(stream.str());
     }
 
     if (useNNUE)

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -123,8 +123,7 @@ public:
 
         if (!l.file.is_open())
         {
-            cerr << "Unable to open debug log file " << fname << endl;
-            exit(EXIT_FAILURE);
+            throw std::runtime_error("Unable to open debug log file " + fname);
         }
 
         cin.rdbuf(&l.in);
@@ -471,10 +470,11 @@ void aligned_large_pages_free(void* mem) {
   if (mem && !VirtualFree(mem, 0, MEM_RELEASE))
   {
       DWORD err = GetLastError();
-      std::cerr << "Failed to free large page memory. Error code: 0x"
-                << std::hex << err
-                << std::dec << std::endl;
-      exit(EXIT_FAILURE);
+      std::stringstream stream;
+      stream << "Failed to free large page memory. Error code: 0x"
+             << std::hex << err
+             << std::dec << std::endl;
+      throw std::runtime_error(stream.str());
   }
 }
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -217,9 +217,7 @@ public:
 
         if (statbuf.st_size % 64 != 16)
         {
-            std::cerr << "Corrupt tablebase file " << fname << std::endl;
-            exit(EXIT_FAILURE);
-        }
+            throw std::runtime_error("Corrupt tablebase file " + fname);        }
 
         *mapping = statbuf.st_size;
         *baseAddress = mmap(nullptr, statbuf.st_size, PROT_READ, MAP_SHARED, fd, 0);
@@ -230,8 +228,9 @@ public:
 
         if (*baseAddress == MAP_FAILED)
         {
-            std::cerr << "Could not mmap() " << fname << std::endl;
-            exit(EXIT_FAILURE);
+            std::stringstream stream;
+            stream << "Could not mmap() " << fname;
+            throw std::runtime_error(stream.str());
         }
 #else
         // Note FILE_FLAG_RANDOM_ACCESS is only a hint to Windows and as such may get ignored.
@@ -246,8 +245,7 @@ public:
 
         if (size_low % 64 != 16)
         {
-            std::cerr << "Corrupt tablebase file " << fname << std::endl;
-            exit(EXIT_FAILURE);
+            throw std::runtime_error("Corrupt tablebase file " + fname);
         }
 
         HANDLE mmap = CreateFileMapping(fd, nullptr, PAGE_READONLY, size_high, size_low, nullptr);
@@ -255,8 +253,7 @@ public:
 
         if (!mmap)
         {
-            std::cerr << "CreateFileMapping() failed" << std::endl;
-            exit(EXIT_FAILURE);
+            throw std::runtime_error("CreateFileMapping() failed");
         }
 
         *mapping = (uint64_t)mmap;
@@ -264,9 +261,10 @@ public:
 
         if (!*baseAddress)
         {
-            std::cerr << "MapViewOfFile() failed, name = " << fname
-                      << ", error = " << GetLastError() << std::endl;
-            exit(EXIT_FAILURE);
+            std::stringstream stream;
+            stream << "MapViewOfFile() failed, name = " << fname
+                   << ", error = " << GetLastError() << std::endl;
+            throw std::runtime_error(stream.str());
         }
 #endif
         uint8_t* data = (uint8_t*)*baseAddress;
@@ -445,8 +443,7 @@ class TBTables {
                 homeBucket = otherHomeBucket;
             }
         }
-        std::cerr << "TB hash table size too low!" << std::endl;
-        exit(EXIT_FAILURE);
+        throw std::runtime_error("TB hash table size too low!");
     }
 
 public:

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -18,6 +18,7 @@
 
 #include <cstring>   // For std::memset
 #include <iostream>
+#include <sstream>
 #include <thread>
 
 #include "bitboard.h"
@@ -71,9 +72,10 @@ void TranspositionTable::resize(size_t mbSize) {
   table = static_cast<Cluster*>(aligned_large_pages_alloc(clusterCount * sizeof(Cluster)));
   if (!table)
   {
-      std::cerr << "Failed to allocate " << mbSize
-                << "MB for transposition table." << std::endl;
-      exit(EXIT_FAILURE);
+      std::stringstream stream;
+      stream << "Failed to allocate " << mbSize
+             << "MB for transposition table.";
+      throw std::runtime_error(stream.str());
   }
 
   clear();


### PR DESCRIPTION
The main goal is to build SF as a shared library, so it can be used without restrictions on Android and other platforms.
This is the 1st commit to implement the idea that a server or a method should never crash or stop without the explicit request from the caller.