### PR TITLE
Use complexity in search

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -166,6 +166,7 @@ Rodrigo Exterckötter Tjäder
 Ron Britvich (Britvich)
 Ronald de Man (syzygy1, syzygy)
 rqs
+Rui Coelho (ruicoelhopedro)
 Ryan Schmitt
 Ryan Takker
 Sami Kiminki (skiminki)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -589,7 +589,7 @@ namespace {
     bool givesCheck, improving, didLMR, priorCapture;
     bool captureOrPromotion, doFullDepthSearch, moveCountPruning, ttCapture;
     Piece movedPiece;
-    int moveCount, captureCount, quietCount, bestMoveCount, improvement;
+    int moveCount, captureCount, quietCount, bestMoveCount, improvement, complexity;
 
     // Step 1. Initialize node
     ss->inCheck        = pos.checkers();
@@ -760,6 +760,7 @@ namespace {
         ss->staticEval = eval = VALUE_NONE;
         improving = false;
         improvement = 0;
+        complexity = 0;
         goto moves_loop;
     }
     else if (ss->ttHit)
@@ -803,6 +804,7 @@ namespace {
                   :                                    200;
 
     improving = improvement > 0;
+    complexity = abs(ss->staticEval - (us == WHITE ? eg_value(pos.psq_score()) : -eg_value(pos.psq_score())));
 
     // Step 7. Futility pruning: child node (~25 Elo).
     // The depth condition is important for mate finding.
@@ -818,7 +820,7 @@ namespace {
         && (ss-1)->statScore < 23767
         &&  eval >= beta
         &&  eval >= ss->staticEval
-        &&  ss->staticEval >= beta - 20 * depth - improvement / 15 + 204
+        &&  ss->staticEval >= beta - 20 * depth - improvement / 15 + 204 + complexity / 25
         && !excludedMove
         &&  pos.non_pawn_material(us)
         && (ss->ply >= thisThread->nmpMinPly || us != thisThread->nmpColor))


### PR DESCRIPTION
This patch uses the complexity measure (from #3875) as a heuristic for null move pruning. Hopefully, there may be room to use it in other pruning techniques.
I would like to thank @vondele and @locutus2 for the feedback and suggestions during testing.

Passed STC
LLR: 2.95 (-2.94,2.94) <0.00,2.50>
Total: 35000 W: 9624 L: 9347 D: 16029
Ptnml(0-2): 156, 3894, 9137, 4143, 170
https://tests.stockfishchess.org/tests/view/61dda784c65bf87d6c45ab80

Passed LTC
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 230776 W: 64227 L: 63454 D: 103095
Ptnml(0-2): 1082, 23100, 66380, 23615, 1211
https://tests.stockfishchess.org/tests/view/61ddd0cf3ddbc32543e72c2b

Closes #3890 

Bench: 4464962