### PR TITLE
Treat mingw as a special case of gcc rather than as a distinct compiler

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -502,7 +502,8 @@ ifeq ($(COMP),gcc)
 		profile_make = clang-profile-make
 		profile_use = clang-profile-use
 	endif
-	gccismingw = $(findstring MSYS2, $(gccversion))
+	gcctarget = $(shell $(CXX) -dumpmachine)
+	gccismingw = $(findstring mingw, $(gcctarget))
 endif
 
 ### On mingw use Windows threads, otherwise POSIX

--- a/src/Makefile
+++ b/src/Makefile
@@ -494,7 +494,7 @@ ifdef COMPCXX
 	CXX=$(COMPCXX)
 endif
 
-### Sometimes gcc is really clang
+### Sometimes gcc is really clang or mingw
 ifeq ($(COMP),gcc)
 	gccversion = $(shell $(CXX) --version)
 	gccisclang = $(findstring clang,$(gccversion))
@@ -502,6 +502,7 @@ ifeq ($(COMP),gcc)
 		profile_make = clang-profile-make
 		profile_use = clang-profile-use
 	endif
+	gccismingw = $(findstring MSYS2, $(gccversion))
 endif
 
 ### On mingw use Windows threads, otherwise POSIX
@@ -681,7 +682,12 @@ ifeq ($(debug), no)
 # GCC and CLANG use different methods for parallelizing LTO and CLANG pretends to be
 # GCC on some systems.
 	else ifeq ($(comp),gcc)
-	ifeq ($(gccisclang),)
+	ifneq ($(gccismingw),)
+	ifneq ($(arch),i386)
+		CXXFLAGS += -flto
+		LDFLAGS += $(CXXFLAGS) -save-temps
+	endif
+	else ifeq ($(gccisclang),)
 		CXXFLAGS += -flto
 		LDFLAGS += $(CXXFLAGS) -flto=jobserver
 	else


### PR DESCRIPTION
This is accomplished by adding a gccismingw flag similar to the gccisclang flag that is active when the comp variable is set to gcc, but the compiler is actually mingw.