### PR TITLE
Update default net to nn-ea57bea57e32.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-0dd1cebea573.nnue"
+  #define EvalFileDefaultName   "nn-ea57bea57e32.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
Created by retraining an earlier epoch (ep659) of the experiment that led to the first SFNNv6 net:
- First retrained on the nn-0dd1cebea573 dataset
- Then retrained with skip 20 on a smaller dataset containing unfiltered Leela data
- And then retrained again with skip 27 on the nn-0dd1cebea573 dataset

The equivalent 7-step training sequence from scratch that led here was:

1. max-epoch 400, lambda 1.0, constant LR 9.75e-4, T79T77-filter-v6-dd.min.binpack
  ep379 chosen for retraining in step2

2. max-epoch 800, end-lambda 0.75, T60T70wIsRightFarseerT60T74T75T76.binpack
  ep679 chosen for retraining in step3

3. max-epoch 800, end-lambda 0.75, skip 28, nn-e1fb1ade4432 dataset
  ep799 chosen for retraining in step4

4. max-epoch 800, end-lambda 0.7, skip 28, nn-e1fb1ade4432 dataset
  ep759 became nn-8d69132723e2.nnue (first SFNNv6 net)
  ep659 chosen for retraining in step5

5. max-epoch 800, end-lambda 0.7, skip 28, nn-0dd1cebea573 dataset
  ep759 chosen for retraining in step6

6. max-epoch 800, end-lambda 0.7, skip 20, leela-dfrc-v2-T77decT78janfebT79aprT80apr.binpack
  ep639 chosen for retraining in step7

7. max-epoch 800, end-lambda 0.7, skip 27, nn-0dd1cebea573 dataset
  ep619 became nn-ea57bea57e32.nnue

For the last retraining (step7):

```
python3 easy_train.py
  --experiment-name L1-1536-Re6-masterShuffled-ep639-sk27-Re5-leela-dfrc-v2-T77toT80small-Re4-masterShuffled-ep659-Re3-sameAs-Re2-leela96-dfrc99-16t-v2-T60novdecT80juntonovjanfebT79aprmayT78jantosepT77dec-v6dd-Re1-LeelaFarseer-new-T77T79 \
  --training-dataset /data/leela96-dfrc99-T60novdec-v2-T80juntonovjanfebT79aprmayT78jantosepT77dec-v6dd-T80apr.binpack \
  --nnue-pytorch-branch linrock/nnue-pytorch/misc-fixes-L1-1536 \
  --early-fen-skipping 27 \
  --start-lambda 1.0 \
  --end-lambda 0.7 \
  --max_epoch 800 \
  --start-from-engine-test-net False \
  --start-from-model /data/L1-1536-Re5-leela-dfrc-v2-T77toT80small-epoch639.nnue \
  --lr 4.375e-4 \
  --gamma 0.995 \
  --tui False \
  --seed $RANDOM \
  --gpus "0,"
```

For preparing the step6 leela-dfrc-v2-T77decT78janfebT79aprT80apr.binpack dataset:

```
python3 interleave_binpacks.py \
  leela96-filt-v2.binpack \
  dfrc99-16tb7p-eval-filt-v2.binpack \
  test77-dec2021-16tb7p.no-db.min-mar2023.binpack \
  test78-janfeb2022-16tb7p.no-db.min-mar2023.binpack \
  test79-apr2022-16tb7p-filter-v6-dd.binpack \
  test80-apr2022-16tb7p.no-db.min-mar2023.binpack \
  /data/leela-dfrc-v2-T77decT78janfebT79aprT80apr.binpack
```

The unfiltered Leela data used for the step6 dataset can be found at:
https://robotmoon.com/nnue-training-data

Local elo at 25k nodes per move:
nn-epoch619.nnue : 2.3 +/- 1.9

Passed STC:
https://tests.stockfishchess.org/tests/view/6480d43c6e6ce8d9fc6d7cc8
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 40992 W: 11017 L: 10706 D: 19269
Ptnml(0-2): 113, 4400, 11170, 4689, 124

Passed LTC:
https://tests.stockfishchess.org/tests/view/648119ac6e6ce8d9fc6d8208
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 129174 W: 35059 L: 34579 D: 59536
Ptnml(0-2): 66, 12548, 38868, 13050, 55

bench 2614824