### PR TITLE
Simplify singular depth increment

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1083,7 +1083,7 @@ moves_loop: // When in check, search starts here
                       && ss->doubleExtensions <= 10)
                   {
                       extension = 2;
-                      depth += depth < 12;
+                      depth += 1;
                   }
               }
 


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/63ec2025fe833123fef34109
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 501984 W: 132449 L: 132730 D: 236805
Ptnml(0-2): 1402, 55789, 136915, 55460, 1426

LTC: https://tests.stockfishchess.org/tests/view/63eeacdee74a12625bcc0255
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 443224 W: 117983 L: 118182 D: 207059
Ptnml(0-2): 173, 43599, 134275, 43384, 181

bench 4224825