### PR TITLE
Invalid fen detection and crash prevention

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -83,8 +83,8 @@ const vector<string> Defaults = {
   // Mate and stalemate positions
   "6k1/3b3r/1p1p4/p1n2p2/1PPNpP1q/P3Q1p1/1R1RB1P1/5K2 b - - 0 1",
   "r2r1n2/pp2bk2/2p1p2p/3q4/3PN1QP/2P3R1/P4PP1/5RK1 w - - 0 1",
-  "8/8/8/8/8/6k1/6p1/6K1 w - -",
-  "7k/7P/6K1/8/3B4/8/8/8 b - -",
+  "8/8/8/8/8/6k1/6p1/6K1 w - - 0 1",
+  "7k/7P/6K1/8/3B4/8/8/8 b - - 0 1",
 
   // Chess 960
   "setoption name UCI_Chess960 value true",

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -70,7 +70,10 @@ namespace {
 
     string rfen = fen;
     regex c("\\s*([rnbqkpRNBQKP1-8]+\\/){7}([rnbqkpRNBQKP1-8]+)\\s[bw-]\\s(([a-hkqA-HKQ]{1,4})|(-))\\s(([a-h][3-6])|(-))\\s\\d+\\s\\d+ \\s*");
-    if (regex_match(rfen, c));  else { cout << "Invaild fen" << endl; return; }
+    if (!regex_match(rfen, c)) {
+    cout << "Invalid fen" << endl;
+    return;
+    }
 
     states = StateListPtr(new std::deque<StateInfo>(1)); // Drop the old state and create a new one
     pos.set(fen, Options["UCI_Chess960"], &states->back(), Threads.main());

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -68,9 +68,13 @@ namespace {
     else
         return;
 
+#if __APPLE__
+    false;
+#else
     string rfen = fen;
     regex c("\\s*([rnbqkpRNBQKP1-8]+\\/){7}([rnbqkpRNBQKP1-8]+)\\s[bw-]\\s(([a-hkqA-HKQ]{1,4})|(-))\\s(([a-h][3-6])|(-))\\s\\d+\\s\\d+ \\s*");
     if (regex_match(rfen, c));  else { sync_cout << "Invaild fen" << sync_endl; return; }
+#endif
 
     states = StateListPtr(new std::deque<StateInfo>(1)); // Drop the old state and create a new one
     pos.set(fen, Options["UCI_Chess960"], &states->back(), Threads.main());

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -69,7 +69,7 @@ namespace {
         return;
 
     string rfen = fen;
-    regex c("\s*([rnbqkpRNBQKP1-8]+\/){7}([rnbqkpRNBQKP1-8]+)\\s[bw-]\\s(([a-hkqA-HKQ]{1,4})|(-))\\s(([a-h][3-6])|(-))\\s\\d+\\s\\d+ \s*");
+    regex c("\\s*([rnbqkpRNBQKP1-8]+\\/){7}([rnbqkpRNBQKP1-8]+)\\s[bw-]\\s(([a-hkqA-HKQ]{1,4})|(-))\\s(([a-h][3-6])|(-))\\s\\d+\\s\\d+ \\s*");
     if (regex_match(rfen, c));  else { sync_cout << "Invaild fen" << sync_endl; return; }
 
     states = StateListPtr(new std::deque<StateInfo>(1)); // Drop the old state and create a new one

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <regex>
 
 #include "benchmark.h"
 #include "evaluate.h"
@@ -41,7 +42,7 @@ namespace Stockfish {
 namespace {
 
   // FEN string for the initial position in standard chess
-  const char* StartFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+  const char* StartFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 ";
 
 
   // position() is called when the engine receives the "position" UCI command.
@@ -66,6 +67,10 @@ namespace {
             fen += token + " ";
     else
         return;
+
+    string rfen = fen;
+    regex c("\s*([rnbqkpRNBQKP1-8]+\/){7}([rnbqkpRNBQKP1-8]+)\\s[bw-]\\s(([a-hkqA-HKQ]{1,4})|(-))\\s(([a-h][3-6])|(-))\\s\\d+\\s\\d+ \s*");
+    if (regex_match(rfen, c));  else { sync_cout << "Invaild fen" << sync_endl; return; }
 
     states = StateListPtr(new std::deque<StateInfo>(1)); // Drop the old state and create a new one
     pos.set(fen, Options["UCI_Chess960"], &states->back(), Threads.main());

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -68,13 +68,9 @@ namespace {
     else
         return;
 
-#if __APPLE__
-    false;
-#else
     string rfen = fen;
     regex c("\\s*([rnbqkpRNBQKP1-8]+\\/){7}([rnbqkpRNBQKP1-8]+)\\s[bw-]\\s(([a-hkqA-HKQ]{1,4})|(-))\\s(([a-h][3-6])|(-))\\s\\d+\\s\\d+ \\s*");
-    if (regex_match(rfen, c));  else { sync_cout << "Invaild fen" << sync_endl; return; }
-#endif
+    if (regex_match(rfen, c));  else { cout << "Invaild fen" << endl; return; }
 
     states = StateListPtr(new std::deque<StateInfo>(1)); // Drop the old state and create a new one
     pos.set(fen, Options["UCI_Chess960"], &states->back(), Threads.main());

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -21,8 +21,8 @@ cat << EOF > perft.exp
 EOF
 
 expect perft.exp startpos 5 4865609 > /dev/null
-expect perft.exp "fen r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -" 5 193690690 > /dev/null
-expect perft.exp "fen 8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - -" 6 11030083 > /dev/null
+expect perft.exp "fen r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1" 5 193690690 > /dev/null
+expect perft.exp "fen 8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1" 6 11030083 > /dev/null
 expect perft.exp "fen r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1" 5 15833292 > /dev/null
 expect perft.exp "fen rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8" 5 89941194 > /dev/null
 expect perft.exp "fen r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10" 5 164075551 > /dev/null


### PR DESCRIPTION
This regex can detect all valid fen and prevent Stockfish from crashing.

```regex
\s*([rnbqkpRNBQKP1-8]+\/){7}([rnbqkpRNBQKP1-8]+)\\s[bw-]\\s(([a-hkqA-HKQ]{1,4})|(-))\\s(([a-h][3-6])|(-))\\s\\d+\\s\\d+ \s*
```



