### PR TITLE
Adjust reduction less at medium depths

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -89,7 +89,7 @@ Hongzhi Cheng
 Ivan Ivec (IIvec)
 Jacques B. (Timshel)
 Jan Ondruš (hxim)
-Jared Kish (Kurtbusch)
+Jared Kish (Kurtbusch, kurt22i)
 Jarrod Torriero (DU-jdto)
 Jean Gauthier (OuaisBla)
 Jean-Francois Romang (jromang)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1177,7 +1177,7 @@ moves_loop: // When in check, search starts here
                          - 4433;
 
           // Decrease/increase reduction for moves with a good/bad history (~30 Elo)
-          r -= ss->statScore / 13628;
+          r -= ss->statScore / (13628 + 4000 * (depth > 7 && depth < 19));
 
           // In general we want to cap the LMR depth search at newDepth, but when
           // reduction is negative, we allow this move a limited search extension


### PR DESCRIPTION
This patch dampens the reduction increase/decrease from statScore at mid-range depths.
Inspired by patterns noticed in this tune: https://tests.stockfishchess.org/tests/view/635188930e5f47a8d0ffe8f5

Passed STC:
https://tests.stockfishchess.org/tests/view/63599dfd6b27ef94d9ec04af
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 87464 W: 23519 L: 23134 D: 40811
Ptnml(0-2): 319, 9599, 23524, 9958, 332

Passed LTC:
https://tests.stockfishchess.org/tests/view/635a73046b27ef94d9ec2313
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 154792 W: 41746 L: 41214 D: 71832
Ptnml(0-2): 79, 15181, 46349, 15703, 84

Bench 4271738