### PR TITLE
Simplify away best move count logic.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -556,7 +556,7 @@ namespace {
     bool givesCheck, improving, didLMR, priorCapture;
     bool capture, doFullDepthSearch, moveCountPruning, ttCapture;
     Piece movedPiece;
-    int moveCount, captureCount, quietCount, bestMoveCount, improvement, complexity;
+    int moveCount, captureCount, quietCount, improvement, complexity;
 
     // Step 1. Initialize node
     Thread* thisThread = pos.this_thread();
@@ -564,7 +564,7 @@ namespace {
     ss->inCheck        = pos.checkers();
     priorCapture       = pos.captured_piece();
     Color us           = pos.side_to_move();
-    moveCount          = bestMoveCount = captureCount = quietCount = ss->moveCount = 0;
+    moveCount          = captureCount = quietCount = ss->moveCount = 0;
     bestValue          = -VALUE_INFINITE;
     maxValue           = VALUE_INFINITE;
 
@@ -1145,11 +1145,6 @@ moves_loop: // When in check, search starts here
       {
           Depth r = reduction(improving, depth, moveCount, delta, thisThread->rootDelta);
 
-          // Decrease reduction at some PvNodes (~2 Elo)
-          if (   PvNode
-              && bestMoveCount <= 3)
-              r--;
-
           // Decrease reduction if position is or has been on the PV
           // and node is not likely to fail low. (~3 Elo)
           if (   ss->ttPv
@@ -1173,9 +1168,9 @@ moves_loop: // When in check, search starts here
           if (PvNode && !ss->inCheck && abs(ss->staticEval - bestValue) > 250)
               r--;
 
-          // Increase depth based reduction if PvNode
+          // Decrease reduction at PvNodes depending on depth
           if (PvNode)
-              r -= 15 / ( 3 + depth );
+              r -= 1 + 15 / ( 3 + depth );
 
           ss->statScore =  thisThread->mainHistory[us][from_to(move)]
                          + (*contHist[0])[movedPiece][to_sq(move)]
@@ -1297,10 +1292,7 @@ moves_loop: // When in check, search starts here
                   update_pv(ss->pv, move, (ss+1)->pv);
 
               if (PvNode && value < beta) // Update alpha! Always alpha < beta
-              {
                   alpha = value;
-                  bestMoveCount++;
-              }
               else
               {
                   assert(value >= beta); // Fail high


### PR DESCRIPTION
Simplify away best move count logic - the only place where it was used it was true with >99% probability so it seemed to not be doing much any more.
Passed STC:
https://tests.stockfishchess.org/tests/view/625f4778d00da81c22dd4c93
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 85152 W: 22487 L: 22406 D: 40259
Ptnml(0-2): 313, 9035, 23818, 9078, 332 
Passed LTC:
https://tests.stockfishchess.org/tests/view/625ff1f1b03f22647441a215
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 66776 W: 17768 L: 17673 D: 31335
Ptnml(0-2): 46, 6200, 20792, 6313, 37 
bench 7280798