### PR TITLE
‏

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -131,7 +131,7 @@ namespace {
     ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
 
     uint64_t cnt, nodes = 0;
-    const bool leaf = (depth == 2);
+    const bool leaf = (depth == 1);
 
     for (const auto& m : MoveList<LEGAL>(pos))
     {
@@ -140,7 +140,7 @@ namespace {
         else
         {
             pos.do_move(m, st);
-            cnt = leaf ? MoveList<LEGAL>(pos).size() : perft<false>(pos, depth - 1);
+            cnt = leaf ? 1 : perft<false>(pos, depth - 1);
             nodes += cnt;
             pos.undo_move(m);
         }

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -11,7 +11,7 @@ trap 'error ${LINENO}' ERR
 echo "perft testing started"
 
 cat << EOF > perft.exp
-   set timeout 10
+   set timeout 20
    lassign \$argv pos depth result
    spawn ./stockfish
    send "position \$pos\\ngo perft \$depth\\n"


### PR DESCRIPTION
-----------
_Thanks for your suggestion. However, slowing down perft testing doesn't seem like a desirable goal to me. The main purpose of `perft` (at least for me) is to validate and debug move generation, so slowing it down doesn't help there, and having the speedup isn't a bug. I see that for profiling reasons actually traversing the whole tree might be useful in some cases, but in the rare case that this scenario occurs one can always apply your change manually._

----------
_Originally posted by @ianfab in https://github.com/ianfab/Fairy-Stockfish/issues/489#issuecomment-1142515709_