### PR TITLE
Remove an unneeded randomization of evals.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -742,10 +742,6 @@ namespace {
         else // Fall back to (semi)classical complexity for TT hits, the NNUE complexity is lost
             complexity = abs(ss->staticEval - pos.psq_eg_stm());
 
-        // Randomize draw evaluation
-        if (eval == VALUE_DRAW)
-            eval = value_draw(thisThread);
-
         // ttValue can be used as a better position evaluation (~4 Elo)
         if (    ttValue != VALUE_NONE
             && (tte->bound() & (ttValue > eval ? BOUND_LOWER : BOUND_UPPER)))


### PR DESCRIPTION
most of the effect comes from the randomization of 3-folds.

passed STC:
https://tests.stockfishchess.org/tests/view/62e697e97e84186e5d19af6f
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 572976 W: 153168 L: 153539 D: 266269
Ptnml(0-2): 2505, 64783, 152364, 64250, 2586

passed LTC:
https://tests.stockfishchess.org/tests/view/62ee5977523c86dcd6957154
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 704808 W: 191212 L: 191680 D: 321916
Ptnml(0-2): 1340, 70579, 208972, 70235, 1278

Bench: 5868987