### PR TITLE
Remove Zobrist::noPawns which is no longer necessary

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -42,7 +42,7 @@ namespace Zobrist {
   Key psq[PIECE_NB][SQUARE_NB];
   Key enpassant[FILE_NB];
   Key castling[CASTLING_RIGHT_NB];
-  Key side, noPawns;
+  Key side;
 }
 
 namespace {
@@ -125,7 +125,6 @@ void Position::init() {
       Zobrist::castling[cr] = rng.rand<Key>();
 
   Zobrist::side = rng.rand<Key>();
-  Zobrist::noPawns = rng.rand<Key>();
 
   // Prepare the cuckoo tables
   std::memset(cuckoo, 0, sizeof(cuckoo));
@@ -336,8 +335,7 @@ void Position::set_check_info(StateInfo* si) const {
 
 void Position::set_state(StateInfo* si) const {
 
-  si->key = si->materialKey = 0;
-  si->pawnKey = Zobrist::noPawns;
+  si->key = si->materialKey = si->pawnKey = 0;
   si->nonPawnMaterial[WHITE] = si->nonPawnMaterial[BLACK] = VALUE_ZERO;
   si->checkersBB = attackers_to(square<KING>(sideToMove)) & pieces(~sideToMove);
 


### PR DESCRIPTION
This Zobrist key is only used once, to initialize a `Position`'s `si->pawnKey`. The `si->pawnKey` is then updated with pawn information as board state is changed.

The `si->pawnKey` is itself only used in one place: `Entry::probe`, where it is used to look into the current thread's `pawnsTable`. This is likewise the only place that the thread's `pawnsTable` is used.

As a result of the above, we can be confident that this particular key can be removed. It's only ever mixed into a key once, and that key is only ever used to index into a hash table that no other key is used for. Therefore its removal cannot possibly lead to colliding with another key from another source.

Bench: 4106793

https://tests.stockfishchess.org/tests/view/63c5cb8418c20f4929c5fd7e