### PR TITLE
Adjust timeman constants

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -80,7 +80,7 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
   // game time for the current move, so also cap to 20% of available game time.
   if (limits.movestogo == 0)
   {
-      optScale = std::min(0.0084 + std::pow(ply + 3.0, 0.5) * 0.0042,
+      optScale = std::min(0.0120 + std::pow(ply + 3.0, 0.45) * 0.0039,
                            0.2 * limits.time[us] / double(timeLeft))
                  * optExtra;
       maxScale = std::min(7.0, 4.0 + ply / 12.0);


### PR DESCRIPTION
Adjust timeman constants to use more time in early part of game.

STC @ 10+0.1 th 1 :
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 93984 W: 25177 L: 24787 D: 44020
Ptnml(0-2): 350, 10096, 25729, 10448, 369
https://tests.stockfishchess.org/tests/live_elo/6339077135f43d649ff6162a

LTC @ 60+0.6 th 1 :
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 329368 W: 88953 L: 88093 D: 152322
Ptnml(0-2): 170, 31457, 100594, 32269, 194
https://tests.stockfishchess.org/tests/live_elo/6339baed35f43d649ff63142

Bench 4114228