### PR TITLE
Follow up to #4584

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -614,11 +614,10 @@ namespace {
         ss->ttPv = PvNode || (ss->ttHit && tte->is_pv());
 
     // At non-PV nodes we check for an early TT cutoff
-    if (  !PvNode
-        && ss->ttHit
+    if (   !PvNode
         && !excludedMove
         && tte->depth() > depth - (tte->bound() == BOUND_EXACT)
-        && ttValue != VALUE_NONE // Possible in case of TT access race
+        && ttValue != VALUE_NONE // !ttHit or TT access race
         && (tte->bound() & (ttValue >= beta ? BOUND_LOWER : BOUND_UPPER)))
     {
         // If ttMove is quiet, update move sorting heuristics on TT hit (~2 Elo)


### PR DESCRIPTION
Follow up to #4584, removing the same condition in search.
Credit to @peregrineshahin for finding this follow up.

Passed non-regression test:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 60672 W: 16194 L: 16011 D: 28467
Ptnml(0-2): 107, 6262, 17471, 6333, 163
https://tests.stockfishchess.org/tests/view/646e9c7c68661bfd98431c1f