### PR TITLE
Fixed implicit type casts from double to integer

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -231,7 +231,7 @@ void MainThread::search() {
       Time.availableNodes += Limits.inc[us] - Threads.nodes_searched();
 
   Thread* bestThread = this;
-  Skill skill = Skill(Options["Skill Level"], Options["UCI_LimitStrength"] ? int(Options["UCI_Elo"]) : 0);
+  Skill skill = Skill(std::lround(Options["Skill Level"]), std::lround(Options["UCI_LimitStrength"]) ? std::lround(Options["UCI_Elo"]) : 0);
 
   if (   int(Options["MultiPV"]) == 1
       && !Limits.depth
@@ -301,7 +301,7 @@ void Thread::search() {
   }
 
   size_t multiPV = size_t(Options["MultiPV"]);
-  Skill skill(Options["Skill Level"], Options["UCI_LimitStrength"] ? int(Options["UCI_Elo"]) : 0);
+  Skill skill(std::lround(Options["Skill Level"]), std::lround(Options["UCI_LimitStrength"]) ? std::lround(Options["UCI_Elo"]) : 0);
 
   // When playing with strength handicap enable MultiPV search that we will
   // use behind the scenes to retrieve a set of possible moves.


### PR DESCRIPTION
### Summary of changes

This pull request fixes implicit type casts from double to integer and made them explicit for better readability.

This implicit type cast (with theoretical data loss) caused MSVC compiler to give a warning.

I offer to use std::lround because it returns an explicit integer type (long int) and looks semantically nicer than static_cast<>.

### Fishtest results
https://tests.stockfishchess.org/tests/view/640dff2465775d3b539cc31f

```
LLR: -0.22 (-2.94,2.94) <0.00,2.00>
Total: 1000 W: 261 L: 278 D: 461
Ptnml(0-2): 5, 114, 274, 107, 0
```