### PR TITLE
Cleanup: Remove redundant spaces

### DIFF
--- a/src/bitbase.cpp
+++ b/src/bitbase.cpp
@@ -107,14 +107,14 @@ namespace {
     psq        = make_square(File((idx >> 13) & 0x3), Rank(RANK_7 - ((idx >> 15) & 0x7)));
 
     // Invalid if two pieces are on the same square or if a king can be captured
-    if (   distance(ksq[WHITE], ksq[BLACK]) <= 1
+    if (distance(ksq[WHITE], ksq[BLACK]) <= 1
         || ksq[WHITE] == psq
         || ksq[BLACK] == psq
         || (stm == WHITE && (pawn_attacks_bb(WHITE, psq) & ksq[BLACK])))
         result = INVALID;
 
     // Win if the pawn can be promoted without getting captured
-    else if (   stm == WHITE
+    else if (stm == WHITE
              && rank_of(psq) == RANK_7
              && ksq[WHITE] != psq + NORTH
              && (    distance(ksq[BLACK], psq + NORTH) > 1
@@ -122,7 +122,7 @@ namespace {
         result = WIN;
 
     // Draw if it is stalemate or the black king can capture the pawn
-    else if (   stm == BLACK
+    else if (stm == BLACK
              && (  !(attacks_bb<KING>(ksq[BLACK]) & ~(attacks_bb<KING>(ksq[WHITE]) | pawn_attacks_bb(WHITE, psq)))
                  || (attacks_bb<KING>(ksq[BLACK]) & ~attacks_bb<KING>(ksq[WHITE]) & psq)))
         result = DRAW;
@@ -158,7 +158,7 @@ namespace {
         if (rank_of(psq) < RANK_7)      // Single push
             r |= db[index(BLACK, ksq[BLACK], ksq[WHITE], psq + NORTH)];
 
-        if (   rank_of(psq) == RANK_2   // Double push
+        if (rank_of(psq) == RANK_2   // Double push
             && psq + NORTH != ksq[WHITE]
             && psq + NORTH != ksq[BLACK])
             r |= db[index(BLACK, ksq[BLACK], ksq[WHITE], psq + NORTH + NORTH)];

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -113,7 +113,7 @@ Value Endgame<KXK>::operator()(const Position& pos) const {
                 + push_to_edge(weakKing)
                 + push_close(strongKing, weakKing);
 
-  if (   pos.count<QUEEN>(strongSide)
+  if (pos.count<QUEEN>(strongSide)
       || pos.count<ROOK>(strongSide)
       ||(pos.count<BISHOP>(strongSide) && pos.count<KNIGHT>(strongSide))
       || (   (pos.pieces(strongSide, BISHOP) & ~DarkSquares)
@@ -194,13 +194,13 @@ Value Endgame<KRKP>::operator()(const Position& pos) const {
 
   // If the weaker side's king is too far from the pawn and the rook,
   // it's a win.
-  else if (   distance(weakKing, weakPawn) >= 3 + (pos.side_to_move() == weakSide)
+  else if (distance(weakKing, weakPawn) >= 3 + (pos.side_to_move() == weakSide)
            && distance(weakKing, strongRook) >= 3)
       result = RookValueEg - distance(strongKing, weakPawn);
 
   // If the pawn is far advanced and supported by the defending king,
   // the position is drawish
-  else if (   relative_rank(strongSide, weakKing) <= RANK_3
+  else if (relative_rank(strongSide, weakKing) <= RANK_3
            && distance(weakKing, weakPawn) == 1
            && relative_rank(strongSide, strongKing) >= RANK_4
            && distance(strongKing, weakPawn) > 2 + (pos.side_to_move() == strongSide))
@@ -259,7 +259,7 @@ Value Endgame<KQKP>::operator()(const Position& pos) const {
 
   Value result = Value(push_close(strongKing, weakKing));
 
-  if (   relative_rank(weakSide, weakPawn) != RANK_7
+  if (relative_rank(weakSide, weakPawn) != RANK_7
       || distance(weakKing, weakPawn) != 1
       || ((FileBBB | FileDBB | FileEBB | FileGBB) & weakPawn))
       result += QueenValueEg - PawnValueEg;
@@ -338,7 +338,7 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
   {
       Square queeningSquare = relative_square(strongSide, make_square(file_of(lsb(strongPawns)), RANK_8));
 
-      if (   opposite_colors(queeningSquare, strongBishop)
+      if (opposite_colors(queeningSquare, strongBishop)
           && distance(queeningSquare, weakKing) <= 1)
           return SCALE_FACTOR_DRAW;
   }
@@ -353,7 +353,7 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
 
       // There's potential for a draw if our pawn is blocked on the 7th rank,
       // the bishop cannot attack it or they only have one pawn left.
-      if (   relative_rank(strongSide, weakPawn) == RANK_7
+      if (relative_rank(strongSide, weakPawn) == RANK_7
           && (strongPawns & (weakPawn + pawn_push(weakSide)))
           && (opposite_colors(strongBishop, weakPawn) || !more_than_one(strongPawns)))
       {
@@ -366,7 +366,7 @@ ScaleFactor Endgame<KBPsK>::operator()(const Position& pos) const {
           // unreachable positions such as 5k1K/6p1/6P1/8/8/3B4/8/8 w
           // and positions where qsearch will immediately correct the
           // problem such as 8/4k1p1/6P1/1K6/3B4/8/8/8 w).
-          if (   relative_rank(strongSide, weakKing) >= RANK_7
+          if (relative_rank(strongSide, weakKing) >= RANK_7
               && weakKingDist <= 2
               && weakKingDist <= strongKingDist)
               return SCALE_FACTOR_DRAW;
@@ -390,7 +390,7 @@ ScaleFactor Endgame<KQKRPs>::operator()(const Position& pos) const {
   Square weakKing   = pos.square<KING>(weakSide);
   Square weakRook   = pos.square<ROOK>(weakSide);
 
-  if (    relative_rank(weakSide,   weakKing) <= RANK_2
+  if (relative_rank(weakSide,   weakKing) <= RANK_2
       &&  relative_rank(weakSide, strongKing) >= RANK_4
       &&  relative_rank(weakSide,   weakRook) == RANK_3
       && (  pos.pieces(weakSide, PAWN)
@@ -428,7 +428,7 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
 
   // If the pawn is not too far advanced and the defending king defends the
   // queening square, use the third-rank defence.
-  if (   pawnRank <= RANK_5
+  if (pawnRank <= RANK_5
       && distance(weakKing, queeningSquare) <= 1
       && strongKing <= SQ_H5
       && (rank_of(weakRook) == RANK_6 || (pawnRank <= RANK_3 && rank_of(strongRook) != RANK_6)))
@@ -436,13 +436,13 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
 
   // The defending side saves a draw by checking from behind in case the pawn
   // has advanced to the 6th rank with the king behind.
-  if (   pawnRank == RANK_6
+  if (pawnRank == RANK_6
       && distance(weakKing, queeningSquare) <= 1
       && rank_of(strongKing) + tempo <= RANK_6
       && (rank_of(weakRook) == RANK_1 || (!tempo && distance<File>(weakRook, strongPawn) >= 3)))
       return SCALE_FACTOR_DRAW;
 
-  if (   pawnRank >= RANK_6
+  if (pawnRank >= RANK_6
       && weakKing == queeningSquare
       && rank_of(weakRook) == RANK_1
       && (!tempo || distance(strongKing, strongPawn) >= 2))
@@ -450,7 +450,7 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
 
   // White pawn on a7 and rook on a8 is a draw if black's king is on g7 or h7
   // and the black rook is behind the pawn.
-  if (   strongPawn == SQ_A7
+  if (strongPawn == SQ_A7
       && strongRook == SQ_A8
       && (weakKing == SQ_H7 || weakKing == SQ_G7)
       && file_of(weakRook) == FILE_A
@@ -459,7 +459,7 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
 
   // If the defending king blocks the pawn and the attacking king is too far
   // away, it's a draw.
-  if (   pawnRank <= RANK_5
+  if (pawnRank <= RANK_5
       && weakKing == strongPawn + NORTH
       && distance(strongKing, strongPawn) - tempo >= 2
       && distance(strongKing, weakRook) - tempo >= 2)
@@ -468,7 +468,7 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
   // Pawn on the 7th rank supported by the rook from behind usually wins if the
   // attacking king is closer to the queening square than the defending king,
   // and the defending king cannot gain tempi by threatening the attacking rook.
-  if (   pawnRank == RANK_7
+  if (pawnRank == RANK_7
       && pawnFile != FILE_A
       && file_of(strongRook) == pawnFile
       && strongRook != queeningSquare
@@ -477,7 +477,7 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
       return ScaleFactor(SCALE_FACTOR_MAX - 2 * distance(strongKing, queeningSquare));
 
   // Similar to the above, but with the pawn further back
-  if (   pawnFile != FILE_A
+  if (pawnFile != FILE_A
       && file_of(strongRook) == pawnFile
       && strongRook < strongPawn
       && (distance(strongKing, queeningSquare) < distance(weakKing, queeningSquare) - 2 + tempo)
@@ -495,7 +495,7 @@ ScaleFactor Endgame<KRPKR>::operator()(const Position& pos) const {
   {
       if (file_of(weakKing) == file_of(strongPawn))
           return ScaleFactor(10);
-      if (   distance<File>(weakKing, strongPawn) == 1
+      if (distance<File>(weakKing, strongPawn) == 1
           && distance(strongKing, weakKing) > 2)
           return ScaleFactor(24 - 2 * distance(strongKing, weakKing));
   }
@@ -537,7 +537,7 @@ ScaleFactor Endgame<KRPKB>::operator()(const Position& pos) const {
       // it's drawn if the bishop attacks the square in front of the
       // pawn from a reasonable distance and the defending king is near
       // the corner
-      if (   pawnRank == RANK_6
+      if (pawnRank == RANK_6
           && distance(strongPawn + 2 * push, weakKing) <= 1
           && (attacks_bb<BISHOP>(weakBishop) & (strongPawn + push))
           && distance<File>(weakBishop, strongPawn) >= 2)
@@ -565,7 +565,7 @@ ScaleFactor Endgame<KRPPKRP>::operator()(const Position& pos) const {
 
   Rank pawnRank = std::max(relative_rank(strongSide, strongPawn1), relative_rank(strongSide, strongPawn2));
 
-  if (   distance<File>(weakKing, strongPawn1) <= 1
+  if (distance<File>(weakKing, strongPawn1) <= 1
       && distance<File>(weakKing, strongPawn2) <= 1
       && relative_rank(strongSide, weakKing) > pawnRank)
   {
@@ -589,7 +589,7 @@ ScaleFactor Endgame<KPsK>::operator()(const Position& pos) const {
   Bitboard strongPawns = pos.pieces(strongSide, PAWN);
 
   // If all pawns are ahead of the king on a single rook file, it's a draw.
-  if (   !(strongPawns & ~(FileABB | FileHBB))
+  if (!(strongPawns & ~(FileABB | FileHBB))
       && !(strongPawns & ~passed_pawn_span(weakSide, weakKing)))
       return SCALE_FACTOR_DRAW;
 
@@ -613,7 +613,7 @@ ScaleFactor Endgame<KBPKB>::operator()(const Position& pos) const {
   Square weakKing = pos.square<KING>(weakSide);
 
   // Case 1: Defending king blocks the pawn, and cannot be driven away
-  if (   (forward_file_bb(strongSide, strongPawn) & weakKing)
+  if ((forward_file_bb(strongSide, strongPawn) & weakKing)
       && (   opposite_colors(weakKing, strongBishop)
           || relative_rank(strongSide, weakKing) <= RANK_6))
       return SCALE_FACTOR_DRAW;
@@ -660,7 +660,7 @@ ScaleFactor Endgame<KBPPKB>::operator()(const Position& pos) const {
   case 0:
     // Both pawns are on the same file. It's an easy draw if the defender firmly
     // controls some square in the frontmost pawn's path.
-    if (   file_of(weakKing) == file_of(blockSq1)
+    if (file_of(weakKing) == file_of(blockSq1)
         && relative_rank(strongSide, weakKing) >= relative_rank(strongSide, blockSq1)
         && opposite_colors(weakKing, strongBishop))
         return SCALE_FACTOR_DRAW;
@@ -671,14 +671,14 @@ ScaleFactor Endgame<KBPPKB>::operator()(const Position& pos) const {
     // Pawns on adjacent files. It's a draw if the defender firmly controls the
     // square in front of the frontmost pawn's path, and the square diagonally
     // behind this square on the file of the other pawn.
-    if (   weakKing == blockSq1
+    if (weakKing == blockSq1
         && opposite_colors(weakKing, strongBishop)
         && (   weakBishop == blockSq2
             || (attacks_bb<BISHOP>(blockSq2, pos.pieces()) & pos.pieces(weakSide, BISHOP))
             || distance<Rank>(strongPawn1, strongPawn2) >= 2))
         return SCALE_FACTOR_DRAW;
 
-    else if (   weakKing == blockSq2
+    else if (weakKing == blockSq2
              && opposite_colors(weakKing, strongBishop)
              && (   weakBishop == blockSq1
                  || (attacks_bb<BISHOP>(blockSq1, pos.pieces()) & pos.pieces(weakSide, BISHOP))))
@@ -706,7 +706,7 @@ ScaleFactor Endgame<KBPKN>::operator()(const Position& pos) const {
   Square strongBishop = pos.square<BISHOP>(strongSide);
   Square weakKing = pos.square<KING>(weakSide);
 
-  if (   file_of(weakKing) == file_of(strongPawn)
+  if (file_of(weakKing) == file_of(strongPawn)
       && relative_rank(strongSide, strongPawn) < relative_rank(strongSide, weakKing)
       && (   opposite_colors(weakKing, strongBishop)
           || relative_rank(strongSide, weakKing) <= RANK_6))

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -436,7 +436,7 @@ namespace {
                               & ~pe->pawn_attacks_span(Them);
             Bitboard targets = pos.pieces(Them) & ~pos.pieces(PAWN);
 
-            if (   Pt == KNIGHT
+            if (Pt == KNIGHT
                 && bb & s & ~CenterFiles // on a side outpost
                 && !(b & targets)        // no relevant attacks
                 && (!more_than_one(targets & (s & QueenSide ? QueenSide : KingSide))))
@@ -473,7 +473,7 @@ namespace {
                 // An important Chess960 pattern: a cornered bishop blocked by a friendly
                 // pawn diagonally in front of it is a very serious problem, especially
                 // when that pawn is also blocked.
-                if (   pos.is_chess960()
+                if (pos.is_chess960()
                     && (s == relative_square(Us, SQ_A1) || s == relative_square(Us, SQ_H1)))
                 {
                     Direction d = pawn_push(Us) + (file_of(s) == FILE_A ? EAST : WEST);
@@ -494,7 +494,7 @@ namespace {
             else
             {
                 // If our pawn on this file is blocked, increase penalty
-                if ( pos.pieces(Us, PAWN)
+                if (pos.pieces(Us, PAWN)
                    & shift<Down>(pos.pieces())
                    & file_bb(s))
                 {
@@ -913,7 +913,7 @@ namespace {
         {
             // For pure opposite colored bishops endgames use scale factor
             // based on the number of passed pawns of the strong side.
-            if (   pos.non_pawn_material(WHITE) == BishopValueMg
+            if (pos.non_pawn_material(WHITE) == BishopValueMg
                 && pos.non_pawn_material(BLACK) == BishopValueMg)
                 sf = 18 + 4 * popcount(pe->passed_pawns(strongSide));
             // For every other opposite colored bishops endgames use scale factor
@@ -924,7 +924,7 @@ namespace {
         // For rook endgames with strong side not having overwhelming pawn number advantage
         // and its pawns being on one flank and weak side protecting its pieces with a king
         // use lower scale factor.
-        else if (  pos.non_pawn_material(WHITE) == RookValueMg
+        else if (pos.non_pawn_material(WHITE) == RookValueMg
                 && pos.non_pawn_material(BLACK) == RookValueMg
                 && pos.count<PAWN>(strongSide) - pos.count<PAWN>(~strongSide) <= 1
                 && bool(KingSide & pos.pieces(strongSide, PAWN)) != bool(QueenSide & pos.pieces(strongSide, PAWN))

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -206,7 +206,7 @@ top:
       endMoves = std::end(refutations);
 
       // If the countermove is the same as a killer, skip it
-      if (   refutations[0].move == refutations[2].move
+      if (refutations[0].move == refutations[2].move
           || refutations[1].move == refutations[2].move)
           --endMoves;
 
@@ -235,7 +235,7 @@ top:
       [[fallthrough]];
 
   case QUIET:
-      if (   !skipQuiets
+      if (!skipQuiets
           && select<Next>([&](){return   *cur != refutations[0].move
                                       && *cur != refutations[1].move
                                       && *cur != refutations[2].move;}))

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -173,7 +173,7 @@ namespace {
 
         else if (!neighbours)
         {
-            if (     opposed
+            if (opposed
                 &&  (ourPawns & forward_file_bb(Them, s))
                 && !(theirPawns & adjacent_files_bb(s)))
                 score -= Doubled;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -76,7 +76,7 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
   for (Bitboard b = pos.checkers(); b; )
       os << UCI::square(pop_lsb(b)) << " ";
 
-  if (    int(Tablebases::MaxCardinality) >= popcount(pos.pieces())
+  if (int(Tablebases::MaxCardinality) >= popcount(pos.pieces())
       && !pos.can_castle(ANY_CASTLING))
   {
       StateInfo st;
@@ -256,7 +256,7 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
   // Ignore if square is invalid or not on side to move relative rank 6.
   bool enpassant = false;
 
-  if (   ((ss >> col) && (col >= 'a' && col <= 'h'))
+  if (((ss >> col) && (col >= 'a' && col <= 'h'))
       && ((ss >> row) && (row == (sideToMove == WHITE ? '6' : '3'))))
   {
       st->epSquare = make_square(File(col - 'a'), Rank(row - '1'));
@@ -587,7 +587,7 @@ bool Position::pseudo_legal(const Move m) const {
       if ((Rank8BB | Rank1BB) & to)
           return false;
 
-      if (   !(pawn_attacks_bb(us, from) & pieces(~us) & to) // Not a capture
+      if (!(pawn_attacks_bb(us, from) & pieces(~us) & to) // Not a capture
           && !((from + pawn_push(us) == to) && empty(to))       // Not a single push
           && !(   (from + 2 * pawn_push(us) == to)              // Not a double push
                && (relative_rank(us, from) == RANK_2)
@@ -638,7 +638,7 @@ bool Position::gives_check(Move m) const {
       return true;
 
   // Is there a discovered check?
-  if (   (blockers_for_king(~sideToMove) & from)
+  if ((blockers_for_king(~sideToMove) & from)
       && !aligned(from, to, square<KING>(~sideToMove)))
       return true;
 
@@ -808,7 +808,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   if (type_of(pc) == PAWN)
   {
       // Set en passant square if the moved pawn can be captured
-      if (   (int(to) ^ int(from)) == 16
+      if ((int(to) ^ int(from)) == 16
           && (pawn_attacks_bb(us, to - pawn_push(us)) & pieces(them, PAWN)))
       {
           st->epSquare = to - pawn_push(us);
@@ -1220,7 +1220,7 @@ bool Position::has_game_cycle(int ply) const {
       stp = stp->previous->previous;
 
       Key moveKey = originalKey ^ stp->key;
-      if (   (j = H1(moveKey), cuckoo[j] == moveKey)
+      if ((j = H1(moveKey), cuckoo[j] == moveKey)
           || (j = H2(moveKey), cuckoo[j] == moveKey))
       {
           Move move = cuckooMove[j];
@@ -1292,7 +1292,7 @@ bool Position::pos_is_ok() const {
 
   constexpr bool Fast = true; // Quick (default) or full check?
 
-  if (   (sideToMove != WHITE && sideToMove != BLACK)
+  if ((sideToMove != WHITE && sideToMove != BLACK)
       || piece_on(square<KING>(WHITE)) != W_KING
       || piece_on(square<KING>(BLACK)) != B_KING
       || (   ep_square() != SQ_NONE
@@ -1302,17 +1302,17 @@ bool Position::pos_is_ok() const {
   if (Fast)
       return true;
 
-  if (   pieceCount[W_KING] != 1
+  if (pieceCount[W_KING] != 1
       || pieceCount[B_KING] != 1
       || attackers_to(square<KING>(~sideToMove)) & pieces(sideToMove))
       assert(0 && "pos_is_ok: Kings");
 
-  if (   (pieces(PAWN) & (Rank1BB | Rank8BB))
+  if ((pieces(PAWN) & (Rank1BB | Rank8BB))
       || pieceCount[W_PAWN] > 8
       || pieceCount[B_PAWN] > 8)
       assert(0 && "pos_is_ok: Pawns");
 
-  if (   (pieces(WHITE) & pieces(BLACK))
+  if ((pieces(WHITE) & pieces(BLACK))
       || (pieces(WHITE) | pieces(BLACK)) != pieces()
       || popcount(pieces(WHITE)) > 16
       || popcount(pieces(BLACK)) > 16)
@@ -1325,7 +1325,7 @@ bool Position::pos_is_ok() const {
 
 
   for (Piece pc : Pieces)
-      if (   pieceCount[pc] != popcount(pieces(color_of(pc), type_of(pc)))
+      if (pieceCount[pc] != popcount(pieces(color_of(pc), type_of(pc)))
           || pieceCount[pc] != std::count(board, board + SQUARE_NB, pc))
           assert(0 && "pos_is_ok: Pieces");
 
@@ -1335,7 +1335,7 @@ bool Position::pos_is_ok() const {
           if (!can_castle(cr))
               continue;
 
-          if (   piece_on(castlingRookSquare[cr]) != make_piece(c, ROOK)
+          if (piece_on(castlingRookSquare[cr]) != make_piece(c, ROOK)
               || castlingRightsMask[castlingRookSquare[cr]] != cr
               || (castlingRightsMask[square<KING>(c)] & cr) != cr)
               assert(0 && "pos_is_ok: Castling");

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -178,7 +178,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
   Search::RootMoves rootMoves;
 
   for (const auto& m : MoveList<LEGAL>(pos))
-      if (   limits.searchmoves.empty()
+      if (limits.searchmoves.empty()
           || std::count(limits.searchmoves.begin(), limits.searchmoves.end(), m))
           rootMoves.emplace_back(m);
 
@@ -234,7 +234,7 @@ Thread* ThreadPool::get_best_thread() const {
             if (th->rootMoves[0].score > bestThread->rootMoves[0].score)
                 bestThread = th;
         }
-        else if (   th->rootMoves[0].score >= VALUE_TB_WIN_IN_MAX_PLY
+        else if (th->rootMoves[0].score >= VALUE_TB_WIN_IN_MAX_PLY
                  || (   th->rootMoves[0].score > VALUE_TB_LOSS_IN_MAX_PLY
                      && (   votes[th->rootMoves[0].pv[0]] > votes[bestThread->rootMoves[0].pv[0]]
                          || (   votes[th->rootMoves[0].pv[0]] == votes[bestThread->rootMoves[0].pv[0]]

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -40,7 +40,7 @@ void TTEntry::save(Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev) 
       move16 = (uint16_t)m;
 
   // Overwrite less valuable entries (cheapest checks first)
-  if (   b == BOUND_EXACT
+  if (b == BOUND_EXACT
       || (uint16_t)k != key16
       || d - DEPTH_OFFSET + 2 * pv > depth8 - 4)
   {
@@ -138,7 +138,7 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
       // is needed to keep the unrelated lowest n bits from affecting
       // the result) to calculate the entry age correctly even after
       // generation8 overflows into the next cycle.
-      if (  replace->depth8 - ((GENERATION_CYCLE + generation8 - replace->genBound8) & GENERATION_MASK)
+      if (replace->depth8 - ((GENERATION_CYCLE + generation8 - replace->genBound8) & GENERATION_MASK)
           >   tte[i].depth8 - ((GENERATION_CYCLE + generation8 -   tte[i].genBound8) & GENERATION_MASK))
           replace = &tte[i];
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -252,8 +252,8 @@ void UCI::loop(int argc, char* argv[]) {
       token.clear(); // Avoid a stale if getline() returns nothing or a blank line
       is >> skipws >> token;
 
-      if (    token == "quit"
-          ||  token == "stop")
+      if (token == "quit"
+          || token == "stop")
           Threads.stop = true;
 
       // The GUI sends 'ponderhit' to tell that the user has played the expected move.

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -164,7 +164,7 @@ Option& Option::operator=(const string& v) {
 
   assert(!type.empty());
 
-  if (   (type != "button" && type != "string" && v.empty())
+  if ((type != "button" && type != "string" && v.empty())
       || (type == "check" && v != "true" && v != "false")
       || (type == "spin" && (stof(v) < min || stof(v) > max)))
       return *this;


### PR DESCRIPTION
Remove the extra spaces after `if` and `while` keywords. The spacing and indentation was very inconsistent, especially between different parts of the code.

No functional change