### PR TITLE
Remove term quadratic in optimism in the eval.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -213,6 +213,7 @@ tttak
 Unai Corzo (unaiic)
 Uri Blass (uriblass)
 Vince Negri (cuddlestmonkey)
+windfishballad
 xefoci7612
 zz4032
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1072,7 +1072,7 @@ Value Eval::evaluate(const Position& pos) {
 
       // Blend nnue complexity with (semi)classical complexity
       nnueComplexity = (  397 * nnueComplexity
-                        + (477 + 0*optimism) * abs(psq - nnue)
+                        + 477 * abs(psq - nnue)
                         ) / 1024;
 
       optimism += optimism * nnueComplexity / 256;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1072,7 +1072,7 @@ Value Eval::evaluate(const Position& pos) {
 
       // Blend nnue complexity with (semi)classical complexity
       nnueComplexity = (  397 * nnueComplexity
-                        + (477 + optimism) * abs(psq - nnue)
+                        + (477 + 0*optimism) * abs(psq - nnue)
                         ) / 1024;
 
       optimism += optimism * nnueComplexity / 256;


### PR DESCRIPTION
Remove term which is quadratic in optimism in the eval. Simplifies and should also remove the bias towards side to move making the eval better for analysis.

STC: https://tests.stockfishchess.org/tests/view/6470a9d8c29e0d4352b0bca5
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 154432 W: 41127 L: 41040 D: 72265
Ptnml(0-2): 380, 17094, 42190, 17163, 389 

LTC: https://tests.stockfishchess.org/tests/view/6471e9b3e549d9cf2fb219ef
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 127926 W: 34474 L: 34369 D: 59083
Ptnml(0-2): 43, 12505, 38776, 12582, 57 
