### PR TITLE
Avoid a warning in clang that IS_64BIT is already defined

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -65,7 +65,9 @@
 
 #if defined(_WIN64) && defined(_MSC_VER) // No Makefile used
 #  include <intrin.h> // Microsoft header for _BitScanForward64()
-#  define IS_64BIT
+#    if !defined(IS_64BIT) // Avoid a warning in clang (LLVM) compiler that IS_64BIT is already defined
+#      define IS_64BIT
+#    endif
 #endif
 
 #if defined(USE_POPCNT) && (defined(__INTEL_COMPILER) || defined(_MSC_VER))


### PR DESCRIPTION
We avoid a warning in clang (LLVM) compiler that IS_64BIT is already defined by checking whether IS_64BIT was defined earlier. If it was already defined, we do not define it again, thus avoiding the warning.

To reproduce it, run `make.exe build ARCH=x86-64-vnni512 COMP=clang` or `make.exe build ARCH=x86-64-vnni512 COMP=icx` under Windows. Prerequisite: LLVM Windows binary, Cygwin make.