### PR TITLE
Remove the enum ScaleFactor

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -157,13 +157,6 @@ enum Phase {
   MG = 0, EG = 1, PHASE_NB = 2
 };
 
-enum ScaleFactor {
-  SCALE_FACTOR_DRAW    = 0,
-  SCALE_FACTOR_NORMAL  = 64,
-  SCALE_FACTOR_MAX     = 128,
-  SCALE_FACTOR_NONE    = 255
-};
-
 enum Bound {
   BOUND_NONE,
   BOUND_UPPER,


### PR DESCRIPTION
The ScaleFactor enum is not used anymore as the classic evaluation is gone