### PR TITLE
Small cleanup in null move pruning.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -815,7 +815,7 @@ namespace {
 
         pos.do_null_move(st);
 
-        Value nullValue = -search<NonPV>(pos, ss+1, -beta, -beta+1, depth-R, !cutNode);
+        Value nullValue = -search<NonPV>(pos, ss+1, -beta, -alpha, depth-R, !cutNode);
 
         pos.undo_null_move();
 
@@ -835,7 +835,7 @@ namespace {
             thisThread->nmpMinPly = ss->ply + 3 * (depth-R) / 4;
             thisThread->nmpColor = us;
 
-            Value v = search<NonPV>(pos, ss, beta-1, beta, depth-R, false);
+            Value v = search<NonPV>(pos, ss, alpha, beta, depth-R, false);
 
             thisThread->nmpMinPly = 0;
 


### PR DESCRIPTION
For whatever reason instead of doing (alpha, beta) or (-beta, -alpha) in master we calculate alpha as beta - 1 which is completely unnesessary.
No functional change.
bench 6079565