### PR TITLE
Update default net to nn-ac07bd334b62.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-4401e826ebcc.nnue"
+  #define EvalFileDefaultName   "nn-ac07bd334b62.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
trained with essentially the same data as provided and used by Farseer (mbabigian) for the previous master net.

T60T70wIsRightFarseerT60T74T75T76.binpack (99GB):
['T60T70wIsRightFarseer.binpack', 'farseerT74.binpack', 'farseerT75.binpack', 'farseerT76.binpack']
using the trainer branch tweakLR1PR (https://github.com/glinscott/nnue-pytorch/pull/158) and
`--gpus 1 --threads 4 --num-workers 4 --batch-size 16384 --progress_bar_refresh_rate 300 --smart-fen-skipping --random-fen-skipping 12 --features=HalfKAv2_hm^   --lambda=1.00` options

passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.50>
Total: 108280 W: 28042 L: 27636 D: 52602
Ptnml(0-2): 328, 12382, 28401, 12614, 415
https://tests.stockfishchess.org/tests/view/61bcd8c257a0d0f327c34fbd

passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 259296 W: 66974 L: 66175 D: 126147
Ptnml(0-2): 146, 27096, 74452, 27721, 233
https://tests.stockfishchess.org/tests/view/61bda70957a0d0f327c37817

Bench: 4633875