### PR TITLE
Added support for the Intel oneAPI DPC++/C++ Compiler (icx)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -96,6 +96,7 @@ VPATH = syzygy:nnue:nnue/features
 # vnni512 = yes/no    --- -mavx512vnni       --- Use Intel Vector Neural Network Instructions 512
 # neon = yes/no       --- -DUSE_NEON         --- Use ARM SIMD architecture
 # dotprod = yes/no    --- -DUSE_NEON_DOTPROD --- Use ARM advanced SIMD Int8 dot product instructions
+# pthread = yes/no    --- -DUSE_PTHREADS     --- include <pthread.h> (should be "no" for Windows native compilers)
 #
 # Note that Makefile is space sensitive, so when adding new architectures
 # or modifying existing flags, you have to make sure there are no extra spaces
@@ -142,6 +143,7 @@ vnni256 = no
 vnni512 = no
 neon = no
 dotprod = no
+pthread = yes
 arm_version = 0
 STRIP = strip
 
@@ -428,7 +430,15 @@ endif
 ifeq ($(COMP),icc)
 	comp=icc
 	CXX=icpc
-	CXXFLAGS += -diag-disable 1476,10120 -Wcheck -Wabi -Wdeprecated -strict-ansi
+	CXXFLAGS += -diag-disable=1476,10120,10441 -Wcheck -Wabi -Wdeprecated -strict-ansi
+	LDFLAGS += -diag-disable=10441
+endif
+
+ifeq ($(COMP),icx)
+        comp=icx
+        CXX=icpx
+        CXXFLAGS += --intel -pedantic -Wextra -Wshadow -Wmissing-prototypes \
+                    -Wconditional-uninitialized -Wabi -Wdeprecated
 endif
 
 ifeq ($(COMP),clang)
@@ -502,6 +512,9 @@ endif
 ifeq ($(comp),icc)
 	profile_make = icc-profile-make
 	profile_use = icc-profile-use
+else ifeq ($(comp),icx)
+        profile_make = icx-profile-make
+        profile_use = icx-profile-use
 else ifeq ($(comp),clang)
 	profile_make = clang-profile-make
 	profile_use = clang-profile-use
@@ -535,6 +548,18 @@ endif
 
 ### On mingw use Windows threads, otherwise POSIX
 ifneq ($(comp),mingw)
+	ifeq ($(target_windows),yes)
+		ifeq ($(comp),$(filter $(comp),icc icx))
+			pthread = no
+		else
+			pthread = yes
+		endif
+        else
+		pthread = yes
+	endif
+endif
+
+ifeq ($(pthread),yes)
 	CXXFLAGS += -DUSE_PTHREADS
 	# On Android Bionic's C library comes with its own pthread implementation bundled in
 	ifneq ($(OS),Android)
@@ -572,7 +597,7 @@ ifeq ($(optimize),yes)
 	endif
 
 	ifeq ($(KERNEL),Darwin)
-		ifeq ($(comp),$(filter $(comp),clang icc))
+		ifeq ($(comp),$(filter $(comp),clang icc icx))
 			CXXFLAGS += -mdynamic-no-pic
 		endif
 
