### PR TITLE
Do more futility pruning for cutNodes that are not in TT.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -63,8 +63,8 @@ namespace {
   enum NodeType { NonPV, PV, Root };
 
   // Futility margin
-  Value futility_margin(Depth d, bool improving) {
-    return Value(140 * (d - improving));
+  Value futility_margin(Depth d, bool noTtCutNode, bool improving) {
+    return Value((140 - 40 * noTtCutNode) * (d - improving));
   }
 
   // Reductions lookup table initialized at startup
@@ -767,7 +767,7 @@ namespace {
     // The depth condition is important for mate finding.
     if (   !ss->ttPv
         &&  depth < 9
-        &&  eval - futility_margin(depth, improving) - (ss-1)->statScore / 306 >= beta
+        &&  eval - futility_margin(depth, cutNode && !ss->ttHit, improving) - (ss-1)->statScore / 306 >= beta
         &&  eval >= beta
         &&  eval < 24923) // larger than VALUE_KNOWN_WIN, but smaller than TB wins
         return eval;


### PR DESCRIPTION
This is somewhat similar to IIR for cutnodes but instead of reducing depth for cutnodes that don't have tt move we reduce margin multiplier in futility pruning for cutnodes that are not in TT.
Passed STC:
https://tests.stockfishchess.org/tests/view/64b244b90cdec37b95734c5b
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 75552 W: 19404 L: 19029 D: 37119
Ptnml(0-2): 233, 8806, 19378, 9071, 288 
Passed LTC:
https://tests.stockfishchess.org/tests/view/64b3ae5a0cdec37b95736516
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 104988 W: 27152 L: 26697 D: 51139
Ptnml(0-2): 41, 11259, 29446, 11700, 48 
bench 1727577