### PR TITLE
Simplify late countermove bonus condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1371,11 +1371,10 @@ moves_loop: // When in check, search starts here
                          quietsSearched, quietCount, capturesSearched, captureCount, depth);
 
     // Bonus for prior countermove that caused the fail low
-    else if (   (depth >= 5 || PvNode || bestValue < alpha - 65 * depth)
-             && !priorCapture)
+    else if (!priorCapture)
     {
         // Extra bonuses for PV/Cut nodes or bad fail lows
-        int bonus = 1 + (PvNode || cutNode) + (bestValue < alpha - 88 * depth);
+        int bonus = (depth > 4) + (PvNode || cutNode) + (bestValue < alpha - 88 * depth);
         update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, stat_bonus(depth) * bonus);
     }
 


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/63d53ac6a67dd929a555e1e2
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 216096 W: 56862 L: 56839 D: 102395
Ptnml(0-2): 648, 24033, 58650, 24082, 635

LTC: https://tests.stockfishchess.org/tests/view/63d7f9a6a67dd929a5565991
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 808512 W: 214060 L: 214610 D: 379842
Ptnml(0-2): 301, 79448, 245293, 78928, 286

bench 4372520