### PR TITLE
Simplify falling eval time factor.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -490,9 +490,8 @@ void Thread::search() {
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
-          double fallingEval = (142 + 6 * (mainThread->bestPreviousScore - bestValue)
-                                    + 6 * (mainThread->bestPreviousAverageScore - bestValue)
-                                    + 6 * (mainThread->iterValue[iterIdx] - bestValue)) / 825.0;
+          double fallingEval = (142 + 12 * (mainThread->bestPreviousAverageScore - bestValue)
+                                    +  6 * (mainThread->iterValue[iterIdx] - bestValue)) / 825.0;
           fallingEval = std::clamp(fallingEval, 0.5, 1.5);
 
           // If the bestMove is stable over several iterations, reduce time accordingly


### PR DESCRIPTION
Remove the difference to previous best score in falling eval calculation. As compensation double the effect of the difference to previous best average score.

STC:
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 86944 W: 22363 L: 22285 D: 42296
Ptnml(0-2): 273, 9227, 24396, 9301, 275
https://tests.stockfishchess.org/tests/view/61b111ce06b4c2dcb1b11546

LTC:
LLR: 2.96 (-2.94,2.94) <-2.25,0.25>
Total: 134944 W: 34606 L: 34596 D: 65742
Ptnml(0-2): 66, 12941, 41456, 12935, 74
https://tests.stockfishchess.org/tests/view/61b19ca206b4c2dcb1b13a8b

Bench: 4729473