### PR TITLE
Reintroduce nnue eval pawn count multipliers again

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -157,7 +157,9 @@ Value Eval::evaluate(const Position& pos) {
 
   // Blend optimism with nnue complexity and (semi)classical complexity
   optimism += optimism * (nnueComplexity + abs(psq - nnue)) / 512;
-  v = (nnue * (945 + npm) + optimism * (150 + npm)) / 1024;
+
+  v = (  nnue     * (915 + npm + 9 * pos.count<PAWN>())
+       + optimism * (154 + npm +     pos.count<PAWN>())) / 1024;
 
   // Damp down the evaluation linearly when shuffling
   v = v * (200 - pos.rule50_count()) / 214;


### PR DESCRIPTION
With separate multipliers for nnue eval and optimism scaling. This patch used 4 out of 7 params tuned with spsa at 30+0.3 using this tuning config:

```c++
Value LazyThreshold1 = Value(3622);
Value LazyThreshold2 = Value(1962);
int psqThresh = 2048;
int nnueNpmBase = 945;
int nnuePcMult = 0;
int optNpmBase = 150;
int optPcMult = 0;
TUNE(SetRange(3322, 3922), LazyThreshold1);
TUNE(SetRange(1662, 2262), LazyThreshold2);
TUNE(SetRange(1748, 2348), psqThresh);
TUNE(SetRange(745, 1145), nnueNpmBase);
TUNE(SetRange(-16, 16), nnuePcMult);
TUNE(SetRange(0, 300), optNpmBase);
TUNE(SetRange(-16, 16), optPcMult);
```

Passed STC:
https://tests.stockfishchess.org/tests/view/64a5a9b402cd07745c60ed07
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 173632 W: 44417 L: 43903 D: 85312
Ptnml(0-2): 547, 20025, 45068, 20719, 457

Passed LTC:
https://tests.stockfishchess.org/tests/view/64a972a302cd07745c6136af
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 277644 W: 70955 L: 70147 D: 136542
Ptnml(0-2): 193, 29902, 77787, 30784, 156

bench 1556301