### PR TITLE
Improve excluded move logic

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -615,21 +615,24 @@ namespace {
     if (!rootNode)
         (ss+2)->statScore = 0;
 
-    // Step 4. Transposition table lookup. We don't want the score of a partial
-    // search to overwrite a previous full search TT value, so we use a different
-    // position key in case of an excluded move.
+    // Step 4. Transposition table lookup.
     excludedMove = ss->excludedMove;
-    posKey = excludedMove == MOVE_NONE ? pos.key() : pos.key() ^ make_key(excludedMove);
+    bool preExcludedTtHit = ss->ttHit; // to guard against TT race conditions
+    posKey = pos.key();
     tte = TT.probe(posKey, ss->ttHit);
     ttValue = ss->ttHit ? value_from_tt(tte->value(), ss->ply, pos.rule50_count()) : VALUE_NONE;
     ttMove =  rootNode ? thisThread->rootMoves[thisThread->pvIdx].pv[0]
             : ss->ttHit    ? tte->move() : MOVE_NONE;
     ttCapture = ttMove && pos.capture(ttMove);
+
+    // At this point, if excluded, skip straight to step 6, static eval. However,
+    // to save indentation, we list the condition in all code between here and there.
     if (!excludedMove)
         ss->ttPv = PvNode || (ss->ttHit && tte->is_pv());
 
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode
+        && !excludedMove
         && ss->ttHit
         && tte->depth() > depth - (tte->bound() == BOUND_EXACT)
         && ttValue != VALUE_NONE // Possible in case of TT access race
@@ -664,7 +667,7 @@ namespace {
     }
 
     // Step 5. Tablebases probe
-    if (!rootNode && TB::Cardinality)
+    if (!rootNode && !excludedMove && TB::Cardinality)
     {
         int piecesCount = pos.count<ALL_PIECES>();
 
@@ -727,6 +730,15 @@ namespace {
         complexity = 0;
         goto moves_loop;
     }
+    else if (excludedMove)
+    {
+       if (preExcludedTtHit)
+           // Static evals from the TT aren't good enough (-13 elo), presumably due to changing optimism context
+           ss->staticEval = eval = evaluate(pos, &complexity);
+       else // However, non-TT evals from the containing non-excluded search,
+            // being fresh, are useful, and re-using them gains about ~1 Elo.
+           eval = ss->staticEval;
+    }
     else if (ss->ttHit)
     {
         // Never assume anything about values stored in TT
@@ -736,6 +748,8 @@ namespace {
         else // Fall back to (semi)classical complexity for TT hits, the NNUE complexity is lost
             complexity = abs(ss->staticEval - pos.psq_eg_stm());
 
+        thisThread->complexityAverage.update(complexity);
+
         // ttValue can be used as a better position evaluation (~7 Elo)
         if (    ttValue != VALUE_NONE
             && (tte->bound() & (ttValue > eval ? BOUND_LOWER : BOUND_UPPER)))
@@ -744,13 +758,13 @@ namespace {
     else
     {
         ss->staticEval = eval = evaluate(pos, &complexity);
+        thisThread->complexityAverage.update(complexity);
 
         // Save static evaluation into transposition table
-        if (!excludedMove)
-            tte->save(posKey, VALUE_NONE, ss->ttPv, BOUND_NONE, DEPTH_NONE, MOVE_NONE, eval);
+        tte->save(posKey, VALUE_NONE, ss->ttPv, BOUND_NONE, DEPTH_NONE, MOVE_NONE, eval);
     }
 
-    thisThread->complexityAverage.update(complexity);
+
 
     // Use static evaluation difference to improve quiet move ordering (~4 Elo)
     if (is_ok((ss-1)->currentMove) && !(ss-1)->inCheck && !priorCapture)


### PR DESCRIPTION
This PR consists of various improvements on nodes with excludedMove set:

1. Remove xoring posKey with make_key(excludedMove)

   Since with excludedMove we never call tte-save anymore,
   the unique left purpose of the xoring seems to (possibly) avoid a ttHit.
   Nevertheless on a normal bench run on master we have 25 false positive ttHits.
   To avoid this prevent early TT cutoff's whenever excludeMove is set.
   
2. Also don't probe Tablebases with excludedMove.

   Tablebases don't deliver information about playing suboptimal moves.

3. Avoid re-calling evaluate when it's assured that ss->staticEval contains already the correct value.

   Very surprisingly it looks like that we cannot use static eval's from TT since they slightly differ due to changing optimism.
   Attempts to use static eval's from TT as well did loose about 13 ELO. This is something about to investigate.

STC: https://tests.stockfishchess.org/tests/view/63d3d9d9721fe2bff6931494
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 65696 W: 17454 L: 17104 D: 31138
Ptnml(0-2): 193, 7151, 17830, 7461, 213

LTC: https://tests.stockfishchess.org/tests/view/63d4ca6abde6e5f3cb4bf726
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 149032 W: 39738 L: 39223 D: 70071
Ptnml(0-2): 64, 14302, 45269, 14817, 64

Bench: 4701066

**Note 1:** 
removal of line 729 (complexity = 0;) was included in the tests, but is now handled separate in PR#4370 where it don't meet with love, so I preffered to let it out.

**Note 2:**
By suggestion of Dubslow in order to save indentation of 'Early TT-cutoff' and Step 5 'Tablebase Probe' blocks,
 this PR in contrast to the code used in the tests lists the !excludedMove in each condition. I hope this does not affect the generated binary.