### PR TITLE
Adding warning for unknown tokens `setoption token option `

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -101,9 +101,9 @@ namespace {
 
     is >> token; // Consume the "name" token
 
-    // warning when there is no token name
+    // Add warning when there is no token name
 	  if(token != "name") 
-		    sync_cout << "Info string no such option: " << token << sync_endl;
+		    sync_cout << "No such token: " << token << sync_endl;
 
     // Read the option name (can contain spaces)
     while (is >> token && token != "value")

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -102,8 +102,8 @@ namespace {
     is >> token; // Consume the "name" token
 
     // Add warning when there is no token name
-	  if(token != "name") 
-		    sync_cout << "No such token: " << token << sync_endl;
+    if (token != "name") 
+	sync_cout << "No such token: " << token << sync_endl;
 
     // Read the option name (can contain spaces)
     while (is >> token && token != "value")
@@ -115,7 +115,7 @@ namespace {
 
     if (Options.count(name))
         Options[name] = value;
-    else
+    else if (name != "")
         sync_cout << "No such option: " << name << sync_endl;
   }
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -101,6 +101,10 @@ namespace {
 
     is >> token; // Consume the "name" token
 
+    // setoption Clear Hash is wrong
+	  if(token == "Clear") 
+		    sync_cout << "No such option: " << name << sync_endl;
+
     // Read the option name (can contain spaces)
     while (is >> token && token != "value")
         name += (name.empty() ? "" : " ") + token;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -101,9 +101,9 @@ namespace {
 
     is >> token; // Consume the "name" token
 
-    // setoption Clear Hash is wrong
-	  if(token == "Clear") 
-		    sync_cout << "No such option: " << name << sync_endl;
+    // warning when there is no token name
+	  if(token != "name") 
+		    sync_cout << "Info string no such option: " << token << sync_endl;
 
     // Read the option name (can contain spaces)
     while (is >> token && token != "value")


### PR DESCRIPTION
Sometimes we may accidentally use this code to clear the hash, but we do not get any warning.
 `setoption Clear Hash`

