### PR TITLE
Adjust pruning constants.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1040,7 +1040,7 @@ moves_loop: // When in check, search starts here
                   continue;
 
               // SEE based pruning (~9 Elo)
-              if (!pos.see_ge(move, Value(-218) * depth))
+              if (!pos.see_ge(move, Value(-217) * depth))
                   continue;
           }
           else
@@ -1051,7 +1051,7 @@ moves_loop: // When in check, search starts here
 
               // Continuation history based pruning (~2 Elo)
               if (   lmrDepth < 5
-                  && history < -3000 * depth + 3000)
+                  && history < -3875 * (depth - 1))
                   continue;
 
               history += thisThread->mainHistory[us][from_to(move)];
@@ -1059,7 +1059,7 @@ moves_loop: // When in check, search starts here
               // Futility pruning: parent node (~9 Elo)
               if (   !ss->inCheck
                   && lmrDepth < 8
-                  && ss->staticEval + 142 + 139 * lmrDepth + history / 64 <= alpha)
+                  && ss->staticEval + 138 + 137 * lmrDepth + history / 64 <= alpha)
                   continue;
 
               // Prune moves with negative SEE (~3 Elo)


### PR DESCRIPTION
This patch is a modification of original tuning done by @vondele that failed yellow. Value differences are divided by 2.
Passed STC
https://tests.stockfishchess.org/tests/view/61d918239fea7913d9c64cdf
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 98968 W: 26248 L: 25858 D: 46862
Ptnml(0-2): 392, 11085, 26156, 11443, 408 
Passed LTC
https://tests.stockfishchess.org/tests/view/61d99e3c9fea7913d9c663e4
LLR: 2.95 (-2.94,2.94) <0.50,3.00>
Total: 215232 W: 58191 L: 57492 D: 99549
Ptnml(0-2): 271, 22124, 62138, 22801, 282 
bench 4572746