### PR TITLE
Increment `ss->doubleExtensions` instead of re-assigning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1082,6 +1082,7 @@ moves_loop: // When in check, search starts here
                       && ss->doubleExtensions <= 11)
                   {
                       extension = 2;
+                      ss->doubleExtensions++;
                       depth += depth < 13;
                   }
               }
@@ -1126,7 +1127,6 @@ moves_loop: // When in check, search starts here
 
       // Add extension to new depth
       newDepth += extension;
-      ss->doubleExtensions = (ss-1)->doubleExtensions + (extension == 2);
 
       // Speculative prefetch as early as possible
       prefetch(TT.first_entry(pos.key_after(move)));


### PR DESCRIPTION
This avoids errors if we were to have a double extension before step 15 in the future, as it is already initialised to `(ss-1)->doubleExtensions` at https://github.com/official-stockfish/Stockfish/blob/master/src/search.cpp#L598

No functional change