### PR TITLE
Remove some ss stack variable zeroing during recursive search.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -275,7 +275,7 @@ void Thread::search() {
   Color us = rootPos.side_to_move();
   int iterIdx = 0;
 
-  std::memset(ss-7, 0, 10 * sizeof(Stack));
+  std::memset(ss-7, 0, (MAX_PLY+10) * sizeof(Stack));
   for (int i = 7; i > 0; --i)
   {
       (ss-i)->continuationHistory = &this->continuationHistory[0][0][NO_PIECE][0]; // Use as a sentinel
@@ -600,8 +600,7 @@ namespace {
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
-    (ss+1)->ttPv         = false;
-    (ss+1)->excludedMove = bestMove = MOVE_NONE;
+    bestMove = MOVE_NONE;
     (ss+2)->killers[0]   = (ss+2)->killers[1] = MOVE_NONE;
     (ss+2)->cutoffCnt    = 0;
     ss->doubleExtensions = (ss-1)->doubleExtensions;
@@ -724,7 +723,6 @@ namespace {
         ss->staticEval = eval = VALUE_NONE;
         improving = false;
         improvement = 0;
-        complexity = 0;
         goto moves_loop;
     }
     else if (ss->ttHit)


### PR DESCRIPTION
Assure proper zeroing of the full ss stack on Thread::search(). This might be slower on super-bullet tc's, but under normal tournament conditions this should be a micro-optimization since we eliminate initializations on the hot path.
While being there also remove zeroing of complexity when in check, seems useless.
Does this pass valgrind?

no functional change
bench: 4208265