### PR TITLE
Simplify nnueComplexity calculation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1072,8 +1072,7 @@ Value Eval::evaluate(const Position& pos, int* complexity) {
 
       // Blend nnue complexity with (semi)classical complexity
       nnueComplexity = (  406 * nnueComplexity
-                        + 424 * abs(psq - nnue)
-                        + int(optimism) * int(psq - nnue)
+                        + (424 + optimism) * abs(psq - nnue)
                         ) / 1024;
 
       // Return hybrid NNUE complexity to caller


### PR DESCRIPTION
This follows https://github.com/official-stockfish/Stockfish/pull/4377
I admit I don't understand why master used the signed difference between psq and nnue  introduced here https://github.com/official-stockfish/Stockfish/pull/4195 instead of the absolute value, which makes more sense to me.  Maybe @snicolet or someone can comment if this should not be committed.

STC https://tests.stockfishchess.org/tests/view/63e02a3773223e7f52ad8190
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 359072 W: 94605 L: 94733 D: 169734
Ptnml(0-2): 994, 39874, 97958, 39686, 1024 

LTC https://tests.stockfishchess.org/tests/view/63e3fd12b5f425d71f77002a
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 248424 W: 66020 L: 66030 D: 116374
Ptnml(0-2): 113, 24653, 74689, 24645, 112 

bench: 4098325