### PR TITLE
Remove Buffer stack align hack for old GCC versions

### DIFF
--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -104,13 +104,7 @@ struct Network
       }
     };
 
-#if defined(ALIGNAS_ON_STACK_VARIABLES_BROKEN)
-    static thread_local char bufferRaw[sizeof(Buffer) + alignment];
-    static thread_local char* bufferRawAligned = align_ptr_up<alignment>(&bufferRaw[0]);
-    static thread_local Buffer& buffer = *(new (bufferRawAligned) Buffer);
-#else
     alignas(alignment) static thread_local Buffer buffer;
-#endif
 
     fc_0.propagate(transformedFeatures, buffer.fc_0_out);
     ac_0.propagate(buffer.fc_0_out, buffer.ac_0_out);


### PR DESCRIPTION
Because the Buffer is now static it's not on the stack any more.  Therefore we no longer need to use the stack alignment workaround for older versions.  Tested with GCC 8.3.0.  Before the Buffer was static thread_local gcc gave this warning:
```
In member function 'int32_t Stockfish::Eval::NNUE::Network::propagate(const TransformedFeatureType*)':
nnue/../nnue/nnue_architecture.h:113:28: warning: requested alignment 64 is larger than 16 [-Wattributes]
alignas(alignment) Buffer buffer;
```
No functional change
bench: 6820724