### PR TITLE
[CI] Save binaries as artifact 

### DIFF
--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -10,6 +10,9 @@ on:
       - master
       - tools
 jobs:
+  Binaries:
+    if: github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/stockfish_binaries.yml
   Stockfish:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
@@ -113,7 +116,7 @@ jobs:
         working-directory: src
         shell: ${{ matrix.config.shell }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/stockfish_binaries.yml
+++ b/.github/workflows/stockfish_binaries.yml
@@ -1,0 +1,110 @@
+name: Stockfish
+on:
+  workflow_call:
+jobs:
+  Stockfish:
+    name: ${{ matrix.config.name }} ${{ matrix.binaries }}
+    runs-on: ${{ matrix.config.os }}
+    env:
+      COMPILER: ${{ matrix.config.compiler }}
+      COMP: ${{ matrix.config.comp }}
+      EXT: ${{ matrix.config.ext }}
+      OS: ${{ matrix.config.os }}
+      BINARY: ${{ matrix.binaries }}
+    strategy:
+      matrix:
+        config:
+          - {
+              name: "Ubuntu 20.04 GCC",
+              os: ubuntu-20.04,
+              compiler: g++,
+              comp: gcc,
+              shell: 'bash {0}'
+            }
+          - {
+              name: "MacOS 12 Apple Clang",
+              os: macos-12,
+              compiler: clang++,
+              comp: clang,
+              shell: 'bash {0}'
+            }
+          - {
+              name: "Windows 2022 Mingw-w64 GCC x86_64",
+              os: windows-2022,
+              compiler: g++,
+              comp: mingw,
+              msys_sys: 'mingw64',
+              msys_env: 'x86_64-gcc',
+              shell: 'msys2 {0}',
+              ext: .exe
+            }
+        binaries:
+          - x86-64
+          - x86-64-modern
+          - x86-64-avx2
+        exclude:
+          - binaries: x86-64-avx2
+            config: {os: macos-12}
+    defaults:
+      run:
+        working-directory: src
+        shell: ${{ matrix.config.shell }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Download required linux packages
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+
+      - name: Setup msys and install required packages
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.config.msys_sys}}
+          install: mingw-w64-${{matrix.config.msys_env}} make git expect
+
+      - name: Download the used network from the fishtest framework
+        run: |
+          make net
+
+      - name: Check compiler
+        run: |
+          export PATH=$PATH:$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin
+          $COMPILER -v
+
+      - name: Test help target
+        run: |
+          make help
+
+      # Compile profile guided builds
+
+      - name: Compile ${{ matrix.binaries }} build
+        run: |
+          make clean
+          make -j2 profile-build ARCH=$BINARY COMP=$COMP
+          strip ./stockfish$EXT
+          mv ./stockfish$EXT ../stockfish-$OS-$BINARY$EXT
+
+      - name: Remove non src files
+        run: rm -f *.o .depend *.nnue
+
+      - name: Create tar archive.
+        run: |
+          cd ..
+          mkdir stockfish
+          cp -r src stockfish/
+          cp stockfish-$OS-$BINARY$EXT stockfish/
+          cp "Top CPU Contributors.txt" stockfish/
+          cp Copying.txt stockfish/
+          cp AUTHORS stockfish/
+          tar -cvf stockfish-$OS-$BINARY.tar stockfish
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: stockfish-${{ matrix.config.os }}-${{ matrix.binaries }}
+          path: |
+            stockfish-${{ matrix.config.os }}-${{ matrix.binaries }}.tar

--- a/src/Makefile
+++ b/src/Makefile
@@ -682,6 +682,18 @@ ifeq ($(pext),yes)
 	endif
 endif
 
+### 3.7.1 Try to include git commit sha for versioning
+GIT_SHA = $(shell git rev-parse --short HEAD 2>/dev/null)
+ifneq ($(GIT_SHA), )
+	CXXFLAGS += -DGIT_SHA=\"$(GIT_SHA)\"
+endif
+
+### 3.7.2 Try to include git commit date for versioning
+GIT_DATE = $(shell git show -s --date=format:'%Y%m%d' --format=%cd HEAD 2>/dev/null)
+ifneq ($(GIT_DATE), )
+	CXXFLAGS += -DGIT_DATE=\"$(GIT_DATE)\"
+endif
+
 ### 3.8 Link Time Optimization
 ### This is a mix of compile and link time options because the lto link phase
 ### needs access to the optimization flags.
