### PR TITLE
Permute master net weights to increase sparsity

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-fdc1d0fe6455.nnue"
+  #define EvalFileDefaultName   "nn-cd2ff4716c34.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
Permutes master net weights to increase sparsity.

Activation data collection using https://github.com/AndrovT/Stockfish/commit/ac468039ab544b03ad9a22c859a4217729c10a77 run as 
```
bench 16 1 13 varied_1000.epd depth NNUE log.bin
```
on FENs from https://gist.github.com/AndrovT/7eae6918eb50764227e2bafe7938953c.

Permutation found using https://gist.github.com/AndrovT/359c831b7223c637e9156b01eb96949e.
Uses a greedy algorithm that goes sequentially through the output positions and chooses a neuron for that position such that the number of nonzero quartets is the smallest.

Net weights permuted using https://gist.github.com/AndrovT/9e3fbaebb7082734dc84d27e02094cb3.

Benchmark:
```
Result of 100 runs of 'bench 16 1 13 default depth NNUE'
========================================================
base (...kfish-master) =     885869  +/- 7395
test (./stockfish    ) =     895885  +/- 7368
diff                   =     +10016  +/- 2984

speedup        = +0.0113
P(speedup > 0) =  1.0000
```

Passed STC:
https://tests.stockfishchess.org/tests/view/648866c4713491385c804728
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 126784 W: 34003 L: 33586 D: 59195
Ptnml(0-2): 283, 13001, 36437, 13358, 313

No functional change.