### PR TITLE
Add MMX code for element-wise multiplication

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -567,7 +567,7 @@ endif
 ### 3.5 prefetch and popcount
 ifeq ($(prefetch),yes)
 	ifeq ($(sse),yes)
-		CXXFLAGS += -msse
+		CXXFLAGS += -DUSE_SSE -msse
 	endif
 else
 	CXXFLAGS += -DNO_PREFETCH

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -39,6 +39,9 @@
 #include <emmintrin.h>
 
 #elif defined(USE_MMX)
+# if defined(USE_SSE)
+#  include <xmmintrin.h>
+# endif
 #include <mmintrin.h>
 
 #elif defined(USE_NEON)


### PR DESCRIPTION
Improves NNUE bench (to be precise, `bench 16 1 13 default depth NNUE`) performance by about 25% on a Pentium III 1.13 GHz:
Before: 42097 nodes/second
After (MMX, no SSE): 51690 nodes/second
After (MMX and SSE): 53045 nodes/second

No functional change.