### PR TITLE
add conditional statements to Makefile objclean

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -798,7 +798,11 @@ net:
 
 # clean binaries and objects
 objclean:
-	@rm -f $(EXE) *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
+	@if [ "$(EXE)" != "stockfish" ]; then \
+	    rm -f $(EXE) *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o; \
+	else \
+	    rm -f *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o; \
+	fi \
 
 # clean auxiliary profiling files
 profileclean:


### PR DESCRIPTION
I would like to suggest a modification in Makefile for building arm Android versions in Windows environment.
Unlike the regular exe files, I think we need to keep the binary file as it can be normally executed in Android, which I tested.
At first I thought I was failing building it but I realized that there was the objclean step in Makefile.