### PR TITLE
Simplify pieceValue to one phase.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -122,7 +122,7 @@ void MovePicker::score() {
 
   for (auto& m : *this)
       if constexpr (Type == CAPTURES)
-          m.value =  (7 * int(PieceValue[MG][pos.piece_on(to_sq(m))])
+          m.value =  (7 * int(PieceValue[pos.piece_on(to_sq(m))])
                    + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))]) / 16;
 
       else if constexpr (Type == QUIETS)
@@ -165,7 +165,7 @@ void MovePicker::score() {
       else // Type == EVASIONS
       {
           if (pos.capture_stage(m))
-              m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
+              m.value =  PieceValue[pos.piece_on(to_sq(m))]
                        - Value(type_of(pos.moved_piece(m)))
                        + (1 << 28);
           else

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -347,7 +347,7 @@ void Position::set_state() const {
       st->key ^= Zobrist::psq[pc][s];
 
       if (type_of(pc) != KING && type_of(pc) != PAWN)
-          st->nonPawnMaterial[color_of(pc)] += PieceValue[MG][pc];
+          st->nonPawnMaterial[color_of(pc)] += PieceValue[pc];
   }
 
   if (st->epSquare != SQ_NONE)
@@ -742,7 +742,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           }
       }
       else
-          st->nonPawnMaterial[them] -= PieceValue[MG][captured];
+          st->nonPawnMaterial[them] -= PieceValue[captured];
 
       dp.dirty_num = 2;  // 1 piece moved, 1 piece captured
       dp.piece[1] = captured;
@@ -822,7 +822,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
                             ^ Zobrist::psq[pc][pieceCount[pc]];
 
           // Update material
-          st->nonPawnMaterial[us] += PieceValue[MG][promotion];
+          st->nonPawnMaterial[us] += PieceValue[promotion];
       }
 
       // Reset rule 50 draw counter
