### PR TITLE
fix lower/upper bounds output

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1250,6 +1250,8 @@ moves_loop: // When in check, search starts here
           {
               rm.score =  rm.uciScore = value;
               rm.selDepth = thisThread->selDepth;
+              rm.scoreLowerbound = rm.scoreUpperbound = false;
+
               if (value >= beta) {
                  rm.scoreLowerbound = true;
                  rm.uciScore = beta;


### PR DESCRIPTION
Commit `cb0c7a98485fbef4e5d6ed5f5b08201113ce0b4e` doesnt reset the lower/upper bounds back to false .

No functional change

closes https://github.com/official-stockfish/Stockfish/issues/4273