### PR TITLE
Fix a dependency bug

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1009,6 +1009,6 @@ icc-profile-use:
 .depend: $(SRCS)
 	-@$(CXX) $(DEPENDFLAGS) -MM $(SRCS) > $@ 2> /dev/null
 
-ifneq (, $(filter $(MAKECMDGOALS), build profile-build))
+ifeq (, $(filter $(MAKECMDGOALS), help strip install clean net objclean profileclean config-sanity))
 -include .depend
 endif


### PR DESCRIPTION
Instead of allowing .depend for specific build-related targets, filter non-build-related targets (i.e. help, clean) so that other targets can normally execute .depend target.

No functional change