### PR TITLE
Skill: Use normal distribution

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1775,7 +1775,7 @@ moves_loop: // When in check, search starts here
     Value topScore = rootMoves[0].score;
     int delta = std::min(topScore - rootMoves[multiPV - 1].score, PawnValueMg);
     int maxScore = -VALUE_INFINITE;
-    double weakness = 120 - 2 * level;
+    double weakness = 160 - 4 * level;
 
     float mean = delta * weakness / 2;
     float stddev = mean * 0.3;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -323,7 +323,7 @@ void Thread::search() {
   // When playing with strength handicap enable MultiPV search that we will
   // use behind the scenes to retrieve a set of possible moves.
   if (skill.enabled())
-      multiPV = std::max(multiPV, (size_t)4);
+      multiPV = std::max(multiPV, (size_t)5);
 
   multiPV = std::min(multiPV, rootMoves.size());
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1778,7 +1778,7 @@ moves_loop: // When in check, search starts here
     double weakness = 130 - 2 * level;
 
     float mean = delta * weakness / 2;
-    float stddev = mean * 0.25;
+    float stddev = mean * 0.2;
 
     std::default_random_engine generator;
     std::normal_distribution<float> distribution(mean, stddev);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1775,7 +1775,7 @@ moves_loop: // When in check, search starts here
     Value topScore = rootMoves[0].score;
     int delta = std::min(topScore - rootMoves[multiPV - 1].score, PawnValueMg);
     int maxScore = -VALUE_INFINITE;
-    double weakness = 140 - 3 * level;
+    double weakness = 130 - 2 * level;
 
     float mean = delta * weakness / 2;
     float stddev = mean * 0.3;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1778,7 +1778,7 @@ moves_loop: // When in check, search starts here
     double weakness = 130 - 2 * level;
 
     float mean = delta * weakness / 2;
-    float stddev = mean * 0.3;
+    float stddev = mean * 0.25;
 
     std::default_random_engine generator;
     std::normal_distribution<float> distribution(mean, stddev);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <cstring>   // For std::memset
 #include <iostream>
+#include <random>
 #include <sstream>
 
 #include "evaluate.h"
@@ -1776,6 +1777,12 @@ moves_loop: // When in check, search starts here
     int maxScore = -VALUE_INFINITE;
     double weakness = 120 - 2 * level;
 
+    float mean = delta * weakness / 2;
+    float stddev = mean * 0.3;
+
+    std::default_random_engine generator;
+    std::normal_distribution<float> distribution(mean, stddev);
+
     // Choose best move. For each move score we add two terms, both dependent on
     // weakness. One is deterministic and bigger for weaker levels, and one is
     // random. Then we choose the move with the resulting highest score.
@@ -1783,7 +1790,7 @@ moves_loop: // When in check, search starts here
     {
         // This is our magic formula
         int push = int((  weakness * int(topScore - rootMoves[i].score)
-                        + delta * (rng.rand<unsigned>() % int(weakness))) / 128);
+                        + distribution(generator)) / 128);
 
         if (rootMoves[i].score + push >= maxScore)
         {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1775,7 +1775,7 @@ moves_loop: // When in check, search starts here
     Value topScore = rootMoves[0].score;
     int delta = std::min(topScore - rootMoves[multiPV - 1].score, PawnValueMg);
     int maxScore = -VALUE_INFINITE;
-    double weakness = 160 - 4 * level;
+    double weakness = 140 - 3 * level;
 
     float mean = delta * weakness / 2;
     float stddev = mean * 0.3;


### PR DESCRIPTION
Use normal distribution instead of a random. 

Limiting the spread of values around the mean should make the quality of the played moves more "coherent" with the set Skill Level so that at low skill levels engine will choose sub-optimal moves more often than not and only rarely best moves.

The idea came to my mind after an [observation ](https://github.com/xefoci7612/Stockfish/commit/80a26f946f670dee898c393e4fb979984dcebe06#commitcomment-59112436 )of @Mindbreaker1 "*Introducing random moves is the worst way to reduce strength. It is very aggravating when a strong computer throws you a scrap and then defends like a postal GM.*"

NOTE:
This patch builds upon 2 previous unmerged patches: the first removes a source of noise making the engine picking the sub-optimal move always at the end of the search, the second increases MultiPV used for Skill from 4 to 5 (-100 ELO as a result). So even if this idea is accepted, a remapping against UCI_Elo will be needed before to merge.

No functional change.