@@ -800,7 +812,7 @@ endif
 
 .PHONY: help build profile-build strip install clean net objclean profileclean \
         config-sanity icc-profile-use icc-profile-make gcc-profile-use gcc-profile-make \
-        clang-profile-use clang-profile-make
+        clang-profile-use clang-profile-make FORCE
 
 build: net config-sanity
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) all
@@ -947,6 +959,10 @@ config-sanity: net
 
 $(EXE): $(OBJS)
 	+$(CXX) -o $@ $(OBJS) $(LDFLAGS)
+
+# Force recompilation to ensure version info is up-to-date
+misc.o: FORCE
+FORCE:
 
 clang-profile-make:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -67,9 +67,8 @@ namespace Stockfish {
 
 namespace {
 
-/// Version number. If Version is left empty, then compile date in the format
-/// DD-MM-YY and show in engine_info.
-const string Version = "";
+/// Version number or dev.
+const string version = "dev";
 
 /// Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 /// cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We
@@ -138,23 +137,44 @@ public:
 } // namespace
 
 
-/// engine_info() returns the full name of the current Stockfish version. This
-/// will be either "Stockfish <Tag> DD-MM-YY" (where DD-MM-YY is the date when
-/// the program was compiled) or "Stockfish <Version>", depending on whether
-/// Version is empty.
+/// engine_info() returns the full name of the current Stockfish version.
+/// For local dev compiles we try to append the commit sha and commit date
+/// from git if that fails only the local compilation date is set and "nogit" is specified.
+/// Stockfish YYYYMMDD-SHA
+/// or
+/// Stockfish YYYYMMDD-nogit
+///
+/// dev CI builds will have the commit date + commit sha.
+/// Stockfish YYYYMMDD-SHA
+///
+/// For non dev builds we only include the version number.
+/// Stockfish version
 
 string engine_info(bool to_uci) {
+  stringstream ss;
+  ss << "Stockfish " << version << setfill('0');
 
-  const string months("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec");
-  string month, day, year;
-  stringstream ss, date(__DATE__); // From compiler, format is "Sep 21 2008"
-
-  ss << "Stockfish " << Version << setfill('0');
-
-  if (Version.empty())
+  if (version == "dev")
   {
+      ss << "-";
+      #ifdef GIT_DATE
+      ss << GIT_DATE;
+      #else
+      const string months("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec");
+      string month, day, year;
+      stringstream date(__DATE__); // From compiler, format is "Sep 21 2008"
+
       date >> month >> day >> year;
-      ss << setw(2) << day << setw(2) << (1 + months.find(month) / 4) << year.substr(2);
+      ss << year << setw(2) << setfill('0') << (1 + months.find(month) / 4) << setw(2) << setfill('0') << day;
+      #endif
+
+      ss << "-";
+
+      #ifdef GIT_SHA
+      ss << GIT_SHA;
+      #else
+      ss << "nogit";
+      #endif
   }
 
   ss << (to_uci  ? "\nid author ": " by ")


### PR DESCRIPTION
The idea is to save the produced binaries and make them publicly available to download.
These binaries will also have a slightly different versioning. <br>

Currently it's `Stockfish DDMMYY`, local builds that have git will now use the commit date and commit sha in their version name `Stockfish YYYYMMDD-SHA` otherwise it will fallback to local compilation date and nogit `Stockfish YYYYMMDD-nogit` <br>
For a release version the maintainer has to change the `dev` string to the version number of the release.

Each executable is available to download on its own.

Folder Structure
```
Stockfish Binaries windows-2022
│   Copying.txt
│   AUTHORS
│   Top CPU Contributors.txt
│   stockfish-windows-2022-x86-64-avx2.exe
│
└───src
```

Github reports the uncompressed size so the actual download is half of that. <br>

No functional change