### PR TITLE
Use all tt moves in qsearch

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -83,7 +83,6 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 
   stage = (pos.checkers() ? EVASION_TT : QSEARCH_TT) +
           !(   ttm
-            && (pos.checkers() || depth > DEPTH_QS_RECAPTURES || to_sq(ttm) == recaptureSquare)
             && pos.pseudo_legal(ttm));
 }
 


### PR DESCRIPTION
In master transposition table moves don't follow usual qsearch logic - for example for every other move we consider quiet checks only if they are at depth >= -1... But we consider any transposition table moves, even if they are not even giving check, up to recapture depth, where we suddenly consider only recaptures. So even usual quiet tt moves are pretty much considered there in master despite it being impossible for any other move.
If tt moves don't follow usual qsearch logic we might as well make them not follow qsearch logic at all rather than doing it partially as we do now.
This patch allows any transposition table move to be searched in qsearch without any restrictions.
Also it simplifies away 3 expressions which look pretty convoluted in conjunction.
Passed STC : 
https://tests.stockfishchess.org/tests/view/6350df2928d3a71cb1eef838
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 90280 W: 24001 L: 23845 D: 42434
Ptnml(0-2): 273, 9779, 24941, 9813, 334 
Passed LTC : 
https://tests.stockfishchess.org/tests/view/6351308b28d3a71cb1ef06ce
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 104504 W: 27937 L: 27807 D: 48760
Ptnml(0-2): 54, 10378, 31260, 10504, 56 
bench 4540268