### PR TITLE
Remove last newline in 'help' command output text

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -291,7 +291,7 @@ void UCI::loop(int argc, char* argv[]) {
                        "\nStockfish is normally used with a graphical user interface (GUI) and implements"
                        "\nthe Universal Chess Interface (UCI) protocol to communicate with a GUI, an API, etc."
                        "\nFor any further information, visit https://github.com/official-stockfish/Stockfish#readme"
-                       "\nor read the corresponding README.md and Copying.txt files distributed along with this program.\n" << sync_endl;
+                       "\nor read the corresponding README.md and Copying.txt files distributed along with this program." << sync_endl;
       else if (!token.empty() && token[0] != '#')
           sync_cout << "Unknown command: '" << cmd << "'. Type help for more information." << sync_endl;
 


### PR DESCRIPTION
As tested in the current Stockfish beta, after the 'help' command output text was modified by me, I noticed that I should remove the last newline there.

If you use the 'help' command now, there are 2 newlines at the end of the help text output, which is not consistent with how other commands end with 1 newline only. I fixed that.