### PR TITLE
NNUE accumulator update in probcut.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -892,6 +892,8 @@ namespace {
                     return value;
                 }
             }
+
+        Eval::NNUE::hint_common_parent_position(pos);
     }
 
     // Step 11. If the position is not in TT, decrease depth by 3.


### PR DESCRIPTION
Call the recently added hint function for NNUE accumulator update after a failed probcut search. In this case we already searched at least some captures and tt move which, however, is not sufficient for a cutoff. So it seems we have a greater chance that the full search will also have no cutoff and hence all moves have to be searched.

STC: https://tests.stockfishchess.org/tests/view/63fa74a4e74a12625bce1823
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 70096 W: 18770 L: 18423 D: 32903
Ptnml(0-2): 191, 7342, 19654, 7651, 210

To be sure that we have no heavy interaction retest on top of PR 4410.

Rebased STC: https://tests.stockfishchess.org/tests/view/63fb2f62e74a12625bce3b03
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 137688 W: 36790 L: 36349 D: 64549
Ptnml(0-2): 397, 14373, 38919, 14702, 453

No functional change