### PR TITLE
Small simplification in low depth pruning.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -979,7 +979,7 @@ moves_loop: // When in check, search starts here
           moveCountPruning = moveCount >= futility_move_count(improving, depth);
 
           // Reduced depth of the next LMR search
-          int lmrDepth = std::max(newDepth - r, 0);
+          int lmrDepth = newDepth - r;
 
           if (   capture
               || givesCheck)


### PR DESCRIPTION
Uncap low depth pruning lmr depth. It's anyway capped for most cases apart from futility pruning for captures - removes one std::min call.
Passed STC:
https://tests.stockfishchess.org/tests/view/645e8fa6d55cccb2e64225a1
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 184064 W: 49039 L: 48982 D: 86043
Ptnml(0-2): 462, 20353, 50349, 20402, 466 
Passed LTC:
https://tests.stockfishchess.org/tests/view/645f4d48d55cccb2e6423335
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 83886 W: 22613 L: 22465 D: 38808
Ptnml(0-2): 31, 8090, 25546, 8252, 24 
bench 3623527