### PR TITLE
Reintroduce nnue pawn scaling with lower lazy thresholds

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -193,8 +193,8 @@ using namespace Trace;
 namespace {
 
   // Threshold for lazy and space evaluation
-  constexpr Value LazyThreshold1    =  Value(3631);
-  constexpr Value LazyThreshold2    =  Value(2084);
+  constexpr Value LazyThreshold1    =  Value(3622);
+  constexpr Value LazyThreshold2    =  Value(1962);
   constexpr Value SpaceThreshold    =  Value(11551);
 
   // KingAttackWeights[PieceType] contains king attack weights by piece type
@@ -1063,7 +1063,7 @@ Value Eval::evaluate(const Position& pos, int* complexity) {
   else
   {
       int nnueComplexity;
-      int scale = 1076 + 96 * pos.non_pawn_material() / 5120;
+      int scale = 1001 + 5 * pos.count<PAWN>() + 61 * pos.non_pawn_material() / 4096;
 
       Color stm = pos.side_to_move();
       Value optimism = pos.this_thread()->optimism[stm];


### PR DESCRIPTION
Params found with the nevergrad TBPSA optimizer via nevergrad4sf modified to:
- use SPRT LLR with fishtest STC elo gainer bounds [0, 2] as the objective function
- increase the game batch size after each new optimal point is found

The params were the optimal point after TBPSA iteration 7 and 160 nevergrad evaluations with:
- initial batch size of 96 games per evaluation
- batch size increase of 64 games after each iteration
- a budget of 512 evaluations
- TC: fixed 1.5 million nodes per move, no time limit

nevergrad4sf enables optimizing stockfish params with TBPSA:
https://github.com/vondele/nevergrad4sf

Using pentanomial game results with smaller game batch sizes was inspired by:
https://github.com/official-stockfish/Stockfish/pull/2446

Use of SPRT LLR calculated from pentanomial game results as the objective function was an experiment at maximizing the information from game batches to reduce the computational cost for TBPSA to converge on good parameters.

For the exact code used to find the params:
https://github.com/linrock/tuning-fork


Passed STC:
https://tests.stockfishchess.org/tests/view/63f4ef5ee74a12625bcd114a
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 66552 W: 17736 L: 17390 D: 31426
Ptnml(0-2): 164, 7229, 18166, 7531, 186

Passed LTC:
https://tests.stockfishchess.org/tests/view/63f56028e74a12625bcd2550
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 71264 W: 19150 L: 18787 D: 33327
Ptnml(0-2): 23, 6728, 21771, 7083, 27



bench 4115926