### PR TITLE
Remove static eval threshold for extensions when giving check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1101,9 +1101,7 @@ moves_loop: // When in check, search starts here
           }
 
           // Check extensions (~1 Elo)
-          else if (   givesCheck
-                   && depth > 9
-                   && abs(ss->staticEval) > 87)
+          else if (givesCheck && depth > 9)
               extension = 1;
 
           // Quiet ttMove extensions (~1 Elo)


### PR DESCRIPTION
Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/647685d54a36543c4c9f4f2a
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 114688 W: 30701 L: 30571 D: 53416
Ptnml(0-2): 336, 12708, 31136, 12818, 346

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/64774b02b81f005b572de770
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 107310 W: 28920 L: 28796 D: 49594
Ptnml(0-2): 33, 10427, 32621, 10531, 43

bench 2294666