### PR TITLE
Fix longest PV selection

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -236,7 +236,8 @@ Thread* ThreadPool::get_best_thread() const {
                  || (   th->rootMoves[0].score > VALUE_TB_LOSS_IN_MAX_PLY
                      && (   votes[th->rootMoves[0].pv[0]] > votes[bestThread->rootMoves[0].pv[0]]
                          || (   votes[th->rootMoves[0].pv[0]] == votes[bestThread->rootMoves[0].pv[0]]
-                             && th->rootMoves[0].pv.size() > bestThread->rootMoves[0].pv.size()))))
+                             &&   th->rootMoves[0].scoreLowerbound + th->rootMoves[0].scoreUpperbound * 2
+                                < bestThread->rootMoves[0].scoreLowerbound + bestThread->rootMoves[0].scoreUpperbound * 2))))
             bestThread = th;
 
     return bestThread;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -222,10 +222,10 @@ Thread* ThreadPool::get_best_thread() const {
 
     // Vote according to score and depth, and select the best thread
     for (Thread* th : *this)
-    {
         votes[th->rootMoves[0].pv[0]] +=
             (th->rootMoves[0].score - minScore + 14) * int(th->completedDepth);
 
+    for (Thread* th : *this)
         if (abs(bestThread->rootMoves[0].score) >= VALUE_TB_WIN_IN_MAX_PLY)
         {
             // Make sure we pick the shortest mate / TB conversion or stave off mate the longest
@@ -238,7 +238,6 @@ Thread* ThreadPool::get_best_thread() const {
                          || (   votes[th->rootMoves[0].pv[0]] == votes[bestThread->rootMoves[0].pv[0]]
                              && th->rootMoves[0].pv.size() > bestThread->rootMoves[0].pv.size()))))
             bestThread = th;
-    }
 
     return bestThread;
 }


### PR DESCRIPTION
In case of equal scores for several threads we try to select the longest PV on line 239 of master.  However, in some cases this actually fails.  Here is a simple example:  Say we have 3 threads 0, 1, 2.  Threads 0 and 2 vote for move m0 and thread 1 votes for move m1.  Thread 1 score is higher than thread 0 alone but lower than thread 0 and thread 2 scores combined.   Thread 0 PV is long and thread 2 PV is truncated.  Currently in master bestThread goes from thread 0 to thread 1 to thread 2.   The correct selection however is thread 0 because it's the same move as thread 2 but with a longer PV.  Executing the voting loop fully before the selection loop fixes this bug.

No functional change
bench: 4390318