### PR TITLE
Scale child node futility pruning with previous move history.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -777,7 +777,8 @@ namespace {
     // The depth condition is important for mate finding.
     if (   !ss->ttPv
         &&  depth < 9
-        &&  eval - futility_margin(depth, improving) >= beta
+        &&  eval - futility_margin(depth, improving) - (ss-1)->statScore / 256 >= beta
+        &&  eval >= beta
         &&  eval < 15000) // 50% larger than VALUE_KNOWN_WIN, but smaller than TB wins.
         return eval;
 


### PR DESCRIPTION
Idea is to do more futility pruning if previous move has bad histories and less if it has good histories.
passed STC
https://tests.stockfishchess.org/tests/view/61e3757fbabab931824e0db7
LLR: 2.96 (-2.94,2.94) <0.00,2.50>
Total: 156816 W: 42282 L: 41777 D: 72757
Ptnml(0-2): 737, 17775, 40913, 18212, 771 
passed LTC
https://tests.stockfishchess.org/tests/view/61e43496928632f7813a5535
LLR: 2.95 (-2.94,2.94) <0.50,3.00>
Total: 349968 W: 94612 L: 93604 D: 161752
Ptnml(0-2): 300, 35934, 101550, 36858, 342 
bench 4720954