### PR TITLE
Remove `ss->ttHit` condition where `ttValue != VALUE_NONE`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -76,6 +76,7 @@ George Sobala (gsobala)
 gguliash
 Giacomo Lorenzetti (G-Lorenz)
 Gian-Carlo Pascutto (gcp)
+Goh CJ (cj5716)
 Gontran Lemaire (gonlem)
 Goodkov Vasiliy Aleksandrovich (goodkov)
 Gregor Cramer

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -615,10 +615,9 @@ namespace {
 
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode
-        && ss->ttHit
         && !excludedMove
         && tte->depth() > depth - (tte->bound() == BOUND_EXACT)
-        && ttValue != VALUE_NONE // Possible in case of TT access race
+        && ttValue != VALUE_NONE // Possible in case of TT access race or if !ttHit
         && (tte->bound() & (ttValue >= beta ? BOUND_LOWER : BOUND_UPPER)))
     {
         // If ttMove is quiet, update move sorting heuristics on TT hit (~2 Elo)
@@ -835,8 +834,7 @@ namespace {
         // there and in further interactions with transposition table cutoff depth is set to depth - 3
         // because probCut search has depth set to depth - 4 but we also do a move before it
         // so effective depth is equal to depth - 3
-        && !(   ss->ttHit
-             && tte->depth() >= depth - 3
+        && !(   tte->depth() >= depth - 3
              && ttValue != VALUE_NONE
              && ttValue < probCutBeta))
     {
@@ -1452,9 +1450,8 @@ moves_loop: // When in check, search starts here
 
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode
-        && ss->ttHit
         && tte->depth() >= ttDepth
-        && ttValue != VALUE_NONE // Only in case of TT access race
+        && ttValue != VALUE_NONE // Only in case of TT access race or if !ttHit
         && (tte->bound() & (ttValue >= beta ? BOUND_LOWER : BOUND_UPPER)))
         return ttValue;
 


### PR DESCRIPTION
Simplification is done at 3 separate places in the code. Thanks to @peregrineshahin for helping me find 2 of such places. (See original PR #4584 

Passed non-regression test
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 120256 W: 32204 L: 32085 D: 55967
Ptnml(0-2): 292, 12473, 34483, 12584, 296
https://tests.stockfishchess.org/tests/view/646f045968661bfd984325e3

No functional change