### PR TITLE
Removing ttValue <= alpha extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1104,10 +1104,6 @@ moves_loop: // When in check, search starts here
               // If the eval of ttMove is less than value, we reduce it (negative extension) (~1 Elo)
               else if (ttValue <= value)
                   extension = -1;
-
-              // If the eval of ttMove is less than alpha, we reduce it (negative extension) (~1 Elo)
-              else if (ttValue <= alpha)
-                  extension = -1;
           }
 
           // Check extensions (~1 Elo)


### PR DESCRIPTION
Removing ttValue <= alpha extension

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 318336 W: 81307 L: 81398 D: 155631
Ptnml(0-2): 1088, 37291, 82469, 37264, 1056
https://tests.stockfishchess.org/tests/view/64b8589fdc56e1650abad61d

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 89388 W: 22925 L: 22775 D: 43688
Ptnml(0-2): 34, 9635, 25210, 9777, 38
https://tests.stockfishchess.org/tests/view/64bc41d0dc56e1650abb29cb