### PR TITLE
Do more singular extensions.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1061,7 +1061,7 @@ moves_loop: // When in check, search starts here
           // a reduced search on all the other moves but the ttMove and if the
           // result is lower than ttValue minus a margin, then we will extend the ttMove.
           if (   !rootNode
-              &&  depth >= 4 + 2 * (PvNode && tte->is_pv())
+              &&  depth >= 3 + 2 * (PvNode && tte->is_pv())
               &&  move == ttMove
               && !excludedMove // Avoid recursive singular search
            /* &&  ttValue != VALUE_NONE Already implicit in the next condition */


### PR DESCRIPTION
This patch continues work on scaling - last VLTC tuning that was really bad at STC but had shown really good performance at LTC and beyond had the most massive change being lowering singular extensions depth threshold.  
This patch does it to even bigger extent - lowers it even more. As a result this patch loses ~8 elo at STC, ~2 elo at LTC but gains elo in both 240+2.4 single thread test and 60+0.6 8 thread test, effectively passing double SPRT (240+2.4 test is fixed games test but it actually passed "STC" SPRT somewhere near 35k games). 
So this patch is confirmed with usual fishtest confidence to be an elo gainer on time controls higher than 60+0.6 - which are almost always where stockfish is actually used.
Corresponding tests:
STC: 
https://tests.stockfishchess.org/tests/view/626a98a88707aa698c008e7e
Elo: -8.27 +-2.5 (95%) LOS: 0.0%
Total: 20000 W: 5031 L: 5507 D: 9462
Ptnml(0-2): 113, 2522, 5179, 2100, 86
nElo: -15.92 +-4.8 (95%) PairsRatio: 0.83 
LTC:
https://tests.stockfishchess.org/tests/view/62694d3309e8b84303aa8df3
LLR: -2.93 (-2.94,2.94) <0.50,3.00>
Total: 22000 W: 5681 L: 5819 D: 10500
Ptnml(0-2): 30, 2335, 6398, 2217, 20 
VLTC:
https://tests.stockfishchess.org/tests/view/626abd7e8707aa698c0093a8
Elo: 2.35 +-1.5 (95%) LOS: 99.9%
Total: 40000 W: 10991 L: 10720 D: 18289
Ptnml(0-2): 8, 3534, 12648, 3799, 11
nElo: 5.47 +-3.4 (95%) PairsRatio: 1.08 
VLTC multicore:
https://tests.stockfishchess.org/tests/view/6272a6afc8f14123163c1997
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 86808 W: 24165 L: 23814 D: 38829
Ptnml(0-2): 11, 7253, 28524, 7606, 10 
bench 7040579