### PR TITLE
Fix tablebase probe for dtz >1000

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -59,6 +59,7 @@ namespace Stockfish {
 namespace {
 
 constexpr int TBPIECES = 7; // Max number of supported pieces
+constexpr int MAX_DTZ = 100000; // Max DTZ supported by this file
 
 enum { BigEndian, LittleEndian };
 enum TBType { WDL, DTZ }; // Used as template parameter
@@ -1522,7 +1523,7 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
     // Check whether a position was repeated since the last zeroing move.
     bool rep = pos.has_repeated();
 
-    int dtz, bound = Options["Syzygy50MoveRule"] ? 900 : 1;
+    int dtz, bound = Options["Syzygy50MoveRule"] ? (MAX_DTZ - 100) : 1;
 
     // Probe and rank each move
     for (auto& m : rootMoves)
@@ -1565,8 +1566,8 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
 
         // Better moves are ranked higher. Certain wins are ranked equally.
         // Losing moves are ranked equally unless a 50-move draw is in sight.
-        int r =  dtz > 0 ? (dtz + cnt50 <= 99 && !rep ? 1000 : 1000 - (dtz + cnt50))
-               : dtz < 0 ? (-dtz * 2 + cnt50 < 100 ? -1000 : -1000 + (-dtz + cnt50))
+        int r =  dtz > 0 ? (dtz + cnt50 <= 99 && !rep ? MAX_DTZ : MAX_DTZ - (dtz + cnt50))
+               : dtz < 0 ? (-dtz * 2 + cnt50 < 100 ? -MAX_DTZ : -MAX_DTZ + (-dtz + cnt50))
                : 0;
         m.tbRank = r;
 
@@ -1574,9 +1575,9 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
         // 1 cp to cursed wins and let it grow to 49 cp as the positions gets
         // closer to a real win.
         m.tbScore =  r >= bound ? VALUE_MATE - MAX_PLY - 1
-                   : r >  0     ? Value((std::max( 3, r - 800) * int(PawnValueEg)) / 200)
+                   : r >  0     ? Value((std::max( 3, r - (MAX_DTZ - 200)) * int(PawnValueEg)) / 200)
                    : r == 0     ? VALUE_DRAW
-                   : r > -bound ? Value((std::min(-3, r + 800) * int(PawnValueEg)) / 200)
+                   : r > -bound ? Value((std::min(-3, r + (MAX_DTZ - 200)) * int(PawnValueEg)) / 200)
                    :             -VALUE_MATE + MAX_PLY + 1;
     }
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1591,7 +1591,7 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
 // A return value false indicates that not all probes were successful.
 bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves) {
 
-    static const int WDL_to_rank[] = { -1000, -899, 0, 899, 1000 };
+    static const int WDL_to_rank[] = { -MAX_DTZ, -MAX_DTZ + 101, 0, MAX_DTZ - 101, MAX_DTZ };
 
     ProbeState result;
     StateInfo st;

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -32,7 +32,7 @@ enum WDLScore {
     WDLCursedWin   =  1, // Win, but draw under 50-move rule
     WDLWin         =  2, // Win
 
-    WDLScoreNone  = -1000
+    WDLScoreNone  = -100000
 };
 
 // Possible states after a probing operation

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -31,8 +31,6 @@ enum WDLScore {
     WDLDraw        =  0, // Draw
     WDLCursedWin   =  1, // Win, but draw under 50-move rule
     WDLWin         =  2, // Win
-
-    WDLScoreNone  = -100000
 };
 
 // Possible states after a probing operation


### PR DESCRIPTION
I was playing around with some 8-men TB attempts and found a bug affecting 7-men TBs today.

For `qn4N1/6R1/3K4/8/B2k4/8/8/8 w - - 0 1`, white loses with DTZ 1034. See https://syzygy-tables.info/?fen=qn4N1/6R1/3K4/8/B2k4/8/8/8_w_-_-_0_1

Yet due to some hardcoded values (see changes), Stockfish interprets it as white winning:
```
E:\stockfish_15_win_x64_avx2> .\stockfish_15_x64_avx2.exe
Stockfish 15 by the Stockfish developers (see AUTHORS file)
setoption name SyzygyPath value E:\syzygy
setoption name Syzygy50MoveRule value false
setoption name MultiPV value 3
position fen qn4N1/6R1/3K4/8/B2k4/8/8/8 w - - 0 1
go depth 1

info depth 1 seldepth 1 multipv 1 score cp 15265 nodes 8 nps 2000 tbhits 26 time 4 pv g7g4 a8e4 g4e4 d4e4
info depth 1 seldepth 1 multipv 2 score cp -15265 nodes 8 nps 2000 tbhits 26 time 4 pv g8f6 a8a4
info depth 1 seldepth 1 multipv 3 score cp -15265 nodes 8 nps 2000 tbhits 26 time 4 pv d6e7 a8a4
bestmove g7g4 ponder a8e4
```

With these changes it sees the right eval:
```
PS E:\stockfish_15_win_x64_avx2> .\stockfish_x86-64-avx2.exe
Stockfish 071022 by the Stockfish developers (see AUTHORS file)
setoption name SyzygyPath value E:\syzygy
setoption name Syzygy50MoveRule value false
setoption name MultiPV value 3
position fen qn4N1/6R1/3K4/8/B2k4/8/8/8 w - - 0 1
go depth 1

info depth 1 seldepth 1 multipv 1 score cp -15265 nodes 8 nps 2666 hashfull 0 tbhits 26 time 3 pv g7g4 a8e4 g4e4 d4e4
info depth 1 seldepth 1 multipv 2 score cp -15265 nodes 8 nps 2666 hashfull 0 tbhits 26 time 3 pv g8f6 a8a4
info depth 1 seldepth 1 multipv 3 score cp -15265 nodes 8 nps 2666 hashfull 0 tbhits 26 time 3 pv d6e7 a8a4
bestmove g7g4 ponder a8e4
```

Let me know if there's anything else I should test or change.