### PR TITLE
Smooth out doDeeperSearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -550,7 +550,7 @@ namespace {
     if (   ss->ply > 10
         && search_explosion(thisThread) == MUST_CALM_DOWN
         && depth > (ss-1)->depth)
-       depth = (ss-1)->depth;
+        depth = (ss-1)->depth;
 
     constexpr bool PvNode = nodeType != NonPV;
     constexpr bool rootNode = nodeType == Root;
@@ -1212,7 +1212,7 @@ moves_loop: // When in check, search starts here
 
           // If the son is reduced and fails high it will be re-searched at full depth
           doFullDepthSearch = value > alpha && d < newDepth;
-          doDeeperSearch = value > alpha + 88;
+          doDeeperSearch = value > alpha + 62 + 20 * (newDepth - d);
           didLMR = true;
       }
       else
@@ -1280,7 +1280,7 @@ moves_loop: // When in check, search starts here
                   rm.pv.push_back(*m);
 
               // We record how often the best move has been changed in each iteration.
-              // This information is used for time management and LMR. In MultiPV mode,
+              // This information is used for time management. In MultiPV mode,
               // we must take care to only do this for the first PV line.
               if (   moveCount > 1
                   && !thisThread->pvIdx)


### PR DESCRIPTION
Adjust threshold based on the difference between newDepth and LMR depth.
With more reduction, bigger fail-high is required in order to perform the deeper search.

STC:
LLR: 2.96 (-2.94,2.94) <0.00,2.50>
Total: 93576 W: 24133 L: 23758 D: 45685
Ptnml(0-2): 260, 10493, 24935, 10812, 288
https://tests.stockfishchess.org/tests/view/61cbb5cee68b2a714b6eaf09

LTC:
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 109280 W: 28198 L: 27754 D: 53328
Ptnml(0-2): 60, 11225, 31637, 11647, 71
https://tests.stockfishchess.org/tests/view/61cc03fee68b2a714b6ec091

Bench: 4464723