### PR TITLE
Added COMP=icx, removed COMP=icc, made Makefile-defined parameters work with native Windows build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -96,6 +96,7 @@ VPATH = syzygy:nnue:nnue/features
 # vnni512 = yes/no    --- -mavx512vnni       --- Use Intel Vector Neural Network Instructions 512
 # neon = yes/no       --- -DUSE_NEON         --- Use ARM SIMD architecture
 # dotprod = yes/no    --- -DUSE_NEON_DOTPROD --- Use ARM advanced SIMD Int8 dot product instructions
+# pthread = yes/no    --- -DUSE_PTHREADS     --- include <pthread.h> (should be "no" for Windows native compilers)
 #
 # Note that Makefile is space sensitive, so when adding new architectures
 # or modifying existing flags, you have to make sure there are no extra spaces
@@ -142,6 +143,7 @@ vnni256 = no
 vnni512 = no
 neon = no
 dotprod = no
+pthread = yes
 arm_version = 0
 STRIP = strip
 
@@ -425,10 +427,11 @@ ifeq ($(COMP),mingw)
 	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-declarations
 endif
 
-ifeq ($(COMP),icc)
-	comp=icc
-	CXX=icpc
-	CXXFLAGS += -diag-disable 1476,10120 -Wcheck -Wabi -Wdeprecated -strict-ansi
+ifeq ($(COMP),icx)
+        comp=icx
+        CXX=icpx
+        CXXFLAGS += --intel -pedantic -Wextra -Wshadow -Wmissing-prototypes \
+                    -Wconditional-uninitialized -Wabi -Wdeprecated
 endif
 
 ifeq ($(COMP),clang)
@@ -499,9 +502,9 @@ ifeq ($(COMP),ndk)
 	LDFLAGS += -static-libstdc++ -pie -lm -latomic
 endif
 
-ifeq ($(comp),icc)
-	profile_make = icc-profile-make
-	profile_use = icc-profile-use
+ifeq ($(comp),icx)
+        profile_make = icx-profile-make
+        profile_use = icx-profile-use
 else ifeq ($(comp),clang)
 	profile_make = clang-profile-make
 	profile_use = clang-profile-use
@@ -535,6 +538,18 @@ endif
 
 ### On mingw use Windows threads, otherwise POSIX
 ifneq ($(comp),mingw)
+	ifeq ($(target_windows),yes)
+		ifeq ($(comp),icx)
+			pthread = no
+		else
+			pthread = yes
+		endif
+        else
+		pthread = yes
+	endif
+endif
+
+ifeq ($(pthread),yes)
 	CXXFLAGS += -DUSE_PTHREADS
 	# On Android Bionic's C library comes with its own pthread implementation bundled in
 	ifneq ($(OS),Android)
@@ -572,7 +587,7 @@ ifeq ($(optimize),yes)
 	endif
 
 	ifeq ($(KERNEL),Darwin)
-		ifeq ($(comp),$(filter $(comp),clang icc))
+		ifeq ($(comp),$(filter $(comp),clang icx))
 			CXXFLAGS += -mdynamic-no-pic
 		endif
 
@@ -608,8 +623,6 @@ endif
 ifeq ($(popcnt),yes)
 	ifeq ($(arch),$(filter $(arch),ppc64 armv7 armv8 arm64))
 		CXXFLAGS += -DUSE_POPCNT
-	else ifeq ($(comp),icc)
-		CXXFLAGS += -msse3 -DUSE_POPCNT
 	else
 		CXXFLAGS += -msse3 -mpopcnt -DUSE_POPCNT
 	endif
