### PR TITLE
Simplify to skip using tt eval and/or ttValue if no tt eval available

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -735,14 +735,10 @@ namespace {
         // Recalculate value with current optimism (without updating thread avgComplexity)
         ss->staticEval = eval = evaluate(pos, &complexity);
     }
-    else if (ss->ttHit)
+    else if (ss->ttHit && tte->eval() != VALUE_NONE)
     {
-        // Never assume anything about values stored in TT
         ss->staticEval = eval = tte->eval();
-        if (eval == VALUE_NONE)
-            ss->staticEval = eval = evaluate(pos, &complexity);
-        else // Fall back to (semi)classical complexity for TT hits, the NNUE complexity is lost
-            complexity = abs(ss->staticEval - pos.psq_eg_stm());
+        complexity = abs(ss->staticEval - pos.psq_eg_stm());
         thisThread->complexityAverage.update(complexity);
 
         // ttValue can be used as a better position evaluation (~7 Elo)


### PR DESCRIPTION
I have some concerns about simplifying `ttValue != VALUE_NONE` since it is commented elsewhere in the code that it can lead to TT access race but I would appreciate it if I got some insights about this in the comment section.

probably the simplification holds without removing that line since as far as I can tell it is non-functional at least in 1 thread.

Passed non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 87520 W: 23178 L: 23023 D: 41319
Ptnml(0-2): 227, 9094, 24946, 9283, 210
https://tests.stockfishchess.org/tests/view/63d3f7cf721fe2bff6931a7f

Passed  non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 117608 W: 31291 L: 31179 D: 55138
Ptnml(0-2): 38, 10996, 36615, 11126, 29
https://tests.stockfishchess.org/tests/view/63d51c36a67dd929a555dc0a

bench: 4208264