### PR TITLE
Follow up fix to capture_stage()

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -394,7 +394,7 @@ inline bool Position::capture(Move m) const {
 // is needed to avoid the generation of duplicate moves.
 inline bool Position::capture_stage(Move m) const {
   assert(is_ok(m));
-  return  capture(m) || promotion_type(m) == QUEEN;
+  return (capture(m) && type_of(m) != PROMOTION) || promotion_type(m) == QUEEN;
 }
 
 inline Piece Position::captured_piece() const {


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/6414203565775d3b539e3aed
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 109216 W: 29198 L: 29064 D: 50954
Ptnml(0-2): 338, 11548, 30674, 11738, 310 

LTC https://tests.stockfishchess.org/tests/view/6415253b65775d3b539e6b84
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 242456 W: 65033 L: 65039 D: 112384
Ptnml(0-2): 103, 23346, 74343, 23326, 110 

bench: 5104847

This is a follow up fix to https://github.com/official-stockfish/Stockfish/pull/4436 and https://github.com/official-stockfish/Stockfish/pull/4405
Credit to @vondele