@@ -1048,11 +1048,11 @@ bool Position::see_ge(Move m, Bitboard& occupied, Value threshold) const {
 
   Square from = from_sq(m), to = to_sq(m);
 
-  int swap = PieceValue[MG][piece_on(to)] - threshold;
+  int swap = PieceValue[piece_on(to)] - threshold;
   if (swap < 0)
       return false;
 
-  swap = PieceValue[MG][piece_on(from)] - swap;
+  swap = PieceValue[piece_on(from)] - swap;
   if (swap <= 0)
       return true;
 
@@ -1089,7 +1089,7 @@ bool Position::see_ge(Move m, Bitboard& occupied, Value threshold) const {
       if ((bb = stmAttackers & pieces(PAWN)))
       {
           occupied ^= least_significant_square_bb(bb);
-          if ((swap = PawnValueMg - swap) < res)
+          if ((swap = PawnValue - swap) < res)
               break;
 
           attackers |= attacks_bb<BISHOP>(to, occupied) & pieces(BISHOP, QUEEN);
@@ -1098,14 +1098,14 @@ bool Position::see_ge(Move m, Bitboard& occupied, Value threshold) const {
       else if ((bb = stmAttackers & pieces(KNIGHT)))
       {
           occupied ^= least_significant_square_bb(bb);
-          if ((swap = KnightValueMg - swap) < res)
+          if ((swap = KnightValue - swap) < res)
               break;
       }
 
       else if ((bb = stmAttackers & pieces(BISHOP)))
       {
           occupied ^= least_significant_square_bb(bb);
-          if ((swap = BishopValueMg - swap) < res)
+          if ((swap = BishopValue - swap) < res)
               break;
 
           attackers |= attacks_bb<BISHOP>(to, occupied) & pieces(BISHOP, QUEEN);
@@ -1114,7 +1114,7 @@ bool Position::see_ge(Move m, Bitboard& occupied, Value threshold) const {
       else if ((bb = stmAttackers & pieces(ROOK)))
       {
           occupied ^= least_significant_square_bb(bb);
-          if ((swap = RookValueMg - swap) < res)
+          if ((swap = RookValue - swap) < res)
               break;
 
           attackers |= attacks_bb<ROOK>(to, occupied) & pieces(ROOK, QUEEN);
@@ -1123,7 +1123,7 @@ bool Position::see_ge(Move m, Bitboard& occupied, Value threshold) const {
       else if ((bb = stmAttackers & pieces(QUEEN)))
       {
           occupied ^= least_significant_square_bb(bb);
-          if ((swap = QueenValueMg - swap) < res)
+          if ((swap = QueenValue - swap) < res)
               break;
 
           attackers |=  (attacks_bb<BISHOP>(to, occupied) & pieces(BISHOP, QUEEN))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -985,7 +985,7 @@ moves_loop: // When in check, search starts here
               if (   !givesCheck
                   && lmrDepth < 7
                   && !ss->inCheck
-                  && ss->staticEval + 197 + 248 * lmrDepth + PieceValue[EG][pos.piece_on(to_sq(move))]
+                  && ss->staticEval + 197 + 248 * lmrDepth + PieceValue[pos.piece_on(to_sq(move))]
                    + captureHistory[movedPiece][to_sq(move)][type_of(pos.piece_on(to_sq(move)))] / 7 < alpha)
                   continue;
 
@@ -1541,7 +1541,7 @@ moves_loop: // When in check, search starts here
                 if (moveCount > 2)
                     continue;
 
-                futilityValue = futilityBase + PieceValue[EG][pos.piece_on(to_sq(move))];
+                futilityValue = futilityBase + PieceValue[pos.piece_on(to_sq(move))];
 
                 if (futilityValue <= alpha)
                 {
@@ -1789,7 +1789,7 @@ moves_loop: // When in check, search starts here
 
     // RootMoves are already sorted by score in descending order
     Value topScore = rootMoves[0].score;
-    int delta = std::min(topScore - rootMoves[multiPV - 1].score, PawnValueMg);
+    int delta = std::min(topScore - rootMoves[multiPV - 1].score, PawnValue);
     int maxScore = -VALUE_INFINITE;
     double weakness = 120 - 2 * level;
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1573,9 +1573,9 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
         // 1 cp to cursed wins and let it grow to 49 cp as the positions gets
         // closer to a real win.
         m.tbScore =  r >= bound ? VALUE_MATE - MAX_PLY - 1
-                   : r >  0     ? Value((std::max( 3, r - (MAX_DTZ - 200)) * int(PawnValueEg)) / 200)
+                   : r >  0     ? Value((std::max( 3, r - (MAX_DTZ - 200)) * int(PawnValue)) / 200)
                    : r == 0     ? VALUE_DRAW
-                   : r > -bound ? Value((std::min(-3, r + (MAX_DTZ - 200)) * int(PawnValueEg)) / 200)
+                   : r > -bound ? Value((std::min(-3, r + (MAX_DTZ - 200)) * int(PawnValue)) / 200)
                    :             -VALUE_MATE + MAX_PLY + 1;
     }
 

--- a/src/types.h
+++ b/src/types.h
@@ -153,10 +153,6 @@ enum CastlingRights {
   CASTLING_RIGHT_NB = 16
 };
 
-enum Phase {
-  MG = 0, EG = 1, PHASE_NB = 2
-};
-
 enum ScaleFactor {
   SCALE_FACTOR_DRAW    = 0,
   SCALE_FACTOR_NORMAL  = 64,
@@ -187,11 +183,11 @@ enum Value : int {
   // In the code, we make the assumption that these values
   // are such that non_pawn_material() can be used to uniquely
   // identify the material on the board.
-  PawnValueMg   = 126,   PawnValueEg   = 208,
-  KnightValueMg = 781,   KnightValueEg = 854,
-  BishopValueMg = 825,   BishopValueEg = 915,
-  RookValueMg   = 1276,  RookValueEg   = 1380,
-  QueenValueMg  = 2538,  QueenValueEg  = 2682,
+  PawnValue   = 208,
+  KnightValue = 781,
+  BishopValue = 825,
+  RookValue   = 1276,
+  QueenValue  = 2538,
 };
 
 enum PieceType {
@@ -207,12 +203,8 @@ enum Piece {
   PIECE_NB = 16
 };
 
-constexpr Value PieceValue[PHASE_NB][PIECE_NB] = {
-  { VALUE_ZERO, PawnValueMg, KnightValueMg, BishopValueMg, RookValueMg, QueenValueMg, VALUE_ZERO, VALUE_ZERO,
-    VALUE_ZERO, PawnValueMg, KnightValueMg, BishopValueMg, RookValueMg, QueenValueMg, VALUE_ZERO, VALUE_ZERO },
-  { VALUE_ZERO, PawnValueEg, KnightValueEg, BishopValueEg, RookValueEg, QueenValueEg, VALUE_ZERO, VALUE_ZERO,
-    VALUE_ZERO, PawnValueEg, KnightValueEg, BishopValueEg, RookValueEg, QueenValueEg, VALUE_ZERO, VALUE_ZERO }
-};
+constexpr Value PieceValue[PIECE_NB] = { VALUE_ZERO, PawnValue, KnightValue, BishopValue, RookValue, QueenValue, VALUE_ZERO, VALUE_ZERO,
+                                         VALUE_ZERO, PawnValue, KnightValue, BishopValue, RookValue, QueenValue, VALUE_ZERO, VALUE_ZERO };
 
 using Depth = int;
 


### PR DESCRIPTION
Simplifies the usage of pieceValues to mg values with the exception of pawnValues, After the removal of PSQT.

passed STC:
https://tests.stockfishchess.org/tests/view/64d147845b17f7c21c0dd86c
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 197248 W: 50168 L: 50125 D: 96955
Ptnml(0-2): 651, 23029, 51222, 23070, 652

passed LTC:
https://tests.stockfishchess.org/tests/view/64d212de5b17f7c21c0debbb
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 181170 W: 45949 L: 45893 D: 89328
Ptnml(0-2): 84, 19656, 51052, 19706, 87

Bench: 1734819