### PR TITLE
negative extension for ttMove that is less than alpha and value bench…

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1098,6 +1098,10 @@ moves_loop: // When in check, search starts here
               // If the eval of ttMove is greater than beta, we reduce it (negative extension)
               else if (ttValue >= beta)
                   extension = -2;
+			  
+			  // If the eval of ttMove is less than alpha and value, we reduce it (negative extension)
+			  else if (ttValue <= alpha && ttValue <= value)
+				  extension = -1;
           }
 
           // Check extensions (~1 Elo)


### PR DESCRIPTION
Negative extension for ttMove that is less than alpha and value

Passed STC: 
https://tests.stockfishchess.org/tests/view/626047e8b03f22647441ade0
LLR: 2.97 (-2.94,2.94) <0.00,2.50>
Total: 50296 W: 13410 L: 13108 D: 23778
Ptnml(0-2): 196, 5548, 13370, 5826, 208

Passed LTC: 
https://tests.stockfishchess.org/tests/view/6260a513b03f22647441b970
LLR: 2.96 (-2.94,2.94) <0.50,3.00>
Total: 83896 W: 22433 L: 22054 D: 39409
Ptnml(0-2): 49, 8273, 24938, 8626, 62
bench: 7729968