### PR TITLE
Update default net to nn-1e7ca356472e.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-a3dc078bafc7.nnue"
+  #define EvalFileDefaultName   "nn-1e7ca356472e.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
Created by retraining the master net on a dataset composed of:
- The Leela-dfrc_n5000.binpack dataset filtered with depth6 multipv2 search to remove positions with only one good move, in addition to removing positions where either of the two best moves are captures
- The same Leela T80 oct+nov 2022 training data used in recent best datasets
- Additional Leela training data from T60 nov+dec 2021 and T79 apr+may 2022

Trained with end lambda 0.7 and started with max epoch 800. All positions with ply <= 28 were skipped:

```
python easy_train.py \
  --experiment-name leela95-dfrc96-mpv-eval-fonly-T80octnov-T79aprmayT60novdec-12tb7p-sk28-lambda7 \
  --training-dataset /data/leela95-dfrc96-mpv-eval-fonly-T80octnov-T79aprmayT60novdec-12tb7p.binpack \
  --nnue-pytorch-branch linrock/nnue-pytorch/misc-fixes-skip-ply-lteq-28 \
  --start-from-engine-test-net True \
  --gpus "0," \
  --start-lambda 1.0 \
  --end-lambda 0.7 \
  --gamma 0.995 \
  --lr 4.375e-4 \
  --tui False \
  --seed $RANDOM \
  --max_epoch 800
```

Around epoch 780, training was manually paused and max epoch increased to 920 before resuming.

During depth6 multipv2 data filtering, positions were considered to have only one good move if the score of the best move was significantly better than the 2nd best move in a way that changes the outcome of the game:
- the best move leads to a significant advantage while the 2nd best move equalizes or loses
- the best move is about equal while the 2nd best move loses

The modified stockfish branch and exact score thresholds used for filtering are at:
https://github.com/linrock/Stockfish/tree/tools-filter-multipv2-eval-diff/src/filter

About 95% of the Leela portion and 96% of the DFRC portion of the Leela-dfrc_n5000.binpack dataset was filtered. Unfiltered parts of the dataset were left out.

The additional Leela training data from T60 nov+dec 2021 and T79 apr+may 2022 was WDL-rescored with about 12TB of syzygy 7-piece tablebases where the material difference is less than around 6 pawns. Best moves were exported to .plain data files during data conversion with the lc0 rescorer.

The exact training data can be found at:
https://robotmoon.com/nnue-training-data/


Local elo at 25k nodes per move
experiment_leela95-dfrc96-mpv-eval-fonly-T80octnov-T79aprmayT60novdec-12tb7p-sk28-lambda7
run_0/nn-epoch899.nnue : 3.8 +/- 1.6

Passed STC
https://tests.stockfishchess.org/tests/view/63bed1f540aa064159b9c89b
LLR: 2.94 (-2.94,2.94) <0.00,2.00>  
Total: 103344 W: 27392 L: 26991 D: 48961  
Ptnml(0-2): 333, 11223, 28099, 11744, 273

Passed LTC
https://tests.stockfishchess.org/tests/view/63c010415705810de2deb3ec
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 21712 W: 5891 L: 5619 D: 10202
Ptnml(0-2): 12, 2022, 6511, 2304, 7

bench 4106793