### PR TITLE
Simplify PvNode reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1136,9 +1136,9 @@ moves_loop: // When in check, search starts here
       if (ttCapture)
           r++;
 
-      // Decrease reduction for PvNodes based on depth (~2 Elo)
+      // Decrease reduction for PvNodes (~2 Elo)
       if (PvNode)
-          r -= 1 + (depth < 6);
+          r--;
 
       // Decrease reduction if ttMove has been singularly extended (~1 Elo)
       if (singularQuietLMR)


### PR DESCRIPTION
Remove the depth condition for PvNode reduction.

Simplification STC: https://tests.stockfishchess.org/tests/view/64d308fa5b17f7c21c0e0303
LLR: 2.93 (-2.94,2.94) <-1.75,0.25> 
Total: 38976 W: 10106 L: 9889 D: 18981 
Ptnml(0-2): 129, 4479, 10040, 4726, 114

Simplification LTC: https://tests.stockfishchess.org/tests/view/64d457db5b17f7c21c0e236f
LLR: 2.94 (-2.94,2.94) <-1.75,0.25> 
Total: 156402 W: 39727 L: 39645 D: 77030
Ptnml(0-2): 71, 17143, 43696, 17215, 76

Bench: 1493904