### PR TITLE
Do more singular extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1071,7 +1071,7 @@ moves_loop: // When in check, search starts here
               && (tte->bound() & BOUND_LOWER)
               &&  tte->depth() >= depth - 3)
           {
-              Value singularBeta = ttValue - (2 + (ss->ttPv && !PvNode)) * depth;
+              Value singularBeta = ttValue - (3 + 2 * (ss->ttPv && !PvNode)) * depth / 2;
               Depth singularDepth = (depth - 1) / 2;
 
               ss->excludedMove = move;


### PR DESCRIPTION
This patch continues trend of last VLTC tuning - as measured by @dubslow most of it gains was in lowering marging in calculation of singularBeta.
This patch is a manual adjustment on top of it - it lowers multiplier of depth in calculation of singularBeta even further, from 2/3 to 1,5/2,5.
Was negative at STC:
https://tests.stockfishchess.org/tests/view/64089c632644b62c3393fc12
Elo: -2.49 +-1.7 (95%) LOS: 0.2%
Total: 40000 W: 10601 L: 10888 D: 18511
Ptnml(0-2): 123, 4580, 10875, 4305, 117
nElo: -5.03 +-3.4 (95%) PairsRatio: 0.94 
Passed 180+1.8 SPRT:
https://tests.stockfishchess.org/tests/view/640096dae74a12625bcf3b33
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 160952 W: 43753 L: 43342 D: 73857
Ptnml(0-2): 25, 13984, 52039, 14411, 17 
Passed 60+0.6 8 threads SPRT:
https://tests.stockfishchess.org/tests/view/640dca8e65775d3b539cb7f6
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 38824 W: 10825 L: 10554 D: 17445
Ptnml(0-2): 0, 2939, 13268, 3200, 5 
bench 5135356