### PR TITLE
Update `complexityAverage` in all branches of static eval

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -743,7 +743,6 @@ namespace {
             ss->staticEval = eval = evaluate(pos, &complexity);
         else // Fall back to (semi)classical complexity for TT hits, the NNUE complexity is lost
             complexity = abs(ss->staticEval - pos.psq_eg_stm());
-        thisThread->complexityAverage.update(complexity);
 
         // ttValue can be used as a better position evaluation (~7 Elo)
         if (    ttValue != VALUE_NONE
@@ -753,11 +752,10 @@ namespace {
     else
     {
         ss->staticEval = eval = evaluate(pos, &complexity);
-        thisThread->complexityAverage.update(complexity);
-
         // Save static evaluation into transposition table
         tte->save(posKey, VALUE_NONE, ss->ttPv, BOUND_NONE, DEPTH_NONE, MOVE_NONE, eval);
     }
+    thisThread->complexityAverage.update(complexity);
 
     // Use static evaluation difference to improve quiet move ordering (~4 Elo)
     if (is_ok((ss-1)->currentMove) && !(ss-1)->inCheck && !priorCapture)


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/63dda49573223e7f52ad0f8c
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 117416 W: 31173 L: 31049 D: 55194
Ptnml(0-2): 290, 12246, 33533, 12328, 311

LTC: https://tests.stockfishchess.org/tests/view/63dfa90873223e7f52ad69b8
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 44416 W: 11924 L: 11744 D: 20748
Ptnml(0-2): 5, 4036, 13968, 4172, 27

bench 4758694