### PR TITLE
Decrease LMR at PV nodes with low depth.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -104,6 +104,7 @@ jundery
 Justin Blanchard (UncombedCoconut)
 Kelly Wilson
 Ken Takusagawa
+Kian E
 kinderchocolate
 Kiran Panditrao (Krgp)
 Kojirion

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1173,6 +1173,10 @@ moves_loop: // When in check, search starts here
           if (PvNode && !ss->inCheck && abs(ss->staticEval - bestValue) > 250)
               r--;
 
+          // Increase depth based reduction if PvNode
+          if (PvNode)
+              r -= 16 / ( 3 + depth );
+
           ss->statScore =  thisThread->mainHistory[us][from_to(move)]
                          + (*contHist[0])[movedPiece][to_sq(move)]
                          + (*contHist[1])[movedPiece][to_sq(move)]


### PR DESCRIPTION
This patch lessens the Late Move Reduction at PV nodes with low depth. Previously the affect of depth on LMR was independant of nodeType. The idea behind this patch is that at PV nodes, LMR at low depth is will miss out on potential alpha-raising moves.

Passed STC:
https://tests.stockfishchess.org/tests/view/625aa867d3367522c4b8965c
LLR: 2.93 (-2.94,2.94) <0.00,2.50>
Total: 19360 W: 5252 L: 5006 D: 9102
Ptnml(0-2): 79, 2113, 5069, 2321, 98

Passed LTC:
https://tests.stockfishchess.org/tests/view/625ae844d3367522c4b8a009
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 39264 W: 10636 L: 10357 D: 18271
Ptnml(0-2): 18, 3928, 11473, 4183, 30

bench: 8129754