### PR TITLE
Fix for profile-build failure using gcc-11 on MacOS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -459,6 +459,9 @@ else ifeq ($(comp),clang)
 else
 	profile_make = gcc-profile-make
 	profile_use = gcc-profile-use
+	ifeq ($(KERNEL),Darwin)
+		EXTRAPROFILEFLAGS = -fvisibility=hidden
+	endif
 endif
 
 ### Travis CI script uses COMPILER to overwrite CXX
@@ -920,12 +923,14 @@ gcc-profile-make:
 	@mkdir -p profdir
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
 	EXTRACXXFLAGS='-fprofile-generate=profdir' \
+	EXTRACXXFLAGS+=$(EXTRAPROFILEFLAGS) \
 	EXTRALDFLAGS='-lgcov' \
 	all
 
 gcc-profile-use:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
 	EXTRACXXFLAGS='-fprofile-use=profdir -fno-peel-loops -fno-tracer' \
+	EXTRACXXFLAGS+=$(EXTRAPROFILEFLAGS) \
 	EXTRALDFLAGS='-lgcov' \
 	all
 


### PR DESCRIPTION
Fixes #3846 

This works for gcc-11 on MacOS and does not break gcc-8, gcc-9 or gcc-10.

```
george@Georges-iMac-Pro-2 src % make clean
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
george@Georges-iMac-Pro-2 src % make -j8 profile-build ARCH=x86-64-avx2 COMP=gcc COMPCXX=g++-11
Default net: nn-d93927199b3d.nnue
Already available.

Config:
debug: 'no'
sanitize: 'none'
optimize: 'yes'
arch: 'x86_64'
bits: '64'
kernel: 'Darwin'
os: ''
prefetch: 'yes'
popcnt: 'yes'
pext: 'no'
sse: 'yes'
mmx: 'no'
sse2: 'yes'
ssse3: 'yes'
sse41: 'yes'
avx2: 'yes'
avxvnni: 'no'
avx512: 'no'
vnni256: 'no'
vnni512: 'no'
neon: 'no'
arm_version: '0'

Flags:
CXX: g++-11
CXXFLAGS: -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto
LDFLAGS:  -m64 -mmacosx-version-min=10.14 -arch x86_64 -lpthread -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto -flto=jobserver

Testing config sanity. If this fails, try 'make help' ...


Step 1/4. Building instrumented executable ...
/Library/Developer/CommandLineTools/usr/bin/make ARCH=x86-64-avx2 COMP=gcc gcc-profile-make
/Library/Developer/CommandLineTools/usr/bin/make ARCH=x86-64-avx2 COMP=gcc \
	EXTRACXXFLAGS='-fprofile-generate=profdir' \
	EXTRACXXFLAGS+=-fvisibility=hidden \
	EXTRALDFLAGS='-lgcov' \
	all
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o benchmark.o benchmark.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o bitbase.o bitbase.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o bitboard.o bitboard.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o endgame.o endgame.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o evaluate.o evaluate.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o main.o main.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o material.o material.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o misc.o misc.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o movegen.o movegen.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o movepick.o movepick.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o pawns.o pawns.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o position.o position.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o psqt.o psqt.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o search.o search.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o thread.o thread.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o timeman.o timeman.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o tt.o tt.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o uci.o uci.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o ucioption.o ucioption.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o tune.o tune.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o tbprobe.o syzygy/tbprobe.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o evaluate_nnue.o nnue/evaluate_nnue.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o half_ka_v2_hm.o nnue/features/half_ka_v2_hm.cpp
g++-11 -o stockfish benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o material.o misc.o movegen.o movepick.o pawns.o position.o psqt.o search.o thread.o timeman.o tt.o uci.o ucioption.o tune.o tbprobe.o evaluate_nnue.o half_ka_v2_hm.o -lgcov -m64 -mmacosx-version-min=10.14 -arch x86_64 -lpthread -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto -flto=jobserver
ld: warning: dylib (/usr/local/Cellar/gcc/11.2.0_3/lib/gcc/11/libstdc++.dylib) was built for newer macOS version (12.0) than being linked (10.14)
lto-wrapper: warning: jobserver is not available: '--jobserver-auth=' is not present in 'MAKEFLAGS'
ld: warning: dylib (/usr/local/Cellar/gcc/11.2.0_3/lib/gcc/11/libstdc++.dylib) was built for newer macOS version (12.0) than being linked (10.14)

Step 2/4. Running benchmark for pgo-build ...
./stockfish bench 2>&1 | tail -n 4
===========================
Total time (ms) : 3591
Nodes searched  : 5121336
Nodes/second    : 1426158

Step 3/4. Building optimized executable ...
/Library/Developer/CommandLineTools/usr/bin/make ARCH=x86-64-avx2 COMP=gcc objclean
/Library/Developer/CommandLineTools/usr/bin/make ARCH=x86-64-avx2 COMP=gcc gcc-profile-use
/Library/Developer/CommandLineTools/usr/bin/make ARCH=x86-64-avx2 COMP=gcc \
	EXTRACXXFLAGS='-fprofile-use=profdir -fno-peel-loops -fno-tracer' \
	EXTRACXXFLAGS+=-fvisibility=hidden \
	EXTRALDFLAGS='-lgcov' \
	all
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o benchmark.o benchmark.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o bitbase.o bitbase.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o bitboard.o bitboard.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o endgame.o endgame.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o evaluate.o evaluate.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o main.o main.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o material.o material.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o misc.o misc.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o movegen.o movegen.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o movepick.o movepick.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o pawns.o pawns.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o position.o position.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o psqt.o psqt.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o search.o search.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o thread.o thread.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o timeman.o timeman.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o tt.o tt.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o uci.o uci.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o ucioption.o ucioption.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o tune.o tune.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o tbprobe.o syzygy/tbprobe.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o evaluate_nnue.o nnue/evaluate_nnue.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o half_ka_v2_hm.o nnue/features/half_ka_v2_hm.cpp
g++-11 -o stockfish benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o material.o misc.o movegen.o movepick.o pawns.o position.o psqt.o search.o thread.o timeman.o tt.o uci.o ucioption.o tune.o tbprobe.o evaluate_nnue.o half_ka_v2_hm.o -lgcov -m64 -mmacosx-version-min=10.14 -arch x86_64 -lpthread -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-use=profdir -fno-peel-loops -fno-tracer -fvisibility=hidden -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch x86_64 -DUSE_PTHREADS -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_AVX2 -mavx2 -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto -flto=jobserver
ld: warning: dylib (/usr/local/Cellar/gcc/11.2.0_3/lib/gcc/11/libstdc++.dylib) was built for newer macOS version (12.0) than being linked (10.14)
lto-wrapper: warning: jobserver is not available: '--jobserver-auth=' is not present in 'MAKEFLAGS'
ld: warning: dylib (/usr/local/Cellar/gcc/11.2.0_3/lib/gcc/11/libstdc++.dylib) was built for newer macOS version (12.0) than being linked (10.14)

Step 4/4. Deleting profile data ...
/Library/Developer/CommandLineTools/usr/bin/make ARCH=x86-64-avx2 COMP=gcc profileclean
george@Georges-iMac-Pro-2 src % ./stockfish bench 2>&1 | tail -n 4
===========================
Total time (ms) : 2788
Nodes searched  : 5121336
Nodes/second    : 1836921
```