### PR TITLE
Simplify away some unneeded code in time management

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -474,7 +474,7 @@ void Thread::search() {
           double reduction = (1.56 + mainThread->previousTimeReduction) / (2.20 * timeReduction);
           double bestMoveInstability = 1 + 1.7 * totBestMoveChanges / Threads.size();
           int complexity = mainThread->complexityAverage.value();
-          double complexPosition = std::clamp(1.0 + (complexity - 277) / 1819.1, 0.5, 1.5);
+          double complexPosition = std::min(1.0 + (complexity - 277) / 1819.1, 1.5);
 
           double totalTime = Time.optimum() * fallingEval * reduction * bestMoveInstability * complexPosition;
 


### PR DESCRIPTION
This part of code was introduced long time ago with usage of clamp function and was subsequently adjusted and tuned with it. 
But lower bound is never used since complexity can't be negative and thus is unneeded.
No functional change.
bench 5182295