### PR TITLE
Export makefile ARCH in binary

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -711,6 +711,11 @@ ifneq ($(GIT_DATE), )
 	CXXFLAGS += -DGIT_DATE=$(GIT_DATE)
 endif
 
+### 3.7.3 Try to include architecture
+ifneq ($(ARCH), )
+	CXXFLAGS += -DARCH=$(ARCH)
+endif
+
 ### 3.8 Link Time Optimization
 ### This is a mix of compile and link time options because the lto link phase
 ### needs access to the optimization flags.

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -200,7 +200,7 @@ std::string compiler_info() {
 /// _WIN32                  Building on Windows (any)
 /// _WIN64                  Building on Windows 64 bit
 
-  std::string compiler = "\nCompiled by ";
+  std::string compiler = "\nCompiled by                : ";
 
   #if defined(__INTEL_LLVM_COMPILER)
      compiler += "ICX ";
@@ -253,8 +253,15 @@ std::string compiler_info() {
      compiler += " on unknown system";
   #endif
 
-  compiler += "\nCompilation settings include: ";
-  compiler += (Is64Bit ? " 64bit" : " 32bit");
+  compiler += "\nCompilation architecture   : ";
+  #if defined(ARCH)
+     compiler += stringify(ARCH);
+  #else
+     compiler += "(undefined architecture)";
+  #endif
+
+  compiler += "\nCompilation settings       : ";
+  compiler += (Is64Bit ? "64bit" : "32bit");
   #if defined(USE_VNNI)
     compiler += " VNNI";
   #endif
@@ -288,12 +295,13 @@ std::string compiler_info() {
     compiler += " DEBUG";
   #endif
 
-  compiler += "\n__VERSION__ macro expands to: ";
+  compiler += "\nCompiler __VERSION__ macro : ";
   #ifdef __VERSION__
      compiler += __VERSION__;
   #else
      compiler += "(undefined macro)";
   #endif
+
   compiler += "\n";
 
   return compiler;


### PR DESCRIPTION
Example of the `./stockfish compiler` command:

```
Compiled by                : g++ (GNUC) 10.3.0 on Apple
Compilation architecture   : x86-64-bmi2
Compilation settings       : 64bit BMI2 AVX2 SSE41 SSSE3 SSE2 POPCNT
Compiler __VERSION__ macro : 10.3.0
```

no functional change