### PR TITLE
Remove last newline character in help text

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -291,7 +291,7 @@ void UCI::loop(int argc, char* argv[]) {
                        "\nStockfish is normally used with a graphical user interface (GUI) and implements"
                        "\nthe Universal Chess Interface (UCI) protocol to communicate with a GUI, an API, etc."
                        "\nFor any further information, visit https://github.com/official-stockfish/Stockfish#readme"
-                       "\nor read the corresponding README.md and Copying.txt files distributed along with this program.\n" << sync_endl;
+                       "\nor read the corresponding README.md and Copying.txt files distributed along with this program." << sync_endl;
       else if (!token.empty() && token[0] != '#')
           sync_cout << "Unknown command: '" << cmd << "'. Type help for more information." << sync_endl;
 


### PR DESCRIPTION
Removed the last newline from being printed if the 'help' command is executed (running Stockfish from within a command-line interface) and the help text is outputted. Now there should be no blank-line gap between the last line of the help text and the caret.