### PR TITLE
Simplification away Cutoff Rest bench:  3929262

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1292,8 +1292,6 @@ moves_loop: // When in check, search starts here
               }
           }
       }
-      else
-         ss->cutoffCnt = 0;
 
 
       // If the move is worse than some previously searched move, remember it to update its stats later


### PR DESCRIPTION
Remove cutoff reset counter code.

STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 150184 W: 39913 L: 39819 D: 70452
Ptnml(0-2): 493, 16796, 40474, 16782, 547
https://tests.stockfishchess.org/tests/view/63723e9e54d69a2f33911d3c


LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 58880 W: 15890 L: 15717 D: 27273
Ptnml(0-2): 35, 5765, 17659, 5954, 27
https://tests.stockfishchess.org/tests/view/6373baf49849fa7a36a65427

Bench:  3929262