### PR TITLE
Do not output to stderr during the build.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -751,7 +751,7 @@ profile-build: net config-sanity objclean profileclean
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_make)
 	@echo ""
 	@echo "Step 2/4. Running benchmark for pgo-build ..."
-	$(PGOBENCH) > /dev/null
+	$(PGOBENCH) > /dev/null 2>&1
 	@echo ""
 	@echo "Step 3/4. Building optimized executable ..."
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) objclean


### PR DESCRIPTION
To help with debugging, the worker sends the output of stderr (suitable truncated) to the action log on the
server, in case a build fails. For this to work it is important that there is no spurious output to stderr.

No functional change