@@ -618,63 +643,63 @@ endif
 ### 3.6 SIMD architectures
 ifeq ($(avx2),yes)
 	CXXFLAGS += -DUSE_AVX2
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icc icx))
 		CXXFLAGS += -mavx2 -mbmi
 	endif
 endif
 
 ifeq ($(avxvnni),yes)
 	CXXFLAGS += -DUSE_VNNI -DUSE_AVXVNNI
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icc icx))
 		CXXFLAGS += -mavxvnni
 	endif
 endif
 
 ifeq ($(avx512),yes)
 	CXXFLAGS += -DUSE_AVX512
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icc icx))
 		CXXFLAGS += -mavx512f -mavx512bw
 	endif
 endif
 
 ifeq ($(vnni256),yes)
 	CXXFLAGS += -DUSE_VNNI
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icc icx))
 		CXXFLAGS += -mavx512f -mavx512bw -mavx512vnni -mavx512dq -mavx512vl -mprefer-vector-width=256
 	endif
 endif
 
 ifeq ($(vnni512),yes)
 	CXXFLAGS += -DUSE_VNNI
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
-		CXXFLAGS += -mavx512vnni -mavx512dq -mavx512vl
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icc icx))
+		CXXFLAGS += -mavx512f -mavx512bw -mavx512vnni -mavx512dq -mavx512vl -mprefer-vector-width=512
 	endif
 endif
 
 ifeq ($(sse41),yes)
 	CXXFLAGS += -DUSE_SSE41
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icc icx))
 		CXXFLAGS += -msse4.1
 	endif
 endif
 
 ifeq ($(ssse3),yes)
 	CXXFLAGS += -DUSE_SSSE3
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icc icx))
 		CXXFLAGS += -mssse3
 	endif
 endif
 
 ifeq ($(sse2),yes)
 	CXXFLAGS += -DUSE_SSE2
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icc icx))
 		CXXFLAGS += -msse2
 	endif
 endif
 
 ifeq ($(mmx),yes)
 	CXXFLAGS += -DUSE_MMX
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icc icx))
 		CXXFLAGS += -mmmx
 	endif
 endif
@@ -697,21 +722,27 @@ endif
 ### 3.7 pext
 ifeq ($(pext),yes)
 	CXXFLAGS += -DUSE_PEXT
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
 		CXXFLAGS += -mbmi2
 	endif
 endif
 
 ### 3.7.1 Try to include git commit sha for versioning
-GIT_SHA = $(shell git rev-parse --short HEAD 2>/dev/null)
-ifneq ($(GIT_SHA), )
-	CXXFLAGS += -DGIT_SHA=\"$(GIT_SHA)\"
+###       if not already specified as a make flag
+ifeq ($(GIT_SHA),)
+	GIT_SHA = $(shell git rev-parse --short HEAD 2>/dev/null)
+	ifneq ($(GIT_SHA), )
+		CXXFLAGS += -DGIT_SHA=\"$(GIT_SHA)\"
+	endif
 endif
 
 ### 3.7.2 Try to include git commit date for versioning
-GIT_DATE = $(shell git show -s --date=format:'%Y%m%d' --format=%cd HEAD 2>/dev/null)
-ifneq ($(GIT_DATE), )
-	CXXFLAGS += -DGIT_DATE=\"$(GIT_DATE)\"
+###       if not already specified as a make flag
+ifeq ($(GIT_DATE),)
+	GIT_DATE = $(shell git show -s --date=format:'%Y%m%d' --format=%cd HEAD 2>/dev/null)
+	ifneq ($(GIT_DATE), )
+		CXXFLAGS += -DGIT_DATE=\"$(GIT_DATE)\"
+	endif
 endif
 
 ### 3.8 Link Time Optimization
@@ -719,8 +750,11 @@ endif
 ### needs access to the optimization flags.
 ifeq ($(optimize),yes)
 ifeq ($(debug), no)
-	ifeq ($(comp),clang)
+        ifeq ($(comp),$(filter $(comp),clang icx))
 		CXXFLAGS += -flto=full
+		ifeq ($(comp),icx)
+			CXXFLAGS += -fwhole-program-vtables
+                endif
 		ifeq ($(target_windows),yes)
 			CXXFLAGS += -fuse-ld=lld
 		endif
@@ -807,7 +841,8 @@ help:
 	@echo "gcc                     > Gnu compiler (default)"
 	@echo "mingw                   > Gnu compiler with MinGW under Windows"
 	@echo "clang                   > LLVM Clang compiler"
-	@echo "icc                     > Intel compiler"
+	@echo "icc                     > Intel compiler classic"
+	@echo "icx                     > Intel oneAPI DPC++/C++ compiler"
 	@echo "ndk                     > Google NDK to cross-compile for Android"
 	@echo ""
 	@echo "Simple examples. If you don't know what to do, you likely want to run one of: "
@@ -833,7 +868,8 @@ endif
 
 
 .PHONY: help build profile-build strip install clean net objclean profileclean \
-        config-sanity icc-profile-use icc-profile-make gcc-profile-use gcc-profile-make \
+        config-sanity icc-profile-use icc-profile-make \
+        icx-profile-use icx-profile-make gcc-profile-use gcc-profile-make \
         clang-profile-use clang-profile-make FORCE
 
 build: net config-sanity
