### PR TITLE
useClassical var

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1094,7 +1094,7 @@ Value Eval::evaluate(const Position& pos) {
   if (useClassical)
   {
       v = Evaluation<NO_TRACE>(pos).value();          // classical
-      useClassical = !useNNUE ? true : abs(v) >= 297;
+      useClassical = abs(v) >= 297;
   }
 
   // If result of a classical evaluation is much lower than threshold fall back to NNUE

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1086,8 +1086,8 @@ Value Eval::evaluate(const Position& pos) {
   // Deciding between classical and NNUE eval (~10 Elo): for high PSQ imbalance we use classical,
   // but we switch to NNUE during long shuffling or with high material on the board.
   bool useClassical = !useNNUE ||
-    ( (pos.this_thread()->depth > 9 || pos.count<ALL_PIECES>() > 7) &&
-      abs(eg_value(pos.psq_score())) * 5 > (856 + pos.non_pawn_material() / 64) * (10 + pos.rule50_count()) );
+        ((pos.this_thread()->depth > 9 || pos.count<ALL_PIECES>() > 7) &&
+         abs(eg_value(pos.psq_score())) * 5 > (856 + pos.non_pawn_material() / 64) * (10 + pos.rule50_count()));
 
   // Deciding between classical and NNUE eval (~10 Elo): for high PSQ imbalance we use classical,
   // but we switch to NNUE during long shuffling or with high material on the board.

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1085,15 +1085,16 @@ Value Eval::evaluate(const Position& pos) {
   Value v;
   // Deciding between classical and NNUE eval (~10 Elo): for high PSQ imbalance we use classical,
   // but we switch to NNUE during long shuffling or with high material on the board.
-  bool useClassical = (pos.this_thread()->depth > 9 || pos.count<ALL_PIECES>() > 7) &&
-          abs(eg_value(pos.psq_score())) * 5 > (856 + pos.non_pawn_material() / 64) * (10 + pos.rule50_count());
+  bool useClassical = !useNNUE ? true 
+  : (pos.this_thread()->depth > 9 || pos.count<ALL_PIECES>() > 7) 
+    && abs(eg_value(pos.psq_score())) * 5 > (856 + pos.non_pawn_material() / 64) * (10 + pos.rule50_count());
 
   // Deciding between classical and NNUE eval (~10 Elo): for high PSQ imbalance we use classical,
   // but we switch to NNUE during long shuffling or with high material on the board.
-  if (!useNNUE || useClassical)
+  if (useClassical)
   {
       v = Evaluation<NO_TRACE>(pos).value();          // classical
-      useClassical = abs(v) >= 297;
+      useClassical = !useNNUE ? true : abs(v) >= 297;
   }
 
   // If result of a classical evaluation is much lower than threshold fall back to NNUE

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1085,9 +1085,9 @@ Value Eval::evaluate(const Position& pos) {
   Value v;
   // Deciding between classical and NNUE eval (~10 Elo): for high PSQ imbalance we use classical,
   // but we switch to NNUE during long shuffling or with high material on the board.
-  bool useClassical = !useNNUE ? true 
-  : (pos.this_thread()->depth > 9 || pos.count<ALL_PIECES>() > 7) 
-    && abs(eg_value(pos.psq_score())) * 5 > (856 + pos.non_pawn_material() / 64) * (10 + pos.rule50_count());
+  bool useClassical = !useNNUE ||
+    ( (pos.this_thread()->depth > 9 || pos.count<ALL_PIECES>() > 7) &&
+      abs(eg_value(pos.psq_score())) * 5 > (856 + pos.non_pawn_material() / 64) * (10 + pos.rule50_count()) );
 
   // Deciding between classical and NNUE eval (~10 Elo): for high PSQ imbalance we use classical,
   // but we switch to NNUE during long shuffling or with high material on the board.


### PR DESCRIPTION
bench 5870283

Trivial change that may give very slight speed ups when nnue = false? Just sets useClassical to true, instead of having to do the two lines of calculations, since classical eval must be used anyway.

Did 3 trials on pyshbench ("b" is my branch's binary). First trial was okay, second and third trials were better.

Trial 1:

Result of  50 runs
-----
base (a              ) =    1550888  +/- 14510
test (b              ) =    1552244  +/- 12588
diff                   =      +1356  +/- 6693

speedup        = +0.0009
P(speedup > 0) =  0.6542

CPU: 8 x AMD Ryzen 7 5700U with Radeon Graphics
Hyperthreading: on

Trial 2:

Result of  50 runs
-----
base (a              ) =    1551989  +/- 13227
test (b              ) =    1556106  +/- 12089
diff                   =      +4116  +/- 8510

speedup        = +0.0027
P(speedup > 0) =  0.8281

CPU: 8 x AMD Ryzen 7 5700U with Radeon Graphics
Hyperthreading: on

Trial 3:

Result of 100 runs
-----
base (a              ) =    1550315  +/- 8176
test (b              ) =    1554543  +/- 9122
diff                   =      +4227  +/- 4613

speedup        = +0.0027
P(speedup > 0) =  0.9636

CPU: 8 x AMD Ryzen 7 5700U with Radeon Graphics
Hyperthreading: on