### PR TITLE
Don't search moves in LMR if their projected depth is less or equal than depth of LMR.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1188,7 +1188,11 @@ moves_loop: // When in check, search starts here
               // was good enough search deeper, if it was bad enough search shallower
               const bool doDeeperSearch = value > (alpha + 64 + 11 * (newDepth - d));
               const bool doShallowerSearch = value < bestValue + newDepth;
-              value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, newDepth + doDeeperSearch - doShallowerSearch, !cutNode);
+
+              newDepth += doDeeperSearch - doShallowerSearch;
+
+              if (newDepth > d)
+                  value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, newDepth, !cutNode);
 
               int bonus = value > alpha ?  stat_bonus(newDepth)
                                         : -stat_bonus(newDepth);


### PR DESCRIPTION
Idea is that with last patch we can have full depth search being less depth than original newDepth and thus be not deeper than LMR search - making searching it more or less a waste of time.
Also as a side effect makes stat bonus assignment after full depth search more consistent - now it reflects real new depth instead of random +/- 1 additions to it.
Passed STC: 
https://tests.stockfishchess.org/tests/view/63795500aa34433735bc1cfe
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 112776 W: 30082 L: 29663 D: 53031
Ptnml(0-2): 352, 12453, 30423, 12744, 416 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6379ea39aa34433735bc2f9b
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 83576 W: 22559 L: 22169 D: 38848
Ptnml(0-2): 38, 8011, 25303, 8395, 41 
bench 4390318