### PR TITLE
Adjust usage of history in futility pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1063,10 +1063,12 @@ moves_loop: // When in check, search starts here
                   && history < -3000 * depth + 3000)
                   continue;
 
+              history += thisThread->mainHistory[us][from_to(move)];                  
+
               // Futility pruning: parent node (~5 Elo)
               if (   !ss->inCheck
                   && lmrDepth < 8
-                  && ss->staticEval + 172 + 145 * lmrDepth + history / 256 <= alpha)
+                  && ss->staticEval + 172 + 145 * lmrDepth + history / 128 <= alpha)
                   continue;
 
               // Prune moves with negative SEE (~20 Elo)


### PR DESCRIPTION
This patch refines my previous passed patch that uses history heuristics in futility pruning.  
Now it adds main history of the move to in and also increases effect by factor of 2.
passed STC
https://tests.stockfishchess.org/tests/view/61a156829e83391467a2b2c9
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 68464 W: 17920 L: 17587 D: 32957
Ptnml(0-2): 239, 7711, 18025, 7992, 265 
passed LTC
https://tests.stockfishchess.org/tests/view/61a1bde99e83391467a2b305
LLR: 2.95 (-2.94,2.94) <0.50,3.00>
Total: 26088 W: 6926 L: 6674 D: 12488
Ptnml(0-2): 18, 2619, 7531, 2845, 31 
bench 6804653
