### PR TITLE
Fix Tuning issue with small values (Addressing C Value)

### DIFF
--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -79,7 +79,7 @@ static void make_option(const string& n, int v, const SetRange& r) {
   std::cout << n << ","
             << v << ","
             << r(v).first << "," << r(v).second << ","
-            << (r(v).second - r(v).first) / 20.0 << ","
+            << std::max((r(v).second - r(v).first) / 20.0, 0.5) << ","
             << "0.0020"
             << std::endl;
 }


### PR DESCRIPTION
The C value is now set to a minimum of 0.5 to have an obvious impact on tuning. This is because the tuning values are rounded down to the nearest integer using floor or truncate functions.
Before this change, for values below 5, the C value was calculated as less than 0.5

Non-functional