### PR TITLE
Simplify NodeType template in qsearch into boolean

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -76,6 +76,7 @@ George Sobala (gsobala)
 gguliash
 Giacomo Lorenzetti (G-Lorenz)
 Gian-Carlo Pascutto (gcp)
+Goh CJ (cj5716)
 Gontran Lemaire (gonlem)
 Goodkov Vasiliy Aleksandrovich (goodkov)
 Gregor Cramer

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -760,7 +760,7 @@ namespace {
     // return a fail low.
     if (eval < alpha - 426 - 256 * depth * depth)
     {
-        value = qsearch<NonPV>(pos, ss, alpha - 1, alpha);
+        value = qsearch<false>(pos, ss, alpha - 1, alpha);
         if (value < alpha)
             return value;
     }
@@ -858,7 +858,7 @@ namespace {
                 pos.do_move(move, st);
 
                 // Perform a preliminary qsearch to verify that the move holds
-                value = -qsearch<NonPV>(pos, ss+1, -probCutBeta, -probCutBeta+1);
+                value = -qsearch<false>(pos, ss+1, -probCutBeta, -probCutBeta+1);
 
                 // If the qsearch held, perform the regular search
                 if (value >= probCutBeta)
@@ -884,7 +884,7 @@ namespace {
         depth -= 2 + 2 * (ss->ttHit && tte->depth() >= depth);
 
     if (depth <= 0)
-        return qsearch<PV>(pos, ss, alpha, beta);
+        return qsearch<true>(pos, ss, alpha, beta);
 
     if (    cutNode
         &&  depth >= 7

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -115,7 +115,7 @@ namespace {
   template <NodeType nodeType>
   Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, bool cutNode);
 
-  template <NodeType nodeType>
+  template <bool PvNode>
   Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth = 0);
 
   Value value_to_tt(Value v, int ply);
@@ -529,7 +529,7 @@ namespace {
 
     // Dive into quiescence search when the depth reaches zero
     if (depth <= 0)
-        return qsearch<PvNode ? PV : NonPV>(pos, ss, alpha, beta);
+        return qsearch<PvNode>(pos, ss, alpha, beta);
 
     assert(-VALUE_INFINITE <= alpha && alpha < beta && beta <= VALUE_INFINITE);
     assert(PvNode || (alpha == beta - 1));
@@ -1398,11 +1398,8 @@ moves_loop: // When in check, search starts here
   // qsearch() is the quiescence search function, which is called by the main search
   // function with zero depth, or recursively with further decreasing depth per call.
   // (~155 Elo)
-  template <NodeType nodeType>
+  template <bool PvNode>
   Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth) {
-
-    static_assert(nodeType != Root);
-    constexpr bool PvNode = nodeType == PV;
 
     assert(alpha >= -VALUE_INFINITE && alpha < beta && beta <= VALUE_INFINITE);
     assert(PvNode || (alpha == beta - 1));
@@ -1590,7 +1587,7 @@ moves_loop: // When in check, search starts here
 
       // Step 7. Make and search the move
       pos.do_move(move, st, givesCheck);
-      value = -qsearch<nodeType>(pos, ss+1, -beta, -alpha, depth - 1);
+      value = -qsearch<PvNode>(pos, ss+1, -beta, -alpha, depth - 1);
       pos.undo_move(move);
 
       assert(value > -VALUE_INFINITE && value < VALUE_INFINITE);


### PR DESCRIPTION
This will prevent a qsearch on rootNodes (thereby allowing us to remove the assert) as well as an assignment of the PvNode variable

Passed non-regression test:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 86656 W: 23001 L: 22846 D: 40809
Ptnml(0-2): 190, 8946, 24933, 9037, 222
https://tests.stockfishchess.org/tests/view/646567d9f3b1a4e86c31839c

No functional change