### PR TITLE
Better PV output V2

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -242,13 +242,16 @@ void MainThread::search() {
   for (Thread* th : Threads)
     th->previousDepth = bestThread->completedDepth;
 
+  bool resendPV =   bestThread->rootMoves[0].pv.size() == 1
+                 && bestThread->rootMoves[0].extract_ponder_from_tt(rootPos);
+
   // Send again PV info if we have a new best thread
-  if (bestThread != this)
+  if (resendPV || bestThread != this)
       sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
 
   sync_cout << "bestmove " << UCI::move(bestThread->rootMoves[0].pv[0], rootPos.is_chess960());
 
-  if (bestThread->rootMoves[0].pv.size() > 1 || bestThread->rootMoves[0].extract_ponder_from_tt(rootPos))
+  if (bestThread->rootMoves[0].pv.size() > 1)
       std::cout << " ponder " << UCI::move(bestThread->rootMoves[0].pv[1], rootPos.is_chess960());
 
   std::cout << sync_endl;


### PR DESCRIPTION
I checked at TCEC that after https://github.com/official-stockfish/Stockfish/pull/4126 we now get more long PVs.  However, we still continue to get some PVs of length 1 which means we don't even know what reply SF expects from the opponent.  This is even in this kind of best case scenario where we have over 100 threads to select from.  See
https://tcec-chess.com/#div=1de&game=2&season=23  moves 144, 170, 171
https://tcec-chess.com/#div=1de&game=4&season=23  moves 23, 57, 141, 258
as examples.  There was some concern about the PV length meaning fail low/high in the original PR.  To the best of my ability to determine there isn't and shouldn't be any such meaning.  See https://github.com/official-stockfish/Stockfish/pull/4126 for additional comments.

bench: 6079565