### PR TITLE
Simplification in evaluate_nnue.cpp

### DIFF
--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -165,12 +165,11 @@ namespace Stockfish::Eval::NNUE {
     const auto psqt = featureTransformer->transform(pos, transformedFeatures, bucket);
     const auto positional = network[bucket]->propagate(transformedFeatures, buffer)[0];
 
-    // Give more value to positional evaluation when material is balanced
-    if (   adjusted
-        && abs(pos.non_pawn_material(WHITE) - pos.non_pawn_material(BLACK)) <= RookValueMg - BishopValueMg)
-      return  static_cast<Value>(((128 - delta) * psqt + (128 + delta) * positional) / 128 / OutputScale);
+    // Give more value to positional evaluation when adjusted flag is set
+    if (adjusted)
+        return static_cast<Value>(((128 - delta) * psqt + (128 + delta) * positional) / 128 / OutputScale);
     else
-      return static_cast<Value>((psqt + positional) / OutputScale);
+        return static_cast<Value>((psqt + positional) / OutputScale);
   }
 
   struct NnueEvalTrace {


### PR DESCRIPTION
Removes the test on non-pawn-material before applying the positional/materialistic bonus.

Passed STC:
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 46904 W: 12197 L: 12059 D: 22648
Ptnml(0-2): 170, 5243, 12479, 5399, 161
https://tests.stockfishchess.org/tests/view/61be57cf57a0d0f327c3999d

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 18760 W: 4958 L: 4790 D: 9012
Ptnml(0-2): 14, 1942, 5301, 2108, 15
https://tests.stockfishchess.org/tests/view/61bed1fb57a0d0f327c3afa9

closes https://github.com/official-stockfish/Stockfish/pull/3866

Bench: 4826206