### PR TITLE
Update links to fishtest

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Thank you for contributing to Stockfish and helping us make it even better!
 [copying-link]: https://github.com/official-stockfish/Stockfish/blob/master/Copying.txt
 [discord-link]: https://discord.gg/GWDRS3kU6R
 [discussions-link]: https://github.com/official-stockfish/Stockfish/discussions/new
-[creating-my-first-test]: https://github.com/glinscott/fishtest/wiki/Creating-my-first-test#create-your-test
+[creating-my-first-test]: https://github.com/official-stockfish/fishtest/wiki/Creating-my-first-test#create-your-test
 [issue-tracker-link]: https://github.com/official-stockfish/Stockfish/issues
 [linux-compiling-link]: https://github.com/official-stockfish/Stockfish/wiki/Compiling-from-source#linux
 [windows-compiling-link]: https://github.com/official-stockfish/Stockfish/wiki/Compiling-from-source#windows

--- a/AUTHORS
+++ b/AUTHORS
@@ -230,4 +230,4 @@ zz4032
 # Additionally, we acknowledge the authors and maintainers of fishtest,
 # an amazing and essential framework for Stockfish development!
 #
-# https://github.com/glinscott/fishtest/blob/master/AUTHORS
+# https://github.com/official-stockfish/fishtest/blob/master/AUTHORS

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ also be made available under GPL v3.
 [issue-link]:         https://github.com/official-stockfish/Stockfish/issues/new?assignees=&labels=&template=BUG-REPORT.yml
 [discussions-link]:   https://github.com/official-stockfish/Stockfish/discussions/new
 [fishtest-link]:      https://tests.stockfishchess.org/tests
-[guideline-link]:     https://github.com/glinscott/fishtest/wiki/Creating-my-first-test
+[guideline-link]:     https://github.com/official-stockfish/fishtest/wiki/Creating-my-first-test
 [license-link]:       https://github.com/official-stockfish/Stockfish/blob/master/Copying.txt
 [programming-link]:   https://www.chessprogramming.org/Main_Page
 [programmingsf-link]: https://www.chessprogramming.org/Stockfish
@@ -155,7 +155,7 @@ also be made available under GPL v3.
 [wiki-usage-link]:    https://github.com/official-stockfish/Stockfish/wiki/Download-and-usage
 [wiki-compile-link]:  https://github.com/official-stockfish/Stockfish/wiki/Compiling-from-source
 [wiki-commands-link]: https://github.com/official-stockfish/Stockfish/wiki/Commands
-[worker-link]:        https://github.com/glinscott/fishtest/wiki/Running-the-worker
+[worker-link]:        https://github.com/official-stockfish/fishtest/wiki/Running-the-worker
 
 [build-badge]:        https://img.shields.io/github/actions/workflow/status/official-stockfish/Stockfish/stockfish.yml?branch=master&style=for-the-badge&label=stockfish&logo=github
 [commits-badge]:      https://img.shields.io/github/commits-since/official-stockfish/Stockfish/latest?style=for-the-badge


### PR DESCRIPTION
Now moved to https://github.com/official-stockfish/fishtest/

No functional change