### PR TITLE
create prereleases upon push to master

### DIFF
--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -12,6 +12,30 @@ on:
       - master
       - tools
 jobs:
+  Prerelease:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # returns null if no pre-release exists
+      - name: Get Commit SHA of Latest Pre-release
+        run: |
+          # Install required packages
+          sudo apt-get update
+          sudo apt-get install -y curl jq
+
+          echo "COMMIT_SHA=$(jq -r 'map(select(.prerelease)) | first | .tag_name' <<< $(curl -s https://api.github.com/repos/${{ github.repository_owner }}/Stockfish/releases))" >> $GITHUB_ENV
+
+      # delete old previous pre-release and tag
+      - uses: dev-drprasad/delete-tag-and-release@v0.2.1
+        if: env.COMMIT_SHA != 'null'
+        with:
+          tag_name: ${{ env.COMMIT_SHA }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   Sanitizers:
     uses: ./.github/workflows/stockfish_sanitizers.yml
   Tests:

--- a/.github/workflows/stockfish_arm_binaries.yml
+++ b/.github/workflows/stockfish_arm_binaries.yml
@@ -130,3 +130,29 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: stockfish-android-${{ matrix.binaries }}.tar
+
+      - name: Get last commit sha
+        id: last_commit
+        run: echo "COMMIT_SHA=$(git rev-parse HEAD | cut -c 1-8)" >> $GITHUB_ENV
+
+      - name: Get commit date
+        id: commit_date
+        run: echo "COMMIT_DATE=$(git show -s --date=format:'%Y%m%d' --format=%cd HEAD)" >> $GITHUB_ENV
+
+      # Make sure that an old ci which still runs on master doesn't recreate a prerelease
+      - name: Check Pullable Commits
+        id: check_commits
+        run: |
+          git fetch
+          CHANGES=$(git rev-list HEAD..origin/master --count)
+          echo "CHANGES=$CHANGES" >> $GITHUB_ENV
+
+      - name: Prerelease
+        if: github.ref_name == 'master' && env.CHANGES == '0'
+        continue-on-error: true
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Stockfish dev-${{ env.COMMIT_DATE }}-${{ env.COMMIT_SHA }}
+          tag_name: stockfish-dev-${{ env.COMMIT_DATE }}-${{ env.COMMIT_SHA }}
+          prerelease: true
+          files: stockfish-android-${{ matrix.binaries }}.tar

--- a/.github/workflows/stockfish_binaries.yml
+++ b/.github/workflows/stockfish_binaries.yml
@@ -20,12 +20,14 @@ jobs:
             compiler: g++
             comp: gcc
             shell: bash {0}
+            archive_ext: tar
           - name: MacOS 12 Apple Clang
             os: macos-12
             simple_name: macos
             compiler: clang++
             comp: clang
             shell: bash {0}
+            archive_ext: tar
           - name: Windows 2022 Mingw-w64 GCC x86_64
             os: windows-2022
             simple_name: windows
@@ -35,6 +37,7 @@ jobs:
             msys_env: x86_64-gcc
             shell: msys2 {0}
             ext: .exe
+            archive_ext: zip
         binaries:
           - x86-64
           - x86-64-modern
@@ -60,7 +63,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.config.msys_sys }}
-          install: mingw-w64-${{ matrix.config.msys_env }} make git
+          install: mingw-w64-${{ matrix.config.msys_env }} make git zip
 
       - name: Download the used network from the fishtest framework
         run: make net
@@ -90,7 +93,7 @@ jobs:
           git clone https://github.com/official-stockfish/Stockfish.wiki.git ../wiki
           rm -rf ../wiki/.git
 
-      - name: Create tar archive.
+      - name: Create directory.
         run: |
           cd ..
           mkdir stockfish
@@ -102,16 +105,64 @@ jobs:
           cp AUTHORS stockfish/
           cp CITATION.cff stockfish/
           cp README.md stockfish/
+
+      - name: Create tar
+        if: runner.os != 'Windows'
+        run: |
+          cd ..
           tar -cvf stockfish-$NAME-$BINARY.tar stockfish
 
+      - name: Create zip
+        if: runner.os == 'Windows'
+        run: |
+          cd ..
+          zip -r stockfish-$NAME-$BINARY.zip stockfish
+
       - name: Upload binaries
+        if: runner.os != 'Windows'
         uses: actions/upload-artifact@v3
         with:
           name: stockfish-${{ matrix.config.os }}-${{ matrix.binaries }}
           path: stockfish-${{ matrix.config.simple_name }}-${{ matrix.binaries }}.tar
 
+      # Artifacts automatically get zipped
+      # to avoid double zipping, we use the unzipped directory
+      - name: Upload binaries
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v3
+        with:
+          name: stockfish-${{ matrix.config.os }}-${{ matrix.binaries }}
+          path: stockfish
+
       - name: Release
         if: startsWith(github.ref_name, 'sf_') && github.ref_type == 'tag'
         uses: softprops/action-gh-release@v1
         with:
-          files: stockfish-${{ matrix.config.simple_name }}-${{ matrix.binaries }}.tar
+          files: stockfish-${{ matrix.config.simple_name }}-${{ matrix.binaries }}.${{ matrix.config.archive_ext }}
+
+      - name: Get last commit sha
+        id: last_commit
+        run: echo "COMMIT_SHA=$(git rev-parse HEAD | cut -c 1-8)" >> $GITHUB_ENV
+
+      - name: Get commit date
+        id: commit_date
+        run: echo "COMMIT_DATE=$(git show -s --date=format:'%Y%m%d' --format=%cd HEAD)" >> $GITHUB_ENV
+
+      # Make sure that an old ci which still runs on master doesn't recreate a prerelease
+      - name: Check Pullable Commits
+        id: check_commits
+        run: |
+          git fetch
+          CHANGES=$(git rev-list HEAD..origin/master --count)
+          echo "CHANGES=$CHANGES" >> $GITHUB_ENV
+
+      - name: Prerelease
+        if: github.ref_name == 'master' && env.CHANGES == '0'
+        continue-on-error: true
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Stockfish dev-${{ env.COMMIT_DATE }}-${{ env.COMMIT_SHA }}
+          tag_name: stockfish-dev-${{ env.COMMIT_DATE }}-${{ env.COMMIT_SHA }}
+          prerelease: true
+          files: stockfish-${{ matrix.config.simple_name }}-${{ matrix.binaries }}.${{ matrix.config.archive_ext }}
+


### PR DESCRIPTION
With these CI changes we will be able create a prerelease after a push to master has made.

I've made sure that multiple pushes to master while two actions are running dont conflict which eachother.

The first step in the stockfish.yml makes sure that the previous prerelease gets deleted if one exists. 
Then before the binaries are attached it will check if there are any new changes to master, if so it wont upload the binaries to the prerelease. 

Here I made two commits shortly after eachother:
https://github.com/Disservin/Stockfish/actions

and there will be only a prerelease for the latest one.:
https://github.com/Disservin/Stockfish/releases

Potential issue:
If in the relatively short time between `Check Pullable Commits` and `Prerelease` a commit was made we will end up with two prereleases... nonetheless I dont think this will be an issue, since such a case will be very rare and even if it occurs one can simply delete the superfluous prerelease.
