### PR TITLE
Simplify away nnueComplexity in evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1055,21 +1055,21 @@ Value Eval::evaluate(const Position& pos) {
   // We use the much less accurate but faster Classical eval when the NNUE
   // option is set to false. Otherwise we use the NNUE eval unless the
   // PSQ advantage is decisive. (~4 Elo at STC, 1 Elo at LTC)
-  bool useClassical = !useNNUE || abs(psq) > 2213;
+  bool useClassical = !useNNUE || abs(psq) > 2210;
 
   if (useClassical)
       v = Evaluation<NO_TRACE>(pos).value();
   else
   {
-      int scale = 1010 + 16 * pos.non_pawn_material() / 1024;
+      int scale = 1011 + 16 * pos.non_pawn_material() / 1024;
 
       Color stm = pos.side_to_move();
       Value optimism = pos.this_thread()->optimism[stm];
 
       Value nnue = NNUE::evaluate(pos, true);
 
-      optimism = optimism * (273 + (443 + optimism) * abs(psq - nnue) / 1024) / 256;
-      v = (nnue * scale + optimism * (scale - 753)) / 1024;
+      optimism = optimism * (274 + (443 + optimism) * abs(psq - nnue) / 1024) / 256;
+      v = (nnue * scale + optimism * (scale - 752)) / 1024;
   }
 
   // Damp down the evaluation linearly when shuffling

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1055,21 +1055,21 @@ Value Eval::evaluate(const Position& pos) {
   // We use the much less accurate but faster Classical eval when the NNUE
   // option is set to false. Otherwise we use the NNUE eval unless the
   // PSQ advantage is decisive. (~4 Elo at STC, 1 Elo at LTC)
-  bool useClassical = !useNNUE || abs(psq) > 2019;
+  bool useClassical = !useNNUE || abs(psq) > 2213;
 
   if (useClassical)
       v = Evaluation<NO_TRACE>(pos).value();
   else
   {
-      int scale = 964 + 16 * pos.non_pawn_material() / 1024;
+      int scale = 1010 + 16 * pos.non_pawn_material() / 1024;
 
       Color stm = pos.side_to_move();
       Value optimism = pos.this_thread()->optimism[stm];
 
       Value nnue = NNUE::evaluate(pos, true);
 
-      optimism = optimism * (291 + (446 + optimism) * abs(psq - nnue) / 1024) / 256;
-      v = (nnue * scale + optimism * (scale - 787)) / 1024;
+      optimism = optimism * (273 + (443 + optimism) * abs(psq - nnue) / 1024) / 256;
+      v = (nnue * scale + optimism * (scale - 753)) / 1024;
   }
 
   // Damp down the evaluation linearly when shuffling

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1042,12 +1042,6 @@ make_v:
 
 } // namespace Eval
 
-int a1 = 2048,
-    b1 = 1001, b2 = 16,
-    c1 = 272, c2 = 424, c3 = 748;
-
-TUNE(a1, b1, b2, c1, c2, c3);
-
 /// evaluate() is the evaluator for the outer world. It returns a static
 /// evaluation of the position from the point of view of the side to move.
 
@@ -1061,21 +1055,21 @@ Value Eval::evaluate(const Position& pos) {
   // We use the much less accurate but faster Classical eval when the NNUE
   // option is set to false. Otherwise we use the NNUE eval unless the
   // PSQ advantage is decisive. (~4 Elo at STC, 1 Elo at LTC)
-  bool useClassical = !useNNUE || abs(psq) > a1;
+  bool useClassical = !useNNUE || abs(psq) > 2019;
 
   if (useClassical)
       v = Evaluation<NO_TRACE>(pos).value();
   else
   {
-      int scale = b1 + b2 * pos.non_pawn_material() / 1024;
+      int scale = 964 + 16 * pos.non_pawn_material() / 1024;
 
       Color stm = pos.side_to_move();
       Value optimism = pos.this_thread()->optimism[stm];
 
       Value nnue = NNUE::evaluate(pos, true);
 
-      optimism = optimism * (c1 + (c2 + optimism) * abs(psq - nnue) / 1024) / 256;
-      v = (nnue * scale + optimism * (scale - c3)) / 1024;
+      optimism = optimism * (291 + (446 + optimism) * abs(psq - nnue) / 1024) / 256;
+      v = (nnue * scale + optimism * (scale - 787)) / 1024;
   }
 
   // Damp down the evaluation linearly when shuffling

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -142,7 +142,7 @@ namespace Stockfish::Eval::NNUE {
   }
 
   // Evaluation function. Perform differential calculation.
-  Value evaluate(const Position& pos, bool adjusted, int* complexity) {
+  Value evaluate(const Position& pos, bool adjusted) {
 
     // We manually align the arrays on the stack because with gcc < 9.3
     // overaligning stack variables with alignas() doesn't work correctly.
@@ -165,9 +165,6 @@ namespace Stockfish::Eval::NNUE {
     const int bucket = (pos.count<ALL_PIECES>() - 1) / 4;
     const auto psqt = featureTransformer->transform(pos, transformedFeatures, bucket);
     const auto positional = network[bucket]->propagate(transformedFeatures);
-
-    if (complexity)
-        *complexity = abs(psqt - positional) / OutputScale;
 
     // Give more value to positional evaluation when adjusted flag is set
     if (adjusted)

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -56,7 +56,7 @@ namespace Stockfish::Eval::NNUE {
   using LargePagePtr = std::unique_ptr<T, LargePageDeleter<T>>;
 
   std::string trace(Position& pos);
-  Value evaluate(const Position& pos, bool adjusted = false, int* complexity = nullptr);
+  Value evaluate(const Position& pos, bool adjusted = false);
   void hint_common_parent_position(const Position& pos);
 
   bool load_eval(std::string name, std::istream& stream);


### PR DESCRIPTION
Simplify away usage of NNUE complexity. This is a follow-up to #4530. 

Also includes a parameter tuning for NNUE evaluation.

Simplification STC: https://tests.stockfishchess.org/tests/view/6447ae09c05f2b136ed50196
LLR: 2.96 (-2.94,2.94) <-1.75,0.25> 
Total: 72832 W: 19516 L: 19340 D: 33976
Ptnml(0-2): 166, 8044, 19878, 8104, 224

Simplification LTC: https://tests.stockfishchess.org/tests/view/64485ffe5d29c10f4f213c9d
LLR: 2.93 (-2.94,2.94) <-1.75,0.25> 
Total: 76992 W: 20893 L: 20741 D: 35358
Ptnml(0-2): 20, 7425, 23473, 7539, 39

Bench: 3783553