### PR TITLE
do more tt cutoffs in case of exact bound.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -637,7 +637,7 @@ namespace {
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode
         && ss->ttHit
-        && tte->depth() > depth - ((int)thisThread->id() & 0x1)
+        && tte->depth() > depth - ((int)thisThread->id() & 0x1) - (tte->bound() == BOUND_EXACT)
         && ttValue != VALUE_NONE // Possible in case of TT access race
         && (tte->bound() & (ttValue >= beta ? BOUND_LOWER : BOUND_UPPER)))
     {


### PR DESCRIPTION
Idea is that this tt entries are considered move valuable in tt replacement scheme - they are always overwriting other entries. So it makes sence for them to produce more aggressive cutoffs.
passed STC
https://tests.stockfishchess.org/tests/view/62e4d407b383a712b1385410
LLR: 2.95 (-2.94,2.94) <0.00,2.50>
Total: 96632 W: 26045 L: 25659 D: 44928
Ptnml(0-2): 434, 10635, 25770, 11065, 412 
passed LTC
https://tests.stockfishchess.org/tests/view/62e523e2b383a712b1386193
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 77960 W: 21363 L: 20989 D: 35608
Ptnml(0-2): 190, 7591, 23009, 8035, 155 
bench 5912001