### PR TITLE
[RFC] Handle *some* out-of-spec behaviour explicitly

### DIFF
--- a/src/endgame.h
+++ b/src/endgame.h
@@ -109,9 +109,14 @@ namespace Endgames {
   template<EndgameCode E, typename T = eg_type<E>>
   void add(const std::string& code) {
 
+    Position pos;
     StateInfo st;
-    map<T>()[Position().set(code, WHITE, &st).material_key()] = Ptr<T>(new Endgame<E>(WHITE));
-    map<T>()[Position().set(code, BLACK, &st).material_key()] = Ptr<T>(new Endgame<E>(BLACK));
+
+    pos.set(code, WHITE, &st);
+    map<T>()[pos.material_key()] = Ptr<T>(new Endgame<E>(WHITE));
+
+    pos.set(code, BLACK, &st);
+    map<T>()[pos.material_key()] = Ptr<T>(new Endgame<E>(BLACK));
   }
 
   template<typename T>

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -227,6 +227,26 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
         UCI::critical_error(std::string("Invalid FEN. Invalid piece: ") + std::string(1, token));
   }
 
+  int pawns_w = count<PAWN>(WHITE);
+  int pawns_b = count<PAWN>(BLACK);
+  if (pawns_w > 8)
+    UCI::critical_error("Invalid FEN. WHITE has more than 8 pawns.");
+  if (pawns_b > 8)
+    UCI::critical_error("Invalid FEN. BLACK has more than 8 pawns.");
+
+  int additional_knights_w = std::max((int)count<KNIGHT>(WHITE) - 2, 0);
+  int additional_knights_b = std::max((int)count<KNIGHT>(BLACK) - 2, 0);
+  int additional_bishops_w = std::max((int)count<BISHOP>(WHITE) - 2, 0);
+  int additional_bishops_b = std::max((int)count<BISHOP>(BLACK) - 2, 0);
+  int additional_rooks_w = std::max((int)count<ROOK>(WHITE) - 2, 0);
+  int additional_rooks_b = std::max((int)count<ROOK>(BLACK) - 2, 0);
+  int additional_queens_w = std::max((int)count<QUEEN>(WHITE) - 1, 0);
+  int additional_queens_b = std::max((int)count<QUEEN>(BLACK) - 1, 0);
+  if (additional_knights_w + additional_bishops_w + additional_rooks_w + additional_queens_w > 8 - pawns_w)
+    UCI::critical_error("Invalid FEN. Invalid piece configuration for WHITE.");
+  if (additional_knights_b + additional_bishops_b + additional_rooks_b + additional_queens_b > 8 - pawns_b)
+    UCI::critical_error("Invalid FEN. Invalid piece configuration for BLACK.");
+
   // 2. Active color
   ss >> token;
   if (token != 'w' && token != 'b')

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -215,7 +215,7 @@ std::optional<PositionSetError> Position::set(const string& fenStr, bool isChess
 
   ss >> std::noskipws;
 
-  int piece_count = 0;
+  int numPieces = 0;
   File file = FILE_A;
   Rank rank = RANK_8;
 
@@ -253,7 +253,7 @@ std::optional<PositionSetError> Position::set(const string& fenStr, bool isChess
           const size_t idx = PieceToChar.find(token);
           if (idx == string::npos)
               return PositionSetError(std::string("Invalid FEN. Invalid piece: ") + std::string(1, token));
-          if (++piece_count > 32)
+          if (++numPieces > 32)
               return PositionSetError("Invalid FEN. More than 32 pieces on the board.");
 
           const Square sq = make_square(file, rank);
@@ -269,24 +269,24 @@ std::optional<PositionSetError> Position::set(const string& fenStr, bool isChess
       return PositionSetError("Invalid FEN. Board state encoding ended but cursor not at end.");
 
   {
-      const int pawns_w = count<PAWN>(WHITE);
-      const int pawns_b = count<PAWN>(BLACK);
-      if (pawns_w > 8)
+      const int wPawns = count<PAWN>(WHITE);
+      const int bPawns = count<PAWN>(BLACK);
+      if (wPawns > 8)
           return PositionSetError("Invalid FEN. WHITE has more than 8 pawns.");
-      if (pawns_b > 8)
+      if (bPawns > 8)
           return PositionSetError("Invalid FEN. BLACK has more than 8 pawns.");
 
-      const int additional_knights_w = std::max((int)count<KNIGHT>(WHITE) - 2, 0);
-      const int additional_knights_b = std::max((int)count<KNIGHT>(BLACK) - 2, 0);
-      const int additional_bishops_w = std::max((int)count<BISHOP>(WHITE) - 2, 0);
-      const int additional_bishops_b = std::max((int)count<BISHOP>(BLACK) - 2, 0);
-      const int additional_rooks_w = std::max((int)count<ROOK>(WHITE) - 2, 0);
-      const int additional_rooks_b = std::max((int)count<ROOK>(BLACK) - 2, 0);
-      const int additional_queens_w = std::max((int)count<QUEEN>(WHITE) - 1, 0);
-      const int additional_queens_b = std::max((int)count<QUEEN>(BLACK) - 1, 0);
-      if (additional_knights_w + additional_bishops_w + additional_rooks_w + additional_queens_w > 8 - pawns_w)
+      const int wAdditionalKnights = std::max((int)count<KNIGHT>(WHITE) - 2, 0);
+      const int bAdditionalKnights = std::max((int)count<KNIGHT>(BLACK) - 2, 0);
+      const int wAdditionalBishops = std::max((int)count<BISHOP>(WHITE) - 2, 0);
+      const int bAdditionalBishops = std::max((int)count<BISHOP>(BLACK) - 2, 0);
+      const int wAdditionalRooks = std::max((int)count<ROOK>(WHITE) - 2, 0);
+      const int bAdditionalRooks = std::max((int)count<ROOK>(BLACK) - 2, 0);
+      const int wAdditionalQueens = std::max((int)count<QUEEN>(WHITE) - 1, 0);
+      const int bAdditionalQueens = std::max((int)count<QUEEN>(BLACK) - 1, 0);
+      if (wAdditionalKnights + wAdditionalBishops + wAdditionalRooks + wAdditionalQueens > 8 - wPawns)
           return PositionSetError("Invalid FEN. Invalid piece configuration for WHITE.");
-      if (additional_knights_b + additional_bishops_b + additional_rooks_b + additional_queens_b > 8 - pawns_b)
+      if (bAdditionalKnights + bAdditionalBishops + bAdditionalRooks + bAdditionalQueens > 8 - bPawns)
           return PositionSetError("Invalid FEN. Invalid piece configuration for BLACK.");
   }
 
@@ -391,17 +391,17 @@ std::optional<PositionSetError> Position::set(const string& fenStr, bool isChess
 
   // Technically, positions with rule50==100 are correct, just no moves can be made further.
   // However, due to human stuff, we want to *support* rule50 up to 150.
-  constexpr int max_rule50_fullmoves = 75;
-  if (st->rule50 < 0 || st->rule50 > max_rule50_fullmoves * 2)
+  constexpr int MaxRule50Fullmoves = 75;
+  if (st->rule50 < 0 || st->rule50 > MaxRule50Fullmoves * 2)
       return PositionSetError("Invalid FEN. Rule50 counter outside of range, got: " + std::to_string(st->rule50));
 
   // https://chess.stackexchange.com/questions/4113/longest-chess-game-possible-maximum-moves
-  constexpr int max_moves =   max_rule50_fullmoves - 1
-                            + 32 * max_rule50_fullmoves
-                            + 6 * 8 * max_rule50_fullmoves
-                            + 7 * max_rule50_fullmoves
-                            + 30 * max_rule50_fullmoves;
-  if (gamePly < 1 || gamePly > max_moves)
+  constexpr int MaxMoves =   MaxRule50Fullmoves - 1
+                            + 32 * MaxRule50Fullmoves
+                            + 6 * 8 * MaxRule50Fullmoves
+                            + 7 * MaxRule50Fullmoves
+                            + 30 * MaxRule50Fullmoves;
+  if (gamePly < 1 || gamePly > MaxMoves)
       return PositionSetError("Invalid FEN. Full-move counter outside of range, got: " + std::to_string(gamePly));
 
   // Convert from fullmove starting from 1 to gamePly starting from 0,

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -377,7 +377,8 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
   }
 
   // Technically, positions with rule50==100 are correct, just no moves can be made further.
-  if (st->rule50 < 0 || st->rule50 > 100)
+  // However, due to human stuff, we want to *support* rule50 up to 150.
+  if (st->rule50 < 0 || st->rule50 > 150)
       UCI::critical_error("Invalid FEN. Rule50 counter outside of range, got: " + std::to_string(st->rule50));
 
   // https://chess.stackexchange.com/questions/4113/longest-chess-game-possible-maximum-moves

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -378,11 +378,17 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
 
   // Technically, positions with rule50==100 are correct, just no moves can be made further.
   // However, due to human stuff, we want to *support* rule50 up to 150.
-  if (st->rule50 < 0 || st->rule50 > 150)
+  constexpr int max_rule50_fullmoves = 75;
+  if (st->rule50 < 0 || st->rule50 > max_rule50_fullmoves * 2)
       UCI::critical_error("Invalid FEN. Rule50 counter outside of range, got: " + std::to_string(st->rule50));
 
   // https://chess.stackexchange.com/questions/4113/longest-chess-game-possible-maximum-moves
-  if (gamePly < 1 || gamePly > 5900)
+  constexpr int max_moves =   max_rule50_fullmoves - 1
+                            + 32 * max_rule50_fullmoves
+                            + 6 * 8 * max_rule50_fullmoves
+                            + 7 * max_rule50_fullmoves
+                            + 30 * max_rule50_fullmoves;
+  if (gamePly < 1 || gamePly > max_moves)
       UCI::critical_error("Invalid FEN. Full-move counter outside of range, got: " + std::to_string(gamePly));
 
   // Convert from fullmove starting from 1 to gamePly starting from 0,

--- a/src/position.h
+++ b/src/position.h
@@ -23,6 +23,8 @@
 #include <deque>
 #include <memory> // For std::unique_ptr
 #include <string>
+#include <stdexcept>
+#include <optional>
 
 #include "bitboard.h"
 #include "evaluate.h"
@@ -36,6 +38,10 @@ namespace Stockfish {
 /// StateInfo struct stores information needed to restore a Position object to
 /// its previous state when we retract a move. Whenever a move is made on the
 /// board (by calling Position::do_move), a StateInfo object must be passed.
+
+struct PositionSetError : std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
 
 struct StateInfo {
 
@@ -86,8 +92,8 @@ public:
   Position& operator=(const Position&) = delete;
 
   // FEN string input/output
-  Position& set(const std::string& fenStr, bool isChess960, StateInfo* si, Thread* th);
-  Position& set(const std::string& code, Color c, StateInfo* si);
+  std::optional<PositionSetError> set(const std::string& fenStr, bool isChess960, StateInfo* si, Thread* th);
+  std::optional<PositionSetError> set(const std::string& code, Color c, StateInfo* si);
   std::string fen() const;
 
   // Position representation

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -363,7 +363,8 @@ TBTable<WDL>::TBTable(const std::string& code) : TBTable() {
     StateInfo st;
     Position pos;
 
-    key = pos.set(code, WHITE, &st).material_key();
+    pos.set(code, WHITE, &st);
+    key = pos.material_key();
     pieceCount = pos.count<ALL_PIECES>();
     hasPawns = pos.pieces(PAWN);
 
@@ -382,7 +383,8 @@ TBTable<WDL>::TBTable(const std::string& code) : TBTable() {
     pawnCount[0] = pos.count<PAWN>(c ? WHITE : BLACK);
     pawnCount[1] = pos.count<PAWN>(c ? BLACK : WHITE);
 
-    key2 = pos.set(code, BLACK, &st).material_key();
+    pos.set(code, BLACK, &st);
+    key2 = pos.material_key();
 }
 
 template<>

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -68,18 +68,20 @@ namespace {
         return;
 
     states = StateListPtr(new std::deque<StateInfo>(1)); // Drop the old state and create a new one
-    pos.set(fen, Options["UCI_Chess960"], &states->back(), Threads.main());
+    auto err = pos.set(fen, Options["UCI_Chess960"], &states->back(), Threads.main());
+    if (err)
+        UCI::terminate_on_critical_error(err->what());
 
     // Parse the move list, if any
     while (is >> token)
     {
         if (pos.state()->rule50 > 99)
-            UCI::critical_error("Invalid move. Draw by rule50 reached.");
+            UCI::terminate_on_critical_error("Invalid move. Draw by rule50 reached.");
 
         m = UCI::to_move(pos, token);
 
         if (m == MOVE_NONE)
-            UCI::critical_error("Invalid moves. Illegal move.");
+            UCI::terminate_on_critical_error("Invalid moves. Illegal move.");
 
         states->emplace_back();
         pos.do_move(m, states->back());
@@ -403,7 +405,7 @@ Move UCI::to_move(const Position& pos, string& str) {
   return MOVE_NONE;
 }
 
-void UCI::critical_error(const std::string& message) {
+void UCI::terminate_on_critical_error(const std::string& message) {
   // Ideally we would report the error and continue, but UCI does not define such a situation nor
   // gives any guarantees as to the program's behaviour for the user to rely on,
   // so the safest option is to terminate.

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -73,10 +73,13 @@ namespace {
     // Parse the move list, if any
     while (is >> token)
     {
+        if (pos.state()->rule50 > 99)
+            UCI::critical_error("Invalid move. Draw by rule50 reached.");
+
         m = UCI::to_move(pos, token);
 
         if (m == MOVE_NONE)
-          UCI::critical_error("Invalid moves. Illegal move.");
+            UCI::critical_error("Invalid moves. Illegal move.");
 
         states->emplace_back();
         pos.do_move(m, states->back());

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -395,4 +395,12 @@ Move UCI::to_move(const Position& pos, string& str) {
   return MOVE_NONE;
 }
 
+void UCI::critical_error(const std::string& message) {
+  // Ideally we would report the error and continue, but UCI does not define such a situation nor
+  // gives any guarantees as to the program's behaviour for the user to rely on,
+  // so the safest option is to terminate.
+  sync_cout << "info string CRITICAL ERROR: " << message << '\n' << sync_endl;
+  std::terminate();
+}
+
 } // namespace Stockfish

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -71,8 +71,13 @@ namespace {
     pos.set(fen, Options["UCI_Chess960"], &states->back(), Threads.main());
 
     // Parse the move list, if any
-    while (is >> token && (m = UCI::to_move(pos, token)) != MOVE_NONE)
+    while (is >> token)
     {
+        m = UCI::to_move(pos, token);
+
+        if (m == MOVE_NONE)
+          UCI::critical_error("Invalid moves. Illegal move.");
+
         states->emplace_back();
         pos.do_move(m, states->back());
     }

--- a/src/uci.h
+++ b/src/uci.h
@@ -83,7 +83,7 @@ std::string pv(const Position& pos, Depth depth);
 std::string wdl(Value v, int ply);
 Move to_move(const Position& pos, std::string& str);
 
-[[noreturn]] void critical_error(const std::string& message);
+[[noreturn]] void terminate_on_critical_error(const std::string& message);
 
 } // namespace UCI
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -83,7 +83,7 @@ std::string pv(const Position& pos, Depth depth);
 std::string wdl(Value v, int ply);
 Move to_move(const Position& pos, std::string& str);
 
-[[noreturn]] void terminate_on_critical_error(const std::string& message);
+[[noreturn]] void terminate_on_critical_error(const std::string& fullCommand, const std::string& message);
 
 } // namespace UCI
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -83,6 +83,8 @@ std::string pv(const Position& pos, Depth depth);
 std::string wdl(Value v, int ply);
 Move to_move(const Position& pos, std::string& str);
 
+[[noreturn]] void critical_error(const std::string& message);
+
 } // namespace UCI
 
 extern UCI::OptionsMap Options;


### PR DESCRIPTION
This is a preliminary set of changes to explicitly handle some cases that resulted in undefined behaviour previously:

1. UCI is given a fen that has more than 32 pieces
2. UCI is given a fen that has invalid number of kings
3. UCI is given a fen that has a piece configuration definitely unreachable piece counts (prevents positions with >256 moves)
4. UCI is given a fen that would write outside of a board (due to implementation details)
5. UCI is given a fen that otherwise fails `pos_is_ok` check
6. UCI is given a fen with rule50 counter >100

Additional validation changes:

1. During FEN parsing, error on invalid castling rights (previously ignored)
2. During FEN parsing, error on invalid ep-square (previously ignored)
3. During FEN parsing, error on invalid side to move (previously assumed white)
4. During FEN + moves parsing, error on illegal move (previously was being ignored)

TODO (at least what I have on mind right now, there's definitely more):

1. When parsing FEN, ensure that the file cannot change by means other than '/'

Any above errors are handled by calling `std::terminate`. The motivation for such behaviour is lack of specification from the UCI protocol. UCI allows ignoring errors, but ignoring errors never a good idea as it leads to differences between expected and actual state. Crashing is the only responsible thing we can do in this case.

The test under https://tests.stockfishchess.org/tests/view/645b9b0a175801c38d5c4e85 was mostly a sanity check (with a slightly older version), I don't expect any performance degradation. The current state of this PR is that the changes are slapped on top of whatever was there. It may be better to rewrite some parts completely, but first I'd like to know if this is desired, and if I'm not missing something important.