### PR TITLE
Fix a small compile error under msvc

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -107,8 +107,8 @@ void MovePicker::score() {
 
   for (auto& m : *this)
       if constexpr (Type == CAPTURES)
-          m.value = 6 * PieceValue[MG][pos.piece_on(to_sq(m))]
-                   +    (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))];
+          m.value =  6 * int(PieceValue[MG][pos.piece_on(to_sq(m))])
+                   +     (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))];
 
       else if constexpr (Type == QUIETS)
           m.value =      (*mainHistory)[pos.side_to_move()][from_to(m)]


### PR DESCRIPTION
"Error C2666 'Stockfish::operator +': 2 overloads have similar conversions \src\movepick.cpp	110"
Introduced in https://github.com/official-stockfish/Stockfish/pull/3922
No functional change.
bench: 6739741