### PR TITLE
add -mbmi to makefile for avx2

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -593,7 +593,7 @@ endif
 ifeq ($(avx2),yes)
 	CXXFLAGS += -DUSE_AVX2
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
-		CXXFLAGS += -mavx2
+		CXXFLAGS += -mavx2 -mbmi
 	endif
 endif
 


### PR DESCRIPTION
Theres currently a patch running on fishtest https://tests.stockfishchess.org/tests/view/634bfdcf4bc7650f0755520e
which enables the use of _blsr_u64 when pext is also being used, which should be the case for very few workers. 

In the recent commit I changed this from pext to avx2. According to https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html it looks like all avx2 platforms support `-mbmi`. 

Speedup test from @G-Lorenz 
```
System:
Linux 5.9.14-100.fc35.x86_64
Intel i7-7500U (4) @ 3.500GHz

Command:
./bench_parallel.sh ./stockfish_master ./stockfish 16 150

make build -j ARCH=x86-64-bmi2
gcc 11.3.1:
sf_base =   957035 +/- 2313
sf_test =   960622 +/- 2291
diff    =     3587 +/- 438
speedup = 0.003748

make build -j ARCH=x86-64-bmi2 COMP=clang
clang 13.0.1
sf_base =   984790 +/- 3039
sf_test =   991626 +/- 3157
diff    =     6835 +/- 507
speedup = 0.006942
```

Would be useful if others could test this patch for a speedup as well.
`make build ARCH=x86-64-avx2`