### PR TITLE
Do stats updates after LMR for captures.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1194,10 +1194,13 @@ moves_loop: // When in check, search starts here
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, newDepth + doDeeperSearch, !cutNode);
 
           // If the move passed LMR update its stats
-          if (didLMR && !captureOrPromotion)
+          if (didLMR)
           {
               int bonus = value > alpha ?  stat_bonus(newDepth)
                                         : -stat_bonus(newDepth);
+
+              if (captureOrPromotion)
+                  bonus /= 4;
 
               update_continuation_histories(ss, movedPiece, to_sq(move), bonus);
           }


### PR DESCRIPTION
Since captures that are in LMR use continuation histories of corresponding quiet moves it makes sense to update this histories if this capture passes LMR by analogy to existing logic for quiet moves.
Passed STC
https://tests.stockfishchess.org/tests/view/61f367eef7fba9f1a4f1318b
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 208464 W: 56006 L: 55407 D: 97051
Ptnml(0-2): 964, 23588, 54655, 23935, 1090 
Passed LTC
https://tests.stockfishchess.org/tests/view/61f41e34f7fba9f1a4f15241
LLR: 2.96 (-2.94,2.94) <0.50,3.00>
Total: 69144 W: 18793 L: 18441 D: 31910
Ptnml(0-2): 65, 6982, 20142, 7302, 81 
bench 4637392