@@ -618,63 +631,63 @@ endif
 ### 3.6 SIMD architectures
 ifeq ($(avx2),yes)
 	CXXFLAGS += -DUSE_AVX2
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
 		CXXFLAGS += -mavx2 -mbmi
 	endif
 endif
 
 ifeq ($(avxvnni),yes)
 	CXXFLAGS += -DUSE_VNNI -DUSE_AVXVNNI
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
 		CXXFLAGS += -mavxvnni
 	endif
 endif
 
 ifeq ($(avx512),yes)
 	CXXFLAGS += -DUSE_AVX512
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
 		CXXFLAGS += -mavx512f -mavx512bw
 	endif
 endif
 
 ifeq ($(vnni256),yes)
 	CXXFLAGS += -DUSE_VNNI
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
 		CXXFLAGS += -mavx512f -mavx512bw -mavx512vnni -mavx512dq -mavx512vl -mprefer-vector-width=256
 	endif
 endif
 
 ifeq ($(vnni512),yes)
 	CXXFLAGS += -DUSE_VNNI
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
-		CXXFLAGS += -mavx512vnni -mavx512dq -mavx512vl
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
+		CXXFLAGS += -mavx512f -mavx512bw -mavx512vnni -mavx512dq -mavx512vl -mprefer-vector-width=512
 	endif
 endif
 
 ifeq ($(sse41),yes)
 	CXXFLAGS += -DUSE_SSE41
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
 		CXXFLAGS += -msse4.1
 	endif
 endif
 
 ifeq ($(ssse3),yes)
 	CXXFLAGS += -DUSE_SSSE3
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
 		CXXFLAGS += -mssse3
 	endif
 endif
 
 ifeq ($(sse2),yes)
 	CXXFLAGS += -DUSE_SSE2
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
 		CXXFLAGS += -msse2
 	endif
 endif
 
 ifeq ($(mmx),yes)
 	CXXFLAGS += -DUSE_MMX
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
 		CXXFLAGS += -mmmx
 	endif
 endif
@@ -697,21 +710,38 @@ endif
 ### 3.7 pext
 ifeq ($(pext),yes)
 	CXXFLAGS += -DUSE_PEXT
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
 		CXXFLAGS += -mbmi2
 	endif
 endif
 
-### 3.7.1 Try to include git commit sha for versioning
 GIT_SHA = $(shell git rev-parse --short HEAD 2>/dev/null)
 ifneq ($(GIT_SHA), )
-	CXXFLAGS += -DGIT_SHA=\"$(GIT_SHA)\"
+	ifeq ($(target_windows),yes)
+		# No need to quote the argument under Windows using the backslash,
+		# otherwise get an error in compiling misc.cpp;
+		# and since the SHA hash may only contain alphanumeric characters,
+		# we don't need to quote it at all, but pass it as a hex number,
+		# with 0x prefix (unsigned int 64-bit).
+		CXXFLAGS += -DGIT_SHA=0x$(GIT_SHA) -DGIT_SHA_IS_UINT
+	else
+		CXXFLAGS += -DGIT_SHA=\"$(GIT_SHA)\"
+	endif
 endif
 
 ### 3.7.2 Try to include git commit date for versioning
+###       if not already specified as a make flag
 GIT_DATE = $(shell git show -s --date=format:'%Y%m%d' --format=%cd HEAD 2>/dev/null)
 ifneq ($(GIT_DATE), )
-	CXXFLAGS += -DGIT_DATE=\"$(GIT_DATE)\"
+	ifeq ($(target_windows),yes)
+		# No need to quote the argument under Windows using the backslash,
+		# otherwise get an error in compiling misc.cpp;
+		# and since the date formatted as %Y%m%d may only contain digits,
+		# we don't need to quote it at all, but pass it as a decimal number (int).
+		CXXFLAGS += -DGIT_DATE=$(GIT_DATE)
+	else
+		CXXFLAGS += -DGIT_DATE=\"$(GIT_DATE)\"
+	endif
 endif
 
 ### 3.8 Link Time Optimization
@@ -719,8 +749,11 @@ endif
 ### needs access to the optimization flags.
 ifeq ($(optimize),yes)
 ifeq ($(debug), no)
-	ifeq ($(comp),clang)
+        ifeq ($(comp),$(filter $(comp),clang icx))
 		CXXFLAGS += -flto=full
+		ifeq ($(comp),icx)
+			CXXFLAGS += -fwhole-program-vtables
+                endif
 		ifeq ($(target_windows),yes)
 			CXXFLAGS += -fuse-ld=lld
 		endif
@@ -807,7 +840,7 @@ help:
 	@echo "gcc                     > Gnu compiler (default)"
 	@echo "mingw                   > Gnu compiler with MinGW under Windows"
 	@echo "clang                   > LLVM Clang compiler"
-	@echo "icc                     > Intel compiler"
+	@echo "icx                     > Intel oneAPI DPC++/C++ Compiler"
 	@echo "ndk                     > Google NDK to cross-compile for Android"
 	@echo ""
 	@echo "Simple examples. If you don't know what to do, you likely want to run one of: "
@@ -833,7 +866,9 @@ endif
 
 
 .PHONY: help build profile-build strip install clean net objclean profileclean \
