### PR TITLE
Remove ttPv tree shrinking.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1359,10 +1359,6 @@ moves_loop: // When in check, search starts here
     // opponent move is probably good and the new position is added to the search tree.
     if (bestValue <= alpha)
         ss->ttPv = ss->ttPv || ((ss-1)->ttPv && depth > 3);
-    // Otherwise, a counter move has been found and if the position is the last leaf
-    // in the search tree, remove the position from the search tree.
-    else if (depth > 3)
-        ss->ttPv = ss->ttPv && (ss+1)->ttPv;
 
     // Write gathered information in transposition table
     if (!excludedMove && !(rootNode && thisThread->pvIdx))


### PR DESCRIPTION
Via the ttPv flag an implicit tree of current and former PV nodes is maintained. In addition this tree is grown or shrinked at the leafs dependant on the search results. But now the shrinking step has been removed.

As the frequency of ttPv nodes decreases with depth the shown scaling behavior (STC barely passed but LTC scales well) of the tests was expected.
Below are measurements of the frequency of ttPv nodes at inner nodes for root depths from 1 to 16:

[1] Total 1000 Hits 1000 hit rate (%) 100
[2] Total 31690 Hits 2594 hit rate (%) 8.18555
[3] Total 57539 Hits 6688 hit rate (%) 11.6234
[4] Total 143523 Hits 19131 hit rate (%) 13.3296
[5] Total 339311 Hits 35276 hit rate (%) 10.3964
[6] Total 675667 Hits 58448 hit rate (%) 8.65042
[7] Total 1448687 Hits 100804 hit rate (%) 6.9583
[8] Total 2729553 Hits 160793 hit rate (%) 5.89082
[9] Total 5053729 Hits 257966 hit rate (%) 5.10447
[10] Total 8398738 Hits 382016 hit rate (%) 4.54849
[11] Total 14025278 Hits 554255 hit rate (%) 3.95183
[12] Total 22356203 Hits 816994 hit rate (%) 3.65444
[13] Total 35175449 Hits 1207575 hit rate (%) 3.43301
[14] Total 51969948 Hits 1700590 hit rate (%) 3.27226
[15] Total 79081378 Hits 2457942 hit rate (%) 3.10812
[16] Total 119598296 Hits 3531856 hit rate (%) 2.9531

STC:
LLR: 2.93 (-2.94,2.94) <-2.25,0.25>
Total: 270408 W: 71593 L: 71785 D: 127030
Ptnml(0-2): 1339, 31024, 70630, 30912, 1299
https://tests.stockfishchess.org/tests/view/622fbf9dc9e950cbfc2376d6

LTC:
LLR: 2.96 (-2.94,2.94) <-2.25,0.25>
Total: 34368 W: 9135 L: 8992 D: 16241
Ptnml(0-2): 28, 3423, 10135, 3574, 24
https://tests.stockfishchess.org/tests/view/62305257c9e950cbfc238964

Bench: 7044203