### PR TITLE
Simplify away FRC adjustment

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1042,38 +1042,6 @@ make_v:
     return v;
   }
 
-
-  /// Fisher Random Chess: correction for cornered bishops, to fix chess960 play with NNUE
-
-  Value fix_FRC(const Position& pos) {
-
-    constexpr Bitboard Corners =  1ULL << SQ_A1 | 1ULL << SQ_H1 | 1ULL << SQ_A8 | 1ULL << SQ_H8;
-
-    if (!(pos.pieces(BISHOP) & Corners))
-        return VALUE_ZERO;
-
-    int correction = 0;
-
-    if (   pos.piece_on(SQ_A1) == W_BISHOP
-        && pos.piece_on(SQ_B2) == W_PAWN)
-        correction -= CorneredBishop;
-
-    if (   pos.piece_on(SQ_H1) == W_BISHOP
-        && pos.piece_on(SQ_G2) == W_PAWN)
-        correction -= CorneredBishop;
-
-    if (   pos.piece_on(SQ_A8) == B_BISHOP
-        && pos.piece_on(SQ_B7) == B_PAWN)
-        correction += CorneredBishop;
-
-    if (   pos.piece_on(SQ_H8) == B_BISHOP
-        && pos.piece_on(SQ_G7) == B_PAWN)
-        correction += CorneredBishop;
-
-    return pos.side_to_move() == WHITE ?  Value(3 * correction)
-                                       : -Value(3 * correction);
-  }
-
 } // namespace Eval
 
 
@@ -1113,9 +1081,6 @@ Value Eval::evaluate(const Position& pos, int* complexity) {
 
        optimism = optimism * (269 + nnueComplexity) / 256;
        v = (nnue * scale + optimism * (scale - 754)) / 1024;
-
-       if (pos.is_chess960())
-           v += fix_FRC(pos);
   }
 
   // Damp down the evaluation linearly when shuffling


### PR DESCRIPTION
Since new net is trained partially using FRC data this part of adjustment that penalises bishops that are locked in the corner is no longer needed - net should "know" this things itself much better.
STC on FRC book : 
https://tests.stockfishchess.org/tests/view/62c3031b9e7d9997a12d852f
LLR: 2.96 (-2.94,2.94) <-2.25,0.25>
Total: 22048 W: 3003 L: 2845 D: 16200
Ptnml(0-2): 96, 1778, 7149, 1874, 127 
LTC on FRC book : 
https://tests.stockfishchess.org/tests/view/62c32e939e7d9997a12d8c5e
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 36784 W: 3138 L: 3037 D: 30609
Ptnml(0-2): 36, 1842, 14537, 1939, 38 
STC on DFRC book : 
https://tests.stockfishchess.org/tests/view/62c32efb9e7d9997a12d8c6f
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 20424 W: 3903 L: 3721 D: 12800
Ptnml(0-2): 172, 1984, 5724, 2154, 178 
LTC on DFRC book : 
https://tests.stockfishchess.org/tests/view/62c358c79e7d9997a12d9319
LLR: 2.93 (-2.94,2.94) <-2.25,0.25>
Total: 53784 W: 7581 L: 7480 D: 38723
Ptnml(0-2): 87, 3887, 18856, 3962, 100 
bench 5182295