### PR TITLE
Always output hashfull

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1860,12 +1860,9 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
           ss << (v >= beta ? " lowerbound" : v <= alpha ? " upperbound" : "");
 
       ss << " nodes "    << nodesSearched
-         << " nps "      << nodesSearched * 1000 / elapsed;
-
-      if (elapsed > 1000) // Earlier makes little sense
-          ss << " hashfull " << TT.hashfull();
-
-      ss << " tbhits "   << tbHits
+         << " nps "      << nodesSearched * 1000 / elapsed
+         << " hashfull " << TT.hashfull()
+         << " tbhits "   << tbHits
          << " time "     << elapsed
          << " pv";
 


### PR DESCRIPTION
This removes the restriction that no `hashfull` information is printed within the first second of a search.
On modern systems, a non-zero value is returned within 6 ms with default settings. Within one second the hash is filled to about 50 percent on my system without getting any information about it.

passed non-regression STC
https://tests.stockfishchess.org/tests/view/63277b08b9c0caa5f4a798e4
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 290096 W: 77505 L: 77561 D: 135030
Ptnml(0-2): 1008, 30713, 81592, 30797, 938

bench: 4326572