### PR TITLE
Fall back to NNUE if classical evaluation is much lower than threshold.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1086,10 +1086,17 @@ Value Eval::evaluate(const Position& pos) {
   // Deciding between classical and NNUE eval (~10 Elo): for high PSQ imbalance we use classical,
   // but we switch to NNUE during long shuffling or with high material on the board.
 
+  bool classical = false;
+
   if (  !useNNUE
       || abs(eg_value(pos.psq_score())) * 5 > (850 + pos.non_pawn_material() / 64) * (5 + pos.rule50_count()))
+  {
       v = Evaluation<NO_TRACE>(pos).value();          // classical
-  else
+      classical = abs(v) >= 300;
+  }
+
+  // If result of a classical evaluation is much lower than threshold fall back to NNUE
+  if (!classical && useNNUE)
   {
        int scale = 1136
                    + 20 * pos.non_pawn_material() / 1024;


### PR DESCRIPTION
Idea is that if classical eval returns value much lower than threshold of it usage it most likely means that position isn't that simple so we need more precise NNUE evaluation.
passed STC:
https://tests.stockfishchess.org/tests/view/61bf3e7557a0d0f327c3c47a
LLR: 2.95 (-2.94,2.94) <0.00,2.50>
Total: 108072 W: 28007 L: 27604 D: 52461
Ptnml(0-2): 352, 12147, 28650, 12520, 367 
passed LTC:
https://tests.stockfishchess.org/tests/view/61c0581657a0d0f327c3fa0c
LLR: 2.95 (-2.94,2.94) <0.50,3.00>
Total: 155096 W: 40392 L: 39841 D: 74863
Ptnml(0-2): 88, 15983, 44843, 16558, 76 