### PR TITLE
Assign negative stat bonuses for quiet moves at Pv nodes.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1261,6 +1261,9 @@ moves_loop: // When in check, search starts here
           (ss+1)->pv[0] = MOVE_NONE;
 
           value = -search<PV>(pos, ss+1, -beta, -alpha, newDepth, false);
+
+          if (moveCount > 1 && newDepth >= depth && !capture)
+              update_continuation_histories(ss, movedPiece, to_sq(move), -stat_bonus(newDepth));
       }
 
       // Step 19. Undo move


### PR DESCRIPTION
This patch assigns negative stat bonuses for quiet moves at pv nodes which are searched at depth greater than this node assumes, so are extended.
Passed STC:
https://tests.stockfishchess.org/tests/view/6426198bdb43ab2ba6f9cfa2
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 548944 W: 147287 L: 146254 D: 255403
Ptnml(0-2): 1662, 59772, 150671, 60605, 1762 
Passed LTC:
https://tests.stockfishchess.org/tests/view/642be4f177ff3301150d892d
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 93352 W: 25400 L: 24994 D: 42958
Ptnml(0-2): 44, 8817, 28547, 9225, 43 
bench 4945384