### PR TITLE
Simplify away complexityAverage

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -86,32 +86,6 @@ static inline const union { uint32_t i; char c[4]; } Le = { 0x01020304 };
 static inline const bool IsLittleEndian = (Le.c[0] == 4);
 
 
-// RunningAverage : a class to calculate a running average of a series of values.
-// For efficiency, all computations are done with integers.
-class RunningAverage {
-  public:
-
-      // Reset the running average to rational value p / q
-      void set(int64_t p, int64_t q)
-        { average = p * PERIOD * RESOLUTION / q; }
-
-      // Update average with value v
-      void update(int64_t v)
-        { average = RESOLUTION * v + (PERIOD - 1) * average / PERIOD; }
-
-      // Test if average is strictly greater than rational a / b
-      bool is_greater(int64_t a, int64_t b) const
-        { return b * average > a * (PERIOD * RESOLUTION); }
-
-      int64_t value() const
-        { return average / (PERIOD * RESOLUTION); }
-
-  private :
-      static constexpr int64_t PERIOD     = 4096;
-      static constexpr int64_t RESOLUTION = 1024;
-      int64_t average;
-};
-
 template <typename T, std::size_t MaxSize>
 class ValueList {
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -206,6 +206,16 @@ void MainThread::search() {
   }
   else
   {
+      int rootComplexity;
+      bestValue = -VALUE_INFINITE;
+
+      if (Eval::useNNUE)
+          Eval::NNUE::evaluate(rootPos, true, &rootComplexity);
+      else
+          Eval::evaluate(rootPos, &rootComplexity);
+
+      complexity = std::min(1.03 + (rootComplexity - 241) / 1552.0, 1.45);
+
       Threads.start_searching(); // start non-main threads
       Thread::search();          // main thread start searching
   }
@@ -310,8 +320,6 @@ void Thread::search() {
       multiPV = std::max(multiPV, (size_t)4);
 
   multiPV = std::min(multiPV, rootMoves.size());
-
-  complexityAverage.set(153, 1);
 
   optimism[us] = optimism[~us] = VALUE_ZERO;
 
@@ -472,10 +480,8 @@ void Thread::search() {
           timeReduction = lastBestMoveDepth + 8 < completedDepth ? 1.57 : 0.65;
           double reduction = (1.4 + mainThread->previousTimeReduction) / (2.08 * timeReduction);
           double bestMoveInstability = 1 + 1.8 * totBestMoveChanges / Threads.size();
-          int complexity = mainThread->complexityAverage.value();
-          double complexPosition = std::min(1.03 + (complexity - 241) / 1552.0, 1.45);
 
-          double totalTime = Time.optimum() * fallingEval * reduction * bestMoveInstability * complexPosition;
+          double totalTime = Time.optimum() * fallingEval * reduction * bestMoveInstability * mainThread->complexity;
 
           // Cap used time in case of a single legal move for a better viewer experience in tournaments
           // yielding correct scores and sufficiently fast moves.
@@ -754,8 +760,6 @@ namespace {
         // Save static evaluation into transposition table
         tte->save(posKey, VALUE_NONE, ss->ttPv, BOUND_NONE, DEPTH_NONE, MOVE_NONE, eval);
     }
-
-    thisThread->complexityAverage.update(complexity);
 
     // Use static evaluation difference to improve quiet move ordering (~4 Elo)
     if (is_ok((ss-1)->currentMove) && !(ss-1)->inCheck && !priorCapture)

--- a/src/thread.h
+++ b/src/thread.h
@@ -60,7 +60,6 @@ public:
   Pawns::Table pawnsTable;
   Material::Table materialTable;
   size_t pvIdx, pvLast;
-  RunningAverage complexityAverage;
   std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;
   int selDepth, nmpMinPly;
   Color nmpColor;
@@ -87,6 +86,7 @@ struct MainThread : public Thread {
   void search() override;
   void check_time();
 
+  double complexity;
   double previousTimeReduction;
   Value bestPreviousScore;
   Value bestPreviousAverageScore;


### PR DESCRIPTION
Instead of tracking the average of complexity values, calculate complexity of root position at the beginning of the search and use it as a scaling factor in time management.

This patch is observed to be very effective with relatively short time controls.

Passed non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 58752 W: 15738 L: 15551 D: 27463
Ptnml(0-2): 164, 6194, 16478, 6371, 169
https://tests.stockfishchess.org/tests/view/6423010edb43ab2ba6f9424a

Passed non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 92872 W: 24865 L: 24729 D: 43278
Ptnml(0-2): 38, 8652, 28929, 8770, 47
https://tests.stockfishchess.org/tests/view/6423c1f0db43ab2ba6f9644f

Bench: 4935616