### PR TITLE
Increase MAX_MOVES to prevent buffer overflow and stack corruption

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -106,7 +106,7 @@ constexpr bool Is64Bit = false;
 using Key = uint64_t;
 using Bitboard = uint64_t;
 
-constexpr int MAX_MOVES = 256;
+constexpr int MAX_MOVES = 256 + 64;
 constexpr int MAX_PLY   = 246;
 
 /// A move needs 16 bits to be stored


### PR DESCRIPTION
SF's move buffer `ExtMove moveList[MAX_MOVES]` assumes a maximum move count of 256, but there are many "impossible" positions in which more than 256 moves are generated.

When running on these impossible positions, SF crashes due to out-of-bounds memory accesses.
This poses a potential security issue because this buffer overflow leads to stack corruption.
Due to the dense encoding of moves, and the many possible >256-move positions, it is theoretically possible to design a position to write specific memory outside of the buffer.

With modern DEP and frame pointer security checks, it is unlikely that this can be exploited to perform RCE or anything, but having a buffer overflow and stack corruption in such a popular program seems quite dangerous to me.

**Steps to reproduce:**
`position fen QQQQQQBk/Q6B/Q6Q/Q6Q/Q6Q/Q6Q/Q6Q/KQQQQQQQ w - - 0 1`
`go depth 1`

**Solutions:**
The simplest solution, as this PR commits, is to simply increases the maximum move count by 64.
Another solution is to prevent generating moves for any position with >16 pieces for either side, as the position cannot be reached from any normal chess game. This also prevents to potential (albeit very slight) performance impact of having a larger move list.