### PR TITLE
Fix altering stats landing on B1 Square after a null move and…

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -416,6 +416,10 @@ inline Color color_of(Piece pc) {
   return Color(pc >> 3);
 }
 
+constexpr bool is_ok(Move m) {
+  return m != MOVE_NONE && m != MOVE_NULL;
+}
+
 constexpr bool is_ok(Square s) {
   return s >= SQ_A1 && s <= SQ_H8;
 }
@@ -445,10 +449,12 @@ constexpr Direction pawn_push(Color c) {
 }
 
 constexpr Square from_sq(Move m) {
+  assert(is_ok(m));
   return Square((m >> 6) & 0x3F);
 }
 
 constexpr Square to_sq(Move m) {
+  assert(is_ok(m));
   return Square(m & 0x3F);
 }
 
@@ -471,10 +477,6 @@ constexpr Move make_move(Square from, Square to) {
 template<MoveType T>
 constexpr Move make(Square from, Square to, PieceType pt = KNIGHT) {
   return Move(T + ((pt - KNIGHT) << 12) + (from << 6) + to);
-}
-
-constexpr bool is_ok(Move m) {
-  return from_sq(m) != to_sq(m); // Catch MOVE_NULL and MOVE_NONE
 }
 
 /// Based on a congruential pseudo random number generator

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -358,14 +358,14 @@ std::string UCI::square(Square s) {
 
 string UCI::move(Move m, bool chess960) {
 
-  Square from = from_sq(m);
-  Square to = to_sq(m);
-
   if (m == MOVE_NONE)
       return "(none)";
 
   if (m == MOVE_NULL)
       return "0000";
+
+  Square from = from_sq(m);
+  Square to = to_sq(m);
 
   if (type_of(m) == CASTLING && !chess960)
       to = make_square(to > from ? FILE_G : FILE_C, rank_of(from));


### PR DESCRIPTION
… considering counter-moves on A1 for root node.

fixes https://github.com/official-stockfish/Stockfish/issues/4333 by preventing calls to from_sq and to_sq functions over null-moves and none-moves.

Passed STC:
https://tests.stockfishchess.org/tests/view/640ebba865775d3b539cea70
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 207720 W: 55272 L: 55240 D: 97208
Ptnml(0-2): 657, 22919, 56667, 22969, 648

Passed LTC:
https://tests.stockfishchess.org/tests/view/640fb39965775d3b539d2a78
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 193040 W: 51959 L: 51917 D: 89164
Ptnml(0-2): 93, 18711, 58877, 18739, 100

bench: 4980082