### PR TITLE
Do more negative extensions.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1109,6 +1109,10 @@ moves_loop: // When in check, search starts here
               // If the eval of ttMove is less than value, we reduce it (negative extension)
               else if (ttValue <= value)
                   extension = -1;
+
+              // If the eval of ttMove is less than alpha, we reduce it (negative extension)
+              else if (ttValue <= alpha)
+                  extension = -1;
           }
 
           // Check extensions (~1 Elo)


### PR DESCRIPTION
This patch does negatively extend transposition table move if singular search failed and tt value is not bigger than alpha.
Logic is close to what we had before recent simplification of negative extensions but uses or condition instead of and condition.
Passed STC:
https://tests.stockfishchess.org/tests/view/6404c8102644b62c33934607
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 119040 W: 31841 L: 31416 D: 55783
Ptnml(0-2): 356, 13070, 32292, 13397, 405 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6405abda2644b62c33937119
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 47216 W: 12816 L: 12496 D: 21904
Ptnml(0-2): 12, 4500, 14286, 4776, 34 
bench 4747020