### PR TITLE
SingExt depth: simplify away PV conditions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1055,7 +1055,7 @@ moves_loop: // When in check, search starts here
           // a reduced search on all the other moves but the ttMove and if the
           // result is lower than ttValue minus a margin, then we will extend the ttMove.
           if (   !rootNode
-              &&  depth >= 4 - (thisThread->previousDepth > 27) + 2 * (PvNode && tte->is_pv())
+              &&  depth >= 6 - thisThread->previousDepth / 13
               &&  move == ttMove
               && !excludedMove // Avoid recursive singular search
            /* &&  ttValue != VALUE_NONE Already implicit in the next condition */


### PR DESCRIPTION
This has technically met the standard procedural requirements for a simplification, with blue STC and LTC.

However this singular extension depth bound is known to have highly-nonlinear scaling behavior, and the LTC performance was rather poor, i.e. possibly lucky, so Viz and I consider that this should receive a VLTC test before being merged. (This is very low priority, it can be 1% thruput and take a month or more.)

Nevertheless, I make the PR now as I do intend to see this merged, pending the VLTC (excepting of course some other gainer in this line of code).

blue STC: https://tests.stockfishchess.org/tests/view/62bd4cfc4ab6fec5049af1fd
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 43456 W: 11826 L: 11682 D: 19948
Ptnml(0-2): 200, 4747, 11652, 4967, 162

blue LTC: https://tests.stockfishchess.org/tests/view/62bd914b4ab6fec5049afc68
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 170768 W: 46520 L: 46558 D: 77690
Ptnml(0-2): 258, 17142, 50589, 17170, 225

bench 5596343