### PR TITLE
Tweak history initialization

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1550,8 +1550,8 @@ moves_loop: // When in check, search starts here
       // Continuation history based pruning (~2 Elo)
       if (   !capture
           && bestValue > VALUE_TB_LOSS_IN_MAX_PLY
-          && (*contHist[0])[pos.moved_piece(move)][to_sq(move)] < CounterMovePruneThreshold
-          && (*contHist[1])[pos.moved_piece(move)][to_sq(move)] < CounterMovePruneThreshold)
+          && (*contHist[0])[pos.moved_piece(move)][to_sq(move)] < 0
+          && (*contHist[1])[pos.moved_piece(move)][to_sq(move)] < 0)
           continue;
 
       // movecount pruning for quiet check evasions

--- a/src/search.h
+++ b/src/search.h
@@ -31,9 +31,6 @@ class Position;
 
 namespace Search {
 
-/// Threshold used for countermoves based pruning
-constexpr int CounterMovePruneThreshold = 0;
-
 
 /// Stack struct keeps track of the information we need to remember from nodes
 /// shallower and deeper in the tree during the search. Each search thread has

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -64,12 +64,9 @@ void Thread::clear() {
 
   for (bool inCheck : { false, true })
       for (StatsType c : { NoCaptures, Captures })
-      {
           for (auto& to : continuationHistory[inCheck][c])
-                for (auto& h : to)
-                      h->fill(-71);
-          continuationHistory[inCheck][c][NO_PIECE][0]->fill(Search::CounterMovePruneThreshold - 1);
-      }
+              for (auto& h : to)
+                  h->fill(-71);
 }
 
 


### PR DESCRIPTION
Simplify initialization of continuation history by using everywhere the same starting value.

STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 90952 W: 24312 L: 24153 D: 42487
Ptnml(0-2): 356, 10168, 24290, 10285, 377
https://tests.stockfishchess.org/tests/view/633948f235f43d649ff61fd0

LTC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 162416 W: 43540 L: 43466 D: 75410
Ptnml(0-2): 77, 16289, 48417, 16333, 92
https://tests.stockfishchess.org/tests/view/6339ee8a35f43d649ff63986

Bench: 4757726