### PR TITLE
remove trend

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -981,7 +981,7 @@ namespace {
     // Initialize score by reading the incrementally updated scores included in
     // the position object (material + piece square tables) and the material
     // imbalance. Score is computed internally from the white point of view.
-    Score score = pos.psq_score() + me->imbalance() + pos.this_thread()->trend;
+    Score score = pos.psq_score() + me->imbalance();
 
     // Probe the pawn hash table
     pe = Pawns::probe(pos);
@@ -1115,7 +1115,6 @@ std::string Eval::trace(Position& pos) {
   std::memset(scores, 0, sizeof(scores));
 
   // Reset any global variable used in eval
-  pos.this_thread()->trend           = SCORE_ZERO;
   pos.this_thread()->bestValue       = VALUE_ZERO;
   pos.this_thread()->optimism[WHITE] = VALUE_ZERO;
   pos.this_thread()->optimism[BLACK] = VALUE_ZERO;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -309,7 +309,6 @@ void Thread::search() {
 
   complexityAverage.set(155, 1);
 
-  trend = SCORE_ZERO;
   optimism[us] = optimism[~us] = VALUE_ZERO;
 
   int searchAgainCounter = 0;
@@ -356,11 +355,7 @@ void Thread::search() {
               alpha = std::max(prev - delta,-VALUE_INFINITE);
               beta  = std::min(prev + delta, VALUE_INFINITE);
 
-              // Adjust trend and optimism based on root move's previousScore
-              int tr = 116 * prev / (std::abs(prev) + 89);
-              trend = (us == WHITE ?  make_score(tr, tr / 2)
-                                   : -make_score(tr, tr / 2));
-
+              // Adjust optimism based on root move's previousScore
               int opt = 118 * prev / (std::abs(prev) + 169);
               optimism[ us] = Value(opt);
               optimism[~us] = -optimism[us];

--- a/src/thread.h
+++ b/src/thread.h
@@ -75,7 +75,6 @@ public:
   ButterflyHistory mainHistory;
   CapturePieceToHistory captureHistory;
   ContinuationHistory continuationHistory[2][2];
-  Score trend;
 };
 
 


### PR DESCRIPTION
Simplify trend away.

passed Non-regression STC:
https://tests.stockfishchess.org/tests/view/63642a63a90afcecbd1cb887
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 130000 W: 34683 L: 34567 D: 60750
Ptnml(0-2): 455, 14424, 35135, 14522, 464

passed Non-regression LTC:
https://tests.stockfishchess.org/tests/view/636566fda90afcecbd1cded9
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 81592 W: 21938 L: 21787 D: 37867
Ptnml(0-2): 42, 8035, 24490, 8188, 41

Bench: 4239512
