### PR TITLE
Remove some conditions at PV improvement reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1331,9 +1331,6 @@ moves_loop: // When in check, search starts here
               {
                   // Reduce other moves if we have found at least one score improvement (~1 Elo)
                   if (   depth > 1
-                      && (   (improving && complexity > 971)
-                          || value < (5 * alpha + 75 * beta) / 87
-                          || depth < 6)
                       && beta  <  12535
                       && value > -12535)
                       depth -= 1;


### PR DESCRIPTION
Non-regression STC (master 59f20854):
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 63664 W: 17007 L: 16823 D: 29834
Ptnml(0-2): 163, 6998, 17336, 7162, 173
https://tests.stockfishchess.org/tests/view/6430b124028b029b01ac99f2

Non-regression LTC (master 59f20854):
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 90016 W: 24399 L: 24258 D: 41359
Ptnml(0-2): 52, 8672, 27405, 8841, 38
https://tests.stockfishchess.org/tests/view/64310e74028b029b01ad3131

Bench: 3661938