### PR TITLE
Simplify away 'pos.non_pawn_material()' condition in early exits

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -988,8 +988,7 @@ namespace {
     // Early exit if score is high
     auto lazy_skip = [&](Value lazyThreshold) {
         return abs(mg_value(score) + eg_value(score)) >   lazyThreshold
-                                                        + std::abs(pos.this_thread()->bestValue) * 5 / 4
-                                                        + pos.non_pawn_material() / 32;
+                                                        + std::abs(pos.this_thread()->bestValue) * 3 / 2;
     };
 
     if (lazy_skip(LazyThreshold1))


### PR DESCRIPTION
Simplify away 'pos.non_pawn_material()' condition in early exits.

Passed non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 46336 W: 12417 L: 12214 D: 21705
Ptnml(0-2): 136, 5015, 12678, 5188, 151
https://tests.stockfishchess.org/tests/view/6432744031feee5c6d306a38

Passed non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 238728 W: 64485 L: 64487 D: 109756
Ptnml(0-2): 106, 23220, 72723, 23200, 115
https://tests.stockfishchess.org/tests/view/64334a44596a20f264272a2d

Bench: 4370579