### PR TITLE
Update default net to nn-1ee1aba5ed4c.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -40,7 +40,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-c38c3d8d3920.nnue"
+  #define EvalFileDefaultName   "nn-1ee1aba5ed4c.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
Created by retraining the master net on a dataset composed by:
- adding Leela data from T60 jul-dec 2020, T77 nov 2021, T80 jun-jul 2023
- deduplicating and unminimizing parts of the dataset before interleaving

Trained initially with max epoch 800, then increased near the end of training twice. First to 960, then 1200.
After training, post-processing involved:
- greedy permuting L1 weights with https://github.com/official-stockfish/Stockfish/pull/4620
- greedy 2- and 3- cycle permuting with https://github.com/official-stockfish/Stockfish/pull/4640

```bash
python3 easy_train.py \
  --experiment-name 2048-retrain-S6-sk28 \
  --training-dataset /data/S6.binpack \
  --early-fen-skipping 28 \
  --start-from-engine-test-net True \
  --max_epoch 1200 \
  --lr 4.375e-4 \
  --gamma 0.995 \
  --start-lambda 1.0 \
  --end-lambda 0.7 \
  --tui False \
  --seed $RANDOM \
  --gpus 0
```

In the list of datasets below, periods in the filename represent the sequence of steps applied to arrive at the particular binpack. For example:

`test77-dec2021-16tb7p.filter-v6-dd.min-mar2023.unminimized.binpack`
1. test77 dec2021 data rescored with 16 TB of syzygy tablebases during data conversion
2. filtered with csv_filter_v6_dd.py - v6 filtering and deduplication in one step
3. minimized with the original mar2023 implementation of `minimize_binpack` in the tools branch
4. unminimized by removing all positions with score == 32002 (`VALUE_NONE`)

Binpacks were:
- filtered with: https://github.com/linrock/nnue-data
- unminimized with: https://github.com/linrock/Stockfish/tree/tools-unminify
- deduplicated with: https://github.com/linrock/Stockfish/tree/tools-dd

```bash
DATASETS=(
  leela96-filt-v2.min.unminimized.binpack
  dfrc99-16tb7p-eval-filt-v2.min.unminimized.binpack

  # most of the 0dd1cebea57 v6-dd dataset (without test80-jul2022)
  # https://github.com/official-stockfish/Stockfish/pull/4606
  test60-novdec2021-12tb7p.filter-v6-dd.min-mar2023.unminimized.binpack
  test77-dec2021-16tb7p.filter-v6-dd.min-mar2023.unminimized.binpack
  test78-jantomay2022-16tb7p.filter-v6-dd.min-mar2023.unminimized.binpack
  test78-juntosep2022-16tb7p.filter-v6-dd.min-mar2023.unminimized.binpack
  test79-apr2022-16tb7p.filter-v6-dd.min-mar2023.unminimized.binpack
  test79-may2022-16tb7p.filter-v6-dd.min-mar2023.unminimized.binpack
  test80-jun2022-16tb7p.filter-v6-dd.min-mar2023.unminimized.binpack
  test80-aug2022-16tb7p.filter-v6-dd.min-mar2023.unminimized.binpack
  test80-sep2022-16tb7p.filter-v6-dd.min-mar2023.unminimized.binpack
  test80-oct2022-16tb7p.filter-v6-dd.min.binpack
  test80-nov2022-16tb7p.filter-v6-dd.min.binpack
  test80-jan2023-3of3-16tb7p.filter-v6-dd.min-mar2023.unminimized.binpack
  test80-feb2023-16tb7p.filter-v6-dd.min-mar2023.unminimized.binpack

  # older Leela data, recently converted
  test60-octnovdec2020-2tb7p.min.unminimized.binpack
  test60-julaugsep2020-2tb7p.min.binpack
  test77-nov2021-2tb7p.min.dd.binpack

  # newer Leela data
  test80-mar2023-2tb7p.min.unminimized.binpack
  test80-apr2023-2tb7p.filter-v6-sk16.min.unminimized.binpack
  test80-may2023-2tb7p.min.dd.binpack
  test80-jun2023-2tb7p.min.binpack
  test80-jul2023-2tb7p.binpack
)
python3 interleave_binpacks.py ${DATASETS[@]} /data/S6.binpack
```

Training data can be found at:
https://robotmoon.com/nnue-training-data/

Local elo at 25k nodes per move:
nn-epoch1059 : 2.7 +/- 1.6

Passed STC:
https://tests.stockfishchess.org/tests/view/64fc8d705dab775b5359db42
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 168352 W: 43216 L: 42704 D: 82432
Ptnml(0-2): 599, 19672, 43134, 20160, 611

Passed LTC:
https://tests.stockfishchess.org/tests/view/64fd44a75dab775b5359f065
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 154194 W: 39436 L: 38881 D: 75877
Ptnml(0-2): 78, 16577, 43238, 17120, 84

bench 1672490