### PR TITLE
Update Elo estimates for terms in search.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1083,7 +1083,7 @@ Value Eval::evaluate(const Position& pos) {
 
   Value v;
 
-  // Deciding between classical and NNUE eval: for high PSQ imbalance we use classical,
+  // Deciding between classical and NNUE eval (~10 Elo): for high PSQ imbalance we use classical,
   // but we switch to NNUE during long shuffling or with high material on the board.
 
   if (  !useNNUE

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -671,20 +671,20 @@ namespace {
         && (ttValue >= beta ? (tte->bound() & BOUND_LOWER)
                             : (tte->bound() & BOUND_UPPER)))
     {
-        // If ttMove is quiet, update move sorting heuristics on TT hit
+        // If ttMove is quiet, update move sorting heuristics on TT hit (~1 Elo)
         if (ttMove)
         {
             if (ttValue >= beta)
             {
-                // Bonus for a quiet ttMove that fails high
+                // Bonus for a quiet ttMove that fails high (~3 Elo)
                 if (!ttCapture)
                     update_quiet_stats(pos, ss, ttMove, stat_bonus(depth));
 
-                // Extra penalty for early quiet moves of the previous ply
+                // Extra penalty for early quiet moves of the previous ply (~0 Elo)
                 if ((ss-1)->moveCount <= 2 && !priorCapture)
                     update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth + 1));
             }
-            // Penalty for a quiet ttMove that fails low
+            // Penalty for a quiet ttMove that fails low (~1 Elo)
             else if (!ttCapture)
             {
                 int penalty = -stat_bonus(depth);
@@ -773,7 +773,7 @@ namespace {
         if (eval == VALUE_DRAW)
             eval = value_draw(thisThread);
 
-        // Can ttValue be used as a better position evaluation?
+        // ttValue can be used as a better position evaluation (~4 Elo)
         if (    ttValue != VALUE_NONE
             && (tte->bound() & (ttValue > eval ? BOUND_LOWER : BOUND_UPPER)))
             eval = ttValue;
@@ -787,7 +787,7 @@ namespace {
             tte->save(posKey, VALUE_NONE, ss->ttPv, BOUND_NONE, DEPTH_NONE, MOVE_NONE, eval);
     }
 
-    // Use static evaluation difference to improve quiet move ordering
+    // Use static evaluation difference to improve quiet move ordering (~3 Elo)
     if (is_ok((ss-1)->currentMove) && !(ss-1)->inCheck && !priorCapture)
     {
         int bonus = std::clamp(-16 * int((ss-1)->staticEval + ss->staticEval), -2000, 2000);
@@ -804,7 +804,7 @@ namespace {
 
     improving = improvement > 0;
 
-    // Step 7. Futility pruning: child node (~50 Elo).
+    // Step 7. Futility pruning: child node (~25 Elo).
     // The depth condition is important for mate finding.
     if (   !ss->ttPv
         &&  depth < 9
@@ -812,7 +812,7 @@ namespace {
         &&  eval < 15000) // 50% larger than VALUE_KNOWN_WIN, but smaller than TB wins.
         return eval;
 
-    // Step 8. Null move search with verification search (~40 Elo)
+    // Step 8. Null move search with verification search (~22 Elo)
     if (   !PvNode
         && (ss-1)->currentMove != MOVE_NULL
         && (ss-1)->statScore < 23767
@@ -925,7 +925,7 @@ namespace {
          ss->ttPv = ttPv;
     }
 
-    // Step 10. If the position is not in TT, decrease depth by 2 or 1 depending on node type
+    // Step 10. If the position is not in TT, decrease depth by 2 or 1 depending on node type (~3 Elo)
     if (   PvNode
         && depth >= 6
         && !ttMove)
@@ -940,7 +940,7 @@ moves_loop: // When in check, search starts here
 
     int rangeReduction = 0;
 
-    // Step 11. A small Probcut idea, when we are in check
+    // Step 11. A small Probcut idea, when we are in check (~0 Elo)
     probCutBeta = beta + 409;
     if (   ss->inCheck
         && !PvNode
@@ -1017,12 +1017,12 @@ moves_loop: // When in check, search starts here
 
       Value delta = beta - alpha;
 
-      // Step 13. Pruning at shallow depth (~200 Elo). Depth conditions are important for mate finding.
+      // Step 13. Pruning at shallow depth (~98 Elo). Depth conditions are important for mate finding.
       if (  !rootNode
           && pos.non_pawn_material(us)
           && bestValue > VALUE_TB_LOSS_IN_MAX_PLY)
       {
-          // Skip quiet moves if movecount exceeds our FutilityMoveCount threshold
+          // Skip quiet moves if movecount exceeds our FutilityMoveCount threshold (~7 Elo)
           moveCountPruning = moveCount >= futility_move_count(improving, depth);
 
           // Reduced depth of the next LMR search
@@ -1037,7 +1037,7 @@ moves_loop: // When in check, search starts here
                   && captureHistory[movedPiece][to_sq(move)][type_of(pos.piece_on(to_sq(move)))] < 0)
                   continue;
 
-              // Futility pruning for captures
+              // Futility pruning for captures (~0 Elo)
               if (   !pos.empty(to_sq(move))
                   && !givesCheck
                   && !PvNode
@@ -1047,8 +1047,8 @@ moves_loop: // When in check, search starts here
                    + captureHistory[movedPiece][to_sq(move)][type_of(pos.piece_on(to_sq(move)))] / 8 < alpha)
                   continue;
 
-              // SEE based pruning
-              if (!pos.see_ge(move, Value(-218) * depth)) // (~25 Elo)
+              // SEE based pruning (~9 Elo)
+              if (!pos.see_ge(move, Value(-218) * depth))
                   continue;
           }
           else
@@ -1057,28 +1057,28 @@ moves_loop: // When in check, search starts here
                             + (*contHist[1])[movedPiece][to_sq(move)]
                             + (*contHist[3])[movedPiece][to_sq(move)];
 
-              // Continuation history based pruning (~20 Elo)
+              // Continuation history based pruning (~2 Elo)
               if (   lmrDepth < 5
                   && history < -3000 * depth + 3000)
                   continue;
 
               history += thisThread->mainHistory[us][from_to(move)];
 
-              // Futility pruning: parent node (~5 Elo)
+              // Futility pruning: parent node (~9 Elo)
               if (   !ss->inCheck
                   && lmrDepth < 8
                   && ss->staticEval + 142 + 139 * lmrDepth + history / 64 <= alpha)
                   continue;
 
-              // Prune moves with negative SEE (~20 Elo)
+              // Prune moves with negative SEE (~3 Elo)
               if (!pos.see_ge(move, Value(-21 * lmrDepth * lmrDepth - 21 * lmrDepth)))
                   continue;
           }
       }
 
-      // Step 14. Extensions (~75 Elo)
+      // Step 14. Extensions (~66 Elo)
 
-      // Singular extension search (~70 Elo). If all moves but one fail low on a
+      // Singular extension search (~58 Elo). If all moves but one fail low on a
       // search of (alpha-s, beta-s), and just one fails high on (alpha, beta),
       // then that move is singular and should be extended. To verify this we do
       // a reduced search on all the other moves but the ttMove and if the
@@ -1129,13 +1129,13 @@ moves_loop: // When in check, search starts here
                && moveCount != 1)
           extension = 1;
 
-      // Check extensions
+      // Check extensions (~1 Elo)
       else if (   givesCheck
                && depth > 6
                && abs(ss->staticEval) > 100)
           extension = 1;
 
-      // Quiet ttMove extensions
+      // Quiet ttMove extensions (~0 Elo)
       else if (   PvNode
                && move == ttMove
                && move == ss->killers[0]
@@ -1161,7 +1161,7 @@ moves_loop: // When in check, search starts here
 
       bool doDeeperSearch = false;
 
-      // Step 16. Late moves reduction / extension (LMR, ~200 Elo)
+      // Step 16. Late moves reduction / extension (LMR, ~98 Elo)
       // We use various heuristics for the sons of a node after the first son has
       // been searched. In general we would like to reduce them, but there are many
       // cases where we extend a son if it has good chances to be "interesting".
@@ -1479,7 +1479,7 @@ moves_loop: // When in check, search starts here
             if ((ss->staticEval = bestValue = tte->eval()) == VALUE_NONE)
                 ss->staticEval = bestValue = evaluate(pos);
 
-            // Can ttValue be used as a better position evaluation?
+            // ttValue can be used as a better position evaluation (~7 Elo)
             if (    ttValue != VALUE_NONE
                 && (tte->bound() & (ttValue > bestValue ? BOUND_LOWER : BOUND_UPPER)))
                 bestValue = ttValue;
@@ -1534,7 +1534,7 @@ moves_loop: // When in check, search starts here
 
       moveCount++;
 
-      // Futility pruning and moveCount pruning
+      // Futility pruning and moveCount pruning (~5 Elo)
       if (    bestValue > VALUE_TB_LOSS_IN_MAX_PLY
           && !givesCheck
           &&  futilityBase > -VALUE_KNOWN_WIN
@@ -1559,7 +1559,7 @@ moves_loop: // When in check, search starts here
           }
       }
 
-      // Do not search moves with negative SEE values
+      // Do not search moves with negative SEE values (~5 Elo)
       if (    bestValue > VALUE_TB_LOSS_IN_MAX_PLY
           && !pos.see_ge(move))
           continue;
@@ -1573,7 +1573,7 @@ moves_loop: // When in check, search starts here
                                                                 [pos.moved_piece(move)]
                                                                 [to_sq(move)];
 
-      // Continuation history based pruning
+      // Continuation history based pruning (~2 Elo)
       if (  !captureOrPromotion
           && bestValue > VALUE_TB_LOSS_IN_MAX_PLY
           && (*contHist[0])[pos.moved_piece(move)][to_sq(move)] < CounterMovePruneThreshold


### PR DESCRIPTION
This updates estimates from 2yr ago #2401, and adds missing terms.
All tests run at 10+0.1 (STC), 20000 games, error bars +- 1.8 Elo, book 8moves_v3.png.

| Test | Estimative (Elo) |
| --- | --- |
| [If ttMove is quiet, update move sorting heuristics on TT hit](https://tests.stockfishchess.org/tests/view/61bb8efa57a0d0f327c30d0e) | +0.80 |
| [Bonus for a quiet ttMove that fails high](https://tests.stockfishchess.org/tests/view/61bc19fc57a0d0f327c32a31) | +2.66 |
| [Extra penalty for early quiet moves of the previous ply](https://tests.stockfishchess.org/tests/view/61bc1a0357a0d0f327c32a34) | -0.52 |
| [Penalty for a quiet ttMove that fails low](https://tests.stockfishchess.org/tests/view/61bc1a0d57a0d0f327c32a36) | +1.08 |
| [Can ttValue be used as a better position evaluation (search)](https://tests.stockfishchess.org/tests/view/61bc1a1657a0d0f327c32a3a) | +4.13 |
| [Use static evaluation difference to improve quiet move ordering](https://tests.stockfishchess.org/tests/view/61bb8ee157a0d0f327c30d01) | +2.88 |
| [Futility pruning: child node](https://tests.stockfishchess.org/tests/view/61bb8e8d57a0d0f327c30cd3) | +24.55 |
| [Null move search with verification search](https://tests.stockfishchess.org/tests/view/61bb8e9757a0d0f327c30cd8) | +22.00 |
| [If not in TT, decrease depth by 2 or 1](https://tests.stockfishchess.org/tests/view/61bb8e9d57a0d0f327c30cdc) | +2.50 |
| [A small Probcut idea, when we are in check](https://tests.stockfishchess.org/tests/view/61bb8ea457a0d0f327c30cde) | -0.28 |
| [Pruning at shallow depth](https://tests.stockfishchess.org/tests/view/61bb8eab57a0d0f327c30ce2) | +98.63 |
| [FutilityMoveCount](https://tests.stockfishchess.org/tests/view/61bb8eb057a0d0f327c30ce5) | +6.91 |
| [Futility pruning for captures](https://tests.stockfishchess.org/tests/view/61c0978ea2c8d878e5de73bd) | +0.42 |
| [SEE based pruning](https://tests.stockfishchess.org/tests/view/61bb8eba57a0d0f327c30cea) | +9.10 |
| [Continuation history based pruning](https://tests.stockfishchess.org/tests/view/61bb8ebf57a0d0f327c30ced) | +1.7 |
| [Futility pruning: parent node](https://tests.stockfishchess.org/tests/view/61bb8ec657a0d0f327c30cf1) | +8.71 |
| [Prune moves with negative SEE](https://tests.stockfishchess.org/tests/view/61bb8ecc57a0d0f327c30cf3) | +3.25 |
| [Extensions](https://tests.stockfishchess.org/tests/view/61bb8ed757a0d0f327c30cf8) | +65.85 |
| [Singular extension](https://tests.stockfishchess.org/tests/view/61bb8ed157a0d0f327c30cf5) | +57.82 |
| [Check extensions](https://tests.stockfishchess.org/tests/view/61bc1a2857a0d0f327c32a3f) | +0.94 |
| [Quiet ttMove extensions](https://tests.stockfishchess.org/tests/view/61bc1a3057a0d0f327c32a44) | -1.20 |
| [LMR](https://tests.stockfishchess.org/tests/view/61bb8edc57a0d0f327c30cfd) | +98.20 |
| [Can ttValue be used as a better position evaluation (qsearch)](https://tests.stockfishchess.org/tests/view/61bc1a4357a0d0f327c32a4d) | +6.85 |
| [Futility pruning and moveCount pruning](https://tests.stockfishchess.org/tests/view/61bb8ee657a0d0f327c30d03) | +4.95 |
| [Do not search moves with negative SEE values](https://tests.stockfishchess.org/tests/view/61bb8eeb57a0d0f327c30d05) | +5.14 |
| [Continuation history based pruning](https://tests.stockfishchess.org/tests/view/61bb8ef057a0d0f327c30d09) | +2.05 |

Values are rounded to the nearest non-negative integer.

Non-red tests that have been tried simplification and failed:
[If ttMove is quiet, update move sorting heuristics on TT hit](https://tests.stockfishchess.org/tests/view/61bc62df57a0d0f327c338da)
[Extra penalty for early quiet moves of the previous ply](https://tests.stockfishchess.org/tests/view/61bdc32e57a0d0f327c37d6b)
[Penalty for a quiet ttMove that fails low](https://tests.stockfishchess.org/tests/view/61bc646157a0d0f327c3392e)
[A small Probcut idea, when we are in check](https://tests.stockfishchess.org/tests/view/61bbdeda57a0d0f327c31e79)
[Check extensions](https://tests.stockfishchess.org/tests/view/61bcbf1357a0d0f327c34aa5)

Simplification found by these tests:
#3863
#3867

Test about pure NNUE vs Hybrid:
LTC: https://tests.stockfishchess.org/tests/view/61b5785cdffbe89a3580948a  (~10 Elo)
STC: https://tests.stockfishchess.org/tests/view/61b5784ddffbe89a35809484 ( ~7 Elo)

No functional change.