### PR TITLE
Fix pruning to (in TB loss) in Null move pruning.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -782,7 +782,8 @@ namespace {
         &&  ss->staticEval >= beta - 21 * depth - improvement / 13 + 258
         && !excludedMove
         &&  pos.non_pawn_material(us)
-        && (ss->ply >= thisThread->nmpMinPly))
+        &&  ss->ply >= thisThread->nmpMinPly
+        &&  beta > VALUE_TB_LOSS_IN_MAX_PLY)
     {
         assert(eval - beta >= 0);
 


### PR DESCRIPTION
Current logic can apply Null move pruning on a dead-lost position returning an unproven loss (i.e. in TB loss score or mated in losing score) on nonPv nodes.

on a default bench, this can be observed by adding this debugging line:
```
if (nullValue >= beta)
{
    // Do not return unproven mate or TB scores
    nullValue = std::min(nullValue, VALUE_TB_WIN_IN_MAX_PLY-1);
    dbg_hit_on(nullValue <= VALUE_TB_LOSS_IN_MAX_PLY); // Hit #0: Total 73983 Hits 1 Hit Rate (%) 0.00135166
    if (thisThread->nmpMinPly || depth < 14)
        return nullValue;
```

This fixes this very rare issue (happens at ~0.00135166% of the time) by eliminating the need to try Null Move Pruning with dead-lost positions and leaving it to be determined by a normal searching flow.

The previous try to fix was not as safe enough because it was capping the returned value to (out of TB range) thus reviving the dead-lost position based on an artificial clamp (i.e. the in TB score/mate score can be lost on that nonPv node): https://tests.stockfishchess.org/tests/view/649756d5dc7002ce609cd794

Final fix:
Passed STC:
https://tests.stockfishchess.org/tests/view/649a5446dc7002ce609d1049
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 577280 W: 153613 L: 153965 D: 269702
Ptnml(0-2): 1320, 60594, 165190, 60190, 1346

Passed LTC:
https://tests.stockfishchess.org/tests/view/649cd048dc7002ce609d4801
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 246432 W: 66769 L: 66778 D: 112885
Ptnml(0-2): 83, 22105, 78847, 22100, 81

Bench: 2529739