### PR TITLE
Allow PvNode in futility pruning for captures.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1005,7 +1005,6 @@ moves_loop: // When in check, search starts here
           {
               // Futility pruning for captures (~2 Elo)
               if (   !givesCheck
-                  && !PvNode
                   && lmrDepth < 6
                   && !ss->inCheck
                   && ss->staticEval + 182 + 230 * lmrDepth + PieceValue[EG][pos.piece_on(to_sq(move))]


### PR DESCRIPTION
Passed non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 148128 W: 39428 L: 39333 D: 69367
Ptnml(0-2): 492, 16326, 40315, 16457, 474
https://tests.stockfishchess.org/tests/view/641c2dbfdb43ab2ba6f804e8

Passed non-regression LTC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 376256 W: 100906 L: 101039 D: 174311
Ptnml(0-2): 186, 36697, 114494, 36566, 185
https://tests.stockfishchess.org/tests/view/641d33b2db43ab2ba6f83338

bench: 4882639