### PR TITLE
Depth Tweak

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -72,7 +72,7 @@ namespace {
 
   Depth reduction(bool i, Depth d, int mn, Value delta, Value rootDelta) {
     int r = Reductions[d] * Reductions[mn];
-    return (r + 1449 - int(delta) * 1001 / int(rootDelta)) / 1024 + (!i && r > 941);
+    return (r + 1449 - int(delta) * 937 / int(rootDelta)) / 1024 + (!i && r > 941);
   }
 
   constexpr int futility_move_count(bool improving, Depth depth) {
@@ -82,7 +82,7 @@ namespace {
 
   // History and stats update bonus, based on depth
   int stat_bonus(Depth d) {
-    return std::min(341 * d - 470, 1855);
+    return std::min(341 * d - 470, 1710);
   }
 
   // Add a small random component to draw evaluations to avoid 3-fold blindness
@@ -775,7 +775,7 @@ namespace {
     // Step 7. Razoring (~1 Elo).
     // If eval is really low check with qsearch if it can exceed alpha, if it can't,
     // return a fail low.
-    if (eval < alpha - 426 - 252 * depth * depth)
+    if (eval < alpha - 426 - 256 * depth * depth)
     {
         value = qsearch<NonPV>(pos, ss, alpha - 1, alpha);
         if (value < alpha)
@@ -797,7 +797,7 @@ namespace {
         && (ss-1)->statScore < 18755
         &&  eval >= beta
         &&  eval >= ss->staticEval
-        &&  ss->staticEval >= beta - 19 * depth - improvement / 13 + 253 + complexity / 25
+        &&  ss->staticEval >= beta - 20 * depth - improvement / 13 + 253 + complexity / 25
         && !excludedMove
         &&  pos.non_pawn_material(us)
         && (ss->ply >= thisThread->nmpMinPly || us != thisThread->nmpColor))
@@ -805,7 +805,7 @@ namespace {
         assert(eval - beta >= 0);
 
         // Null move dynamic reduction based on depth, eval and complexity of position
-        Depth R = std::min(int(eval - beta) / 168, 6) + depth / 3 + 4 - (complexity > 825);
+        Depth R = std::min(int(eval - beta) / 172, 6) + depth / 3 + 4 - (complexity > 825);
 
         ss->currentMove = MOVE_NULL;
         ss->continuationHistory = &thisThread->continuationHistory[0][0][NO_PIECE][0];
@@ -1333,16 +1333,18 @@ moves_loop: // When in check, search starts here
 
               if (PvNode && value < beta) // Update alpha! Always alpha < beta
               {
-                  alpha = value;
 
                   // Reduce other moves if we have found at least one score improvement (~1 Elo)
                   if (   depth > 1
-                      && depth < 6
-                      && beta  <  10534
-                      && alpha > -10534)
-                      depth -= 1;
+                      && ((improving && complexity > 971) || (value < (5 * alpha + 75 * beta) / 87) || depth < 6)
+                      && beta  <  12535
+                      && value > -12535) {
+                      bool extraReduction = depth > 2 && alpha > -12535 && bestValue != -VALUE_INFINITE && (value - bestValue) > (7 * (beta - alpha)) / 8;
+                      depth -= 1 + extraReduction;
+                  }
 
                   assert(depth > 0);
+                  alpha = value;
               }
               else
               {


### PR DESCRIPTION
Some credit for this patch goes to all the following amazing persons, for helping me, either through inspiration or through helping with debugging some parts of the code:
@candirufish 
@Yoshie2000
@dubslow 
@peregrineshahin 
@Vizvezdenec 

I removed two useless/redundant duplicated conditions from the form that passed the tests.

I also tested the version with just the pure logic (Without the other parameters tweak, and it passed smoothly the STC test, proving that the logic is improving the engine strength, but I didn't feel the need to waste more resources by performing an LTC, since this form of the patch already passed both tests).

I also need to add that this patch contains some complex logic in its current form, but it can potentially be improved in the future.

I'm also very proud to have been able to generate my personal third Elo gainer in less than a week! 😍

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 38424 W: 10346 L: 10040 D: 18038
Ptnml(0-2): 103, 4111, 10473, 4427, 98
https://tests.stockfishchess.org/tests/view/642ca74277ff3301150db511

Passed LTC:
LLR: 2.97 (-2.94,2.94) <0.50,2.50>
Total: 136968 W: 37151 L: 36660 D: 63157
Ptnml(0-2): 43, 13052, 41808, 13533, 48
https://tests.stockfishchess.org/tests/view/642d632377ff3301150dddbe