### PR TITLE
Add double bonus for prior countermove fail low

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -145,6 +145,7 @@ Mira
 Miroslav Fontán (Hexik)
 Moez Jellouli (MJZ1977)
 Mohammed Li (tthsqe12)
+Muzhen J (XInTheDark)
 Nathan Rugg (nmrugg)
 Nick Pelling (nickpelling)
 Nicklas Persson (NicklasPersson)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1353,16 +1353,17 @@ moves_loop: // When in check, search starts here
                          quietsSearched, quietCount, capturesSearched, captureCount, depth);
 
     // Bonus for prior countermove that caused the fail low
-    else if (   (depth >= 5 || PvNode)
+    else if (   (depth >= 5 || PvNode || bestValue < alpha - 62 * depth)
              && !priorCapture)
     {
         //Assign extra bonus if current node is PvNode or cutNode
         //or fail low was really bad
         bool extraBonus =    PvNode
-                          || cutNode
-                          || bestValue < alpha - 62 * depth;
+                          || cutNode;
 
-        update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, stat_bonus(depth) * (1 + extraBonus));
+        bool doubleExtraBonus = extraBonus && bestValue < alpha - 85 * depth;
+
+        update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, stat_bonus(depth) * (1 + extraBonus + doubleExtraBonus));
     }
 
     if (PvNode)


### PR DESCRIPTION
Add a double extra bonus for particularly bad fail low cases. Original idea by Yoshie2000.

STC: https://tests.stockfishchess.org/tests/view/63a2f0d86b5bf07ac7fad543
LLR: 2.94 (-2.94,2.94) <0.00,2.00> 
Total: 146488 W: 38992 L: 38532 D: 68964 
Ptnml(0-2): 385, 16036, 39965, 16450, 408

LTC: https://tests.stockfishchess.org/tests/view/63a3eaeb6b5bf07ac7fafdec
LLR: 2.95 (-2.94,2.94) <0.50,2.50> 
Total: 103992 W: 27853 L: 27423 D: 48716
Ptnml(0-2): 41, 10029, 31435, 10441, 50

Bench: 3801857