### PR TITLE
Fix capturing underpromotions issue

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -25,13 +25,21 @@ namespace Stockfish {
 
 namespace {
 
-  template<GenType Type, Direction D>
+  template<GenType Type, Direction D, bool Enemy>
   ExtMove* make_promotions(ExtMove* moveList, [[maybe_unused]] Square to) {
 
     if constexpr (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS)
+    {
         *moveList++ = make<PROMOTION>(to - D, to, QUEEN);
+        if constexpr (Enemy && Type == CAPTURES)
+        {
+            *moveList++ = make<PROMOTION>(to - D, to, ROOK);
+            *moveList++ = make<PROMOTION>(to - D, to, BISHOP);
+            *moveList++ = make<PROMOTION>(to - D, to, KNIGHT);
+        }   
+    }
 
-    if constexpr (Type == QUIETS || Type == EVASIONS || Type == NON_EVASIONS)
+    if constexpr ((Type == QUIETS && !Enemy) || Type == EVASIONS || Type == NON_EVASIONS)
     {
         *moveList++ = make<PROMOTION>(to - D, to, ROOK);
         *moveList++ = make<PROMOTION>(to - D, to, BISHOP);
@@ -106,13 +114,13 @@ namespace {
             b3 &= target;
 
         while (b1)
-            moveList = make_promotions<Type, UpRight>(moveList, pop_lsb(b1));
+            moveList = make_promotions<Type, UpRight, true>(moveList, pop_lsb(b1));
 
         while (b2)
-            moveList = make_promotions<Type, UpLeft >(moveList, pop_lsb(b2));
+            moveList = make_promotions<Type, UpLeft, true>(moveList, pop_lsb(b2));
 
         while (b3)
-            moveList = make_promotions<Type, Up     >(moveList, pop_lsb(b3));
+            moveList = make_promotions<Type, Up,    false>(moveList, pop_lsb(b3));
     }
 
     // Standard and en passant captures


### PR DESCRIPTION
Fix underpromotion captures are generated amongst quiets although dealt with as a capture_stage in search, this makes not skipping them when move count pruning kicks-in consistent with updating their histories amongst captures.

Passed STC:
https://tests.stockfishchess.org/tests/view/6415579f65775d3b539e7537
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 118896 W: 31678 L: 31553 D: 55665
Ptnml(0-2): 356, 12911, 32793, 13028, 360

Passed LTC:
https://tests.stockfishchess.org/tests/view/641633b965775d3b539e9e95
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 126800 W: 34255 L: 34148 D: 58397
Ptnml(0-2): 57, 12216, 38763, 12291, 73

bench: 5049716