### PR TITLE
Remove redundant condition in qsearch 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -76,6 +76,7 @@ George Sobala (gsobala)
 gguliash
 Giacomo Lorenzetti (G-Lorenz)
 Gian-Carlo Pascutto (gcp)
+Goh CJ (cj5716)
 Gontran Lemaire (gonlem)
 Goodkov Vasiliy Aleksandrovich (goodkov)
 Gregor Cramer

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1452,9 +1452,8 @@ moves_loop: // When in check, search starts here
 
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode
-        && ss->ttHit
         && tte->depth() >= ttDepth
-        && ttValue != VALUE_NONE // Only in case of TT access race
+        && ttValue != VALUE_NONE // TT access race or !ttHit
         && (tte->bound() & (ttValue >= beta ? BOUND_LOWER : BOUND_UPPER)))
         return ttValue;
 


### PR DESCRIPTION
Simplify away a redundant `ss->ttHit` condition which is already implicit 2 lines later.

Passed non-regression test
LLR: 2.98 (-2.94,2.94) <-1.75,0.25>
Total: 41312 W: 11117 L: 10914 D: 19281
Ptnml(0-2): 84, 4184, 11929, 4363, 96
https://tests.stockfishchess.org/tests/view/646da037921b183f2d83210f

No functional change