### PR TITLE
Mix alpha and statScore for reduction

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,7 +11,7 @@ Yu Nasu (ynasu87)
 Motohiro Isozaki (yaneurao)
 Hisayori Noda (nodchip)
 
-# all other authors of the code in alphabetical order.
+# all other authors of the code in alphabetical order
 Aditya (absimaldata)
 Adrian Petrescu (apetresc)
 Ajith Chandy Jose (ajithcj)

--- a/AUTHORS
+++ b/AUTHORS
@@ -11,7 +11,7 @@ Yu Nasu (ynasu87)
 Motohiro Isozaki (yaneurao)
 Hisayori Noda (nodchip)
 
-# all other authors of the code in alphabetical order
+# all other authors of the code in alphabetical order.
 Aditya (absimaldata)
 Adrian Petrescu (apetresc)
 Ajith Chandy Jose (ajithcj)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -787,9 +787,9 @@ namespace {
     // The depth condition is important for mate finding.
     if (   !ss->ttPv
         &&  depth < 8
-        &&  eval - futility_margin(depth, improving) - (ss-1)->statScore / 303 >= beta
+        &&  eval - futility_margin(depth, improving) - (ss-1)->statScore / 301 >= beta
         &&  eval >= beta
-        &&  eval < 28031) // larger than VALUE_KNOWN_WIN, but smaller than TB wins
+        &&  eval < 28692) // larger than VALUE_KNOWN_WIN, but smaller than TB wins
         return eval;
 
     // Step 9. Null move search with verification search (~22 Elo)
@@ -1179,7 +1179,7 @@ moves_loop: // When in check, search starts here
                          - 4433;
 
           // Decrease/increase reduction for moves with a good/bad history (~30 Elo)
-          r -= ss->statScore / 13628;
+          r -= (ss->statScore + 5 * alpha) / 15448;
 
           // In general we want to cap the LMR depth search at newDepth, but when
           // reduction is negative, we allow this move a limited search extension


### PR DESCRIPTION
The main idea credit goes to @xoto10 
I @FauziAkram  picked up the idea, and tuned it a little bit, enough to make it pass both STC and LTC tests convincingly:

STC: https://tests.stockfishchess.org/tests/view/6338db6f35f43d649ff60fdc
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 57832 W: 15540 L: 15199 D: 27093
Ptnml(0-2): 207, 6343, 15477, 6680, 209

LTC: https://tests.stockfishchess.org/tests/view/6339777035f43d649ff62686
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 50968 W: 13770 L: 13440 D: 23758
Ptnml(0-2): 25, 4905, 15306, 5211, 37