### PR TITLE
Simplify away piece count condition for useClassical

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1053,7 +1053,7 @@ Value Eval::evaluate(const Position& pos, int* complexity) {
 
   // We use the much less accurate but faster Classical eval when the NNUE
   // option is set to false. Otherwise we use the NNUE eval unless the
-  // PSQ advantage is decisive. (~5 Elo at STC, 1 Elo at LTC)
+  // PSQ advantage is decisive. (~4 Elo at STC, 1 Elo at LTC)
   bool useClassical = !useNNUE || abs(psq) > 2048;
 
   if (useClassical)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1053,8 +1053,8 @@ Value Eval::evaluate(const Position& pos, int* complexity) {
 
   // We use the much less accurate but faster Classical eval when the NNUE
   // option is set to false. Otherwise we use the NNUE eval unless the
-  // PSQ advantage is decisive and several pieces remain. (~3 Elo)
-  bool useClassical = !useNNUE || (pos.count<ALL_PIECES>() > 7 && abs(psq) > 1781);
+  // PSQ advantage is decisive. (~5 Elo at STC, 1 Elo at LTC)
+  bool useClassical = !useNNUE || abs(psq) > 2048;
 
   if (useClassical)
       v = Evaluation<NO_TRACE>(pos).value();


### PR DESCRIPTION
Simplify away the piece count condition for useClassical. In compensation, the psq requirement is increased by 15%.

Also updated the Elo estimate for useClassical, based on recent testing. 

Simplification STC: https://tests.stockfishchess.org/tests/view/642acbb577ff3301150d3ef5
LLR: 2.96 (-2.94,2.94) <-1.75,0.25> 
Total: 51984 W: 13906 L: 13707 D: 24371
Ptnml(0-2): 150, 5638, 14227, 5817, 160

Simplification LTC:  https://tests.stockfishchess.org/tests/view/642b9c5777ff3301150d778a
LLR: 2.94 (-2.94,2.94) <-1.75,0.25> 
Total: 119696 W: 32412 L: 32300 D: 54984
Ptnml(0-2): 53, 11529, 36567, 11651, 48

Bench: 4985313