### PR TITLE
Simplify optimism, removing the (psq - nnue) difference.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1062,21 +1062,15 @@ Value Eval::evaluate(const Position& pos) {
       v = Evaluation<NO_TRACE>(pos).value();
   else
   {
-      int nnueComplexity;
-      int scale = 1001 + pos.non_pawn_material() / 64;
-
       Color stm = pos.side_to_move();
-      Value optimism = pos.this_thread()->optimism[stm];
 
+      int scale = 1001 + pos.non_pawn_material() / 64;
+      int nnueComplexity;
       Value nnue = NNUE::evaluate(pos, true, &nnueComplexity);
+      Value optimism = pos.this_thread()->optimism[stm]
+                       * (1220000 + 11 * nnueComplexity * (scale - 860));
 
-      // Blend nnue complexity with (semi)classical complexity
-      nnueComplexity = (  406 * nnueComplexity
-                        + (424 + optimism) * abs(psq - nnue)
-                        ) / 1024;
-
-      optimism = optimism * (272 + nnueComplexity) / 256;
-      v = (nnue * scale + optimism * (scale - 748)) / 1024;
+      v = nnue * scale / 1024 + optimism / (4096*1024);
   }
 
   // Damp down the evaluation linearly when shuffling


### PR DESCRIPTION
Simplify optimism, removing the (psq - nnue) difference.

STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 59040 W: 15699 L: 15510 D: 27831
Ptnml(0-2): 133, 6555, 16007, 6640, 185
https://tests.stockfishchess.org/tests/live_elo/6448de595d29c10f4f214c5f

LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 107712 W: 29199 L: 29076 D: 49437
Ptnml(0-2): 37, 10358, 32955, 10457, 49
https://tests.stockfishchess.org/tests/live_elo/6448eca45d29c10f4f215bdc

Future work:
This patch was created by only tuning the 1220000 and 860 constants, so further tuning in evaluate() and beyond might yield more gains. This removes a reference to psq, so can be seen as another step towards removing classical eval from stockfish.

Bench 4162805