### PR TITLE
Simplify SEE verification logic

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -996,8 +996,6 @@ moves_loop: // When in check, search starts here
               // SEE based pruning (~11 Elo)
               if (!pos.see_ge(move, occupied, Value(-206) * depth))
               {
-                  if (depth < 2 - capture)
-                      continue;
                   // Don't prune the move if opp. King/Queen/Rook gets a discovered attack during or after the exchanges
                   Bitboard leftEnemies = pos.pieces(~us, KING, QUEEN, ROOK);
                   Bitboard attacks = 0;
@@ -1006,7 +1004,7 @@ moves_loop: // When in check, search starts here
                   {
                       Square sq = pop_lsb(leftEnemies);
                       attacks = pos.attackers_to(sq, occupied) & pos.pieces(us) & occupied;
-                      // Exclude Queen/Rook(s) which were already threatened before SEE (opp King can't be in check when it's our turn)
+                      // Exclude Queen/Rook(s) which were already threatened before SEE (opp. King can't be in check when it's our turn)
                       if (attacks && sq != pos.square<KING>(~us) && (pos.attackers_to(sq, pos.pieces()) & pos.pieces(us)))
                           attacks = 0;
                   }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -996,7 +996,7 @@ moves_loop: // When in check, search starts here
               // SEE based pruning (~11 Elo)
               if (!pos.see_ge(move, occupied, Value(-206) * depth))
               {
-                  // Don't prune the move if opp. King/Queen/Rook gets a discovered attack during or after the exchanges
+                  // Don't prune the move if opponent King/Queen/Rook gets a discovered attack during or after the exchanges
                   Bitboard leftEnemies = pos.pieces(~us, KING, QUEEN, ROOK);
                   Bitboard attacks = 0;
                   occupied |= to_sq(move);
@@ -1004,7 +1004,7 @@ moves_loop: // When in check, search starts here
                   {
                       Square sq = pop_lsb(leftEnemies);
                       attacks = pos.attackers_to(sq, occupied) & pos.pieces(us) & occupied;
-                      // Exclude Queen/Rook(s) which were already threatened before SEE (opp. King can't be in check when it's our turn)
+                      // Exclude Queen/Rook(s) which were already threatened before SEE (opponent King can't be in check when it's our turn)
                       if (attacks && sq != pos.square<KING>(~us) && (pos.attackers_to(sq, pos.pieces()) & pos.pieces(us)))
                           attacks = 0;
                   }


### PR DESCRIPTION
Simplify SEE verification logic

Passed STC
https://tests.stockfishchess.org/tests/view/6461d51887f6567dd4df27d0
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 177056 W: 47181 L: 47118 D: 82757
Ptnml(0-2): 456, 19381, 48792, 19442, 457

Passed LTC
https://tests.stockfishchess.org/tests/view/64631a9287f6567dd4df4502
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 104346 W: 28062 L: 27935 D: 48349
Ptnml(0-2): 25, 10190, 31631, 10287, 40

bench: 3930762