### PR TITLE
Remove PvNode Parameter for cutoff LMR bench:  3733322

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1162,7 +1162,7 @@ moves_loop: // When in check, search starts here
               r--;
 
           // Increase reduction if next ply has a lot of fail high
-          if ((ss+1)->cutoffCnt > 3 && !PvNode)
+          if ((ss+1)->cutoffCnt > 3)
               r++;
 
           ss->statScore =  2 * thisThread->mainHistory[us][from_to(move)]

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1156,7 +1156,7 @@ moves_loop: // When in check, search starts here
           if (singularQuietLMR)
               r--;
 
-          // Dicrease reduction if we move a threatened piece (~1 Elo)
+          // Decrease reduction if we move a threatened piece (~1 Elo)
           if (   depth > 9
               && (mp.threatenedPieces & from_sq(move)))
               r--;


### PR DESCRIPTION
Remove PvNode Parameter for cutoff LMR


STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 198520 W: 52673 L: 52632 D: 93215
Ptnml(0-2): 645, 22241, 53499, 22178, 697
https://tests.stockfishchess.org/tests/view/63746e8f9849fa7a36a6698f


LTC:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 253568 W: 67487 L: 67501 D: 118580
Ptnml(0-2): 109, 25222, 76141, 25198, 114
https://tests.stockfishchess.org/tests/view/63839859d2b9c924c4c4feb7

Bench:  3733322