### PR TITLE
Simplify delta calculation in aspiration window

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -409,7 +409,7 @@ void Thread::search() {
               else
                   break;
 
-              delta += delta / 4 + 2;
+              delta += delta / 3;
 
               assert(alpha >= -VALUE_INFINITE && beta <= VALUE_INFINITE);
           }


### PR DESCRIPTION
In aspiration window calculation, Instead of `delta += delta / 4 + 2` simply `delta += delta / 3`, making much more sense.

Simplification STC: https://tests.stockfishchess.org/tests/view/6468cb200db5177f2b76ecbb
LLR: 2.93 (-2.94,2.94) <-1.75,0.25> 
Total: 220416 W: 58503 L: 58487 D: 103426
Ptnml(0-2): 596, 24384, 60188, 24488, 552

Simplification LTC: https://tests.stockfishchess.org/tests/view/646a15840db5177f2b770704
LLR: 2.94 (-2.94,2.94) <-1.75,0.25> 
Total: 177756 W: 47882 L: 47825 D: 82049
Ptnml(0-2): 55, 17430, 53858, 17473, 62

Bench: 3228224