### PR TITLE
Update default net to nn-dabb1ed23026.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-52471d67216a.nnue"
+  #define EvalFileDefaultName   "nn-dabb1ed23026.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
Created by retraining the master net with these modifications:
- New filtering methods for existing data from T80 sep+oct2022, T79 apr2022, T78 jun+jul+aug+sep2022, T77 dec2021
- Adding new filtered data from T80 aug2022 and T78 apr+may2022
- Increasing early-fen-skipping from 28 to 30

```
python3 easy_train.py \
  --experiment-name leela96-dfrc99-T80novT79mayT60novdec-v2-T80augsepoctT79aprT78aprtosep-v6-T77dec-v3-sk30 \
  --training-dataset /data/leela96-dfrc99-T80novT79mayT60novdec-v2-T80augsepoctT79aprT78aprtosep-v6-T77dec-v3.binpack \
  --nnue-pytorch-branch linrock/nnue-pytorch/misc-fixes \
  --start-from-engine-test-net True \
  --early-fen-skipping 30 \
  --max_epoch 900 \
  --start-lambda 1.0 \
  --end-lambda 0.7 \
  --lr 4.375e-4 \
  --gamma 0.995 \
  --tui False \
  --gpus "0," \
  --seed $RANDOM
```

The v3 filtering used for data from T77dec 2021 differs from v2 filtering in that:
- To improve binpack compression, positions after ply 28 were skipped during training by setting position scores to VALUE_NONE (32002) instead of removing them entirely
- All early-game positions with ply <= 28 were removed to maximize binpack compression
- Only bestmove captures at d6pv2 search were skipped, not 2nd bestmove captures
- Binpack compression was repaired for the remaining positions by effectively replacing bestmoves with "played moves" to maintain contiguous sequences of positions in the training game data

After improving binpack compression, The T77 dec2021 data size was reduced from 95G to 19G.

The v6 filtering used for data from T80augsepoctT79aprT78aprtosep 2022 differs from v2 in that:
- All positions with only one legal move were removed
- Tighter score differences at d6pv2 search were used to remove more positions with only one good move than before
- d6pv2 search was not used to remove positions where the best 2 moves were captures

The command for preparing the dataset:

```
python3 interleave_binpacks.py \
  nn-547-dataset/leela96-eval-filt-v2.binpack \
  nn-547-dataset/dfrc99-eval-filt-v2.binpack \
  nn-547-dataset/test80-nov2022-12tb7p-eval-filt-v2-d6.binpack \
  nn-547-dataset/T79-may2022-12tb7p-eval-filt-v2.binpack \
  nn-547-dataset/T60-nov2021-12tb7p-eval-filt-v2.binpack \
  nn-547-dataset/T60-dec2021-12tb7p-eval-filt-v2.binpack \
  filt-v6/test80-aug2022-16tb7p-filter-v6.binpack \
  filt-v6/test80-sep2022-16tb7p-filter-v6.binpack \
  filt-v6/test80-oct2022-16tb7p-filter-v6.binpack \
  filt-v6/test79-apr2022-16tb7p-filter-v6.binpack \
  filt-v6/test78-aprmay2022-16tb7p-filter-v6.binpack \
  filt-v6/test78-junjulaug2022-16tb7p-filter-v6.binpack \
  filt-v6/test78-sep2022-16tb7p-filter-v6.binpack \
  filt-v3/test77-dec2021-16tb7p-filt-v3.binpack \
  /data/leela96-dfrc99-T80novT79mayT60novdec-v2-T80augsepoctT79aprT78aprtosep-v6-T77dec-v3.binpack
```

The code for the new data filtering methods is available at:
https://github.com/linrock/Stockfish/tree/nnue-data-v3/nnue-data

The code for giving hexword names to .nnue files is at:
https://github.com/linrock/nnue-namer

Links for downloading the training data components can be found at:
https://robotmoon.com/nnue-training-data/

Local elo at 25k nodes per move:
nn-epoch779.nnue : 0.6 +/- 3.1

Passed STC:
https://tests.stockfishchess.org/tests/view/64212412db43ab2ba6f8efb0
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 82256 W: 22185 L: 21809 D: 38262
Ptnml(0-2): 286, 9065, 22067, 9407, 303

Passed LTC:
https://tests.stockfishchess.org/tests/view/64223726db43ab2ba6f91d6c
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 30840 W: 8437 L: 8149 D: 14254
Ptnml(0-2): 14, 2891, 9323, 3177, 15

bench 5101970