### PR TITLE
Negative extension on cutNodes based on depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1096,7 +1096,8 @@ moves_loop: // When in check, search starts here
               // If the eval of ttMove is greater than beta, we reduce it (negative extension) (~7 Elo)
               else if (ttValue >= beta)
                   extension = -2 - !PvNode;
-              
+
+              // If we are on a cutNode, reduce it based on depth (negative extension) (~1 Elo)
               else if (cutNode)
                   extension = depth > 8 && depth < 17 ? -3 : -1;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1096,6 +1096,9 @@ moves_loop: // When in check, search starts here
               // If the eval of ttMove is greater than beta, we reduce it (negative extension) (~7 Elo)
               else if (ttValue >= beta)
                   extension = -2 - !PvNode;
+              
+              else if (cutNode)
+                  extension = depth > 8 && depth < 17 ? -3 : -1;
 
               // If the eval of ttMove is less than value, we reduce it (negative extension) (~1 Elo)
               else if (ttValue <= value)


### PR DESCRIPTION
This patch was inspired by @candirufish original attempt at negative extensions here that failed yellow: https://tests.stockfishchess.org/tests/view/6486529065ffe077ca124f32

I tested some variations of the idea and tuned a depth condition for a modified version of it here https://tests.stockfishchess.org/tests/view/648db80a91c58631ce31fe00 after noticing abnormal scaling (ie many passed STC but not LTC)
After some small tweaks I got the final version here

Passed STC:
LLR: 2.98 (-2.94,2.94) <0.00,2.00>
Total: 122208 W: 32776 L: 32350 D: 57082
Ptnml(0-2): 310, 13250, 33553, 13686, 305
https://tests.stockfishchess.org/tests/view/64997934dc7002ce609d01e3

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 145092 W: 39617 L: 39115 D: 66360
Ptnml(0-2): 54, 13691, 44552, 14197, 52
https://tests.stockfishchess.org/tests/view/649a1c5ddc7002ce609d0bff

Bench: 2637784