### PR TITLE
Tweak history initialization.

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -67,7 +67,7 @@ void Thread::clear() {
       {
           for (auto& to : continuationHistory[inCheck][c])
                 for (auto& h : to)
-                      h->fill(0);
+                      h->fill(-71);
           continuationHistory[inCheck][c][NO_PIECE][0]->fill(Search::CounterMovePruneThreshold - 1);
       }
 }


### PR DESCRIPTION
Initialize continuation history with a slighlty negative value -71 instead of zero.

The idea is that because the most history entries will be later negative anyway to shift the starting values a little bit in the "correct" direction.
Naturally the effect of initialization dimishes with greater depth so i had the appreshension that LTC tests are difficult to pass but it does.

STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 34520 W: 9076 L: 8803 D: 16641
Ptnml(0-2): 136, 3837, 9047, 4098, 142
https://tests.stockfishchess.org/tests/view/61aa52e39e8855bba1a3776b

LTC:
LLR: 2.93 (-2.94,2.94) <0.50,3.00>
Total: 75568 W: 19620 L: 19254 D: 36694
Ptnml(0-2): 44, 7773, 21796, 8115, 56
https://tests.stockfishchess.org/tests/view/61aa87d39e8855bba1a383a5

Bench: 4674029