### PR TITLE
Remove non_pawn_material in NNUE::evaluate

### DIFF
--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -148,7 +148,7 @@ namespace Stockfish::Eval::NNUE {
     // overaligning stack variables with alignas() doesn't work correctly.
 
     constexpr uint64_t alignment = CacheLineSize;
-    int delta = 24 - pos.non_pawn_material() / 9560;
+    constexpr int delta = 24;
 
 #if defined(ALIGNAS_ON_STACK_VARIABLES_BROKEN)
     TransformedFeatureType transformedFeaturesUnaligned[


### PR DESCRIPTION
After "Use NNUE complexity in search, retune related parameters" commit, the effect of non-pawn material adjustment has been nearly diminished. This patch removes pos.non_pawn_material as a simplification, which passed non-regression tests with both STC and LTC.

Passed non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 75152 W: 20030 L: 19856 D: 35266
Ptnml(0-2): 215, 8281, 20459, 8357, 264
https://tests.stockfishchess.org/tests/view/641ab471db43ab2ba6f7bc58

Passed non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 193864 W: 51870 L: 51829 D: 90165
Ptnml(0-2): 86, 18968, 58794, 18987, 97
https://tests.stockfishchess.org/tests/view/641b4fe6db43ab2ba6f7db96

Bench: 4476915