### PR TITLE
MSVC native application code had char vs wchar_t type mismatch and didn't compile

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -605,7 +605,7 @@ static int best_node(size_t idx) {
   DWORD byteOffset = 0;
 
   // Early exit if the needed API is not available at runtime
-  HMODULE k32 = GetModuleHandle("Kernel32.dll");
+  HMODULE k32 = GetModuleHandle(TEXT("Kernel32.dll"));
   auto fun1 = (fun1_t)(void(*)())GetProcAddress(k32, "GetLogicalProcessorInformationEx");
   if (!fun1)
       return -1;
@@ -675,7 +675,7 @@ void bindThisThread(size_t idx) {
       return;
 
   // Early exit if the needed API are not available at runtime
-  HMODULE k32 = GetModuleHandle("Kernel32.dll");
+  HMODULE k32 = GetModuleHandle(TEXT("Kernel32.dll"));
   auto fun2 = (fun2_t)(void(*)())GetProcAddress(k32, "GetNumaNodeProcessorMaskEx");
   auto fun3 = (fun3_t)(void(*)())GetProcAddress(k32, "SetThreadGroupAffinity");
   auto fun4 = (fun4_t)(void(*)())GetProcAddress(k32, "GetNumaNodeProcessorMask2");

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -234,7 +234,7 @@ public:
         }
 #else
         // Note FILE_FLAG_RANDOM_ACCESS is only a hint to Windows and as such may get ignored.
-        HANDLE fd = CreateFile(fname.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+        HANDLE fd = CreateFileA(fname.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
                                OPEN_EXISTING, FILE_FLAG_RANDOM_ACCESS, nullptr);
 
         if (fd == INVALID_HANDLE_VALUE)


### PR DESCRIPTION
### Summary of changes
It now compiles under Microsoft Visual Studio.

In Win32 API, by default, most null-terminated character strings arguments are of wchar_t (UTF16, formerly UCS16-LE) type, i.e. 2 bytes (at least) per character. So, src/misc.cpp should have proper type. Respectively, for src/syzygy/tbprobe.cpp, in Widows, file paths should be std::wstring rather than std::string. However, this requires a very big number of changes, since the config files are also keeping the 8-bit-per-character std::string strings. Therefore, just one change of using 8-byte-per-character CreateFileA make it compile under MSVC.

### Performance comparison
The existing MSVC code in Stockfish seem outdated and did not probably ever was compiled for a long time. However, with these small changes it compiles with the most recent MSVC version. This compiler can be used to debug the application, as it has very decent GUI IDE. Also, even with plan C++ it gives decent performance, comparable to that one by the officially-released Windows .EXE (POPCNT).

command: 
```
bench 2048 1 1000 default movetime
```

MSVC (no architecture like AVX512 specified, just default target basic x64):
```
Total time (ms) : 46032
Nodes searched  : 52812000
Nodes/second    : 1147288
```

Official .exe (POPCNT):
```
Total time (ms) : 46029
Nodes searched  : 56108568
Nodes/second    : 1218982
```

### Fishtest
I have submitted this diff to FishTest at https://tests.stockfishchess.org/tests/view/640dd56165775d3b539cba42 but it will unlikely affect anything. According to Disservin in Discord, "you dont need fishtest that for that local compilation and ci should be enough. also CreateFileA can even crash but no one knows since its not called; im gonna put prio -1 since fishtest is rather full and i dont see any value in this; no windows worker has picked it up :p; though you can open a pr and start a github discussion"

```
LLR: -0.11 (-2.94,2.94) <0.00,2.00>
Total: 2872 W: 760 L: 765 D: 1347
Ptnml(0-2): 17, 281, 839, 288, 11
```