### PR TITLE
Remove redundant extern modifier for function declarations

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -204,7 +204,7 @@ private:
   bool chess960;
 };
 
-extern std::ostream& operator<<(std::ostream& os, const Position& pos);
+std::ostream& operator<<(std::ostream& os, const Position& pos);
 
 inline Color Position::side_to_move() const {
   return sideToMove;

--- a/src/psqt.h
+++ b/src/psqt.h
@@ -30,7 +30,7 @@ namespace Stockfish::PSQT
 extern Score psq[PIECE_NB][SQUARE_NB];
 
 // Fill psqt array from a set of internally linked parameters
-extern void init();
+void init();
 
 } // namespace Stockfish::PSQT
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -36,7 +36,7 @@ using namespace std;
 
 namespace Stockfish {
 
-extern vector<string> setup_bench(const Position&, istream&);
+vector<string> setup_bench(const Position&, istream&);
 
 namespace {
 


### PR DESCRIPTION
Functions have external linkage by default, so there's no need to declare them extern.

No functional change