### PR TITLE
Simplify usage of optimism in complexity.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1073,7 +1073,7 @@ Value Eval::evaluate(const Position& pos, int* complexity) {
       // Blend nnue complexity with (semi)classical complexity
       nnueComplexity = (  406 * nnueComplexity
                         + 424 * abs(psq - nnue)
-                        + (optimism  > 0 ? int(optimism) * int(psq - nnue) : 0)
+                        + int(optimism) * int(psq - nnue)
                         ) / 1024;
 
       // Return hybrid NNUE complexity to caller


### PR DESCRIPTION
This patch removes one condition in optimism usage in complexity, now negative optimism also impacts it.
Passed STC:
https://tests.stockfishchess.org/tests/view/63d34f43721fe2bff692fb12
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 204920 W: 54343 L: 54309 D: 96268
Ptnml(0-2): 598, 22648, 55897, 22756, 561 
Passed LTC:
https://tests.stockfishchess.org/tests/view/63d612a2a67dd929a556075c
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 200712 W: 53207 L: 53172 D: 94333
Ptnml(0-2): 58, 19664, 60901, 19651, 82 
bench 4204964