### PR TITLE
Increase reduction on retrying a move we just retreated that repeats

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1143,6 +1143,11 @@ moves_loop: // When in check, search starts here
       // Decrease reduction if ttMove has been singularly extended (~1 Elo)
       if (singularQuietLMR)
           r--;
+      
+      // Increase reduction on retrying the move we have just retreated if it falls in repetition (~1 Elo)
+      if (   (ss-4)->currentMove == move
+          &&  pos.has_repeated())
+          r += 2;
 
       // Increase reduction if next ply has a lot of fail high (~5 Elo)
       if ((ss+1)->cutoffCnt > 3)


### PR DESCRIPTION
the idea of this patch is if current move can be the same move from previous-previous turn then we retreated that move on the immediate previous turn, this patch increases reduction if retrying that move results in a repetition.

Passed STC:
https://tests.stockfishchess.org/tests/view/64e1aede883cbb7cbd9ad976
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 424000 W: 108675 L: 107809 D: 207516
Ptnml(0-2): 1296, 47350, 113896, 48108, 1350

Passed LTC:
https://tests.stockfishchess.org/tests/view/64e32d629970091252666872
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 89682 W: 22976 L: 22569 D: 44137
Ptnml(0-2): 39, 8843, 26675, 9240, 44

bench: 1602920