### PR TITLE
Init Stack::staticEval to VALUE_NONE instead of 0

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -276,10 +276,13 @@ void Thread::search() {
   int iterIdx = 0;
 
   std::memset(ss-7, 0, 10 * sizeof(Stack));
-  for (int i = 7; i > 0; i--)
+  for (int i = 7; i > 0; --i)
+  {
       (ss-i)->continuationHistory = &this->continuationHistory[0][0][NO_PIECE][0]; // Use as a sentinel
+      (ss-i)->staticEval = VALUE_NONE;
+  }
 
-  for (int i = 0; i <= MAX_PLY + 2; ++i)
+  for (int i = 1; i < MAX_PLY + 3; ++i)
       (ss+i)->ply = i;
 
   ss->pv = pv;


### PR DESCRIPTION
https://tests.stockfishchess.org/tests/view/63ab91cf39af998100ce1666
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 53736 W: 14285 L: 13955 D: 25496
Ptnml(0-2): 121, 5921, 14500, 6159, 167 

https://tests.stockfishchess.org/tests/view/63b2af5ee28ed36c814bed52
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 33776 W: 9130 L: 8934 D: 15712
Ptnml(0-2): 14, 3240, 10185, 3434, 15 

bench: 4068510

This fixes a bug where on line 278 the Stack::staticEvals are initialized to 0.  However VALUE_NONE is defined as 32002 so this is a bug in master.  (Also includes a couple of non functional cleanups of the for loops.)  Some additional comments at https://github.com/mstembera/Stockfish/commit/0c62ca58dfd8fcdb0810a7ef4453af7c6d829c53

