### PR TITLE
Update default net to nn-d93927199b3d.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-63376713ba63.nnue"
+  #define EvalFileDefaultName   "nn-d93927199b3d.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
Using the same dataset as before but slightly reduced initial LR as in
https://github.com/vondele/nnue-pytorch/tree/tweakLR1

passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 51368 W: 13492 L: 13191 D: 24685
Ptnml(0-2): 168, 5767, 13526, 6042, 181
https://tests.stockfishchess.org/tests/view/61b61f43dffbe89a3580b529

passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 45128 W: 11763 L: 11469 D: 21896
Ptnml(0-2): 24, 4583, 13063, 4863, 31
https://tests.stockfishchess.org/tests/view/61b6612edffbe89a3580c447

Bench: 5121336