### PR TITLE
Fullfail-lmr2

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1205,13 +1205,13 @@ moves_loop: // When in check, search starts here
       {
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, newDepth + doDeeperSearch, !cutNode);
 
-          if (value < alpha)
-              fullDidnt++;
-
           // If the move passed LMR update its stats
           if (didLMR)
           {
-              int bonus = value > alpha ?  stat_bonus(newDepth)
+              if (value < alpha)
+                  fullDidnt++;
+
+	      int bonus = value > alpha ?  stat_bonus(newDepth)
                                         : -stat_bonus(newDepth);
 
               if (captureOrPromotion)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1205,12 +1205,12 @@ moves_loop: // When in check, search starts here
       {
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, newDepth + doDeeperSearch, !cutNode);
 
+          if (value < alpha)
+              fullDidnt++;
+
           // If the move passed LMR update its stats
           if (didLMR)
           {
-              if (!PvNode
-	          && value < alpha)
-                  fullDidnt++;
               int bonus = value > alpha ?  stat_bonus(newDepth)
                                         : -stat_bonus(newDepth);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -918,6 +918,7 @@ namespace {
         depth--;
 
 moves_loop: // When in check, search starts here
+    int fullDidnt = 0;
 
     // Step 12. A small Probcut idea, when we are in check (~0 Elo)
     probCutBeta = beta + 401;
@@ -1005,7 +1006,7 @@ moves_loop: // When in check, search starts here
           moveCountPruning = moveCount >= futility_move_count(improving, depth);
 
           // Reduced depth of the next LMR search
-          int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount, delta, thisThread->rootDelta), 0);
+          int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount, delta, thisThread->rootDelta) - (moveCount > 3 && fullDidnt > 3 && !captureOrPromotion && !ss->inCheck), 0); // instead of complexity < 250 delta < 200 // without the > 3 and just with - fullDidnt is best rn
 
           if (   captureOrPromotion
               || givesCheck)
@@ -1207,6 +1208,9 @@ moves_loop: // When in check, search starts here
           // If the move passed LMR update its stats
           if (didLMR)
           {
+              if (!PvNode
+	          && value < alpha)
+                  fullDidnt++;
               int bonus = value > alpha ?  stat_bonus(newDepth)
                                         : -stat_bonus(newDepth);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1208,7 +1208,7 @@ moves_loop: // When in check, search starts here
           // If the move passed LMR update its stats
           if (didLMR)
           {
-              if (alpha - value > 50 * depth)
+              if (alpha - value > 25 * newDepth)
                   fullDidnt++;
 
 	      int bonus = value > alpha ?  stat_bonus(newDepth)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1006,7 +1006,7 @@ moves_loop: // When in check, search starts here
           moveCountPruning = moveCount >= futility_move_count(improving, depth);
 
           // Reduced depth of the next LMR search
-          int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount, delta, thisThread->rootDelta) - (moveCount > 3 && fullDidnt > 3 && !captureOrPromotion && !ss->inCheck), 0); // instead of complexity < 250 delta < 200 // without the > 3 and just with - fullDidnt is best rn
+          int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount, delta, thisThread->rootDelta), 0);
 
           if (   captureOrPromotion
               || givesCheck)
@@ -1166,6 +1166,8 @@ moves_loop: // When in check, search starts here
           // Increase reduction if ttMove is a capture (~3 Elo)
           if (ttCapture)
               r++;
+
+          r += (moveCount > 3 && fullDidnt > 3 && !captureOrPromotion && !ss->inCheck); // instead of complexity < 250 delta < 200 // without the > 3 and just with - fullDidnt is best rn
 
           ss->statScore =  thisThread->mainHistory[us][from_to(move)]
                          + (*contHist[0])[movedPiece][to_sq(move)]

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1167,7 +1167,7 @@ moves_loop: // When in check, search starts here
           if (ttCapture)
               r++;
 
-          r += (fullDidnt > 4 && !captureOrPromotion && !ss->inCheck); // instead of complexity < 250 delta < 200 // without the > 3 and just with - fullDidnt is best rn
+          r += (fullDidnt > 4 && !captureOrPromotion && !ss->inCheck);
 
           ss->statScore =  thisThread->mainHistory[us][from_to(move)]
                          + (*contHist[0])[movedPiece][to_sq(move)]

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1208,7 +1208,7 @@ moves_loop: // When in check, search starts here
           // If the move passed LMR update its stats
           if (didLMR)
           {
-              if (value < alpha)
+              if (alpha - value > 50 * depth)
                   fullDidnt++;
 
 	      int bonus = value > alpha ?  stat_bonus(newDepth)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1167,7 +1167,7 @@ moves_loop: // When in check, search starts here
           if (ttCapture)
               r++;
 
-          r += (moveCount > 3 && fullDidnt > 3 && !captureOrPromotion && !ss->inCheck); // instead of complexity < 250 delta < 200 // without the > 3 and just with - fullDidnt is best rn
+          r += (fullDidnt > 4 && !captureOrPromotion && !ss->inCheck); // instead of complexity < 250 delta < 200 // without the > 3 and just with - fullDidnt is best rn
 
           ss->statScore =  thisThread->mainHistory[us][from_to(move)]
                          + (*contHist[0])[movedPiece][to_sq(move)]
@@ -1210,8 +1210,14 @@ moves_loop: // When in check, search starts here
           // If the move passed LMR update its stats
           if (didLMR)
           {
-              if (alpha - value > 25 * newDepth)
-                  fullDidnt++;
+              fullDidnt += alpha - value > 25 * newDepth;
+
+              if (value > alpha)
+                  fullDidnt = 0;
+              else {
+                  fullDidnt = fullDidnt * 3 / 2;
+                  fullDidnt += alpha - value > 25 * newDepth;
+              }
 
 	      int bonus = value > alpha ?  stat_bonus(newDepth)
                                         : -stat_bonus(newDepth);


### PR DESCRIPTION
passed both ltc and stc:
stc:
https://tests.stockfishchess.org/tests/view/620cf0ec57b7b652f23958a1
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 67408 W: 17808 L: 17483 D: 32117
Ptnml(0-2): 264, 7188, 18457, 7549, 246 
ltc:
https://tests.stockfishchess.org/tests/view/620d161357b7b652f2395c9e
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 65168 W: 17344 L: 17009 D: 30815
Ptnml(0-2): 36, 6423, 19337, 6746, 42 