### PR TITLE
Extend all moves at low depth if ttMove is doubly extended

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1067,7 +1067,10 @@ moves_loop: // When in check, search starts here
                   if (  !PvNode
                       && value < singularBeta - 25
                       && ss->doubleExtensions <= 9)
+                  {
                       extension = 2;
+                      depth += depth < 12;
+                  }
               }
 
               // Multi-cut pruning
@@ -1296,7 +1299,7 @@ moves_loop: // When in check, search starts here
                       && depth < 6
                       && beta  <  VALUE_KNOWN_WIN
                       && alpha > -VALUE_KNOWN_WIN)
-                     depth -= 1;
+                      depth -= 1;
 
                   assert(depth > 0);
               }
@@ -1521,7 +1524,6 @@ moves_loop: // When in check, search starts here
           &&  futilityBase > -VALUE_KNOWN_WIN
           &&  type_of(move) != PROMOTION)
       {
-
           if (moveCount > 2)
               continue;
 


### PR DESCRIPTION
If ttMove is doubly extended, we allow a depth growth of the remaining moves. The idea is to get a more realistic score comparison, because of the depth difference. We take some care to avoid this extension for high depths, in order to avoid the cost, since the search result is supposed to be more accurate in this case.

This pull request includes some small cleanups.

STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 60256 W: 16189 L: 15848 D: 28219
Ptnml(0-2): 182, 6546, 16330, 6889, 181
https://tests.stockfishchess.org/tests/view/639109a1792a529ae8f27777

LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 106232 W: 28487 L: 28053 D: 49692
Ptnml(0-2): 46, 10224, 32145, 10652, 49
https://tests.stockfishchess.org/tests/view/63914cba792a529ae8f282ee

Bench: 3622368