### PR TITLE
Remove old line in "Futility pruning for captures"

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1002,8 +1002,7 @@ moves_loop: // When in check, search starts here
               || givesCheck)
           {
               // Futility pruning for captures (~0 Elo)
-              if (   !pos.empty(to_sq(move))
-                  && !givesCheck
+              if (   !givesCheck
                   && !PvNode
                   && lmrDepth < 7
                   && !ss->inCheck


### PR DESCRIPTION
The line is no longer needed after https://github.com/official-stockfish/Stockfish/commit/910cf8b21839eb9f1991934a5436eea112021723. This patch incidentally applies "Futility Pruning for Captures" also in case of en-passant, changing the bench signature.

Passed STC:
https://tests.stockfishchess.org/tests/view/6332c1f1208c26088697b731
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 68760 W: 18440 L: 18256 D: 32064
Ptnml(0-2): 267, 7530, 18595, 7728, 260

Passed LTC:
https://tests.stockfishchess.org/tests/view/633312e9208c26088697c59b
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 455552 W: 121910 L: 122123 D: 211519
Ptnml(0-2): 253, 45439, 136600, 45236, 248

Bench: 4340187