### PR TITLE
Remove Capture history pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1031,12 +1031,6 @@ moves_loop: // When in check, search starts here
           if (   captureOrPromotion
               || givesCheck)
           {
-              // Capture history based pruning when the move doesn't give check
-              if (   !givesCheck
-                  && lmrDepth < 1
-                  && captureHistory[movedPiece][to_sq(move)][type_of(pos.piece_on(to_sq(move)))] < 0)
-                  continue;
-
               // Futility pruning for captures
               if (   !pos.empty(to_sq(move))
                   && !givesCheck


### PR DESCRIPTION
Remove Capture history based pruning, introduced in #2618

Fixed number of games. (book: 8moves_v3.png):
ELO: -0.69 +-1.8 (95%) LOS: 22.1%
Total: 20000 W: 1592 L: 1632 D: 16776
Ptnml(0-2): 44, 1194, 7566, 1150, 46
https://tests.stockfishchess.org/tests/view/61bb8eb657a0d0f327c30ce8

STC:
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 139976 W: 36039 L: 36036 D: 67901
Ptnml(0-2): 435, 16138, 36885, 16049, 481
https://tests.stockfishchess.org/tests/view/61be731857a0d0f327c39ea2

LTC:
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 70656 W: 18284 L: 18189 D: 34183
Ptnml(0-2): 34, 7317, 20529, 7416, 32
https://tests.stockfishchess.org/tests/view/61bf39b657a0d0f327c3c37b

bench: 4638602