### PR TITLE
Remove one condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -908,7 +908,6 @@ moves_loop: // When in check, search starts here
         && (tte->bound() & BOUND_LOWER)
         && tte->depth() >= depth - 4
         && ttValue >= probCutBeta
-        && abs(ttValue) <= VALUE_KNOWN_WIN
         && abs(beta) <= VALUE_KNOWN_WIN)
         return probCutBeta;
 


### PR DESCRIPTION
Remove one condition that seems to not give much benefit
Same bench at lower depths, and a little different in high depths

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 89504 W: 22973 L: 22815 D: 43716
Ptnml(0-2): 274, 9890, 24289, 10002, 297
https://tests.stockfishchess.org/tests/view/64fb06105a91a8476352721a

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 73500 W: 18756 L: 18597 D: 36147
Ptnml(0-2): 32, 7309, 21913, 7460, 36
https://tests.stockfishchess.org/tests/view/64fbad7a5a91a847635283c0