### PR TITLE
Tune a few parameters related to evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -192,8 +192,8 @@ using namespace Trace;
 namespace {
 
   // Threshold for lazy and space evaluation
-  constexpr Value LazyThreshold1    =  Value(3130);
-  constexpr Value LazyThreshold2    =  Value(2204);
+  constexpr Value LazyThreshold1    =  Value(3631);
+  constexpr Value LazyThreshold2    =  Value(2084);
   constexpr Value SpaceThreshold    =  Value(11551);
 
   // KingAttackWeights[PieceType] contains king attack weights by piece type
@@ -1087,10 +1087,10 @@ Value Eval::evaluate(const Position& pos) {
   // Deciding between classical and NNUE eval (~10 Elo): for high PSQ imbalance we use classical,
   // but we switch to NNUE during long shuffling or with high material on the board.
   if (  !useNNUE
-      || abs(eg_value(pos.psq_score())) * 5 > (850 + pos.non_pawn_material() / 64) * (5 + pos.rule50_count()))
+      || abs(eg_value(pos.psq_score())) * 5 > (849 + pos.non_pawn_material() / 64) * (5 + pos.rule50_count()))
   {
       v = Evaluation<NO_TRACE>(pos).value();          // classical
-      useClassical = abs(v) >= 300;
+      useClassical = abs(v) >= 298;
   }
 
   // If result of a classical evaluation is much lower than threshold fall back to NNUE
@@ -1101,9 +1101,9 @@ Value Eval::evaluate(const Position& pos) {
        Color stm      = pos.side_to_move();
        Value optimism = pos.this_thread()->optimism[stm];
        Value psq      = (stm == WHITE ? 1 : -1) * eg_value(pos.psq_score());
-       int complexity = abs(nnue - psq) / 256;
+       int complexity = 35 * abs(nnue - psq) / 256;
 
-       optimism *= (1 + complexity);
+       optimism = optimism * (44 + complexity) / 32;
        v = (nnue + optimism) * scale / 1024 - optimism;
 
        if (pos.is_chess960())
@@ -1111,7 +1111,7 @@ Value Eval::evaluate(const Position& pos) {
   }
 
   // Damp down the evaluation linearly when shuffling
-  v = v * (207 - pos.rule50_count()) / 207;
+  v = v * (208 - pos.rule50_count()) / 208;
 
   // Guarantee evaluation does not hit the tablebase range
   v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);


### PR DESCRIPTION
based on a SPSA tune (using Autoselect)
https://tests.stockfishchess.org/tests/view/61d5aa63a314fed318a57046

passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.50>
Total: 61960 W: 16640 L: 16316 D: 29004
Ptnml(0-2): 278, 6934, 16204, 7314, 250
https://tests.stockfishchess.org/tests/view/61d7fe4af5fd40f357469a8d

passed LTC:
LLR: 2.97 (-2.94,2.94) <0.50,3.00>
Total: 79408 W: 21994 L: 21618 D: 35796
Ptnml(0-2): 106, 7887, 23331, 8285, 95
https://tests.stockfishchess.org/tests/view/61d836b7f5fd40f35746a3d5

Bench: 4266621