### PR TITLE
Late counter bonus: boost underestimated moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1383,8 +1383,7 @@ moves_loop: // When in check, search starts here
     // Bonus for prior countermove that caused the fail low
     else if (!priorCapture)
     {
-        // Extra bonuses for PV/Cut nodes or bad fail lows
-        int bonus = (depth > 5) + (PvNode || cutNode) + (bestValue < alpha - 97 * depth);
+        int bonus = (depth > 5) + (PvNode || cutNode) + (bestValue < alpha - 97 * depth) + ((ss-1)->moveCount > 10);
         update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, stat_bonus(depth) * bonus);
     }
 


### PR DESCRIPTION
The idea here is very intuitive: since we've just proven that the move is good, then if it previously had poor stats, boost those stats more than otherwise.

Passed STC: https://tests.stockfishchess.org/tests/view/63fb504ce74a12625bce4154
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 21128 W: 5763 L: 5481 D: 9884
Ptnml(0-2): 52, 2212, 5759, 2484, 57

Passed LTC: https://tests.stockfishchess.org/tests/view/63fb7825e74a12625bce491b
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 91904 W: 24764 L: 24359 D: 42781
Ptnml(0-2): 45, 8735, 27984, 9146, 42

bench 4318808