### PR TITLE
Don't direct prune a move if it's a retake

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1503,10 +1503,11 @@ moves_loop: // When in check, search starts here
     // to search the moves. Because the depth is <= 0 here, only captures,
     // queen promotions, and other checks (only if depth >= DEPTH_QS_CHECKS)
     // will be generated.
+    Square prevSq = to_sq((ss-1)->currentMove);
     MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory,
                                       &thisThread->captureHistory,
                                       contHist,
-                                      to_sq((ss-1)->currentMove));
+                                      prevSq);
 
     // Loop through the moves until no moves remain or a beta cutoff occurs
     while ((move = mp.next_move()) != MOVE_NONE)
@@ -1525,6 +1526,7 @@ moves_loop: // When in check, search starts here
       // Futility pruning and moveCount pruning (~5 Elo)
       if (    bestValue > VALUE_TB_LOSS_IN_MAX_PLY
           && !givesCheck
+          &&  to_sq(move) != prevSq
           &&  futilityBase > -VALUE_KNOWN_WIN
           &&  type_of(move) != PROMOTION)
       {


### PR DESCRIPTION
Don't direct prune a move if it's a retake

STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 36304 W: 9499 L: 9226 D: 17579
Ptnml(0-2): 96, 4102, 9508, 4325, 121
https://tests.stockfishchess.org/tests/view/61c7069ae68b2a714b6dca27

LTC:
LLR: 2.95 (-2.94,2.94) <0.50,3.00>
Total: 93824 W: 24478 L: 24068 D: 45278
Ptnml(0-2): 70, 9644, 27082, 10038, 78
https://tests.stockfishchess.org/tests/view/61c725fee68b2a714b6dcfa2

Bench: 4106806