### PR TITLE
Widen the aspiration window for larger evals

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -380,7 +380,7 @@ void Thread::search() {
           if (rootDepth >= 4)
           {
               Value prev = rootMoves[pvIdx].previousScore;
-              delta = Value(17);
+              delta = Value(17) + int(prev) * prev / 16384;
               alpha = std::max(prev - delta,-VALUE_INFINITE);
               beta  = std::min(prev + delta, VALUE_INFINITE);
 


### PR DESCRIPTION
passed STC
LLR: 2.93 (-2.94,2.94) <-0.50,2.50>
Total: 36840 W: 9359 L: 9134 D: 18347
Ptnml(0-2): 111, 4130, 9722, 4337, 120
https://tests.stockfishchess.org/tests/view/617c601301c6d0988731d10a

passed LTC
LLR: 2.98 (-2.94,2.94) <0.50,3.50>
Total: 64824 W: 16377 L: 16043 D: 32404
Ptnml(0-2): 27, 6712, 18618, 7010, 45
https://tests.stockfishchess.org/tests/view/617c720d01c6d0988731d114

Bench: 7683058