### PR TITLE
Do more reductions at Pv nodes with low delta.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -625,6 +625,8 @@ namespace {
         if (alpha >= beta)
             return alpha;
     }
+    else
+        thisThread->rootDelta = beta - alpha;
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
@@ -1166,6 +1168,9 @@ moves_loop: // When in check, search starts here
           if (   PvNode
               && bestMoveCount <= 3)
               r--;
+
+          if (PvNode && beta - alpha < thisThread->rootDelta / 4)
+              r++;
 
           // Decrease reduction if position is or has been on the PV
           // and node is not likely to fail low. (~3 Elo)

--- a/src/thread.h
+++ b/src/thread.h
@@ -72,6 +72,7 @@ public:
   StateInfo rootState;
   Search::RootMoves rootMoves;
   Depth rootDepth, completedDepth;
+  Value rootDelta;
   CounterMoveHistory counterMoves;
   ButterflyHistory mainHistory;
   LowPlyHistory lowPlyHistory;


### PR DESCRIPTION
passed STC
https://tests.stockfishchess.org/tests/view/617f9063af49befdeee40226
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 220840 W: 55752 L: 55150 D: 109938
Ptnml(0-2): 583, 24982, 58712, 25536, 607 
passed LTC
https://tests.stockfishchess.org/tests/view/61815de959e71df00dcc42ed
LLR: 2.95 (-2.94,2.94) <0.50,3.00>
Total: 79000 W: 19937 L: 19562 D: 39501
Ptnml(0-2): 36, 8190, 22674, 8563, 37 
This patch increases reduction for PvNodes that have their delta (difference between beta and alpha) significantly reduced compared to what it was at root.
bench 7114728