### PR TITLE
Introduce a King Safety setting to control how highly scores king safety

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -539,7 +539,7 @@ namespace {
 
     Bitboard weak, b1, b2, b3, safe, unsafeChecks = 0;
     Bitboard rookChecks, queenChecks, bishopChecks, knightChecks;
-    int kingDanger = 0;
+    int kingDanger = Options["King Safety"];
     const Square ksq = pos.square<KING>(Us);
 
     // Init the score with king shelter and enemy pawns storm
@@ -607,8 +607,7 @@ namespace {
                  - 873 * !pos.count<QUEEN>(Them)                              // (~24 Elo)
                  - 100 * bool(attackedBy[Us][KNIGHT] & attackedBy[Us][KING])  // (~5 Elo)
                  -   6 * mg_value(score) / 8                                  // (~8 Elo)
-                 -   4 * kingFlankDefense                                     // (~5 Elo)
-                 +  37;                                                       // (~0.5 Elo)
+                 -   4 * kingFlankDefense;                                    // (~5 Elo)
 
     // Transform the kingDanger units into a Score, and subtract it from the evaluation
     if (kingDanger > 100)

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -66,6 +66,7 @@ void init(OptionsMap& o) {
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);
+  o["King Safety"]           << Option(37, 0, 200);
   o["Skill Level"]           << Option(20, 0, 20);
   o["Move Overhead"]         << Option(10, 0, 5000);
   o["Slow Mover"]            << Option(100, 10, 1000);


### PR DESCRIPTION
**Good evaluation of the king safety is one of the most challenging tasks in writing an evaluation function, but also the most rewarding.**

**This controls how highly Stockfish scores king safety.  The higher the value, the greater the effects of attacks on the king in  Stockfish's evaluation.  The default is 37 in  Stockfish.**

![Chess analysis board](https://user-images.githubusercontent.com/121218340/212709449-e26df9ce-2478-4308-8172-0914268b6b7b.png)


