### PR TITLE
Assign extra bonus for previous move that caused a fail low more often.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1380,7 +1380,15 @@ moves_loop: // When in check, search starts here
     // Bonus for prior countermove that caused the fail low
     else if (   (depth >= 3 || PvNode)
              && !priorCapture)
-        update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, stat_bonus(depth) * (1 + (PvNode || cutNode)));
+    {
+        //Assign extra bonus if current node is PvNode or cutNode
+        //or fail low was really bad
+        bool extraBonus =    PvNode 
+                          || cutNode 
+                          || bestValue < alpha - 94 * depth;
+
+        update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, stat_bonus(depth) * (1 + extraBonus));
+    }
 
     if (PvNode)
         bestValue = std::min(bestValue, maxValue);


### PR DESCRIPTION
This patch allows to assign extra bonus for previous move that caused a fail low not only for PvNodes and cutNodes but also fo some allNodes - namely if the best result we could've got from the search is still far below alpha.
passed STC
https://tests.stockfishchess.org/tests/view/61aa26a49e8855bba1a36d96
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 73808 W: 19183 L: 18842 D: 35783
Ptnml(0-2): 251, 8257, 19564, 8564, 268 
passed LTC
https://tests.stockfishchess.org/tests/view/61aa7dc29e8855bba1a3814f
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 142416 W: 36717 L: 36192 D: 69507
Ptnml(0-2): 106, 14799, 40862, 15346, 95 
bench 4724181