### PR TITLE
More negative extensions on nonsingular nonpv nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1104,7 +1104,7 @@ moves_loop: // When in check, search starts here
 
               // If the eval of ttMove is greater than beta, we reduce it (negative extension)
               else if (ttValue >= beta)
-                  extension = -2;
+                  extension = -2 - !PvNode;
 
               // If the eval of ttMove is less than value, we reduce it (negative extension)
               else if (ttValue <= value)


### PR DESCRIPTION
Following up the previous gainer also in this nonsingular node section of code.

Credit shared with @FauziAkram for realizing this nonsingular node stuff had some potential, and @XInTheDark for reminding us that !PvNodes better handle extensions/reductions than Pv.

Passed STC: https://tests.stockfishchess.org/tests/view/640a7bb32644b62c339457c3
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 136776 W: 36598 L: 36149 D: 64029
Ptnml(0-2): 439, 14834, 37384, 15301, 430

Passed LTC: https://tests.stockfishchess.org/tests/view/640c43a02644b62c3394b23c
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 79536 W: 21363 L: 20984 D: 37189
Ptnml(0-2): 28, 7525, 24285, 7900, 30

bench 4444953