### PR TITLE
Simplify PvNode reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1162,7 +1162,7 @@ moves_loop: // When in check, search starts here
 
       // Decrease reduction for PvNodes based on depth (~2 Elo)
       if (PvNode)
-          r -= 1 + 12 / (3 + depth);
+          r -= 1 + (depth < 6);
 
       // Decrease reduction if ttMove has been singularly extended (~1 Elo)
       if (singularQuietLMR)


### PR DESCRIPTION
Simplification STC: https://tests.stockfishchess.org/tests/view/64a415803ee09aa549c539c3
LLR: 2.93 (-2.94,2.94) <-1.75,0.25> 
Total: 37856 W: 9719 L: 9504 D: 18633
Ptnml(0-2): 98, 4277, 9977, 4464, 112

Simplification LTC: https://tests.stockfishchess.org/tests/view/64a5ffe202cd07745c60f360
LLR: 2.96 (-2.94,2.94) <-1.75,0.25> 
Total: 55878 W: 14323 L: 14138 D: 27417
Ptnml(0-2): 21, 5993, 15732, 6166, 27

Bench: 2604965