### PR TITLE
 Apply penalties for non-threatend pieces moving to threatend squares in mp

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -137,6 +137,17 @@ void MovePicker::score() {
                           :                                         !(to_sq(m) & threatenedByPawn)  ? 15000
                           :                                                                           0)
                           :                                                                           0)
+                   -     (!(threatenedPieces & from_sq(m)) ?
+                           (type_of(pos.moved_piece(m)) == QUEEN ?
+                                (bool(to_sq(m) & threatenedByRook)  * 50000
+                               + bool(to_sq(m) & threatenedByMinor) * 10000
+                               + bool(to_sq(m) & threatenedByPawn)  * 20000)
+                          : type_of(pos.moved_piece(m)) == ROOK  ?
+                                (bool(to_sq(m) & threatenedByMinor) * 25000
+                               + bool(to_sq(m) & threatenedByPawn)  * 10000)
+                          : type_of(pos.moved_piece(m)) != PAWN  && (to_sq(m) & threatenedByPawn) ? 15000
+                          :                                                                         0)
+                          :                                                                         0)
                    +     bool(pos.check_squares(type_of(pos.moved_piece(m))) & to_sq(m)) * 16384;
       else // Type == EVASIONS
       {


### PR DESCRIPTION
Passed STC:
https://tests.stockfishchess.org/tests/live_elo/64c11269dc56e1650abb935d
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 95552 W: 24654 L: 24250 D: 46648
Ptnml(0-2): 322, 11098, 24562, 11442, 352 

Passed LTC:
https://tests.stockfishchess.org/tests/live_elo/64c2004ddc56e1650abba8b3
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 190230 W: 48806 L: 48178 D: 93246
Ptnml(0-2): 90, 20439, 53453, 21019, 114 

Bench 1350831