### PR TITLE
Small cleanup

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -154,6 +154,7 @@ Pascal Romaret
 Pasquale Pigazzini (ppigazzini)
 Patrick Jansen (mibere)
 pellanda
+Peter Schneider (pschneider1968)
 Peter Zsifkovits (CoffeeOne)
 Praveen Kumar Tummala (praveentml)
 Rahul Dsilva (silversolver1)

--- a/src/misc.h
+++ b/src/misc.h
@@ -163,7 +163,7 @@ inline int64_t sigmoid(int64_t t, int64_t x0,
                                   int64_t  P,
                                   int64_t  Q)
 {
-   assert(C > 0);
+   assert(C > 0 && Q != 0);
    return y0 + P * (t-x0) / (Q * (std::abs(t-x0) + C)) ;
 }
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -107,8 +107,8 @@ void MovePicker::score() {
 
   for (auto& m : *this)
       if constexpr (Type == CAPTURES)
-          m.value =  int(PieceValue[MG][pos.piece_on(to_sq(m))]) * 6
-                   + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))];
+          m.value = 6 * PieceValue[MG][pos.piece_on(to_sq(m))]
+                   +    (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))];
 
       else if constexpr (Type == QUIETS)
           m.value =      (*mainHistory)[pos.side_to_move()][from_to(m)]


### PR DESCRIPTION
Remove cast in MovePicker::score(), as in line 123.
Update AUTHORS' file
Check if sigmoid's Q is not zero

No functional change