### PR TITLE
Simplifying the Prune moves with negative SEE formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1037,7 +1037,7 @@ moves_loop: // When in check, search starts here
               lmrDepth = std::max(lmrDepth, 0);
 
               // Prune moves with negative SEE (~4 Elo)
-              if (!pos.see_ge(move, Value(-27 * lmrDepth * lmrDepth - 16 * lmrDepth)))
+              if (!pos.see_ge(move, Value(-31 * lmrDepth * lmrDepth)))
                   continue;
           }
       }


### PR DESCRIPTION
Simplifying the Prune moves with negative SEE formula, by removing one multiplication and subtraction operation.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 214272 W: 54596 L: 54572 D: 105104
Ptnml(0-2): 741, 25160, 55320, 25164, 751
https://tests.stockfishchess.org/tests/view/64c430d1dc56e1650abbdbf6

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 238380 W: 60600 L: 60601 D: 117179
Ptnml(0-2): 132, 26069, 66791, 26064, 134
https://tests.stockfishchess.org/tests/view/64c81f155b17f7c21c0cee2b