### PR TITLE
Use lld linker when building with COMP=clang

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -723,7 +723,10 @@ ifeq ($(debug), no)
 		ifeq ($(comp),icx)
 			CXXFLAGS += -fwhole-program-vtables
 		endif
-		LDFLAGS += -fuse-ld=lld $(CXXFLAGS)
+		ifeq ($(target_windows),yes)
+			LDFLAGS += -fuse-ld=lld
+		endif
+		LDFLAGS += -v $(CXXFLAGS)
 
 # GCC and CLANG use different methods for parallelizing LTO and CLANG pretends to be
 # GCC on some systems.

--- a/src/Makefile
+++ b/src/Makefile
@@ -722,11 +722,8 @@ ifeq ($(debug), no)
 		CXXFLAGS += -flto=full
 		ifeq ($(comp),icx)
 			CXXFLAGS += -fwhole-program-vtables
-                endif
-		ifeq ($(target_windows),yes)
-			CXXFLAGS += -fuse-ld=lld
 		endif
-		LDFLAGS += $(CXXFLAGS)
+		LDFLAGS += -fuse-ld=lld $(CXXFLAGS)
 
 # GCC and CLANG use different methods for parallelizing LTO and CLANG pretends to be
 # GCC on some systems.


### PR DESCRIPTION
As the lld linker is part of LLVM's toolchain, it supports link-time optimization for clang by default. Thus, working link-time optimization now only requires the lld linker instead of the gold linker + the LLVM gold plugin.

No functional change