### PR TITLE
Improve output of 'd' command if no checkers exist

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -72,8 +72,11 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
      << std::setfill('0') << std::setw(16) << pos.key()
      << std::setfill(' ') << std::dec << "\nCheckers: ";
 
-  for (Bitboard b = pos.checkers(); b; )
-      os << UCI::square(pop_lsb(b)) << " ";
+  if (!pos.checkers())
+      os << '0';
+  else
+      for (Bitboard b = pos.checkers(); b;)
+          os << UCI::square(pop_lsb(b)) << " ";
 
   if (    int(Tablebases::MaxCardinality) >= popcount(pos.pieces())
       && !pos.can_castle(ANY_CASTLING))


### PR DESCRIPTION
I am opening a new PR to try to improve upon PR #4085 created by @johndoknjas. The word `none` (as stated by @vondele in issue #4084) is, indeed, not a good value in case no checkers exist, since C++ scripts might rely on this particular value in an `if` statement. So, this PR tries to improve upon that by giving a `0` in case no checkers exist in a position.

I assume that C++ developers in their scripts rely upon the fact that `pos.checkers()` returns `0` (hence `false`) if no checkers exist. So, they probably use an `if` statement like this:
```cpp
if (!pos.checkers())
    // No checkers exist, processing this condition...
else
    // Checkers do exist, processing this condition differently...
```
I hope `0` is a good value when no checkers exist. Having a blank space really looks like a bug.