### PR TITLE
Remove optimism multiplier in nnue eval calculation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1071,8 +1071,8 @@ Value Eval::evaluate(const Position& pos) {
       Value nnue = NNUE::evaluate(pos, true, &nnueComplexity);
 
       // Blend optimism with nnue complexity and (semi)classical complexity
-      optimism += 25 * optimism * (nnueComplexity + abs(psq - nnue)) / 16384;
-      v = (nnue * (945 + npm) + optimism * (174 + npm)) / 1024;
+      optimism += optimism * (nnueComplexity + abs(psq - nnue)) / 512;
+      v = (nnue * (945 + npm) + optimism * (150 + npm)) / 1024;
   }
 
   // Damp down the evaluation linearly when shuffling


### PR DESCRIPTION
The same formula had passed SPRT against an earlier version of master.

Passed non-regression STC vs. d99942f:
https://tests.stockfishchess.org/tests/view/6478e76654dd118e1d98f72e
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 118720 W: 31402 L: 31277 D: 56041
Ptnml(0-2): 301, 13148, 32344, 13259, 308

Passed non-regression LTC vs. d99942f:
https://tests.stockfishchess.org/tests/view/647a22c154dd118e1d991146
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 74286 W: 20019 L: 19863 D: 34404
Ptnml(0-2): 31, 7189, 22540, 7359, 24

The earlier patch had conflicted with a faster SPRT passer, so this was tested again after rebasing on latest master.

Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/647d6e46726f6b400e408790
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 166176 W: 44309 L: 44234 D: 77633
Ptnml(0-2): 461, 18252, 45557, 18387, 431

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/647eb00ba268d1bc11255e7b
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 28170 W: 7713 L: 7513 D: 12944
Ptnml(0-2): 14, 2609, 8635, 2817, 10

bench 2633028