### PR TITLE
`stat_bonus`: replace quadratic with nearly identical line

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -81,7 +81,7 @@ namespace {
 
   // History and stats update bonus, based on depth
   int stat_bonus(Depth d) {
-    return std::min((11 * d + 284) * d - 363 , 1650);
+    return std::min(350 * d - 400, 1650);
   }
 
   // Add a small random component to draw evaluations to avoid 3-fold blindness


### PR DESCRIPTION
blue stc: https://tests.stockfishchess.org/tests/view/63ca58c90eefe8694a0c4eac
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 287960 W: 76146 L: 76201 D: 135613
Ptnml(0-2): 947, 31890, 78307, 31943, 893

blue ltc: https://tests.stockfishchess.org/tests/view/63cc8a51344bb01c191b30f0
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 73784 W: 19559 L: 19402 D: 34823
Ptnml(0-2): 33, 7171, 22327, 7328, 33

bench 3990490