### PR TITLE
Separation of uci info string Illegal setoption (name vs token)

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -112,8 +112,10 @@ namespace {
 
     if (Options.count(name))
         Options[name] = value;
+    else if (name != "")
+        sync_cout << "info string " << name << " not recognized" << sync_endl;
     else
-        sync_cout << "No such option: " << name << sync_endl;
+        sync_cout << "No such option: " << token << sync_endl;
   }
 
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -98,9 +98,10 @@ namespace {
 
   void setoption(istringstream& is) {
 
-    string token, name, value;
+    string token, rtoken, name, value;
 
     is >> token; // Consume the "name" token
+    rtoken = token;
 
     // Read the option name (can contain spaces)
     while (is >> token && token != "value")
@@ -115,7 +116,7 @@ namespace {
     else if (name != "")
         sync_cout << "info string " << name << " not recognized" << sync_endl;
     else
-        sync_cout << "No such option: " << token << sync_endl;
+        sync_cout << "No such option: " << rtoken << sync_endl;
   }
 
 


### PR DESCRIPTION
```
setoption name EnableTranspositionTable value false
info string EnableTranspositionTable not recognized
```

```
setoption name PruneAtShallowDepth value true
info string PruneAtShallowDepth not recognized
```

```
setoption MultiPV value 2
No such option: MultiPV
```

```
setoption Threads value 4
No such option: Threads
```

Thanks to @vdbergh, the creator of this idea.