### PR TITLE
Simplify both position calls in useClassical

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1054,12 +1054,10 @@ Value Eval::evaluate(const Position& pos, int* complexity) {
   Color stm = pos.side_to_move();
   Value psq = pos.psq_eg_stm();
 
-  // Deciding between classical and NNUE eval: for high PSQ imbalance we use classical,
-  // but we switch to NNUE during long shuffling or with high material on the board.
-  bool useClassical = !useNNUE ||
-                      ((pos.count<ALL_PIECES>() > 7)
-                       && abs(psq) * 5 > (856 + pos.non_pawn_material() / 64) * (10 + pos.rule50_count()));
-
+  // We use the much less accurate but faster Classical eval when the NNUE 
+  // option is set to false. Otherwise we use the NNUE eval unless the
+  // PSQ advantage is decisive and several pieces remain (~3 Elo)
+  bool useClassical = !useNNUE || (pos.count<ALL_PIECES>() > 7 && abs(psq) > 1760);
   if (useClassical)
       v = Evaluation<NO_TRACE>(pos).value();
   else


### PR DESCRIPTION
Simplify the use of classical evaluation when using default settings to only be dependent on piece count and decisive PSQ

passed STC:
https://tests.stockfishchess.org/tests/view/632d32a7006ef9eb96d86ce9
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 108048 W: 28904 L: 28763 D: 50381
Ptnml(0-2): 383, 12060, 29006, 12183, 392

passed LTC:
https://tests.stockfishchess.org/tests/view/632d705a006ef9eb96d87649
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 76600 W: 20671 L: 20516 D: 35413
Ptnml(0-2): 34, 7533, 23023, 7664, 46

Inspired by [@sorais](https://github.com/sorais) Credit to him.
bench: 4173163