### PR TITLE
Partial fix of search explosions.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1178,11 +1178,12 @@ moves_loop: // When in check, search starts here
           // In general we want to cap the LMR depth search at newDepth. But if reductions
           // are really negative and movecount is low, we allow this move to be searched
           // deeper than the first move (this may lead to hidden double extensions).
-          int deeper =   r >= -1                   ? 0
-                       : moveCount <= 4            ? 2
-                       : PvNode && depth > 4       ? 1
-                       : cutNode && moveCount <= 8 ? 1
-                       :                             0;
+          int deeper =   r >= -1                              ? 0
+                       : ss->ply >= thisThread->rootDepth * 2 ? 0
+                       : moveCount <= 4                       ? 2
+                       : PvNode && depth > 4                  ? 1
+                       : cutNode && moveCount <= 8            ? 1
+                       :                                        0;
 
           Depth d = std::clamp(newDepth - r, 1, newDepth + deeper);
 


### PR DESCRIPTION
Following issue https://github.com/official-stockfish/Stockfish/issues/3911
I tried to limit deeper the same way we have limits in extensions.
I need confirmation @Karma-Tron @stuwph that this fixes this explosions in cases you mentioned.
Passed STC:
https://tests.stockfishchess.org/tests/view/6213c4374d3d46665b65be09
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 120000 W: 32029 L: 31996 D: 55975
Ptnml(0-2): 686, 12983, 32592, 13090, 649 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6214495093ebf6882c33ca61
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 62880 W: 16787 L: 16684 D: 29409
Ptnml(0-2): 54, 6101, 19028, 6202, 55 