### PR TITLE
do not store qsearch positions in TT as exact.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1410,13 +1410,12 @@ moves_loop: // When in check, search starts here
     Key posKey;
     Move ttMove, move, bestMove;
     Depth ttDepth;
-    Value bestValue, value, ttValue, futilityValue, futilityBase, oldAlpha;
+    Value bestValue, value, ttValue, futilityValue, futilityBase;
     bool pvHit, givesCheck, captureOrPromotion;
     int moveCount;
 
     if (PvNode)
     {
-        oldAlpha = alpha; // To flag BOUND_EXACT when eval above alpha and no available moves
         (ss+1)->pv = pv;
         ss->pv[0] = MOVE_NONE;
     }
@@ -1606,8 +1605,7 @@ moves_loop: // When in check, search starts here
 
     // Save gathered info in transposition table
     tte->save(posKey, value_to_tt(bestValue, ss->ply), pvHit,
-              bestValue >= beta ? BOUND_LOWER :
-              PvNode && bestValue > oldAlpha  ? BOUND_EXACT : BOUND_UPPER,
+              bestValue >= beta ? BOUND_LOWER : BOUND_UPPER,
               ttDepth, bestMove, ss->staticEval);
 
     assert(bestValue > -VALUE_INFINITE && bestValue < VALUE_INFINITE);


### PR DESCRIPTION
in qsearch don't store positions in TT with the exact flag.

passed STC:
https://tests.stockfishchess.org/tests/view/617f9a29af49befdeee40231
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 155568 W: 39003 L: 39022 D: 77543
Ptnml(0-2): 403, 17854, 41305, 17803, 419

passed LTC:
https://tests.stockfishchess.org/tests/view/6180d47259e71df00dcc42a5
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 79640 W: 19993 L: 19910 D: 39737
Ptnml(0-2): 37, 8356, 22957, 8427, 43

Bench: 7516995