### PR TITLE
nnue namespace cleanup

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -36,7 +36,7 @@
 #include "timeman.h"
 #include "uci.h"
 #include "incbin/incbin.h"
-
+#include "nnue/evaluate_nnue.h"
 
 // Macro to embed the default efficiently updatable neural network (NNUE) file
 // data in the engine binary (using incbin.h, by Dale Weiler).
@@ -95,7 +95,7 @@ namespace Eval {
             if (directory != "<internal>")
             {
                 ifstream stream(directory + eval_file, ios::binary);
-                if (load_eval(eval_file, stream))
+                if (NNUE::load_eval(eval_file, stream))
                     currentEvalFileName = eval_file;
             }
 
@@ -111,7 +111,7 @@ namespace Eval {
                 (void) gEmbeddedNNUEEnd; // Silence warning on unused variable
 
                 istream stream(&buffer);
-                if (load_eval(eval_file, stream))
+                if (NNUE::load_eval(eval_file, stream))
                     currentEvalFileName = eval_file;
             }
         }

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -43,16 +43,8 @@ namespace Eval {
 
   namespace NNUE {
 
-    std::string trace(Position& pos);
-    Value evaluate(const Position& pos, bool adjusted = false, int* complexity = nullptr);
-    void hint_common_parent_position(const Position& pos);
-
     void init();
     void verify();
-
-    bool load_eval(std::string name, std::istream& stream);
-    bool save_eval(std::ostream& stream);
-    bool save_eval(const std::optional<std::string>& filename);
 
   } // namespace NNUE
 

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -55,6 +55,14 @@ namespace Stockfish::Eval::NNUE {
   template <typename T>
   using LargePagePtr = std::unique_ptr<T, LargePageDeleter<T>>;
 
+  std::string trace(Position& pos);
+  Value evaluate(const Position& pos, bool adjusted = false, int* complexity = nullptr);
+  void hint_common_parent_position(const Position& pos);
+
+  bool load_eval(std::string name, std::istream& stream);
+  bool save_eval(std::ostream& stream);
+  bool save_eval(const std::optional<std::string>& filename);
+
 }  // namespace Stockfish::Eval::NNUE
 
 #endif // #ifndef NNUE_EVALUATE_NNUE_H_INCLUDED

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -34,6 +34,7 @@
 #include "tt.h"
 #include "uci.h"
 #include "syzygy/tbprobe.h"
+#include "nnue/evaluate_nnue.h"
 
 namespace Stockfish {
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -32,6 +32,7 @@
 #include "tt.h"
 #include "uci.h"
 #include "syzygy/tbprobe.h"
+#include "nnue/evaluate_nnue.h"
 
 using namespace std;
 


### PR DESCRIPTION
This patch moves the nnue namespace in the appropiate header that correspondes with the definition. It also makes navigation a bit easier imo.

I removed the `init` and `verify` functions from the nnue namespace since I think they dont quite belong there.

Im happy to hear other people's comment on this.
