### PR TITLE
Cleanup git checkout actions

### DIFF
--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -16,10 +16,6 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
       # returns null if no pre-release exists
       - name: Get Commit SHA of Latest Pre-release
         run: |

--- a/.github/workflows/stockfish_compile_test.yml
+++ b/.github/workflows/stockfish_compile_test.yml
@@ -52,8 +52,6 @@ jobs:
         shell: ${{ matrix.config.shell }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Setup msys and install required packages
         if: runner.os == 'Windows'

--- a/.github/workflows/stockfish_sanitizers.yml
+++ b/.github/workflows/stockfish_sanitizers.yml
@@ -36,8 +36,6 @@ jobs:
         shell: ${{ matrix.config.shell }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Download required linux packages
         run: |


### PR DESCRIPTION
We now fetch only the current commit for jobs that don't need the git history. For the Prerelease job, we don't checkout the code at all.

No functional change