### PR TITLE
Simplify score improvement reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1318,12 +1318,12 @@ moves_loop: // When in check, search starts here
               }
               else
               {
-                  // Reduce other moves if we have found at least one score improvement (~1 Elo)
-                  // Reduce more for depth > 3 and depth < 12 (~1 Elo)
-                  if (   depth > 1
+                  // Reduce other moves if we have found at least one score improvement (~2 Elo)
+                  if (   depth > 2
+                      && depth < 12
                       && beta  <  14362
                       && value > -12393)
-                      depth -= depth > 3 && depth < 12 ? 2 : 1;
+                      depth -= 2;
 
                   assert(depth > 0);
                   alpha = value; // Update alpha! Always alpha < beta


### PR DESCRIPTION
Reduce depth by 2 based on score improvement, only for depths 3 to 11. 

Simplification STC: https://tests.stockfishchess.org/tests/view/64929a53dc7002ce609c7807
LLR: 2.95 (-2.94,2.94) <-1.75,0.25> 
Total: 238912 W: 63466 L: 63468 D: 111978
Ptnml(0-2): 564, 26262, 65805, 26262, 563

Simplification LTC: https://tests.stockfishchess.org/tests/view/64942e47dc7002ce609c9e07
LLR: 2.94 (-2.94,2.94) <-1.75,0.25> 
Total: 64452 W: 17485 L: 17320 D: 29647
Ptnml(0-2): 19, 6161, 19706, 6316, 24

Bench: 2623646