### PR TITLE
Simplify away bestMoveChanges from LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1187,9 +1187,8 @@ moves_loop: // When in check, search starts here
               && !likelyFailLow)
               r -= 2;
 
-          // Increase reduction at non-PV nodes when the best move does not change frequently
-          if (  !PvNode
-              && thisThread->bestMoveChanges <= 2)
+          // Increase reduction at non-PV nodes
+          if (!PvNode)
               r++;
 
           // Decrease reduction if opponent's move count is high (~1 Elo)


### PR DESCRIPTION
Simplifies bestMoveChanges from LMR. As it's only reset on mainThread and it could change how other threads search, a SMP test was made.

STC:
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 146776 W: 37934 L: 37941 D: 70901
Ptnml(0-2): 477, 15644, 41173, 15597, 497
https://tests.stockfishchess.org/tests/view/61a8f9f34ed77d629d4ea2d6

LTC:
LLR: 3.11 (-2.94,2.94) <-2.25,0.25>
Total: 114040 W: 29314 L: 29269 D: 55457
Ptnml(0-2): 50, 10584, 35722, 10599, 65
https://tests.stockfishchess.org/tests/view/61a9d4bf9e8855bba1a35c4f

SMP STC:
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 23888 W: 6308 L: 6143 D: 11437
Ptnml(0-2): 36, 2557, 6600, 2708, 43
https://tests.stockfishchess.org/tests/view/61ac27a756fcf33bce7d3677

bench: 4829419