### PR TITLE
AffineTransformSparseInput for armv8

### DIFF
--- a/src/nnue/layers/simd.h
+++ b/src/nnue/layers/simd.h
@@ -239,6 +239,12 @@ namespace Stockfish::Simd {
         acc = vdotq_s32(acc, a1, b1);
     }
 
+    [[maybe_unused]] static void dotprod_m128_add_dpbusd_epi32(
+        int32x4_t& acc,
+        int8x16_t a, int8x16_t b) {
+
+        acc = vdotq_s32(acc, a, b);
+    }
 #endif
 
 #if defined (USE_NEON)
@@ -277,9 +283,19 @@ namespace Stockfish::Simd {
       product = vmlal_s8(product, a1, b1);
       acc = vpadalq_s16(acc, product);
     }
-
 #endif
 
+#if USE_NEON >= 8
+    [[maybe_unused]] static void neon_m128_add_dpbusd_epi32(
+        int32x4_t& acc,
+        int8x16_t a, int8x16_t b) {
+
+      int16x8_t product0 = vmull_s8(vget_low_s8(a), vget_low_s8(b));
+      int16x8_t product1 = vmull_high_s8(a, b);
+      int16x8_t sum = vpaddq_s16(product0, product1);
+      acc = vpadalq_s16(acc, sum);
+    }
+#endif
 }
 
 #endif // STOCKFISH_SIMD_H_INCLUDED


### PR DESCRIPTION
Implements AffineTransformSparseInput layer for armv8 and armv8-dotprod.

Benchmarks:

armv8, Cortex-X1:
```
Result of  10 runs
==================
base (./sf_master    ) =     420391  +/- 14839
test (./stockfish    ) =     498040  +/- 17831
diff                   =     +77649  +/- 3090

speedup        = +0.1847
P(speedup > 0) =  1.0000
```

armv8, Cortex-A76:
```
Result of  10 runs
==================
base (./sf_master    ) =     227329  +/- 346
test (./stockfish    ) =     257255  +/- 577
diff                   =     +29926  +/- 546

speedup        = +0.1316
P(speedup > 0) =  1.0000
```

armv8-dotprod, Cortex-X1:
```
Result of  10 runs
==================
base (...ster_dotprod) =     429689  +/- 13402
test (./stockfish    ) =     546215  +/- 17730
diff                   =    +116526  +/- 4426

speedup        = +0.2712
P(speedup > 0) =  1.0000
```

armv8-dotprod, Cortex-A76:
```
Result of  10 runs
==================
base (...ster_dotprod) =     254232  +/- 420
test (./stockfish    ) =     285308  +/- 678
diff                   =     +31076  +/- 535

speedup        = +0.1222
P(speedup > 0) =  1.0000
```

No functional change.