### PR TITLE
More Depth Reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1317,6 +1317,7 @@ moves_loop: // When in check, search starts here
               else
               {
                   // Reduce other moves if we have found at least one score improvement (~1 Elo)
+                  // Reduce more for depth > 3 and depth < 12 (~1 Elo)
                   if (   depth > 1
                       && beta  <  14001
                       && value > -12754)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1320,7 +1320,7 @@ moves_loop: // When in check, search starts here
                   if (   depth > 1
                       && beta  <  14001
                       && value > -12754)
-                      depth -= depth > 3 && depth < 8 ? 2 : 1;
+                      depth -= depth > 3 && depth < 12 ? 2 : 1;
 
                   assert(depth > 0);
                   alpha = value; // Update alpha! Always alpha < beta

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1320,7 +1320,7 @@ moves_loop: // When in check, search starts here
                   if (   depth > 1
                       && beta  <  14001
                       && value > -12754)
-                      depth -= 1;
+                      depth -= depth > 3 && depth < 10 ? 2 : 1;
 
                   assert(depth > 0);
                   alpha = value; // Update alpha! Always alpha < beta

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1320,7 +1320,7 @@ moves_loop: // When in check, search starts here
                   if (   depth > 1
                       && beta  <  14001
                       && value > -12754)
-                      depth -= depth > 3 && depth < 10 ? 2 : 1;
+                      depth -= depth > 3 && depth < 8 ? 2 : 1;
 
                   assert(depth > 0);
                   alpha = value; // Update alpha! Always alpha < beta


### PR DESCRIPTION
Reduce more for depth > 3 and depth < 12

LTC: https://tests.stockfishchess.org/tests/view/646c5abbd1f14fd69a6f2fab
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 197280 W: 53405 L: 52797 D: 91078
Ptnml(0-2): 62, 19025, 59886, 19577, 90

STC: https://tests.stockfishchess.org/tests/view/646bee71d1f14fd69a6f259d
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 100832 W: 26861 L: 26466 D: 47505
Ptnml(0-2): 240, 10985, 27622, 11278, 291

bench: 2276617