### PR TITLE
Better PV output

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -237,7 +237,9 @@ Thread* ThreadPool::get_best_thread() const {
         }
         else if (   th->rootMoves[0].score >= VALUE_TB_WIN_IN_MAX_PLY
                  || (   th->rootMoves[0].score > VALUE_TB_LOSS_IN_MAX_PLY
-                     && votes[th->rootMoves[0].pv[0]] > votes[bestThread->rootMoves[0].pv[0]]))
+                     && (   votes[th->rootMoves[0].pv[0]] > votes[bestThread->rootMoves[0].pv[0]]
+                         || (   votes[th->rootMoves[0].pv[0]] == votes[bestThread->rootMoves[0].pv[0]]
+                             && th->rootMoves[0].pv.size() > bestThread->rootMoves[0].pv.size()))))
             bestThread = th;
     }
 


### PR DESCRIPTION
Sometimes we produce extremely short PV output and at times w/o even listing the ponder move.  For example see
https://tcec-chess.com/#div=ch&game=30&season=23 . On move 13 we just output h5.

No functional change.
bench: 5921315