### PR TITLE
Adjust singular extension depth restriction.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1089,7 +1089,7 @@ moves_loop: // When in check, search starts here
       // a reduced search on all the other moves but the ttMove and if the
       // result is lower than ttValue minus a margin, then we will extend the ttMove.
       if (   !rootNode
-          &&  depth >= 7
+          &&  depth >= 6 + 2 * (PvNode && tte->is_pv())
           &&  move == ttMove
           && !excludedMove // Avoid recursive singular search
        /* &&  ttValue != VALUE_NONE Already implicit in the next condition */


### PR DESCRIPTION
This patch is a modification of original idea by @lonfom169 which had a good yellow run - do singular extension search with depth threshold 6 unless this is a PvNode with is a part of a PV line - for them set threshold to 8 instead.
Passed STC 
https://tests.stockfishchess.org/tests/view/61b1080406b4c2dcb1b1128c
LLR: 2.95 (-2.94,2.94) <0.00,2.50>
Total: 84352 W: 21917 L: 21555 D: 40880
Ptnml(0-2): 288, 9524, 22185, 9896, 283 
Passed LTC
https://tests.stockfishchess.org/tests/view/61b1860a06b4c2dcb1b134a1
LLR: 2.95 (-2.94,2.94) <0.50,3.00>
Total: 63520 W: 16575 L: 16237 D: 30708
Ptnml(0-2): 27, 6519, 18350, 6817, 47 
bench 4729473