### PR TITLE
Simplify Pv nodes related logic in LMR.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1164,14 +1164,11 @@ moves_loop: // When in check, search starts here
       {
           Depth r = reduction(improving, depth, moveCount, rangeReduction > 2);
 
-          // Decrease reduction if on the PV (~2 Elo)
+          // Decrease reduction at some PvNodes (~2 Elo)
           if (   PvNode
-              && bestMoveCount <= 3)
+              && bestMoveCount <= 3
+              && beta - alpha >= thisThread->rootDelta / 4)
               r--;
-
-          // Increases reduction for PvNodes that have small window
-          if (PvNode && beta - alpha < thisThread->rootDelta / 4)
-              r++;
 
           // Decrease reduction if position is or has been on the PV
           // and node is not likely to fail low. (~3 Elo)


### PR DESCRIPTION
passed STC:
https://tests.stockfishchess.org/tests/view/618ce27cd7a085ad008ef4e9
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 37488 W: 9424 L: 9279 D: 18785
Ptnml(0-2): 90, 3903, 10634, 4006, 111 
passed LTC:
https://tests.stockfishchess.org/tests/view/618d2585d7a085ad008ef527
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 49968 W: 12449 L: 12331 D: 25188
Ptnml(0-2): 27, 4745, 15309, 4889, 14 
Instead of having 2 separate conditions for Pv nodes reductions we can actually write them together. Despite it's not being strictly logically the same bench actually doesn't change up to depth 20, so them interacting is really rare and thus it's just a removal of extra PvNode check most of the time.
bench 6339548