### PR TITLE
Switch to macos 13 for CI

### DIFF
--- a/.github/workflows/stockfish_binaries.yml
+++ b/.github/workflows/stockfish_binaries.yml
@@ -23,8 +23,8 @@ jobs:
             shell: bash
             archive_ext: tar
             sde: /home/runner/work/Stockfish/Stockfish/.output/sde-temp-files/sde-external-9.14.0-2022-10-25-lin/sde -future --
-          - name: MacOS 12 Apple Clang
-            os: macos-12
+          - name: MacOS 13 Apple Clang
+            os: macos-13
             simple_name: macos
             compiler: clang++
             comp: clang
@@ -52,24 +52,20 @@ jobs:
           - x86-64-vnni256
           - x86-64-vnni512
         exclude:
-          - binaries: x86-32
-            config: { os: macos-12 }
-          - binaries: x86-32
-            config: { os: windows-2022}
-          - binaries: x86-64-avx2
-            config: { os: macos-12 }
-          - binaries: x86-64-bmi2
-            config: { os: macos-12 }
-          - binaries: x86-64-avxvnni
-            config: { os: macos-12 }
           - binaries: x86-64-avxvnni
             config: { ubuntu-20.04 }
+          - binaries: x86-32
+            config: { os: windows-2022}
+          - binaries: x86-32
+            config: { os: macos-13 }
+          - binaries: x86-64-avxvnni
+            config: { os: macos-13 }
           - binaries: x86-64-avx512
-            config: { os: macos-12 }
+            config: { os: macos-13 }
           - binaries: x86-64-vnni256
-            config: { os: macos-12 }
+            config: { os: macos-13 }
           - binaries: x86-64-vnni512
-            config: { os: macos-12 }
+            config: { os: macos-13 }
     defaults:
       run:
         working-directory: src
@@ -84,6 +80,10 @@ jobs:
         run: |
           sudo apt update
           sudo apt install g++-multilib g++-11-multilib
+
+      - name: Download required macOS packages
+        if: runner.os == 'macOS'
+        run: brew install coreutils
 
       - name: Install fixed GCC on Linux
         if: runner.os == 'Linux'
@@ -117,6 +117,14 @@ jobs:
 
       - name: Check compiler
         run: $COMPILER -v
+
+      - name: Show g++ cpu info
+        if: runner.os != 'macOS'
+        run: g++ -Q -march=native --help=target
+
+      - name: Show clang++ cpu info
+        if: runner.os == 'macOS'
+        run: clang++ -E - -march=native -###
 
       - name: Test help target
         run: make help

--- a/.github/workflows/stockfish_compile_test.yml
+++ b/.github/workflows/stockfish_compile_test.yml
@@ -21,13 +21,13 @@ jobs:
             compiler: clang++
             comp: clang
             shell: bash
-          - name: MacOS 12 Apple Clang
-            os: macos-12
+          - name: MacOS 13 Apple Clang
+            os: macos-13
             compiler: clang++
             comp: clang
             shell: bash
-          - name: MacOS 12 GCC 11
-            os: macos-12
+          - name: MacOS 13 GCC 11
+            os: macos-13
             compiler: g++-11
             comp: gcc
             shell: bash

--- a/.github/workflows/stockfish_test.yml
+++ b/.github/workflows/stockfish_test.yml
@@ -38,14 +38,14 @@ jobs:
             comp: ndk
             run_armv7_tests: true
             shell: bash
-          - name: MacOS 12 Apple Clang
-            os: macos-12
+          - name: MacOS 13 Apple Clang
+            os: macos-13
             compiler: clang++
             comp: clang
             run_64bit_tests: true
             shell: bash
-          - name: MacOS 12 GCC 11
-            os: macos-12
+          - name: MacOS 13 GCC 11
+            os: macos-13
             compiler: g++-11
             comp: gcc
             run_64bit_tests: true
@@ -177,23 +177,23 @@ jobs:
 
       # x86-64 tests
 
-      - name: Test debug x86-64-sse41-popcnt build
+      - name: Test debug x86-64-avx2 build
         if: matrix.config.run_64bit_tests
         run: |
           export CXXFLAGS="-Werror -D_GLIBCXX_DEBUG"
           make clean
-          make -j2 ARCH=x86-64-sse41-popcnt optimize=no debug=yes build
+          make -j2 ARCH=x86-64-avx2 optimize=no debug=yes build
           ../tests/signature.sh $benchref
 
       - name: Test x86-64-bmi2 build
-        if: matrix.config.run_64bit_tests && runner.os != 'macOS'
+        if: matrix.config.run_64bit_tests
         run: |
           make clean
           make -j2 ARCH=x86-64-bmi2 build
           ../tests/signature.sh $benchref
 
       - name: Test x86-64-avx2 build
-        if: matrix.config.run_64bit_tests && runner.os != 'macOS'
+        if: matrix.config.run_64bit_tests
         run: |
           make clean
           make -j2 ARCH=x86-64-avx2 build
@@ -279,6 +279,6 @@ jobs:
         if: matrix.config.run_64bit_tests
         run: |
           make clean
-          make -j2 ARCH=x86-64-sse41-popcnt build
+          make -j2 ARCH=x86-64-avx2 build
           ../tests/perft.sh
           ../tests/reprosearch.sh


### PR DESCRIPTION
allows for building x86-64-avx2 and x86-64-bmi2 binaries for mac

install coreutils
show hardware capabilities as seen by the compilers move some tests from sse41 to avx2 as platforms support it

No functional change