### PR TITLE
update default net to nn-cdf1785602d6.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-4f56ecfca5b7.nnue"
+  #define EvalFileDefaultName   "nn-cdf1785602d6.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
same process as in https://github.com/official-stockfish/Stockfish/commit/e4a0c6c75950bf27b6dc32490a1102499643126b with the training started from the current master net.

passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.50>
Total: 38224 W: 10023 L: 9742 D: 18459
Ptnml(0-2): 133, 4328, 9940, 4547, 164
https://tests.stockfishchess.org/tests/view/61a8611e4ed77d629d4e836e

passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 115176 W: 29783 L: 29321 D: 56072
Ptnml(0-2): 68, 12039, 32936, 12453, 92
https://tests.stockfishchess.org/tests/view/61a8963e4ed77d629d4e8d9b

Bench: 4829419