### PR TITLE
mingw target fixup

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -368,22 +368,18 @@ endif
 ifeq ($(COMP),mingw)
 	comp=mingw
 
-	ifeq ($(KERNEL),Linux)
-		ifeq ($(bits),64)
-			ifeq ($(shell which x86_64-w64-mingw32-c++-posix),)
-				CXX=x86_64-w64-mingw32-c++
-			else
-				CXX=x86_64-w64-mingw32-c++-posix
-			endif
+	ifeq ($(bits),64)
+		ifeq ($(shell which x86_64-w64-mingw32-c++-posix 2> /dev/null),)
+			CXX=x86_64-w64-mingw32-c++
 		else
-			ifeq ($(shell which i686-w64-mingw32-c++-posix),)
-				CXX=i686-w64-mingw32-c++
-			else
-				CXX=i686-w64-mingw32-c++-posix
-			endif
+			CXX=x86_64-w64-mingw32-c++-posix
 		endif
 	else
-		CXX=g++
+		ifeq ($(shell which i686-w64-mingw32-c++-posix 2> /dev/null),)
+			CXX=i686-w64-mingw32-c++
+		else
+			CXX=i686-w64-mingw32-c++-posix
+		endif
 	endif
 
 	CXXFLAGS += -pedantic -Wextra -Wshadow


### PR DESCRIPTION
There is no need to point g++ (else branch), if we explicitly choose mingw.
Now for cygwin:

```
make COMP=mingw ARCH=x86-64-modern build CXX=x86_64-w64-mingw32-g++.exe
---->
 make COMP=mingw ARCH=x86-64-modern build
```

If we wanna g++, we just don't type COMP=mingw in cygwin,msys2.