### PR TITLE
Tune FRC trapped Bishop patch

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -87,6 +87,7 @@ const vector<string> Defaults = {
   // Chess 960
   "setoption name UCI_Chess960 value true",
   "bbqnnrkr/pppppppp/8/8/8/8/PPPPPPPP/BBQNNRKR w HFhf - 0 1 moves g2g3 d7d5 d2d4 c8h3 c1g5 e8d6 g5e7 f7f6",
+  "nqbnrkrb/pppppppp/8/8/8/8/PPPPPPPP/NQBNRKRB w KQkq - 0 1",
   "setoption name UCI_Chess960 value false"
 };
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1069,8 +1069,8 @@ make_v:
         && pos.piece_on(SQ_G7) == B_PAWN)
         correction += CorneredBishop;
 
-    return pos.side_to_move() == WHITE ?  Value(5 * correction)
-                                       : -Value(5 * correction);
+    return pos.side_to_move() == WHITE ?  Value(3 * correction)
+                                       : -Value(3 * correction);
   }
 
 } // namespace Eval


### PR DESCRIPTION
now that fishtest can deal with FRC, retune this correction.

Add an additional fen to bench with cornered B and N.

passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.50>
Total: 49672 W: 7358 L: 7082 D: 35232
Ptnml(0-2): 241, 4329, 15458, 4529, 279
https://tests.stockfishchess.org/tests/view/61d8b7bf9fea7913d9c63cb7

passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,3.00>
Total: 86688 W: 8308 L: 8007 D: 70373
Ptnml(0-2): 92, 4943, 32989, 5212, 108
https://tests.stockfishchess.org/tests/view/61d92dcb9fea7913d9c650ad

Bench: 4326560