### PR TITLE
[RFC] Sub probing syzygy TB

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -678,7 +678,7 @@ namespace {
 
         bool subProbe =   !doProbe
                        &&  piecesCount - 1 <= TB::Cardinality
-                       && (piecesCount - 1 <  TB::Cardinality || depth >= TB::ProbeDepth + 2)
+                       && (piecesCount - 1 <  TB::Cardinality || depth >= TB::ProbeDepth)
                        &&  pos.state()->epSquare == SQ_NONE;
 
         if (   (doProbe || subProbe)
@@ -690,6 +690,27 @@ namespace {
             {
                 removablePieces = pos.pieces() ^ pos.pieces(KING);
                 removablePieces &= ~(pos.blockers_for_king(us) | pos.blockers_for_king(~us));
+
+                int minV[COLOR_NB] = { INT_MAX, INT_MAX };
+                Square minS[COLOR_NB] = { SQ_NONE, SQ_NONE };
+                while (removablePieces)
+                {
+                    Square s = pop_lsb(removablePieces);
+                    Piece  p = pos.piece_on(s);
+                    Color  c = color_of(p);
+                    int psqV = abs(eg_value(PSQT::psq[p][s]));
+                    
+                    if (psqV < minV[c])
+                    {
+                        minV[c] = psqV;
+                        minS[c] = s;
+                    }
+                }
+
+                if (minS[WHITE] != SQ_NONE)
+                    removablePieces |= square_bb(minS[WHITE]);
+                if (minS[BLACK] != SQ_NONE)
+                    removablePieces |= square_bb(minS[BLACK]);
             }
 
             Piece rPc = NO_PIECE;


### PR DESCRIPTION
bench: 6079565

This is a draft implementation to get useful information from syzygy TB for positions that have one too many pieces.  The idea is that if we remove one of our pieces and the resulting position is a TB win it's very likely the original position is also a win.  Conversely if we remove one of our opponents pieces and the resulting position is a TB loss very likely the original position is also a loss.   This isn't 100% true of course but hopefully often enough to gain elo.  The current version is slightly weaker than master but I don't know the best way to implement syzygy probing.   For example is there a way to probe using
```
template<TBType Type, typename Ret = typename TBTable<Type>::Ret>
Ret probe_table(const Position& pos, ProbeState* result, WDLScore wdl = WDLDraw)
```
directly w/o calling 
```
template<bool CheckZeroingMoves>
WDLScore search(Position& pos, ProbeState* result)
```
If anyone can look at the changes and offer comments or suggestions I would appreciate it.
@syzygy1 Yours would be especially helpful.