### PR TITLE
Less futility pruning.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -817,7 +817,7 @@ namespace {
 
     // Step 7. Futility pruning: child node (~50 Elo).
     // The depth condition is important for mate finding.
-    if (   !PvNode
+    if (   !ss->ttPv
         &&  depth < 9
         &&  eval - futility_margin(depth, improving) >= beta
         &&  eval < 15000) // 50% larger than VALUE_KNOWN_WIN, but smaller than TB wins.


### PR DESCRIPTION
At former PV nodes stored in the transposition table disable futility pruning.

STC:
LLR: 2.96 (-2.94,2.94) <0.00,2.50>
Total: 102256 W: 25708 L: 25318 D: 51230
Ptnml(0-2): 276, 11511, 27168, 11893, 280
https://tests.stockfishchess.org/tests/view/61990b3135c7c6348cb602db

LTC:
LLR: 2.96 (-2.94,2.94) <0.50,3.00>
Total: 183304 W: 46027 L: 45408 D: 91869
Ptnml(0-2): 96, 19029, 52778, 19658, 91
https://tests.stockfishchess.org/tests/view/619a0d1b35c7c6348cb603bc

Bench: 7334766