### PR TITLE
Add ARM NDK to Github Actions matrix

### DIFF
--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -5,6 +5,7 @@ on:
       - master
       - tools
       - github_ci
+      - github_ci_armv7
   pull_request:
     branches:
       - master
@@ -20,6 +21,12 @@ jobs:
     strategy:
       matrix:
         config:
+          # set the variable for the required tests:
+          # run_expensive_tests: true
+          # run_32bit_tests: true
+          # run_64bit_tests: true
+          # run_armv8_tests: true
+          # run_armv7_tests: true
           - {
               name: "Ubuntu 20.04 GCC",
               os: ubuntu-20.04,
@@ -35,9 +42,24 @@ jobs:
               os: ubuntu-20.04,
               compiler: clang++,
               comp: clang,
-              run_expensive_tests: false,
               run_32bit_tests: true,
               run_64bit_tests: true,
+              shell: 'bash {0}'
+            }
+          - {
+              name: "Ubuntu 20.04 NDK armv8",
+              os: ubuntu-20.04,
+              compiler: aarch64-linux-android21-clang++,
+              comp: ndk,
+              run_armv8_tests: true,
+              shell: 'bash {0}'
+            }
+          - {
+              name: "Ubuntu 20.04 NDK armv7",
+              os: ubuntu-20.04,
+              compiler: armv7a-linux-androideabi21-clang++,
+              comp: ndk,
+              run_armv7_tests: true,
               shell: 'bash {0}'
             }
           - {
@@ -45,8 +67,6 @@ jobs:
               os: macos-10.15,
               compiler: clang++,
               comp: clang,
-              run_expensive_tests: false,
-              run_32bit_tests: false,
               run_64bit_tests: true,
               shell: 'bash {0}'
             }
@@ -55,8 +75,6 @@ jobs:
               os: macos-10.15,
               compiler: g++-10,
               comp: gcc,
-              run_expensive_tests: false,
-              run_32bit_tests: false,
               run_64bit_tests: true,
               shell: 'bash {0}'
             }
@@ -65,8 +83,6 @@ jobs:
               os: windows-2022,
               compiler: g++,
               comp: gcc,
-              run_expensive_tests: false,
-              run_32bit_tests: false,
               run_64bit_tests: true,
               msys_sys: 'mingw64',
               msys_env: 'x86_64',
@@ -77,9 +93,7 @@ jobs:
               os: windows-2022,
               compiler: g++,
               comp: gcc,
-              run_expensive_tests: false,
               run_32bit_tests: true,
-              run_64bit_tests: false,
               msys_sys: 'mingw32',
               msys_env: 'i686',
               shell: 'msys2 {0}'
@@ -89,8 +103,6 @@ jobs:
               os: windows-2022,
               compiler: clang++,
               comp: clang,
-              run_expensive_tests: false,
-              run_32bit_tests: false,
               run_64bit_tests: true,
               msys_sys: 'clang64',
               msys_env: 'clang-x86_64',
@@ -110,7 +122,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt update
-          sudo apt install expect valgrind g++-multilib
+          sudo apt install expect valgrind g++-multilib qemu-user
 
       - name: Setup msys and install required packages
         if: runner.os == 'Windows'
@@ -130,6 +142,7 @@ jobs:
 
       - name: Check compiler
         run: |
+          export PATH=$PATH:$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin
           $COMPILER -v
 
       - name: Test help target
@@ -250,6 +263,37 @@ jobs:
         run: |
           make clean
           make -j2 ARCH=x86-64-vnni256 build
+
+      # armv8 tests
+
+      - name: Test armv8 build
+        if: ${{ matrix.config.run_armv8_tests }}
+        run: |
+          export PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH
+          export LDFLAGS="-static -Wno-unused-command-line-argument"
+          make clean
+          make -j2 ARCH=armv8 build
+          ../tests/signature.sh $benchref
+
+      # armv7 tests
+
+      - name: Test armv7 build
+        if: ${{ matrix.config.run_armv7_tests }}
+        run: |
+          export PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH
+          export LDFLAGS="-static -Wno-unused-command-line-argument"
+          make clean
+          make -j2 ARCH=armv7 build 
+          ../tests/signature.sh $benchref
+
+      - name: Test armv7-neon build
+        if: ${{ matrix.config.run_armv7_tests }}
+        run: |
+          export PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH
+          export LDFLAGS="-static -Wno-unused-command-line-argument"
+          make clean
+          make -j2 ARCH=armv7-neon build
+          ../tests/signature.sh $benchref
 
       # Other tests
 


### PR DESCRIPTION
- set the variable only for the required tests to keep simple the yml file
- use NDK 21.x until will be fixed the Stockfish static build problem
  with NDK 23.x
- set the test for armv7, armv7-neon, armv8 builds:
  - use armv7a-linux-androideabi21-clang++ compiler for armv7 armv7-neon
  - enforce a static build
  - silence the Warning for the unused compilation flag "-pie" with
    the static build, otherwise the Github workflow stops
  - use qemu to bench the build and get the signature

Many thanks to @pschneider1968 that made all the hard work with NDK :)

No functional change

closes #3924