-        config-sanity icc-profile-use icc-profile-make gcc-profile-use gcc-profile-make \
+        config-sanity \
+        icx-profile-use icx-profile-make \
+        gcc-profile-use gcc-profile-make \
         clang-profile-use clang-profile-make FORCE
 
 build: net config-sanity
@@ -949,7 +984,10 @@ config-sanity: net
 	@echo "vnni256: '$(vnni256)'"
 	@echo "vnni512: '$(vnni512)'"
 	@echo "neon: '$(neon)'"
+	@echo "dotprod: '$(dotprod)'"
+	@echo "pthread: '$(pthread)'"
 	@echo "arm_version: '$(arm_version)'"
+	@echo "target_windows: '$(target_windows)'"
 	@echo ""
 	@echo "Flags:"
 	@echo "CXX: $(CXX)"
@@ -978,7 +1016,7 @@ config-sanity: net
 	@test "$(vnni256)" = "yes" || test "$(vnni256)" = "no"
 	@test "$(vnni512)" = "yes" || test "$(vnni512)" = "no"
 	@test "$(neon)" = "yes" || test "$(neon)" = "no"
-	@test "$(comp)" = "gcc" || test "$(comp)" = "icc" || test "$(comp)" = "mingw" || test "$(comp)" = "clang" \
+	@test "$(comp)" = "gcc" || test "$(comp)" = "icx" || test "$(comp)" = "mingw" || test "$(comp)" = "clang" \
 	|| test "$(comp)" = "armv7a-linux-androideabi16-clang"  || test "$(comp)" = "aarch64-linux-android21-clang"
 
 $(EXE): $(OBJS)
@@ -1016,15 +1054,17 @@ gcc-profile-use:
 	EXTRALDFLAGS='-lgcov' \
 	all
 
-icc-profile-make:
-	@mkdir -p profdir
+icx-profile-make:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-prof-gen=srcpos -prof_dir ./profdir' \
+	EXTRACXXFLAGS='-fprofile-instr-generate ' \
+	EXTRALDFLAGS=' -fprofile-instr-generate' \
 	all
 
-icc-profile-use:
+icx-profile-use:
+	$(XCRUN) llvm-profdata merge -output=stockfish.profdata *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-prof_use -prof_dir ./profdir' \
+	EXTRACXXFLAGS='-fprofile-instr-use=stockfish.profdata' \
+	EXTRALDFLAGS='-fprofile-use ' \
 	all
 
 .depend: $(SRCS)

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -157,22 +157,27 @@ string engine_info(bool to_uci) {
   {
       ss << "-";
       #ifdef GIT_DATE
-      ss << GIT_DATE;
+        ss << GIT_DATE;
       #else
-      constexpr string_view months("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec");
-      string month, day, year;
-      stringstream date(__DATE__); // From compiler, format is "Sep 21 2008"
+        constexpr string_view months("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec");
+        string month, day, year;
+        stringstream date(__DATE__); // From compiler, format is "Sep 21 2008"
 
-      date >> month >> day >> year;
-      ss << year << setw(2) << setfill('0') << (1 + months.find(month) / 4) << setw(2) << setfill('0') << day;
+        date >> month >> day >> year;
+        ss << year << setw(2) << setfill('0') << (1 + months.find(month) / 4) << setw(2) << setfill('0') << day;
       #endif
 
       ss << "-";
 
       #ifdef GIT_SHA
-      ss << GIT_SHA;
+	#ifdef GIT_SHA_IS_UINT
+          const uint64_t git_sha = GIT_SHA;
+          ss << std::hex << git_sha;
+        #else
+          ss << GIT_SHA;
+        #endif
       #else
-      ss << "nogit";
+        ss << "nogit";
       #endif
   }
 


### PR DESCRIPTION
This pull request is an alternative, it is one (see p.3)) of the following three:

1) https://github.com/official-stockfish/Stockfish/pull/4464 - added icx, updated icc, added git params for Makefile (for Windows)
2) https://github.com/official-stockfish/Stockfish/pull/4468 - added icx, removed icc, added git params for Makefile (for Windows)
3) current one - https://github.com/official-stockfish/Stockfish/pull/4474 - added icx, removed icc, modified the way to display git data for Makefile to work for Windows
4) https://github.com/official-stockfish/Stockfish/pull/4475 - added icx, removed icc, no changes to address the issues of git parameters in Makefile for Windows