### PR TITLE
Introduce a quadratics in the singular margin formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1063,7 +1063,9 @@ moves_loop: // When in check, search starts here
               && (tte->bound() & BOUND_LOWER)
               &&  tte->depth() >= depth - 3)
           {
-              Value singularBeta = ttValue - (82 + 65 * (ss->ttPv && !PvNode)) * depth / 64;
+              int margin =   depth * depth / 32
+                           + (1 + (ss->ttPv && !PvNode)) * depth;
+              Value singularBeta = ttValue - margin;
               Depth singularDepth = (depth - 1) / 2;
 
               ss->excludedMove = move;


### PR DESCRIPTION
Tweak the singular margin formula by using a simpler form for the part of the formula which is linear in depth, and adding a part which is quadratic in depth.

STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 21312 W: 5755 L: 5477 D: 10080
Ptnml(0-2): 39, 2208, 5894, 2466, 49
https://tests.stockfishchess.org/tests/view/648c70ac91c58631ce31e421

LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 107856 W: 29424 L: 28992 D: 49440
Ptnml(0-2): 31, 10179, 33087, 10589, 42
https://tests.stockfishchess.org/tests/view/648f4cb6dc7002ce609c3223

Verification run at VLTC: to be done
[edit] verification run failed !
https://tests.stockfishchess.org/tests/view/64973959dc7002ce609cd500

closes https://github.com/official-stockfish/Stockfish/pull/4639

bench: 2396474