### PR TITLE
Renaming 'r' variable to 'reductionScale'

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -71,8 +71,8 @@ namespace {
   int Reductions[MAX_MOVES]; // [depth or moveNumber]
 
   Depth reduction(bool i, Depth d, int mn, Value delta, Value rootDelta) {
-    int r = Reductions[d] * Reductions[mn];
-    return (r + 1372 - int(delta) * 1073 / int(rootDelta)) / 1024 + (!i && r > 936);
+    int reductionScale = Reductions[d] * Reductions[mn];
+    return (reductionScale + 1372 - int(delta) * 1073 / int(rootDelta)) / 1024 + (!i && reductionScale > 936);
   }
 
   constexpr int futility_move_count(bool improving, Depth depth) {


### PR DESCRIPTION
To enhance code clarity and prevent potential confusion with the 'r' variable assigned to reduction later in the code, this pull request renames the 'r' variable to 'reductionScale'. Using distinct variable names for separate functions improves code readability and maintainability.

Not-Functional