### PR TITLE
Update default net to nn-52471d67216a.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-1337b1adec5b.nnue"
+  #define EvalFileDefaultName   "nn-52471d67216a.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
Created by retraining the master net with modifications to the previous best dataset:
- Improving T80 oct+nov 2022 endgame lambda accuracy by rescoring with 12-16tb of syzygy 7p tablebases
- Filtering T78 jun+jul+aug 2022 with d6pv2 search to remove positions with bestmove captures or one good move
- Adding T80 sep 2022 data, rescored with 16tb of 7p tablebases, unfiltered

Trained with max-epoch 900, end-lambda 0.7, and early-fen-skipping 28.

```
python3 easy_train.py \
  --experiment-name leela96-dfrc99-T80octnovT79aprmayT78junjulaugT60novdec-filt-v2-T78sep12tb7p-T77decT80sep16tb7p-lambda7-sk28 \
  --training-dataset /data/leela96-dfrc99-T80octnovT79aprmayT78junjulaugT60novdec-filt-v2-T78sep12tb7p-T77decT80sep16tb7p.binpack \
  --nnue-pytorch-branch linrock/nnue-pytorch/easy-train-early-fen-skipping \
  --early-fen-skipping 28 \
  --start-from-engine-test-net True \
  --gpus "0," \
  --max_epoch 900 \
  --start-lambda 1.0 \
  --end-lambda 0.7 \
  --gamma 0.995 \
  --lr 4.375e-4 \
  --tui False \
  --seed $RANDOM
```

Training data was rescored and d6pv2 filtered in the same way as recent best datasets.
For preparing the merged training dataset:

```
python3 interleave_binpacks.py \
  leela96-eval-filt-v2.binpack \
  dfrc99-eval-filt-v2.binpack \
  test80-oct2022-16tb7p-eval-filt-v2-d6.binpack \
  test80-nov2022-12tb7p-eval-filt-v2-d6.binpack \
  T79-apr2022-12tb7p-eval-filt-v2.binpack \
  T79-may2022-12tb7p-eval-filt-v2.binpack \
  test78-junjulaug2022-16tb7p-eval-filt-v2-d6.binpack \
  T60-nov2021-12tb7p-eval-filt-v2.binpack \
  T60-dec2021-12tb7p-eval-filt-v2.binpack \
  T78-sep2022-12tb7p.binpack \
  test77-dec2021-16gb7p.binpack \
  test80-sep2022-16tb7p.binpack \
  /data/leela96-dfrc99-T80octnovT79aprmayT78junjulaugT60novdec-filt-v2-T78sep12tb7p-T77decT80sep16tb7p.binpack
```

Links for downloading the training data components can be found at:
https://robotmoon.com/nnue-training-data/

Local elo at 25k nodes per move:
nn-epoch839.nnue : 0.6 +/- 1.4

Passed STC:
https://tests.stockfishchess.org/tests/view/63f9ab4be74a12625bcdf02e
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 84656 W: 22681 L: 22302 D: 39673
Ptnml(0-2): 271, 9343, 22734, 9696, 284

Passed LTC:
https://tests.stockfishchess.org/tests/view/63fa3833e74a12625bce0c0e
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 184664 W: 49933 L: 49344 D: 85387
Ptnml(0-2): 111, 17977, 55561, 18578, 105

bench 4315719