### PR TITLE
Simplify qSearch initial ttEntry saving.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1489,9 +1489,9 @@ moves_loop: // When in check, search starts here
         if (bestValue >= beta)
         {
             // Save gathered info in transposition table
+            // bestValue coming from staticEval is guaranteed not to hit the tablebase range
             if (!ss->ttHit)
-                tte->save(posKey, value_to_tt(bestValue, ss->ply), false, BOUND_LOWER,
-                          DEPTH_NONE, MOVE_NONE, ss->staticEval);
+                tte->save(posKey, bestValue, false, BOUND_LOWER, DEPTH_NONE, MOVE_NONE, ss->staticEval);
 
             return bestValue;
         }


### PR DESCRIPTION
The Best Value is the Static Evaluation of the position if we don't have this position in the transposition table before the moves loop and the static evaluation is guaranteed to be inside the table-base range, no need for adjusting the score for table-base ranges when saving that entry.

Passed STC:
https://tests.stockfishchess.org/tests/view/64bccf96dc56e1650abb34ed
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 98688 W: 25319 L: 25169 D: 48200
Ptnml(0-2): 300, 11073, 26480, 11159, 332

No functional change