### PR TITLE
Remove good killer reduction rule.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1188,11 +1188,6 @@ moves_loop: // When in check, search starts here
       if ((ss+1)->cutoffCnt > 3)
           r++;
 
-      // Decrease reduction if move is a killer and we have a good history (~1 Elo)
-      if (move == ss->killers[0]
-          && (*contHist[0])[movedPiece][to_sq(move)] >= 3722)
-          r--;
-
       ss->statScore =  2 * thisThread->mainHistory[us][from_to(move)]
                      + (*contHist[0])[movedPiece][to_sq(move)]
                      + (*contHist[1])[movedPiece][to_sq(move)]


### PR DESCRIPTION
STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 246544 W: 65646 L: 65657 D: 115241
Ptnml(0-2): 706, 27350, 67138, 27405, 673
https://tests.stockfishchess.org/tests/view/642e253277ff3301150e9aa2

LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 165136 W: 44878 L: 44809 D: 75449
Ptnml(0-2): 64, 15991, 50378, 16082, 53
https://tests.stockfishchess.org/tests/view/6430db07028b029b01acd87f

Bench: 3830480