### PR TITLE
Simplify away depth condition for aspiration window adjust

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -357,18 +357,15 @@ void Thread::search() {
           selDepth = 0;
 
           // Reset aspiration window starting size
-          if (rootDepth >= 4)
-          {
-              Value prev = rootMoves[pvIdx].averageScore;
-              delta = Value(10) + int(prev) * prev / 16502;
-              alpha = std::max(prev - delta,-VALUE_INFINITE);
-              beta  = std::min(prev + delta, VALUE_INFINITE);
+          Value prev = rootMoves[pvIdx].averageScore;
+          delta = Value(10) + int(prev) * prev / 16502;
+          alpha = std::max(prev - delta,-VALUE_INFINITE);
+          beta  = std::min(prev + delta, VALUE_INFINITE);
 
-              // Adjust optimism based on root move's previousScore
-              int opt = 120 * prev / (std::abs(prev) + 161);
-              optimism[ us] = Value(opt);
-              optimism[~us] = -optimism[us];
-          }
+          // Adjust optimism based on root move's previousScore
+          int opt = 120 * prev / (std::abs(prev) + 161);
+          optimism[ us] = Value(opt);
+          optimism[~us] = -optimism[us];
 
           // Start with a small aspiration window and, in the case of a fail
           // high/low, re-search with a bigger window until we don't fail


### PR DESCRIPTION
Simplification STC: https://tests.stockfishchess.org/tests/view/64351654596a20f264276ded
LLR: 2.95 (-2.94,2.94) <-1.75,0.25> 
Total: 374664 W: 98942 L: 99089 D: 176633 
Ptnml(0-2): 1049, 41767, 101878, 41558, 1080

Simplification LTC: https://tests.stockfishchess.org/tests/view/6439499f605991a801b4f684
LLR: 2.95 (-2.94,2.94) <-1.75,0.25> 
Total: 457880 W: 123021 L: 123233 D: 211626
Ptnml(0-2): 166, 44739, 139335, 44541, 159

Bench: 3644729