### PR TITLE
Small speedup in futility_move_count

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -75,7 +75,8 @@ namespace {
   }
 
   constexpr int futility_move_count(bool improving, Depth depth) {
-    return (3 + depth * depth) / (2 - improving);
+    return improving ? (3 + depth * depth)
+                     : (3 + depth * depth) / 2;
   }
 
   // History and stats update bonus, based on depth


### PR DESCRIPTION
The speedup is around 0.25% using gcc 11.3.1 (bmi2, nnue bench, depth 16
and 23) while it is neutral using clang (same conditions).
According to `perf` that integer division was one of the most time-consuming
instructions in search (gcc disassembly).

Passed STC:
https://tests.stockfishchess.org/tests/view/628a17fe24a074e5cd59b3aa
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 22232 W: 5992 L: 5751 D: 10489
Ptnml(0-2): 88, 2235, 6218, 2498, 77

LTC:
https://tests.stockfishchess.org/tests/view/628a35d7ccae0450e35106f7

Further development:
Local tests shows a 4% overperformance by clang, so probably there is a lot more
to extract, since gcc is the default compiler.
This patch also suggests that UHO is sensible to small speedups (< 0.50%).

No functional change