### PR TITLE
omit unneeded tests

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -518,7 +518,6 @@ namespace {
     // Check if we have an upcoming move that draws by repetition, or
     // if the opponent had an alternative move earlier to this position.
     if (   !rootNode
-        && pos.rule50_count() >= 3
         && alpha < VALUE_DRAW
         && pos.has_game_cycle(ss->ply))
     {
@@ -1398,7 +1397,6 @@ moves_loop: // When in check, search starts here
     // Check if we have an upcoming move that draws by repetition, or
     // if the opponent had an alternative move earlier to this position.
     if (   depth < 0
-        && pos.rule50_count() >= 3
         && alpha < VALUE_DRAW
         && pos.has_game_cycle(ss->ply))
     {


### PR DESCRIPTION
These redundant tests were intended as a speedup, but they don't seem to provide one and probably never did.

STC: https://tests.stockfishchess.org/tests/view/64e9079c85e3e95030fd8259
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 134688 W: 34338 L: 34226 D: 66124
Ptnml(0-2): 426, 15122, 36124, 15258, 414

No functional change