### PR TITLE
Simplify EVASIONS scoring

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -145,11 +145,11 @@ void MovePicker::score() {
       {
           if (pos.capture(m))
               m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
-                       - Value(type_of(pos.moved_piece(m)));
+                       - Value(type_of(pos.moved_piece(m)))
+                       + (1 << 28);
           else
-              m.value =  2 * (*mainHistory)[pos.side_to_move()][from_to(m)]
-                       + 2 * (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
-                       - (1 << 28);
+              m.value =  (*mainHistory)[pos.side_to_move()][from_to(m)]
+                       + (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)];
       }
 }
 


### PR DESCRIPTION
Non functional version of https://tests.stockfishchess.org/tests/view/631d898e162491686d2e3c90

STC https://tests.stockfishchess.org/tests/view/6325c1c9b9c0caa5f4a759ae
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 192760 W: 51528 L: 51482 D: 89750
Ptnml(0-2): 642, 20490, 54148, 20380, 720 

Credit to @locutus2

bench: 4326572