### PR TITLE
Position::key_after(Move m)

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1056,8 +1056,8 @@ Key Position::key_after(Move m) const {
 
   k ^= Zobrist::psq[pc][to] ^ Zobrist::psq[pc][from];
 
-  return (st->rule50 < 13 || captured || type_of(pc) == PAWN)
-      ? k : k ^ make_key((st->rule50 - 13) / 8);
+  return (captured || type_of(pc) == PAWN)
+      ? k : adjust_key50<true>(k);
 }
 
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1054,7 +1054,10 @@ Key Position::key_after(Move m) const {
   if (captured)
       k ^= Zobrist::psq[captured][to];
 
-  return k ^ Zobrist::psq[pc][to] ^ Zobrist::psq[pc][from];
+  k ^= Zobrist::psq[pc][to] ^ Zobrist::psq[pc][from];
+
+  return (st->rule50 < 13 || captured || type_of(pc) == PAWN)
+      ? k : k ^ make_key((st->rule50 - 13) / 8);
 }
 
 

--- a/src/position.h
+++ b/src/position.h
@@ -185,6 +185,8 @@ private:
   void move_piece(Square from, Square to);
   template<bool Do>
   void do_castling(Color us, Square from, Square& to, Square& rfrom, Square& rto);
+  template<bool AfterMove>
+  Key adjust_key50(Key k) const;
 
   // Data members
   Piece board[SQUARE_NB];
@@ -327,8 +329,14 @@ inline int Position::pawns_on_same_color_squares(Color c, Square s) const {
 }
 
 inline Key Position::key() const {
-  return st->rule50 < 14 ? st->key
-                         : st->key ^ make_key((st->rule50 - 14) / 8);
+  return adjust_key50<false>(st->key);
+}
+
+template<bool AfterMove>
+inline Key Position::adjust_key50(Key k) const
+{
+  return st->rule50 < 14 - AfterMove
+      ? k : k ^ make_key((st->rule50 - (14 - AfterMove)) / 8);
 }
 
 inline Key Position::pawn_key() const {


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/62f8547123d42b50a8dac674
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 176640 W: 47699 L: 47189 D: 81752
Ptnml(0-2): 776, 18599, 49129, 18971, 845 

A bug fix plus non functional speed optimization.  Position::key_after(Move m) is now consistent with Position::key() thus prefetching correct TT entries which speeds things up.  Related PR https://github.com/official-stockfish/Stockfish/pull/3759

No functional change
bench: 5868987