### PR TITLE
add binaries to release

### DIFF
--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -1,6 +1,8 @@
 name: Stockfish
 on:
   push:
+    tags:        
+      - '*' 
     branches:
       - master
       - tools
@@ -17,8 +19,8 @@ jobs:
   Compiles:
     uses: ./.github/workflows/stockfish_compile_test.yml
   Binaries:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || (startsWith(github.ref_name, 'sf_') && github.ref_type == 'tag')
     uses: ./.github/workflows/stockfish_binaries.yml
   ARM_Binaries:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || (startsWith(github.ref_name, 'sf_') && github.ref_type == 'tag')
     uses: ./.github/workflows/stockfish_arm_binaries.yml

--- a/.github/workflows/stockfish_arm_binaries.yml
+++ b/.github/workflows/stockfish_arm_binaries.yml
@@ -115,6 +115,8 @@ jobs:
           cp "Top CPU Contributors.txt" stockfish/
           cp Copying.txt stockfish/
           cp AUTHORS stockfish/
+          cp CITATION.cff stockfish/
+          cp README.md stockfish/
           tar -cvf stockfish-android-$BINARY.tar stockfish
 
       - name: Upload binaries
@@ -122,3 +124,9 @@ jobs:
         with:
           name: stockfish-android-${{ matrix.binaries }}
           path: stockfish-android-${{ matrix.binaries }}.tar
+
+      - name: Release
+        if: startsWith(github.ref_name, 'sf_') && github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: stockfish-android-${{ matrix.binaries }}.tar

--- a/.github/workflows/stockfish_binaries.yml
+++ b/.github/workflows/stockfish_binaries.yml
@@ -9,23 +9,26 @@ jobs:
       COMPILER: ${{ matrix.config.compiler }}
       COMP: ${{ matrix.config.comp }}
       EXT: ${{ matrix.config.ext }}
-      OS: ${{ matrix.config.os }}
+      NAME: ${{ matrix.config.simple_name }}
       BINARY: ${{ matrix.binaries }}
     strategy:
       matrix:
         config:
           - name: Ubuntu 20.04 GCC
             os: ubuntu-20.04
+            simple_name: ubuntu
             compiler: g++
             comp: gcc
             shell: bash {0}
           - name: MacOS 12 Apple Clang
             os: macos-12
+            simple_name: macos
             compiler: clang++
             comp: clang
             shell: bash {0}
           - name: Windows 2022 Mingw-w64 GCC x86_64
             os: windows-2022
+            simple_name: windows
             compiler: g++
             comp: mingw
             msys_sys: mingw64
@@ -75,19 +78,17 @@ jobs:
 
       - name: Compile ${{ matrix.binaries }} build
         run: |
-          make clean
           make -j2 profile-build ARCH=$BINARY COMP=$COMP
           make strip ARCH=$BINARY COMP=$COMP
-          mv ./stockfish$EXT ../stockfish-$OS-$BINARY$EXT
+          mv ./stockfish$EXT ../stockfish-$NAME-$BINARY$EXT
 
       - name: Remove non src files
-        run: rm -f *.o .depend *.nnue
+        run: git clean -fx
 
       - name: Download wiki
         run: |
           git clone https://github.com/official-stockfish/Stockfish.wiki.git ../wiki
-          cd ../wiki
-          rm -rf .git
+          rm -rf ../wiki/.git
 
       - name: Create tar archive.
         run: |
@@ -95,14 +96,20 @@ jobs:
           mkdir stockfish
           cp -r wiki stockfish/
           cp -r src stockfish/
-          cp stockfish-$OS-$BINARY$EXT stockfish/
+          cp stockfish-$NAME-$BINARY$EXT stockfish/
           cp "Top CPU Contributors.txt" stockfish/
           cp Copying.txt stockfish/
           cp AUTHORS stockfish/
-          tar -cvf stockfish-$OS-$BINARY.tar stockfish
+          tar -cvf stockfish-$NAME-$BINARY.tar stockfish
 
       - name: Upload binaries
         uses: actions/upload-artifact@v3
         with:
           name: stockfish-${{ matrix.config.os }}-${{ matrix.binaries }}
-          path: stockfish-${{ matrix.config.os }}-${{ matrix.binaries }}.tar
+          path: stockfish-${{ matrix.config.simple_name }}-${{ matrix.binaries }}.tar
+
+      - name: Release
+        if: startsWith(github.ref_name, 'sf_') && github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: stockfish-${{ matrix.config.simple_name }}-${{ matrix.binaries }}.tar

--- a/.github/workflows/stockfish_binaries.yml
+++ b/.github/workflows/stockfish_binaries.yml
@@ -100,6 +100,8 @@ jobs:
           cp "Top CPU Contributors.txt" stockfish/
           cp Copying.txt stockfish/
           cp AUTHORS stockfish/
+          cp CITATION.cff stockfish/
+          cp README.md stockfish/
           tar -cvf stockfish-$NAME-$BINARY.tar stockfish
 
       - name: Upload binaries


### PR DESCRIPTION
reworked pr regarding https://github.com/official-stockfish/Stockfish/pull/4536

example: 
release: https://github.com/Disservin/Stockfish/releases/tag/sf_test_release_v6
action: https://github.com/Disservin/Stockfish/actions/runs/5137636779

logic is more or less the same as before, when a release is made with a tag matching `sf_*` the binaries will also be uploaded to the release.