### PR TITLE
Remove previousScore

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -348,11 +348,6 @@ void Thread::search() {
       if (mainThread)
           totBestMoveChanges /= 2;
 
-      // Save the last iteration's scores before first PV line is searched and
-      // all the move scores except the (new) PV are set to -VALUE_INFINITE.
-      for (RootMove& rm : rootMoves)
-          rm.previousScore = rm.score;
-
       size_t pvFirst = 0;
       pvLast = 0;
 
@@ -1858,7 +1853,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
           continue;
 
       Depth d = updated ? depth : std::max(1, depth - 1);
-      Value v = updated ? rootMoves[i].score : rootMoves[i].previousScore;
+      Value v = updated ? rootMoves[i].score : rootMoves[i].averageScore;
 
       if (v == -VALUE_INFINITE)
           v = VALUE_ZERO;

--- a/src/search.h
+++ b/src/search.h
@@ -68,11 +68,10 @@ struct RootMove {
   bool operator==(const Move& m) const { return pv[0] == m; }
   bool operator<(const RootMove& m) const { // Sort in descending order
     return m.score != score ? m.score < score
-                            : m.previousScore < previousScore;
+                            : m.averageScore < averageScore;
   }
 
   Value score = -VALUE_INFINITE;
-  Value previousScore = -VALUE_INFINITE;
   Value averageScore = -VALUE_INFINITE;
   int selDepth = 0;
   int tbRank = 0;


### PR DESCRIPTION
https://tests.stockfishchess.org/tests/view/6187061ed7a085ad008ef120
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 113944 W: 28521 L: 28482 D: 56941
Ptnml(0-2): 259, 12116, 32243, 12035, 319 

No functional change.
bench: 6547978