### PR TITLE
Fix Potential in TB cutoffs for NMP.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -800,11 +800,12 @@ namespace {
 
         if (nullValue >= beta)
         {
-            // Do not return unproven mate or TB scores
-            if (nullValue >= VALUE_TB_WIN_IN_MAX_PLY)
-                nullValue = beta;
+            if (nullValue >= Value(15000))
+                nullValue = Value(15000-1);
 
-            if (thisThread->nmpMinPly || (abs(beta) < VALUE_KNOWN_WIN && depth < 14))
+            assert(nullValue < VALUE_TB_WIN_IN_MAX_PLY); // Do not return unproven mate or TB scores
+
+            if (thisThread->nmpMinPly || depth < 14)
                 return nullValue;
 
             assert(!thisThread->nmpMinPly); // Recursive verification is not allowed


### PR DESCRIPTION
Removes the second dependency on beta and caps the return value to a maximum greater than a 'known win' but smaller than a 'TB win'.

STC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 193632 W: 51372 L: 51326 D: 90934
Ptnml(0-2): 447, 20111, 55687, 20091, 480
https://tests.stockfishchess.org/tests/view/6486ee4465ffe077ca125bc1

LTC:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 331758 W: 89538 L: 89624 D: 152596
Ptnml(0-2): 114, 30121, 105516, 29993, 135
https://tests.stockfishchess.org/tests/view/6489401af42a44347ed7be42

fixes: https://github.com/official-stockfish/Stockfish/issues/4598

bench: 2370027