### PR TITLE
Make posix and msys2 shells consistent in CI

### DIFF
--- a/.github/workflows/stockfish_arm_binaries.yml
+++ b/.github/workflows/stockfish_arm_binaries.yml
@@ -20,13 +20,13 @@ jobs:
             compiler: aarch64-linux-android21-clang++
             emu: qemu-aarch64
             comp: ndk
-            shell: bash {0}
+            shell: bash
           - name: Android NDK arm
             os: ubuntu-22.04
             compiler: armv7a-linux-androideabi21-clang++
             emu: qemu-arm
             comp: ndk
-            shell: bash {0}
+            shell: bash
         binaries:
           - armv8
           - armv7

--- a/.github/workflows/stockfish_binaries.yml
+++ b/.github/workflows/stockfish_binaries.yml
@@ -19,14 +19,14 @@ jobs:
             simple_name: ubuntu
             compiler: g++
             comp: gcc
-            shell: bash {0}
+            shell: bash
             archive_ext: tar
           - name: MacOS 12 Apple Clang
             os: macos-12
             simple_name: macos
             compiler: clang++
             comp: clang
-            shell: bash {0}
+            shell: bash
             archive_ext: tar
           - name: Windows 2022 Mingw-w64 GCC x86_64
             os: windows-2022

--- a/.github/workflows/stockfish_compile_test.yml
+++ b/.github/workflows/stockfish_compile_test.yml
@@ -15,22 +15,22 @@ jobs:
             os: ubuntu-20.04
             compiler: g++
             comp: gcc
-            shell: bash {0}
+            shell: bash
           - name: Ubuntu 20.04 Clang
             os: ubuntu-20.04
             compiler: clang++
             comp: clang
-            shell: bash {0}
+            shell: bash
           - name: MacOS 12 Apple Clang
             os: macos-12
             compiler: clang++
             comp: clang
-            shell: bash {0}
+            shell: bash
           - name: MacOS 12 GCC 11
             os: macos-12
             compiler: g++-11
             comp: gcc
-            shell: bash {0}
+            shell: bash
           - name: Windows 2022 Mingw-w64 GCC x86_64
             os: windows-2022
             compiler: g++

--- a/.github/workflows/stockfish_sanitizers.yml
+++ b/.github/workflows/stockfish_sanitizers.yml
@@ -16,7 +16,7 @@ jobs:
             os: ubuntu-20.04
             compiler: g++
             comp: gcc
-            shell: bash {0}
+            shell: bash
         sanitizers:
           - name: Run with thread sanitizer
             make_option: sanitize=thread

--- a/.github/workflows/stockfish_test.yml
+++ b/.github/workflows/stockfish_test.yml
@@ -18,38 +18,38 @@ jobs:
             comp: gcc
             run_32bit_tests: true
             run_64bit_tests: true
-            shell: bash {0}
+            shell: bash
           - name: Ubuntu 20.04 Clang
             os: ubuntu-20.04
             compiler: clang++
             comp: clang
             run_32bit_tests: true
             run_64bit_tests: true
-            shell: bash {0}
+            shell: bash
           - name: Android NDK aarch64
             os: ubuntu-22.04
             compiler: aarch64-linux-android21-clang++
             comp: ndk
             run_armv8_tests: true
-            shell: bash {0}
+            shell: bash
           - name: Android NDK arm
             os: ubuntu-22.04
             compiler: armv7a-linux-androideabi21-clang++
             comp: ndk
             run_armv7_tests: true
-            shell: bash {0}
+            shell: bash
           - name: MacOS 12 Apple Clang
             os: macos-12
             compiler: clang++
             comp: clang
             run_64bit_tests: true
-            shell: bash {0}
+            shell: bash
           - name: MacOS 12 GCC 11
             os: macos-12
             compiler: g++-11
             comp: gcc
             run_64bit_tests: true
-            shell: bash {0}
+            shell: bash
           - name: Windows 2022 Mingw-w64 GCC x86_64
             os: windows-2022
             compiler: g++
@@ -115,8 +115,8 @@ jobs:
 
       - name: Extract the bench number from the commit history
         run: |
-          git log HEAD | grep -o "\b[Bb]ench[ :]\+[1-9][0-9]\{5,9\}\b" | head -n 1 | sed "s/[^0-9]//g" > git_sig
-          [ -s git_sig ] && echo "benchref=$(cat git_sig)" >> $GITHUB_ENV && echo "Reference bench:" $(cat git_sig) || echo "No bench found"
+          benchref=$(git log HEAD | grep -m 1 -o -x "[[:space:]]*\b[Bb]ench[ :]\+[1-9][0-9]\{5,7\}\b[[:space:]]*" | sed "s/[^0-9]//g") || true
+          [[ -n "$benchref" ]] && echo "benchref=$benchref" >> $GITHUB_ENV && echo "Reference bench: $benchref" || echo "No bench found"
 
       - name: Check compiler
         run: |


### PR DESCRIPTION
In CI, it is typical for the process to halt immediately when an error is encountered. However, with our `shell: bash {0}` configuration, the process continues despite errors for posix shells.
This commit updates the behavior of posix and msys2 shells to ensure consistency in terms of pipeline exit codes and stop conditions. We adopt the most appropriate default behavior as recommended by the GitHub documentation.

Update the code that searches for the bench value in the git log:
- to be compatible with the new shell settings
- to retry the value from the first line that contains only the template and spaces/tabs/newlines

```
$ false | true
$ echo $?
1
```
Shell parameters in Github Actions:
```
- posix:
  - shell undefined  -> bash -e {0}
  - shell: bash      -> bash --noprofile --norc -eo pipefail {0}
- msys2:
  - shell: msys2 {0} -> bash -leo pipefail {0}
```

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference https://github.com/msys2/setup-msys2/blob/main/main.js

closes https://github.com/official-stockfish/Stockfish/pull/4653

No functional change