### PR TITLE
Do more deeper LMR searches.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1209,10 +1209,11 @@ moves_loop: // When in check, search starts here
           // In general we want to cap the LMR depth search at newDepth. But if reductions
           // are really negative and movecount is low, we allow this move to be searched
           // deeper than the first move (this may lead to hidden double extensions).
-          int deeper =   r >= -1             ? 0
-                       : moveCount <= 5      ? 2
-                       : PvNode && depth > 6 ? 1
-                       :                       0;
+          int deeper =   r >= -1                   ? 0
+                       : moveCount <= 5            ? 2
+                       : PvNode && depth > 6       ? 1
+                       : cutNode && moveCount <= 7 ? 1
+                       :                             0;
 
           Depth d = std::clamp(newDepth - r, 1, newDepth + deeper);
 


### PR DESCRIPTION
At expected cut nodes allow at least one ply deeper LMR search for the first seventh moves.

STC:
LLR: 2.93 (-2.94,2.94) <-0.50,2.50>
Total: 42880 W: 10964 L: 10738 D: 21178
Ptnml(0-2): 105, 4565, 11883, 4773, 114
https://tests.stockfishchess.org/tests/view/6179abd7a9b1d8fbcc4ee6f4

LTC:
LLR: 2.93 (-2.94,2.94) <0.50,3.50>
Total: 66872 W: 16930 L: 16603 D: 33339
Ptnml(0-2): 36, 6509, 20024, 6826, 41
https://tests.stockfishchess.org/tests/view/617a30fb2fbca9ca65972b5e

Bench: 7162960