@@ -949,7 +985,10 @@ config-sanity: net
 	@echo "vnni256: '$(vnni256)'"
 	@echo "vnni512: '$(vnni512)'"
 	@echo "neon: '$(neon)'"
+	@echo "dotprod: '$(dotprod)'"
+	@echo "pthread: '$(pthread)'"
 	@echo "arm_version: '$(arm_version)'"
+	@echo "target_windows: '$(target_windows)'"
 	@echo ""
 	@echo "Flags:"
 	@echo "CXX: $(CXX)"
@@ -978,7 +1017,7 @@ config-sanity: net
 	@test "$(vnni256)" = "yes" || test "$(vnni256)" = "no"
 	@test "$(vnni512)" = "yes" || test "$(vnni512)" = "no"
 	@test "$(neon)" = "yes" || test "$(neon)" = "no"
-	@test "$(comp)" = "gcc" || test "$(comp)" = "icc" || test "$(comp)" = "mingw" || test "$(comp)" = "clang" \
+	@test "$(comp)" = "gcc" || test "$(comp)" = "icc" || test "$(comp)" = "icx" || test "$(comp)" = "mingw" || test "$(comp)" = "clang" \
 	|| test "$(comp)" = "armv7a-linux-androideabi16-clang"  || test "$(comp)" = "aarch64-linux-android21-clang"
 
 $(EXE): $(OBJS)
@@ -1025,6 +1064,19 @@ icc-profile-make:
 icc-profile-use:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
 	EXTRACXXFLAGS='-prof_use -prof_dir ./profdir' \
+	all
+
+icx-profile-make:
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+	EXTRACXXFLAGS='-fprofile-instr-generate ' \
+	EXTRALDFLAGS=' -fprofile-instr-generate' \
+	all
+
+icx-profile-use:
+	$(XCRUN) llvm-profdata merge -output=stockfish.profdata *.profraw
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+	EXTRACXXFLAGS='-fprofile-instr-use=stockfish.profdata' \
+	EXTRALDFLAGS='-fprofile-use ' \
 	all
 
 .depend: $(SRCS)


### PR DESCRIPTION
# Summary of Changes

This pull request modifies the Makefile to add support for the Intel oneAPI DPC++/C++ Compiler (icx). The previously used Intel C++ Compiler Classic (icc) is deprecated according to the Intel C++ Compiler Classic Developer Guide and Reference. Intel recommends transition to the Intel oneAPI DPC++/C++ Compiler (icx). See https://www.intel.com/content/www/us/en/docs/cpp-compiler/developer-guide-reference/2021-8/overview.html

1. Added the new COMP value `icx` - for the Intel oneAPI DPC++/C++ Compiler
2. Updated the parameters for the old `icc` COMP value to ensure it compiles by ICC under all Linux targets
3. The parameters of Git date and commit can be passed as make arguments to avoid shell calls if make is run under Windows
4. Added the new "pthread" option to be able to compile by native Windows compiles that does not use <pthread.h>

# Note

There is an alternative pull request https://github.com/official-stockfish/Stockfish/pull/4468 that also removes support of `icc` value for the COMP parameter and for https://github.com/official-stockfish/Stockfish/pull/4474 - added icx, removed icc, and modified the way to display git data for Makefile to work for Windows, and https://github.com/official-stockfish/Stockfish/pull/4475 with no changes to address the issues of git parameters in Makefile for Windows

# Example
```
make build ARCH=vnni512 COMP=icx
```

# Benchmarks
The reason to implement support for icx is that it generates the code which gives around 10% more nodes per second.

```
Stockfish version: dev-20230328
gcc version: 12.2.0
icx version: 2023.0.0.20221201
```
## CPU: Intel Core i9-13900; Linux
```
command: stockfish bench 1024 32 26 default depth nnue

The values below are nodes per second.

                       icx             gcc        gain
                ----------      ----------     -------
avx2            27 933 025      27 627 181       1.11%
avxvnni         29 486 536      25 908 900      13.81%
bmi2            28 039 142      26 518 643       5.73%
sse3-popcnt     20 595 596      20 118 798       2.37%
sse41-popcnt    25 866 670      25 618 401       0.97%
ssse3           27 023 829      24 725 774       9.29%
x86-64          20 614 068      17 713 642      16.37%
```

