### PR TITLE
Tweak time management.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -260,6 +260,7 @@ void MainThread::search() {
       bestThread = Threads.get_best_thread();
 
   bestPreviousScore = bestThread->rootMoves[0].score;
+  bestPreviousAverageScore = bestThread->rootMoves[0].averageScore;
 
   // Send again PV info if we have a new best thread
   if (bestThread != this)
@@ -489,7 +490,8 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (318 + 6 * (mainThread->bestPreviousScore - bestValue)
+          double fallingEval = (142 + 6 * (mainThread->bestPreviousScore - bestValue)
+                                    + 6 * (mainThread->bestPreviousAverageScore - bestValue)
                                     + 6 * (mainThread->iterValue[iterIdx] - bestValue)) / 825.0;
           fallingEval = std::clamp(fallingEval, 0.5, 1.5);
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -162,6 +162,7 @@ void ThreadPool::clear() {
 
   main()->callsCnt = 0;
   main()->bestPreviousScore = VALUE_INFINITE;
+  main()->bestPreviousAverageScore = VALUE_INFINITE;
   main()->previousTimeReduction = 1.0;
 }
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -95,6 +95,7 @@ struct MainThread : public Thread {
 
   double previousTimeReduction;
   Value bestPreviousScore;
+  Value bestPreviousAverageScore;
   Value iterValue[4];
   int callsCnt;
   bool stopOnPonderhit;


### PR DESCRIPTION
Use for adjustment of the falling eval time factor now also the difference between previous best average score and current best score.

STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.50>
Total: 109216 W: 28296 L: 27900 D: 53020
Ptnml(0-2): 312, 11759, 30148, 11999, 390
https://tests.stockfishchess.org/tests/view/61aafa8d1b31b85bcfa29d9c

LTC:
LLR: 2.93 (-2.94,2.94) <0.50,3.00>
Total: 54096 W: 14091 L: 13787 D: 26218
Ptnml(0-2): 29, 5124, 16447, 5410, 38
https://tests.stockfishchess.org/tests/view/61abbbbd56fcf33bce7d1d64

Bench: 4829419