### PR TITLE
Reduce more if current node has a lot of refuted moves.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1326,7 +1326,7 @@ moves_loop: // When in check, search starts here
               }
               else
               {
-                  ss->cutoffCnt++;
+                  ss->cutoffCnt += 1 + !ttMove;
                   assert(value >= beta); // Fail high
                   break;
               }


### PR DESCRIPTION
This patch refines idea of cutoff count - in master we reduce more if current node has at least 4 moves that are refuted by search, this patch increases this count by 1 if refutation happened without having a tt move.
Passed STC: 
https://tests.stockfishchess.org/tests/view/645363c36206ee34ebf8191d
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 67616 W: 18220 L: 17874 D: 31522
Ptnml(0-2): 142, 7346, 18504, 7656, 160 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6453a0ea6206ee34ebf82796
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 195228 W: 52741 L: 52140 D: 90347
Ptnml(0-2): 53, 18718, 59482, 19297, 64 
bench 3448916