### PR TITLE
Remove NNUE scaling term

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1091,8 +1091,7 @@ Value Eval::evaluate(const Position& pos) {
       v = Evaluation<NO_TRACE>(pos).value();          // classical
   else
   {
-       int scale = 1049
-                   +  8 * pos.count<PAWN>()
+       int scale = 1136
                    + 20 * pos.non_pawn_material() / 1024;
 
        Value nnue     = NNUE::evaluate(pos, true);     // NNUE


### PR DESCRIPTION
remove pawns scaling, probably correlated with piece scaling, and might be less useful with the recent improved nets. Might allow for another tune of the scaling params.

passed STC
https://tests.stockfishchess.org/tests/view/61afdb2e56fcf33bce7df31a
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 280864 W: 72198 L: 72399 D: 136267
Ptnml(0-2): 854, 32356, 74346, 31889, 987

passed LTC
https://tests.stockfishchess.org/tests/view/61b233a606b4c2dcb1b16140
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 400136 W: 102669 L: 103012 D: 194455
Ptnml(0-2): 212, 42005, 116047, 41522, 282

Bench: 4735679