### PR TITLE
fail high count lmr bench: 7084802

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -604,6 +604,7 @@ namespace {
     (ss+1)->ttPv         = false;
     (ss+1)->excludedMove = bestMove = MOVE_NONE;
     (ss+2)->killers[0]   = (ss+2)->killers[1] = MOVE_NONE;
+	(ss+2)->cutoffCnt = 0;
     ss->doubleExtensions = (ss-1)->doubleExtensions;
     ss->depth            = depth;
     Square prevSq        = to_sq((ss-1)->currentMove);
@@ -1175,6 +1176,10 @@ moves_loop: // When in check, search starts here
           // Decrease reduction for PvNodes based on depth
           if (PvNode)
               r -= 1 + 15 / ( 3 + depth );
+		  
+		  // Increase reduction if next ply has a lot of fail high else reset count to 0
+		  if ((ss+1)->cutoffCnt > 3 && !PvNode)
+			  r++;
 
           ss->statScore =  thisThread->mainHistory[us][from_to(move)]
                          + (*contHist[0])[movedPiece][to_sq(move)]
@@ -1299,11 +1304,17 @@ moves_loop: // When in check, search starts here
                   alpha = value;
               else
               {
+				  ss->cutoffCnt++;
                   assert(value >= beta); // Fail high
                   break;
               }
           }
       }
+	  else
+      {
+         ss->cutoffCnt = 0;
+      }
+
 
       // If the move is worse than some previously searched move, remember it to update its stats later
       if (move != bestMove)

--- a/src/search.h
+++ b/src/search.h
@@ -54,6 +54,7 @@ struct Stack {
   bool ttPv;
   bool ttHit;
   int doubleExtensions;
+  int cutoffCnt;
 };
 
 


### PR DESCRIPTION
Increase reduction if next ply has a lot of fail high else reset count to 0

Passed STC:
https://tests.stockfishchess.org/tests/view/626ea8299116b52aa83b71f6
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 144288 W: 38377 L: 37902 D: 68009
Ptnml(0-2): 565, 16298, 38054, 16551, 676

Passed LTC:
https://tests.stockfishchess.org/tests/view/626fa0fb79f761bab2e382f0
LLR: 2.98 (-2.94,2.94) <0.50,3.00>
Total: 74872 W: 20050 L: 19686 D: 35136
Ptnml(0-2): 51, 7541, 21893, 7895, 56

bench: 7084802