### PR TITLE
Deprecate the x86-64-modern arch

### DIFF
--- a/.github/workflows/stockfish_binaries.yml
+++ b/.github/workflows/stockfish_binaries.yml
@@ -44,7 +44,7 @@ jobs:
         binaries:
           - x86-32
           - x86-64
-          - x86-64-modern
+          - x86-64-sse41-popcnt
           - x86-64-avx2
           - x86-64-bmi2
           - x86-64-avxvnni

--- a/.github/workflows/stockfish_sanitizers.yml
+++ b/.github/workflows/stockfish_sanitizers.yml
@@ -62,5 +62,5 @@ jobs:
         run: |
           export CXXFLAGS="-O1 -fno-inline"
           make clean
-          make -j2 ARCH=x86-64-modern ${{ matrix.sanitizers.make_option }} debug=yes optimize=no build > /dev/null
+          make -j2 ARCH=x86-64-sse41-popcnt ${{ matrix.sanitizers.make_option }} debug=yes optimize=no build > /dev/null
           ../tests/instrumented.sh --${{ matrix.sanitizers.instrumented_option }}

--- a/.github/workflows/stockfish_test.yml
+++ b/.github/workflows/stockfish_test.yml
@@ -177,12 +177,12 @@ jobs:
 
       # x86-64 tests
 
-      - name: Test debug x86-64-modern build
+      - name: Test debug x86-64-sse41-popcnt build
         if: matrix.config.run_64bit_tests
         run: |
           export CXXFLAGS="-Werror -D_GLIBCXX_DEBUG"
           make clean
-          make -j2 ARCH=x86-64-modern optimize=no debug=yes build
+          make -j2 ARCH=x86-64-sse41-popcnt optimize=no debug=yes build
           ../tests/signature.sh $benchref
 
       - name: Test x86-64-bmi2 build
@@ -199,11 +199,19 @@ jobs:
           make -j2 ARCH=x86-64-avx2 build
           ../tests/signature.sh $benchref
 
+      # Test a deprecated arch
       - name: Test x86-64-modern build
         if: matrix.config.run_64bit_tests
         run: |
           make clean
           make -j2 ARCH=x86-64-modern build
+          ../tests/signature.sh $benchref
+
+      - name: Test x86-64-sse41-popcnt build
+        if: matrix.config.run_64bit_tests
+        run: |
+          make clean
+          make -j2 ARCH=x86-64-sse41-popcnt build
           ../tests/signature.sh $benchref
 
       - name: Test x86-64-ssse3 build
@@ -271,6 +279,6 @@ jobs:
         if: matrix.config.run_64bit_tests
         run: |
           make clean
-          make -j2 ARCH=x86-64-modern build
+          make -j2 ARCH=x86-64-sse41-popcnt build
           ../tests/perft.sh
           ../tests/reprosearch.sh

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ big-endian machines such as Power PC, and other platforms.
 On Unix-like systems, it should be easy to compile Stockfish directly from the
 source code with the included Makefile in the folder `src`. In general, it is
 recommended to run `make help` to see a list of make targets with corresponding
-descriptions.
+descriptions. An example suitable for most Intel and AMD chips:
 
 ```
 cd src
-make -j build ARCH=x86-64-modern
+make -j profile-build ARCH=x86-64-avx2
 ```
 
 Detailed compilation instructions for all platforms can be found in our

--- a/src/Makefile
+++ b/src/Makefile
@@ -104,7 +104,7 @@ VPATH = syzygy:nnue:nnue/features
 ### 2.1. General and architecture defaults
 
 ifeq ($(ARCH),)
-   ARCH = x86-64-modern
+   ARCH = x86-64-avx2
    help_skip_sanity = yes
 endif
 # explicitly check for the list of supported architectures (as listed with make help),
@@ -189,6 +189,8 @@ ifeq ($(findstring -sse41,$(ARCH)),-sse41)
 endif
 
 ifeq ($(findstring -modern,$(ARCH)),-modern)
+        $(warning *** ARCH=$(ARCH) is deprecated, defaulting to ARCH=x86-64-sse41-popcnt. Execute `make help` for a list of available architectures. ***)
+        $(shell sleep 5)
 	popcnt = yes
 	sse = yes
 	sse2 = yes
@@ -781,7 +783,7 @@ help:
 	@echo "x86-64-bmi2             > x86 64-bit with bmi2 support"
 	@echo "x86-64-avx2             > x86 64-bit with avx2 support"
 	@echo "x86-64-sse41-popcnt     > x86 64-bit with sse41 and popcnt support"
-	@echo "x86-64-modern           > common modern CPU, currently x86-64-sse41-popcnt"
+	@echo "x86-64-modern           > deprecated, currently x86-64-sse41-popcnt"
 	@echo "x86-64-ssse3            > x86 64-bit with ssse3 support"
 	@echo "x86-64-sse3-popcnt      > x86 64-bit with sse3 and popcnt support"
 	@echo "x86-64                  > x86 64-bit generic (with sse2 support)"
@@ -811,13 +813,13 @@ help:
 	@echo "Simple examples. If you don't know what to do, you likely want to run one of: "
 	@echo ""
 	@echo "make -j profile-build ARCH=x86-64-avx2    # typically a fast compile for common systems "
-	@echo "make -j profile-build ARCH=x86-64-modern  # A more portable compile for 64-bit systems "
+	@echo "make -j profile-build ARCH=x86-64-sse41-popcnt  # A more portable compile for 64-bit systems "
 	@echo "make -j profile-build ARCH=x86-64         # A portable compile for 64-bit systems "
 	@echo ""
 	@echo "Advanced examples, for experienced users: "
 	@echo ""
-	@echo "make -j profile-build ARCH=x86-64-bmi2"
-	@echo "make -j profile-build ARCH=x86-64-bmi2 COMP=gcc COMPCXX=g++-9.0"
+	@echo "make -j profile-build ARCH=x86-64-avxvnni"
+	@echo "make -j profile-build ARCH=x86-64-avxvnni COMP=gcc COMPCXX=g++-12.0"
 	@echo "make -j build ARCH=x86-64-ssse3 COMP=clang"
 	@echo ""
 	@echo "-------------------------------"


### PR DESCRIPTION
Explicitly describe the architecture as deprecated, it remains available as its current alias x86-64-sse41-popcnt

CPUs that support just this instruction set are now years old, any few years old Intel or AMD CPU supports x86-64-avx2. However, naming things 'modern' doesn't age well, so instead use explicit names.

Adjust CI accordingly. Wiki / fishtest etc update needed as well.

No functional change.