### PR TITLE
SE depth scaling using the previous depth

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -125,6 +125,7 @@ marotear
 Matt Ginsberg (mattginsberg)
 Matthew Lai (matthewlai)
 Matthew Sullivan (Matt14916)
+Max A. (Disservin)
 Maxim Molchanov (Maxim)
 Michael An (man)
 Michael Byrne (MichaelB7)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -238,6 +238,9 @@ void MainThread::search() {
   bestPreviousScore = bestThread->rootMoves[0].score;
   bestPreviousAverageScore = bestThread->rootMoves[0].averageScore;
 
+  for (Thread* th : Threads)
+    th->previousDepth = bestThread->completedDepth;
+
   // Send again PV info if we have a new best thread
   if (bestThread != this)
       sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
@@ -1061,7 +1064,7 @@ moves_loop: // When in check, search starts here
           // a reduced search on all the other moves but the ttMove and if the
           // result is lower than ttValue minus a margin, then we will extend the ttMove.
           if (   !rootNode
-              &&  depth >= 4 + 2 * (PvNode && tte->is_pv())
+              &&  depth >= 4 - (thisThread->previousDepth > 27) + 2 * (PvNode && tte->is_pv())
               &&  move == ttMove
               && !excludedMove // Avoid recursive singular search
            /* &&  ttValue != VALUE_NONE Already implicit in the next condition */

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -60,7 +60,8 @@ void Thread::clear() {
   counterMoves.fill(MOVE_NONE);
   mainHistory.fill(0);
   captureHistory.fill(0);
-
+  previousDepth = 0;
+  
   for (bool inCheck : { false, true })
       for (StatsType c : { NoCaptures, Captures })
       {

--- a/src/thread.h
+++ b/src/thread.h
@@ -69,7 +69,7 @@ public:
   Position rootPos;
   StateInfo rootState;
   Search::RootMoves rootMoves;
-  Depth rootDepth, completedDepth, depth;
+  Depth rootDepth, completedDepth, depth, previousDepth;
   Value rootDelta;
   CounterMoveHistory counterMoves;
   ButterflyHistory mainHistory;


### PR DESCRIPTION
This patch makes the SE depth condition more robust and allows it to scale with completed depth
from a previous search.

At long TC this patch is almost equivalent to https://github.com/official-stockfish/Stockfish/pull/4016 which had

VLTC:
https://tests.stockfishchess.org/tests/view/626abd7e8707aa698c0093a8
Elo: 2.35 +-1.5 (95%) LOS: 99.9%
Total: 40000 W: 10991 L: 10720 D: 18289
Ptnml(0-2): 8, 3534, 12648, 3799, 11
nElo: 5.47 +-3.4 (95%) PairsRatio: 1.08

VLTC multicore:
https://tests.stockfishchess.org/tests/view/6272a6afc8f14123163c1997
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 86808 W: 24165 L: 23814 D: 38829
Ptnml(0-2): 11, 7253, 28524, 7606, 10

however, it is now also gaining at LTC:

LTC:
https://tests.stockfishchess.org/tests/view/627e7cb523c0c72a05b651a9
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 27064 W: 7285 L: 7046 D: 12733
Ptnml(0-2): 8, 2446, 8390, 2675, 13

and should have nearly no influence at STC as depth 27 is rarely reached.
It was noticed that initializing the threshold with MAX_PLY, had an adverse effect,
possibly because the first move is sensitive to this.

closes https://github.com/official-stockfish/Stockfish/pull/4021
closes https://github.com/official-stockfish/Stockfish/pull/4016

Bench: 6481017