### PR TITLE
Change c style casts to cpp static_cast

### DIFF
--- a/src/bitbase.cpp
+++ b/src/bitbase.cpp
@@ -43,7 +43,7 @@ namespace {
   // bit 13-14: white pawn file (from FILE_A to FILE_D)
   // bit 15-17: white pawn RANK_7 - rank (from RANK_7 - RANK_7 to RANK_7 - RANK_2)
   unsigned index(Color stm, Square bksq, Square wksq, Square psq) {
-    return int(wksq) | (bksq << 6) | (stm << 12) | (file_of(psq) << 13) | ((RANK_7 - rank_of(psq)) << 15);
+    return static_cast<int>(wksq) | (bksq << 6) | (stm << 12) | (file_of(psq) << 13) | ((RANK_7 - rank_of(psq)) << 15);
   }
 
   enum Result {

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -343,7 +343,7 @@ inline int popcount(Bitboard b) {
 
 #elif defined(_MSC_VER) || defined(__INTEL_COMPILER)
 
-  return (int)_mm_popcnt_u64(b);
+  return static_cast<int>(_mm_popcnt_u64(b));
 
 #else // Assumed gcc or compatible compiler
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -228,7 +228,7 @@ namespace {
 
   // BishopPawns[distance from edge] contains a file-dependent penalty for pawns on
   // squares of the same color as our bishop.
-  constexpr Score BishopPawns[int(FILE_NB) / 2] = {
+  constexpr Score BishopPawns[static_cast<int>(FILE_NB) / 2] = {
     S(3, 8), S(3, 9), S(2, 7), S(3, 7)
   };
 
@@ -871,7 +871,7 @@ namespace {
   Value Evaluation<T>::winnable(Score score) const {
 
     int outflanking =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
-                    + int(rank_of(pos.square<KING>(WHITE)) - rank_of(pos.square<KING>(BLACK)));
+                    + static_cast<int>(rank_of(pos.square<KING>(WHITE)) - rank_of(pos.square<KING>(BLACK)));
 
     bool pawnsOnBothFlanks =   (pos.pieces(PAWN) & QueenSide)
                             && (pos.pieces(PAWN) & KingSide);
@@ -947,8 +947,8 @@ namespace {
     }
 
     // Interpolate between the middlegame and (scaled by 'sf') endgame score
-    v =  mg * int(me->game_phase())
-       + eg * int(PHASE_MIDGAME - me->game_phase()) * ScaleFactor(sf) / SCALE_FACTOR_NORMAL;
+    v =  mg * static_cast<int>(me->game_phase())
+       + eg * static_cast<int>(PHASE_MIDGAME - me->game_phase()) * ScaleFactor(sf) / SCALE_FACTOR_NORMAL;
     v /= PHASE_MIDGAME;
 
     if constexpr (T)

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -124,7 +124,7 @@ void MovePicker::score() {
 
   for (auto& m : *this)
       if constexpr (Type == CAPTURES)
-          m.value =  6 * int(PieceValue[MG][pos.piece_on(to_sq(m))])
+          m.value =  6 * static_cast<int>(PieceValue[MG][pos.piece_on(to_sq(m))])
                    +     (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))];
 
       else if constexpr (Type == QUIETS)

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -87,7 +87,7 @@ enum StatsType { NoCaptures, Captures };
 /// ordering decisions. It uses 2 tables (one for each color) indexed by
 /// the move's from and to squares, see www.chessprogramming.org/Butterfly_Boards
 /// (~11 elo)
-typedef Stats<int16_t, 7183, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)> ButterflyHistory;
+typedef Stats<int16_t, 7183, COLOR_NB, static_cast<int>(SQUARE_NB) * static_cast<int>(SQUARE_NB)> ButterflyHistory;
 
 /// CounterMoveHistory stores counter moves indexed by [piece][to] of the previous
 /// move, see www.chessprogramming.org/Countermove_Heuristic

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -251,7 +251,7 @@ namespace Stockfish::Eval::NNUE {
 
     buffer[0] = (v < 0 ? '-' : v > 0 ? '+' : ' ');
 
-    double cp = 1.0 * std::abs(int(v)) / PawnValueEg;
+    double cp = 1.0 * std::abs(static_cast<int>(v)) / PawnValueEg;
     sprintf(&buffer[1], "%6.2f", cp);
   }
 
@@ -271,8 +271,8 @@ namespace Stockfish::Eval::NNUE {
     // A lambda to output one box of the board
     auto writeSquare = [&board](File file, Rank rank, Piece pc, Value value) {
 
-      const int x = ((int)file) * 8;
-      const int y = (7 - (int)rank) * 3;
+      const int x = (static_cast<int>(file)) * 8;
+      const int y = (7 - static_cast<int>(rank)) * 3;
       for (int i = 1; i < 8; ++i)
          board[y][x+i] = board[y+3][x+i] = '-';
       for (int i = 1; i < 3; ++i)

--- a/src/nnue/features/half_ka_v2_hm.cpp
+++ b/src/nnue/features/half_ka_v2_hm.cpp
@@ -26,7 +26,7 @@ namespace Stockfish::Eval::NNUE::Features {
 
   // Orient a square according to perspective (rotates by 180 for black)
   inline Square HalfKAv2_hm::orient(Color perspective, Square s, Square ksq) {
-    return Square(int(s) ^ (bool(perspective) * SQ_A8) ^ ((file_of(ksq) < FILE_E) * SQ_H1));
+    return Square(static_cast<int>(s) ^ (bool(perspective) * SQ_A8) ^ ((file_of(ksq) < FILE_E) * SQ_H1));
   }
 
   // Index of a feature for a given king position and another piece on some square

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -506,7 +506,7 @@ namespace Stockfish::Eval::NNUE::Layers {
         vec_t sum0 = vec_setzero();
         const auto row0 = reinterpret_cast<const vec_t*>(&weights[0]);
 
-        for (int j = 0; j < (int)NumChunks; ++j)
+        for (int j = 0; j < static_cast<int>(NumChunks); ++j)
         {
           const vec_t in = inputVector[j];
           vec_add_dpbusd_32(sum0, in, row0[j]);

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -126,7 +126,7 @@ struct Network
 
     // buffer.fc_0_out[FC_0_OUTPUTS] is such that 1.0 is equal to 127*(1<<WeightScaleBits) in quantized form
     // but we want 1.0 to be equal to 600*OutputScale
-    std::int32_t fwdOut = int(buffer.fc_0_out[FC_0_OUTPUTS]) * (600*OutputScale) / (127*(1<<WeightScaleBits));
+    std::int32_t fwdOut = static_cast<int>(buffer.fc_0_out[FC_0_OUTPUTS]) * (600*OutputScale) / (127*(1<<WeightScaleBits));
     std::int32_t outputValue = buffer.fc_2_out[0] + fwdOut;
 
     return outputValue;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -51,7 +51,7 @@ namespace {
 
   // Strength of pawn shelter for our king by [distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawn, or pawn is behind our king.
-  constexpr Value ShelterStrength[int(FILE_NB) / 2][RANK_NB] = {
+  constexpr Value ShelterStrength[static_cast<int>(FILE_NB) / 2][RANK_NB] = {
     { V(-2), V(85), V(95), V(53), V(39), V(23), V(25) },
     { V(-55), V(64), V(32), V(-55), V(-30), V(-11), V(-61) },
     { V(-11), V(75), V(19), V(-6), V(26), V(9), V(-47) },
@@ -62,7 +62,7 @@ namespace {
   // RANK_1 = 0 is used for files where the enemy has no pawn, or their pawn
   // is behind our king. Note that UnblockedStorm[0][1-2] accommodate opponent pawn
   // on edge, likely blocked by our king.
-  constexpr Value UnblockedStorm[int(FILE_NB) / 2][RANK_NB] = {
+  constexpr Value UnblockedStorm[static_cast<int>(FILE_NB) / 2][RANK_NB] = {
     { V(94), V(-280), V(-170), V(90), V(59), V(47), V(53) },
     { V(43), V(-17), V(128), V(39), V(26), V(-17), V(15) },
     { V(-9), V(62), V(170), V(34), V(-5), V(-20), V(-11) },

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -75,7 +75,7 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
   for (Bitboard b = pos.checkers(); b; )
       os << UCI::square(pop_lsb(b)) << " ";
 
-  if (    int(Tablebases::MaxCardinality) >= popcount(pos.pieces())
+  if (    static_cast<int>(Tablebases::MaxCardinality) >= popcount(pos.pieces())
       && !pos.can_castle(ANY_CASTLING))
   {
       StateInfo st;
@@ -812,7 +812,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   if (type_of(pc) == PAWN)
   {
       // Set en passant square if the moved pawn can be captured
-      if (   (int(to) ^ int(from)) == 16
+      if (   (static_cast<int>(to) ^ static_cast<int>(from)) == 16
           && (pawn_attacks_bb(us, to - pawn_push(us)) & pieces(them, PAWN)))
       {
           st->epSquare = to - pawn_push(us);

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -33,7 +33,7 @@ auto constexpr S = make_score;
 
 // 'Bonus' contains Piece-Square parameters.
 // Scores are explicit for files A to D, implicitly mirrored for E to H.
-constexpr Score Bonus[][RANK_NB][int(FILE_NB) / 2] = {
+constexpr Score Bonus[][RANK_NB][static_cast<int>(FILE_NB) / 2] = {
   { },
   { },
   { // Knight

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -71,7 +71,7 @@ namespace {
 
   Depth reduction(bool i, Depth d, int mn, Value delta, Value rootDelta) {
     int r = Reductions[d] * Reductions[mn];
-    return (r + 1642 - int(delta) * 1024 / int(rootDelta)) / 1024 + (!i && r > 916);
+    return (r + 1642 - static_cast<int>(delta) * 1024 / static_cast<int>(rootDelta)) / 1024 + (!i && r > 916);
   }
 
   constexpr int futility_move_count(bool improving, Depth depth) {
@@ -101,7 +101,7 @@ namespace {
             level = double(skill_level);
     }
     bool enabled() const { return level < 20.0; }
-    bool time_to_pick(Depth depth) const { return depth == 1 + int(level); }
+    bool time_to_pick(Depth depth) const { return depth == 1 + static_cast<int>(level); }
     Move pick_best(size_t multiPV);
 
     double level;
@@ -158,7 +158,7 @@ namespace {
 void Search::init() {
 
   for (int i = 1; i < MAX_MOVES; ++i)
-      Reductions[i] = int((20.26 + std::log(Threads.size()) / 2) * std::log(i));
+      Reductions[i] = static_cast<int>((20.26 + std::log(Threads.size()) / 2) * std::log(i));
 }
 
 
@@ -228,9 +228,9 @@ void MainThread::search() {
       Time.availableNodes += Limits.inc[us] - Threads.nodes_searched();
 
   Thread* bestThread = this;
-  Skill skill = Skill(Options["Skill Level"], Options["UCI_LimitStrength"] ? int(Options["UCI_Elo"]) : 0);
+  Skill skill = Skill(Options["Skill Level"], Options["UCI_LimitStrength"] ? static_cast<int>(Options["UCI_Elo"]) : 0);
 
-  if (   int(Options["MultiPV"]) == 1
+  if (   static_cast<int>(Options["MultiPV"]) == 1
       && !Limits.depth
       && !skill.enabled()
       && rootMoves[0].pv[0] != MOVE_NONE)
@@ -298,7 +298,7 @@ void Thread::search() {
   }
 
   size_t multiPV = size_t(Options["MultiPV"]);
-  Skill skill(Options["Skill Level"], Options["UCI_LimitStrength"] ? int(Options["UCI_Elo"]) : 0);
+  Skill skill(Options["Skill Level"], Options["UCI_LimitStrength"] ? static_cast<int>(Options["UCI_Elo"]) : 0);
 
   // When playing with strength handicap enable MultiPV search that we will
   // use behind the scenes to retrieve a set of possible moves.
@@ -352,7 +352,7 @@ void Thread::search() {
           if (rootDepth >= 4)
           {
               Value prev = rootMoves[pvIdx].averageScore;
-              delta = Value(10) + int(prev) * prev / 15620;
+              delta = Value(10) + static_cast<int>(prev) * prev / 15620;
               alpha = std::max(prev - delta,-VALUE_INFINITE);
               beta  = std::min(prev + delta, VALUE_INFINITE);
 
@@ -759,7 +759,7 @@ namespace {
     // Use static evaluation difference to improve quiet move ordering (~3 Elo)
     if (is_ok((ss-1)->currentMove) && !(ss-1)->inCheck && !priorCapture)
     {
-        int bonus = std::clamp(-19 * int((ss-1)->staticEval + ss->staticEval), -1914, 1914);
+        int bonus = std::clamp(-19 * static_cast<int>((ss-1)->staticEval + ss->staticEval), -1914, 1914);
         thisThread->mainHistory[~us][from_to((ss-1)->currentMove)] << bonus;
     }
 
@@ -806,7 +806,7 @@ namespace {
         assert(eval - beta >= 0);
 
         // Null move dynamic reduction based on depth, eval and complexity of position
-        Depth R = std::min(int(eval - beta) / 168, 7) + depth / 3 + 4 - (complexity > 861);
+        Depth R = std::min(static_cast<int>(eval - beta) / 168, 7) + depth / 3 + 4 - (complexity > 861);
 
         ss->currentMove = MOVE_NULL;
         ss->continuationHistory = &thisThread->continuationHistory[0][0][NO_PIECE][0];
@@ -1770,8 +1770,8 @@ moves_loop: // When in check, search starts here
     for (size_t i = 0; i < multiPV; ++i)
     {
         // This is our magic formula
-        int push = int((  weakness * int(topScore - rootMoves[i].score)
-                        + delta * (rng.rand<unsigned>() % int(weakness))) / 128);
+        int push = static_cast<int>((  weakness * static_cast<int>(topScore - rootMoves[i].score)
+                        + delta * (rng.rand<unsigned>() % static_cast<int>(weakness))) / 128);
 
         if (rootMoves[i].score + push >= maxScore)
         {
@@ -1795,7 +1795,7 @@ void MainThread::check_time() {
       return;
 
   // When using nodes, ensure checking rate is not lower than 0.1% of nodes
-  callsCnt = Limits.nodes ? std::min(1024, int(Limits.nodes / 1024)) : 1024;
+  callsCnt = Limits.nodes ? std::min(1024, static_cast<int>(Limits.nodes / 1024)) : 1024;
 
   static TimePoint lastInfoTime = now();
 
@@ -1913,8 +1913,8 @@ void Tablebases::rank_root_moves(Position& pos, Search::RootMoves& rootMoves) {
 
     RootInTB = false;
     UseRule50 = bool(Options["Syzygy50MoveRule"]);
-    ProbeDepth = int(Options["SyzygyProbeDepth"]);
-    Cardinality = int(Options["SyzygyProbeLimit"]);
+    ProbeDepth = static_cast<int>(Options["SyzygyProbeDepth"]);
+    Cardinality = static_cast<int>(Options["SyzygyProbeLimit"]);
     bool dtz_available = true;
 
     // Tables with fewer pieces than SyzygyProbeLimit are searched with

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -66,8 +66,8 @@ enum TBType { WDL, DTZ }; // Used as template parameter
 // Each table has a set of flags: all of them refer to DTZ tables, the last one to WDL tables
 enum TBFlag { STM = 1, Mapped = 2, WinPlies = 4, LossPlies = 8, Wide = 16, SingleValue = 128 };
 
-inline WDLScore operator-(WDLScore d) { return WDLScore(-int(d)); }
-inline Square operator^(Square s, int i) { return Square(int(s) ^ i); }
+inline WDLScore operator-(WDLScore d) { return WDLScore(-static_cast<int>(d)); }
+inline Square operator^(Square s, int i) { return Square(static_cast<int>(s) ^ i); }
 
 const std::string PieceToChar = " PNBRQK  pnbrqk";
 
@@ -82,7 +82,7 @@ int LeadPawnsSize[6][4];       // [leadPawnsCnt][FILE_A..FILE_D]
 
 // Comparison function to sort leading pawns in ascending MapPawns[] order
 bool pawns_comp(Square i, Square j) { return MapPawns[i] < MapPawns[j]; }
-int off_A1H8(Square sq) { return int(rank_of(sq)) - file_of(sq); }
+int off_A1H8(Square sq) { return static_cast<int>(rank_of(sq)) - file_of(sq); }
 
 constexpr Value WDL_to_value[] = {
    -VALUE_MATE + MAX_PLY + 1,
@@ -485,7 +485,7 @@ void TBTables::add(const std::vector<PieceType>& pieces) {
 
     file.close();
 
-    MaxCardinality = std::max((int)pieces.size(), MaxCardinality);
+    MaxCardinality = std::max(static_cast<int>(pieces.size()), MaxCardinality);
 
     wdlTable.emplace_back(code);
     dtzTable.emplace_back(wdlTable.back());
@@ -1574,9 +1574,9 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
         // 1 cp to cursed wins and let it grow to 49 cp as the positions gets
         // closer to a real win.
         m.tbScore =  r >= bound ? VALUE_MATE - MAX_PLY - 1
-                   : r >  0     ? Value((std::max( 3, r - 800) * int(PawnValueEg)) / 200)
+                   : r >  0     ? Value((std::max( 3, r - 800) * static_cast<int>(PawnValueEg)) / 200)
                    : r == 0     ? VALUE_DRAW
-                   : r > -bound ? Value((std::min(-3, r + 800) * int(PawnValueEg)) / 200)
+                   : r > -bound ? Value((std::min(-3, r + 800) * static_cast<int>(PawnValueEg)) / 200)
                    :             -VALUE_MATE + MAX_PLY + 1;
     }
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -224,7 +224,7 @@ Thread* ThreadPool::get_best_thread() const {
     for (Thread* th : *this)
     {
         votes[th->rootMoves[0].pv[0]] +=
-            (th->rootMoves[0].score - minScore + 14) * int(th->completedDepth);
+            (th->rootMoves[0].score - minScore + 14) * static_cast<int>(th->completedDepth);
 
         if (abs(bestThread->rootMoves[0].score) >= VALUE_TB_WIN_IN_MAX_PLY)
         {

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -82,14 +82,14 @@ template<> void Tune::Entry<int>::init_option() { make_option(name, value, range
 
 template<> void Tune::Entry<int>::read_option() {
   if (Options.count(name))
-      value = int(Options[name]);
+      value = static_cast<int>(Options[name]);
 }
 
 template<> void Tune::Entry<Value>::init_option() { make_option(name, value, range); }
 
 template<> void Tune::Entry<Value>::read_option() {
   if (Options.count(name))
-      value = Value(int(Options[name]));
+      value = Value(static_cast<int>(Options[name]));
 }
 
 template<> void Tune::Entry<Score>::init_option() {
@@ -99,10 +99,10 @@ template<> void Tune::Entry<Score>::init_option() {
 
 template<> void Tune::Entry<Score>::read_option() {
   if (Options.count("m" + name))
-      value = make_score(int(Options["m" + name]), eg_value(value));
+      value = make_score(static_cast<int>(Options["m" + name]), eg_value(value));
 
   if (Options.count("e" + name))
-      value = make_score(mg_value(value), int(Options["e" + name]));
+      value = make_score(mg_value(value), static_cast<int>(Options["e" + name]));
 }
 
 // Instead of a variable here we have a PostUpdate function: just call it

--- a/src/types.h
+++ b/src/types.h
@@ -285,7 +285,7 @@ struct DirtyPiece {
 enum Score : int { SCORE_ZERO };
 
 constexpr Score make_score(int mg, int eg) {
-  return Score((int)((unsigned int)eg << 16) + mg);
+  return Score(static_cast<int>((unsigned int)eg << 16) + mg);
 }
 
 /// Extracting the signed lower and upper 16 bits is not so trivial because
@@ -302,24 +302,24 @@ inline Value mg_value(Score s) {
 }
 
 #define ENABLE_BASE_OPERATORS_ON(T)                                \
-constexpr T operator+(T d1, int d2) { return T(int(d1) + d2); }    \
-constexpr T operator-(T d1, int d2) { return T(int(d1) - d2); }    \
-constexpr T operator-(T d) { return T(-int(d)); }                  \
+constexpr T operator+(T d1, int d2) { return T(static_cast<int>(d1) + d2); }    \
+constexpr T operator-(T d1, int d2) { return T(static_cast<int>(d1) - d2); }    \
+constexpr T operator-(T d) { return T(-static_cast<int>(d)); }                  \
 inline T& operator+=(T& d1, int d2) { return d1 = d1 + d2; }       \
 inline T& operator-=(T& d1, int d2) { return d1 = d1 - d2; }
 
 #define ENABLE_INCR_OPERATORS_ON(T)                                \
-inline T& operator++(T& d) { return d = T(int(d) + 1); }           \
-inline T& operator--(T& d) { return d = T(int(d) - 1); }
+inline T& operator++(T& d) { return d = T(static_cast<int>(d) + 1); }           \
+inline T& operator--(T& d) { return d = T(static_cast<int>(d) - 1); }
 
 #define ENABLE_FULL_OPERATORS_ON(T)                                \
 ENABLE_BASE_OPERATORS_ON(T)                                        \
-constexpr T operator*(int i, T d) { return T(i * int(d)); }        \
-constexpr T operator*(T d, int i) { return T(int(d) * i); }        \
-constexpr T operator/(T d, int i) { return T(int(d) / i); }        \
-constexpr int operator/(T d1, T d2) { return int(d1) / int(d2); }  \
-inline T& operator*=(T& d, int i) { return d = T(int(d) * i); }    \
-inline T& operator/=(T& d, int i) { return d = T(int(d) / i); }
+constexpr T operator*(int i, T d) { return T(i * static_cast<int>(d)); }        \
+constexpr T operator*(T d, int i) { return T(static_cast<int>(d) * i); }        \
+constexpr T operator/(T d, int i) { return T(static_cast<int>(d) / i); }        \
+constexpr int operator/(T d1, T d2) { return static_cast<int>(d1) / static_cast<int>(d2); }  \
+inline T& operator*=(T& d, int i) { return d = T(static_cast<int>(d) * i); }    \
+inline T& operator/=(T& d, int i) { return d = T(static_cast<int>(d) / i); }
 
 ENABLE_FULL_OPERATORS_ON(Value)
 ENABLE_FULL_OPERATORS_ON(Direction)
@@ -337,8 +337,8 @@ ENABLE_BASE_OPERATORS_ON(Score)
 #undef ENABLE_BASE_OPERATORS_ON
 
 /// Additional operators to add a Direction to a Square
-constexpr Square operator+(Square s, Direction d) { return Square(int(s) + int(d)); }
-constexpr Square operator-(Square s, Direction d) { return Square(int(s) - int(d)); }
+constexpr Square operator+(Square s, Direction d) { return Square(static_cast<int>(s) + static_cast<int>(d)); }
+constexpr Square operator-(Square s, Direction d) { return Square(static_cast<int>(s) - static_cast<int>(d)); }
 inline Square& operator+=(Square& s, Direction d) { return s = s + d; }
 inline Square& operator-=(Square& s, Direction d) { return s = s - d; }
 
@@ -354,7 +354,7 @@ inline Score operator/(Score s, int i) {
 /// Multiplication of a Score by an integer. We check for overflow in debug mode.
 inline Score operator*(Score s, int i) {
 
-  Score result = Score(int(s) * i);
+  Score result = Score(static_cast<int>(s) * i);
 
   assert(eg_value(result) == (i * eg_value(s)));
   assert(mg_value(result) == (i * mg_value(s)));

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -216,7 +216,7 @@ namespace {
      double x = std::clamp(double(100 * v) / PawnValueEg, -2000.0, 2000.0);
 
      // Return the win rate in per mille units rounded to the nearest value
-     return int(0.5 + 1000 / (1 + std::exp((a - x) / b)));
+     return static_cast<int>(0.5 + 1000 / (1 + std::exp((a - x) / b)));
   }
 
 } // namespace

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -100,7 +100,7 @@ std::ostream& operator<<(std::ostream& os, const OptionsMap& om) {
                   os << " default " << o.defaultValue;
 
               if (o.type == "spin")
-                  os << " default " << int(stof(o.defaultValue))
+                  os << " default " << static_cast<int>(stof(o.defaultValue))
                      << " min "     << o.min
                      << " max "     << o.max;
 


### PR DESCRIPTION
Change all C Style casts to C++ casts, for better readability and checks by compiler.
Furthermore there should be no difference in the generated assembly and thus no performance hit. 

No functional change
bench: 4156027