### PR TITLE
Update winrate model with June data

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -207,8 +207,8 @@ namespace {
      // The coefficients of a third-order polynomial fit is based on the fishtest data
      // for two parameters that need to transform eval to the argument of a logistic
      // function.
-     constexpr double as[] = {   1.07390458,   -6.94334517,   31.95090161,  317.75424048};
-     constexpr double bs[] = {  -2.82843814,   16.64518180,  -19.74439200,   68.39499088 };
+     constexpr double as[] = {   0.38036525,   -2.82015070,   23.17882135,  307.36768407};
+     constexpr double bs[] = {  -2.29434733,   13.27689788,  -14.26828904,   63.45318330 };
 
      // Enforce that NormalizeToPawnValue corresponds to a 50% win rate at ply 64
      static_assert(UCI::NormalizeToPawnValue == int(as[0] + as[1] + as[2] + as[3]));

--- a/src/uci.h
+++ b/src/uci.h
@@ -35,7 +35,7 @@ namespace UCI {
 // the win_rate_model() such that Stockfish outputs an advantage of
 // "100 centipawns" for a position if the engine has a 50% probability to win
 // from this position in selfplay at fishtest LTC time control.
-const int NormalizeToPawnValue = 343;
+const int NormalizeToPawnValue = 328;
 
 class Option;
 


### PR DESCRIPTION
Retained 748191776 scored positions for analysis

const int NormalizeToPawnValue = 328;
Corresponding spread = 60;
Corresponding normalized spread = 0.18337766691628035; Draw rate at 0.0 eval at move 32 = 0.9914715947898592;

No functional change