### PR TITLE
Simplify futility_move_count

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -79,6 +79,7 @@ George Sobala (gsobala)
 gguliash
 Giacomo Lorenzetti (G-Lorenz)
 Gian-Carlo Pascutto (gcp)
+Goh CJ (cj5716)
 Gontran Lemaire (gonlem)
 Goodkov Vasiliy Aleksandrovich (goodkov)
 Gregor Cramer

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -76,8 +76,7 @@ namespace {
   }
 
   constexpr int futility_move_count(bool improving, Depth depth) {
-    return improving ? (3 + depth * depth)
-                     : (3 + depth * depth) / 2;
+    return (3 + depth * depth) >> (!improving);
   }
 
   // History and stats update bonus, based on depth

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -76,7 +76,7 @@ namespace {
   }
 
   constexpr int futility_move_count(bool improving, Depth depth) {
-    return (3 + depth * depth) >> (!improving);
+    return (3 + depth * depth) >> !improving;
   }
 
   // History and stats update bonus, based on depth


### PR DESCRIPTION
Credit is shared with @maximmasiutin for suggesting to use bit shift.
I was told by @dubslow to submit a pull request with yellow result at gainer bounds as well as blue result at non-regression bounds (STC). In the meantime if the maintainers want LTC at non-regression bounds, I have submitted a test already.

Yellow at STC:
LLR: -2.95 (-2.94,2.94) <0.00,2.00>
Total: 183560 W: 48831 L: 48823 D: 85906
Ptnml(0-2): 578, 19127, 52335, 19189, 551
https://tests.stockfishchess.org/tests/view/6424fe11db43ab2ba6f99d17

Passed non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 92944 W: 25034 L: 24884 D: 43026
Ptnml(0-2): 266, 9659, 26499, 9755, 293
https://tests.stockfishchess.org/tests/view/64277acedb43ab2ba6fa0bdd

LTC still ongoing: 
https://tests.stockfishchess.org/tests/view/6428c50a77ff3301150ca124