### PR TITLE
Do less depth reduction in null move pruning for complex positions.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -805,8 +805,8 @@ namespace {
     {
         assert(eval - beta >= 0);
 
-        // Null move dynamic reduction based on depth and value
-        Depth R = std::min(int(eval - beta) / 205, 3) + depth / 3 + 4;
+        // Null move dynamic reduction based on depth, eval and complexity of position
+        Depth R = std::min(int(eval - beta) / 205, 3) + depth / 3 + 4 - (complexity > 500);
 
         ss->currentMove = MOVE_NULL;
         ss->continuationHistory = &thisThread->continuationHistory[0][0][NO_PIECE][0];


### PR DESCRIPTION
This patch makes us reduce less depth in null move pruning if complexity is high enough, so now null move pruning will have 2 parameters that are dependent on it.
passed STC
https://tests.stockfishchess.org/tests/view/61fde60fd508ec6a1c9f7754
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 170000 W: 45555 L: 45027 D: 79418
Ptnml(0-2): 760, 19352, 44359, 19658, 871 
passed LTC
https://tests.stockfishchess.org/tests/view/61fe91febf46cb834cbd5c90
LLR: 2.96 (-2.94,2.94) <0.50,3.00>
Total: 145272 W: 39182 L: 38651 D: 67439
Ptnml(0-2): 127, 14864, 42157, 15327, 161 
bench 4461945