### PR TITLE
Simplify multiplier for improvement

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -779,7 +779,7 @@ namespace {
         && (ss-1)->statScore < 17329
         &&  eval >= beta
         &&  eval >= ss->staticEval
-        &&  ss->staticEval >= beta - 21 * depth - improvement * 99 / 1300 + 258
+        &&  ss->staticEval >= beta - 21 * depth - improvement / 13 + 258
         && !excludedMove
         &&  pos.non_pawn_material(us)
         && (ss->ply >= thisThread->nmpMinPly))


### PR DESCRIPTION
This simplifies a `* 99 / 1300` term into just `/ 13`.

Passed non-regression STC:
LLR: 2.92 (-2.94,2.94) <-1.75,0.25>
Total: 58816 W: 15727 L: 15540 D: 27549
Ptnml(0-2): 149, 6370, 16203, 6517, 169
https://tests.stockfishchess.org/tests/view/647d25e4726f6b400e408165

Passed non-regression LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 154386 W: 41749 L: 41669 D: 70968
Ptnml(0-2): 94, 14992, 46956, 15042, 109
https://tests.stockfishchess.org/tests/view/647d9b3c726f6b400e408b2a


Bench: 2511327