### PR TITLE
Update default net to nn-c38c3d8d3920.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-1b951f8b449d.nnue"
+  #define EvalFileDefaultName   "nn-c38c3d8d3920.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
This was a later epoch from the same experiment that led to the previous master net.
After training, it was prepared the same way:

1. greedy permuting L1 weights with https://github.com/official-stockfish/Stockfish/pull/4620
2. leb128 compression with https://github.com/glinscott/nnue-pytorch/pull/251
3. greedy 2- and 3- cycle permuting with https://github.com/official-stockfish/Stockfish/pull/4640

Local elo at 25k nodes per move (vs. L1-1536 nn-fdc1d0fe6455.nnue):
nn-epoch739.nnue : 20.2 +/- 1.7

Passed STC:
https://tests.stockfishchess.org/tests/view/64a050b33ee09aa549c4e4c8
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 195552 W: 49977 L: 49430 D: 96145
Ptnml(0-2): 556, 22775, 50607, 23242, 596

Passed LTC:
https://tests.stockfishchess.org/tests/view/64a127bd3ee09aa549c4f60c
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 235452 W: 60327 L: 59609 D: 115516
Ptnml(0-2): 119, 25173, 66426, 25887, 121

bench 2427629