### PR TITLE
[tools] Fix castling moves counting towards # captures in gather_statistics

### DIFF
--- a/src/tools/stats.cpp
+++ b/src/tools/stats.cpp
@@ -650,7 +650,7 @@ namespace Stockfish::Tools::Stats
         {
             m_total += 1;
 
-            if (!pos.empty(to_sq(move)))
+            if (!pos.empty(to_sq(move)) && type_of(move) != CASTLING)
                 m_capture += 1;
 
             if (type_of(move) == CASTLING)


### PR DESCRIPTION
Fixes incorrect # of captures reported in `gather_statistics` "Number of moves by type" due to # castling moves counting towards # of captures. Fixes https://github.com/official-stockfish/Stockfish/issues/4282

Here's a quick shell script for repro'ing the bug and confirming the fix:
```bash
cat <<EOF > some-positions.plain
fen rnbqk2r/pppp1ppp/5n2/2b1p3/4P3/3B1N2/PPPP1PPP/RNBQK2R w KQkq - 4 4
move e1h1
score 123
ply 1
result 1
e
fen rnbqk2r/pppp1ppp/5n2/2b1p3/4P3/3B1N2/PPPP1PPP/RNBQ1RK1 b kq - 5 4
move e8h8
score 123
ply 1
result 1
e
EOF
rm -f some-positions.binpack
./stockfish convert some-positions.plain some-positions.binpack
./stockfish gather_statistics position_count move_type input_file some-positions.binpack
```

Expected output after the fix:
```
Stockfish 121222 by the Stockfish developers (see AUTHORS file)
Converting some-positions.plain to some-positions.binpack
Finished. Converted 2 positions.
Stockfish 121222 by the Stockfish developers (see AUTHORS file)
Finished gathering statistics.

Results:

Number of positions: 2
Number of moves by type:
    Total: 2
    Normal: 0
    Capture: 0
    Promotion: 0
    Castling: 2
    En-passant: 0
```