### PR TITLE
Remove unused return type from propagate()

### DIFF
--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -171,7 +171,7 @@ namespace Stockfish::Eval::NNUE::Layers {
       return hashValue;
     }
 
-    static IndexType get_weight_index_scrambled(IndexType i)
+    static constexpr IndexType get_weight_index_scrambled(IndexType i)
     {
       return
         (i / 4) % (PaddedInputDimensions / 4) * OutputDimensions * 4 +
@@ -179,7 +179,7 @@ namespace Stockfish::Eval::NNUE::Layers {
         i % 4;
     }
 
-    static IndexType get_weight_index(IndexType i)
+    static constexpr IndexType get_weight_index(IndexType i)
     {
 #if defined (USE_SSSE3)
       return get_weight_index_scrambled(i);
@@ -207,7 +207,7 @@ namespace Stockfish::Eval::NNUE::Layers {
       return !stream.fail();
     }
     // Forward propagation
-    const OutputType* propagate(
+    void propagate(
         const InputType* input, OutputType* output) const {
 
 #if defined (USE_AVX512)
@@ -291,8 +291,6 @@ namespace Stockfish::Eval::NNUE::Layers {
         PaddedInputDimensions,
         OutputDimensions>(output, weights, biases, input);
 #endif
-
-      return output;
     }
 
    private:

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -103,7 +103,6 @@ namespace Stockfish::Eval::NNUE::Layers {
   class AffineTransformSparseInput {
    public:
     // Input/output type
-    // Input/output type
     using InputType = std::uint8_t;
     using OutputType = std::int32_t;
 
@@ -135,7 +134,7 @@ namespace Stockfish::Eval::NNUE::Layers {
       return hashValue;
     }
 
-    static IndexType get_weight_index_scrambled(IndexType i)
+    static constexpr IndexType get_weight_index_scrambled(IndexType i)
     {
       return
         (i / ChunkSize) % (PaddedInputDimensions / ChunkSize) * OutputDimensions * ChunkSize +
@@ -143,7 +142,7 @@ namespace Stockfish::Eval::NNUE::Layers {
         i % ChunkSize;
     }
 
-    static IndexType get_weight_index(IndexType i)
+    static constexpr IndexType get_weight_index(IndexType i)
     {
 #if defined (USE_SSSE3)
       return get_weight_index_scrambled(i);
@@ -171,7 +170,7 @@ namespace Stockfish::Eval::NNUE::Layers {
       return !stream.fail();
     }
     // Forward propagation
-    const OutputType* propagate(
+    void propagate(
         const InputType* input, OutputType* output) const {
 
 #if defined (USE_SSSE3)
@@ -230,8 +229,6 @@ namespace Stockfish::Eval::NNUE::Layers {
         PaddedInputDimensions,
         OutputDimensions>(output, weights, biases, input);
 #endif
-
-      return output;
     }
 
    private:

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -59,7 +59,7 @@ namespace Stockfish::Eval::NNUE::Layers {
     }
 
     // Forward propagation
-    const OutputType* propagate(
+    void propagate(
         const InputType* input, OutputType* output) const {
 
   #if defined(USE_AVX2)
@@ -170,8 +170,6 @@ namespace Stockfish::Eval::NNUE::Layers {
         output[i] = static_cast<OutputType>(
             std::max(0, std::min(127, input[i] >> WeightScaleBits)));
       }
-
-      return output;
     }
   };
 

--- a/src/nnue/layers/sqr_clipped_relu.h
+++ b/src/nnue/layers/sqr_clipped_relu.h
@@ -59,7 +59,7 @@ namespace Stockfish::Eval::NNUE::Layers {
     }
 
     // Forward propagation
-    const OutputType* propagate(
+    void propagate(
         const InputType* input, OutputType* output) const {
 
   #if defined(USE_SSE2)
@@ -110,8 +110,6 @@ namespace Stockfish::Eval::NNUE::Layers {
             // needs to be accounted for in the trainer
             std::max(0ll, std::min(127ll, (((long long)input[i] * input[i]) >> (2 * WeightScaleBits)) / 128)));
       }
-
-      return output;
     }
   };
 


### PR DESCRIPTION
Remove unused return type from propagate()
Make two AffineTransform and AffineTransformSparseInput static methods constexpr
No functional change
bench: 1601764