### PR TITLE
Simplify away lookup_count

### DIFF
--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -24,7 +24,6 @@
 #include <iostream>
 #include <algorithm>
 #include <array>
-#include <bitset>
 #include <type_traits>
 #include "../nnue_common.h"
 #include "affine_transform.h"
@@ -75,12 +74,6 @@ namespace Stockfish::Eval::NNUE::Layers {
     }
     return v;
   }();
-  alignas(CacheLineSize) static inline const std::array<unsigned, 256> lookup_count = [](){
-    std::array<unsigned, 256> v;
-    for (int i = 0; i < 256; ++i)
-      v[i] = unsigned(std::bitset<8>(i).count());
-    return v;
-  }();
 
   // Find indices of nonzero numbers in an int32_t array
   template<const IndexType InputDimensions>
@@ -120,7 +113,7 @@ namespace Stockfish::Eval::NNUE::Layers {
         const auto lookup = (nnz >> (j * 8)) & 0xFF;
         const auto offsets = _mm_loadu_si128(reinterpret_cast<const __m128i*>(&lookup_indices[lookup]));
         _mm_storeu_si128(reinterpret_cast<__m128i*>(out + count), _mm_add_epi16(base, offsets));
-        count += lookup_count[lookup];
+        count += popcount(lookup);
         base = _mm_add_epi16(base, increment);
       }
     }


### PR DESCRIPTION
https://tests.stockfishchess.org/tests/view/64a3c1a93ee09aa549c53167
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 32832 W: 8497 L: 8280 D: 16055
Ptnml(0-2): 80, 3544, 8967, 3729, 96 

No functional change
bench: 2740142