### PR TITLE
Remove meaningless const qualifiers in function declarations

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -124,7 +124,7 @@ public:
 
   // Properties of moves
   bool legal(Move m) const;
-  bool pseudo_legal(const Move m) const;
+  bool pseudo_legal(Move m) const;
   bool capture(Move m) const;
   bool gives_check(Move m) const;
   Piece moved_piece(Move m) const;

--- a/src/tt.h
+++ b/src/tt.h
@@ -83,7 +83,7 @@ class TranspositionTable {
 public:
  ~TranspositionTable() { aligned_large_pages_free(table); }
   void new_search() { generation8 += GENERATION_DELTA; } // Lower bits are used for other things
-  TTEntry* probe(const Key key, bool& found) const;
+  TTEntry* probe(Key key, bool& found) const;
   int hashfull() const;
   void resize(size_t mbSize);
   void clear();


### PR DESCRIPTION
Declaring a parameter const in a function declaration has no effect.

No functional change