### PR TITLE
Generate binaries for more advanced architectures

### DIFF
--- a/.github/workflows/stockfish_binaries.yml
+++ b/.github/workflows/stockfish_binaries.yml
@@ -9,6 +9,7 @@ jobs:
       COMPILER: ${{ matrix.config.compiler }}
       COMP: ${{ matrix.config.comp }}
       EXT: ${{ matrix.config.ext }}
+      SDE: ${{ matrix.config.sde }}
       NAME: ${{ matrix.config.simple_name }}
       BINARY: ${{ matrix.binaries }}
     strategy:
@@ -21,6 +22,7 @@ jobs:
             comp: gcc
             shell: bash
             archive_ext: tar
+            sde: /home/runner/work/Stockfish/Stockfish/.output/sde-temp-files/sde-external-9.14.0-2022-10-25-lin/sde -future
           - name: MacOS 12 Apple Clang
             os: macos-12
             simple_name: macos
@@ -37,16 +39,27 @@ jobs:
             msys_env: x86_64-gcc
             shell: msys2 {0}
             ext: .exe
+            sde: /d/a/Stockfish/Stockfish/.output/sde-temp-files/sde-external-9.14.0-2022-10-25-win/sde.exe -future
             archive_ext: zip
         binaries:
           - x86-64
           - x86-64-modern
           - x86-64-avx2
           - x86-64-bmi2
+          # - x86-64-avxvnni needs more recent gcc
+          - x86-64-avx512
+          - x86-64-vnni256
+          - x86-64-vnni512
         exclude:
-          - binaries: x86-64-avx2
-            config: { os: macos-12 }
           - binaries: x86-64-bmi2
+            config: { os: macos-12 }
+          #- binaries: x86-64-avxvnni
+          #  config: { os: macos-12 }
+          - binaries: x86-64-avx512
+            config: { os: macos-12 }
+          - binaries: x86-64-vnni256
+            config: { os: macos-12 }
+          - binaries: x86-64-vnni512
             config: { os: macos-12 }
     defaults:
       run:
@@ -68,6 +81,13 @@ jobs:
           msystem: ${{ matrix.config.msys_sys }}
           install: mingw-w64-${{ matrix.config.msys_env }} make git zip
 
+      - name: Download SDE package
+        if: runner.os == 'Linux' || runner.os == 'Windows'
+        uses: petarpetrovt/setup-sde@v2.1
+        with:
+          environmentVariableName: SDE_DIR
+          sdeVersion: 9.14.0
+
       - name: Download the used network from the fishtest framework
         run: make net
 
@@ -84,7 +104,7 @@ jobs:
 
       - name: Compile ${{ matrix.binaries }} build
         run: |
-          make -j2 profile-build ARCH=$BINARY COMP=$COMP
+          make -j2 profile-build ARCH=$BINARY COMP=$COMP SDE_PATH="$SDE"
           make strip ARCH=$BINARY COMP=$COMP
           mv ./stockfish$EXT ../stockfish-$NAME-$BINARY$EXT
 


### PR DESCRIPTION
use intel's Software Development Emulator (SDE) in the actions that build the binaries. This allows for building on Windows and Linux binaries for
- x86-64-avx512
- x86-64-vnni256
- x86-64-vnni512 (x86-64-avxvnni needs more recent gcc in the actions)

also build x86-64-avx2 on macos.

No functional change