### PR TITLE
Normalize evaluation

### DIFF
--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -220,7 +220,7 @@ namespace Stockfish::Eval::NNUE {
 
     buffer[0] = (v < 0 ? '-' : v > 0 ? '+' : ' ');
 
-    int cp = std::abs(100 * v / PawnValueEg);
+    int cp = std::abs(100 * v / UCI::NormalizeToPawnValue);
     if (cp >= 10000)
     {
         buffer[1] = '0' + cp / 10000; cp %= 10000;
@@ -251,7 +251,7 @@ namespace Stockfish::Eval::NNUE {
 
     buffer[0] = (v < 0 ? '-' : v > 0 ? '+' : ' ');
 
-    double cp = 1.0 * std::abs(int(v)) / PawnValueEg;
+    double cp = 1.0 * std::abs(int(v)) / UCI::NormalizeToPawnValue;
     sprintf(&buffer[1], "%6.2f", cp);
   }
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -207,13 +207,17 @@ namespace {
      // The coefficients of a third-order polynomial fit is based on the fishtest data
      // for two parameters that need to transform eval to the argument of a logistic
      // function.
-     double as[] = { 0.50379905,  -4.12755858,  18.95487051, 152.00733652};
-     double bs[] = {-1.71790378,  10.71543602, -17.05515898,  41.15680404};
+     constexpr double as[] = {   1.04790516,   -8.58534089,   39.42615625,  316.17524816};
+     constexpr double bs[] = {  -3.57324784,   22.28816201,  -35.47480551,   85.60617701 };
+
+     // Enforce that NormalizeToPawnValue corresponds to a 50% win rate at ply 64
+     static_assert(UCI::NormalizeToPawnValue == int(as[0] + as[1] + as[2] + as[3]));
+
      double a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
      double b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];
 
      // Transform the eval to centipawns with limited range
-     double x = std::clamp(double(100 * v) / PawnValueEg, -2000.0, 2000.0);
+     double x = std::clamp(double(v), -4000.0, 4000.0);
 
      // Return the win rate in per mille units rounded to the nearest value
      return int(0.5 + 1000 / (1 + std::exp((a - x) / b)));
@@ -312,7 +316,7 @@ string UCI::value(Value v) {
   stringstream ss;
 
   if (abs(v) < VALUE_MATE_IN_MAX_PLY)
-      ss << "cp " << v * 100 / PawnValueEg;
+      ss << "cp " << v * 100 / NormalizeToPawnValue;
   else
       ss << "mate " << (v > 0 ? VALUE_MATE - v + 1 : -VALUE_MATE - v) / 2;
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -30,6 +30,13 @@ class Position;
 
 namespace UCI {
 
+// Normalizes the internal value as reported by evaluate or search
+// to the UCI centipawn result used in output. This value is derived from
+// the win_rate_model() such that Stockfish outputs an advantage of
+// "100 centipawns" for a position if the engine has a 50% probability to win
+// from this position in selfplay at fishtest LTC time control.
+const int NormalizeToPawnValue = 348;
+
 class Option;
 
 /// Define a custom comparator, because the UCI options should be case-insensitive


### PR DESCRIPTION
With NNUE, our evaluation is no longer related to the classical parameter PawnValueEg (=208).

This leads to the current evaluation changing quite a bit from release to release, for example, the eval needed to have 50% win rate at fishtest LTC (in cp and internal Value):

June 2020  :   113cp (237)
June 2021  :   115cp (240)
April 2022 :   134cp (279)
July 2022  :   167cp (348)

This inflation can be fixed if one fixes 100cp to mean 50% win chance, and decouple this conversion from PawnValueEg. This conversion is somewhat arbitrary, only the relative ranking of positions is important for an engine, which is designed the find the best move.

While there is no simple 1-to-1 relation between the internally used Value, and the win rate, we can base this on the win_rate_model. The 'a' parameter of this model, gives 50%, and by picking this value at move 32, this is just the sum of the parameters of the model for a (i.e. the 'as' array).

This patch introduces Internal2Pawn to convert the internal units to cp, and converts to win_rate_model to internal units.

Generally, it might be better to directly use the wdl values (available with the option UCI_ShowWDL) in analysis, or focus directly on the bestmove and PV lines provided.

No functional change