### PR TITLE
Remove depth dependence and use same limit (2000) as stat_bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -801,7 +801,7 @@ namespace {
     // Use static evaluation difference to improve quiet move ordering
     if (is_ok((ss-1)->currentMove) && !(ss-1)->inCheck && !priorCapture)
     {
-        int bonus = std::clamp(-depth * 4 * int((ss-1)->staticEval + ss->staticEval), -1000, 1000);
+        int bonus = std::clamp(-16 * int((ss-1)->staticEval + ss->staticEval), -2000, 2000);
         thisThread->mainHistory[~us][from_to((ss-1)->currentMove)] << bonus;
     }
 


### PR DESCRIPTION
The bonus in question is based on the static eval difference between current and next ply.
At higher depth's the final move evaluation is based on a position which is far away from the second ply,
thus it seems that scaling the bonus with depth is not reasonable.

Tested with simplification bounds.

STC:
https://tests.stockfishchess.org/tests/view/619df59dc0a4ea18ba95a424
LLR: 2.96 (-2.94,2.94) <-2.25,0.25>
Total: 83728 W: 21329 L: 21242 D: 41157
Ptnml(0-2): 297, 9669, 21847, 9752, 299

LTC:
https://tests.stockfishchess.org/tests/view/619e64d7c0a4ea18ba95a475
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 79888 W: 20238 L: 20155 D: 39495
Ptnml(0-2): 57, 8391, 22980, 8444, 72

bench: 8245412