### PR TITLE
Adjust futility pruning base in qsearch.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1495,7 +1495,7 @@ moves_loop: // When in check, search starts here
         if (bestValue > alpha)
             alpha = bestValue;
 
-        futilityBase = bestValue + 200;
+        futilityBase = std::min(ss->staticEval, bestValue) + 200;
     }
 
     const PieceToHistory* contHist[] = { (ss-1)->continuationHistory, (ss-2)->continuationHistory,


### PR DESCRIPTION
In master we used value from tt there if it existed, current version uses minimum between it and static eval instead.
Passed STC:
https://tests.stockfishchess.org/tests/view/64cd57285b17f7c21c0d6a8c
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 252544 W: 64671 L: 64039 D: 123834
Ptnml(0-2): 839, 29207, 65575, 29785, 866 
Passed LTC:
https://tests.stockfishchess.org/tests/view/64cf6c915b17f7c21c0d9fcb
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 60150 W: 15374 L: 15012 D: 29764
Ptnml(0-2): 24, 6321, 17024, 6681, 25 
bench 1573024