### PR TITLE
Tune scale and optimism.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -192,6 +192,7 @@ using namespace Trace;
 
 namespace {
 
+
   // Threshold for lazy and space evaluation
   constexpr Value LazyThreshold1    =  Value(3631);
   constexpr Value LazyThreshold2    =  Value(2084);
@@ -1099,14 +1100,14 @@ Value Eval::evaluate(const Position& pos) {
   if (useNNUE && !useClassical)
   {
        Value nnue     = NNUE::evaluate(pos, true);     // NNUE
-       int scale      = 1036 + 22 * pos.non_pawn_material() / 1024;
+       int scale      = 1014 + 21 * pos.non_pawn_material() / 1024;
        Color stm      = pos.side_to_move();
        Value optimism = pos.this_thread()->optimism[stm];
        Value psq      = (stm == WHITE ? 1 : -1) * eg_value(pos.psq_score());
        int complexity = 35 * abs(nnue - psq) / 256;
 
-       optimism = optimism * (44 + complexity) / 31;
-       v = (nnue + optimism) * scale / 1024 - optimism;
+       optimism = optimism * (32 + complexity) / 32;
+       v = (nnue * scale + optimism * (scale - 846)) / 1024;
 
        if (pos.is_chess960())
            v += fix_FRC(pos);


### PR DESCRIPTION
Tune scale and optimism in effort to make stockfish play more aggressively.

STC @ 10+0.1 th 1:
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 27896 W: 7506 L: 7248 D: 13142
Ptnml(0-2): 103, 3047, 7388, 3309, 101
https://tests.stockfishchess.org/tests/live_elo/627fd0cfab44257388ab1f13

LTC @ 60+0.6 th 1:
LLR: 2.93 (-2.94,2.94) <0.50,3.00>
Total: 65576 W: 17512 L: 17178 D: 30886
Ptnml(0-2): 37, 6397, 19587, 6729, 38
https://tests.stockfishchess.org/tests/live_elo/627ff666ab44257388ab256d

Bench 6407734