### PR TITLE
Update default data to nn-a3d1bfca1672.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-5af11540bbfe.nnue"
+  #define EvalFileDefaultName   "nn-a3d1bfca1672.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
Activation data taken from https://drive.google.com/drive/folders/1Ec9YuuRx4N03GPnVPoQOW70eucOKngQe?usp=sharing
Permutation found using https://github.com/Ergodice/nnue-pytorch/blob/836387a0e5e690431d404158c46648710f13904d/ftperm.py

The algorithm greedily selects 2- and 3-cycles that can be permuted to increase the number of runs of zeroes. The percent of zero runs from the master net increased from 68.46 to 70.11 from 2-cycles and only increased to 70.32 when considering 3-cycles. Interestingly, allowing both halves of L1 to intermix when creating zero runs can give another 0.5% zero-run density increase with this method. Given how tiny the gain is when adding 3-cycles, I am led to believe that this is the limit for post-training permutation and that it may be beneficial to add sparsity awareness to nn training.

Speedup test courtesy of vondele

CPU: 16 x AMD Ryzen 9 3950X 16-Core Processor
Result of  50 runs

base (./stockfish.master       ) =    1561556  +/- 5439
test (./stockfish.patch        ) =    1575788  +/- 5427
diff                             =     +14231  +/- 2636

speedup        = +0.0091
P(speedup > 0) =  1.0000

