### PR TITLE
Blend nnue complexity with classical.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1099,15 +1099,16 @@ Value Eval::evaluate(const Position& pos) {
   // If result of a classical evaluation is much lower than threshold fall back to NNUE
   if (useNNUE && !useClassical)
   {
-       Value nnue     = NNUE::evaluate(pos, true);     // NNUE
-       int scale      = 1080 + 110 * pos.non_pawn_material() / 5120;
+       int complexity;
+       int scale      = 1048 + 109 * pos.non_pawn_material() / 5120;
        Color stm      = pos.side_to_move();
        Value optimism = pos.this_thread()->optimism[stm];
        Value psq      = (stm == WHITE ? 1 : -1) * eg_value(pos.psq_score());
-       int complexity = (278 * abs(nnue - psq)) / 256;
+       Value nnue     = NNUE::evaluate(pos, true, &complexity);     // NNUE
 
-       optimism = optimism * (251 + complexity) / 256;
-       v = (nnue * scale + optimism * (scale - 852)) / 1024;
+       complexity = (137 * complexity + 137 * abs(nnue - psq)) / 256;
+       optimism = optimism * (255 + complexity) / 256;
+       v = (nnue * scale + optimism * (scale - 848)) / 1024;
 
        if (pos.is_chess960())
            v += fix_FRC(pos);

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -44,7 +44,7 @@ namespace Eval {
   namespace NNUE {
 
     std::string trace(Position& pos);
-    Value evaluate(const Position& pos, bool adjusted = false);
+    Value evaluate(const Position& pos, bool adjusted = false, int* complexity = nullptr);
 
     void init();
     void verify();


### PR DESCRIPTION
Following mstembera's test of the complexity value derived from nnue values, this change blends that idea with the old complexity calculation.

STC 10+0.1:
LLR: 2.95 (-2.94,2.94) <0.00,2.50>
Total: 42320 W: 11436 L: 11148 D: 19736
Ptnml(0-2): 209, 4585, 11263, 4915, 188
https://tests.stockfishchess.org/tests/live_elo/6295c9239c8c2fcb2bad7fd9

LTC 60+0.6:
LLR: 2.98 (-2.94,2.94) <0.50,3.00>
Total: 34600 W: 9393 L: 9125 D: 16082
Ptnml(0-2): 32, 3323, 10319, 3597, 29
https://tests.stockfishchess.org/tests/view/6295fd5d9c8c2fcb2bad88cf

Bench 6291213