### PR TITLE
Use -flto-partition=one for gcc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -678,7 +678,7 @@ endif
 ifeq ($(optimize),yes)
 ifeq ($(debug), no)
 	ifeq ($(comp),clang)
-		CXXFLAGS += -flto
+		CXXFLAGS += -flto -flto-partition=one
 		ifeq ($(target_windows),yes)
 			CXXFLAGS += -fuse-ld=lld
 		endif
@@ -688,10 +688,10 @@ ifeq ($(debug), no)
 # GCC on some systems.
 	else ifeq ($(comp),gcc)
 	ifeq ($(gccisclang),)
-		CXXFLAGS += -flto
+		CXXFLAGS += -flto -flto-partition=one
 		LDFLAGS += $(CXXFLAGS) -flto=jobserver
 	else
-		CXXFLAGS += -flto
+		CXXFLAGS += -flto -flto-partition=one
 		LDFLAGS += $(CXXFLAGS)
 	endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -688,10 +688,10 @@ ifeq ($(debug), no)
 # GCC on some systems.
 	else ifeq ($(comp),gcc)
 	ifeq ($(gccisclang),)
-		CXXFLAGS += -flto=full
+		CXXFLAGS += -flto -flto-partition=one
 		LDFLAGS += $(CXXFLAGS) -flto=jobserver
 	else
-		CXXFLAGS += -flto -flto-partition=one
+		CXXFLAGS += -flto=full
 		LDFLAGS += $(CXXFLAGS)
 	endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -678,7 +678,7 @@ endif
 ifeq ($(optimize),yes)
 ifeq ($(debug), no)
 	ifeq ($(comp),clang)
-		CXXFLAGS += -flto -flto-partition=one
+		CXXFLAGS += -flto=full
 		ifeq ($(target_windows),yes)
 			CXXFLAGS += -fuse-ld=lld
 		endif
@@ -688,7 +688,7 @@ ifeq ($(debug), no)
 # GCC on some systems.
 	else ifeq ($(comp),gcc)
 	ifeq ($(gccisclang),)
-		CXXFLAGS += -flto -flto-partition=one
+		CXXFLAGS += -flto=full
 		LDFLAGS += $(CXXFLAGS) -flto=jobserver
 	else
 		CXXFLAGS += -flto -flto-partition=one


### PR DESCRIPTION
This patch fixes a potential bug derived from an incompatibility between LTO and top-level assembly code (INCBIN).

Passed non-regression STC (master e90341f9):
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 119352 W: 31986 L: 31862 D: 55504
Ptnml(0-2): 439, 12624, 33400, 12800, 413
https://tests.stockfishchess.org/tests/view/634aacf84bc7650f0755188b

No functional change