### PR TITLE
Remove unnecesary initialization for s+1.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -605,8 +605,7 @@ namespace {
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
-    (ss+1)->ttPv         = false;
-    (ss+1)->excludedMove = bestMove = MOVE_NONE;
+    bestMove = MOVE_NONE;
     (ss+2)->killers[0]   = (ss+2)->killers[1] = MOVE_NONE;
     (ss+2)->cutoffCnt    = 0;
     ss->doubleExtensions = (ss-1)->doubleExtensions;


### PR DESCRIPTION
ttPv is always set for current node. Except for excludedMove search where it is set in the previous interaction. There is not needed to initialize this variable for (ss+1).

ExcludedMove is initialize to zero (MOVE_NONE) when the stack is create, and always set to MOVE_NONE after a excludedMove search. No need to initialize for (ss+1).

No functional change.
bench 6079565