### PR TITLE
removed unnessecary xor

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -670,7 +670,7 @@ bool Position::gives_check(Move m) const {
       Square rto = relative_square(sideToMove, to > from ? SQ_F1 : SQ_D1);
 
       return   (attacks_bb<ROOK>(rto) & ksq)
-            && (attacks_bb<ROOK>(rto, pieces() ^ from ^ to) & ksq);
+            && (attacks_bb<ROOK>(rto, pieces() ^ from) & ksq);
   }
   }
 }


### PR DESCRIPTION
The removed xor was used to remove the rook on its origin square from the blocker bitboard, which is used to calculate wether a check was given by castling. This xor is unnessecary because if the rook on its origin square to blocks a check by the rook on the square it was moved to the rook on the origin square would already be giving check ,which means the starting position is not a position that can occur through a sequence of legal moves in the first place, and therefore this should not chnage any functionality.