### PR TITLE
Remove unnecessary check for non-excluded moves inside move-picking loop

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1058,7 +1058,6 @@ moves_loop: // When in check, search starts here
           if (   !rootNode
               &&  depth >= 4 - (thisThread->completedDepth > 21) + 2 * (PvNode && tte->is_pv())
               &&  move == ttMove
-              && !excludedMove // Avoid recursive singular search
            /* &&  ttValue != VALUE_NONE Already implicit in the next condition */
               &&  abs(ttValue) < VALUE_KNOWN_WIN
               && (tte->bound() & BOUND_LOWER)


### PR DESCRIPTION
This removes checking for !excludedMove condition where the check (singularExtensionNode) was done outside the move-picking loop in search thus was needed to avoid a recursive singular search. The check is now not needed since excluded moves are pruned at the very beginning of the move-picking loop.

No functional change