### PR TITLE
Remove one term in QUIETS-movepick formula

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -126,18 +126,17 @@ void MovePicker::score() {
                    +     (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))]) / 16;
 
       else if constexpr (Type == QUIETS)
-          m.value =  2 * (*mainHistory)[pos.side_to_move()][from_to(m)]
-                   + 2 * (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
-                   +     (*continuationHistory[1])[pos.moved_piece(m)][to_sq(m)]
-                   +     (*continuationHistory[3])[pos.moved_piece(m)][to_sq(m)]
-                   +     (*continuationHistory[5])[pos.moved_piece(m)][to_sq(m)]
+          m.value =  2 * (*mainHistory)[pos.side_to_move()][from_to(m)]              //(~8 Elo)
+                   + 2 * (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]     //(~3 Elo)
+                   +     (*continuationHistory[1])[pos.moved_piece(m)][to_sq(m)]     //(~1 Elo)
+                   +     (*continuationHistory[5])[pos.moved_piece(m)][to_sq(m)]     //(~1 Elo)
                    +     (threatenedPieces & from_sq(m) ?
                            (type_of(pos.moved_piece(m)) == QUEEN && !(to_sq(m) & threatenedByRook)  ? 50000
                           : type_of(pos.moved_piece(m)) == ROOK  && !(to_sq(m) & threatenedByMinor) ? 25000
                           :                                         !(to_sq(m) & threatenedByPawn)  ? 15000
                           :                                                                           0)
-                          :                                                                           0)
-                   +     bool(pos.check_squares(type_of(pos.moved_piece(m))) & to_sq(m)) * 16384;
+                          :                                                                           0)        //(~1 Elo)
+                   +     bool(pos.check_squares(type_of(pos.moved_piece(m))) & to_sq(m)) * 16384;               //(~2 Elo)
       else // Type == EVASIONS
       {
           if (pos.capture_stage(m))


### PR DESCRIPTION
Remove one term in QUIETS-movepick formula.
Meanwhile, also updating the Elo worth for each term.

Test of Elo worth that made me consider the simplification test: https://tests.stockfishchess.org/tests/view/643734bbc7e4fc7c3cf4b071 (+2.4 Elo for removing the term)

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 226168 W: 59876 L: 59865 D: 106427
Ptnml(0-2): 708, 25080, 61443, 25199, 654
https://tests.stockfishchess.org/tests/view/643757c794daa91835c2873a

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 169720 W: 45797 L: 45733 D: 78190
Ptnml(0-2): 68, 16449, 51756, 16525, 62
https://tests.stockfishchess.org/tests/view/6439ae488f12f6c9a9c3332a

Elo worth tests:
https://tests.stockfishchess.org/tests/view/64372a6cc7e4fc7c3cf4ae94
https://tests.stockfishchess.org/tests/view/64372a6fc7e4fc7c3cf4ae97
https://tests.stockfishchess.org/tests/view/64372affc7e4fc7c3cf4aeb8
https://tests.stockfishchess.org/tests/view/643734bbc7e4fc7c3cf4b071
https://tests.stockfishchess.org/tests/view/643734c4c7e4fc7c3cf4b075
https://tests.stockfishchess.org/tests/view/64372caac7e4fc7c3cf4af02
https://tests.stockfishchess.org/tests/view/64372e53c7e4fc7c3cf4af4f