### PR TITLE
Update default net to nn-3678835b1d3d.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-13406b1dcbe0.nnue"
+  #define EvalFileDefaultName   "nn-3678835b1d3d.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
new net trained with nnue-pytorch, started from the master net on a data set of Leela (T60.binpack+T74.binpack)
and Stockfish data (wrongIsRight_nodes5000pv2.binpack), available as a single interleaved binpack:
https://drive.google.com/file/d/12uWZIA3F2cNbraAzQNb1jgf3tq_6HkTr/view?usp=sharing

The nnue-pytorch branch used is https://github.com/vondele/nnue-pytorch/tree/wdl, which has the new feature to
filter positions based on the likelihood of the current evaluation leading to the game outcome.
It should make it less likely to try to learn from misevaluated positions. Standard options have been used:
   --gpus 1 --threads 4 --num-workers 4 --batch-size 16384 --progress_bar_refresh_rate 300
   --smart-fen-skipping --random-fen-skipping 12 --features=HalfKAv2_hm^   --lambda=1.0
starting from the master net.

testing with games shows neutral Elo at STC, and good performance at LTC:

STC:
https://tests.stockfishchess.org/tests/view/619eb597c0a4ea18ba95a4dc
ELO: -0.44 +-1.8 (95%) LOS: 31.2%
Total: 40000 W: 10447 L: 10498 D: 19055
Ptnml(0-2): 254, 4576, 10260, 4787, 123

LTC:
https://tests.stockfishchess.org/tests/view/619f6e87c0a4ea18ba95a53f
ELO: 3.30 +-1.8 (95%) LOS: 100.0%
Total: 33062 W: 8560 L: 8246 D: 16256
Ptnml(0-2): 54, 3358, 9352, 3754, 13

passed LTC SPRT:
https://tests.stockfishchess.org/tests/view/61a0864e8967bbf894416e65
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 29376 W: 7663 L: 7396 D: 14317
Ptnml(0-2): 67, 3017, 8205, 3380, 19

Bench: 7011501