### PR TITLE
cutnode and movecount lmr extension simplification bench: 6410652

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1194,8 +1194,7 @@ moves_loop: // When in check, search starts here
           // deeper than the first move (this may lead to hidden double extensions).
           int deeper =   r >= -1                   ? 0
                        : moveCount <= 4            ? 2
-                       : PvNode                    ? 1
-                       : cutNode && moveCount <= 8 ? 1
+                       : PvNode || cutNode         ? 1
                        :                             0;
 
           Depth d = std::clamp(newDepth - r, 1, newDepth + deeper);


### PR DESCRIPTION
cutnode and movecount lmr extension simplification

stc: https://tests.stockfishchess.org/tests/view/6294133cb0d5a7d1b780ece3
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 41072 W: 11052 L: 10908 D: 19112
Ptnml(0-2): 153, 4324, 11461, 4422, 176

ltc: https://tests.stockfishchess.org/tests/view/62947ae6b0d5a7d1b780fe86
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 102736 W: 27509 L: 27459 D: 47768
Ptnml(0-2): 98, 9734, 31669, 9754, 113

bench: 6410652