### PR TITLE
Update default net to nn-5af11540bbfe.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-78bacfcee510.nnue"
+  #define EvalFileDefaultName   "nn-5af11540bbfe.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
Created by retraining the sparsified master net (nn-cd2ff4716c34.nnue) on a 100% minified dataset including Leela transformers data from T80 may2023.

Weights permuted with the exact methods and code in: https://github.com/official-stockfish/Stockfish/pull/4620

LEB128 compression done with the new serialize.py param in: https://github.com/glinscott/nnue-pytorch/pull/251

Initially trained with max epoch 800. Around epoch 780, training was paused and max epoch raised to 960.

```bash
python3 easy_train.py \
  --experiment-name L1-1536-sparse-master-retrain \
  --training-dataset /data/leela96-dfrc99-v2-T60novdecT77decT78jantosepT79aprmayT80juntonovjan-v6dd-T80febtomay2023.min.binpack \
  --early-fen-skipping 27 \
  --start-from-engine-test-net True \
  --max_epoch 960 \
  --lr 4.375e-4 \
  --gamma 0.995 \
  --start-lambda 1.0 \
  --end-lambda 0.7 \
  --tui False \
  --seed $RANDOM \
  --gpus 0
```

For preparing the training dataset (interleaved size 328G):

```bash
python3 interleave_binpacks.py \
  leela96-filt-v2.min.binpack \
  dfrc99-16tb7p-eval-filt-v2.min.binpack \
  filt-v6-dd-min/test60-novdec2021-12tb7p-filter-v6-dd.min.binpack \
  filt-v6-dd-min/test77-dec2021-16tb7p-filter-v6-dd.min.binpack \
  filt-v6-dd-min/test78-jantomay2022-16tb7p-filter-v6-dd.min.binpack \
  filt-v6-dd-min/test78-juntosep2022-16tb7p-filter-v6-dd.min.binpack \
  filt-v6-dd-min/test79-apr2022-16tb7p-filter-v6-dd.min.binpack \
  filt-v6-dd-min/test79-may2022-16tb7p-filter-v6-dd.min.binpack \
  filt-v6-dd-min/test80-jun2022-16tb7p-filter-v6-dd.min.binpack \
  filt-v6-dd-min/test80-jul2022-16tb7p-filter-v6-dd.min.binpack \
  filt-v6-dd-min/test80-aug2022-16tb7p-filter-v6-dd.min.binpack \
  filt-v6-dd-min/test80-sep2022-16tb7p-filter-v6-dd.min.binpack \
  filt-v6-dd-min/test80-oct2022-16tb7p-filter-v6-dd.min.binpack \
  filt-v6-dd-min/test80-nov2022-16tb7p-filter-v6-dd.min.binpack \
  filt-v6-dd-min/test80-jan2023-16tb7p-filter-v6-dd.min.binpack \
  test80-2023/test80-feb2023-16tb7p-no-db.min.binpack \
  test80-2023/test80-mar2023-2tb7p-no-db.min.binpack \
  test80-2023/test80-apr2023-2tb7p-no-db.min.binpack \
  test80-2023/test80-may2023-2tb7p-no-db.min.binpack \
  /data/leela96-dfrc99-v2-T60novdecT77decT78jantosepT79aprmayT80juntonovjan-v6dd-T80febtomay2023.min.binpack
```

Minified binpacks and Leela T80 training data from 2023 available at:
https://robotmoon.com/nnue-training-data/

Local elo at 25k nodes per move:
nn-epoch879.nnue : 3.9 +/- 5.7

Passed STC:
https://tests.stockfishchess.org/tests/view/64928c1bdc7002ce609c7690
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 72000 W: 19242 L: 18889 D: 33869
Ptnml(0-2): 182, 7787, 19716, 8126, 189

Passed LTC:
https://tests.stockfishchess.org/tests/view/64930a37dc7002ce609c82e3
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 54552 W: 14978 L: 14647 D: 24927
Ptnml(0-2): 23, 5123, 16650, 5460, 20

bench 2593605