### PR TITLE
Cleanup code after removal of classical evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -119,7 +119,7 @@ namespace Eval {
     {
 
         string msg1 = "Network evaluation parameters compatible with the engine must be available.";
-        string msg2 = "The option is set to true, but the network file " + eval_file + " was not loaded successfully.";
+        string msg2 = "The network file " + eval_file + " was not loaded successfully.";
         string msg3 = "The UCI option EvalFile might need to specify the full path, including the directory name, to the network file.";
         string msg4 = "The default net can be downloaded from: https://tests.stockfishchess.org/api/nn/" + std::string(EvalFileDefaultName);
         string msg5 = "The engine will be terminated now.";

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,6 @@ namespace Eval {
   std::string trace(Position& pos);
   Value evaluate(const Position& pos);
 
-  extern bool useNNUE;
   extern std::string currentEvalFileName;
 
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue


### PR DESCRIPTION
This includes the following changes:
- Remove declaration of removed global variable
- Adapt string that mentions removed UCI option

No functional change