### PR TITLE
Simplify verification search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -824,8 +824,6 @@ namespace {
             if (nullValue >= VALUE_TB_WIN_IN_MAX_PLY)
                 nullValue = beta;
 
-            assert(!thisThread->nmpMinPly); // Recursive verification is not allowed
-
             // Do verification search at high depths, with null move pruning disabled
             // until ply exceeds nmpMinPly.
             thisThread->nmpMinPly = ss->ply + 3 * (depth-R) / 4;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -824,9 +824,6 @@ namespace {
             if (nullValue >= VALUE_TB_WIN_IN_MAX_PLY)
                 nullValue = beta;
 
-            if (thisThread->nmpMinPly || (abs(beta) < VALUE_KNOWN_WIN && depth < 14))
-                return nullValue;
-
             assert(!thisThread->nmpMinPly); // Recursive verification is not allowed
 
             // Do verification search at high depths, with null move pruning disabled


### PR DESCRIPTION
This removes a redundant line in verfication search where some pruning is carried out. 

Simplification STC: https://tests.stockfishchess.org/tests/view/643b3e44d547701e2778f38b
LLR: 2.94 (-2.94,2.94) <-1.75,0.25> 
Total: 63360 W: 16859 L: 16673 D: 29828
Ptnml(0-2): 199, 6962, 17136, 7220, 163

Simplification LTC: https://tests.stockfishchess.org/tests/view/643be737dd42400a97f29c70
LLR: 2.94 (-2.94,2.94) <-1.75,0.25> 
Total: 80832 W: 21959 L: 21809 D: 37064
Ptnml(0-2): 33, 7797, 24611, 7937, 38

Bench: 3334480