### PR TITLE
Only accept one king per side in FEN

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -191,6 +191,17 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
    6) Fullmove number. The number of the full move. It starts at 1, and is
       incremented after Black's move.
 */
+  
+
+  // 0. Make sure there is ony one king for each side
+  std::string fen2 = fenStr.substr(0, fenStr.find_first_of(' '));
+  int K = std::count(fen2.begin(), fen2.end(), 'K');
+  int k = std::count(fenStr.begin(), fenStr.end(), 'k');
+
+  if (K != 1 && k != 1) {
+    sync_cout << "info string invalid FEN (bad number of kings)" << sync_endl;
+    return *this;
+  };
 
   unsigned char col, row, token;
   size_t idx;


### PR DESCRIPTION
Author : Paul Jérôme--Filio

Stockfish was accepting more than one king per side, and we could run a `go perf` command without any problem. This commit prevent form this.

No functional change