### PR TITLE
Fixed misleading achitecture description for x86-64-avxvnni vs x86-64-vnni256

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -92,7 +92,7 @@ VPATH = syzygy:nnue:nnue/features
 # avx2 = yes/no       --- -mavx2             --- Use Intel Advanced Vector Extensions 2
 # avxvnni = yes/no    --- -mavxvnni          --- Use Intel Vector Neural Network Instructions AVX
 # avx512 = yes/no     --- -mavx512bw         --- Use Intel Advanced Vector Extensions 512
-# vnni256 = yes/no    --- -mavx512vnni       --- Use Intel Vector Neural Network Instructions 256
+# vnni256 = yes/no    --- -mavx256vnni       --- Use Intel Vector Neural Network Instructions 512 with 256bit operands
 # vnni512 = yes/no    --- -mavx512vnni       --- Use Intel Vector Neural Network Instructions 512
 # neon = yes/no       --- -DUSE_NEON         --- Use ARM SIMD architecture
 # dotprod = yes/no    --- -DUSE_NEON_DOTPROD --- Use ARM advanced SIMD Int8 dot product instructions
@@ -773,10 +773,10 @@ help:
 	@echo ""
 	@echo "Supported archs:"
 	@echo ""
-	@echo "x86-64-vnni512          > x86 64-bit with vnni support 512bit wide"
-	@echo "x86-64-vnni256          > x86 64-bit with vnni support 256bit wide"
+	@echo "x86-64-vnni512          > x86 64-bit with vnni 512bit support"
+	@echo "x86-64-vnni256          > x86 64-bit with vnni 512bit support, limit operands to 256bit wide"
 	@echo "x86-64-avx512           > x86 64-bit with avx512 support"
-	@echo "x86-64-avxvnni          > x86 64-bit with avxvnni support"
+	@echo "x86-64-avxvnni          > x86 64-bit with vnni 256bit support"
 	@echo "x86-64-bmi2             > x86 64-bit with bmi2 support"
 	@echo "x86-64-avx2             > x86 64-bit with avx2 support"
 	@echo "x86-64-sse41-popcnt     > x86 64-bit with sse41 and popcnt support"


### PR DESCRIPTION
The description of the following achitectures was misleading: x86-64-vnni256 and x86-64-avxvnni (also 256bit wide) - it was unclear what difference was between the two. Now it is clearly explained that "x86-64-vnni256" requires full support of AVX512-VNNI, but only 256-bit operands are used.

Here are the examples of how the instructions are generated:

x86-64-vnni512:  62 e2 7d 48 50 08       vpdpbusd (%rax),%zmm0,%zmm17
x86-64-vnni256:  62 f2 6d 28 50 08       vpdpbusd (%rax),%ymm2,%ymm1
x86-64-avxvnni:  c4 e2 65 50 40 60       {vex} vpdpbusd 0x60(%rax),%ymm3,%ymm0

As you see, the x86-64-vnni256 architecture generates 256-bit operands for a VNNI instruction vpdpbusd, but uses the EVEX previx only available on processors with AVX-512 support. Therefore, on processors with performance+efficiency cores that support VNNI 256, but have AVX512 disabled or fused off, such as Alder Lake, running Stockfish compiled with x86-64-vnni256 will give "Illegal instruction" error due to the EVEX-prefix even for a VNNI 256-bit wide instruction.

This commit does only update the description without affecting any program or build logic.