### PR TITLE
Add ispc generic architecture

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -364,6 +364,7 @@ ifeq ($(ARCH),ispc)
 	ispc = yes
 	prefetch = yes
 	OBJS := nnue/layers/affine_transform.o nnue/nnue_feature_transformer.o helpers.o $(OBJS)
+	EXTRACXXFLAGS += -march=native
 endif
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -362,7 +362,8 @@ endif
 ifeq ($(ARCH),ispc)
 	arch = any
 	ispc = yes
-	OBJS := nnue/layers/affine_transform.o nnue/nnue_feature_transformer.o $(OBJS)
+	prefetch = yes
+	OBJS := nnue/layers/affine_transform.o nnue/nnue_feature_transformer.o helpers.o $(OBJS)
 endif
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,6 +55,10 @@ else
 	PGOBENCH = $(SDE_PATH) -- $(WINE_PATH) ./$(EXE) bench
 endif
 
+### Pattern rule for ispc files
+%.o %_ispc.h: %.ispc
+	ispc -O2 --target=host $< -h $*_ispc.h -o $*.o
+
 ### Source and object files
 SRCS = benchmark.cpp bitbase.cpp bitboard.cpp endgame.cpp evaluate.cpp main.cpp \
 	material.cpp misc.cpp movegen.cpp movepick.cpp pawns.cpp position.cpp psqt.cpp \
@@ -117,7 +121,7 @@ ifeq ($(ARCH), $(filter $(ARCH), \
                  x86-64-vnni512 x86-64-vnni256 x86-64-avx512 x86-64-avxvnni x86-64-bmi2 \
                  x86-64-avx2 x86-64-sse41-popcnt x86-64-modern x86-64-ssse3 x86-64-sse3-popcnt \
                  x86-64 x86-32-sse41-popcnt x86-32-sse2 x86-32 ppc-64 ppc-32 e2k \
-                 armv7 armv7-neon armv8 armv8-dotprod apple-silicon general-64 general-32 riscv64))
+                 armv7 armv7-neon armv8 armv8-dotprod apple-silicon general-64 general-32 riscv64 ispc))
    SUPPORTED_ARCH=true
 else
    SUPPORTED_ARCH=false
@@ -143,6 +147,7 @@ vnni512 = no
 neon = no
 dotprod = no
 arm_version = 0
+ispc = no
 STRIP = strip
 
 ### 2.2 Architecture specific
@@ -352,6 +357,12 @@ endif
 
 ifeq ($(ARCH),riscv64)
 	arch = riscv64
+endif
+
+ifeq ($(ARCH),ispc)
+	arch = any
+	ispc = yes
+	OBJS := nnue/layers/affine_transform.o nnue/nnue_feature_transformer.o $(OBJS)
 endif
 endif
 
@@ -694,6 +705,10 @@ ifeq ($(dotprod),yes)
 	CXXFLAGS += -march=armv8.2-a+dotprod -DUSE_NEON_DOTPROD
 endif
 
+ifeq ($(ispc),yes)
+	CXXFLAGS += -DUSE_ISPC
+endif
+
 ### 3.7 pext
 ifeq ($(pext),yes)
 	CXXFLAGS += -DUSE_PEXT
@@ -904,7 +919,7 @@ net:
 
 # clean binaries and objects
 objclean:
-	@rm -f stockfish stockfish.exe *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
+	@rm -f stockfish stockfish.exe *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o ./nnue/layers/*.o
 
 # clean auxiliary profiling files
 profileclean:

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -23,6 +23,10 @@
 
 #include "types.h"
 
+#if defined(USE_ISPC)
+#include "helpers_ispc.h"
+#endif
+
 namespace Stockfish {
 
 namespace Bitbases {
@@ -336,10 +340,12 @@ inline Bitboard attacks_bb(PieceType pt, Square s, Bitboard occupied) {
 inline int popcount(Bitboard b) {
 
 #ifndef USE_POPCNT
-
+#ifdef USE_ISPC
+  return ispc::popcnt64(b);
+#else
   union { Bitboard bb; uint16_t u[4]; } v = { b };
   return PopCnt16[v.u[0]] + PopCnt16[v.u[1]] + PopCnt16[v.u[2]] + PopCnt16[v.u[3]];
-
+#endif
 #elif defined(_MSC_VER) || defined(__INTEL_COMPILER)
 
   return (int)_mm_popcnt_u64(b);

--- a/src/helpers.ispc
+++ b/src/helpers.ispc
@@ -20,3 +20,6 @@ export void prefetch(const void *uniform ptr) {
   prefetch_l1(ptr);
 }
 
+export uniform int popcnt64(const uniform int64 x) {
+  return popcnt(x);
+}

--- a/src/helpers.ispc
+++ b/src/helpers.ispc
@@ -1,0 +1,22 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2023 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+export void prefetch(const void *uniform ptr) {
+  prefetch_l1(ptr);
+}
+

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -60,6 +60,10 @@ using fun5_t = WORD(*)();
 #include <stdlib.h>
 #endif
 
+#if defined(USE_ISPC)
+#include "helpers_ispc.h"
+#endif
+
 #include "misc.h"
 #include "thread.h"
 
@@ -431,6 +435,8 @@ void prefetch(void* addr) {
 
 #  if defined(__INTEL_COMPILER) || defined(_MSC_VER)
   _mm_prefetch((char*)addr, _MM_HINT_T0);
+#  elif defined(USE_ISPC)
+  ispc::prefetch(addr);
 #  else
   __builtin_prefetch(addr);
 #  endif

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -52,6 +52,9 @@
     - inputs are processed in chunks of 4, weights are respectively transposed
     - accumulation happens directly to int32s
 */