[Download output of benchmark runs of binaries compiled wish icx](https://www.masiutin.net/results-Intel-Core-i9-13900-stockfish-dev-icx.7z)
[Download output of benchmark runs of binaries compiled wish gcc](https://www.masiutin.net/results-Intel-Core-i9-13900-stockfish-dev-gcc.7z)
[Download output of benchmark runs of binaries compiled wish icc](https://www.masiutin.net/results-Intel-Core-i9-13900-stockfish-dev-icc.7z)

## CPU: AMD Ryzen 7 7700; Linux

```
command: stockfish bench 1024 32 26 default depth nnue
                     icx             gcc        gain
              ----------      ----------     -------
avx2          27 086 323      24 668 825       9.80%
avx512        27 981 608      24 094 761      16.13%
bmi2          27 688 739      24 681 561      12.18%
sse3-popcnt   16 124 186      15 992 134       0.83%
sse41-popcnt  23 565 971      21 217 509      11.07%
ssse3         22 251 882      21 639 767       2.83%
vnni256       26 860 562      24 190 235      11.04%
vnni512       26 226 429      24 475 436       7.15%
x86-64        16 582 238      16 385 216       1.20%
```

[Download output of benchmark runs on Ryzen 7 7700 of binaries compiled wish icx](https://www.masiutin.net/results-AMD-Ryzen-7-7700-stockfish-dev-icx.7z)
[Download output of benchmark runs on Ryzen 7 7700 of binaries compiled wish gcc](https://www.masiutin.net/results-AMD-Ryzen-7-7700-stockfish-dev-gcc.7z)


## CPU: i7-1065G7; Windows
### vnni512
```
command: python.exe pyshbench/pyshbench stockfish-x86-64-vnni512-mingw.exe stockfish-x86-64-vnni512-icx.exe 100

Result of 100 runs
base (...12-mingw.exe) = 1422864 +/- 15297
test (...i512-icx.exe) = 1495356 +/- 16631
diff                   =  +72491 +/- 2007

speedup        = +0.9569 
p(speedup > 0) = 1.0000
  
CPU: 4 x Intel64 Family 6 Model 126 Stepping 5, Genuinelntel
Hyperthreading: on
```
### sse4-popcnt
```
Command: python.exe pyshbench/pyshbench stockfish-x86-64-sse41-popcnt-mingw.exe stockfish-x86-64-sse41-popcnt-icx.exe 100 

Result of 100 runs
==================
base (...nt-mingw.exe) =    1268357  +/- 6427
test (...pcnt-icx.exe) =    1295157  +/- 6741
diff                   =     +26801  +/- 1053

speedup        = +0.0211
P(speedup > 0) =  1.0000

CPU: 4 x Intel64 Family 6 Model 126 Stepping 5, GenuineIntel
Hyperthreading: on 
```
## Binaries tested

[Download Linux x86-64 binaries of Stockfish dev-20230328 compiled by icx](https://www.masiutin.net/binaries-stockfish-dev-icx.7z)
[Download Linux x86-64 binaries of Stockfish dev-20230328 compiled by gcc](https://www.masiutin.net/binaries-stockfish-dev-gcc.7z)
[Download Linux x86-64 binaries of Stockfish dev-20230328 compiled by icc](https://www.masiutin.net/binaries-stockfish-dev-icc.7z)
[Download Windows x86-64 binaries of Stockfish dev-20230328 compiled by icx](https://www.masiutin.net/binaries-stockfish-dev-icx-windows-x86-64.7z)
[Download Linux x86-64 binaries  of Stockfish avxvnni dev-20230325 compiled by gcc in two variants based on whether nnue is embedded into binary](https://www.masiutin.net//stockfish-x86-64-avxvnni-gcc-nnue-embedded-vs-external.7z)
[Download Linux x86-64 binaries  of Stockfish dev-20230329-3f01e3f4 compiled by clang 16.0.0](https://www.masiutin.net/binaries-stockfish-dev-clang.7z)

