### PR TITLE
Do shallower search in case of lmr being not successful enough.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1184,8 +1184,11 @@ moves_loop: // When in check, search starts here
           // Do full depth search when reduced LMR search fails high
           if (value > alpha && d < newDepth)
           {
+              // Adjust full depth search based on LMR results - if result
+              // was good enough search deeper, if it was bad enough search shallower
               const bool doDeeperSearch = value > (alpha + 64 + 11 * (newDepth - d));
-              value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, newDepth + doDeeperSearch, !cutNode);
+              const bool doShallowerSearch = value < bestValue + newDepth;
+              value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, newDepth + doDeeperSearch - doShallowerSearch, !cutNode);
 
               int bonus = value > alpha ?  stat_bonus(newDepth)
                                         : -stat_bonus(newDepth);


### PR DESCRIPTION
Original idea by @lonfom169 .
In case of a move passing LMR but it results being not too far from current best search result produce a full depth search with reduced depth.
Passed STC:
https://tests.stockfishchess.org/tests/view/6373409b54d69a2f33913fbd
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 169504 W: 45351 L: 44848 D: 79305
Ptnml(0-2): 598, 18853, 45353, 19344, 604 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6374c58528e3405283eb8d2d
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 51144 W: 13802 L: 13471 D: 23871
Ptnml(0-2): 19, 4928, 15362, 5229, 34 
bench 4277005