### PR TITLE
Fix root complexity pr

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -295,10 +295,12 @@ void Thread::search() {
   if (mainThread)
   {
 
-      int rootComplexity;
-      Eval::evaluate(rootPos, &rootComplexity);
-
-      mainThread->complexity = std::min(1.03 + (rootComplexity - 241) / 1552.0, 1.45);
+      if (!rootPos.checkers())
+      {
+          int rootComplexity;
+          Eval::evaluate(rootPos, &rootComplexity);
+          mainThread->complexity = std::min(1.03 + (rootComplexity - 241) / 1552.0, 1.45);
+      }
 
       if (mainThread->bestPreviousScore == VALUE_INFINITE)
           for (int i = 0; i < 4; ++i)

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -160,6 +160,7 @@ void ThreadPool::clear() {
   main()->bestPreviousScore = VALUE_INFINITE;
   main()->bestPreviousAverageScore = VALUE_INFINITE;
   main()->previousTimeReduction = 1.0;
+  main()->complexity = 1.0;
 }
 
 


### PR DESCRIPTION
The calculation of rootComplexity can't call eval when in check.
Doing so triggers an assert if compiled in debug mode when
the rootpos is evaluated using classical eval.

Fixes https://github.com/official-stockfish/Stockfish/issues/4512

Passed STC:
https://tests.stockfishchess.org/tests/view/6432697431feee5c6d306876
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 41096 W: 11017 L: 10815 D: 19264
Ptnml(0-2): 113, 4172, 11780, 4366, 117

Passed LTC:
https://tests.stockfishchess.org/tests/view/6432974d31feee5c6d306fc0
...

No functional change