### PR TITLE
Use unsigned vector pointer for ARM

### DIFF
--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -72,10 +72,10 @@ namespace Stockfish::Eval::NNUE::Layers {
     #define vec128_storeu(a, b) _mm_storeu_si128(a, b)
     #define vec128_add(a, b) _mm_add_epi16(a, b)
 #elif defined (USE_NEON)
-    using vec_t = int32x4_t;
+    using vec_t = uint32x4_t;
     static const std::uint32_t Mask[4] = {1, 2, 4, 8};
     #define vec_nnz(a) vaddvq_u32(vandq_u32(vtstq_u32(a, a), vld1q_u32(Mask)))
-    using vec128_t = int16x8_t;
+    using vec128_t = uint16x8_t;
     #define vec128_zero vdupq_n_u16(0)
     #define vec128_set_16(a) vdupq_n_u16(a)
     #define vec128_load(a) vld1q_u16(reinterpret_cast<const std::uint16_t*>(a))


### PR DESCRIPTION
Current master fails to compile for ARMv8 on Raspi cause gcc (version 10.2.1) doesn't like to cast between signed and unsigned vector types.
```
make build ARCH=armv8
...
nnue/layers/affine_transform_sparse_input.h:111:27: error: cannot convert 'vec128_t' {aka 'int16x8_t'} to 'uint16x8_t'
  111 |         base = vec128_add(base, increment);
```

This patch fixes it.

No functional change