### PR TITLE
Improve transposition table remplacement strategy

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -40,9 +40,9 @@ void TTEntry::save(Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev) 
       move16 = (uint16_t)m;
 
   // Overwrite less valuable entries (cheapest checks first)
-  if (b == BOUND_EXACT
+  if (   b == BOUND_EXACT
       || (uint16_t)k != key16
-      || d - DEPTH_OFFSET > depth8 - 4)
+      || d - DEPTH_OFFSET + 2 * pv > depth8 - 4)
   {
       assert(d > DEPTH_OFFSET);
       assert(d < 256 + DEPTH_OFFSET);


### PR DESCRIPTION
Increase chance that PV node replaces old entry in transposition table.

STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.50>
Total: 46744 W: 12108 L: 11816 D: 22820
Ptnml(0-2): 156, 5221, 12344, 5477, 174
https://tests.stockfishchess.org/tests/view/61ae068356fcf33bce7d99d0

LTC:
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 88464 W: 22912 L: 22513 D: 43039
Ptnml(0-2): 84, 9133, 25393, 9544, 78
https://tests.stockfishchess.org/tests/view/61ae973656fcf33bce7db3e1

Bench: 5292488