### PR TITLE
Use common_parent_position hint also at PVNode TT hits.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -742,7 +742,11 @@ namespace {
         if (eval == VALUE_NONE)
             ss->staticEval = eval = evaluate(pos, &complexity);
         else // Fall back to (semi)classical complexity for TT hits, the NNUE complexity is lost
+        {
             complexity = abs(ss->staticEval - pos.psq_eg_stm());
+            if (PvNode)
+               Eval::NNUE::hint_common_parent_position(pos);
+        }
 
         // ttValue can be used as a better position evaluation (~7 Elo)
         if (    ttValue != VALUE_NONE


### PR DESCRIPTION
Credits to Stefan Geschwentner (locutus2) showing that the hint is useful on PvNodes. In contrast to his test,
this version avoids to use the hint when in check. I believe checking positions aren't good candidates for the hint because:
- evasion moves are rather few, so a checking pos. has much less childs than a normal position
- if the king has to move the NNUE eval can't use incremental updates, so the child nodes have to do a full refresh anyway.

Passed STC speedup bounds

[https://tests.stockfishchess.org/tests/view/63f9c5b1e74a12625bcdf585](https://tests.stockfishchess.org/tests/view/63f9c5b1e74a12625bcdf585)
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 124472 W: 33268 L: 32846 D: 58358
Ptnml(0-2): 350, 12986, 35170, 13352, 378

no functional change
bench:  4705194