### PR TITLE
Tweak initial aspiration window.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -376,7 +376,7 @@ void Thread::search() {
           // Reset aspiration window starting size
           if (rootDepth >= 4)
           {
-              Value prev = rootMoves[pvIdx].previousScore;
+              Value prev = rootMoves[pvIdx].averageScore;
               delta = Value(17) + int(prev) * prev / 16384;
               alpha = std::max(prev - delta,-VALUE_INFINITE);
               beta  = std::min(prev + delta, VALUE_INFINITE);
@@ -1273,6 +1273,8 @@ moves_loop: // When in check, search starts here
       {
           RootMove& rm = *std::find(thisThread->rootMoves.begin(),
                                     thisThread->rootMoves.end(), move);
+
+          rm.averageScore = rm.averageScore != -VALUE_INFINITE ? (2 * value + rm.averageScore) / 3 : value;
 
           // PV move or new best move?
           if (moveCount == 1 || value > alpha)

--- a/src/search.h
+++ b/src/search.h
@@ -73,6 +73,7 @@ struct RootMove {
 
   Value score = -VALUE_INFINITE;
   Value previousScore = -VALUE_INFINITE;
+  Value averageScore = -VALUE_INFINITE;
   int selDepth = 0;
   int tbRank = 0;
   Value tbScore;


### PR DESCRIPTION
Maintain for each root move an exponential average of the search value with a weight ratio of 2:1 (new value vs old values). Then the average score is used as the center of the initial aspiration window instead of the previous score.

For this test i had collected some interresting statistics on my 1000 positions bench:
1. using previous score: mean difference of previous score and found search value
[all depths] Total 37359 Mean 51.4138
[depth=1] Total 74 Mean 294.986
[depth=2] Total 3253 Mean -130.099
[depth=3] Total 2246 Mean 162.687
[depth=4] Total 3775 Mean 144.603
[depth=5] Total 3416 Mean 108.089
[depth=6] Total 3407 Mean 71.6228
[depth=7] Total 3487 Mean 71.8959
[depth=8] Total 3573 Mean 44.8483
[depth=9] Total 3315 Mean 33.4992
[depth=10] Total 3198 Mean 29.0075
[depth=11] Total 3039 Mean 22.7943
[depth=12] Total 2608 Mean 23.9628
[depth=13] Total 1968 Mean 25.9639

2. using average score: mean difference of last average score (not including current search value) and found search value
[all depths] Total 673613 Mean 10.3302
[depth=1] Total 1441 Mean 105.351
[depth=2] Total 31878 Mean 11.5225
[depth=3] Total 41230 Mean 107.319
[depth=4] Total 60369 Mean 38.8653
[depth=5] Total 68015 Mean 20.5957
[depth=6] Total 66504 Mean 10.4651
[depth=7] Total 68946 Mean 4.85171
[depth=8] Total 69448 Mean 9.51513
[depth=9] Total 60509 Mean -8.85936
[depth=10] Total 61270 Mean -11.213
[depth=11] Total 59268 Mean -12.3605
[depth=12] Total 47883 Mean -17.7107
[depth=13] Total 36852 Mean -16.8232

This stats indicate that the deviation for previous score is in general greater than using average score, so later seems a better estimation of the next search value. This is probably the reason this patch succeded besides smoothing the sometimes wild swings in search score. An additional observation is that at higher depth previous score is above but average score below zero. So for average score more/less fail/low highs should be occur than previous score.

The same picture shows a measurement of linear correlations (for higher depth they start to converge):
1. using previous score: linear correlation of previous score and found search value
[all depths] Total 37359 Correlation(x,y) = 0.634061
[depth=1] Total 74 Correlation(x,y) = 0.712144
[depth=2] Total 3253 Correlation(x,y) = 0.458019
[depth=3] Total 2246 Correlation(x,y) = 0.493131
[depth=4] Total 3775 Correlation(x,y) = 0.641849
[depth=5] Total 3416 Correlation(x,y) = 0.946575
[depth=6] Total 3407 Correlation(x,y) = 0.9026
[depth=7] Total 3487 Correlation(x,y) = 0.69803
[depth=8] Total 3573 Correlation(x,y) = 0.947752
[depth=9] Total 3315 Correlation(x,y) = 0.966204
[depth=10] Total 3198 Correlation(x,y) = 0.908967
[depth=11] Total 3039 Correlation(x,y) = 0.942879
[depth=12] Total 2608 Correlation(x,y) = 0.880256
[depth=13] Total 1968 Correlation(x,y) = 0.945462

2. using average score: linear correlation of last average score (not including current search value) and found search value
[all depths] Total 673613 Correlation(x,y) = 0.949564
[depth=1] Total 1441 Correlation(x,y) = 0.98196
[depth=2] Total 31878 Correlation(x,y) = 0.807721
[depth=3] Total 41230 Correlation(x,y) = 0.815621
[depth=4] Total 60369 Correlation(x,y) = 0.952998
[depth=5] Total 68015 Correlation(x,y) = 0.952568
[depth=6] Total 66504 Correlation(x,y) = 0.966561
[depth=7] Total 68946 Correlation(x,y) = 0.976207
[depth=8] Total 69448 Correlation(x,y) = 0.959745
[depth=9] Total 60509 Correlation(x,y) = 0.956626
[depth=10] Total 61270 Correlation(x,y) = 0.95662
[depth=11] Total 59268 Correlation(x,y) = 0.967777
[depth=12] Total 47883 Correlation(x,y) = 0.970461
[depth=13] Total 36852 Correlation(x,y) = 0.962927

STC:
LLR: 2.97 (-2.94,2.94) <0.00,2.50>
Total: 59792 W: 15106 L: 14792 D: 29894
Ptnml(0-2): 144, 6718, 15869, 7010, 155
https://tests.stockfishchess.org/tests/view/61841612d7a085ad008eef06

LTC:
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 46448 W: 11835 L: 11537 D: 23076
Ptnml(0-2): 21, 4756, 13374, 5050, 23
https://tests.stockfishchess.org/tests/view/618463abd7a085ad008eef3e

Bench: 7047335