### PR TITLE
Wtime and btime values

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -455,7 +455,7 @@ void Thread::search() {
       }
 
       // Do we have time for the next iteration? Can we stop searching now?
-      if (    Limits.use_time_management()
+      if (    Limits.use_time_management(us == BLACK)
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
@@ -1835,7 +1835,7 @@ void MainThread::check_time() {
   if (ponder)
       return;
 
-  if (   (Limits.use_time_management() && (elapsed > Time.maximum() - 10 || stopOnPonderhit))
+  if (   (Limits.use_time_management(rootPos.side_to_move() == BLACK) && (elapsed > Time.maximum() - 10 || stopOnPonderhit))
       || (Limits.movetime && elapsed >= Limits.movetime)
       || (Limits.nodes && Threads.nodes_searched() >= (uint64_t)Limits.nodes))
       Threads.stop = true;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -459,7 +459,7 @@ void Thread::search() {
       }
 
       // Do we have time for the next iteration? Can we stop searching now?
-      if (    Limits.use_time_management(us == BLACK)
+      if (    Limits.use_time_management()
           && !Threads.stop
           && !mainThread->stopOnPonderhit)
       {
@@ -1835,7 +1835,7 @@ void MainThread::check_time() {
   if (ponder)
       return;
 
-  if (   (Limits.use_time_management(rootPos.side_to_move() == BLACK) && (elapsed > Time.maximum() - 10 || stopOnPonderhit))
+  if (   (Limits.use_time_management() && (elapsed > Time.maximum() - 10 || stopOnPonderhit))
       || (Limits.movetime && elapsed >= Limits.movetime)
       || (Limits.nodes && Threads.nodes_searched() >= (uint64_t)Limits.nodes))
       Threads.stop = true;

--- a/src/search.h
+++ b/src/search.h
@@ -94,8 +94,8 @@ struct LimitsType {
     nodes = 0;
   }
 
-  bool use_time_management(bool black_to_move) const {
-    return use_wtime_and_btime[black_to_move];
+  bool use_time_management() const {
+    return use_wtime_and_btime[0] || use_wtime_and_btime[1];
   }
 
   std::vector<Move> searchmoves;

--- a/src/search.h
+++ b/src/search.h
@@ -95,14 +95,14 @@ struct LimitsType {
   }
 
   bool use_time_management() const {
-    return use_wtime_and_btime[0] || use_wtime_and_btime[1];
+    return time_management;
   }
 
   std::vector<Move> searchmoves;
   TimePoint time[COLOR_NB], inc[COLOR_NB], npmsec, movetime, startTime;
   int movestogo, depth, mate, perft, infinite;
   int64_t nodes;
-  bool use_wtime_and_btime[2] = {false};
+  bool time_management = false;
 };
 
 extern LimitsType Limits;

--- a/src/search.h
+++ b/src/search.h
@@ -95,14 +95,15 @@ struct LimitsType {
     nodes = 0;
   }
 
-  bool use_time_management() const {
-    return time[WHITE] || time[BLACK];
+  bool use_time_management(bool black_to_move) const {
+    return use_wtime_and_btime[black_to_move];
   }
 
   std::vector<Move> searchmoves;
   TimePoint time[COLOR_NB], inc[COLOR_NB], npmsec, movetime, startTime;
   int movestogo, depth, mate, perft, infinite;
   int64_t nodes;
+  bool use_wtime_and_btime[2] = {false};
 };
 
 extern LimitsType Limits;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -134,8 +134,16 @@ namespace {
             while (is >> token)
                 limits.searchmoves.push_back(UCI::to_move(pos, token));
 
-        else if ((limits.use_wtime_and_btime[0] = token == "wtime"))      is >> limits.time[WHITE];
-        else if ((limits.use_wtime_and_btime[1] = token == "btime"))      is >> limits.time[BLACK];
+        else if (token == "wtime")
+        {
+            is >> limits.time[WHITE];
+            limits.use_wtime_and_btime[0] = pos.side_to_move() == WHITE;
+        }
+        else if (token == "btime")
+        {
+            is >> limits.time[BLACK];
+            limits.use_wtime_and_btime[1] = pos.side_to_move() == BLACK;
+        }
         else if (token == "winc")      is >> limits.inc[WHITE];
         else if (token == "binc")      is >> limits.inc[BLACK];
         else if (token == "movestogo") is >> limits.movestogo;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -134,8 +134,8 @@ namespace {
             while (is >> token)
                 limits.searchmoves.push_back(UCI::to_move(pos, token));
 
-        else if (token == "wtime")     is >> limits.time[WHITE];
-        else if (token == "btime")     is >> limits.time[BLACK];
+        else if ((limits.use_wtime_and_btime[0] = token == "wtime"))      is >> limits.time[WHITE];
+        else if ((limits.use_wtime_and_btime[1] = token == "btime"))      is >> limits.time[BLACK];
         else if (token == "winc")      is >> limits.inc[WHITE];
         else if (token == "binc")      is >> limits.inc[BLACK];
         else if (token == "movestogo") is >> limits.movestogo;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -137,12 +137,12 @@ namespace {
         else if (token == "wtime")
         {
             is >> limits.time[WHITE];
-            limits.use_wtime_and_btime[0] = pos.side_to_move() == WHITE;
+            limits.time_management |= pos.side_to_move() == WHITE;
         }
         else if (token == "btime")
         {
             is >> limits.time[BLACK];
-            limits.use_wtime_and_btime[1] = pos.side_to_move() == BLACK;
+            limits.time_management |= pos.side_to_move() == BLACK;
         }
         else if (token == "winc")      is >> limits.inc[WHITE];
         else if (token == "binc")      is >> limits.inc[BLACK];


### PR DESCRIPTION
Nodes searched : 6237567

- If it's White's turn and something like "go btime 50000" is given, SF currently sets White's remaining time to 0 (and vice versa if only wtime is specified). This patch would make SF search for White the same way it would if just "go" were given - i.e., without wtime being a factor.

- If it's White's turn and "go wtime 0" is given, SF searches without stopping. This patch makes it stop instantly, which was the behaviour before commit a84e3ac (June 24, 2020). I think that changing this part of SF's behaviour wasn't part of the commit's intention.

No functional change