### PR TITLE
Improve and simplify finding of executable's path

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -71,7 +71,7 @@ namespace Eval {
   /// in the engine directory. Distro packagers may define the DEFAULT_NNUE_DIRECTORY
   /// variable to have the engine search in a special directory in their distro.
 
-  void NNUE::init() {
+  void NNUE::init(char* arg0) {
 
     useNNUE = Options["Use NNUE"];
     if (!useNNUE)
@@ -81,12 +81,14 @@ namespace Eval {
     if (eval_file.empty())
         eval_file = EvalFileDefaultName;
 
+    string sf_dir = binary_directory(arg0);
+
     #if defined(DEFAULT_NNUE_DIRECTORY)
     #define stringify2(x) #x
     #define stringify(x) stringify2(x)
-    vector<string> dirs = { "<internal>" , "" , CommandLine::binaryDirectory , stringify(DEFAULT_NNUE_DIRECTORY) };
+    vector<string> dirs = { "<internal>" , "" , sf_dir, stringify(DEFAULT_NNUE_DIRECTORY) };
     #else
-    vector<string> dirs = { "<internal>" , "" , CommandLine::binaryDirectory };
+    vector<string> dirs = { "<internal>" , "" , sf_dir };
     #endif
 
     for (string directory : dirs)

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -46,7 +46,7 @@ namespace Eval {
     std::string trace(Position& pos);
     Value evaluate(const Position& pos, bool adjusted = false);
 
-    void init();
+    void init(char* arg0 = nullptr);
     void verify();
 
     bool load_eval(std::string name, std::istream& stream);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,6 @@ int main(int argc, char* argv[]) {
 
   std::cout << engine_info() << std::endl;
 
-  CommandLine::init(argc, argv);
   UCI::init(Options);
   Tune::init();
   PSQT::init();
@@ -42,9 +41,9 @@ int main(int argc, char* argv[]) {
   Position::init();
   Bitbases::init();
   Endgames::init();
+  Eval::NNUE::init(argv[0]);
   Threads.set(size_t(Options["Threads"]));
   Search::clear(); // After threads are up
-  Eval::NNUE::init();
 
   UCI::loop(argc, argv);
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -32,6 +32,7 @@ namespace Stockfish {
 
 std::string engine_info(bool to_uci = false);
 std::string compiler_info();
+std::string binary_directory(char* arg0);
 void prefetch(void* addr);
 void start_logger(const std::string& fname);
 void* std_aligned_alloc(size_t alignment, size_t size);
@@ -196,13 +197,6 @@ inline uint64_t mul_hi64(uint64_t a, uint64_t b) {
 
 namespace WinProcGroup {
   void bindThisThread(size_t idx);
-}
-
-namespace CommandLine {
-  void init(int argc, char* argv[]);
-
-  extern std::string binaryDirectory;  // path of the executable directory
-  extern std::string workingDirectory; // path of the working directory
 }
 
 } // namespace Stockfish


### PR DESCRIPTION
Under Windows rely on GetModuleFileName() to get stockfish.exe, This is always reliable, even in non-ASCII path.

Simplify other cases too using std::filesystem functions.

This link has some good info on using arg[0] to find executable's path:
https://stackoverflow.com/questions/1023306/finding-current-executables-path-without-proc-self-exe/1024937

No functional change.