### PR TITLE
Couple UCI display cosmetics.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -245,7 +245,7 @@ void MainThread::search() {
 
   // Send again PV info if we have a new best thread
   if (bestThread != this)
-      sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth) << sync_endl;
+      sync_cout << UCI::pv(bestThread->rootPos, bestThread->rootDepth) << sync_endl;
 
   sync_cout << "bestmove " << UCI::move(bestThread->rootMoves[0].pv[0], rootPos.is_chess960());
 
@@ -1939,6 +1939,7 @@ bool RootMove::extract_ponder_from_tt(Position& pos) {
     }
 
     pos.undo_move(pv[0]);
+    pos.this_thread()->nodes.fetch_add(-1, std::memory_order_relaxed);
     return pv.size() > 1;
 }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -245,7 +245,7 @@ void MainThread::search() {
 
   // Send again PV info if we have a new best thread
   if (bestThread != this)
-      sync_cout << UCI::pv(bestThread->rootPos, bestThread->rootDepth) << sync_endl;
+      sync_cout << UCI::pv(bestThread->rootPos, bestThread->rootDepth-1) << sync_endl;
 
   sync_cout << "bestmove " << UCI::move(bestThread->rootMoves[0].pv[0], rootPos.is_chess960());
 


### PR DESCRIPTION
Two small UCI display changes:

- Remove the spurious node being counted when ponder move is extracted from TT.

- Fix depth being displayed when a thread other than main thread is selected (it was non-consistent and in general understated by 1 compared to main thread).

When main thread makes her last UCI update, it shows depth = UCI::pv(...,rootDepth), then the thread gets stop, rootDepth gets incremented by 1 in the top iterative deepening loop. So equivalent of the rootDepth above is rootDepth - 1  once out of the loop.

When threads get the stop, almost all the time it happens when they are in the while(true) loop, so completedDepth is at rootDepth - 1, then rootDepth gets re-incremented in the top while statement, so once out of the loop completedDepth is at rootDepth - 2. So in general depth is understated by 1 when using completedDepth for the non-main thread being selected.

Only (extremely rare) case where completedDepth = rootDepth - 1 once out of the loop is if the stop is received between being checked in line 425 and re-checked in the top iterative deepening loop.

