### PR TITLE
Simplify nnue eval complexity calculation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1071,9 +1071,7 @@ Value Eval::evaluate(const Position& pos) {
       Value nnue = NNUE::evaluate(pos, true, &nnueComplexity);
 
       // Blend nnue complexity with (semi)classical complexity
-      nnueComplexity = (  397 * nnueComplexity
-                        + 477 * abs(psq - nnue)
-                        ) / 1024;
+      nnueComplexity = 25 * (nnueComplexity + abs(psq - nnue)) / 64;
 
       optimism += optimism * nnueComplexity / 256;
       v = (nnue * (945 + npm) + optimism * (174 + npm)) / 1024;


### PR DESCRIPTION
Remove a multiplier when blending nnue complexity with semi-classical complexity.

Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/6473a71dd29264e4cfa75839
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 124768 W: 33180 L: 33060 D: 58528
Ptnml(0-2): 314, 13797, 34030, 13941, 302

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/6474af3dd29264e4cfa768f4
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 108180 W: 29008 L: 28884 D: 50288
Ptnml(0-2): 29, 10420, 33075, 10530, 36

bench 2624365