### PR TITLE
Do more full window searches

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1212,9 +1212,8 @@ moves_loop: // When in check, search starts here
       }
 
       // For PV nodes only, do a full PV search on the first move or after a fail
-      // high (in the latter case search only if value < beta), otherwise let the
-      // parent node fail low with value <= alpha and try another move.
-      if (PvNode && (moveCount == 1 || (value > alpha && (rootNode || value < beta))))
+      // high, otherwise let the parent node fail low with value <= alpha and try another move.
+      if (PvNode && (moveCount == 1 || value > alpha))
       {
           (ss+1)->pv = pv;
           (ss+1)->pv[0] = MOVE_NONE;


### PR DESCRIPTION
Remove the `value < beta` condition for doing full window searches.
As an added bonus the condition for full-window search is now much more similar to other fail-soft engines.

Passed STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 244608 W: 62286 L: 62294 D: 120028
Ptnml(0-2): 758, 28772, 63214, 28840, 720
https://tests.stockfishchess.org/tests/view/64d72d365b17f7c21c0e6675

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 311460 W: 78909 L: 78985 D: 153566
Ptnml(0-2): 129, 33959, 87656, 33831, 155
https://tests.stockfishchess.org/tests/view/64dca2265b17f7c21c0ee06c

Bench: 1624221