### PR TITLE
Fix failing pr's because of missing permissions

### DIFF
--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -13,6 +13,7 @@ on:
       - tools
 jobs:
   Prerelease:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
adds a guard to prevent pull requests from trying to delete the previous pre-release

No functional change.