### PR TITLE
Clean-up Of Fix duplicated moves generation in movepicker.

### DIFF
--- a/src/movegen.h
+++ b/src/movegen.h
@@ -28,7 +28,7 @@ namespace Stockfish {
 class Position;
 
 enum GenType {
-  CAPTURES,
+  NON_QUIETS,
   QUIETS,
   QUIET_CHECKS,
   EVASIONS,

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -80,7 +80,7 @@ struct Stats<T, D, Size> : public std::array<StatsEntry<T, D>, Size> {};
 
 /// In stats table, D=0 means that the template parameter is not used
 enum StatsParams { NOT_USED = 0 };
-enum StatsType { NoCaptures, Captures };
+enum StatsType { Quiets, NonQuiets };
 
 /// ButterflyHistory records how often quiet moves have been successful or
 /// unsuccessful during the current search, and is used for reduction and move
@@ -93,8 +93,8 @@ typedef Stats<int16_t, 7183, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)> Butterfl
 /// move, see www.chessprogramming.org/Countermove_Heuristic
 typedef Stats<Move, NOT_USED, PIECE_NB, SQUARE_NB> CounterMoveHistory;
 
-/// CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
-typedef Stats<int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB> CapturePieceToHistory;
+/// NonQuietPieceToHistory is addressed by a move's [piece][to][captured piece type]
+typedef Stats<int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB> NonQuietPieceToHistory;
 
 /// PieceToHistory is like ButterflyHistory but is addressed by a move's [piece][to]
 typedef Stats<int16_t, 29952, PIECE_NB, SQUARE_NB> PieceToHistory;
@@ -120,15 +120,15 @@ public:
   MovePicker(const MovePicker&) = delete;
   MovePicker& operator=(const MovePicker&) = delete;
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*,
-                                           const CapturePieceToHistory*,
+                                           const NonQuietPieceToHistory*,
                                            const PieceToHistory**,
                                            Move,
                                            const Move*);
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*,
-                                           const CapturePieceToHistory*,
+                                           const NonQuietPieceToHistory*,
                                            const PieceToHistory**,
                                            Square);
-  MovePicker(const Position&, Move, Value, const CapturePieceToHistory*);
+  MovePicker(const Position&, Move, Value, const NonQuietPieceToHistory*);
   Move next_move(bool skipQuiets = false);
 
   Bitboard threatenedPieces;
@@ -141,10 +141,10 @@ private:
 
   const Position& pos;
   const ButterflyHistory* mainHistory;
-  const CapturePieceToHistory* captureHistory;
+  const NonQuietPieceToHistory* nonQuietHistory;
   const PieceToHistory** continuationHistory;
   Move ttMove;
-  ExtMove refutations[3], *cur, *endMoves, *endBadCaptures;
+  ExtMove refutations[3], *cur, *endMoves, *endBadNonQuiets;
   int stage;
   Square recaptureSquare;
   Value threshold;

--- a/src/position.h
+++ b/src/position.h
@@ -383,7 +383,9 @@ inline bool Position::is_chess960() const {
 
 inline bool Position::capture(Move m) const {
   assert(is_ok(m));
-  // Castling is encoded as "king captures rook"
+  // Castling is encoded as "king captures rook" so needs to be separately excluded
+  // Queen promotions are included in captures like in move generation
+  // En passant is a capture by definition so is also included
   return ((    !empty(to_sq(m)) || (type_of(m) == PROMOTION && promotion_type(m) == QUEEN)) && type_of(m) != CASTLING) 
             || type_of(m) == EN_PASSANT;
 }

--- a/src/position.h
+++ b/src/position.h
@@ -384,7 +384,8 @@ inline bool Position::is_chess960() const {
 inline bool Position::capture(Move m) const {
   assert(is_ok(m));
   // Castling is encoded as "king captures rook"
-  return (!empty(to_sq(m)) && type_of(m) != CASTLING) || type_of(m) == EN_PASSANT;
+  return ((    !empty(to_sq(m)) || (type_of(m) == PROMOTION && promotion_type(m) == QUEEN)) && type_of(m) != CASTLING) 
+            || type_of(m) == EN_PASSANT;
 }
 
 inline Piece Position::captured_piece() const {

--- a/src/position.h
+++ b/src/position.h
@@ -125,7 +125,7 @@ public:
   // Properties of moves
   bool legal(Move m) const;
   bool pseudo_legal(const Move m) const;
-  bool capture(Move m) const;
+  bool is_non_quiet(Move m) const;
   bool gives_check(Move m) const;
   Piece moved_piece(Move m) const;
   Piece captured_piece() const;
@@ -381,11 +381,14 @@ inline bool Position::is_chess960() const {
   return chess960;
 }
 
-inline bool Position::capture(Move m) const {
+inline bool Position::is_non_quiet(Move m) const {
   assert(is_ok(m));
-  // Castling is encoded as "king captures rook" so needs to be separately excluded
-  // Queen promotions are included in captures like in move generation
-  // En passant is a capture by definition so is also included
+  // We consider a move to be non-quiet if it is a capture or a queen promotion
+  // this becomes necessary for a consistent behavior through move generation, move picker and search
+  // to refute previously picked queen promotions in movepicker.
+  
+  // We exclude Castling because it is encoded as "king captures rook"
+  // En passant is a capture by definition so is included
   return ((    !empty(to_sq(m)) || (type_of(m) == PROMOTION && promotion_type(m) == QUEEN)) && type_of(m) != CASTLING) 
             || type_of(m) == EN_PASSANT;
 }

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1203,7 +1203,7 @@ WDLScore search(Position& pos, ProbeState* result) {
 
     for (const Move move : moveList)
     {
-        if (   !pos.capture(move)
+        if (   ((pos.empty(to_sq(move)) || type_of(move) == CASTLING) && type_of(move) != EN_PASSANT)
             && (!CheckZeroingMoves || type_of(pos.moved_piece(move)) != PAWN))
             continue;
 
@@ -1472,7 +1472,8 @@ int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
 
     for (const Move move : MoveList<LEGAL>(pos))
     {
-        bool zeroing = pos.capture(move) || type_of(pos.moved_piece(move)) == PAWN;
+        bool zeroing =   (!pos.empty(to_sq(move)) && type_of(move) != CASTLING)
+                      || type_of(pos.moved_piece(move)) == PAWN;
 
         pos.do_move(move, st);
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -59,10 +59,10 @@ void Thread::clear() {
 
   counterMoves.fill(MOVE_NONE);
   mainHistory.fill(0);
-  captureHistory.fill(0);
+  nonQuietHistory.fill(0);
 
   for (bool inCheck : { false, true })
-      for (StatsType c : { NoCaptures, Captures })
+      for (StatsType c : { Quiets, NonQuiets })
           for (auto& to : continuationHistory[inCheck][c])
               for (auto& h : to)
                   h->fill(-71);

--- a/src/thread.h
+++ b/src/thread.h
@@ -73,7 +73,7 @@ public:
   Value rootDelta;
   CounterMoveHistory counterMoves;
   ButterflyHistory mainHistory;
-  CapturePieceToHistory captureHistory;
+  NonQuietPieceToHistory nonQuietHistory;
   ContinuationHistory continuationHistory[2][2];
 };
 


### PR DESCRIPTION
A clean-up dependent on pr/4405 that uses descriptive naming to better understand/read through the consistent connection between different parts of the code (movegen, movepicker and search).

No functional change