### PR TITLE
repair variables

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -333,9 +333,11 @@ endif
 ### ==========================================================================
 
 ### 3.1 Selecting compiler (default = gcc)
-CXXFLAGS += -Wall -Wcast-qual -fno-exceptions -std=c++17 $(EXTRACXXFLAGS)
-DEPENDFLAGS += -std=c++17
-LDFLAGS += $(EXTRALDFLAGS)
+override EXTRACXXFLAGS := $(EXTRACXXFLAGS)
+override EXTRALDFLAGS := $(EXTRALDFLAGS)
+override CXXFLAGS += -Wall -Wcast-qual -fno-exceptions -std=c++17 $(EXTRACXXFLAGS)
+override DEPENDFLAGS += -std=c++17
+override LDFLAGS += $(EXTRALDFLAGS)
 
 ifeq ($(COMP),)
 	COMP=gcc


### PR DESCRIPTION
Variables had different behavior via recursive dependency hell.
If there is no environment variable -> variable treated as local with correct behavior.
If there is environment variable      -> variable treated as global with multiple extending.

E.g. 
CXXFLAGS="-march=native -DNNUE_EMBEDDING_OFF" make COMP=mingw ARCH=x86-64-modern -j3 profile-build CXX=x86_64-w64-mingw32-g++.exe
...
x86_64-w64-mingw32-g++.exe -march=native -DNNUE_EMBEDDING_OFF -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -DNDEBUG -O3 -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -DNDEBUG -O3 -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -pedantic -Wextra -Wshadow -DNDEBUG -O3 -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2   -c -o bitboard.o bitboard.cpp
...