### PR TITLE
repair variables

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -905,39 +905,39 @@ $(EXE): $(OBJS)
 
 clang-profile-make:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-instr-generate ' \
-	EXTRALDFLAGS=' -fprofile-instr-generate' \
+	EXTRACXXFLAGS+='-fprofile-instr-generate ' \
+	EXTRALDFLAGS+=' -fprofile-instr-generate' \
 	all
 
 clang-profile-use:
 	$(XCRUN) llvm-profdata merge -output=stockfish.profdata *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-instr-use=stockfish.profdata' \
-	EXTRALDFLAGS='-fprofile-use ' \
+	EXTRACXXFLAGS+='-fprofile-instr-use=stockfish.profdata' \
+	EXTRALDFLAGS+='-fprofile-use ' \
 	all
 
 gcc-profile-make:
 	@mkdir -p profdir
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-generate=profdir' \
-	EXTRALDFLAGS='-lgcov' \
+	EXTRACXXFLAGS+='-fprofile-generate=profdir' \
+	EXTRALDFLAGS+='-lgcov' \
 	all
 
 gcc-profile-use:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-use=profdir -fno-peel-loops -fno-tracer' \
-	EXTRALDFLAGS='-lgcov' \
+	EXTRACXXFLAGS+='-fprofile-use=profdir -fno-peel-loops -fno-tracer' \
+	EXTRALDFLAGS+='-lgcov' \
 	all
 
 icc-profile-make:
 	@mkdir -p profdir
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-prof-gen=srcpos -prof_dir ./profdir' \
+	EXTRACXXFLAGS+='-prof-gen=srcpos -prof_dir ./profdir' \
 	all
 
 icc-profile-use:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-prof_use -prof_dir ./profdir' \
+	EXTRACXXFLAGS+='-prof_use -prof_dir ./profdir' \
 	all
 
 .depend: $(SRCS)


### PR DESCRIPTION
Variables had different behavior via recursive dependency hell.
If there is no environment variable -> variable treated as local with correct behavior.
If there is environment variable      -> variable treated as global with multiple extending.

E.g. 
CXXFLAGS="-march=native -DNNUE_EMBEDDING_OFF" make COMP=mingw ARCH=x86-64-modern -j3 profile-build CXX=x86_64-w64-mingw32-g++.exe
...
x86_64-w64-mingw32-g++.exe -march=native -DNNUE_EMBEDDING_OFF **-Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -DNDEBUG -O3 -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2** -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -DNDEBUG -O3 -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -Wall -Wcast-qual -fno-exceptions -std=c++17 -fprofile-generate=profdir -pedantic -Wextra -Wshadow -DNDEBUG -O3 -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2   -c -o bitboard.o bitboard.cpp
...

Now:
EXTRACXXFLAGS="-march=native -DNNUE_EMBEDDING_OFF" make COMP=mingw ARCH=x86-64-modern -j3 profile-build CXX=x86_64-w64-mingw32-g++.exe