### PR TITLE
Do more aggressive pruning for some node types.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1063,7 +1063,9 @@ moves_loop: // When in check, search starts here
                   && history < -3000 * depth + 3000)
                   continue;
 
-              history += thisThread->mainHistory[us][from_to(move)];
+              history += thisThread->mainHistory[us][from_to(move)];  
+
+              lmrDepth = std::max(0, lmrDepth - (beta - alpha < thisThread->rootDelta / 4));   
 
               // Futility pruning: parent node (~5 Elo)
               if (   !ss->inCheck


### PR DESCRIPTION
This patch allows more aggressive futility/see based pruning for PV nodes with low delta and non-pv nodes.
Passed STC
https://tests.stockfishchess.org/tests/view/61a5ed33d16c530b5dcc27cc
LLR: 2.95 (-2.94,2.94) <0.00,2.50>
Total: 182088 W: 47121 L: 46584 D: 88383
Ptnml(0-2): 551, 20687, 48037, 21212, 557 
Passed LTC
https://tests.stockfishchess.org/tests/view/61a74dfdbd5c4360bcded0ac
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 87136 W: 22494 L: 22103 D: 42539
Ptnml(0-2): 38, 8918, 25272, 9295, 45 
bench 4332259