### PR TITLE
Parameters Tweak

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -72,7 +72,7 @@ namespace {
 
   Depth reduction(bool i, Depth d, int mn, Value delta, Value rootDelta) {
     int r = Reductions[d] * Reductions[mn];
-    return (r + 1449 - int(delta) * 1032 / int(rootDelta)) / 1024 + (!i && r > 941);
+    return (r + 1449 - int(delta) * 1001 / int(rootDelta)) / 1024 + (!i && r > 941);
   }
 
   constexpr int futility_move_count(bool improving, Depth depth) {
@@ -82,7 +82,7 @@ namespace {
 
   // History and stats update bonus, based on depth
   int stat_bonus(Depth d) {
-    return std::min(340 * d - 470, 1855);
+    return std::min(341 * d - 470, 1855);
   }
 
   // Add a small random component to draw evaluations to avoid 3-fold blindness
@@ -1061,7 +1061,7 @@ moves_loop: // When in check, search starts here
               lmrDepth = std::max(lmrDepth, 0);
 
               // Prune moves with negative SEE (~4 Elo)
-              if (!pos.see_ge(move, Value(-24 * lmrDepth * lmrDepth - 15 * lmrDepth)))
+              if (!pos.see_ge(move, Value(-24 * lmrDepth * lmrDepth - 16 * lmrDepth)))
                   continue;
           }
       }
@@ -1197,10 +1197,10 @@ moves_loop: // When in check, search starts here
                      + (*contHist[0])[movedPiece][to_sq(move)]
                      + (*contHist[1])[movedPiece][to_sq(move)]
                      + (*contHist[3])[movedPiece][to_sq(move)]
-                     - 4182;
+                     - 4082;
 
       // Decrease/increase reduction for moves with a good/bad history (~25 Elo)
-      r -= ss->statScore / (11791 + 3992 * (depth > 6 && depth < 19));
+      r -= ss->statScore / (11079 + 4626 * (depth > 6 && depth < 19));
 
       // Step 17. Late moves reduction / extension (LMR, ~117 Elo)
       // We use various heuristics for the sons of a node after the first son has


### PR DESCRIPTION
Parameters Tweak:

Passed STC (It included a redundant part that didn't do anything that got removed in the LTC test):
LLR: 3.22 (-2.94,2.94) <0.00,2.00>
Total: 664048 W: 177526 L: 176301 D: 310221
Ptnml(0-2): 2002, 72968, 180891, 74129, 2034
https://tests.stockfishchess.org/tests/live_elo/64219901db43ab2ba6f901fa

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 77576 W: 21125 L: 20750 D: 35701
Ptnml(0-2): 24, 7350, 23669, 7717, 28
https://tests.stockfishchess.org/tests/view/642abe3377ff3301150d3a16
