### PR TITLE
Small simplification for probcut in check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -895,7 +895,6 @@ moves_loop: // When in check, search starts here
     probCutBeta = beta + 430;
     if (   ss->inCheck
         && !PvNode
-        && depth >= 2
         && ttCapture
         && (tte->bound() & BOUND_LOWER)
         && tte->depth() >= depth - 4


### PR DESCRIPTION
Remove depth condition from there as not longer needed.
Passed STC:
https://tests.stockfishchess.org/tests/view/647367cad29264e4cfa753e6
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 254336 W: 67830 L: 67847 D: 118659
Ptnml(0-2): 580, 28181, 69697, 28096, 614 
Passed LTC:
https://tests.stockfishchess.org/tests/view/647576184a36543c4c9f3af7
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 80706 W: 22048 L: 21898 D: 36760
Ptnml(0-2): 28, 7721, 24712, 7857, 35 
bench 2630538