### PR TITLE
Simplify Skill implementation

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -112,14 +112,22 @@ namespace {
     return thisThread->state;
   }
 
-  // Skill structure is used to implement strength limit
+  // Skill structure is used to implement strength limit. If we have an uci_elo then
+  // we convert it to a suitable fractional skill level using anchoring to CCRL Elo
+  // (goldfish 1.13 = 2000) and a fit through Ordo derived Elo for match (TC 60+0.6)
+  // results spanning a wide range of k values.
   struct Skill {
-    explicit Skill(int l) : level(l) {}
-    bool enabled() const { return level < 20; }
-    bool time_to_pick(Depth depth) const { return depth == 1 + level; }
+    Skill(int skill_level, int uci_elo) {
+        if (uci_elo)
+            level = std::clamp(std::pow((uci_elo - 1346.6) / 143.4, 1 / 0.806), 0.0, 20.0);
+        else
+            level = double(skill_level);
+    }
+    bool enabled() const { return level < 20.0; }
+    bool time_to_pick(Depth depth) const { return depth == 1 + int(level); }
     Move pick_best(size_t multiPV);
 
-    int level;
+    double level;
     Move best = MOVE_NONE;
   };
 
@@ -243,10 +251,11 @@ void MainThread::search() {
       Time.availableNodes += Limits.inc[us] - Threads.nodes_searched();
 
   Thread* bestThread = this;
+  Skill skill = Skill(Options["Skill Level"], Options["UCI_LimitStrength"] ? int(Options["UCI_Elo"]) : 0);
 
   if (   int(Options["MultiPV"]) == 1
       && !Limits.depth
-      && !(Skill(Options["Skill Level"]).enabled() || int(Options["UCI_LimitStrength"]))
+      && !skill.enabled()
       && rootMoves[0].pv[0] != MOVE_NONE)
       bestThread = Threads.get_best_thread();
 
@@ -311,19 +320,7 @@ void Thread::search() {
   std::fill(&lowPlyHistory[MAX_LPH - 2][0], &lowPlyHistory.back().back() + 1, 0);
 
   size_t multiPV = size_t(Options["MultiPV"]);
-
-  // Pick integer skill levels, but non-deterministically round up or down
-  // such that the average integer skill corresponds to the input floating point one.
-  // UCI_Elo is converted to a suitable fractional skill level, using anchoring
-  // to CCRL Elo (goldfish 1.13 = 2000) and a fit through Ordo derived Elo
-  // for match (TC 60+0.6) results spanning a wide range of k values.
-  PRNG rng(now());
-  double floatLevel = Options["UCI_LimitStrength"] ?
-                      std::clamp(std::pow((Options["UCI_Elo"] - 1346.6) / 143.4, 1 / 0.806), 0.0, 20.0) :
-                        double(Options["Skill Level"]);
-  int intLevel = int(floatLevel) +
-                 ((floatLevel - int(floatLevel)) * 1024 > rng.rand<unsigned>() % 1024  ? 1 : 0);
-  Skill skill(intLevel);
+  Skill skill(Options["Skill Level"], Options["UCI_LimitStrength"] ? int(Options["UCI_Elo"]) : 0);
 
   // When playing with strength handicap enable MultiPV search that we will
   // use behind the scenes to retrieve a set of possible moves.
@@ -1779,8 +1776,8 @@ moves_loop: // When in check, search starts here
     // RootMoves are already sorted by score in descending order
     Value topScore = rootMoves[0].score;
     int delta = std::min(topScore - rootMoves[multiPV - 1].score, PawnValueMg);
-    int weakness = 120 - 2 * level;
     int maxScore = -VALUE_INFINITE;
+    double weakness = 120 - 2 * level;
 
     // Choose best move. For each move score we add two terms, both dependent on
     // weakness. One is deterministic and bigger for weaker levels, and one is
@@ -1788,8 +1785,8 @@ moves_loop: // When in check, search starts here
     for (size_t i = 0; i < multiPV; ++i)
     {
         // This is our magic formula
-        int push = (  weakness * int(topScore - rootMoves[i].score)
-                    + delta * (rng.rand<unsigned>() % weakness)) / 128;
+        int push = int((  weakness * int(topScore - rootMoves[i].score)
+                        + delta * (rng.rand<unsigned>() % int(weakness))) / 128);
 
         if (rootMoves[i].score + push >= maxScore)
         {


### PR DESCRIPTION
Currently we handle the UCI_Elo with a double randomization. This
seems not necessary and a bit involuted (and also not precise, see later).

This patch removes the first randomization and unifies the 2 cases.

Verified for compatibility against current master on 3 test points, at 1800, 2000 and 2200 ELO. Here the results:

```
This patch vs master both set at 2200 ELO -> -3   ELO
This patch vs master both set at 2000 ELO -> -26 ELO
This patch vs master both set at 1800 ELO -> -9   ELO
```

At 2000 ELO we have a sensible difference, so I have further measured effective ELO difference between 2000 ELO and 1800 ELO for both master and this patch. The result is:

```
master set at 2000 ELO vs master set at 1800 ELO -> 220 ELO(!)
this patch set at 2000 ELO vs this patch set at 1800 ELO -> 197 ELO
```

We can see that while this patch scales smoothly and test results follow very well the set UCI_ELO parameter, current master instead is not so smooth, master at 2000 vs 1800 scores a 220 ELO difference instead of 200 as it should be. This also explains why this patch vs master at 2000 ELO has -26 ELO difference. This is due to master not scaling correctly.

Here are the relevant tests:
https://tests.stockfishchess.org/tests/view/617d94c0169a915bc5fcb071
https://tests.stockfishchess.org/tests/view/617d935e169a915bc5fcb06d
https://tests.stockfishchess.org/tests/view/617e5ed02094e7ab11a7b54e
https://tests.stockfishchess.org/tests/view/617e5fcb2094e7ab11a7b552
https://tests.stockfishchess.org/tests/view/617e5f832094e7ab11a7b550

No functional change.
