### PR TITLE
Introduce movecount pruning for quiet check evasions in qsearch.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1479,6 +1479,8 @@ moves_loop: // When in check, search starts here
                                       contHist,
                                       prevSq);
 
+    int queitCheckEvasions = 0;
+
     // Loop through the moves until no moves remain or a beta cutoff occurs
     while ((move = mp.next_move()) != MOVE_NONE)
     {
@@ -1539,6 +1541,15 @@ moves_loop: // When in check, search starts here
           && (*contHist[0])[pos.moved_piece(move)][to_sq(move)] < CounterMovePruneThreshold
           && (*contHist[1])[pos.moved_piece(move)][to_sq(move)] < CounterMovePruneThreshold)
           continue;
+
+      // movecount pruning for quiet check evasions
+      if (  bestValue > VALUE_TB_LOSS_IN_MAX_PLY 
+            && queitCheckEvasions > 1 
+            && !captureOrPromotion 
+            && ss->inCheck)
+          continue;
+
+      queitCheckEvasions += !captureOrPromotion && ss->inCheck;
 
       // Make and search the move
       pos.do_move(move, st, givesCheck);


### PR DESCRIPTION
Idea of this patch is that we usually don't consider quiet check evasions as "good" ones and prefer capture based ones instead. So it makes sense to think that if in qsearch 2 quiet check evasions failed to produce anything good 3rd and further ones wouldn't be good either.
passed STC 
https://tests.stockfishchess.org/tests/view/61fc1b1ed508ec6a1c9f397c
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 58800 W: 15947 L: 15626 D: 27227
Ptnml(0-2): 273, 6568, 15462, 6759, 338 
passed LTC
https://tests.stockfishchess.org/tests/view/61fcc56dd508ec6a1c9f5619
LLR: 2.95 (-2.94,2.94) <0.50,3.00>
Total: 89544 W: 24208 L: 23810 D: 41526
Ptnml(0-2): 81, 9038, 26134, 9440, 79 