### PR TITLE
Simplify away singularQuietLMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -590,8 +590,7 @@ namespace {
     Depth extension, newDepth;
     Value bestValue, value, ttValue, eval, maxValue, probCutBeta;
     bool givesCheck, improving, didLMR, priorCapture;
-    bool captureOrPromotion, doFullDepthSearch, moveCountPruning,
-         ttCapture, singularQuietLMR;
+    bool captureOrPromotion, doFullDepthSearch, moveCountPruning, ttCapture;
     Piece movedPiece;
     int moveCount, captureCount, quietCount, bestMoveCount, improvement;
 
@@ -982,7 +981,7 @@ moves_loop: // When in check, search starts here
                                       ss->ply);
 
     value = bestValue;
-    singularQuietLMR = moveCountPruning = false;
+    moveCountPruning = false;
 
     // Indicate PvNodes that will probably fail low if the node was searched
     // at a depth equal or greater than the current depth, and the result of this search was a fail low.
@@ -1106,7 +1105,6 @@ moves_loop: // When in check, search starts here
           if (value < singularBeta)
           {
               extension = 1;
-              singularQuietLMR = !ttCapture;
 
               // Avoid search explosion by limiting the number of double extensions
               if (   !PvNode
@@ -1190,16 +1188,12 @@ moves_loop: // When in check, search starts here
               && !likelyFailLow)
               r -= 2;
 
-          // Increase reduction at non-PV nodes
+          // Increase reduction at non-PV nodes (~3 Elo)
           if (!PvNode)
               r++;
 
           // Decrease reduction if opponent's move count is high (~1 Elo)
           if ((ss-1)->moveCount > 13)
-              r--;
-
-          // Decrease reduction if ttMove has been singularly extended (~1 Elo)
-          if (singularQuietLMR)
               r--;
 
           // Increase reduction for cut nodes (~3 Elo)


### PR DESCRIPTION
Simplify away singularQuietLMR

While at it, we also update the Elo estimate of:
https://github.com/official-stockfish/Stockfish/blob/c6edf33f539f160d4a7009f3aac25e7ec5668eda/src/search.cpp#L1193-L1195
Source: https://tests.stockfishchess.org/tests/view/61acf97156fcf33bce7d6303

STC:
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 243632 W: 62874 L: 63022 D: 117736
Ptnml(0-2): 810, 28024, 64249, 27970, 763
https://tests.stockfishchess.org/tests/view/61b8b1b7dffbe89a35814c0d

LTC:
LLR: 2.93 (-2.94,2.94) <-2.25,0.25>
Total: 91392 W: 23520 L: 23453 D: 44419
Ptnml(0-2): 51, 9568, 26387, 9643, 47
https://tests.stockfishchess.org/tests/view/61b97316dffbe89a35817da7

bench: 4483842