### PR TITLE
Fixed division by zero

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -39,7 +39,7 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
   // if we have no time, no need to initialize TM, except for the start time,
   // which is used by movetime.
   startTime = limits.startTime;
-  if (limits.time[us] ==0)
+  if (limits.time[us] == 0)
       return;
 
   TimePoint moveOverhead    = TimePoint(Options["Move Overhead"]);

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -36,6 +36,12 @@ TimeManagement Time; // Our global time management object
 
 void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
 
+  // if we have no time, no need to initialize TM, except for the start time,
+  // which is used by movetime.
+  startTime = limits.startTime;
+  if (limits.time[us] ==0)
+      return;
+
   TimePoint moveOverhead    = TimePoint(Options["Move Overhead"]);
   TimePoint slowMover       = TimePoint(Options["Slow Mover"]);
   TimePoint npmsec          = TimePoint(Options["nodestime"]);
@@ -58,8 +64,6 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
       limits.inc[us] *= npmsec;
       limits.npmsec = npmsec;
   }
-
-  startTime = limits.startTime;
 
   // Maximum move horizon of 50 moves
   int mtg = limits.movestogo ? std::min(limits.movestogo, 50) : 50;


### PR DESCRIPTION
Fixed division by zero if time limit was zero (which usually happened at start) - it gave exception in debug mode `Expression: invalid comparator' in clamp()` when comparing to a NaN floating point value. `clamp()` gives an assertion when receives NaN. Tested in MSVC 2022 Debug mode x64.