### PR TITLE
Simplify away condition in ttSave in probCut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -895,13 +895,8 @@ namespace {
 
                 if (value >= probCutBeta)
                 {
-                    // if transposition table doesn't have equal or more deep info write probCut data into it
-                    if ( !(ss->ttHit
-                       && tte->depth() >= depth - 3
-                       && ttValue != VALUE_NONE))
-                        tte->save(posKey, value_to_tt(value, ss->ply), ttPv,
-                            BOUND_LOWER,
-                            depth - 3, move, ss->staticEval);
+                    // Save ProbCut data into transposition table
+                    tte->save(posKey, value_to_tt(value, ss->ply), ttPv, BOUND_LOWER, depth - 3, move, ss->staticEval);
                     return value;
                 }
             }


### PR DESCRIPTION
Remove condition for tte->save in probCut so it always saves on probCut cutoff.

STC:
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 47848 W: 12921 L: 12782 D: 22145
Ptnml(0-2): 207, 5340, 12715, 5431, 231
https://tests.stockfishchess.org/tests/view/62a1f7c87bd8e641e44436f7

LTC:
LLR: 2.97 (-2.94,2.94) <-2.25,0.25>
Total: 132736 W: 35895 L: 35881 D: 60960
Ptnml(0-2): 109, 13384, 39360, 13414, 101
https://tests.stockfishchess.org/tests/view/62a2421a7bd8e641e444434f

bench: 4900864