### PR TITLE
Remove nmpColor

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -800,7 +800,7 @@ namespace {
         &&  ss->staticEval >= beta - 20 * depth - improvement / 13 + 253 + complexity / 25
         && !excludedMove
         &&  pos.non_pawn_material(us)
-        && (ss->ply >= thisThread->nmpMinPly || us != thisThread->nmpColor))
+        && (ss->ply >= thisThread->nmpMinPly))
     {
         assert(eval - beta >= 0);
 
@@ -828,9 +828,8 @@ namespace {
             assert(!thisThread->nmpMinPly); // Recursive verification is not allowed
 
             // Do verification search at high depths, with null move pruning disabled
-            // for us, until ply exceeds nmpMinPly.
+            // until ply exceeds nmpMinPly.
             thisThread->nmpMinPly = ss->ply + 3 * (depth-R) / 4;
-            thisThread->nmpColor = us;
 
             Value v = search<NonPV>(pos, ss, beta-1, beta, depth-R, false);
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -62,7 +62,6 @@ public:
   size_t pvIdx, pvLast;
   std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;
   int selDepth, nmpMinPly;
-  Color nmpColor;
   Value bestValue, optimism[COLOR_NB];
 
   Position rootPos;


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/642e293977ff3301150e9b55
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 161848 W: 43332 L: 43254 D: 75262
Ptnml(0-2): 418, 16987, 46058, 17021, 440

LTC: https://tests.stockfishchess.org/tests/view/642fea9420eb941419bde296
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 120208 W: 32529 L: 32418 D: 55261
Ptnml(0-2): 35, 11424, 37080, 11525, 40

bench 3672914