### PR TITLE
Increase maximum no. of threads to 8192

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -61,7 +61,7 @@ void init(OptionsMap& o) {
   constexpr int MaxHashMB = Is64Bit ? 33554432 : 2048;
 
   o["Debug Log File"]        << Option("", on_logger);
-  o["Threads"]               << Option(1, 1, 1024, on_threads);
+  o["Threads"]               << Option(1, 1, 8192, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(false);


### PR DESCRIPTION
Right now, the maximum number of threads for Stockfish is 1024 (see #4152). Why not increase the number of maximum threads to 4096, 8192 or 16384, etc.? (In my commit, I have changed it to 8192.) 

There will be no practical difference for users, and this change may be useful in the future, such as for computer chess competitions.