### PR TITLE
Remove last newline character in 'help' output text

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -291,7 +291,7 @@ void UCI::loop(int argc, char* argv[]) {
                        "\nStockfish is normally used with a graphical user interface (GUI) and implements"
                        "\nthe Universal Chess Interface (UCI) protocol to communicate with a GUI, an API, etc."
                        "\nFor any further information, visit https://github.com/official-stockfish/Stockfish#readme"
-                       "\nor read the corresponding README.md and Copying.txt files distributed along with this program.\n" << sync_endl;
+                       "\nor read the corresponding README.md and Copying.txt files distributed along with this program." << sync_endl;
       else if (!token.empty() && token[0] != '#')
           sync_cout << "Unknown command: '" << cmd << "'. Type help for more information." << sync_endl;
 


### PR DESCRIPTION
In the most recent Stockfish dev build, the 'help' output text (improved by me in my last PR) should have **no last newline character** there.

If you execute the 'help' command, there appears 1 empty line in your CLI between the end of the 'help' output text and the caret. This produces an ugly gap that is not consistent with how all other textual outputs end with no empty lines between them and the caret.

I want to fix the mentioned issue in this PR.