### PR TITLE
Made Git parameters as numeric types

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -705,13 +705,13 @@ endif
 ### 3.7.1 Try to include git commit sha for versioning
 GIT_SHA = $(shell git rev-parse --short HEAD 2>/dev/null)
 ifneq ($(GIT_SHA), )
-	CXXFLAGS += -DGIT_SHA=\"$(GIT_SHA)\"
+	CXXFLAGS += -DGIT_SHA=0x$(GIT_SHA)
 endif
 
 ### 3.7.2 Try to include git commit date for versioning
 GIT_DATE = $(shell git show -s --date=format:'%Y%m%d' --format=%cd HEAD 2>/dev/null)
 ifneq ($(GIT_DATE), )
-	CXXFLAGS += -DGIT_DATE=\"$(GIT_DATE)\"
+	CXXFLAGS += -DGIT_DATE=$(GIT_DATE)
 endif
 
 ### 3.8 Link Time Optimization

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -170,7 +170,7 @@ string engine_info(bool to_uci) {
       ss << "-";
 
       #ifdef GIT_SHA
-      ss << GIT_SHA;
+      ss << std::hex << GIT_SHA;
       #else
       ss << "nogit";
       #endif


### PR DESCRIPTION
Made Git parameters as numeric types rather than string types so we no longer need quote characters which themselves should be quoted. 

Rationale: when GIT_DATE is a number (%Y%m%d) like 20230331 and the SHA_HASH is a number (result of a hash function, truncated certain number of bits) we should pass them as numeric types.

This resolves with running this Makefile with native Windows compilers and with native Windows make.