### PR TITLE
Remove "adjusted" parameter from NNUE::evaluate

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -79,6 +79,7 @@ George Sobala (gsobala)
 gguliash
 Giacomo Lorenzetti (G-Lorenz)
 Gian-Carlo Pascutto (gcp)
+Goh CJ (cj5716)
 Gontran Lemaire (gonlem)
 Goodkov Vasiliy Aleksandrovich (goodkov)
 Gregor Cramer

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1066,7 +1066,7 @@ Value Eval::evaluate(const Position& pos, int* complexity) {
       Color stm = pos.side_to_move();
       Value optimism = pos.this_thread()->optimism[stm];
 
-      Value nnue = NNUE::evaluate(pos, true, &nnueComplexity);
+      Value nnue = NNUE::evaluate(pos, &nnueComplexity);
 
       // Blend nnue complexity with (semi)classical complexity
       nnueComplexity = (  406 * nnueComplexity
@@ -1150,7 +1150,7 @@ std::string Eval::trace(Position& pos) {
   ss << "\nClassical evaluation   " << to_cp(v) << " (white side)\n";
   if (Eval::useNNUE)
   {
-      v = NNUE::evaluate(pos, false);
+      v = NNUE::evaluate(pos);
       v = pos.side_to_move() == WHITE ? v : -v;
       ss << "NNUE evaluation        " << to_cp(v) << " (white side)\n";
   }

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -142,7 +142,7 @@ namespace Stockfish::Eval::NNUE {
   }
 
   // Evaluation function. Perform differential calculation.
-  Value evaluate(const Position& pos, bool adjusted, int* complexity) {
+  Value evaluate(const Position& pos, int* complexity) {
 
     // We manually align the arrays on the stack because with gcc < 9.3
     // overaligning stack variables with alignas() doesn't work correctly.
@@ -169,11 +169,8 @@ namespace Stockfish::Eval::NNUE {
     if (complexity)
         *complexity = abs(psqt - positional) / OutputScale;
 
-    // Give more value to positional evaluation when adjusted flag is set
-    if (adjusted)
-        return static_cast<Value>(((1024 - delta) * psqt + (1024 + delta) * positional) / (1024 * OutputScale));
-    else
-        return static_cast<Value>((psqt + positional) / OutputScale);
+    // Give more value to positional evaluation
+    return static_cast<Value>(((1024 - delta) * psqt + (1024 + delta) * positional) / (1024 * OutputScale));
   }
 
   struct NnueEvalTrace {

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -56,7 +56,7 @@ namespace Stockfish::Eval::NNUE {
   using LargePagePtr = std::unique_ptr<T, LargePageDeleter<T>>;
 
   std::string trace(Position& pos);
-  Value evaluate(const Position& pos, bool adjusted = false, int* complexity = nullptr);
+  Value evaluate(const Position& pos, int* complexity = nullptr);
   void hint_common_parent_position(const Position& pos);
 
   bool load_eval(std::string name, std::istream& stream);


### PR DESCRIPTION
It will give the adjusted NNUE eval during debugging and not the more balanced eval. However it seems more correct to put the NNUE evaluation used in the game for debugging. Thanks to @dubslow who helped to point this out.
I believe it will gain Elo due to removing a redundant condition, and it was gaining during STC test (https://tests.stockfishchess.org/tests/view/6430d06b028b029b01acc67d) before it was stopped

No functional change