### PR TITLE
Small simplification in history pruning.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1021,8 +1021,8 @@ moves_loop: // When in check, search starts here
                             + (*contHist[3])[movedPiece][to_sq(move)];
 
               // Continuation history based pruning (~2 Elo)
-              if (   lmrDepth < 5
-                  && history < -4405 * (depth - 1))
+              if (   lmrDepth < 6
+                  && history < -4405 * depth)
                   continue;
 
               history += 2 * thisThread->mainHistory[us][from_to(move)];


### PR DESCRIPTION
Remove the constant term of the history threshold which lowers the chance that pruning occurs. As compensation allow pruning at a slightly higher depth.

Passed STC:
https://tests.stockfishchess.org/tests/view/64634c9a87f6567dd4df4901
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>Total: 101536 W: 27156 L: 27012 D: 47368
Ptnml(0-2): 266, 11165, 27772, 11289, 276

Passed LTC:
https://tests.stockfishchess.org/tests/view/6463d68b17982fde89d2bc2b
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 32154 W: 8741 L: 8543 D: 14870
Ptnml(0-2): 8, 3093, 9687, 3271, 18

Bench: 3554854