### PR TITLE
Add option `UCI_EvalMode`

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -169,7 +169,7 @@ vector<string> setup_bench(const Position& current, istream& is) {
           ++posCounter;
       }
 
-  list.emplace_back("setoption name Use NNUE value true");
+  list.emplace_back("setoption name UCI_EvalMode value Hybrid");
 
   return list;
 }

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -161,9 +161,9 @@ vector<string> setup_bench(const Position& current, istream& is) {
       else
       {
           if (evalType == "classical" || (evalType == "mixed" && posCounter % 2 == 0))
-              list.emplace_back("setoption name Use NNUE value false");
+              list.emplace_back("setoption name UCI_EvalMode value HCE");
           else if (evalType == "NNUE" || (evalType == "mixed" && posCounter % 2 != 0))
-              list.emplace_back("setoption name Use NNUE value true");
+              list.emplace_back("setoption name UCI_EvalMode value Hybrid");
           list.emplace_back("position fen " + fen);
           list.emplace_back(go);
           ++posCounter;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -72,7 +72,7 @@ namespace Eval {
   /// variable to have the engine search in a special directory in their distro.
 
   void NNUE::init() {
-    useNNUE = Options["Use NNUE"] && std::string(Options["UCI_EvalMode"]) != "HCE";
+    useNNUE = Options["Use NNUE"] && !(Options["UCI_EvalMode"] == "HCE");
     if (!useNNUE)
         return;
 
@@ -1055,7 +1055,7 @@ Value Eval::evaluate(const Position& pos, int* complexity) {
   // We use the much less accurate but faster Classical eval when the NNUE
   // option is set to false. Otherwise we use the NNUE eval unless the
   // PSQ advantage is decisive and several pieces remain. (~3 Elo)
-  bool useClassical = !useNNUE || (std::string(Options["UCI_EvalMode"]) == "Hybrid"
+  bool useClassical = !useNNUE || (Options["UCI_EvalMode"] == "Hybrid"
           && pos.count<ALL_PIECES>() > 7 && abs(psq) > 1781);
 
   if (useClassical)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -72,8 +72,7 @@ namespace Eval {
   /// variable to have the engine search in a special directory in their distro.
 
   void NNUE::init() {
-
-    useNNUE = Options["Use NNUE"];
+    useNNUE = Options["Use NNUE"] && std::string(Options["UCI_EvalMode"]) != "HCE";
     if (!useNNUE)
         return;
 
@@ -1056,7 +1055,8 @@ Value Eval::evaluate(const Position& pos, int* complexity) {
   // We use the much less accurate but faster Classical eval when the NNUE
   // option is set to false. Otherwise we use the NNUE eval unless the
   // PSQ advantage is decisive and several pieces remain. (~3 Elo)
-  bool useClassical = !useNNUE || (pos.count<ALL_PIECES>() > 7 && abs(psq) > 1781);
+  bool useClassical = !useNNUE || (std::string(Options["UCI_EvalMode"]) == "Hybrid"
+          && pos.count<ALL_PIECES>() > 7 && abs(psq) > 1781);
 
   if (useClassical)
       v = Evaluation<NO_TRACE>(pos).value();

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -45,6 +45,7 @@ static void on_threads(const Option& o) { Threads.set(size_t(o)); }
 static void on_tb_path(const Option& o) { Tablebases::init(o); }
 static void on_use_NNUE(const Option&) { Eval::NNUE::init(); }
 static void on_eval_file(const Option&) { Eval::NNUE::init(); }
+static void on_eval_type(const Option&) { Eval::NNUE::init(); }
 
 /// Our case insensitive less() function as required by UCI protocol
 bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const {
@@ -80,6 +81,7 @@ void init(OptionsMap& o) {
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(7, 0, 7);
   o["Use NNUE"]              << Option(true, on_use_NNUE);
+  o["UCI_EvalMode"]          << Option("Hybrid", on_eval_type);
   o["EvalFile"]              << Option(EvalFileDefaultName, on_eval_file);
 }
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -81,7 +81,7 @@ void init(OptionsMap& o) {
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(7, 0, 7);
   o["Use NNUE"]              << Option(true, on_use_NNUE);
-  o["UCI_EvalMode"]          << Option("Hybrid", on_eval_type);
+  o["UCI_EvalMode"]          << Option("Hybrid var Hybrid var NNUE var HCE", "Hybrid", on_eval_type);
   o["EvalFile"]              << Option(EvalFileDefaultName, on_eval_file);
 }
 


### PR DESCRIPTION
This option allows the user to set the evaluation mode to 3 values: "Hybrid" (default), "NNUE" (pure NNUE), "HCE" (pure classical).

It should be noted that this option completely overrides the "Use NNUE" option. However, the previous option is still kept for backwards compatibility.

In particular, this allows for pure NNUE evaluation, which has been a missing feature.

No functional change