### PR TITLE
Introduce simple_eval() for lazy evaluations

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -135,6 +135,18 @@ namespace Eval {
   }
 }
 
+
+/// simple_eval() returns a static, purely materialistic evaluation of
+/// the position from the point of view of the given color. It can be
+/// divided by PawnValue to get an approximation of the material advantage
+/// on the board in terms of pawns.
+
+Value Eval::simple_eval(const Position& pos, Color c) {
+   return  PawnValue * (pos.count<PAWN>(c)       - pos.count<PAWN>(~c))
+           +           (pos.non_pawn_material(c) - pos.non_pawn_material(~c));
+}
+
+
 /// evaluate() is the evaluator for the outer world. It returns a static
 /// evaluation of the position from the point of view of the side to move.
 
@@ -143,27 +155,35 @@ Value Eval::evaluate(const Position& pos) {
   assert(!pos.checkers());
 
   Value v;
+  Color stm      = pos.side_to_move();
+  int shuffling  = pos.rule50_count();
+  int simpleEval = simple_eval(pos, stm) + (int(pos.key() & 7) - 3);
 
-  int nnueComplexity;
-  int npm = pos.non_pawn_material() / 64;
+  bool lazy = abs(simpleEval) >=   RookValue + KnightValue
+                                 + 16 * shuffling * shuffling
+                                 + abs(pos.this_thread()->bestValue)
+                                 + abs(pos.this_thread()->rootSimpleEval);
 
-  Color stm = pos.side_to_move();
-  Value optimism = pos.this_thread()->optimism[stm];
+  if (lazy)
+      v = Value(simpleEval);
+  else
+  {
+      int nnueComplexity;
+      Value nnue = NNUE::evaluate(pos, true, &nnueComplexity);
 
-  Value nnue = NNUE::evaluate(pos, true, &nnueComplexity);
+      Value optimism = pos.this_thread()->optimism[stm];
 
-  int material =  pos.non_pawn_material(stm) - pos.non_pawn_material(~stm)
-                + 126 * (pos.count<PAWN>(stm) - pos.count<PAWN>(~stm));
+      // Blend optimism and eval with nnue complexity and material imbalance
+      optimism += optimism * (nnueComplexity + abs(simpleEval - nnue)) / 512;
+      nnue     -= nnue     * (nnueComplexity + abs(simpleEval - nnue)) / 32768;
 
-  // Blend optimism and eval with nnue complexity and material imbalance
-  optimism += optimism * (nnueComplexity + abs(material - nnue)) / 512;
-  nnue     -= nnue     * (nnueComplexity + abs(material - nnue)) / 32768;
-
-  v = (  nnue     * (915 + npm + 9 * pos.count<PAWN>())
-       + optimism * (154 + npm +     pos.count<PAWN>())) / 1024;
+      int npm = pos.non_pawn_material() / 64;
+      v = (  nnue     * (915 + npm + 9 * pos.count<PAWN>())
+           + optimism * (154 + npm +     pos.count<PAWN>())) / 1024;
+  }
 
   // Damp down the evaluation linearly when shuffling
-  v = v * (200 - pos.rule50_count()) / 214;
+  v = v * (200 - shuffling) / 214;
 
   // Guarantee evaluation does not hit the tablebase range
   v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
@@ -183,6 +203,7 @@ std::string Eval::trace(Position& pos) {
 
   // Reset any global variable used in eval
   pos.this_thread()->bestValue       = VALUE_ZERO;
+  pos.this_thread()->rootSimpleEval  = VALUE_ZERO;
   pos.this_thread()->optimism[WHITE] = VALUE_ZERO;
   pos.this_thread()->optimism[BLACK] = VALUE_ZERO;
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -31,6 +31,8 @@ class Position;
 namespace Eval {
 
   std::string trace(Position& pos);
+
+  Value simple_eval(const Position& pos, Color c);
   Value evaluate(const Position& pos);
 
   extern std::string currentEvalFileName;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -204,6 +204,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
       th->rootMoves = rootMoves;
       th->rootPos.set(pos.fen(), pos.is_chess960(), &th->rootState, th);
       th->rootState = setupStates->back();
+      th->rootSimpleEval = Eval::simple_eval(pos, pos.side_to_move());
   }
 
   main()->start_searching();

--- a/src/thread.h
+++ b/src/thread.h
@@ -65,6 +65,7 @@ public:
   Search::RootMoves rootMoves;
   Depth rootDepth, completedDepth;
   Value rootDelta;
+  Value rootSimpleEval;
   CounterMoveHistory counterMoves;
   ButterflyHistory mainHistory;
   CapturePieceToHistory captureHistory;


### PR DESCRIPTION
This patch implements the pure materialistic evaluation called simple_eval() to gain a speed-up during Stockfish search.

We use the so-called lazy evaluation trick: replace the accurate but slow NNUE network evaluation by the super-fast simple_eval() if the position seems to be already won (high material advantage). To guard against some of the most obvious blunders introduced by this idea, this patch uses the following features which will raise the lazy evaluation threshold in some situations:

- avoid lazy evals on shuffling branches in the search tree
- avoid lazy evals if the position at root already has a material imbalance
- avoid lazy evals if the search value at root is already winning/losing.

Moreover, we add a small random noise to the simple_eval() term. This idea (stochastic mobility in the minimax tree) was worth about 200 Elo in the pure simple_eval() player on Lichess.

Overall, the current implementation in this patch evaluates about 2% of the leaves in the search tree lazily.

--------------------------------------------

STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 60352 W: 15585 L: 15234 D: 29533
Ptnml(0-2): 216, 6906, 15578, 7263, 213
https://tests.stockfishchess.org/tests/view/64f1d9bcbd9967ffae366209

LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 35106 W: 8990 L: 8678 D: 17438
Ptnml(0-2): 14, 3668, 9887, 3960, 24
https://tests.stockfishchess.org/tests/view/64f25204f5b0c54e3f04c0e7

verification run at VLTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 74362 W: 19088 L: 18716 D: 36558
Ptnml(0-2): 6, 7226, 22348, 7592, 9
https://tests.stockfishchess.org/tests/view/64f2ecdbf5b0c54e3f04d3ae

All three tests above were with adjudication off, we also verified that there
was no regression on matetracker (thanks Disservin!).

----------------------------------------------

closes https://github.com/official-stockfish/Stockfish/pull/4771

Bench: 1393714