### PR TITLE
Add AVX-512 support for small FC layers

### DIFF
--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -470,7 +470,14 @@ namespace Stockfish::Eval::NNUE::Layers {
     const OutputType* propagate(
         const InputType* input, OutputType* output) const {
 
-#if defined (USE_AVX2)
+#if defined (USE_AVX512)
+      using vec_t = __m512i;
+      #define vec_setzero _mm512_setzero_si512
+      #define vec_set_32 _mm512_set1_epi32
+      #define vec_add_dpbusd_32 Simd::m512_add_dpbusd_epi32
+      #define vec_add_dpbusd_32x2 Simd::m512_add_dpbusd_epi32x2
+      #define vec_hadd Simd::m512_hadd
+#elif defined (USE_AVX2)
       using vec_t = __m256i;
       #define vec_setzero _mm256_setzero_si256
       #define vec_set_32 _mm256_set1_epi32
@@ -489,12 +496,14 @@ namespace Stockfish::Eval::NNUE::Layers {
 #if defined (USE_SSSE3)
       const auto inputVector = reinterpret_cast<const vec_t*>(input);
 
-      static_assert(OutputDimensions % OutputSimdWidth == 0 || OutputDimensions == 1);
+      constexpr std::size_t accumulatorElementCount = sizeof(vec_t) / sizeof(OutputType);
 
-      if constexpr (OutputDimensions % OutputSimdWidth == 0)
+      static_assert(OutputDimensions % accumulatorElementCount == 0 || OutputDimensions == 1);
+
+      if constexpr (OutputDimensions % accumulatorElementCount == 0)
       {
         constexpr IndexType NumChunks = ceil_to_multiple<IndexType>(InputDimensions, 8) / 4;
-        constexpr IndexType NumRegs = OutputDimensions / OutputSimdWidth;
+        constexpr IndexType NumRegs = OutputDimensions / accumulatorElementCount;
 
         const auto input32 = reinterpret_cast<const std::int32_t*>(input);
         const vec_t* biasvec = reinterpret_cast<const vec_t*>(biases);


### PR DESCRIPTION
This patch adds AVX-512 support for small FC layers. It makes one instance of the propagate method of AffineTransform (called as `fc_1.propagate`) use full-size vector registers on AVX-512 while on the master, the AVX-2 version of these register was used. Credits to @Sopel97 for the guidance.

The difference is only in in the following archs:

- avx512 (master: zmm registers used 5585 times (grep), ymm - 1436 times; patch: zmm - 6131 times, ymm - 1018; i.e. the number of zmm registers in the patch increased whilst that of ymm decreased comparing to the master).

- vnni512 (master had some vpdpbusd on ymm whilst patch does not).

master:
```
   3cdfb:       62 f2 45 28 50 82 00    vpdpbusd 0x4100(%rdx),%ymm7,%ymm0
   3ce05:       62 f2 4d 28 50 82 80    vpdpbusd 0x4180(%rdx),%ymm6,%ymm0
   3ce23:       62 f2 45 28 50 9a 20    vpdpbusd 0x4120(%rdx),%ymm7,%ymm3
   3ce2d:       62 f2 4d 28 50 9a a0    vpdpbusd 0x41a0(%rdx),%ymm6,%ymm3
   3ce37:       62 f2 45 28 50 8a 40    vpdpbusd 0x4140(%rdx),%ymm7,%ymm1
   3ce41:       62 f2 4d 28 50 8a c0    vpdpbusd 0x41c0(%rdx),%ymm6,%ymm1
   3ce6a:       62 f2 45 28 50 92 60    vpdpbusd 0x4160(%rdx),%ymm7,%ymm2
   3ce74:       62 f2 4d 28 50 92 e0    vpdpbusd 0x41e0(%rdx),%ymm6,%ymm2
   3ce9b:       62 f2 5d 28 50 82 00    vpdpbusd 0x4200(%rdx),%ymm4,%ymm0
   3cea5:       62 f2 4d 28 50 82 80    vpdpbusd 0x4280(%rdx),%ymm6,%ymm0
   3ceaf:       62 f2 5d 28 50 9a 20    vpdpbusd 0x4220(%rdx),%ymm4,%ymm3
   3ceb9:       62 f2 4d 28 50 9a a0    vpdpbusd 0x42a0(%rdx),%ymm6,%ymm3
   3cec3:       62 f2 5d 28 50 8a 40    vpdpbusd 0x4240(%rdx),%ymm4,%ymm1
   3cecd:       62 f2 4d 28 50 8a c0    vpdpbusd 0x42c0(%rdx),%ymm6,%ymm1
   3ced7:       62 f2 5d 28 50 92 60    vpdpbusd 0x4260(%rdx),%ymm4,%ymm2
   3cee1:       62 f2 4d 28 50 92 e0    vpdpbusd 0x42e0(%rdx),%ymm6,%ymm2
   3cf13:       62 f2 5d 28 50 82 00    vpdpbusd 0x4300(%rdx),%ymm4,%ymm0
   3cf1d:       62 f2 4d 28 50 82 80    vpdpbusd 0x4380(%rdx),%ymm6,%ymm0
   3cf27:       62 f2 5d 28 50 9a 20    vpdpbusd 0x4320(%rdx),%ymm4,%ymm3
   3cf31:       62 f2 4d 28 50 9a a0    vpdpbusd 0x43a0(%rdx),%ymm6,%ymm3
   3cf3b:       62 f2 5d 28 50 8a 40    vpdpbusd 0x4340(%rdx),%ymm4,%ymm1
   3cf45:       62 f2 4d 28 50 8a c0    vpdpbusd 0x43c0(%rdx),%ymm6,%ymm1
   3cf4f:       62 f2 5d 28 50 92 60    vpdpbusd 0x4360(%rdx),%ymm4,%ymm2
   3cf59:       62 f2 4d 28 50 92 e0    vpdpbusd 0x43e0(%rdx),%ymm6,%ymm2
   3cf77:       62 f2 5d 28 50 9a 20    vpdpbusd 0x4420(%rdx),%ymm4,%ymm3
   3cf81:       62 f2 4d 28 50 9a a0    vpdpbusd 0x44a0(%rdx),%ymm6,%ymm3
   3cf8b:       62 f2 5d 28 50 82 00    vpdpbusd 0x4400(%rdx),%ymm4,%ymm0
   3cf95:       62 f2 4d 28 50 82 80    vpdpbusd 0x4480(%rdx),%ymm6,%ymm0
   3cf9f:       62 f2 5d 28 50 8a 40    vpdpbusd 0x4440(%rdx),%ymm4,%ymm1
   3cfa9:       62 f2 4d 28 50 8a c0    vpdpbusd 0x44c0(%rdx),%ymm6,%ymm1
   3cfb3:       62 f2 5d 28 50 92 60    vpdpbusd 0x4460(%rdx),%ymm4,%ymm2
   3cfbd:       62 f2 4d 28 50 92 e0    vpdpbusd 0x44e0(%rdx),%ymm6,%ymm2
   3d038:       62 f2 7d 28 50 8a 80    vpdpbusd 0x4580(%rdx),%ymm0,%ymm1
```
patch:
```
   3cafa:       62 f2 55 48 50 81 40    vpdpbusd 0x4140(%rcx),%zmm5,%zmm0
   3cb04:       62 f2 65 48 50 81 c0    vpdpbusd 0x41c0(%rcx),%zmm3,%zmm0
   3cb22:       62 f2 55 48 50 89 00    vpdpbusd 0x4100(%rcx),%zmm5,%zmm1
   3cb2c:       62 f2 65 48 50 89 80    vpdpbusd 0x4180(%rcx),%zmm3,%zmm1
   3cb4c:       62 f2 6d 48 50 89 00    vpdpbusd 0x4200(%rcx),%zmm2,%zmm1
   3cb56:       62 f2 65 48 50 89 80    vpdpbusd 0x4280(%rcx),%zmm3,%zmm1
   3cb70:       62 f2 6d 48 50 81 40    vpdpbusd 0x4240(%rcx),%zmm2,%zmm0
   3cb7a:       62 f2 65 48 50 81 c0    vpdpbusd 0x42c0(%rcx),%zmm3,%zmm0
   3cbb5:       62 f2 6d 48 50 89 00    vpdpbusd 0x4300(%rcx),%zmm2,%zmm1
   3cbbf:       62 f2 65 48 50 89 80    vpdpbusd 0x4380(%rcx),%zmm3,%zmm1
   3cbc9:       62 f2 6d 48 50 81 40    vpdpbusd 0x4340(%rcx),%zmm2,%zmm0
   3cbd3:       62 f2 65 48 50 81 c0    vpdpbusd 0x43c0(%rcx),%zmm3,%zmm0
   3cbfa:       62 f2 6d 48 50 81 40    vpdpbusd 0x4440(%rcx),%zmm2,%zmm0
   3cc04:       62 f2 65 48 50 81 c0    vpdpbusd 0x44c0(%rcx),%zmm3,%zmm0
   3cc0e:       62 f2 6d 48 50 89 00    vpdpbusd 0x4400(%rcx),%zmm2,%zmm1
   3cc18:       62 f2 65 48 50 89 80    vpdpbusd 0x4480(%rcx),%zmm3,%zmm1
   3cc92:       62 f2 65 48 50 89 80    vpdpbusd 0x4580(%rcx),%zmm3,%zmm1
```

On the other architectures (avx2, avxvnni, vnni256) there is no difference.

According to the profiler, the overall program speedup is less than 1%: the function `fc_1.propagate` is supposedly became about twice faster, however, it took just about 1% of total CPU time in `stockfish bench 128 1 20000 file.fen movetime nnue`. However, according to the cutechess-cli matches, there is some benefit in the speedup. These are the results on the AMD Zen 4 Ryzen 7 7700 CPU:

```
cutechess-cli -engine name=New cmd=./stockfish-x86-64-vnni512-gcc-avx512-affine-transform -engine name=Old cmd=./stockfish-x86-64-vnni512-gcc-master -each proto=uci tc=inf/30+1 option.Threads=16 option.Hash=1024 -recover -openings file=UHO_XXL_0.90_1.19.epd format=epd order=random plies=6 -repeat 2 -games 200 -concurrency 1 -ratinginterval 100 -sprt elo0=0 elo1=2 alpha=0.05 beta=0.05 -wait 1000

Score of New vs Old: 63 - 53 - 84  [0.525] 200
...      New playing White: 63 - 0 - 37  [0.815] 100
...      New playing Black: 0 - 53 - 47  [0.235] 100
...      White vs Black: 116 - 0 - 84  [0.790] 200
Elo difference: 17.4 +/- 36.8, LOS: 82.3 %, DrawRatio: 42.0 %
SPRT: llr 0.0937 (3.2%), lbound -2.94, ubound 2.94

Player: New
   "Draw by 3-fold repetition": 18
   "Draw by fifty moves rule": 22
   "Draw by insufficient mating material": 41
   "Draw by stalemate": 3
   "Loss: White mates": 53
   "Win: White mates": 63
Player: Old
   "Draw by 3-fold repetition": 18
   "Draw by fifty moves rule": 22
   "Draw by insufficient mating material": 41
   "Draw by stalemate": 3
   "Loss: White mates": 63
   "Win: White mates": 53
Finished match
```

Full results are available at https://www.masiutin.net/2023-04-05-match-Ryzen-7-7700-vnni512-30s-1s-1024.7z

More testing is needed to confirm these findings.

This pull request is aimed to replace https://github.com/official-stockfish/Stockfish/pull/4496 in accordance with the comments at https://github.com/official-stockfish/Stockfish/pull/4496#issuecomment-1498027346