### PR TITLE
Simplify both quiet check evasions' conditions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1547,12 +1547,11 @@ moves_loop: // When in check, search starts here
           && (*contHist[1])[pos.moved_piece(move)][to_sq(move)] < 0)
           continue;
 
-      // movecount pruning for quiet check evasions
+      // We prune after 2nd quiet check evasion where being 'in check' is implicitly checked through the counter
+      // and being a 'quiet' apart from being a tt move is assumed after an increment because captures are pushed ahead.
       if (   bestValue > VALUE_TB_LOSS_IN_MAX_PLY
-          && quietCheckEvasions > 1
-          && !capture
-          && ss->inCheck)
-          continue;
+          && quietCheckEvasions > 1)
+          break;
 
       quietCheckEvasions += !capture && ss->inCheck;
 


### PR DESCRIPTION
Since we push captures ahead of quiet moves apart from quiet move being a tt move, we can safely break and assume this move is not a capture.

passed Non-regression STC:
https://tests.stockfishchess.org/tests/view/6370b647f1b748d4819e0b64
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 162904 W: 43249 L: 43171 D: 76484
Ptnml(0-2): 491, 17089, 46220, 17155, 497

No functional change