### PR TITLE
Capture full sort bench:  4161648

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -191,7 +191,7 @@ top:
       endMoves = generate<CAPTURES>(pos, cur);
 
       score<CAPTURES>();
-      partial_insertion_sort(cur, endMoves, -10000000);
+      partial_insertion_sort(cur, endMoves, std::numeric_limits<int>::min());
       ++stage;
       goto top;
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -88,8 +88,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 
 /// MovePicker constructor for ProbCut: we generate captures with SEE greater
 /// than or equal to the given threshold.
-MovePicker::MovePicker(const Position& p, Move ttm, Value th, Depth d, const CapturePieceToHistory* cph)
-           : pos(p), captureHistory(cph), ttMove(ttm), threshold(th), depth(d)
+MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePieceToHistory* cph)
+           : pos(p), captureHistory(cph), ttMove(ttm), threshold(th)
 {
   assert(!pos.checkers());
 
@@ -191,7 +191,7 @@ top:
       endMoves = generate<CAPTURES>(pos, cur);
 
       score<CAPTURES>();
-      partial_insertion_sort(cur, endMoves, -3000 * depth);
+      partial_insertion_sort(cur, endMoves, -10000000);
       ++stage;
       goto top;
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -128,7 +128,7 @@ public:
                                            const CapturePieceToHistory*,
                                            const PieceToHistory**,
                                            Square);
-  MovePicker(const Position&, Move, Value, Depth, const CapturePieceToHistory*);
+  MovePicker(const Position&, Move, Value, const CapturePieceToHistory*);
   Move next_move(bool skipQuiets = false);
 
   Bitboard threatenedPieces;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -855,7 +855,7 @@ namespace {
     {
         assert(probCutBeta < VALUE_INFINITE);
 
-        MovePicker mp(pos, ttMove, probCutBeta - ss->staticEval, depth - 3, &captureHistory);
+        MovePicker mp(pos, ttMove, probCutBeta - ss->staticEval, &captureHistory);
 
         while ((move = mp.next_move()) != MOVE_NONE)
             if (move != excludedMove && pos.legal(move))


### PR DESCRIPTION
Simply do full sort on captures.

STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 42712 W: 11413 L: 11203 D: 20096
Ptnml(0-2): 145, 4661, 11544, 4851, 155
https://tests.stockfishchess.org/tests/view/6384df57d2b9c924c4c53900

LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 239072 W: 64065 L: 64067 D: 110940
Ptnml(0-2): 106, 23735, 71859, 23727, 109
https://tests.stockfishchess.org/tests/view/63851120d2b9c924c4c541ee

Bench:  4161648