### PR TITLE
Update 7 eval and optimism params

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1063,7 +1063,7 @@ Value Eval::evaluate(const Position& pos) {
   else
   {
       int nnueComplexity;
-      int scale = 1001 + pos.non_pawn_material() / 64;
+      int scale = 967 + pos.non_pawn_material() / 64;
 
       Color stm = pos.side_to_move();
       Value optimism = pos.this_thread()->optimism[stm];
@@ -1071,12 +1071,12 @@ Value Eval::evaluate(const Position& pos) {
       Value nnue = NNUE::evaluate(pos, true, &nnueComplexity);
 
       // Blend nnue complexity with (semi)classical complexity
-      nnueComplexity = (  406 * nnueComplexity
-                        + (424 + optimism) * abs(psq - nnue)
+      nnueComplexity = (  402 * nnueComplexity
+                        + (454 + optimism) * abs(psq - nnue)
                         ) / 1024;
 
-      optimism = optimism * (272 + nnueComplexity) / 256;
-      v = (nnue * scale + optimism * (scale - 748)) / 1024;
+      optimism = optimism * (274 + nnueComplexity) / 256;
+      v = (nnue * scale + optimism * (scale - 791)) / 1024;
   }
 
   // Damp down the evaluation linearly when shuffling

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -353,7 +353,7 @@ void Thread::search() {
           beta  = std::min(prev + delta, VALUE_INFINITE);
 
           // Adjust optimism based on root move's previousScore
-          int opt = 120 * prev / (std::abs(prev) + 161);
+          int opt = 102 * prev / (std::abs(prev) + 147);
           optimism[ us] = Value(opt);
           optimism[~us] = -optimism[us];
 


### PR DESCRIPTION
Params found using spsa at 30+0.3 with this tuning config:

```c++
// evaluate.cpp
int nnueOptScaleBase = 1001;
int nnueComplexityMult = 406;
int nnueComplexityOptOffset = 424;
int evalOptComplexityOffset = 272;
int evalOptScaleOffset = 748;
TUNE(SetRange(801, 1201), nnueOptScaleBase);
TUNE(SetRange(306, 506), nnueComplexityMult);
TUNE(SetRange(324, 524), nnueComplexityOptOffset);
TUNE(SetRange(172, 372), evalOptComplexityOffset);
TUNE(SetRange(648, 848), evalOptScaleOffset);

// search.cpp
int searchOptBase = 120;
int searchOptDenom = 161;
TUNE(SetRange(20, 220), searchOptBase);
TUNE(SetRange(111, 211), searchOptDenom);
```

Passed STC:
https://tests.stockfishchess.org/tests/view/644dda8accf5e93df5e50cbe
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 136800 W: 36682 L: 36237 D: 63881
Ptnml(0-2): 353, 14910, 37492, 15229, 416

Passed LTC:
https://tests.stockfishchess.org/tests/view/644eaedb3f31c3bbe4a3d345
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 64548 W: 17624 L: 17272 D: 29652
Ptnml(0-2): 33, 6112, 19631, 6466, 32

bench 3670343