### PR TITLE
Remove reduction for moving threatened piece

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1181,11 +1181,6 @@ moves_loop: // When in check, search starts here
       if (singularQuietLMR)
           r--;
 
-      // Decrease reduction if we move a threatened piece (~1 Elo)
-      if (   depth > 9
-          && (mp.threatenedPieces & from_sq(move)))
-          r--;
-
       // Increase reduction if next ply has a lot of fail high (~5 Elo)
       if ((ss+1)->cutoffCnt > 3)
           r++;


### PR DESCRIPTION
Simplify away "Decrease reduction if we move a threatened piece". 

Running a `dbg_hit_on()` shows that this line is only called ~0.12% of the time.

Simplification STC: https://tests.stockfishchess.org/tests/view/641ec2dcdb43ab2ba6f88103
LLR: 2.95 (-2.94,2.94) <-1.75,0.25> 
Total: 146128 W: 39168 L: 39070 D: 67890 
Ptnml(0-2): 466, 16117, 39830, 16155, 496

Simplification LTC: https://tests.stockfishchess.org/tests/view/64200689db43ab2ba6f8bca8
LLR: 2.94 (-2.94,2.94) <-1.75,0.25> 
Total: 248016 W: 66703 L: 66714 D: 114599
Ptnml(0-2): 105, 24202, 75406, 24189, 106

Bench: 4961236
