### PR TITLE
Does user want chess960

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1338,7 +1338,9 @@ bool Position::pos_is_ok() const {
 
           if (   piece_on(castlingRookSquare[cr]) != make_piece(c, ROOK)
               || castlingRightsMask[castlingRookSquare[cr]] != cr
-              || (castlingRightsMask[square<KING>(c)] & cr) != cr)
+              || (castlingRightsMask[square<KING>(c)] & cr) != cr
+              || (!chess960 && (   (c == WHITE && square<KING>(c) != SQ_E1)
+                                || (c == BLACK && square<KING>(c) != SQ_E8))))
               assert(0 && "pos_is_ok: Castling");
       }
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -279,7 +279,12 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
   // handle also common incorrect FEN with fullmove = 0.
   gamePly = std::max(2 * (gamePly - 1), 0) + (sideToMove == BLACK);
 
-  chess960 = isChess960;
+  chess960 =    isChess960
+             || (can_castle(WHITE & KING_SIDE) && (piece_on(SQ_E1) != W_KING || piece_on(SQ_H1) != W_ROOK))
+             || (can_castle(WHITE & QUEEN_SIDE) && (piece_on(SQ_E1) != W_KING || piece_on(SQ_A1) != W_ROOK))
+             || (can_castle(BLACK & KING_SIDE) && (piece_on(SQ_E8) != B_KING || piece_on(SQ_H8) != B_ROOK))
+             || (can_castle(BLACK & QUEEN_SIDE) && (piece_on(SQ_E8) != B_KING || piece_on(SQ_A8) != B_ROOK));
+
   thisThread = th;
   set_state(st);
 
@@ -1338,9 +1343,7 @@ bool Position::pos_is_ok() const {
 
           if (   piece_on(castlingRookSquare[cr]) != make_piece(c, ROOK)
               || castlingRightsMask[castlingRookSquare[cr]] != cr
-              || (castlingRightsMask[square<KING>(c)] & cr) != cr
-              || (!chess960 && (   (c == WHITE && square<KING>(c) != SQ_E1)
-                                || (c == BLACK && square<KING>(c) != SQ_E8))))
+              || (castlingRightsMask[square<KING>(c)] & cr) != cr)
               assert(0 && "pos_is_ok: Castling");
       }
 


### PR DESCRIPTION
Tries to detect if the user meant to play Chess960, even if they didn't set UCI_Chess960 to true.

E.g., for this position: 4rkr1/4p1p1/8/8/8/8/8/5K1R w K - 0 1

If UCI_Chess960 is false, SF is still told White can castle short, and its best move is f1g1, with mate. This patch will let SF recognize that the game should be Chess960 (in this case, due to the king being on f1 but there still being a "K" field in the FEN), and its best move will instead be outputted as f1h1.