### PR TITLE
add -funroll-loops to CXXFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -562,7 +562,7 @@ endif
 ### 3.3 Optimization
 ifeq ($(optimize),yes)
 
-	CXXFLAGS += -O3
+	CXXFLAGS += -O3 -funroll-loops 
 
 	ifeq ($(comp),gcc)
 		ifeq ($(OS), Android)


### PR DESCRIPTION
local speedup

```
sf_base =  1392875 +/-   5905 (95%)
sf_test =  1402332 +/-   7303 (95%)
diff    =     9457 +/-   4413 (95%)
speedup = 0.67896% +/- 0.317% (95%)
```

STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 34784 W: 8970 L: 8665 D: 17149
Ptnml(0-2): 115, 3730, 9405, 4019, 123
https://tests.stockfishchess.org/tests/view/64d944815b17f7c21c0e92e1

closes https://github.com/official-stockfish/Stockfish/pull/4750

No functional change