### PR TITLE
Play turbulent when defending, simpler when attacking

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -155,8 +155,9 @@ Value Eval::evaluate(const Position& pos) {
   int material =  pos.non_pawn_material(stm) - pos.non_pawn_material(~stm)
                 + 126 * (pos.count<PAWN>(stm) - pos.count<PAWN>(~stm));
 
-  // Blend optimism with nnue complexity and (semi)classical complexity
+  // Blend optimism and eval with nnue complexity and material imbalance
   optimism += optimism * (nnueComplexity + abs(material - nnue)) / 512;
+  nnue     -= nnue     * (nnueComplexity + abs(material - nnue)) / 32768;
 
   v = (  nnue     * (915 + npm + 9 * pos.count<PAWN>())
        + optimism * (154 + npm +     pos.count<PAWN>())) / 1024;


### PR DESCRIPTION
This patch decays a little the evaluation (up to a few percent) for positions which have a large complexity measure (material imbalance, positional compensations, etc).

This may have nice consequences on the playing style, as it modifies the search differently for attack and defense, both effects being desirable:

- to see the effect on positions when Stockfish is defending, let us suppose for instance that the side to move is Stockfish and the nnue evaluation on the principal variation is -100 : this patch will decay positions with an evaluation of -103 (say) to the same level, provided they have huge material imbalance or huge positional compensation. In other words, chaotic positions with an evaluation of -103 are now comparable in our search tree to stable positions with an evaluation of -100, and chaotic positions with an evaluation of -102 are now preferred to stable positions with an evaluation of -100.

- the effect on positions when Stockfish is attacking is the opposite. Let us suppose for instance that the side to move is Stockfish and the nnue evaluation on the principal variation is +100 : this patch will decay the evaluation to +97 if the positions on the principal variation have huge material imbalance or huge positional compensation. In other words, stable positions with an evaluation of +97 are now comparable in our search tree to chaotic positions with an evaluation of +100, and  stable positions with an evaluation of +98 are now preferred to chaotic positions with an evaluation of +100.

So the effect of this small change of evaluation on the playing style is that Stockfish should now play a little bit more turbulent when defending, and choose slightly simpler lines when attacking.

passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 268448 W: 68713 L: 68055 D: 131680
Ptnml(0-2): 856, 31514, 68943, 31938, 973
https://tests.stockfishchess.org/tests/view/64e252bb99700912526653ed

passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 141060 W: 36066 L: 35537 D: 69457
Ptnml(0-2): 71, 15179, 39522, 15666, 92
https://tests.stockfishchess.org/tests/view/64e4447a9009777747553725

closes https://github.com/official-stockfish/Stockfish/pull/4762

Bench: 1426295