### PR TITLE
[WIP] Binpack minimizer

### DIFF
--- a/src/extra/nnue_data_binpack_format.h
+++ b/src/extra/nnue_data_binpack_format.h
@@ -5048,11 +5048,21 @@ namespace chess
 
         // Generates all pseudo legal moves for the position.
         // `pos` must be a legal chess position
-        [[nodiscard]] std::vector<Move> generatePseudoLegalMoves(const Position& pos);
+        [[nodiscard]] inline std::vector<Move> generatePseudoLegalMoves(const Position& pos)
+        {
+            std::vector<Move> moves;
+            forEachPseudoLegalMove(pos, [&moves](Move move) { moves.emplace_back(move); });
+            return moves;
+        }
 
         // Generates all legal moves for the position.
         // `pos` must be a legal chess position
-        [[nodiscard]] std::vector<Move> generateLegalMoves(const Position& pos);
+        [[nodiscard]] inline std::vector<Move> generateLegalMoves(const Position& pos)
+        {
+            std::vector<Move> moves;
+            forEachLegalMove(pos, [&moves](Move move) { moves.emplace_back(move); });
+            return moves;
+        }
     }
 
     [[nodiscard]] inline bool Position::isCheck() const
@@ -6835,6 +6845,17 @@ namespace binpack
         {
             return pos.isMoveLegal(move);
         }
+
+        [[nodiscard]] bool isCapturingMove() const
+        {
+            return pos.pieceAt(move.to) != chess::Piece::none() &&
+                   pos.pieceAt(move.to).color() != pos.pieceAt(move.from).color(); // Exclude castling
+        }
+
+        [[nodiscard]] bool isInCheck() const
+        {
+            return pos.isCheck();
+        }
     };
 
     [[nodiscard]] inline TrainingDataEntry packedSfenValueToTrainingDataEntry(const nodchip::PackedSfenValue& psv)
@@ -7109,6 +7130,11 @@ namespace binpack
     {
         std::uint16_t numPlies = 0;
         std::vector<unsigned char> movetext;
+
+        [[nodiscard]] std::size_t numBytes() const
+        {
+            return movetext.size();
+        }
 
         void clear(const TrainingDataEntry& e)
         {


### PR DESCRIPTION
This a WIP binpack minimizer, motivated by the recent increase in the amount of dataset and their reduced compressibility. The following transformations are performed by the minimizer:

1. Positions that are skipped during training due to the next move being a capture/check are assigned score of 0 to improve score compression.
2. Between any two non-consecutive positions a guided search is performed to try find a missing move chain. This move chain is used if it lowers the overall size. All added positions are made to be either skipped due to move or score==VALUE_NONE.
3. Heads and tails of positions chains are trimmed if there are only positions to be skipped during training.

The search performed in pt 2. is capped by the number of nodes searched. By default the limit is `64*1024`. It is not clear what limit is good, and this part of the minimizer is the most costly. For testing purposes it can be changed by parameter `chain_search_nodes`

Since the minimization is performed under the assumptions of the **current** trainer minimized binpacks will yield different behaviour on older instances of the official trainer, and may give different behaviour on other trainers. However, the set of assumptions is limited to the absolute basics:

1. Positons with score==30002 (VALUE_NONE) are always skipped.
2. Positions with the next move being either a capture or check are always skipped.

The minimizer respects the number of threads set by `setoption name Threads value N` and uses all of them. If `N>1` then the order of positions in the dataset will (pretty much always) change.

Example invocation:

`stockfish.exe transform minimize_binpack input_file a.binpack output_file a.min.binpack`

I would like to get some feedback on whether and how we should handle versioning (of assumptions) of this. Also, I'd like feedback from @linrock on how long (estimate) it would take to minimize the currently available data and how big gains would be expected.

Personally, I tested it on a small part of some dataset I found on linrock's site https://robotmoon.com/nnue-training-data/ `dfrc_piece_0.binpack.filtered.binpack`. I took the first chunk of this file only to speed up testing. The results are as follows:
```
1.bin           3 593 240 bytes - 40 bytes per position
1.binpack       1 048 602 bytes - ~11.67 bytes per position
1.min.binpack     422 431 bytes - ~4.7 bytes per position
```

I do not know if this file is representative of other's hosted on the site and currently used during training of Stockfish networks, but I expect the gains to be similar for all the filtered datasets. Ultimately I'd like the whole dataset used for training Stockfish to be consolidated and minimized, because it got messy recently and not I know what to do to train master-strength networks.