### PR TITLE
Fix no previous moves on root.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1489,7 +1489,7 @@ moves_loop: // When in check, search starts here
     // to search the moves. Because the depth is <= 0 here, only captures,
     // queen promotions, and other checks (only if depth >= DEPTH_QS_CHECKS)
     // will be generated.
-    Square prevSq = (ss-1)->currentMove != MOVE_NULL ? to_sq((ss-1)->currentMove) : SQ_NONE;
+    Square prevSq = is_ok((ss-1)->currentMove) ? to_sq((ss-1)->currentMove) : SQ_NONE;
     MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory,
                                       &thisThread->captureHistory,
                                       contHist,


### PR DESCRIPTION
guards against no previous move existing if qSearch is called on the root node (i.e. when razoring).

Passed Non-regression STC:
https://tests.stockfishchess.org/tests/view/647d242d726f6b400e408143
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 53120 W: 14167 L: 13976 D: 24977
Ptnml(0-2): 109, 5597, 14981, 5740, 133

No functional change