### PR TITLE
Revert -flto=auto on mingw

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -683,7 +683,7 @@ ifeq ($(debug), no)
 # the tool chain requires gcc version 10.1 or later.
 	else ifeq ($(comp),mingw)
 	ifneq ($(arch),i386)
-		CXXFLAGS += -flto=auto
+		CXXFLAGS += -flto
 		LDFLAGS += $(CXXFLAGS) -save-temps
 	endif
 	endif


### PR DESCRIPTION
causes issues on some installations (https://github.com/glinscott/fishtest/issues/1255)

No functional change