### PR TITLE
Simplify away smp adjustment in transposition table.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -636,7 +636,7 @@ namespace {
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode
         && ss->ttHit
-        && tte->depth() > depth - ((int)thisThread->id() & 0x1) - (tte->bound() == BOUND_EXACT)
+        && tte->depth() > depth - (tte->bound() == BOUND_EXACT)
         && ttValue != VALUE_NONE // Possible in case of TT access race
         && (tte->bound() & (ttValue >= beta ? BOUND_LOWER : BOUND_UPPER)))
     {


### PR DESCRIPTION
After my previous elo gainer tt cutoffs depth in SMP could be < current depth which doesn't make a lot of sense. 
This patch simplifies away condition that may cause it.
Passed STC
https://tests.stockfishchess.org/tests/view/62f7d81f23d42b50a8dab568
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 98160 W: 26307 L: 26165 D: 45688
Ptnml(0-2): 201, 10282, 27960, 10448, 189 
Passed LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 81544 W: 22346 L: 22200 D: 36998
Ptnml(0-2): 44, 7542, 25446, 7704, 36 
bench 5868987