### PR TITLE
Make the displayed evaluation more symmetric

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -126,33 +126,6 @@ private:
 };
 
 
-/// sigmoid(t, x0, y0, C, P, Q) implements a sigmoid-like function using only integers,
-/// with the following properties:
-///
-///  -  sigmoid is centered in (x0, y0)
-///  -  sigmoid has amplitude [-P/Q , P/Q] instead of [-1 , +1]
-///  -  limit is (y0 - P/Q) when t tends to -infinity
-///  -  limit is (y0 + P/Q) when t tends to +infinity
-///  -  the slope can be adjusted using C > 0, smaller C giving a steeper sigmoid
-///  -  the slope of the sigmoid when t = x0 is P/(Q*C)
-///  -  sigmoid is increasing with t when P > 0 and Q > 0
-///  -  to get a decreasing sigmoid, change sign of P
-///  -  mean value of the sigmoid is y0
-///
-/// Use <https://www.desmos.com/calculator/jhh83sqq92> to draw the sigmoid
-
-inline int64_t sigmoid(int64_t t, int64_t x0,
-                                  int64_t y0,
-                                  int64_t  C,
-                                  int64_t  P,
-                                  int64_t  Q)
-{
-   assert(C > 0);
-   assert(Q != 0);
-   return y0 + P * (t-x0) / (Q * (std::abs(t-x0) + C)) ;
-}
-
-
 /// xorshift64star Pseudo-Random Number Generator
 /// This class is based on original code written and dedicated
 /// to the public domain by Sebastiano Vigna (2014).

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -309,9 +309,8 @@ void Thread::search() {
 
   complexityAverage.set(155, 1);
 
-  trend         = SCORE_ZERO;
-  optimism[ us] = Value(37);
-  optimism[~us] = -optimism[us];
+  trend = SCORE_ZERO;
+  optimism[us] = optimism[~us] = VALUE_ZERO;
 
   int searchAgainCounter = 0;
 
@@ -358,11 +357,11 @@ void Thread::search() {
               beta  = std::min(prev + delta, VALUE_INFINITE);
 
               // Adjust trend and optimism based on root move's previousScore
-              int tr = sigmoid(prev, 3, 10, 89, 116, 1);
+              int tr = 116 * prev / (std::abs(prev) + 89);
               trend = (us == WHITE ?  make_score(tr, tr / 2)
                                    : -make_score(tr, tr / 2));
 
-              int opt = sigmoid(prev, 7, 20, 169, 19350, 164);
+              int opt = 118 * prev / (std::abs(prev) + 169);
               optimism[ us] = Value(opt);
               optimism[~us] = -optimism[us];
           }


### PR DESCRIPTION
This patch simplifies the formulas used to compute the trend and optimism values before each search iteration. Also and more importantly, this removes the parameters which make the relationship between the displayed evaluation value and the expected game result asymmetric. Here by symmetricity we mean that f(x) + f(-x) = 1, where f(x) is the expected score when the evaluation shows x. This has implications in usability for analysis, where more symmetric eval values mean less fluctuations of eval during a traverse of a game.
The patch has passed both STC and LTC simplification tests. The patch in the LTC test (which is functionally equivalent to the version in the present pull request) is slightly different from the patch used in the STC: in the LTC version the change is applied to the latest version of master and the fraction of two integers is rounded to an integer. Both was tested without automatic adjudication.
I've also provided links to the results of isotonic regression analysis of the relationship between the evaluation and game result (statistical data and a graph) for both tests, which demonstrate that the new version has a more symmetric relationship.

#### STC
[Test result](https://tests.stockfishchess.org/tests/view/6313f44b8202a039920e27e6)
[Data and graph](https://github.com/official-stockfish/Stockfish/discussions/4150#discussioncomment-3548954)
```
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 108016 W: 28903 L: 28760 D: 50353
Ptnml(0-2): 461, 12075, 28850, 12104, 518 
```

#### LTC
[Test result](https://tests.stockfishchess.org/tests/view/631de45db85daa436625dfe6)
[Data and graph](https://github.com/official-stockfish/Stockfish/discussions/4150#discussioncomment-3626311)
```
LLR: 3.01 (-2.94,2.94) <-1.75,0.25>
Total: 34792 W: 9412 L: 9209 D: 16171
Ptnml(0-2): 24, 3374, 10397, 3577, 24
```

After the patch is commited I suggest running more tests to verify if the eval-result relationship is symmetric and thinking what can be changed to make it even more symmetric in case it still isn't.
Fixes at least partly: https://github.com/official-stockfish/Stockfish/issues/4142 (but please don't close the issue yet, because the eval may be still asymmetric).
Closes: https://github.com/official-stockfish/Stockfish/pull/4163

Bench: 4425574
