### PR TITLE
Decrease reduction for killer moves with good history

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1164,6 +1164,11 @@ moves_loop: // When in check, search starts here
       if ((ss+1)->cutoffCnt > 3)
           r++;
 
+      // Decrease reduction if move is a killer and we have a good history
+      if (move == ss->killers[0]
+          && (*contHist[0])[movedPiece][to_sq(move)] >= 3600)
+          r--;
+
       ss->statScore =  2 * thisThread->mainHistory[us][from_to(move)]
                      + (*contHist[0])[movedPiece][to_sq(move)]
                      + (*contHist[1])[movedPiece][to_sq(move)]


### PR DESCRIPTION
If move is a main killer and we have a good history, decrease reduction.

STC: https://tests.stockfishchess.org/tests/view/63d38b37721fe2bff693069a
LLR: 2.95 (-2.94,2.94) <0.00,2.00> 
Total: 46688 W: 12542 L: 12222 D: 21924
Ptnml(0-2): 126, 5013, 12769, 5287, 149

LTC: https://tests.stockfishchess.org/tests/view/63d471e2bde6e5f3cb4be5d3
LLR: 2.93 (-2.94,2.94) <0.50,2.50> 
Total: 130976 W: 35033 L: 34555 D: 61388
Ptnml(0-2): 38, 12551, 39833, 13027, 39

Bench: 4069938