### PR TITLE
Use average complexity for time management

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -105,6 +105,9 @@ class RunningAverage {
       bool is_greater(int64_t a, int64_t b)
         { return b * average > a * PERIOD * RESOLUTION ; }
 
+      int64_t value()
+        { return average / (PERIOD * RESOLUTION); }
+
   private :
       static constexpr int64_t PERIOD     = 4096;
       static constexpr int64_t RESOLUTION = 1024;

--- a/src/thread.h
+++ b/src/thread.h
@@ -61,6 +61,7 @@ public:
   Material::Table materialTable;
   size_t pvIdx, pvLast;
   RunningAverage doubleExtensionAverage[COLOR_NB];
+  RunningAverage complexityAverage;
   uint64_t nodesLastExplosive;
   uint64_t nodesLastNormal;
   std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;


### PR DESCRIPTION
This patch is a variant of the idea by @locutus2 (https://tests.stockfishchess.org/tests/view/61e1f24cb1f9959fe5d88168) to adjust the total time depending on the average complexity of the position.

Passed STC
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 39664 W: 10765 L: 10487 D: 18412
Ptnml(0-2): 162, 4213, 10837, 4425, 195
https://tests.stockfishchess.org/tests/view/61e2df8b65a644da8c9ea708

Passed LTC
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 127656 W: 34505 L: 34028 D: 59123
Ptnml(0-2): 116, 12435, 38261, 12888, 128
https://tests.stockfishchess.org/tests/view/61e31db5babab931824dff5e

Closes #3892

Bench: 4464962