### PR TITLE
Adjust usage of LMR for 2nd move in move ordering.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1136,7 +1136,7 @@ moves_loop: // When in check, search starts here
       // been searched. In general we would like to reduce them, but there are many
       // cases where we extend a son if it has good chances to be "interesting".
       if (    depth >= 2
-          &&  moveCount > 1 + rootNode
+          &&  moveCount > 1 + (PvNode && ss->ply <= 1)
           && (   !ss->ttPv
               || !captureOrPromotion
               || (cutNode && (ss-1)->moveCount > 1)))


### PR DESCRIPTION
Current master prohibits usage of LMR for 2nd move at rootNode. This patch also disables LMR for 2nd move not only at rootNode but also at first PvNode that is a reply to rootNode.
passed STC:
https://tests.stockfishchess.org/tests/view/620e8c9026f5b17ec885143a
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 54096 W: 14305 L: 13996 D: 25795
Ptnml(0-2): 209, 6075, 14192, 6342, 230 
passed LTC:
https://tests.stockfishchess.org/tests/view/620eb327b1792e8985f81fb8
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 110864 W: 29602 L: 29156 D: 52106
Ptnml(0-2): 112, 11147, 32455, 11619, 99 
bench 6820724