### PR TITLE
Move internal iterative reduction before probcut.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -822,7 +822,7 @@ namespace {
         }
     }
 
-    // Step 10. If the position is not in TT, decrease depth by 2 
+    // Step 10. If the position doesn't have ttMove, decrease depth by 2 
     // (or by 4 if the TT entry for the current position was hit and the stored depth is greater than or equal to the current depth).
     // Use qsearch if depth is equal or below zero (~9 Elo)
     if (    PvNode

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -822,9 +822,24 @@ namespace {
         }
     }
 
+    // Step 10. If the position is not in TT, decrease depth by 2 
+    // (or by 4 if the TT entry for the current position was hit and the stored depth is greater than or equal to the current depth).
+    // Use qsearch if depth is equal or below zero (~9 Elo)
+    if (    PvNode
+        && !ttMove)
+        depth -= 2 + 2 * (ss->ttHit && tte->depth() >= depth);
+
+    if (depth <= 0)
+        return qsearch<PV>(pos, ss, alpha, beta);
+
+    if (    cutNode
+        &&  depth >= 8
+        && !ttMove)
+        depth -= 2;
+
     probCutBeta = beta + 174 - 60 * improving;
 
-    // Step 10. ProbCut (~10 Elo)
+    // Step 11. ProbCut (~10 Elo)
     // If we have a good enough capture (or queen promotion) and a reduced search returns a value
     // much above beta, we can (almost) safely prune the previous move.
     if (   !PvNode
@@ -874,20 +889,6 @@ namespace {
 
         Eval::NNUE::hint_common_parent_position(pos);
     }
-
-    // Step 11. If the position is not in TT, decrease depth by 2 (or by 4 if the TT entry for the current position was hit and the stored depth is greater than or equal to the current depth).
-    // Use qsearch if depth is equal or below zero (~9 Elo)
-    if (    PvNode
-        && !ttMove)
-        depth -= 2 + 2 * (ss->ttHit && tte->depth() >= depth);
-
-    if (depth <= 0)
-        return qsearch<PV>(pos, ss, alpha, beta);
-
-    if (    cutNode
-        &&  depth >= 8
-        && !ttMove)
-        depth -= 2;
 
 moves_loop: // When in check, search starts here
 


### PR DESCRIPTION
This patch moves IIR before probcut which allows probcut to be produced at lower depths. Comments in IIR are also slightly updated.
Passed STC:
https://tests.stockfishchess.org/tests/view/6472d604d29264e4cfa749fd
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 387616 W: 103295 L: 102498 D: 181823
Ptnml(0-2): 976, 42322, 106381, 43187, 942 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6475eb8c4a36543c4c9f42e8
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 202836 W: 54901 L: 54281 D: 93654
Ptnml(0-2): 85, 19609, 61422, 20205, 97 
bench 2312985