### PR TITLE
Make a depth condition less strict

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1131,7 +1131,7 @@ moves_loop: // When in check, search starts here
       // Decrease further on cutNodes. (~1 Elo)
       if (   ss->ttPv
           && !likelyFailLow)
-          r -= cutNode && tte->depth() >= depth + 3 ? 3 : 2;
+          r -= cutNode && tte->depth() >= depth ? 3 : 2;
 
       // Decrease reduction if opponent's move count is high (~1 Elo)
       if ((ss-1)->moveCount > 8)


### PR DESCRIPTION
With this patch, the depth condition for decreasing reduction further on cutNodes is loosened from tte->depth() >= depth + 3 to just tte->depth() >= depth.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 101152 W: 25830 L: 25682 D: 49640
Ptnml(0-2): 312, 11788, 26258, 11876, 342
https://tests.stockfishchess.org/tests/view/64fd15635dab775b5359eaa6

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 82542 W: 20980 L: 20824 D: 40738
Ptnml(0-2): 42, 8795, 23440, 8953, 41
https://tests.stockfishchess.org/tests/view/64fda3545dab775b5359fbf1

Bench 1479029