### PR TITLE
remove useClassical depth condition

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1055,7 +1055,7 @@ Value Eval::evaluate(const Position& pos, int* complexity) {
   Value psq = pos.psq_eg_stm();
   // Deciding between classical and NNUE eval (~10 Elo): for high PSQ imbalance we use classical,
   // but we switch to NNUE during long shuffling or with high material on the board.
-  bool useClassical =    (pos.this_thread()->depth > 9 || pos.count<ALL_PIECES>() > 7)
+  bool useClassical =    (pos.count<ALL_PIECES>() > 7)
                       && abs(psq) * 5 > (856 + pos.non_pawn_material() / 64) * (10 + pos.rule50_count());
 
   // Deciding between classical and NNUE eval (~10 Elo): for high PSQ imbalance we use classical,


### PR DESCRIPTION
blue stc: https://tests.stockfishchess.org/tests/view/62e0c3e98e4fa6ae472695ed
LLR: 2.96 (-2.94,2.94) <-2.25,0.25>
Total: 293568 W: 78934 L: 79151 D: 135483
Ptnml(0-2): 1344, 31488, 81366, 31213, 1373

https://tests.stockfishchess.org/tests/view/62e190aa8e4fa6ae4726b5b5
LLR: 2.98 (-2.94,2.94) <-2.25,0.25>
Total: 187392 W: 50971 L: 51028 D: 85393
Ptnml(0-2): 384, 17801, 57369, 17772, 370

The negative elo of both these tests is a bit concerning, I leave this one up to the community, I'd be fine with not merging it

other attempts to otherwise tune this parameter failed, bounds 6,7,10,11 failed STC, 8 passed STC but failed LTC

bench 5796377