### PR TITLE
Prioritize checks in movepicker

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -147,8 +147,8 @@ void MovePicker::score() {
                           : type_of(pos.moved_piece(m)) == ROOK  && !(to_sq(m) & threatenedByMinor) ? 25000
                           :                                         !(to_sq(m) & threatenedByPawn)  ? 15000
                           :                                                                           0)
-                          :                                                                           0);
-
+                          :                                                                           0)
+                   +     bool(pos.check_squares(type_of(pos.moved_piece(m))) & to_sq(m)) * 16384;
       else // Type == EVASIONS
       {
           if (pos.capture(m))


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/631da742162491686d2e40b5
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 80072 W: 21753 L: 21368 D: 36951
Ptnml(0-2): 421, 8876, 21075, 9225, 439 

LTC: https://tests.stockfishchess.org/tests/view/631dd9e6b85daa436625de1d
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 263480 W: 70916 L: 70158 D: 122406
Ptnml(0-2): 322, 26156, 78029, 26908, 325 

Original idea by @Vizvezdenec.  Credit to him.
bench: 4332915