### PR TITLE
Update WDL model for current SF

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -207,8 +207,8 @@ namespace {
      // The coefficients of a third-order polynomial fit is based on the fishtest data
      // for two parameters that need to transform eval to the argument of a logistic
      // function.
-     double as[] = {-1.17202460e-01, 5.94729104e-01, 1.12065546e+01, 1.22606222e+02};
-     double bs[] = {-1.79066759,  11.30759193, -17.43677612,  36.47147479};
+     double as[] = { 0.50379905,  -4.12755858,  18.95487051, 152.00733652};
+     double bs[] = {-1.71790378,  10.71543602, -17.05515898,  41.15680404};
      double a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
      double b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];
 


### PR DESCRIPTION
This updates the WDL model based on the LTC statistics for the two weeks (3M games).

for old results see:

No functional change.