### PR TITLE
Update default net to nn-1ceb1a57d117.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-dabb1ed23026.nnue"
+  #define EvalFileDefaultName   "nn-1ceb1a57d117.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
Created by retraining the master net with these changes to the dataset:
- Extending v6 filtering to data from T77 dec2021, T79 may2022, and T80 nov2022
- Reducing the number of duplicate positions, prioritizing position scores seen later in time
- Using a binpack minimizer to reduce the overall data size

Trained the same way as the previous master net, aside from the dataset changes:

```
python3 easy_train.py \
  --experiment-name leela96-dfrc99-T60novdec-v2-T80augsep-v6-T80junjuloctnovT79aprmayT78jantosepT77dec-v6dd \
  --training-dataset /data/leela96-dfrc99-T60novdec-v2-T80augsep-v6-T80junjuloctnovT79aprmayT78jantosepT77dec-v6dd.binpack \
  --nnue-pytorch-branch linrock/nnue-pytorch/misc-fixes \
  --start-from-engine-test-net True \
  --early-fen-skipping 30 \
  --start-lambda 1.0 \
  --end-lambda 0.7 \
  --max_epoch 900 \
  --lr 4.375e-4 \
  --gamma 0.995 \
  --tui False \
  --gpus "0," \
  --seed $RANDOM
```

The new v6-dd filtering reduces duplicate positions by iterating over hourly data files within leela test runs, starting with the most recent, then keeping positions the first time they're seen and ignoring positions that are seen again. This ordering was done with the assumption that position scores seen later in time are generally more accurate than scores seen earlier in the test run. Positions are de-duplicated based on piece orientations, the first token in fen strings. 

The binpack minimizer was run with default settings after first merging monthly data into single binpacks.

```
python3 interleave_binpacks.py \
  leela96-filt-v2.binpack \
  dfrc99-filt-v2.binpack \
  T60-nov2021-12tb7p-eval-filt-v2.binpack \
  T60-dec2021-12tb7p-eval-filt-v2.binpack \
  filt-v6/test80-aug2022-16tb7p-filter-v6.min-mar2023.binpack \
  filt-v6/test80-sep2022-16tb7p-filter-v6.min-mar2023.binpack \
  filt-v6-dd/test80-jun2022-16tb7p-filter-v6-dd.min-mar2023.binpack \
  filt-v6-dd/test80-jul2022-16tb7p-filter-v6-dd.binpack \
  filt-v6-dd/test80-oct2022-16tb7p-filter-v6-dd.binpack \
  filt-v6-dd/test80-nov2022-16tb7p-filter-v6-dd.binpack \
  filt-v6-dd/test79-apr2022-16tb7p-filter-v6-dd.binpack \
  filt-v6-dd/test79-may2022-16tb7p-filter-v6-dd.binpack \
  filt-v6-dd/test78-jantomay2022-16tb7p-filter-v6-dd.min-mar2023.binpack \
  filt-v6-dd/test78-juntosep2022-16tb7p-filter-v6-dd.binpack \
  filt-v6-dd/test77-dec2021-16tb7p-filter-v6-dd.binpack \
  /data/leela96-dfrc99-T60novdec-v2-T80augsep-v6-T80junjuloctnovT79aprmayT78jantosepT77dec-v6dd.binpack
```

The code for v6-dd filtering is available along with training data preparation scripts at:
https://github.com/linrock/nnue-data

Links for downloading the training data components:
https://robotmoon.com/nnue-training-data/

The binpack minimizer is from:
https://github.com/official-stockfish/Stockfish/pull/4447

Local elo at 25k nodes per move:
nn-epoch859.nnue : 1.2 +/- 2.6

Passed STC:
https://tests.stockfishchess.org/tests/view/643aad7db08900ff1bc5a832
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 565040 W: 150225 L: 149162 D: 265653
Ptnml(0-2): 1875, 62137, 153229, 63608, 1671

Passed LTC:
https://tests.stockfishchess.org/tests/view/643ecf2fa43cf30e719d2042
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 1014840 W: 274645 L: 272456 D: 467739
Ptnml(0-2): 515, 98565, 306970, 100956, 414

bench 3476305