### PR TITLE
Rebalance usage of history heuristics in pruning.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1026,11 +1026,16 @@ moves_loop: // When in check, search starts here
 
               history += 2 * thisThread->mainHistory[us][from_to(move)];
 
+              lmrDepth += history / 7208;
+              lmrDepth = std::max(lmrDepth, -2);
+
               // Futility pruning: parent node (~13 Elo)
               if (   !ss->inCheck
                   && lmrDepth < 13
-                  && ss->staticEval + 103 + 136 * lmrDepth + history / 53 <= alpha)
+                  && ss->staticEval + 103 + 136 * lmrDepth <= alpha)
                   continue;
+
+              lmrDepth = std::max(lmrDepth, 0);
 
               // Prune moves with negative SEE (~4 Elo)
               if (!pos.see_ge(move, Value(-25 * lmrDepth * lmrDepth - 16 * lmrDepth)))


### PR DESCRIPTION
This patch has multiple effects:
1) history heuristics sum in futility pruning now can't exceed some negative value so futility pruning for moves with negative histories should become slightly less aggressive;
2) history heuristics are now used in SEE pruning for quiet moves;
Passed STC:
https://tests.stockfishchess.org/tests/view/63cde339c93e8828d0f02e3a
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 88424 W: 23681 L: 23303 D: 41440
Ptnml(0-2): 258, 9559, 24219, 9899, 277 
Passed LTC:
https://tests.stockfishchess.org/tests/view/63ce9009c93e8828d0f04e4f
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 79536 W: 21223 L: 20843 D: 37470
Ptnml(0-2): 22, 7599, 24146, 7979, 22 
Bench 3910316