### PR TITLE
Remove maxNextDepth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -525,7 +525,6 @@ namespace {
 
     constexpr bool PvNode = nodeType != NonPV;
     constexpr bool rootNode = nodeType == Root;
-    const Depth maxNextDepth = rootNode ? depth : depth + 1;
 
     // Check if we have an upcoming move which draws by repetition, or
     // if the opponent had an alternative move earlier to this position.
@@ -1238,8 +1237,7 @@ moves_loop: // When in check, search starts here
           (ss+1)->pv = pv;
           (ss+1)->pv[0] = MOVE_NONE;
 
-          value = -search<PV>(pos, ss+1, -beta, -alpha,
-                              std::min(maxNextDepth, newDepth), false);
+          value = -search<PV>(pos, ss+1, -beta, -alpha, newDepth, false);
       }
 
       // Step 19. Undo move


### PR DESCRIPTION
Remove maxNextDepth

This patch allows full PV search to have double extensions as well when
extension == 1 && doDeeperSearch && doEvenDeeperSearch && !doShallowerSearch
is true, which is extremely rare to occur.

Passed non-regression STC (master 3d2381d):
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 370824 W: 97835 L: 97974 D: 175015
Ptnml(0-2): 1073, 38814, 105731, 38767, 1027
https://tests.stockfishchess.org/tests/view/63c89416a83c702aac08314c

Passed non-regression LTC (master 3d2381d):
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 306048 W: 81173 L: 81237 D: 143638
Ptnml(0-2): 117, 27977, 96901, 27911, 118
https://tests.stockfishchess.org/tests/view/63cc4e84344bb01c191b2658

Bench: 4208265