### PR TITLE
More futility pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -816,7 +816,7 @@ namespace {
     if (   !PvNode
         &&  depth < 9
         &&  eval - futility_margin(depth, improving) >= beta
-        &&  eval < VALUE_KNOWN_WIN) // Do not return unproven wins
+        &&  eval < 15000) // Do not return unproven wins
         return eval;
 
     // Step 8. Null move search with verification search (~40 Elo)


### PR DESCRIPTION
Expand maximum allowed eval by 50% in futility pruning.

STC:
LLR: 2.95 (-2.94,2.94) <-0.50,2.50>
Total: 128208 W: 32534 L: 32192 D: 63482
Ptnml(0-2): 298, 13484, 36216, 13790, 316
https://tests.stockfishchess.org/tests/view/6179c069a9b1d8fbcc4ee716

LTC:
LLR: 2.96 (-2.94,2.94) <0.50,3.50>
Total: 89816 W: 22645 L: 22265 D: 44906
Ptnml(0-2): 41, 8404, 27650, 8760, 53
https://tests.stockfishchess.org/tests/view/617ad728f411ea45cc39f895

bench: 6804175