### PR TITLE
Fixes build failure under gcc-11 on Apple M1 Silicon

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -519,9 +519,17 @@ ifeq ($(optimize),yes)
 		endif
 	endif
 
-	ifeq ($(comp),$(filter $(comp),gcc clang icc))
+	ifeq ($(comp),$(filter $(comp),clang icc))
 		ifeq ($(KERNEL),Darwin)
 			CXXFLAGS += -mdynamic-no-pic
+		endif
+	endif
+
+	ifeq ($(comp),gcc)
+		ifeq ($(KERNEL),Darwin)
+			ifneq ($(arch),arm64)
+				CXXFLAGS += -mdynamic-no-pic
+			endif
 		endif
 	endif
 


### PR DESCRIPTION
Fixes #3847 

This PR selectively avoids `-mdynamic-no-pic` only for gcc on Apple Silicon. (gcc-11 is the only gcc currently supported by brew on M1.)

```
george@Georges-MacBook-Air src % make clean
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
george@Georges-MacBook-Air src % make build ARCH=apple-silicon COMP=gcc COMPCXX=g++-11
Default net: nn-d93927199b3d.nnue
Downloading https://tests.stockfishchess.org/api/nn/nn-d93927199b3d.nnue

Config:
debug: 'no'
sanitize: 'none'
optimize: 'yes'
arch: 'arm64'
bits: '64'
kernel: 'Darwin'
os: ''
prefetch: 'yes'
popcnt: 'yes'
pext: 'no'
sse: 'no'
mmx: 'no'
sse2: 'no'
ssse3: 'no'
sse41: 'no'
avx2: 'no'
avxvnni: 'no'
avx512: 'no'
vnni256: 'no'
vnni512: 'no'
neon: 'yes'
arm_version: '8'

Flags:
CXX: g++-11
CXXFLAGS: -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto
LDFLAGS:  -m64 -mmacosx-version-min=10.14 -arch arm64 -lpthread -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto -flto=jobserver

Testing config sanity. If this fails, try 'make help' ...

/Library/Developer/CommandLineTools/usr/bin/make ARCH=apple-silicon COMP=gcc all
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o benchmark.o benchmark.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o bitbase.o bitbase.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o bitboard.o bitboard.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o endgame.o endgame.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o evaluate.o evaluate.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o main.o main.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o material.o material.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o misc.o misc.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o movegen.o movegen.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o movepick.o movepick.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o pawns.o pawns.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o position.o position.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o psqt.o psqt.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o search.o search.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o thread.o thread.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o timeman.o timeman.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o tt.o tt.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o uci.o uci.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o ucioption.o ucioption.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o tune.o tune.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o tbprobe.o syzygy/tbprobe.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o evaluate_nnue.o nnue/evaluate_nnue.cpp
g++-11 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto   -c -o half_ka_v2_hm.o nnue/features/half_ka_v2_hm.cpp
g++-11 -o stockfish benchmark.o bitbase.o bitboard.o endgame.o evaluate.o main.o material.o misc.o movegen.o movepick.o pawns.o position.o psqt.o search.o thread.o timeman.o tt.o uci.o ucioption.o tune.o tbprobe.o evaluate_nnue.o half_ka_v2_hm.o  -m64 -mmacosx-version-min=10.14 -arch arm64 -lpthread -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -mmacosx-version-min=10.14 -arch arm64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON=8 -flto -flto=jobserver
ld: warning: object file (benchmark.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (bitbase.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (bitboard.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (endgame.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (main.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (material.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (misc.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (movegen.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (movepick.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (pawns.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (position.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (psqt.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (thread.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (search.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (timeman.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (tt.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (uci.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (ucioption.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (tune.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (tbprobe.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (evaluate_nnue.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (half_ka_v2_hm.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (evaluate.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: dylib (/opt/homebrew/Cellar/gcc/11.2.0_3/lib/gcc/11/libstdc++.dylib) was built for newer macOS version (12.0) than being linked (10.14)
ld: warning: dylib (/opt/homebrew/Cellar/gcc/11.2.0_3/lib/gcc/11/libgcc_s.1.1.dylib) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (/opt/homebrew/Cellar/gcc/11.2.0_3/lib/gcc/11/gcc/aarch64-apple-darwin21/11/libgcc.a(ldadd_8_4.o)) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (/opt/homebrew/Cellar/gcc/11.2.0_3/lib/gcc/11/gcc/aarch64-apple-darwin21/11/libgcc.a(ldadd_8_1.o)) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (/opt/homebrew/Cellar/gcc/11.2.0_3/lib/gcc/11/gcc/aarch64-apple-darwin21/11/libgcc.a(lse-init.o)) was built for newer macOS version (11.0) than being linked (10.14)
lto-wrapper: warning: jobserver is not available: '--jobserver-auth=' is not present in 'MAKEFLAGS'
ld: warning: object file (/var/folders/zr/1m4k41d57kqd9qbr346nngbw0000gn/T//cclkrWcr.ltrans1.ltrans.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (/var/folders/zr/1m4k41d57kqd9qbr346nngbw0000gn/T//cclkrWcr.ltrans2.ltrans.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (/var/folders/zr/1m4k41d57kqd9qbr346nngbw0000gn/T//cclkrWcr.ltrans3.ltrans.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (/var/folders/zr/1m4k41d57kqd9qbr346nngbw0000gn/T//cclkrWcr.ltrans4.ltrans.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (/var/folders/zr/1m4k41d57kqd9qbr346nngbw0000gn/T//cclkrWcr.ltrans5.ltrans.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (/var/folders/zr/1m4k41d57kqd9qbr346nngbw0000gn/T//cclkrWcr.ltrans0.ltrans.o) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: dylib (/opt/homebrew/Cellar/gcc/11.2.0_3/lib/gcc/11/libstdc++.dylib) was built for newer macOS version (12.0) than being linked (10.14)
ld: warning: dylib (/opt/homebrew/Cellar/gcc/11.2.0_3/lib/gcc/11/libgcc_s.1.1.dylib) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (/opt/homebrew/Cellar/gcc/11.2.0_3/lib/gcc/11/gcc/aarch64-apple-darwin21/11/libgcc.a(ldadd_8_4.o)) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (/opt/homebrew/Cellar/gcc/11.2.0_3/lib/gcc/11/gcc/aarch64-apple-darwin21/11/libgcc.a(ldadd_8_1.o)) was built for newer macOS version (11.0) than being linked (10.14)
ld: warning: object file (/opt/homebrew/Cellar/gcc/11.2.0_3/lib/gcc/11/gcc/aarch64-apple-darwin21/11/libgcc.a(lse-init.o)) was built for newer macOS version (11.0) than being linked (10.14)
george@Georges-MacBook-Air src % file stockfish 
stockfish: Mach-O 64-bit executable arm64
george@Georges-MacBook-Air src % ./stockfish bench 2>&1 | tail -4
===========================
Total time (ms) : 3703
Nodes searched  : 5121336
Nodes/second    : 1383023
george@Georges-MacBook-Air src % 

```