### PR TITLE
fixed uci tb win values

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -314,8 +314,13 @@ string UCI::value(Value v) {
 
   stringstream ss;
 
-  if (abs(v) < VALUE_MATE_IN_MAX_PLY)
+  if (abs(v) < VALUE_TB_WIN_IN_MAX_PLY)
       ss << "cp " << v * 100 / NormalizeToPawnValue;
+  else if (abs(v) < VALUE_MATE_IN_MAX_PLY)
+  {
+      const int ply = VALUE_MATE_IN_MAX_PLY - 1 - std::abs(v);  // recompute ss->ply
+      ss << "cp " << (v > 0 ? 20000 - ply : -20000 + ply);
+  }
   else
       ss << "mate " << (v > 0 ? VALUE_MATE - v + 1 : -VALUE_MATE - v) / 2;
 


### PR DESCRIPTION
A change like this was shortly discussed on discord https://discord.com/channels/435943710472011776/1040540069372637194/1040540069372637194 and it received many upvotes, but no action was taken. Thus I'll take the discussion to Github and propose one solution which doesnt divide the value by `NormalizeToPawnValue` so that future versions all report the same value for a TB win.

No functional change