### PR TITLE
Fix duplicated moves generation in movepicker.

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -383,7 +383,9 @@ inline bool Position::is_chess960() const {
 
 inline bool Position::capture(Move m) const {
   assert(is_ok(m));
-  // Castling is encoded as "king captures rook"
+  // Castling is encoded as "king captures rook" so needs to be separately excluded
+  // Queen promotions are included in captures like in move generation
+  // En passant is a capture by definition so is also included
   return ((    !empty(to_sq(m)) || (type_of(m) == PROMOTION && promotion_type(m) == QUEEN)) && type_of(m) != CASTLING) 
             || type_of(m) == EN_PASSANT;
 }

--- a/src/position.h
+++ b/src/position.h
@@ -384,7 +384,8 @@ inline bool Position::is_chess960() const {
 inline bool Position::capture(Move m) const {
   assert(is_ok(m));
   // Castling is encoded as "king captures rook"
-  return (!empty(to_sq(m)) && type_of(m) != CASTLING) || type_of(m) == EN_PASSANT;
+  return ((    !empty(to_sq(m)) || (type_of(m) == PROMOTION && promotion_type(m) == QUEEN)) && type_of(m) != CASTLING) 
+            || type_of(m) == EN_PASSANT;
 }
 
 inline Piece Position::captured_piece() const {


### PR DESCRIPTION
This patch fixes a pretty old bug which can be described as following - in a lot of cases movepicker returned some moves more than once which lead to them being searched more than once.
This bug was possible because of how we use queen promotions - they are generated as a captures but are not included in position function which checks if move is a capture. Thus if any refutation (killer or countermove) was a queen promotion it was searched twice - once as a capture and one as a refutation.
This patch affects various things, namely stats assignments for queen promotions and other moves if best move is queen promotion, also some heuristics in search and qsearch.
With this patch every queen promotion is now considered a capture.
After this patch number of found duplicated moves is 0 during normal 13 depth bench run.
Passed STC:
https://tests.stockfishchess.org/tests/view/63f77e01e74a12625bcd87d7
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 80920 W: 21455 L: 21289 D: 38176
Ptnml(0-2): 198, 8839, 22241, 8963, 219 
Passed LTC:
https://tests.stockfishchess.org/tests/view/63f7e020e74a12625bcd9a76
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 89712 W: 23674 L: 23533 D: 42505
Ptnml(0-2): 24, 8737, 27202, 8860, 33 
bench 4057163