### PR TITLE
Small cleanup

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1313,7 +1313,7 @@ moves_loop: // When in check, search starts here
               if (PvNode && !rootNode) // Update pv even in fail-high case
                   update_pv(ss->pv, move, (ss+1)->pv);
 
-              if (value >= beta) // Update alpha! Always alpha < beta
+              if (value >= beta)
               {
                   ss->cutoffCnt += 1 + !ttMove;
                   assert(value >= beta); // Fail high
@@ -1328,7 +1328,7 @@ moves_loop: // When in check, search starts here
                       depth -= 1;
 
                   assert(depth > 0);
-                  alpha = value;
+                  alpha = value; // Update alpha! Always alpha < beta
               }
           }
       }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1313,7 +1313,13 @@ moves_loop: // When in check, search starts here
               if (PvNode && !rootNode) // Update pv even in fail-high case
                   update_pv(ss->pv, move, (ss+1)->pv);
 
-              if (PvNode && value < beta) // Update alpha! Always alpha < beta
+              if (value >= beta) // Update alpha! Always alpha < beta
+              {
+                  ss->cutoffCnt += 1 + !ttMove;
+                  assert(value >= beta); // Fail high
+                  break;
+              }
+              else
               {
                   // Reduce other moves if we have found at least one score improvement (~1 Elo)
                   if (   depth > 1
@@ -1323,12 +1329,6 @@ moves_loop: // When in check, search starts here
 
                   assert(depth > 0);
                   alpha = value;
-              }
-              else
-              {
-                  ss->cutoffCnt += 1 + !ttMove;
-                  assert(value >= beta); // Fail high
-                  break;
               }
           }
       }


### PR DESCRIPTION
In search remove one condition check and reorder conditions. Removes some code.
Passed non-regression test:
https://tests.stockfishchess.org/tests/view/64548fa06206ee34ebf853ad
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 282976 W: 75327 L: 75374 D: 132275
Ptnml(0-2): 604, 29673, 80995, 29598, 618 
no functional change