### PR TITLE
Simplify a depth condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1099,7 +1099,7 @@ moves_loop: // When in check, search starts here
 
               // If we are on a cutNode, reduce it based on depth (negative extension) (~1 Elo)
               else if (cutNode)
-                  extension = depth > 8 && depth < 17 ? -3 : -1;
+                  extension = depth < 17 ? -3 : -1;
 
               // If the eval of ttMove is less than value, we reduce it (negative extension) (~1 Elo)
               else if (ttValue <= value)


### PR DESCRIPTION
As the negative extension term has sensitive scaling, it would make more sense to allow more negative extension also at lower depth, and not just a region between low and high depth.

Passed STC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 124096 W: 31611 L: 31485 D: 61000
Ptnml(0-2): 422, 14437, 32205, 14561, 423
https://tests.stockfishchess.org/tests/view/64d205d75b17f7c21c0dea82

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 387882 W: 97840 L: 97993 D: 192049
Ptnml(0-2): 198, 42004, 109668, 41895, 176
https://tests.stockfishchess.org/tests/view/64d333f85b17f7c21c0e06c6

Bench 1669577