### PR TITLE
Remove setting of static to none if in check in qsearch

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -215,6 +215,7 @@ tttak
 Unai Corzo (unaiic)
 Uri Blass (uriblass)
 Vince Negri (cuddlestmonkey)
+Viren
 windfishballad
 xefoci7612
 zz4032

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1464,7 +1464,6 @@ moves_loop: // When in check, search starts here
     // Step 4. Static evaluation of the position
     if (ss->inCheck)
     {
-        ss->staticEval = VALUE_NONE;
         bestValue = futilityBase = -VALUE_INFINITE;
     }
     else


### PR DESCRIPTION
Small simplification 

Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/6487924d713491385c8034ae
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 59616 W: 15885 L: 15703 D: 28028
Ptnml(0-2): 144, 6130, 17086, 6296, 152

No functional change.