### PR TITLE
Reintroduce singularQuietLMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -558,7 +558,7 @@ namespace {
     Move ttMove, move, excludedMove, bestMove;
     Depth extension, newDepth;
     Value bestValue, value, ttValue, eval, maxValue, probCutBeta;
-    bool givesCheck, improving, didLMR, priorCapture;
+    bool givesCheck, improving, didLMR, priorCapture, singularQuietLMR;
     bool capture, doFullDepthSearch, moveCountPruning, ttCapture;
     Piece movedPiece;
     int moveCount, captureCount, quietCount, improvement, complexity;
@@ -945,7 +945,7 @@ moves_loop: // When in check, search starts here
                                       ss->killers);
 
     value = bestValue;
-    moveCountPruning = false;
+    moveCountPruning = singularQuietLMR = false;
 
     // Indicate PvNodes that will probably fail low if the node was searched
     // at a depth equal or greater than the current depth, and the result of this search was a fail low.
@@ -1075,6 +1075,7 @@ moves_loop: // When in check, search starts here
               if (value < singularBeta)
               {
                   extension = 1;
+                  singularQuietLMR = !ttCapture;
 
                   // Avoid search explosion by limiting the number of double extensions
                   if (  !PvNode
@@ -1166,6 +1167,10 @@ moves_loop: // When in check, search starts here
           // Decrease reduction for PvNodes based on depth
           if (PvNode)
               r -= 1 + 15 / (3 + depth);
+
+          // Decrease reduction if ttMove has been singularly extended (~1 Elo)
+          if (singularQuietLMR)
+              r--;
 
           // Increase reduction if next ply has a lot of fail high else reset count to 0
           if ((ss+1)->cutoffCnt > 3 && !PvNode)


### PR DESCRIPTION
Reintroduce singularQuietLMR. It was simplified away in [#3854](https://github.com/official-stockfish/Stockfish/pull/3854).

STC:
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 88912 W: 23972 L: 23580 D: 41360
Ptnml(0-2): 365, 9820, 23712, 10176, 383
https://tests.stockfishchess.org/tests/view/62e9537a400addce2c13399b

LTC:
LLR: 2.97 (-2.94,2.94) <0.50,2.50>
Total: 85672 W: 23607 L: 23192 D: 38873
Ptnml(0-2): 219, 8316, 25365, 8703, 233
https://tests.stockfishchess.org/tests/view/62e9a174400addce2c1346e4

Bench: 5363282