### PR TITLE
Allow recursive singular search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1059,7 +1059,6 @@ moves_loop: // When in check, search starts here
           if (   !rootNode
               &&  depth >= 4 - (thisThread->previousDepth > 27) + 2 * (PvNode && tte->is_pv())
               &&  move == ttMove
-              && !excludedMove // Avoid recursive singular search
            /* &&  ttValue != VALUE_NONE Already implicit in the next condition */
               &&  abs(ttValue) < VALUE_KNOWN_WIN
               && (tte->bound() & BOUND_LOWER)


### PR DESCRIPTION
This patch allows recursive singular search. The thing is that even if we somehow get into this loop depths will deplete really fast and it will end quite shortly.
Passed STC:
https://tests.stockfishchess.org/tests/view/62eeeea96f0a08af9f7662a3
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 97456 W: 26118 L: 25966 D: 45372
Ptnml(0-2): 413, 10749, 26248, 10909, 409 
Passed LTC:
https://tests.stockfishchess.org/tests/view/62ef25a56f0a08af9f766ad5
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 42464 W: 11732 L: 11535 D: 19197
Ptnml(0-2): 88, 4166, 12538, 4341, 99 
bench 5921315