### PR TITLE
Remove one `reduction` call

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -987,6 +987,8 @@ moves_loop: // When in check, search starts here
 
       Value delta = beta - alpha;
 
+      Depth r = reduction(improving, depth, moveCount, delta, thisThread->rootDelta);
+
       // Step 14. Pruning at shallow depth (~120 Elo). Depth conditions are important for mate finding.
       if (  !rootNode
           && pos.non_pawn_material(us)
@@ -996,7 +998,7 @@ moves_loop: // When in check, search starts here
           moveCountPruning = moveCount >= futility_move_count(improving, depth);
 
           // Reduced depth of the next LMR search
-          int lmrDepth = std::max(newDepth - reduction(improving, depth, moveCount, delta, thisThread->rootDelta), 0);
+          int lmrDepth = std::max(newDepth - r, 0);
 
           if (   capture
               || givesCheck)
@@ -1132,8 +1134,6 @@ moves_loop: // When in check, search starts here
 
       // Step 16. Make the move
       pos.do_move(move, st, givesCheck);
-
-      Depth r = reduction(improving, depth, moveCount, delta, thisThread->rootDelta);
 
       // Decrease reduction if position is or has been on the PV
       // and node is not likely to fail low. (~3 Elo)


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/63ec21affe833123fef34153
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 195712 W: 51625 L: 51581 D: 92506
Ptnml(0-2): 504, 20527, 55779, 20513, 533

LTC: https://tests.stockfishchess.org/tests/view/63ed3487fe833123fef375ed
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 32176 W: 8631 L: 8442 D: 15103
Ptnml(0-2): 5, 2794, 10309, 2967, 13

It's possible, albeit extremely unlikely, that this is a functional change due to the depth modification in the singular double extension. On the other hand, bench is unchanged up to depth 25.

bench 3841998