### PR TITLE
Simplify away rangeReduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -69,9 +69,9 @@ namespace {
   // Reductions lookup table, initialized at startup
   int Reductions[MAX_MOVES]; // [depth or moveNumber]
 
-  Depth reduction(bool i, Depth d, int mn, bool rangeReduction, Value delta, Value rootDelta) {
+  Depth reduction(bool i, Depth d, int mn, Value delta, Value rootDelta) {
     int r = Reductions[d] * Reductions[mn];
-    return (r + 1358 - int(delta) * 1024 / int(rootDelta)) / 1024 + (!i && r > 904) + rangeReduction;
+    return (r + 1358 - int(delta) * 1024 / int(rootDelta)) / 1024 + (!i && r > 904);
   }
 
   constexpr int futility_move_count(bool improving, Depth depth) {
@@ -938,8 +938,6 @@ namespace {
 
 moves_loop: // When in check, search starts here
 
-    int rangeReduction = 0;
-
     // Step 11. A small Probcut idea, when we are in check (~0 Elo)
     probCutBeta = beta + 409;
     if (   ss->inCheck
@@ -1026,7 +1024,7 @@ moves_loop: // When in check, search starts here
           moveCountPruning = moveCount >= futility_move_count(improving, depth);
 
           // Reduced depth of the next LMR search
-          int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount, rangeReduction > 2, delta, thisThread->rootDelta), 0);
+          int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount, delta, thisThread->rootDelta), 0);
 
           if (   captureOrPromotion
               || givesCheck)
@@ -1159,7 +1157,7 @@ moves_loop: // When in check, search starts here
               || !captureOrPromotion
               || (cutNode && (ss-1)->moveCount > 1)))
       {
-          Depth r = reduction(improving, depth, moveCount, rangeReduction > 2, delta, thisThread->rootDelta);
+          Depth r = reduction(improving, depth, moveCount, delta, thisThread->rootDelta);
 
           // Decrease reduction at some PvNodes (~2 Elo)
           if (   PvNode
@@ -1205,10 +1203,6 @@ moves_loop: // When in check, search starts here
           Depth d = std::clamp(newDepth - r, 1, newDepth + deeper);
 
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, d, true);
-
-          // Range reductions (~3 Elo)
-          if (ss->staticEval - value < 30 && depth > 7)
-              rangeReduction++;
 
           // If the son is reduced and fails high it will be re-searched at full depth
           doFullDepthSearch = value > alpha && d < newDepth;


### PR DESCRIPTION
Remove rangeReduction, introduced in [#3717](https://github.com/official-stockfish/Stockfish/pull/3717), as it seemingly doesn't bring enough ELO anymore.
It might be interesting to add new forms of reduction or tune the reduction formula in the future.

STC:
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 45008 W: 12114 L: 11972 D: 20922
Ptnml(0-2): 174, 5031, 11952, 5173, 174
https://tests.stockfishchess.org/tests/view/61d08b7b069ca917749c9f6f

LTC:
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 30792 W: 8235 L: 8086 D: 14471
Ptnml(0-2): 24, 3162, 8882, 3297, 31
https://tests.stockfishchess.org/tests/view/61d0a6ad069ca917749ca420

Bench: 4048312