### PR TITLE
Correctly output lowerbound/upperbound scores

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1246,8 +1246,14 @@ moves_loop: // When in check, search starts here
           {
               rm.score = value;
               rm.selDepth = thisThread->selDepth;
-              rm.scoreLowerbound = value >= beta;
-              rm.scoreUpperbound = value <= alpha;
+              if (value >= beta) {
+                 rm.scoreLowerbound = true;
+                 rm.score = beta;
+              }
+              else if (value <= alpha) {
+                 rm.scoreUpperbound = true;
+                 rm.score = alpha;
+              }
               rm.pv.resize(1);
 
               assert((ss+1)->pv);


### PR DESCRIPTION
Fixes the lowerbound/upperbound output by avoiding scores outside the alpha,beta bracket.
Since SF search uses fail-soft we can't simply take the returned value as score.

No functional change on single core
Might have an impact on multicore (pick best thread)
bench: 3467381