### PR TITLE
Refine deeper post-lmr searches.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1204,7 +1204,7 @@ moves_loop: // When in check, search starts here
           {
               // Adjust full depth search based on LMR results - if result
               // was good enough search deeper, if it was bad enough search shallower
-              const bool doDeeperSearch = value > (alpha + 58 + 12 * (newDepth - d));
+              const bool doDeeperSearch = value > (bestValue + 68 + 12 * (newDepth - d));
               const bool doEvenDeeperSearch = value > alpha + 588 && ss->doubleExtensions <= 5;
               const bool doShallowerSearch = value < bestValue + newDepth;
 


### PR DESCRIPTION
This patch improves logic conditions for performing deeper searches after passed LMR.
Instead of exceeding alpha by some margin now it requires to exceed current best value - which may be lower than alpha (but never bigger since we update alpha with bestvalue if it exceeds alpha).
Passed STC:
https://tests.stockfishchess.org/tests/view/6455f78008858de8313775b6
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 209344 W: 55993 L: 55448 D: 97903
Ptnml(0-2): 507, 22798, 57526, 23325, 516 
Passed LTC:
https://tests.stockfishchess.org/tests/view/64572d46eb75932ccfebff97
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 66288 W: 17867 L: 17514 D: 30907
Ptnml(0-2): 21, 6240, 20269, 6593, 21 
bench 3808503