### PR TITLE
Update default net to nn-ad9b42354671.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-3c0054ea9860.nnue"
+  #define EvalFileDefaultName   "nn-ad9b42354671.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
using trainer branch https://github.com/glinscott/nnue-pytorch/pull/208 with a slightly
tweaked loss function (power 2.5 instead of 2.6), otherwise same training as in
the previous net update https://github.com/official-stockfish/Stockfish/pull/4100

passed STC:
LLR: 2.97 (-2.94,2.94) <0.00,2.50>
Total: 367536 W: 99465 L: 98573 D: 169498
Ptnml(0-2): 1820, 40994, 97117, 42148, 1689
https://tests.stockfishchess.org/tests/view/62cc43fe50dcbecf5fc1c5b8

passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 25032 W: 6802 L: 6553 D: 11677
Ptnml(0-2): 40, 2424, 7341, 2669, 42
https://tests.stockfishchess.org/tests/view/62ce5f421dacb46e4d5fd277

Bench: 5905619