### PR TITLE
Agressive increasing of lower bound.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -552,7 +552,7 @@ namespace {
     Key posKey;
     Move ttMove, move, excludedMove, bestMove;
     Depth extension, newDepth;
-    Value bestValue, value, ttValue, eval, maxValue, probCutBeta;
+    Value bestValue, value, ttValue, eval, maxValue, probCutBeta, initialAlpha;
     bool givesCheck, improving, didLMR, priorCapture;
     bool capture, doFullDepthSearch, moveCountPruning, ttCapture;
     Piece movedPiece;
@@ -567,6 +567,7 @@ namespace {
     moveCount          = captureCount = quietCount = ss->moveCount = 0;
     bestValue          = -VALUE_INFINITE;
     maxValue           = VALUE_INFINITE;
+    initialAlpha       = alpha;
 
     // Check for the available remaining time
     if (thisThread == Threads.main())
@@ -1296,7 +1297,12 @@ moves_loop: // When in check, search starts here
                   update_pv(ss->pv, move, (ss+1)->pv);
 
               if (PvNode && value < beta) // Update alpha! Always alpha < beta
-                  alpha = value;
+              {
+                  if (beta < VALUE_INFINITE && initialAlpha > -VALUE_INFINITE)
+                      alpha = std::max(value, (beta - 1 + initialAlpha) / 2);
+                  else
+                      alpha = value;
+              }
               else
               {
                   assert(value >= beta); // Fail high


### PR DESCRIPTION
After a new best move was found at a PV node increase the lower bound at least to the middle of the initial search window (instead only to the new best value).

Thanks also to Kian which inspired me with his first tests about the base idea.

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 26792 W: 7158 L: 6902 D: 12732
Ptnml(0-2): 95, 2905, 7163, 3115, 118
https://tests.stockfishchess.org/tests/view/62631482fe69c0c878b83277

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 36928 W: 9923 L: 9651 D: 17354
Ptnml(0-2): 25, 3623, 10897, 3893, 26
https://tests.stockfishchess.org/tests/view/62638a46fe69c0c878b84591

Bench: 7296489