### PR TITLE
Simplify Futility pruning for captures

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -989,7 +989,7 @@ moves_loop: // When in check, search starts here
                   && lmrDepth < 7
                   && !ss->inCheck
                   && ss->staticEval + 207 + 223 * lmrDepth + PieceValue[EG][pos.piece_on(to_sq(move))]
-                   + captureHistory[movedPiece][to_sq(move)][type_of(pos.piece_on(to_sq(move)))] * 1078 / 7000 < alpha)
+                   + captureHistory[movedPiece][to_sq(move)][type_of(pos.piece_on(to_sq(move)))] / 7 < alpha)
                   continue;
 
               Bitboard occupied;


### PR DESCRIPTION
Simplify Futility pruning for captures formula:

Passed STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 412928 W: 109433 L: 109620 D: 193875
Ptnml(0-2): 1071, 45929, 112650, 45744, 1070
https://tests.stockfishchess.org/tests/view/6468eac40db5177f2b76ef4d

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 190200 W: 51465 L: 51420 D: 87315
Ptnml(0-2): 58, 18585, 57788, 18592, 77
https://tests.stockfishchess.org/tests/view/646b66520db5177f2b772a84