### PR TITLE
Simplify SEE pruning for captures

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -989,28 +989,9 @@ moves_loop: // When in check, search starts here
                    + captureHistory[movedPiece][to_sq(move)][type_of(pos.piece_on(to_sq(move)))] / 7 < alpha)
                   continue;
 
-              Bitboard occupied;
-              // SEE based pruning (~11 Elo)
-              if (!pos.see_ge(move, occupied, Value(-205) * depth))
-              {
-                 if (depth < 2 - capture)
-                    continue;
-                 // Don't prune the move if opponent Queen/Rook is under discovered attack after the exchanges
-                 // Don't prune the move if opponent King is under discovered attack after or during the exchanges
-                 Bitboard leftEnemies = (pos.pieces(~us, KING, QUEEN, ROOK)) & occupied;
-                 Bitboard attacks = 0;
-                 occupied |= to_sq(move);
-                 while (leftEnemies && !attacks)
-                 {
-                      Square sq = pop_lsb(leftEnemies);
-                      attacks |= pos.attackers_to(sq, occupied) & pos.pieces(us) & occupied;
-                      // Don't consider pieces that were already threatened/hanging before SEE exchanges
-                      if (attacks && (sq != pos.square<KING>(~us) && (pos.attackers_to(sq, pos.pieces()) & pos.pieces(us))))
-                         attacks = 0;
-                 }
-                 if (!attacks)
-                    continue;
-              }
+              // SEE based pruning for captures and checks (~11 Elo)
+              if (!pos.see_ge(move, Value(-205) * depth))
+                  continue;
           }
           else
           {


### PR DESCRIPTION
It seems that the current search is smart enough to allow us to remove (again) the block of code that checks for discovered attacks after the first pruning condition for captures.

STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 278848 W: 70856 L: 70903 D: 137089
Ptnml(0-2): 960, 32829, 71894, 32780, 961
https://tests.stockfishchess.org/tests/view/64d0af095b17f7c21c0dc440

LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 100704 W: 25564 L: 25425 D: 49715
Ptnml(0-2): 56, 10858, 28381, 11005, 52
https://tests.stockfishchess.org/tests/view/64d293e85b17f7c21c0df844

closes https://github.com/official-stockfish/Stockfish/pull/4736

Bench: 1504631