### PR TITLE
Simplify time management into linear function

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -80,7 +80,8 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
   // game time for the current move, so also cap to 20% of available game time.
   if (limits.movestogo == 0)
   {
-      optScale = std::min(0.0120 + std::pow(ply + 3.0, 0.45) * 0.0039,
+      optScale = std::min(0.0120 + 0.0039 *
+                               (ply < 80 ? 0.059 * ply + 2.58 : 0.0302 * ply + 4.89),
                            0.2 * limits.time[us] / double(timeLeft))
                  * optExtra;
       maxScale = std::min(7.0, 4.0 + ply / 12.0);


### PR DESCRIPTION
Simplify time management to linear function, namely for `ply < 80` and `ply >= 80`. This is similar to the previous function for optScale.

Non-regression STC: https://tests.stockfishchess.org/tests/view/6400220be74a12625bcf2662
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 59784 W: 16068 L: 15881 D: 27835
Ptnml(0-2): 179, 6366, 16611, 6561, 175

Non-regression LTC: https://tests.stockfishchess.org/tests/view/64009e9de74a12625bcf3ca0
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 272168 W: 72970 L: 73003 D: 126195
Ptnml(0-2): 123, 25700, 84474, 25661, 126

No functional change