### PR TITLE
Remove extraReduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1333,15 +1333,14 @@ moves_loop: // When in check, search starts here
 
               if (PvNode && value < beta) // Update alpha! Always alpha < beta
               {
-
                   // Reduce other moves if we have found at least one score improvement (~1 Elo)
                   if (   depth > 1
-                      && ((improving && complexity > 971) || (value < (5 * alpha + 75 * beta) / 87) || depth < 6)
+                      && (   (improving && complexity > 971)
+                          || value < (5 * alpha + 75 * beta) / 87
+                          || depth < 6)
                       && beta  <  12535
-                      && value > -12535) {
-                      bool extraReduction = depth > 2 && alpha > -12535 && bestValue != -VALUE_INFINITE && (value - bestValue) > (7 * (beta - alpha)) / 8;
-                      depth -= 1 + extraReduction;
-                  }
+                      && value > -12535)
+                      depth -= 1;
 
                   assert(depth > 0);
                   alpha = value;


### PR DESCRIPTION
Since bestValue becomes value and beta - alpha is always non-negative, extraReduction is always false, hence it has no effect.

This patch includes small changes to improve readability.

No functional change