### PR TITLE
Update CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,11 +4,11 @@
 cff-version: 1.2.0
 title: Stockfish
 message: >-
-  If you use this software, please cite it using the
+  If you use cffinit, please cite it using the
   metadata from this file.
 type: software
 authors:
-  - given-names: The Stockfish developers (see AUTHORS file)
+  - name: The Stockfish developers (see AUTHORS file)
 repository-code: 'https://github.com/official-stockfish/Stockfish'
 url: 'https://stockfishchess.org/'
 repository-artifact: 'https://stockfishchess.org/download/'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,9 @@
 
 cff-version: 1.2.0
 title: Stockfish
-message: Please cite this software using metadata from this file.
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
 type: software
 authors:
   - given-names: The Stockfish developers (see AUTHORS file)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@
 cff-version: 1.2.0
 title: Stockfish
 message: >-
-  If you use cffinit, please cite it using the
-  metadata from this file.
+  If you use Stockfish, please cite it using the
+  metadata from this CITATION.cff file.
 type: software
 authors:
   - name: The Stockfish developers (see AUTHORS file)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,21 +3,19 @@
 
 cff-version: 1.2.0
 title: Stockfish
-message: >-
-  Please cite this software using the metadata from this
-  file.
+message: Please cite this software using metadata from this file.
 type: software
 authors:
-  - name: The Stockfish developers (see AUTHORS file)
+  - given-names: The Stockfish developers (see AUTHORS file)
 repository-code: 'https://github.com/official-stockfish/Stockfish'
 url: 'https://stockfishchess.org/'
 repository-artifact: 'https://stockfishchess.org/download/'
-abstract: Stockfish is a free and strong UCI chess engine.
+abstract: Stockfish is a UCI chess engine for playing and analyzing.
 keywords:
   - chess
-  - artificial intelligence (AI)
   - tree search
   - alpha-beta search
   - neural networks (NN)
+  - artificial intelligence (AI)
   - efficiently updatable neural networks (NNUE)
 license: GPL-3.0


### PR DESCRIPTION
Fixed the `message` text so that it is written on one line only. Also, fixed the `abstract` text to resemble the first line of the `help` command output in a CLI (as was authored by me). Furthermore, rearranged the keywords from the shortest to the longest. And fixed the naming of the key `name` to the perhaps more correct naming `given-names` as per CFF format guide.