### PR TITLE
Tweak optimism with complexity

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1082,29 +1082,28 @@ make_v:
 Value Eval::evaluate(const Position& pos) {
 
   Value v;
+  bool useClassical = false;
 
   // Deciding between classical and NNUE eval (~10 Elo): for high PSQ imbalance we use classical,
   // but we switch to NNUE during long shuffling or with high material on the board.
-
-  bool classical = false;
-
   if (  !useNNUE
       || abs(eg_value(pos.psq_score())) * 5 > (850 + pos.non_pawn_material() / 64) * (5 + pos.rule50_count()))
   {
       v = Evaluation<NO_TRACE>(pos).value();          // classical
-      classical = abs(v) >= 300;
+      useClassical = abs(v) >= 300;
   }
 
   // If result of a classical evaluation is much lower than threshold fall back to NNUE
-  if (!classical && useNNUE)
+  if (useNNUE && !useClassical)
   {
-       int scale = 1136
-                   + 20 * pos.non_pawn_material() / 1024;
-
        Value nnue     = NNUE::evaluate(pos, true);     // NNUE
+       int scale      = 1136 + 20 * pos.non_pawn_material() / 1024;
        Color stm      = pos.side_to_move();
        Value optimism = pos.this_thread()->optimism[stm];
+       Value psq      = (stm == WHITE ? 1 : -1) * eg_value(pos.psq_score());
+       int complexity = abs(nnue - psq) / 256;
 
+       optimism *= (1 + complexity);
        v = (nnue + optimism) * scale / 1024 - optimism;
 
        if (pos.is_chess960())


### PR DESCRIPTION
This patch increases the optimism bonus for "complex positions", where the
complexity is measured as the absolute value of the difference between material
and the sophisticated NNUE evaluation (idea by Joost VandeVondele).

Also rename some variables in evaluate() while there.

passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 88392 W: 23150 L: 22781 D: 42461
Ptnml(0-2): 318, 9961, 23257, 10354, 306
https://tests.stockfishchess.org/tests/view/61cbbedee68b2a714b6eb110

passed LTC:
LLR: 2.93 (-2.94,2.94) <0.50,3.00>
Total: 37848 W: 10043 L: 9766 D: 18039
Ptnml(0-2): 26, 3815, 10961, 4100, 22
https://tests.stockfishchess.org/tests/view/61cc0cc3e68b2a714b6ec28c

follow-up from https://github.com/official-stockfish/Stockfish/commit/a5a89b27c8e3225fb453d603bc4515d32bb351c3
closes https://github.com/official-stockfish/Stockfish/pull/3875

Bench: 4125221