### PR TITLE
Simplify material

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -152,11 +152,8 @@ Value Eval::evaluate(const Position& pos) {
 
   Value nnue = NNUE::evaluate(pos, true, &nnueComplexity);
 
-  int material =   67 * (pos.count<PAWN>(stm)   - pos.count<PAWN>(~stm))
-                + 395 * (pos.count<KNIGHT>(stm) - pos.count<KNIGHT>(~stm))
-                + 288 * (pos.count<BISHOP>(stm) - pos.count<BISHOP>(~stm))
-                + 630 * (pos.count<ROOK>(stm)   - pos.count<ROOK>(~stm))
-                + 857 * (pos.count<QUEEN>(stm)  - pos.count<QUEEN>(~stm));
+  int material =  pos.non_pawn_material(stm) - pos.non_pawn_material(~stm)
+                + 126 * (pos.count<PAWN>(stm) - pos.count<PAWN>(~stm));
 
   // Blend optimism with nnue complexity and (semi)classical complexity
   optimism += optimism * (nnueComplexity + abs(material - nnue)) / 512;


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/64d166235b17f7c21c0ddc15
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 100032 W: 25698 L: 25547 D: 48787
Ptnml(0-2): 308, 11748, 25771, 11863, 326 

LTC: https://tests.stockfishchess.org/tests/view/64d28c085b17f7c21c0df775
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 123870 W: 31463 L: 31348 D: 61059
Ptnml(0-2): 63, 13487, 34719, 13604, 62 

Besides rebasing I replaced PawnValueMg w/ 126 explicitly to decouple from https://tests.stockfishchess.org/tests/view/64d212de5b17f7c21c0debbb by @peregrineshahin which also passed. https://github.com/official-stockfish/Stockfish/pull/4734

bench: 1622063