### PR TITLE
Update Elo estimates for terms in search.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1048,7 +1048,7 @@ moves_loop: // When in check, search starts here
               lmrDepth = std::max(lmrDepth, 0);
 
               // Prune moves with negative SEE (~4 Elo)
-              if (!pos.see_ge(move, Value(-24 * lmrDepth * lmrDepth - 15 * lmrDepth)))
+              if (!pos.see_ge(move, Value(-24 * lmrDepth * lmrDepth - 16 * lmrDepth)))
                   continue;
           }
       }
@@ -1330,9 +1330,9 @@ moves_loop: // When in check, search starts here
 
                   // Reduce other moves if we have found at least one score improvement
                   if (   depth > 1
-                      && depth < 6
-                      && beta  <  10534
-                      && alpha > -10534)
+                      && ((depth >= 6 && improving && complexity > 1040) || depth < 6)
+                      && beta  <  10794
+                      && alpha > -10794)
                       depth -= 1;
 
                   assert(depth > 0);


### PR DESCRIPTION
Setting the elo worth of some functions which were not tested before.
All tests run at 10+0.1 (STC), 25000 games (Same as #4294).
Book used: UHO_XXL_+0.90_+1.19.epd

Values are rounded to the nearest non-negative integer.

Test links:
https://tests.stockfishchess.org/tests/view/6419ab5b65775d3b539f46c6
https://tests.stockfishchess.org/tests/view/6419adb465775d3b539f4730
https://tests.stockfishchess.org/tests/view/6419ae9c65775d3b539f4756
https://tests.stockfishchess.org/tests/view/6419b03f65775d3b539f47a8
https://tests.stockfishchess.org/tests/view/6419b35d65775d3b539f4860
https://tests.stockfishchess.org/tests/view/6419b6b965775d3b539f48e6
https://tests.stockfishchess.org/tests/view/6419cade65775d3b539f4cd5
https://tests.stockfishchess.org/tests/view/6419cbb565775d3b539f4d01
https://tests.stockfishchess.org/tests/view/6419cc6965775d3b539f4d1e