+#if defined(USE_ISPC)
+#include "affine_transform_ispc.h"
+#endif
 
 namespace Stockfish::Eval::NNUE::Layers {
 
@@ -144,6 +147,9 @@ namespace Stockfish::Eval::NNUE::Layers {
         sum = vpadalq_s16(sum, product);
       }
       output[i] = sum[0] + sum[1] + sum[2] + sum[3];
+
+# elif defined(USE_ISPC)
+      output[i] = biases[i] + ispc::affine_transform(weights + offset, input, InputDimensions);
 
 # else
       std::int32_t sum = biases[i];

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -148,9 +148,6 @@ namespace Stockfish::Eval::NNUE::Layers {
       }
       output[i] = sum[0] + sum[1] + sum[2] + sum[3];
 
-# elif defined(USE_ISPC)
-      output[i] = biases[i] + ispc::affine_transform(weights + offset, input, InputDimensions);
-
 # else
       std::int32_t sum = biases[i];
       for (IndexType j = 0; j < InputDimensions; ++j) {
@@ -382,6 +379,21 @@ namespace Stockfish::Eval::NNUE::Layers {
 # undef vec_add_dpbusd_32x2
 # undef vec_hadd
 # undef vec_haddx4
+
+#elif defined(USE_ISPC)
+
+      static_assert(OutputDimensions % 4 == 0 || OutputDimensions == 1);
+
+      if constexpr (OutputDimensions > 1)
+      {
+        ispc::affine_transform(input, weights, biases, output, InputDimensions,
+                               PaddedInputDimensions, OutputDimensions);
+      }
+      else
+      {
+        output[0] = biases[0] + ispc::affine_transform1(weights, input, InputDimensions);
+      }
+
 #else
       // Use old implementation for the other architectures.
       affine_transform_non_ssse3<
@@ -541,6 +553,21 @@ namespace Stockfish::Eval::NNUE::Layers {
 # undef vec_add_dpbusd_32
 # undef vec_add_dpbusd_32x2
 # undef vec_hadd
+
+#elif defined(USE_ISPC)
+
+      static_assert(OutputDimensions % 4 == 0 || OutputDimensions == 1);
+
+      if constexpr (OutputDimensions > 1)
+      {
+        ispc::affine_transform(input, weights, biases, output, InputDimensions,
+                               PaddedInputDimensions, OutputDimensions);
+      }
+      else
+      {
+        output[0] = biases[0] + ispc::affine_transform1(weights, input, InputDimensions);
+      }
+
 #else
       // Use old implementation for the other architectures.
       affine_transform_non_ssse3<

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -545,7 +545,15 @@ namespace Stockfish::Eval::NNUE::Layers {
 
       static_assert(OutputDimensions % 16 == 0 || OutputDimensions == 1);
 
-      if constexpr (OutputDimensions > 1)
+      if constexpr (OutputDimensions == 16 && InputDimensions == 1024 && PaddedInputDimensions == 1024)
+      {
+        ispc::affine_transform_1024_1024_16(input, weights, biases, output);
+      }
+      else if constexpr (OutputDimensions == 32 && InputDimensions == 30 && PaddedInputDimensions == 32)
+      {
+        ispc::affine_transform_30_32_32(input, weights, biases, output);
+      }
+      else if constexpr (OutputDimensions > 1)
       {
         ispc::affine_transform(input, weights, biases, output, InputDimensions,
                                PaddedInputDimensions, OutputDimensions);

--- a/src/nnue/layers/affine_transform.ispc
+++ b/src/nnue/layers/affine_transform.ispc
@@ -16,6 +16,12 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+export void clip_relu(const uniform int input[], uniform uint8 output[], uniform int size, uniform uint8 scale) {
+  foreach (j = 0 ... size) {
+    output[j] = max(0, min(127, input[j] >> scale));
+  }
+}
+
 export void affine_transform(
     const uniform uint8 input[], const uniform int8 weights[], const uniform int biases[],
     uniform int output[], uniform int InputDimensions, uniform int PaddedInputDimensions,

--- a/src/nnue/layers/affine_transform.ispc
+++ b/src/nnue/layers/affine_transform.ispc
@@ -16,8 +16,41 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-export uniform int affine_transform(const uniform int8 weights[], const uniform uint8 input[],
-                                    uniform int InputDimensions) {
+export void affine_transform(
+    const uniform uint8 input[], const uniform int8 weights[], const uniform int biases[],
+    uniform int output[], uniform int InputDimensions, uniform int PaddedInputDimensions,
+    uniform int OutputDimensions) {
+  assume(InputDimensions % programCount == 0);
+
+  varying int sum0, sum1, sum2, sum3;
+  uniform int offset0 = 0;
+  uniform int offset1 = PaddedInputDimensions;
+  uniform int offset2 = 2 * PaddedInputDimensions;
+  uniform int offset3 = 3 * PaddedInputDimensions;
+  uniform int step = 4 * PaddedInputDimensions;
+  varying int ij;
+  for (uniform int i = 0; i < OutputDimensions; i += 4) {
+    sum0 = sum1 = sum2 = sum3 = 0;
+    foreach (j = 0 ... InputDimensions) {
+      ij = input[j];
+      sum0 += weights[offset0 + j] * ij;
+      sum1 += weights[offset1 + j] * ij;
+      sum2 += weights[offset2 + j] * ij;
+      sum3 += weights[offset3 + j] * ij;
+    }
+    output[i] = biases[i] + reduce_add(sum0);
+    output[i + 1] = biases[i + 1] + reduce_add(sum1);
+    output[i + 2] = biases[i + 2] + reduce_add(sum2);
+    output[i + 3] = biases[i + 3] + reduce_add(sum3);
+    offset0 += step;
+    offset1 += step;
+    offset2 += step;
+    offset3 += step;
+  }
+}
+
+export uniform int affine_transform1(const uniform int8 weights[], const uniform uint8 input[],
+                                     uniform int InputDimensions) {
   assume(InputDimensions % programCount == 0);
 
   int sum = 0;

--- a/src/nnue/layers/affine_transform.ispc
+++ b/src/nnue/layers/affine_transform.ispc
@@ -1,0 +1,29 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2023 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+export uniform int affine_transform(const uniform int8 weights[], const uniform uint8 input[],
+                                    uniform int InputDimensions) {
+  assume(InputDimensions % programCount == 0);
+
+  int sum = 0;
+  foreach (j = 0 ... InputDimensions) {
+    sum += weights[j] * (int)input[j];
+  }
+  return reduce_add(sum);
+}
+

--- a/src/nnue/layers/affine_transform.ispc
+++ b/src/nnue/layers/affine_transform.ispc
@@ -20,32 +20,20 @@ export void affine_transform(
     const uniform uint8 input[], const uniform int8 weights[], const uniform int biases[],
     uniform int output[], uniform int InputDimensions, uniform int PaddedInputDimensions,
     uniform int OutputDimensions) {
-  assume(InputDimensions % programCount == 0);
-
-  varying int sum0, sum1, sum2, sum3;
-  uniform int offset0 = 0;
-  uniform int offset1 = PaddedInputDimensions;
-  uniform int offset2 = 2 * PaddedInputDimensions;
-  uniform int offset3 = 3 * PaddedInputDimensions;
-  uniform int step = 4 * PaddedInputDimensions;
-  varying int ij;
-  for (uniform int i = 0; i < OutputDimensions; i += 4) {
-    sum0 = sum1 = sum2 = sum3 = 0;
-    foreach (j = 0 ... InputDimensions) {
+  #define TILE 16
+  assume(OutputDimensions % TILE == 0);
+  uniform int sum[TILE];
+  uniform uint8 ij;
+  for (uniform int i = 0; i < OutputDimensions; i += TILE) {
+    foreach (j = 0 ... TILE) sum[j] = 0;
+    for (uniform int j = 0; j < InputDimensions; j++) {
       ij = input[j];
-      sum0 += weights[offset0 + j] * ij;
-      sum1 += weights[offset1 + j] * ij;
-      sum2 += weights[offset2 + j] * ij;
-      sum3 += weights[offset3 + j] * ij;
+      foreach (k = 0 ... TILE) {
+        sum[k] += weights[j * OutputDimensions + i + k] * (int)ij;
+      }
     }
-    output[i] = biases[i] + reduce_add(sum0);
-    output[i + 1] = biases[i + 1] + reduce_add(sum1);
-    output[i + 2] = biases[i + 2] + reduce_add(sum2);
-    output[i + 3] = biases[i + 3] + reduce_add(sum3);
-    offset0 += step;
-    offset1 += step;
-    offset2 += step;
-    offset3 += step;
+    foreach (j = 0 ... TILE)
+      output[i + j] = biases[i + j] + sum[j];
   }
 }
 

--- a/src/nnue/layers/affine_transform.ispc
+++ b/src/nnue/layers/affine_transform.ispc
@@ -54,3 +54,13 @@ export uniform int affine_transform1(const uniform int8 weights[], const uniform
   return reduce_add(sum);
 }
 
+// Specializations for common sizes.
+export void affine_transform_1024_1024_16(const uniform uint8 input[], const uniform int8 weights[],
+                                          const uniform int biases[], uniform int output[]) {
+  affine_transform(input, weights, biases, output, 1024, 1024, 16);
+}
+
+export void affine_transform_30_32_32(const uniform uint8 input[], const uniform int8 weights[],
+                                      const uniform int biases[], uniform int output[]) {
+  affine_transform(input, weights, biases, output, 30, 32, 32);
+}

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -23,6 +23,10 @@
 
 #include "../nnue_common.h"
 
+#if defined(USE_ISPC)
+#include "affine_transform_ispc.h"
+#endif
+
 namespace Stockfish::Eval::NNUE::Layers {
 
   // Clipped ReLU
@@ -162,6 +166,9 @@ namespace Stockfish::Eval::NNUE::Layers {
         out[i] = vmax_s8(vqmovn_s16(shifted), Zero);
       }
       constexpr IndexType Start = NumChunks * (SimdWidth / 2);
+  #elif defined(USE_ISPC)
+      ispc::clip_relu(input, output, InputDimensions, WeightScaleBits);
+      constexpr IndexType Start = InputDimensions;
   #else
       constexpr IndexType Start = 0;
   #endif

--- a/src/nnue/nnue_feature_transformer.ispc
+++ b/src/nnue/nnue_feature_transformer.ispc
@@ -1,0 +1,57 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2023 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+export void transform(const uniform int16 in0[], const uniform int16 in1[],
+                      uniform uint8 output[], uniform int size) {
+  foreach (j = 0 ... size) {
+    int16 sum0 = max((uniform int16)0, min((uniform int16)127, in0[j]));
+    int16 sum1 = max((uniform int16)0, min((uniform int16)127, in1[j]));
+    output[j] = (sum0 * sum1) >> 7;
+  }
+}
+
+export void update_accumulator_remove(
+    const uniform uint32 active[], uniform int size, uniform int16 accumulation[],
+    uniform int psqtAccumulation[], const uniform int16 weights[], const uniform int psqtWeights[],
+    uniform int HalfDimensions, uniform int PSQTBuckets) {
+  for (uniform int i = 0; i < size; i++) {
+    int index = active[i];
+
+    foreach (j = 0 ... HalfDimensions)
+      accumulation[j] -= weights[HalfDimensions * index + j];
+
+    foreach (k = 0 ... PSQTBuckets)
+      psqtAccumulation[k] -= psqtWeights[index * PSQTBuckets + k];
+  }
+}
+
+export void update_accumulator_add(
+    const uniform uint32 active[], uniform int size, uniform int16 accumulation[],
+    uniform int psqtAccumulation[], const uniform int16 weights[], const uniform int psqtWeights[],
+    uniform int HalfDimensions, uniform int PSQTBuckets) {
+  for (uniform int i = 0; i < size; i++) {
+    int index = active[i];
+
+    foreach (j = 0 ... HalfDimensions)
+      accumulation[j] += weights[HalfDimensions * index + j];
+
+    foreach (k = 0 ... PSQTBuckets)
+      psqtAccumulation[k] += psqtWeights[index * PSQTBuckets + k];
+  }
+}


### PR DESCRIPTION
This adds a new architecture that instead of processor dependent hand vectorized code uses Intel's open source ispc (Implicit SPMD Program Compiler) with higher level input code. The objective is be able to write experimental evaluation functions in this higher level description and get decent performance, before resorting to low level coding.
The transformer mention in the original title was a joke, but this is the infrastructure I would use if I was actually doing it.