### PR TITLE
Update default net to nn-0dd1cebea573.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-8d69132723e2.nnue"
+  #define EvalFileDefaultName   "nn-0dd1cebea573.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
Created by retraining an earlier epoch of the experiment leading to the first SFNNv6 net on a more-randomized version of the nn-e1fb1ade4432.nnue dataset mixed with unfiltered T80 apr2023 data. Trained using early-fen-skipping 28 and max-epoch 960.

The trainer settings and epochs used in the 5-step training sequence leading here were:
1. train from scratch for 400 epochs, lambda 1.0, constant LR 9.75e-4, T79T77-filter-v6-dd.min.binpack
2. retrain ep379, max-epoch 800, end-lambda 0.75, T60T70wIsRightFarseerT60T74T75T76.binpack
3. retrain ep679, max-epoch 800, end-lambda 0.75, skip 28, nn-e1fb1ade4432 dataset
4. retrain ep799, max-epoch 800, end-lambda 0.7, skip 28, nn-e1fb1ade4432 dataset
5. retrain ep439, max-epoch 960, end-lambda 0.7, skip 28, shuffled nn-e1fb1ade4432 + T80 apr2023

This net was epoch 559 of the final (step 5) retraining:

```bash
python3 easy_train.py \
  --experiment-name L1-1536-Re4-leela96-dfrc99-T60novdec-v2-T80juntonovjanfebT79aprmayT78jantosepT77dec-v6dd-T80apr-shuffled-sk28 \
  --training-dataset /data/leela96-dfrc99-T60novdec-v2-T80juntonovjanfebT79aprmayT78jantosepT77dec-v6dd-T80apr.binpack \
  --nnue-pytorch-branch linrock/nnue-pytorch/misc-fixes-L1-1536 \
  --early-fen-skipping 28 \
  --start-lambda 1.0 \
  --end-lambda 0.7 \
  --max_epoch 960 \
  --start-from-engine-test-net False \
  --start-from-model /data/L1-1536-Re3-nn-epoch439.nnue \
  --engine-test-branch linrock/Stockfish/L1-1536 \
  --lr 4.375e-4 \
  --gamma 0.995 \
  --tui False \
  --seed $RANDOM \
  --gpus "0,"
```

During data preparation, most binpacks were unminimized by removing positions with score 32002 (`VALUE_NONE`). This makes the tradeoff of increasing dataset filesize on disk to increase the randomness of positions in interleaved datasets. The code used for unminimizing is at:
https://github.com/linrock/Stockfish/tree/tools-unminify

For preparing the dataset used in this experiment:

```bash
python3 interleave_binpacks.py \
  leela96-filt-v2.binpack \
  dfrc99-16tb7p-eval-filt-v2.binpack \
  filt-v6-dd-min/test60-novdec2021-12tb7p-filter-v6-dd.min-mar2023.unmin.binpack \
  filt-v6-dd-min/test80-aug2022-16tb7p-filter-v6-dd.min-mar2023.unmin.binpack \
  filt-v6-dd-min/test80-sep2022-16tb7p-filter-v6-dd.min-mar2023.unmin.binpack \
  filt-v6-dd-min/test80-jun2022-16tb7p-filter-v6-dd.min-mar2023.unmin.binpack \
  filt-v6-dd/test80-jul2022-16tb7p-filter-v6-dd.binpack \
  filt-v6-dd/test80-oct2022-16tb7p-filter-v6-dd.binpack \
  filt-v6-dd/test80-nov2022-16tb7p-filter-v6-dd.binpack \
  filt-v6-dd-min/test80-jan2023-3of3-16tb7p-filter-v6-dd.min-mar2023.unmin.binpack \
  filt-v6-dd-min/test80-feb2023-16tb7p-filter-v6-dd.min-mar2023.unmin.binpack \
  filt-v6-dd/test79-apr2022-16tb7p-filter-v6-dd.binpack \
  filt-v6-dd/test79-may2022-16tb7p-filter-v6-dd.binpack \
  filt-v6-dd-min/test78-jantomay2022-16tb7p-filter-v6-dd.min-mar2023.unmin.binpack \
  filt-v6-dd/test78-juntosep2022-16tb7p-filter-v6-dd.binpack \
  filt-v6-dd/test77-dec2021-16tb7p-filter-v6-dd.binpack \
  test80-apr2023-2tb7p.binpack \
  /data/leela96-dfrc99-T60novdec-v2-T80juntonovjanfebT79aprmayT78jantosepT77dec-v6dd-T80apr.binpack
```

T80 apr2023 data was converted using lc0-rescorer with ~2tb of tablebases and can be found at: https://robotmoon.com/nnue-training-data/

Local elo at 25k nodes per move vs. nn-e1fb1ade4432.nnue (L1 size 1024):
nn-epoch559.nnue : 25.7 +/- 1.6

Passed STC:
https://tests.stockfishchess.org/tests/view/647cd3b87cf638f0f53f9cbb
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 59200 W: 16000 L: 15660 D: 27540
Ptnml(0-2): 159, 6488, 15996, 6768, 189

Passed LTC:
https://tests.stockfishchess.org/tests/view/647d58de726f6b400e4085d8
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 58800 W: 16002 L: 15657 D: 27141
Ptnml(0-2): 44, 5607, 17748, 5962, 39

bench 2141197