### PR TITLE
Fixed 'possible loss of data' warnings

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -372,7 +372,7 @@ void dbg_print() {
     for (int i = 0; i < MaxDebugSlots; ++i)
         if ((n = stdev[i][0]))
         {
-            double r = sqrtl(E(stdev[i][2]) - sqr(E(stdev[i][1])));
+            double r = sqrt(E(stdev[i][2]) - sqr(E(stdev[i][1])));
             std::cerr << "Stdev #" << i
                       << ": Total " << n << " Stdev " << r
                       << std::endl;
@@ -382,8 +382,8 @@ void dbg_print() {
         if ((n = correl[i][0]))
         {
             double r = (E(correl[i][5]) - E(correl[i][1]) * E(correl[i][3]))
-                       / (  sqrtl(E(correl[i][2]) - sqr(E(correl[i][1])))
-                          * sqrtl(E(correl[i][4]) - sqr(E(correl[i][3]))));
+                       / (  sqrt(E(correl[i][2]) - sqr(E(correl[i][1])))
+                          * sqrt(E(correl[i][4]) - sqr(E(correl[i][3]))));
             std::cerr << "Correl. #" << i
                       << ": Total " << n << " Coefficient " << r
                       << std::endl;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -471,7 +471,7 @@ void Thread::search() {
           timeReduction = lastBestMoveDepth + 8 < completedDepth ? 1.57 : 0.65;
           double reduction = (1.4 + mainThread->previousTimeReduction) / (2.08 * timeReduction);
           double bestMoveInstability = 1 + 1.8 * totBestMoveChanges / Threads.size();
-          int complexity = mainThread->complexityAverage.value();
+          int64_t complexity = mainThread->complexityAverage.value();
           double complexPosition = std::min(1.03 + (complexity - 241) / 1552.0, 1.45);
 
           double totalTime = Time.optimum() * fallingEval * reduction * bestMoveInstability * complexPosition;


### PR DESCRIPTION
### Rationale for change

These code changes address places where variables of higher size are assigning to variables of lower size, which generate compiler warning as a potential place for loss of data when a source value is higher than the target variable can hold. The warnings are given by MSVC (Visual Studio 2019 and 2022) with default compile options.

### List of changes

On src/misc.cpp - the sqrtl() (for "long double") is not needed since the result is stored to just "double"; otherwise r should have been defined as "long double", anyway, this does not make any difference in the debug output.

On src/search.cpp - the complexityAverage.value() returns data of type "int64_t", therefore, the variable should also be of type "int64_t", it is later stored into a variable of type "double" anyway after a division, so should not be of any problem.

On src/syzygy/tbprobe.cpp - we first cast unsigned size_t "base64.size()" to signed int "base64_size", and then we are able to subtract 2 to avoid unsigned overflow. Then we use consistent type of the for loop variable, i.e. "int" everywhere.

### Fishtest results
https://tests.stockfishchess.org/tests/view/640e1d6165775d3b539cc95d
```
LLR: -0.12 (-2.94,2.94) <0.00,2.00>
Total: 1000 W: 265 L: 274 D: 461
Ptnml(0-2): 3, 112, 278, 105, 2

```