### PR TITLE
Add info about elo gained from some heuristics.

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -86,6 +86,7 @@ enum StatsType { NoCaptures, Captures };
 /// unsuccessful during the current search, and is used for reduction and move
 /// ordering decisions. It uses 2 tables (one for each color) indexed by
 /// the move's from and to squares, see www.chessprogramming.org/Butterfly_Boards
+/// (~11 elo)
 typedef Stats<int16_t, 14365, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)> ButterflyHistory;
 
 /// CounterMoveHistory stores counter moves indexed by [piece][to] of the previous
@@ -101,6 +102,7 @@ typedef Stats<int16_t, 29952, PIECE_NB, SQUARE_NB> PieceToHistory;
 /// ContinuationHistory is the combined history of a given pair of moves, usually
 /// the current one given a previous one. The nested history table is based on
 /// PieceToHistory instead of ButterflyBoards.
+/// (~63 elo)
 typedef Stats<PieceToHistory, NOT_USED, PIECE_NB, SQUARE_NB> ContinuationHistory;
 
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1396,6 +1396,7 @@ moves_loop: // When in check, search starts here
 
   // qsearch() is the quiescence search function, which is called by the main search
   // function with zero depth, or recursively with further decreasing depth per call.
+  // (~155 elo)
   template <NodeType nodeType>
   Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth) {
 


### PR DESCRIPTION
Add info about qsearch and impact of main and continuation histories.
Based on this tests:
https://tests.stockfishchess.org/tests/view/62946ffcb0d5a7d1b780fc7e
https://tests.stockfishchess.org/tests/view/628facb71e7cd5f299669534
https://tests.stockfishchess.org/tests/view/628eade11e7cd5f299666f2e
No functional change.