### PR TITLE
Simplify reduction on rootNode when bestMoveChanges is high

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1063,7 +1063,7 @@ moves_loop: // When in check, search starts here
                   && history < -3000 * depth + 3000)
                   continue;
 
-              history += thisThread->mainHistory[us][from_to(move)];                  
+              history += thisThread->mainHistory[us][from_to(move)];
 
               // Futility pruning: parent node (~5 Elo)
               if (   !ss->inCheck
@@ -1185,8 +1185,8 @@ moves_loop: // When in check, search starts here
               && !likelyFailLow)
               r -= 2;
 
-          // Increase reduction at root and non-PV nodes when the best move does not change frequently
-          if (   (rootNode || !PvNode)
+          // Increase reduction at non-PV nodes when the best move does not change frequently
+          if (  !PvNode
               && thisThread->bestMoveChanges <= 2)
               r++;
 


### PR DESCRIPTION
The reduction introduced in #3736 also consider on rootNode, so we don't have to reduce again.

STC:
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 28736 W: 7494 L: 7329 D: 13913
Ptnml(0-2): 95, 3247, 7503, 3444, 79
https://tests.stockfishchess.org/tests/view/61a3abe01b7fdf52228e74d8

LTC:
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 47816 W: 12434 L: 12308 D: 23074
Ptnml(0-2): 37, 4972, 13755, 5116, 28
https://tests.stockfishchess.org/tests/view/61a3c3e39f0c43dae1c71d71

bench: 6627911