### PR TITLE
Remove LMR condition for complex pos

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1167,11 +1167,6 @@ moves_loop: // When in check, search starts here
           if (ttCapture)
               r++;
 
-          // Decrease reduction at PvNodes if bestvalue
-          // is vastly different from static evaluation
-          if (PvNode && !ss->inCheck && abs(ss->staticEval - bestValue) > 250)
-              r--;
-
           // Decrease reduction for PvNodes based on depth
           if (PvNode)
               r -= 1 + 15 / ( 3 + depth );


### PR DESCRIPTION
Inspired by Kia's similar test: https://tests.stockfishchess.org/tests/view/6292898c1e7cd5f29966fbe0

STC squeaked by:
https://tests.stockfishchess.org/tests/view/62941588b0d5a7d1b780ed4b
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 266872 W: 70850 L: 71033 D: 124989
Ptnml(0-2): 1180, 30114, 70941, 30111, 1090

LTC1 with wrong bounds:
https://tests.stockfishchess.org/tests/view/6295959a9c8c2fcb2bad773b
LLR: -0.14 (-2.94,2.94) <0.50,3.00>
Total: 30824 W: 8198 L: 8136 D: 14490
Ptnml(0-2): 19, 3082, 9164, 3112, 35

LTC2 with correct bounds:
https://tests.stockfishchess.org/tests/view/62964a754628d33daa24f062
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 70160 W: 18756 L: 18662 D: 32742
Ptnml(0-2): 42, 6976, 20950, 7070, 42

LTC2 elo is ~0.3±1.2, when combined with the LTC1 data it's ~0.4±1.0

bench 5926742