### PR TITLE
Add -Wconditional-uninitialized when using Clang

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -426,7 +426,8 @@ ifeq ($(COMP),clang)
 		CXX=x86_64-w64-mingw32-clang++
 	endif
 
-	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-prototypes
+	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-prototypes \
+	            -Wconditional-uninitialized
 
 	ifeq ($(filter $(KERNEL),Darwin OpenBSD FreeBSD),)
 	ifeq ($(target_windows),)


### PR DESCRIPTION
Add -Wconditional-uninitialized as it is not controlled by -Wall.

No functional change