### PR TITLE
Correct number for vector registers for avx-2 and avx-512 and correct register size for avx-512 vector multiplications and additions

### DIFF
--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -58,20 +58,24 @@ namespace Stockfish::Eval::NNUE {
   constexpr std::size_t CacheLineSize = 64;
 
   // SIMD width (in bytes)
-  #if defined(USE_AVX2)
-  constexpr std::size_t SimdWidth = 32;
+  #if defined(USE_AVX512)
+  constexpr std::size_t SimdWidthPlatform = 64;
+
+  #elif defined(USE_AVX2)
+  constexpr std::size_t SimdWidthPlatform = 32;
 
   #elif defined(USE_SSE2)
-  constexpr std::size_t SimdWidth = 16;
+  constexpr std::size_t SimdWidthPlatform = 16;
 
   #elif defined(USE_MMX)
-  constexpr std::size_t SimdWidth = 8;
+  constexpr std::size_t SimdWidthPlatform = 8;
 
   #elif defined(USE_NEON)
-  constexpr std::size_t SimdWidth = 16;
+  constexpr std::size_t SimdWidthPlatform = 16;
   #endif
 
   constexpr std::size_t MaxSimdWidth = 32;
+  constexpr std::size_t SimdWidth = std::min(SimdWidthPlatform, MaxSimdWidth);
 
   // Type of input feature after conversion
   using TransformedFeatureType = std::uint8_t;

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -72,6 +72,12 @@ namespace Stockfish::Eval::NNUE {
 
   #elif defined(USE_NEON)
   constexpr std::size_t SimdWidthPlatform = 16;
+
+  #else
+
+  // Other platforms, such as armv7, should have no SMID
+  constexpr std::size_t SimdWidthPlatform = 0;
+
   #endif
 
   constexpr std::size_t MaxSimdWidth = 32;


### PR DESCRIPTION
This patch adjusts the vector register width to the correct value (i.e., 64 bytes) for architectures based on avx-512 as this value (OutputSimdWidth) was implicitly capped in Stockfish by 32. This cap was probably needed because the constant was used for internal data structures. If you increase it, nnue networks would not get loaded. Now this cap for the internal structure is made explicit to avoid confusion (`constexpr std::size_t SimdWidth = std::min(SimdWidthPlatform, MaxSimdWidth);`). Still, for the vnni nnue calculations (vector multiplications and additions), the real width for the vector registers is used that corresponds to the platform (the `SimdWidthPlatform` constant is introduced which is not capped and not used to define internal data structures). 

This patch allowed to produce CPU instructions to be consistent with the architecture, as there were VPDPBUSD instructions on ymm registers for ARCH=x86-64-vnni512, whilst with this patch, the compiler now generates one VPDPBUSD instruction with zmm register instead of two instructions with ymm registers (please refer to objdump -d output and search for "vpdpbusd").

I run a few tests ("stockfish bench", pyshbench and cutechess-cli mathces). The raw results of the runs that compare the performance of this patch vs master compiled by GCC v12.2.0 "profile-build" are available at http://www.masiutin.net/measurements-avx512-affine-transform.7z 

With "stockfish bench" limited by movetime 10 minutes, 64 threads, 8G hash on Xeon 8272CL (72 cores VM, hyperthreading disabled, one physical core per logical thread) NPS gain was 0.81% on ARCH=x86-64-avx512. On other CPUs (AMD Ryzen 7 7700) or other ARCHs there was no gain in "stockfish bench" results, or the results were inconclusive.

With pyshbench 500 iterations (single-threaded) gain was on Xeon 8272CL (72 cores VM, hyperthreading disabled) 1.31% on ARCH=x86-64-vnni512, and 0.24% on ARCH=x86-64-avx512, and on Core i7-1065G7 physical (notebook) 0.39% on ARCH=x86-64-vnni512. On other CPUs or ARCHs there was no gain in pyshbench results.

I also ran cutechess-cli matches for ARCH=x86-64-vnni512. Each match consistent of 200 game pairs 15s+1s with UHO_XXL_0.90_1.19.epd on Xeon 8272CL (72 cores VM, hyperthreading disabled) with `option.Threads=70` and `-concurrency 1`, but the results were inconclusive ("53 - 59 - 88"). On AMD Zen 4 Ryzen 7 7700 (8 cores, 16 threads) with `option.Threads=16` 30s+1s the results were in favor of the patch ("63 - 53 - 84"). Please refer to cutechess-cli output from the above-mentioned .7z archive for details. 

The results of fishtest are also inconclusive: https://tests.stockfishchess.org/tests/view/642af12577ff3301150d4d1c 

Update: As @Sopel97 correctly mentioned, the objdump assembly produced from the binaries on the following architectures: (1) COMP=x86-64-avx2 and (2) COMP=x86-64-vnni256 are identical if we compare master vs patch. The difference are only for the following architectures: (a) COMP=x86-64-avx512 and (b) COMP=x86-64-vnni512.
 