### PR TITLE
Don't change ttPv at probCut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -867,8 +867,6 @@ namespace {
         assert(probCutBeta < VALUE_INFINITE);
 
         MovePicker mp(pos, ttMove, probCutBeta - ss->staticEval, depth - 3, &captureHistory);
-        bool ttPv = ss->ttPv;
-        ss->ttPv = false;
 
         while ((move = mp.next_move()) != MOVE_NONE)
             if (move != excludedMove && pos.legal(move))
@@ -895,11 +893,10 @@ namespace {
                 if (value >= probCutBeta)
                 {
                     // Save ProbCut data into transposition table
-                    tte->save(posKey, value_to_tt(value, ss->ply), ttPv, BOUND_LOWER, depth - 3, move, ss->staticEval);
+                    tte->save(posKey, value_to_tt(value, ss->ply), ss->ttPv, BOUND_LOWER, depth - 3, move, ss->staticEval);
                     return value;
                 }
             }
-         ss->ttPv = ttPv;
     }
 
     // Step 11. If the position is not in TT, decrease depth by 3.


### PR DESCRIPTION
Don't change ttPv at probCut

STC:
LLR: 2.96 (-2.94,2.94) <-2.25,0.25>
Total: 35672 W: 9618 L: 9462 D: 16592
Ptnml(0-2): 151, 3890, 9601, 4040, 154
https://tests.stockfishchess.org/tests/view/62ab03f750949cfc241b1965

LTC:
LLR: 2.93 (-2.94,2.94) <-2.25,0.25>
Total: 54160 W: 14626 L: 14511 D: 25023
Ptnml(0-2): 42, 5414, 16056, 5523, 45
https://tests.stockfishchess.org/tests/view/62ab5e6fd89eb6cf1e071b87

bench: 5798229