### PR TITLE
Remove reduced LMR capture bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1214,9 +1214,6 @@ moves_loop: // When in check, search starts here
               int bonus = value > alpha ?  stat_bonus(newDepth)
                                         : -stat_bonus(newDepth);
 
-              if (capture)
-                  bonus /= 6;
-
               update_continuation_histories(ss, movedPiece, to_sq(move), bonus);
           }
       }


### PR DESCRIPTION
In LMR, simplify away the reduced capture bonus (i.e. `if (capture) bonus /= 6`). 

Non-regression STC: https://tests.stockfishchess.org/tests/view/63da1da9bbadd17b3787dced
LLR: 2.95 (-2.94,2.94) <-1.75,0.25> 
Total: 28152 W: 7521 L: 7296 D: 13335
Ptnml(0-2): 76, 3069, 7568, 3280, 83

Non-regression LTC: https://tests.stockfishchess.org/tests/view/63da6ad4bbadd17b3787e98c
LLR: 2.96 (-2.94,2.94) <-1.75,0.25> 
Total: 52472 W: 14120 L: 13941 D: 24411
Ptnml(0-2): 16, 5071, 15887, 5242, 20

Bench: 3982060