### PR TITLE
Add command line flags to link to information

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -288,6 +288,7 @@ void UCI::loop(int argc, char* argv[]) {
       else if (token == "--help" || token == "help" || token == "--license" || token == "license")
           sync_cout << "\nStockfish is a powerful chess engine and free software licensed under the GNU GPLv3."
                        "\nStockfish is normally used with a separate graphical user interface (GUI)."
+                       "\nStockfish implements the universal chess interface (UCI) to exchange information."
                        "\nFor further information see https://github.com/official-stockfish/Stockfish#readme"
                        "\nor the corresponding README.md and Copying.txt files distributed with this program.\n" << sync_endl;
       else if (!token.empty() && token[0] != '#')

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -285,8 +285,13 @@ void UCI::loop(int argc, char* argv[]) {
               filename = f;
           Eval::NNUE::save_eval(filename);
       }
+      else if (token == "--help" || token == "help" || token == "--license" || token == "license")
+          sync_cout << "\nStockfish is a powerful chess engine and free software licensed under the GNU GPLv3."
+                       "\nStockfish is normally used with a separate graphical user interface (GUI)."
+                       "\nFor further information see https://github.com/official-stockfish/Stockfish#readme"
+                       "\nor the corresponding README.md and Copying.txt files distributed with this program.\n" << sync_endl;
       else if (!token.empty() && token[0] != '#')
-          sync_cout << "Unknown command: " << cmd << sync_endl;
+          sync_cout << "Unknown command: '" << cmd << "'. Type help for more information." << sync_endl;
 
   } while (token != "quit" && argc == 1); // Command line args are one-shot
 }


### PR DESCRIPTION
This patch provides command line flags `--help` and `--license` as well as the corresponding `help` and `license` commands.

```
$ ./stockfish --help
Stockfish 200522 by the Stockfish developers (see AUTHORS file)

Stockfish is a powerful chess engine and free software licensed under the GNU GPLv3.
Stockfish is normally used with a separate graphical user interface (GUI).
For further information see https://github.com/official-stockfish/Stockfish#readme
or the corresponding README.md and Copying.txt files distributed with this program.

```

The idea is to provide a minimal help that links to the README.md file,
not replicating information that is already available elsewhere.

We use this opportunity to explicitly report the license as well.

No functional change.