### PR TITLE
Calculate attack info in a separate function

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -132,6 +132,7 @@ public:
 private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();
+  void quiet_init();
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }
 
@@ -139,6 +140,7 @@ private:
   const ButterflyHistory* mainHistory;
   const CapturePieceToHistory* captureHistory;
   const PieceToHistory** continuationHistory;
+  Bitboard threatened, threatenedByPawn, threatenedByMinor, threatenedByRook;
   Move ttMove;
   ExtMove refutations[3], *cur, *endMoves, *endBadCaptures;
   int stage;


### PR DESCRIPTION
This patch moves the computation of the attack info needed to score quiet moves evading a possible capture into a separate function. Which is then called right before the score() method during the QUIETS stage.
This keeps the score() method clean and allows easier additions or modifications in the future.

Tested for no regression at STC:
https://tests.stockfishchess.org/tests/view/624b273e3a8a6ac93892bf48
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 285488 W: 75560 L: 75765 D: 134163
Ptnml(0-2): 1203, 30606, 79326, 30411, 1198 

No functional change.