### PR TITLE
Simplify time management.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1098,6 +1098,10 @@ moves_loop: // When in check, search starts here
               // If the eval of ttMove is greater than beta, we reduce it (negative extension)
               else if (ttValue >= beta)
                   extension = -2;
+
+              // If the eval of ttMove is less than alpha and value, we reduce it (negative extension)
+              else if (ttValue <= alpha && ttValue <= value)
+                  extension = -1;
           }
 
           // Check extensions (~1 Elo)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -466,8 +466,7 @@ void Thread::search() {
           // If the bestMove is stable over several iterations, reduce time accordingly
           timeReduction = lastBestMoveDepth + 10 < completedDepth ? 1.63 : 0.73;
           double reduction = (1.56 + mainThread->previousTimeReduction) / (2.20 * timeReduction);
-          double bestMoveInstability = 1.073 + std::max(1.0, 2.25 - 9.9 / rootDepth)
-                                              * totBestMoveChanges / Threads.size();
+          double bestMoveInstability = 1 + 1.7 * totBestMoveChanges / Threads.size()
           int complexity = mainThread->complexityAverage.value();
           double complexPosition = std::clamp(1.0 + (complexity - 326) / 1618.1, 0.5, 1.5);
 


### PR DESCRIPTION
Replace the best move instability adjustment factor by a simpler version which doesn't have a dependency on the iteration depth.

STC:
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 30800 W: 8232 L: 8073 D: 14495
Ptnml(0-2): 101, 3309, 8444, 3422, 124
https://tests.stockfishchess.org/tests/view/6266c77bc5b924ba22908d30

LTC:
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 61664 W: 16375 L: 16272 D: 29017
Ptnml(0-2): 40, 5869, 18897, 6000, 26
https://tests.stockfishchess.org/tests/view/6266fc39b3d1812808915f23

Bench: 7729968