### PR TITLE
Simplify Capture Scoring Bench:  3744486

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -100,7 +100,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePiece
 
 /// MovePicker::score() assigns a numerical value to each move in a list, used
 /// for sorting. Captures are ordered by Most Valuable Victim (MVV), preferring
-/// captures with a good history. Quiets moves are ordered using the histories.
+/// captures with a good history. Quiets moves are ordered using the history tables.
 template<GenType Type>
 void MovePicker::score() {
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -123,8 +123,8 @@ void MovePicker::score() {
 
   for (auto& m : *this)
       if constexpr (Type == CAPTURES)
-          m.value =  6 * int(PieceValue[MG][pos.piece_on(to_sq(m))])
-                   +     (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))];
+          m.value =  (7 * int(PieceValue[MG][pos.piece_on(to_sq(m))])
+                   +     (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))]) / 16;
 
       else if constexpr (Type == QUIETS)
           m.value =  2 * (*mainHistory)[pos.side_to_move()][from_to(m)]
@@ -197,7 +197,7 @@ top:
 
   case GOOD_CAPTURE:
       if (select<Next>([&](){
-                       return pos.see_ge(*cur, Value(-69 * cur->value / 1024)) ?
+                       return pos.see_ge(*cur, Value(-cur->value)) ?
                               // Move losing capture to endBadCaptures to be tried later
                               true : (*endBadCaptures++ = *cur, false); }))
           return *(cur - 1);


### PR DESCRIPTION
Simplify Capture Scoring

The parameters are now in one place for easier tuning.
New formula is very similar to current.

STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 48176 W: 12819 L: 12616 D: 22741
Ptnml(0-2): 139, 5316, 13001, 5467, 165


LTC:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 176752 W: 47364 L: 47304 D: 82084
Ptnml(0-2): 83, 17302, 53536, 17382, 73
https://tests.stockfishchess.org/tests/view/638ec7d068532fcbf79dfa15

Bench:  3744486