### PR TITLE
Decrease Depth more if (ss->ttHit &&  tte->depth() >= depth)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -896,11 +896,11 @@ namespace {
         Eval::NNUE::hint_common_parent_position(pos);
     }
 
-    // Step 11. If the position is not in TT, decrease depth by 3.
+    // Step 11. If the position is not in TT, decrease depth by 2 (or by 4 if the TT entry for the current position was hit and the stored depth is greater than or equal to the current depth).
     // Use qsearch if depth is equal or below zero (~9 Elo)
     if (    PvNode
         && !ttMove)
-        depth -= 3;
+        depth -= 2 + 2 * (ss->ttHit &&  tte->depth() >= depth);
 
     if (depth <= 0)
         return qsearch<PV>(pos, ss, alpha, beta);


### PR DESCRIPTION
If the position is not in TT, decrease depth by 2 (or by 4 if the TT entry for the current position was hit and the stored depth is greater than or equal to the current depth).

Many thanks to @Vizvezdenec as the main idea was his.

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 70664 W: 18995 L: 18639 D: 33030
Ptnml(0-2): 228, 7712, 19090, 8080, 222
https://tests.stockfishchess.org/tests/view/64258a8bdb43ab2ba6f9b682

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 85040 W: 23227 L: 22836 D: 38977
Ptnml(0-2): 26, 8115, 25867, 8466, 46
https://tests.stockfishchess.org/tests/view/64262057db43ab2ba6f9d0e7