### PR TITLE
Invoke .depend on build targets only

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -512,7 +512,7 @@ endif
 
 ### Sometimes gcc is really clang
 ifeq ($(COMP),gcc)
-	gccversion = $(shell $(CXX) --version)
+	gccversion = $(shell $(CXX) --version 2>/dev/null)
 	gccisclang = $(findstring clang,$(gccversion))
 	ifneq ($(gccisclang),)
 		profile_make = clang-profile-make
@@ -1006,4 +1006,6 @@ icc-profile-use:
 .depend: $(SRCS)
 	-@$(CXX) $(DEPENDFLAGS) -MM $(SRCS) > $@ 2> /dev/null
 
+ifneq (, $(filter $(MAKECMDGOALS), build profile-build))
 -include .depend
+endif


### PR DESCRIPTION
Add a constraint so that the dependency build only occurs when users actually run build tasks.
This fixes a bug on some systems where gcc/g++ is not available.

No functional change