### PR TITLE
[tools] Minimal support for FRC in the data generator.

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1370,15 +1370,15 @@ bool Position::pos_is_ok() const {
 // Add a function that directly unpacks for speed. It's pretty tough.
 // Write it by combining packer::unpack() and Position::set().
 // If there is a problem with the passed phase and there is an error, non-zero is returned.
-int Position::set_from_packed_sfen(const Tools::PackedSfen& sfen , StateInfo* si, Thread* th)
+int Position::set_from_packed_sfen(const Tools::PackedSfen& sfen , StateInfo* si, Thread* th, bool frc)
 {
-  return Tools::set_from_packed_sfen(*this, sfen, si, th);
+  return Tools::set_from_packed_sfen(*this, sfen, si, th, frc);
 }
 
 // Get the packed sfen. Returns to the buffer specified in the argument.
-void Position::sfen_pack(Tools::PackedSfen& sfen)
+void Position::sfen_pack(Tools::PackedSfen& sfen, bool resetCastlingRights)
 {
-  sfen = Tools::sfen_pack(*this);
+  sfen = Tools::sfen_pack(*this, resetCastlingRights);
 }
 
 } // namespace Stockfish

--- a/src/position.h
+++ b/src/position.h
@@ -179,17 +179,17 @@ public:
 
   // --sfenization helper
 
-  friend int Tools::set_from_packed_sfen(Position& pos, const Tools::PackedSfen& sfen, StateInfo* si, Thread* th);
+  friend int Tools::set_from_packed_sfen(Position& pos, const Tools::PackedSfen& sfen, StateInfo* si, Thread* th, bool frc);
 
   // Get the packed sfen. Returns to the buffer specified in the argument.
   // Do not include gamePly in pack.
-  void sfen_pack(Tools::PackedSfen& sfen);
+  void sfen_pack(Tools::PackedSfen& sfen, bool resetCastlingRights);
 
   // It is slow to go through sfen, so I made a function to set packed sfen directly.
   // Equivalent to pos.set(sfen_unpack(data),si,th);.
   // If there is a problem with the passed phase and there is an error, non-zero is returned.
   // PackedSfen does not include gamePly so it cannot be restored. If you want to set it, specify it with an argument.
-  int set_from_packed_sfen(const Tools::PackedSfen& sfen, StateInfo* si, Thread* th);
+  int set_from_packed_sfen(const Tools::PackedSfen& sfen, StateInfo* si, Thread* th, bool frc);
 
   void clear() { std::memset(this, 0, sizeof(Position)); }
 

--- a/src/tools/convert.cpp
+++ b/src/tools/convert.cpp
@@ -103,7 +103,7 @@ namespace Stockfish::Tools
                         filtered_size_fen++;
                     }
                     else {
-                        tpos.sfen_pack(p.sfen);
+                        tpos.sfen_pack(p.sfen, false);
                     }
                 }
                 else if (token == "move") {
@@ -337,7 +337,7 @@ namespace Stockfish::Tools
 
                                     StateInfo si;
                                     pos.set(str_fen, false, &si, th);
-                                    pos.sfen_pack(psv.sfen);
+                                    pos.sfen_pack(psv.sfen, false);
                                 }
 
 #if defined(DEBUG_CONVERT_BIN_FROM_PGN_EXTRACT)
