### PR TITLE
Update default net to nn-4401e826ebcc.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-d93927199b3d.nnue"
+  #define EvalFileDefaultName   "nn-4401e826ebcc.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
Update default net to nn-4401e826ebcc.nnue

Using data T60 12/1/20 to 11/2/2021, T74 4/22/21 to 7/27/21, T75 6/3/21 to 10/16/21, T76 (half of the randomly interleaved dataset due to a mistake merging) 11/10/21 to 11/21/21, wrongIsRight_nodes5000pv2.binpack, and WrongIsRight-Reloaded.binpack combined and shuffled position by position.

Trained with:
LR=4.375e-4 and WDL filtering enabled.
python train.py --smart-fen-skipping --random-fen-skipping 0 --features=HalfKAv2_hm^ --lambda=1.0 --max_epochs=800 --seed 910688689 --batch-size 16384 --progress_bar_refresh_rate 30 --threads 4 --num-workers 4 --gpus 1 --resume-from-model C:\msys64\home\Mike\nnue-pytorch\9b3d.pt E:\trainingdata\T60-T74-T75-T76-WiR-WiRR-PbyP.binpack E:\trainingdata\T60-T74-T75-T76-WiR-WiRR-PbyP.binpack

Passed STC
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 41848 W: 10962 L: 10676 D: 20210 Elo +2.16
Ptnml(0-2): 142, 4699, 11016, 4865, 202 
https://tests.stockfishchess.org/tests/view/61ba886857a0d0f327c2cfd6

Passed LTC
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 27776 W: 7208 L: 6953 D: 13615 Elo + 3.00
Ptnml(0-2): 14, 2808, 8007, 3027, 32 
https://tests.stockfishchess.org/tests/view/61baae4d57a0d0f327c2d96f

Bench: 4667591