### PR TITLE
Do less singular extensions for former PVnodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1060,7 +1060,7 @@ moves_loop: // When in check, search starts here
               && (tte->bound() & BOUND_LOWER)
               &&  tte->depth() >= depth - 3)
           {
-              Value singularBeta = ttValue - 3 * depth;
+              Value singularBeta = ttValue - (3 + (ss->ttPv && !PvNode)) * depth;
               Depth singularDepth = (depth - 1) / 2;
 
               ss->excludedMove = move;


### PR DESCRIPTION
Patch is a reintroduction of logic what was simplified a while ago in a slightly different form. Do bigger extension offset in case of non-pv node having a pv.
passed STC
https://tests.stockfishchess.org/tests/view/631977c048f27688a06e66d5
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 23296 W: 6404 L: 6108 D: 10784
Ptnml(0-2): 88, 2539, 6118, 2795, 108 
passed LTC
https://tests.stockfishchess.org/tests/view/631989cb48f27688a06e696c
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 235592 W: 63890 L: 63188 D: 108514
Ptnml(0-2): 275, 23392, 69804, 24006, 319 
bench 5103364