### PR TITLE
Simplify TT cutoff.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -616,7 +616,7 @@ namespace {
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode
         && !excludedMove
-        && tte->depth() > depth - (tte->bound() == BOUND_EXACT)
+        && tte->depth() > depth
         && ttValue != VALUE_NONE // Possible in case of TT access race or if !ttHit
         && (tte->bound() & (ttValue >= beta ? BOUND_LOWER : BOUND_UPPER)))
     {


### PR DESCRIPTION
Remove the exact bound condition from TT depth check.

STC:
https://tests.stockfishchess.org/tests/view/64b30b320cdec37b957359e9
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 332928 W: 84895 L: 85003 D: 163030
Ptnml(0-2): 1242, 39200, 85604, 39260, 1158

LTC:
https://tests.stockfishchess.org/tests/view/64b74e2adc56e1650abac0b6
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 92946 W: 23628 L: 23482 D: 45836
Ptnml(0-2): 38, 10033, 26192, 10165, 45

Bench: 1601764