### PR TITLE
simplified gives check castling

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -638,9 +638,9 @@ bool Position::gives_check(Move m) const {
       return true;
 
   // Is there a discovered check?
-  if (   (blockers_for_king(~sideToMove) & from)
-      && !aligned(from, to, square<KING>(~sideToMove)))
-      return true;
+  if (blockers_for_king(~sideToMove) & from)
+      return   !aligned(from, to, square<KING>(~sideToMove))
+            || type_of(m) == CASTLING;
 
   switch (type_of(m))
   {
@@ -665,11 +665,9 @@ bool Position::gives_check(Move m) const {
   default: //CASTLING
   {
       // Castling is encoded as 'king captures the rook'
-      Square ksq = square<KING>(~sideToMove);
       Square rto = relative_square(sideToMove, to > from ? SQ_F1 : SQ_D1);
 
-      return   (attacks_bb<ROOK>(rto) & ksq)
-            && (attacks_bb<ROOK>(rto, pieces() ^ from ^ to) & ksq);
+      return check_squares(ROOK) & rto;
   }
   }
 }


### PR DESCRIPTION
Simplifies away a few attack lookups in gives_check

This was also tested  for correctness using bench 0 0 6 default perft (results: https://github.com/rn5f107s2/sfBenchResults and on the master branch respectively, FRC positions are from line 1670 onwards (https://github.com/rn5f107s2/sfBenchResults/blob/894402b1580e9dfbfafcab200f1bce0d0b72e011/sfPatchBench006Perft#L1670)). I also tested this on a few more fens using go perft 7, results are in the same file, there was no difference in nodes searched (https://github.com/rn5f107s2/sfBenchResults/pull/1/files) 

Passed non-regression STC:
https://tests.stockfishchess.org/tests/live_elo/648587be65ffe077ca123d78
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 153632 W: 41015 L: 40928 D: 71689
Ptnml(0-2): 377, 16077, 43816, 16174, 372 

No functional change 