### PR TITLE
Simplify away improvement term in null move search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -779,7 +779,7 @@ namespace {
         && (ss-1)->statScore < 17329
         &&  eval >= beta
         &&  eval >= ss->staticEval
-        &&  ss->staticEval >= beta - 21 * depth - improvement / 13 + 258
+        &&  ss->staticEval >= beta - 21 * depth + 258
         && !excludedMove
         &&  pos.non_pawn_material(us)
         && (ss->ply >= thisThread->nmpMinPly))


### PR DESCRIPTION
Simply remove improvement term in null move search.

Simplification STC: https://tests.stockfishchess.org/tests/view/649c0d2edc7002ce609d33b5
LLR: 2.95 (-2.94,2.94) <-1.75,0.25> 
Total: 271104 W: 72181 L: 72217 D: 126706
Ptnml(0-2): 691, 30042, 74129, 29992, 698

Simplification LTC: https://tests.stockfishchess.org/tests/view/649d0dd7dc7002ce609d4efa
LLR: 2.94 (-2.94,2.94) <-1.75,0.25> 
Total: 183120 W: 49469 L: 49418 D: 84233
Ptnml(0-2): 84, 17636, 56063, 17699, 78

Bench: 2613939