### PR TITLE
Simplify the Prior countermove that caused the fail-low formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1371,7 +1371,7 @@ moves_loop: // When in check, search starts here
     // Bonus for prior countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
     {
-        int bonus = (depth > 5) + (PvNode || cutNode) + (bestValue < alpha - 113 * depth) + ((ss-1)->moveCount > 12);
+        int bonus = (depth > 5) + (PvNode || cutNode) + (bestValue < alpha - 800) + ((ss-1)->moveCount > 12);
         update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, stat_bonus(depth) * bonus);
     }
 


### PR DESCRIPTION
Simplify the Prior countermove that caused the fail-low formula
Swapping a multiplication operation between two terms with a simple constant

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 60512 W: 15424 L: 15231 D: 29857
Ptnml(0-2): 200, 6985, 15712, 7140, 219
https://tests.stockfishchess.org/tests/view/64d2addf5b17f7c21c0dfae6

Passed LTC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 108456 W: 27545 L: 27414 D: 53497
Ptnml(0-2): 63, 11629, 30698, 11790, 48
https://tests.stockfishchess.org/tests/view/64d3ab6e5b17f7c21c0e1188