### PR TITLE
Allow consecutive null move searches in the tree.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -787,7 +787,6 @@ namespace {
 
     // Step 9. Null move search with verification search (~35 Elo)
     if (   !PvNode
-        && (ss-1)->currentMove != MOVE_NULL
         && (ss-1)->statScore < 17139
         &&  eval >= beta
         &&  eval >= ss->staticEval


### PR DESCRIPTION
mostly takes effect on higher depths.

Passed non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 71704 W: 19065 L: 18890 D: 33749
Ptnml(0-2): 193, 7760, 19785, 7907, 207 
https://tests.stockfishchess.org/tests/view/63a747caf3a586b4a404312f

Passed non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 32352 W: 8704 L: 8506 D: 15142
Ptnml(0-2): 12, 3090, 9789, 3258, 27
https://tests.stockfishchess.org/tests/view/63a7fd07f3a586b4a4044b3f

bench: 3801857