### PR TITLE
Give extra bonus to main history for moves that caused a fail low.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1373,6 +1373,7 @@ moves_loop: // When in check, search starts here
     {
         int bonus = (depth > 5) + (PvNode || cutNode) + (bestValue < alpha - 113 * depth) + ((ss-1)->moveCount > 12);
         update_continuation_histories(ss-1, pos.piece_on(prevSq), prevSq, stat_bonus(depth) * bonus);
+        thisThread->mainHistory[~us][from_to((ss-1)->currentMove)] << stat_bonus(depth) * bonus / 2;
     }
 
     if (PvNode)


### PR DESCRIPTION
Current master gives this type of bonuses to continuation history, this patch also gives them to main history.
Passed STC:
https://tests.stockfishchess.org/tests/view/64d4802a5b17f7c21c0e27b3
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 480768 W: 122767 L: 121798 D: 236203
Ptnml(0-2): 1563, 56190, 123834, 57309, 1488 
Passed LTC:
https://tests.stockfishchess.org/tests/view/64d7e4c05b17f7c21c0e7456
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 32052 W: 8329 L: 8022 D: 15701
Ptnml(0-2): 19, 3335, 9015, 3634, 23 
bench 1711793