### PR TITLE
LMR: remove `deeper`

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1181,15 +1181,10 @@ moves_loop: // When in check, search starts here
           // Decrease/increase reduction for moves with a good/bad history (~30 Elo)
           r -= ss->statScore / 15914;
 
-          // In general we want to cap the LMR depth search at newDepth. But if reductions
-          // are really negative and movecount is low, we allow this move to be searched
-          // deeper than the first move (this may lead to hidden double extensions).
-          int deeper =   r >= -1                   ? 0
-                       : moveCount <= 4            ? 2
-                       : PvNode || cutNode         ? 1
-                       :                             0;
-
-          Depth d = std::clamp(newDepth - r, 1, newDepth + deeper);
+          // In general we want to cap the LMR depth search at newDepth, but when
+          // reduction is negative, we allow this move a limited search extension
+          // beyond the first move depth. This may lead to hidden double extensions.
+          Depth d = std::clamp(newDepth - r, 1, newDepth + 1);
 
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, d, true);
 


### PR DESCRIPTION
...apparently it wasn't doing much anymore. inspired by a certain rufish's recent attempts to improve this.

blue STC:
https://tests.stockfishchess.org/tests/view/62abca2cd89eb6cf1e072c04
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 85576 W: 22766 L: 22683 D: 40127
Ptnml(0-2): 362, 9607, 22741, 9742, 336

blue LTC:
https://tests.stockfishchess.org/tests/view/62ac90ffd89eb6cf1e07488f
LLR: 2.93 (-2.94,2.94) <-2.25,0.25>
Total: 48248 W: 13018 L: 12896 D: 22334
Ptnml(0-2): 32, 4773, 14400, 4879, 40

bench 6137791