### PR TITLE
Detect repetitions before they happen in qsearch recursive calls.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1409,6 +1409,18 @@ moves_loop: // When in check, search starts here
     assert(PvNode || (alpha == beta - 1));
     assert(depth <= 0);
 
+    // Check if we have an upcoming move that draws by repetition, or
+    // if the opponent had an alternative move earlier to this position.
+    if (   depth < 0
+        && pos.rule50_count() >= 3
+        && alpha < VALUE_DRAW
+        && pos.has_game_cycle(ss->ply))
+    {
+        alpha = value_draw(pos.this_thread());
+        if (alpha >= beta)
+            return alpha;
+    }
+
     Move pv[MAX_PLY+1];
     StateInfo st;
     ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);


### PR DESCRIPTION
Passed STC:
https://tests.stockfishchess.org/tests/view/64d495995b17f7c21c0e29ed
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 340288 W: 86664 L: 85910 D: 167714
Ptnml(0-2): 1030, 38855, 89697, 39455, 1107

Passed LTC:
https://tests.stockfishchess.org/tests/view/64d5e1085b17f7c21c0e4ab5
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 193230 W: 49235 L: 48606 D: 95389
Ptnml(0-2): 98, 20432, 54921, 21071, 93

bench: 1671216