### PR TITLE
Simplifiy TM's root complexity

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -290,15 +290,13 @@ void Thread::search() {
 
   bestValue = delta = alpha = -VALUE_INFINITE;
   beta = VALUE_INFINITE;
+  optimism[us] = optimism[~us] = VALUE_ZERO;
 
   if (mainThread)
   {
 
       int rootComplexity;
-      if (Eval::useNNUE)
-          Eval::NNUE::evaluate(rootPos, true, &rootComplexity);
-      else
-          Eval::evaluate(rootPos, &rootComplexity);
+      Eval::evaluate(rootPos, &rootComplexity);
 
       mainThread->complexity = std::min(1.03 + (rootComplexity - 241) / 1552.0, 1.45);
 
@@ -319,8 +317,6 @@ void Thread::search() {
       multiPV = std::max(multiPV, (size_t)4);
 
   multiPV = std::min(multiPV, rootMoves.size());
-
-  optimism[us] = optimism[~us] = VALUE_ZERO;
 
   int searchAgainCounter = 0;
 


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/6428c39677ff3301150ca0d7
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 51256 W: 13805 L: 13612 D: 23839
Ptnml(0-2): 145, 5283, 14592, 5450, 158

LTC: https://tests.stockfishchess.org/tests/view/64296ff377ff3301150cc519
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 106968 W: 28951 L: 28830 D: 49187
Ptnml(0-2): 47, 9746, 33789, 9843, 59

no functional change (affects TM)