### PR TITLE
Emit helper thread's score according UCI specification with bounds information

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1856,7 +1856,7 @@ string UCI::pv(const Position& pos, Depth depth) {
       if (Options["UCI_ShowWDL"])
           ss << UCI::wdl(v, pos.game_ply());
 
-      if (i == pvIdx && !tb && updated) // TableBase- and previous-scores are exact
+      if (i == pvIdx && !tb && updated) // tablebase- and previous-scores are exact
          ss << (rootMoves[i].scoreLowerbound ? " lowerbound" : (rootMoves[i].scoreUpperbound ? " upperbound" : ""));
 
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -244,7 +244,7 @@ void MainThread::search() {
 
   // Send again PV info if we have a new best thread
   if (bestThread != this)
-      sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
+      sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth) << sync_endl;
 
   sync_cout << "bestmove " << UCI::move(bestThread->rootMoves[0].pv[0], rootPos.is_chess960());
 
@@ -392,7 +392,7 @@ void Thread::search() {
                   && multiPV == 1
                   && (bestValue <= alpha || bestValue >= beta)
                   && Time.elapsed() > 3000)
-                  sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
+                  sync_cout << UCI::pv(rootPos, rootDepth) << sync_endl;
 
               // In case of failing low/high increase aspiration window and
               // re-search, otherwise exit the loop.
@@ -423,7 +423,7 @@ void Thread::search() {
 
           if (    mainThread
               && (Threads.stop || pvIdx + 1 == multiPV || Time.elapsed() > 3000))
-              sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
+              sync_cout << UCI::pv(rootPos, rootDepth) << sync_endl;
       }
 
       if (!Threads.stop)
@@ -1239,6 +1239,8 @@ moves_loop: // When in check, search starts here
           {
               rm.score = value;
               rm.selDepth = thisThread->selDepth;
+              rm.scoreLowerbound = value >= beta;
+              rm.scoreUpperbound = value <= alpha;
               rm.pv.resize(1);
 
               assert((ss+1)->pv);
@@ -1816,7 +1818,7 @@ void MainThread::check_time() {
 /// UCI::pv() formats PV information according to the UCI protocol. UCI requires
 /// that all (if any) unsearched PV lines are sent using a previous search score.
 
-string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
+string UCI::pv(const Position& pos, Depth depth) {
 
   std::stringstream ss;
   TimePoint elapsed = Time.elapsed() + 1;
@@ -1854,8 +1856,9 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
       if (Options["UCI_ShowWDL"])
           ss << UCI::wdl(v, pos.game_ply());
 
-      if (!tb && i == pvIdx)
-          ss << (v >= beta ? " lowerbound" : v <= alpha ? " upperbound" : "");
+      if (i == pvIdx && !tb && updated) // TableBase- and previous-scores are exact
+         ss << (rootMoves[i].scoreLowerbound ? " lowerbound" : (rootMoves[i].scoreUpperbound ? " upperbound" : ""));
+
 
       ss << " nodes "    << nodesSearched
          << " nps "      << nodesSearched * 1000 / elapsed
@@ -1866,6 +1869,7 @@ string UCI::pv(const Position& pos, Depth depth, Value alpha, Value beta) {
 
       for (Move m : rootMoves[i].pv)
           ss << " " << UCI::move(m, pos.is_chess960());
+
   }
 
   return ss.str();

--- a/src/search.h
+++ b/src/search.h
@@ -73,6 +73,8 @@ struct RootMove {
   Value averageScore = -VALUE_INFINITE;
   int selDepth = 0;
   int tbRank = 0;
+  bool scoreLowerbound;
+  bool scoreUpperbound;
   Value tbScore;
   std::vector<Move> pv;
 };

--- a/src/search.h
+++ b/src/search.h
@@ -73,8 +73,8 @@ struct RootMove {
   Value averageScore = -VALUE_INFINITE;
   int selDepth = 0;
   int tbRank = 0;
-  bool scoreLowerbound;
-  bool scoreUpperbound;
+  bool scoreLowerbound = false;
+  bool scoreUpperbound = false;
   Value tbScore;
   std::vector<Move> pv;
 };

--- a/src/uci.h
+++ b/src/uci.h
@@ -79,7 +79,7 @@ void loop(int argc, char* argv[]);
 std::string value(Value v);
 std::string square(Square s);
 std::string move(Move m, bool chess960);
-std::string pv(const Position& pos, Depth depth, Value alpha, Value beta);
+std::string pv(const Position& pos, Depth depth);
 std::string wdl(Value v, int ply);
 Move to_move(const Position& pos, std::string& str);
 


### PR DESCRIPTION
While discussing pull #4126 with @mstembera it came out, that we have a bug when emitting the PV from a helper thread.
Currently when bestThread is not the main thread we emit the PV by calling UCI::pv with infinite bound values:
```
if (bestThread != this)
  sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
```

Thus the helper's thread score get emitted without bounds information and looks therefore being 'exact', while in truth it can also be 'upperbound' or 'lowerbound'.

For reference see [UCI specification](https://www.shredderchess.com/download/div/uci.zip) section "Engine to GUI -> info -> score"
Instead of keeping track which bounds where used in the specific search, in this version we simply store the quality (exact, upperbound, lowerbound) of the score along with the actual score as information on rootMove. 
This way UCI::pv method don't need the bounds parameters anymore.

no functional change
bench: 4239512