### PR TITLE
Late countermove bonus: remove "extraBonus &&"

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1359,14 +1359,9 @@ moves_loop: // When in check, search starts here
     else if (   (depth >= 5 || PvNode || bestValue < alpha - 65 * depth)
              && !priorCapture)
     {
-        //Assign extra bonus if current node is PvNode or cutNode
-        //or fail low was really bad
-        bool extraBonus =    PvNode
-                          || cutNode;
-
-        bool doubleExtraBonus = extraBonus && bestValue < alpha - 88 * depth;
-
-        update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, stat_bonus(depth) * (1 + extraBonus + doubleExtraBonus));
+        // Extra bonuses for PV/Cut nodes or bad fail lows
+        int bonus = 1 + (PvNode || cutNode) + (bestValue < alpha - 88 * depth);
+        update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, stat_bonus(depth) * bonus);
     }
 
     if (PvNode)


### PR DESCRIPTION
Not the finest PR ever but hey

blue stc: https://tests.stockfishchess.org/tests/view/63a71e409c0589b83751dc25
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 432480 W: 113846 L: 114055 D: 204579
Ptnml(0-2): 1164, 48205, 117701, 48016, 1154

blue ltc: https://tests.stockfishchess.org/tests/view/63aba66639af998100ce1aa9
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 245344 W: 65309 L: 65317 D: 114718
Ptnml(0-2): 117, 24257, 73903, 24307, 88

bench 4379218