### PR TITLE
Simplify away TT re-evaluation

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -720,15 +720,9 @@ namespace {
     }
     else if (ss->ttHit)
     {
-        // Never assume anything about values stored in TT
         ss->staticEval = eval = tte->eval();
-        if (eval == VALUE_NONE)
-            ss->staticEval = eval = evaluate(pos);
-        else
-        {
-            if (PvNode)
-               Eval::NNUE::hint_common_parent_position(pos);
-        }
+        if (PvNode)
+            Eval::NNUE::hint_common_parent_position(pos);
 
         // ttValue can be used as a better position evaluation (~7 Elo)
         if (    ttValue != VALUE_NONE
@@ -1472,9 +1466,7 @@ moves_loop: // When in check, search starts here
     {
         if (ss->ttHit)
         {
-            // Never assume anything about values stored in TT
-            if ((ss->staticEval = bestValue = tte->eval()) == VALUE_NONE)
-                ss->staticEval = bestValue = evaluate(pos);
+            ss->staticEval = bestValue = tte->eval();
 
             // ttValue can be used as a better position evaluation (~13 Elo)
             if (    ttValue != VALUE_NONE


### PR DESCRIPTION
Remove re-evaluation of TT positions. Previously this was only done for in-check positions, where the eval may be set to VALUE_NONE. This had only 3 hits out of 1.5 million, and the static eval does not seem to be important for these in-check situations: The TT eval is only used if it is not VALUE_NONE.

Simplification STC: https://tests.stockfishchess.org/tests/view/644f3c140ff0c39f75a16296
LLR: 2.93 (-2.94,2.94) <-1.75,0.25> 
Total: 107168 W: 28612 L: 28479 D: 50077 
Ptnml(0-2): 269, 11136, 30621, 11309, 249

Simplification LTC SMP: https://tests.stockfishchess.org/tests/view/64505ee7a1d4f4b32556947d
LLR: 2.94 (-2.94,2.94) <-1.75,0.25> 
Total: 51552 W: 14218 L: 14049 D: 23285
Ptnml(0-2): 12, 4486, 16614, 4649, 15

Bench: 3569416