### PR TITLE
Simplification of SEE verification logic

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -331,8 +331,7 @@ void Position::set_check_info() const {
 
 /// Position::set_state() computes the hash keys of the position, and other
 /// data that once computed is updated incrementally as moves are made.
-/// The function is only used when a new position is set up, and to verify
-/// the correctness of the StateInfo data when running in debug mode.
+/// The function is only used when a new position is set up
 
 void Position::set_state() const {
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1017,17 +1017,15 @@ moves_loop: // When in check, search starts here
               {
                   if (depth < 2 - capture)
                       continue;
-                  // Don't prune the move if opp. King/Queen/Rook is attacked by a slider after the exchanges.
-                  // Since in see_ge we don't update occupied when the king recaptures, we also don't prune the
-                  // move when the opp. King gets a discovered slider attack DURING the exchanges.
-                  Bitboard leftEnemies = pos.pieces(~us, ROOK, QUEEN, KING) & occupied;
+                  // Don't prune the move if opp. King/Queen/Rook gets a discovered attack during or after the exchanges
+                  Bitboard leftEnemies = pos.pieces(~us, KING, QUEEN, ROOK);
                   Bitboard attacks = 0;
                   occupied |= to_sq(move);
                   while (leftEnemies && !attacks)
                   {
                       Square sq = pop_lsb(leftEnemies);
                       attacks = pos.attackers_to(sq, occupied) & pos.pieces(us) & occupied;
-                      // Exclude Queen/Rook(s) which were already threatened before SEE
+                      // Exclude Queen/Rook(s) which were already threatened before SEE (opp King can't be in check when it's our turn)
                       if (attacks && sq != pos.square<KING>(~us) && (pos.attackers_to(sq, pos.pieces()) & pos.pieces(us)))
                           attacks = 0;
                   }


### PR DESCRIPTION
Use same logic for all handled pieces.
Don't prune the move if opponent King, Queen, Rook gets a discovered attack while or after the exchanges.

Passed STC non regression:
https://tests.stockfishchess.org/tests/view/6437907594daa91835c290d0
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 107432 W: 28359 L: 28221 D: 50852
Ptnml(0-2): 298, 11724, 29524, 11882, 288

Passed LTC non-regression:
https://tests.stockfishchess.org/tests/view/6438ed2ebd1a5470263c51e8
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 236288 W: 63656 L: 63656 D: 108976
Ptnml(0-2): 99, 22960, 72011, 22990, 84

P.S.: While being here, use occasion to remove an obsolete comment in position.cpp

bench: 4171322