### PR TITLE
Tuned some Classical Parameters in Evaluation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# List of authors for Stockfish.
+# List of authors for Stockfish
 
 # Founders of the Stockfish project and fishtest infrastructure
 Tord Romstad (romstad)

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# List of authors for Stockfish
+# List of authors for Stockfish..
 
 # Founders of the Stockfish project and fishtest infrastructure
 Tord Romstad (romstad)

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# List of authors for Stockfish..
+# List of authors for Stockfish
 
 # Founders of the Stockfish project and fishtest infrastructure
 Tord Romstad (romstad)

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# List of authors for Stockfish
+# List of authors for Stockfish.
 
 # Founders of the Stockfish project and fishtest infrastructure
 Tord Romstad (romstad)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -228,58 +228,58 @@ namespace {
   // BishopPawns[distance from edge] contains a file-dependent penalty for pawns on
   // squares of the same color as our bishop.
   constexpr Score BishopPawns[int(FILE_NB) / 2] = {
-    S(3, 8), S(3, 9), S(2, 8), S(3, 8)
+    S(3, 8), S(2, 10), S(2, 7), S(2, 7)
   };
 
   // KingProtector[knight/bishop] contains penalty for each distance unit to own king
-  constexpr Score KingProtector[] = { S(8, 9), S(6, 9) };
+  constexpr Score KingProtector[] = { S(9, 8), S(8, 9) };
 
   // Outpost[knight/bishop] contains bonuses for each knight or bishop occupying a
   // pawn protected square on rank 4 to 6 which is also safe from a pawn attack.
-  constexpr Score Outpost[] = { S(57, 38), S(31, 24) };
+  constexpr Score Outpost[] = { S(51, 31), S(31, 26) };
 
   // PassedRank[Rank] contains a bonus according to the rank of a passed pawn
   constexpr Score PassedRank[RANK_NB] = {
-    S(0, 0), S(7, 27), S(16, 32), S(17, 40), S(64, 71), S(170, 174), S(278, 262)
+    S(0, 0), S(0, 48), S(15, 39), S(27, 57), S(63, 90), S(162, 192), S(290, 273)
   };
 
-  constexpr Score RookOnClosedFile = S(10, 5);
-  constexpr Score RookOnOpenFile[] = { S(19, 6), S(47, 26) };
+  constexpr Score RookOnClosedFile = S(11, 5);
+  constexpr Score RookOnOpenFile[] = { S(17, 11), S(52, 26) };
 
   // ThreatByMinor/ByRook[attacked PieceType] contains bonuses according to
   // which piece type attacks which one. Attacks on lesser pieces which are
   // pawn-defended are not considered.
   constexpr Score ThreatByMinor[PIECE_TYPE_NB] = {
-    S(0, 0), S(5, 32), S(55, 41), S(77, 56), S(89, 119), S(79, 162)
+    S(0, 0), S(6, 42), S(73, 58), S(87, 58), S(118, 140), S(83, 163)
   };
 
   constexpr Score ThreatByRook[PIECE_TYPE_NB] = {
-    S(0, 0), S(3, 44), S(37, 68), S(42, 60), S(0, 39), S(58, 43)
+    S(0, 0), S(3, 45), S(34, 74), S(45, 58), S(0, 40), S(62, 34)
   };
 
   constexpr Value CorneredBishop = Value(50);
 
   // Assorted bonuses and penalties
-  constexpr Score UncontestedOutpost  = S(  1, 10);
+  constexpr Score UncontestedOutpost  = S(  0,  9);
   constexpr Score BishopOnKingRing    = S( 24,  0);
   constexpr Score BishopXRayPawns     = S(  4,  5);
-  constexpr Score FlankAttacks        = S(  8,  0);
-  constexpr Score Hanging             = S( 69, 36);
+  constexpr Score FlankAttacks        = S(  7,  0);
+  constexpr Score Hanging             = S( 76, 44);
   constexpr Score KnightOnQueen       = S( 16, 11);
   constexpr Score LongDiagonalBishop  = S( 45,  0);
   constexpr Score MinorBehindPawn     = S( 18,  3);
-  constexpr Score PassedFile          = S( 11,  8);
-  constexpr Score PawnlessFlank       = S( 17, 95);
-  constexpr Score ReachableOutpost    = S( 31, 22);
-  constexpr Score RestrictedPiece     = S(  7,  7);
+  constexpr Score PassedFile          = S( 14,  9);
+  constexpr Score PawnlessFlank       = S( 21,100);
+  constexpr Score ReachableOutpost    = S( 36, 17);
+  constexpr Score RestrictedPiece     = S(  6,  7);
   constexpr Score RookOnKingRing      = S( 16,  0);
-  constexpr Score SliderOnQueen       = S( 60, 18);
-  constexpr Score ThreatByKing        = S( 24, 89);
+  constexpr Score SliderOnQueen       = S( 63, 25);
+  constexpr Score ThreatByKing        = S( 23, 86);
   constexpr Score ThreatByPawnPush    = S( 48, 39);
-  constexpr Score ThreatBySafePawn    = S(173, 94);
+  constexpr Score ThreatBySafePawn    = S(161,103);
   constexpr Score TrappedRook         = S( 55, 13);
   constexpr Score WeakQueenProtection = S( 14,  0);
-  constexpr Score WeakQueen           = S( 56, 15);
+  constexpr Score WeakQueen           = S( 59, 24);
 
 
 #undef S

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -228,58 +228,58 @@ namespace {
   // BishopPawns[distance from edge] contains a file-dependent penalty for pawns on
   // squares of the same color as our bishop.
   constexpr Score BishopPawns[int(FILE_NB) / 2] = {
-    S(3, 8), S(2, 10), S(2, 7), S(2, 7)
+    S(3, 8), S(3, 9), S(2, 7), S(3, 7)
   };
 
   // KingProtector[knight/bishop] contains penalty for each distance unit to own king
-  constexpr Score KingProtector[] = { S(9, 8), S(8, 9) };
+  constexpr Score KingProtector[] = { S(9, 9), S(7, 9) };
 
   // Outpost[knight/bishop] contains bonuses for each knight or bishop occupying a
   // pawn protected square on rank 4 to 6 which is also safe from a pawn attack.
-  constexpr Score Outpost[] = { S(51, 31), S(31, 26) };
+  constexpr Score Outpost[] = { S(54, 34), S(31, 25) };
 
   // PassedRank[Rank] contains a bonus according to the rank of a passed pawn
   constexpr Score PassedRank[RANK_NB] = {
-    S(0, 0), S(0, 48), S(15, 39), S(27, 57), S(63, 90), S(162, 192), S(290, 273)
+    S(0, 0), S(2, 38), S(15, 36), S(22, 50), S(64, 81), S(166, 184), S(284, 269)
   };
 
-  constexpr Score RookOnClosedFile = S(11, 5);
-  constexpr Score RookOnOpenFile[] = { S(17, 11), S(52, 26) };
+  constexpr Score RookOnClosedFile = S(10, 5);
+  constexpr Score RookOnOpenFile[] = { S(18, 8), S(49, 26) };
 
   // ThreatByMinor/ByRook[attacked PieceType] contains bonuses according to
   // which piece type attacks which one. Attacks on lesser pieces which are
   // pawn-defended are not considered.
   constexpr Score ThreatByMinor[PIECE_TYPE_NB] = {
-    S(0, 0), S(6, 42), S(73, 58), S(87, 58), S(118, 140), S(83, 163)
+    S(0, 0), S(6, 37), S(64, 50), S(82, 57), S(103, 130), S(81, 163)
   };
 
   constexpr Score ThreatByRook[PIECE_TYPE_NB] = {
-    S(0, 0), S(3, 45), S(34, 74), S(45, 58), S(0, 40), S(62, 34)
+    S(0, 0), S(3, 44), S(36, 71), S(44, 59), S(0, 39), S(60, 39)
   };
 
   constexpr Value CorneredBishop = Value(50);
 
   // Assorted bonuses and penalties
-  constexpr Score UncontestedOutpost  = S(  0,  9);
+  constexpr Score UncontestedOutpost  = S(  0, 10);
   constexpr Score BishopOnKingRing    = S( 24,  0);
   constexpr Score BishopXRayPawns     = S(  4,  5);
-  constexpr Score FlankAttacks        = S(  7,  0);
-  constexpr Score Hanging             = S( 76, 44);
+  constexpr Score FlankAttacks        = S(  8,  0);
+  constexpr Score Hanging             = S( 72, 40);
   constexpr Score KnightOnQueen       = S( 16, 11);
   constexpr Score LongDiagonalBishop  = S( 45,  0);
   constexpr Score MinorBehindPawn     = S( 18,  3);
-  constexpr Score PassedFile          = S( 14,  9);
-  constexpr Score PawnlessFlank       = S( 21,100);
-  constexpr Score ReachableOutpost    = S( 36, 17);
+  constexpr Score PassedFile          = S( 13,  8);
+  constexpr Score PawnlessFlank       = S( 19, 97);
+  constexpr Score ReachableOutpost    = S( 33, 19);
   constexpr Score RestrictedPiece     = S(  6,  7);
   constexpr Score RookOnKingRing      = S( 16,  0);
-  constexpr Score SliderOnQueen       = S( 63, 25);
-  constexpr Score ThreatByKing        = S( 23, 86);
+  constexpr Score SliderOnQueen       = S( 62, 21);
+  constexpr Score ThreatByKing        = S( 24, 87);
   constexpr Score ThreatByPawnPush    = S( 48, 39);
-  constexpr Score ThreatBySafePawn    = S(161,103);
+  constexpr Score ThreatBySafePawn    = S(167, 99);
   constexpr Score TrappedRook         = S( 55, 13);
   constexpr Score WeakQueenProtection = S( 14,  0);
-  constexpr Score WeakQueen           = S( 59, 24);
+  constexpr Score WeakQueen           = S( 57, 19);
 
 
 #undef S


### PR DESCRIPTION
Tuned some Classical Parameters in Evaluation.

The following tests shows that it improves the classical evaluation enough to pass both elo gain tests (around +3 Elo both in STC and LTC).
And it improved the overall engine a little bit (enough to pass the non-regression test with a positive score)

Please let me know if any other test is needed in order to merge this patch:

STC , Elo gain, NNue=False :
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 34584 W: 9045 L: 8753 D: 16786
Ptnml(0-2): 248, 4028, 8474, 4268, 274
https://tests.stockfishchess.org/tests/view/6200595fbf46cb834cbd9e57

LTC , Elo gain, NNue=False :
LLR: 2.95 (-2.94,2.94) <0.50,3.00>
Total: 30376 W: 7626 L: 7350 D: 15400
Ptnml(0-2): 43, 3340, 8155, 3598, 52
https://tests.stockfishchess.org/tests/view/6200fd17bf46cb834cbdb88d

STC , Non-regression, NNue=True:
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 40856 W: 10928 L: 10778 D: 19150
Ptnml(0-2): 172, 4600, 10775, 4668, 213
https://tests.stockfishchess.org/tests/view/62028717bf46cb834cbdfd7a

LTC , non-regression, nnue=true, rebased on the new master (on the time of the test)
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 71480 W: 19035 L: 18940 D: 33505
Ptnml(0-2): 71, 7388, 20719, 7499, 63
https://tests.stockfishchess.org/tests/view/62050929d71106ed12a439f1