### PR TITLE
Don't force reset increaseDepth back to true after it has been set to false

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -487,12 +487,11 @@ void Thread::search() {
               else
                   Threads.stop = true;
           }
-          else if (   Threads.increaseDepth
-                   && !mainThread->ponder
+          else if (   !mainThread->ponder
                    && Time.elapsed() > totalTime * 0.53)
-                   Threads.increaseDepth = false;
+              Threads.increaseDepth = false;
           else
-                   Threads.increaseDepth = true;
+              Threads.increaseDepth = true;
       }
 
       mainThread->iterValue[iterIdx] = bestValue;


### PR DESCRIPTION
STC:  https://tests.stockfishchess.org/tests/view/6398c74693ed41c57ede7bfd
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 51128 W: 13543 L: 13220 D: 24365
Ptnml(0-2): 165, 5363, 14174, 5708, 154 

LTC: https://tests.stockfishchess.org/tests/view/6399bcd393ed41c57edea750
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 290864 W: 77282 L: 77334 D: 136248
Ptnml(0-2): 107, 28127, 89029, 28049, 120 

Resetting increaseDepth back to true each time on the very next iteration was not intended so this is a bug fix and a simplification.  See more discussion here https://github.com/official-stockfish/Stockfish/pull/2482#issuecomment-1350978878  Thanks to @xoto10 

bench: 3410998