### PR TITLE
Tune NNUE scaling params

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1091,9 +1091,9 @@ Value Eval::evaluate(const Position& pos) {
       v = Evaluation<NO_TRACE>(pos).value();          // classical
   else
   {
-       int scale =   898
-                   + 24 * pos.count<PAWN>()
-                   + 33 * pos.non_pawn_material() / 1024;
+       int scale = 1049
+                   +  8 * pos.count<PAWN>()
+                   + 20 * pos.non_pawn_material() / 1024;
 
        Value nnue     = NNUE::evaluate(pos, true);     // NNUE
        Color stm      = pos.side_to_move();


### PR DESCRIPTION
passed STC:
https://tests.stockfishchess.org/tests/view/61a156f89e83391467a2b2cc
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 22816 W: 5896 L: 5646 D: 11274
Ptnml(0-2): 55, 2567, 5961, 2723, 102

passed LTC:
https://tests.stockfishchess.org/tests/view/61a1cf3d9e83391467a2b30b
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 17904 W: 4658 L: 4424 D: 8822
Ptnml(0-2): 6, 1821, 5079, 2025, 21

Bench: 7218806