### PR TITLE
Remove depth condition from razoring

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -775,8 +775,7 @@ namespace {
     // Step 7. Razoring.
     // If eval is really low check with qsearch if it can exceed alpha, if it can't,
     // return a fail low.
-    if (   depth <= 7
-        && eval < alpha - 369 - 254 * depth * depth)
+    if (eval < alpha - 369 - 254 * depth * depth)
     {
         value = qsearch<NonPV>(pos, ss, alpha - 1, alpha);
         if (value < alpha)


### PR DESCRIPTION
The eval condition depends on depth anyways, so this patch is nearly (not quite) non-functional

blue STC:
https://tests.stockfishchess.org/tests/view/63428169fb7ccb2ea9be2629
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 185992 W: 49612 L: 49558 D: 86822
Ptnml(0-2): 618, 19956, 51842, 19914, 666

blue LTC:
https://tests.stockfishchess.org/tests/view/634418b14bc7650f07540760
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 126816 W: 34147 L: 34043 D: 58626
Ptnml(0-2): 74, 11941, 39281, 12031, 81

bench 4148700