### PR TITLE
Remove pawnKey from StateInfo

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -40,7 +40,6 @@ namespace Stockfish {
 struct StateInfo {
 
   // Copied when making a move
-  Key    pawnKey;
   Key    materialKey;
   Value  nonPawnMaterial[COLOR_NB];
   int    castlingRights;
@@ -336,10 +335,6 @@ inline Key Position::adjust_key50(Key k) const
 {
   return st->rule50 < 14 - AfterMove
       ? k : k ^ make_key((st->rule50 - (14 - AfterMove)) / 8);
-}
-
-inline Key Position::pawn_key() const {
-  return st->pawnKey;
 }
 
 inline Key Position::material_key() const {


### PR DESCRIPTION
Remove pawnKey since it is not used anymore.

Passed Non-regression STC:
https://tests.stockfishchess.org/tests/view/64b023110cdec37b9573265c
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 334848 W: 85440 L: 85545 D: 163863
Ptnml(0-2): 1134, 38101, 89075, 37964, 1150

No functional change