### PR TITLE
Update search.cpp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -131,7 +131,7 @@ namespace {
     ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
 
     uint64_t cnt, nodes = 0;
-    const bool leaf = (depth == 2);
+    const bool leaf = (depth == 1);
 
     for (const auto& m : MoveList<LEGAL>(pos))
     {
@@ -140,7 +140,7 @@ namespace {
         else
         {
             pos.do_move(m, st);
-            cnt = leaf ? MoveList<LEGAL>(pos).size() : perft<false>(pos, depth - 1);
+            cnt = leaf ? 1 : perft<false>(pos, depth - 1);
             nodes += cnt;
             pos.undo_move(m);
         }

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -11,7 +11,7 @@ trap 'error ${LINENO}' ERR
 echo "perft testing started"
 
 cat << EOF > perft.exp
-   set timeout 10
+   set timeout 30
    lassign \$argv pos depth result
    spawn ./stockfish
    send "position \$pos\\ngo perft \$depth\\n"


### PR DESCRIPTION
The Perft Function must show real Nodes/second Speed base move making & move generation 

the last perft function layer was false because had only move generation , I corrected it ✅

this below example show that about 18 million NPS on perft 64bit , this is real stockfish perft speed 
```
go perft 6

a2a3: 4463267
b2b3: 5310358
c2c3: 5417640
d2d3: 8073082
e2e3: 9726018
f2f3: 4404141
g2g3: 5346260
h2h3: 4463070
a2a4: 5363555
b2b4: 5293555
c2c4: 5866666
d2d4: 8879566
e2e4: 9771632
f2f4: 4890429
g2g4: 5239875
h2h4: 5385554
b1a3: 4856835
b1c3: 5708064
g1f3: 5723523
g1h3: 4877234

Total time (ms) : 6670
Nodes searched: 119060324
Nodes/second    : 17850123
```