@@ -478,7 +478,7 @@ namespace Stockfish::Tools
             {
                 if (fs.read((char*)&p, sizeof(PackedSfenValue))) {
                     StateInfo si;
-                    tpos.set_from_packed_sfen(p.sfen, &si, th);
+                    tpos.set_from_packed_sfen(p.sfen, &si, th, false);
 
                     // write as plain text
                     ofs << "fen " << tpos.fen() << std::endl;

--- a/src/tools/sfen_packer.cpp
+++ b/src/tools/sfen_packer.cpp
@@ -94,7 +94,7 @@ namespace Stockfish::Tools {
     //
     struct SfenPacker
     {
-        void pack(const Position& pos);
+        void pack(const Position& pos, bool resetCastlingRights);
 
         // sfen packed by pack() (256bit = 32bytes)
         // Or sfen to decode with unpack()
@@ -149,7 +149,7 @@ namespace Stockfish::Tools {
     };
 
     // Pack sfen and store in data[32].
-    void SfenPacker::pack(const Position& pos)
+    void SfenPacker::pack(const Position& pos, bool resetCastlingRights)
     {
         memset(data, 0, 32 /* 256bit */);
         stream.set_data(data);
@@ -175,11 +175,17 @@ namespace Stockfish::Tools {
             }
         }
 
-        // TODO(someone): Support chess960.
-        stream.write_one_bit(pos.can_castle(WHITE_OO));
-        stream.write_one_bit(pos.can_castle(WHITE_OOO));
-        stream.write_one_bit(pos.can_castle(BLACK_OO));
-        stream.write_one_bit(pos.can_castle(BLACK_OOO));
+        if (resetCastlingRights)
+        {
+            stream.write_n_bit(0, 4);
+        }
+        else
+        {
+            stream.write_one_bit(pos.can_castle(WHITE_OO));
+            stream.write_one_bit(pos.can_castle(WHITE_OOO));
+            stream.write_one_bit(pos.can_castle(BLACK_OO));
+            stream.write_one_bit(pos.can_castle(BLACK_OOO));
+        }
 
         if (pos.ep_square() == SQ_NONE) {
             stream.write_one_bit(0);
@@ -249,7 +255,7 @@ namespace Stockfish::Tools {
         return make_piece(c, pr);
     }
 
-    int set_from_packed_sfen(Position& pos, const PackedSfen& sfen, StateInfo* si, Thread* th)
+    int set_from_packed_sfen(Position& pos, const PackedSfen& sfen, StateInfo* si, Thread* th, bool frc)
     {
         SfenPacker packer;
         auto& stream = packer.stream;
@@ -304,7 +310,6 @@ namespace Stockfish::Tools {
         }
 
         // Castling availability.
-        // TODO(someone): Support chess960.
         pos.st->castlingRights = 0;
         if (stream.read_one_bit()) {
             Square rsq;
@@ -362,7 +367,7 @@ namespace Stockfish::Tools {
 
         assert(stream.get_cursor() <= 256);
 
-        pos.chess960 = false;
+        pos.chess960 = frc;
         pos.thisThread = th;
         pos.set_state(pos.st);
 
@@ -371,13 +376,13 @@ namespace Stockfish::Tools {
         return 0;
     }
 
-    PackedSfen sfen_pack(Position& pos)
+    PackedSfen sfen_pack(Position& pos, bool resetCastlingRights)
     {
         PackedSfen sfen;
 
         SfenPacker sp;
         sp.data = (uint8_t*)&sfen;
-        sp.pack(pos);
+        sp.pack(pos, resetCastlingRights);
 
         return sfen;
     }

--- a/src/tools/sfen_packer.h
+++ b/src/tools/sfen_packer.h
@@ -15,8 +15,8 @@ namespace Stockfish {
 
 namespace Stockfish::Tools {
 
-    int set_from_packed_sfen(Position& pos, const PackedSfen& sfen, StateInfo* si, Thread* th);
-    PackedSfen sfen_pack(Position& pos);
+    int set_from_packed_sfen(Position& pos, const PackedSfen& sfen, StateInfo* si, Thread* th, bool frc);
+    PackedSfen sfen_pack(Position& pos, bool resetCastlingRights);
 }
 
 #endif

--- a/src/tools/stats.cpp
+++ b/src/tools/stats.cpp
@@ -1192,6 +1192,7 @@ namespace Stockfish::Tools::Stats
         Thread* th = Threads.main();
         Position& pos = th->rootPos;
         StateInfo si;
+        const bool frc = Options["UCI_Chess960"];
 
         auto in = Tools::open_sfen_input_file(filename);
 
@@ -1214,7 +1215,7 @@ namespace Stockfish::Tools::Stats
 
             auto& psv = v.value();
 
-            pos.set_from_packed_sfen(psv.sfen, &si, th);
+            pos.set_from_packed_sfen(psv.sfen, &si, th, frc);
 
             on_entry(pos, (Move)psv.move, psv);
 


### PR DESCRIPTION
Allows UCI_Chess960 to be true during data generation.
If UCI_Chess960 is true then strips castling rights from all saved
positions and skips saving positions with castling move.
UCI_Chess960 is respected in transforms.

`sfen_pack` accepts a boolean that dictates whether to remove castling rights. This Must be true for chess960 positions when binpack data format is used or otherwise the resulting data will be malformed. Because of that positions with castling as a played move must be skipped (no way to save the move).

`set_from_packed_sfen` is made to accept a boolean that sets Position::chess960. While this has no effect when loading .binpack data (because they are all normal positions) it does have an effect when loading .bin or .plain data. This flag also affects evaluation due to frc correction term.