### PR TITLE
Simplify aspiration window widening

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -409,7 +409,7 @@ void Thread::search() {
               else
                   break;
 
-              delta += delta / 3;
+              delta += Value(10);
 
               assert(alpha >= -VALUE_INFINITE && beta <= VALUE_INFINITE);
           }


### PR DESCRIPTION
Instead of scaling based on the current window size, simply widen the window using fixed constant 10.

Simplification STC: https://tests.stockfishchess.org/tests/view/648b10e291c58631ce31c668
LLR: 2.93 (-2.94,2.94) <-1.75,0.25> 
Total: 94752 W: 25238 L: 25089 D: 44425 
Ptnml(0-2): 228, 10346, 26078, 10497, 227

Simplification LTC: https://tests.stockfishchess.org/tests/view/648c017c91c58631ce31db1a
LLR: 2.94 (-2.94,2.94) <-1.75,0.25> 
Total: 248934 W: 67344 L: 67356 D: 114234
Ptnml(0-2): 79, 24038, 76252, 24012, 86

Matetrack scores, courtesy of Viren:
```
Using ./stockfish with 1000000 nodes
Total fens:    6561
Found mates:   3585
Best mates:    2425
```
Negligible regression compared to current master score of 2445 best mates.

Bench: 2584183