### PR TITLE
Remove unneeded bitboard from MP

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -69,7 +69,6 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 
   stage = (pos.checkers() ? EVASION_TT : MAIN_TT) +
           !(ttm && pos.pseudo_legal(ttm));
-  threatenedPieces = 0;
 }
 
 /// MovePicker constructor for quiescence search
@@ -106,7 +105,7 @@ void MovePicker::score() {
 
   static_assert(Type == CAPTURES || Type == QUIETS || Type == EVASIONS, "Wrong type");
 
-  [[maybe_unused]] Bitboard threatenedByPawn, threatenedByMinor, threatenedByRook;
+  [[maybe_unused]] Bitboard threatenedByPawn, threatenedByMinor, threatenedByRook, threatenedPieces;
   if constexpr (Type == QUIETS)
   {
       Color us = pos.side_to_move();

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -131,8 +131,6 @@ public:
   MovePicker(const Position&, Move, Value, const CapturePieceToHistory*);
   Move next_move(bool skipQuiets = false);
 
-  Bitboard threatenedPieces;
-
 private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();


### PR DESCRIPTION
Recent simplification has removed the need for an extra bitboard in MP struct. Use a local variable instead.

STC: Passed Non-regression test
https://tests.stockfishchess.org/tests/view/64294ae677ff3301150cba16
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 64872 W: 17383 L: 17203 D: 30286
Ptnml(0-2): 179, 6675, 18546, 6859, 177

No functional change.
Bench: 4380438