### PR TITLE
Simplify Prune moves with negative SEE

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1037,7 +1037,7 @@ moves_loop: // When in check, search starts here
               lmrDepth = std::max(lmrDepth, 0);
 
               // Prune moves with negative SEE (~4 Elo)
-              if (!pos.see_ge(move, Value(-27 * lmrDepth * lmrDepth - 33 * lmrDepth / 2)))
+              if (!pos.see_ge(move, Value(-27 * lmrDepth * lmrDepth - 16 * lmrDepth)))
                   continue;
           }
       }


### PR DESCRIPTION
Simplify Prune moves with negative SEE

Passed STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 57760 W: 15472 L: 15286 D: 27002
Ptnml(0-2): 123, 6025, 16430, 6147, 155
https://tests.stockfishchess.org/tests/view/6468eb6b0db5177f2b76ef62

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 93966 W: 25274 L: 25141 D: 43551
Ptnml(0-2): 33, 8498, 29792, 8623, 37
https://tests.stockfishchess.org/tests/view/6469570b0db5177f2b76f81b