### PR TITLE
Avoid completely truncated PVs

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -239,7 +239,8 @@ Thread* ThreadPool::get_best_thread() const {
                  || (   th->rootMoves[0].score > VALUE_TB_LOSS_IN_MAX_PLY
                      && (   votes[th->rootMoves[0].pv[0]] > votes[bestThread->rootMoves[0].pv[0]]
                          || (   votes[th->rootMoves[0].pv[0]] == votes[bestThread->rootMoves[0].pv[0]]
-                             && thread_value(th) > thread_value(bestThread)))))
+                             &&   thread_value(th) * int(th->rootMoves[0].pv.size() > 2)
+                                > thread_value(bestThread) * int(bestThread->rootMoves[0].pv.size() > 2)))))
             bestThread = th;
 
     return bestThread;


### PR DESCRIPTION
https://github.com/official-stockfish/Stockfish/pull/4246 had the unfortunate side effect of often producing PVs with a length of 1.  This addresses the issue.  More extensive analysis at https://github.com/official-stockfish/Stockfish/pull/4244
Credit to @vondele for the fix.

No functional change
bench: 3622368