### PR TITLE
adjust scale and optimism

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1100,14 +1100,14 @@ Value Eval::evaluate(const Position& pos) {
   if (useNNUE && !useClassical)
   {
        Value nnue     = NNUE::evaluate(pos, true);     // NNUE
-       int scale      = 1014 + 21 * pos.non_pawn_material() / 1024;
+       int scale      = 1080 + 110 * pos.non_pawn_material() / 5120;
        Color stm      = pos.side_to_move();
        Value optimism = pos.this_thread()->optimism[stm];
        Value psq      = (stm == WHITE ? 1 : -1) * eg_value(pos.psq_score());
-       int complexity = 35 * abs(nnue - psq) / 256;
+       int complexity = (278 * abs(nnue - psq)) / 256;
 
-       optimism = optimism * (32 + complexity) / 32;
-       v = (nnue * scale + optimism * (scale - 846)) / 1024;
+       optimism = optimism * (251 + complexity) / 256;
+       v = (nnue * scale + optimism * (scale - 852)) / 1024;
 
        if (pos.is_chess960())
            v += fix_FRC(pos);


### PR DESCRIPTION
@xoto10's scaleopt tune resulted in a yellow LTC, but the main parameter shift looked almost exactly like the tune rate reduction schedule, so I tried exaggerating that param. It worked!

LTC green: https://tests.stockfishchess.org/tests/view/628c709372775f382300f03e
LLR: 2.93 (-2.94,2.94) <0.50,3.00>
Total: 70112 W: 18932 L: 18584 D: 32596
Ptnml(0-2): 66, 6904, 20757, 7274, 55

STC red (not terribly so): https://tests.stockfishchess.org/tests/view/6290e4441e7cd5f29966bdc8
LLR: -2.96 (-2.94,2.94) <0.00,2.50>
Total: 59976 W: 15919 L: 16018 D: 28039
Ptnml(0-2): 250, 6791, 15974, 6754, 219

xoto10's first yellow LTC: https://tests.stockfishchess.org/tests/view/6288a33f817227d3e5c5b05d
Given the success of this try, I tried twice more to further exaggerate the param, giving two very-borderline yellows.
double exaggerate yellow: https://tests.stockfishchess.org/tests/live_elo/628e140372775f38230129a6
triple exaggerate yellow: https://tests.stockfishchess.org/tests/live_elo/628e2caf72775f3823012d45

For all tests listed here, master's double-kill rate noticeably exceeded the patch's double-kill rate. This seems to indicate that this patch loses a bit of aggression, against xoto's original goal, but LTC elo is LTC elo.

xoto, thoughts?

bench 6800167