### PR TITLE
Clean up repetitive declarations for see_ge

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -95,7 +95,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePiece
 
   stage = PROBCUT_TT + !(ttm && pos.capture_stage(ttm)
                              && pos.pseudo_legal(ttm)
-                             && pos.see_ge(ttm, occupied, threshold));
+                             && pos.see_ge(ttm, threshold));
 }
 
 /// MovePicker::score() assigns a numerical value to each move in a list, used
@@ -197,7 +197,7 @@ top:
 
   case GOOD_CAPTURE:
       if (select<Next>([&](){
-                       return pos.see_ge(*cur, occupied, Value(-cur->value)) ?
+                       return pos.see_ge(*cur, Value(-cur->value)) ?
                               // Move losing capture to endBadCaptures to be tried later
                               true : (*endBadCaptures++ = *cur, false); }))
           return *(cur - 1);
@@ -264,7 +264,7 @@ top:
       return select<Best>([](){ return true; });
 
   case PROBCUT:
-      return select<Next>([&](){ return pos.see_ge(*cur, occupied, threshold); });
+      return select<Next>([&](){ return pos.see_ge(*cur, threshold); });
 
   case QCAPTURE:
       if (select<Next>([&](){ return   depth > DEPTH_QS_RECAPTURES

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -150,7 +150,6 @@ private:
   Value threshold;
   Depth depth;
   ExtMove moves[MAX_MOVES];
-  Bitboard occupied;
 };
 
 } // namespace Stockfish

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1163,6 +1163,11 @@ bool Position::see_ge(Move m, Bitboard& occupied, Value threshold) const {
   return bool(res);
 }
 
+bool Position::see_ge(Move m, Value threshold) const {
+    Bitboard occupied;
+    return see_ge(m, occupied, threshold);
+}
+
 
 /// Position::is_draw() tests whether the position is drawn by 50-move rule
 /// or by repetition. It does not detect stalemates.

--- a/src/position.h
+++ b/src/position.h
@@ -145,6 +145,7 @@ public:
 
   // Static Exchange Evaluation
   bool see_ge(Move m, Bitboard& occupied, Value threshold = VALUE_ZERO) const;
+  bool see_ge(Move m, Value threshold = VALUE_ZERO) const;
 
   // Accessing hash keys
   Key key() const;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1058,9 +1058,8 @@ moves_loop: // When in check, search starts here
 
               lmrDepth = std::max(lmrDepth, 0);
 
-              Bitboard occupied;
               // Prune moves with negative SEE (~4 Elo)
-              if (!pos.see_ge(move, occupied, Value(-24 * lmrDepth * lmrDepth - 15 * lmrDepth)))
+              if (!pos.see_ge(move, Value(-24 * lmrDepth * lmrDepth - 15 * lmrDepth)))
                   continue;
           }
       }
@@ -1545,7 +1544,6 @@ moves_loop: // When in check, search starts here
                                       prevSq);
 
     int quietCheckEvasions = 0;
-    Bitboard occupied;
 
     // Step 5. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
@@ -1582,7 +1580,7 @@ moves_loop: // When in check, search starts here
               continue;
           }
 
-          if (futilityBase <= alpha && !pos.see_ge(move, occupied, VALUE_ZERO + 1))
+          if (futilityBase <= alpha && !pos.see_ge(move, VALUE_ZERO + 1))
           {
               bestValue = std::max(bestValue, futilityBase);
               continue;
@@ -1601,7 +1599,7 @@ moves_loop: // When in check, search starts here
           continue;
 
       // Do not search moves with bad enough SEE values (~5 Elo)
-      if (!pos.see_ge(move, occupied, Value(-110)))
+      if (!pos.see_ge(move, Value(-110)))
           continue;
     }
 


### PR DESCRIPTION
The occupied bitboard is only used in one place and is otherwise thrown away. To simplify use, see_ge function can instead be overloaded. Repetitive declarations for occupied bitboard can be removed.

Passed non-regression test
https://tests.stockfishchess.org/tests/view/6421c286db43ab2ba6f908eb
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 48912 W: 13196 L: 13001 D: 22715
Ptnml(0-2): 146, 5003, 13967, 5190, 150

No functional change.
Bench: 5020718