### PR TITLE
on step 18 increase reduction by 2 if not ttmove and cutnode

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1215,6 +1215,10 @@ moves_loop: // When in check, search starts here
       // Step 18. Full depth search when LMR is skipped. If expected reduction is high, reduce its depth by 1.
       else if (!PvNode || moveCount > 1)
       {
+               // Increase reduction for cut nodes and not ttMove (~1 Elo) 
+               if (!ttMove && cutNode)
+                         r += 2;
+
                value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, newDepth - (r > 4), !cutNode);
       }
 


### PR DESCRIPTION
bench: 4003343

stc: https://tests.stockfishchess.org/tests/view/63babc9fcd3db0c8d399f723
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 43104 W: 11711 L: 11389 D: 20004
Ptnml(0-2): 211, 4518, 11793, 4798, 232

ltc: https://tests.stockfishchess.org/tests/view/63bb1857cd3db0c8d39a0661
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 127104 W: 33810 L: 33339 D: 59955
Ptnml(0-2): 39, 12155, 38702, 12608, 48