### PR TITLE
Simplify away Penalty for Reverse Move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1756,10 +1756,6 @@ moves_loop: // When in check, search starts here
     thisThread->mainHistory[us][from_to(move)] << bonus;
     update_continuation_histories(ss, pos.moved_piece(move), to_sq(move), bonus);
 
-    // Penalty for reversed move in case of moved piece not being a pawn
-    if (type_of(pos.moved_piece(move)) != PAWN)
-        thisThread->mainHistory[us][from_to(reverse_move(move))] << -bonus;
-
     // Update countermove history
     if (is_ok((ss-1)->currentMove))
     {

--- a/src/types.h
+++ b/src/types.h
@@ -470,10 +470,6 @@ constexpr Move make_move(Square from, Square to) {
   return Move((from << 6) + to);
 }
 
-constexpr Move reverse_move(Move m) {
-  return make_move(to_sq(m), from_sq(m));
-}
-
 template<MoveType T>
 constexpr Move make(Square from, Square to, PieceType pt = KNIGHT) {
   return Move(T + ((pt - KNIGHT) << 12) + (from << 6) + to);


### PR DESCRIPTION
This simplifies penalty for reverse move introduced in https://github.com/official-stockfish/Stockfish/pull/2294 .

STC:
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 81696 W: 20627 L: 20540 D: 40529
Ptnml(0-2): 221, 9390, 21559, 9437, 241
https://tests.stockfishchess.org/tests/view/618810acd7a085ad008ef1cc

LTC:
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 44136 W: 11021 L: 10890 D: 22225
Ptnml(0-2): 28, 4570, 12746, 4691, 33
https://tests.stockfishchess.org/tests/view/61885686d7a085ad008ef20b

bench: 6761995