### PR TITLE
SE depth scaling using the previous depth

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -125,6 +125,7 @@ marotear
 Matt Ginsberg (mattginsberg)
 Matthew Lai (matthewlai)
 Matthew Sullivan (Matt14916)
+Max A. (Disservin)
 Maxim Molchanov (Maxim)
 Michael An (man)
 Michael Byrne (MichaelB7)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -504,6 +504,9 @@ void Thread::search() {
 
   mainThread->previousTimeReduction = timeReduction;
 
+  for (Thread* th : Threads)
+    th->previousDepth = completedDepth;
+
   // If skill level is enabled, swap best PV line with the sub-optimal one
   if (skill.enabled())
       std::swap(rootMoves[0], *std::find(rootMoves.begin(), rootMoves.end(),
@@ -1061,7 +1064,7 @@ moves_loop: // When in check, search starts here
           // a reduced search on all the other moves but the ttMove and if the
           // result is lower than ttValue minus a margin, then we will extend the ttMove.
           if (   !rootNode
-              &&  depth >= 4 + 2 * (PvNode && tte->is_pv())
+              &&  depth >= 4 - (thisThread->previousDepth > 27) + 2 * (PvNode && tte->is_pv())
               &&  move == ttMove
               && !excludedMove // Avoid recursive singular search
            /* &&  ttValue != VALUE_NONE Already implicit in the next condition */

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -60,7 +60,8 @@ void Thread::clear() {
   counterMoves.fill(MOVE_NONE);
   mainHistory.fill(0);
   captureHistory.fill(0);
-
+  previousDepth = 0;
+  
   for (bool inCheck : { false, true })
       for (StatsType c : { NoCaptures, Captures })
       {

--- a/src/thread.h
+++ b/src/thread.h
@@ -69,7 +69,7 @@ public:
   Position rootPos;
   StateInfo rootState;
   Search::RootMoves rootMoves;
-  Depth rootDepth, completedDepth, depth;
+  Depth rootDepth, completedDepth, depth, previousDepth;
   Value rootDelta;
   CounterMoveHistory counterMoves;
   ButterflyHistory mainHistory;


### PR DESCRIPTION
This patch makes the SE depth condition more robust and allows it to scale with completed depth
from a previous search. <br>
Tests like this: https://tests.stockfishchess.org/tests/view/6272a6afc8f14123163c1997
Have shown that longer time controls benefit from a lower SE depth but
short time controls were too senetive to such a change.
This patch maintains the elo at STC (because we rarely ever reach the specified depth)
and gains elo at LTC.

LTC:
https://tests.stockfishchess.org/tests/view/627e7cb523c0c72a05b651a9
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 27064 W: 7285 L: 7046 D: 12733
Ptnml(0-2): 8, 2446, 8390, 2675, 13

Bench: 6174823