### PR TITLE
Reorder some lines

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -525,6 +525,10 @@ namespace {
     constexpr bool PvNode = nodeType != NonPV;
     constexpr bool rootNode = nodeType == Root;
 
+    // Dive into quiescence search when the depth reaches zero
+    if (depth <= 0)
+        return qsearch<PvNode ? PV : NonPV>(pos, ss, alpha, beta);
+
     // Check if we have an upcoming move that draws by repetition, or
     // if the opponent had an alternative move earlier to this position.
     if (   !rootNode
@@ -535,10 +539,6 @@ namespace {
         if (alpha >= beta)
             return alpha;
     }
-
-    // Dive into quiescence search when the depth reaches zero
-    if (depth <= 0)
-        return qsearch<PvNode ? PV : NonPV>(pos, ss, alpha, beta);
 
     assert(-VALUE_INFINITE <= alpha && alpha < beta && beta <= VALUE_INFINITE);
     assert(PvNode || (alpha == beta - 1));
@@ -1407,8 +1407,7 @@ moves_loop: // When in check, search starts here
 
     // Check if we have an upcoming move that draws by repetition, or
     // if the opponent had an alternative move earlier to this position.
-    if (   depth < 0
-        && alpha < VALUE_DRAW
+    if (   alpha < VALUE_DRAW
         && pos.has_game_cycle(ss->ply))
     {
         alpha = value_draw(pos.this_thread());


### PR DESCRIPTION
Now that qsearch has its own repetition detection we can flip the order of lines and remove the guard of depth < 0 which is not needed after reordering (i.e. it was there to prevent checking repetition again at depth ==0).

Passed STC:
https://tests.stockfishchess.org/tests/view/6502ecbb2cd016da89abc3fb
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 69536 W: 17668 L: 17490 D: 34378
Ptnml(0-2): 190, 7652, 18929, 7784, 213

Passed LTC:
https://tests.stockfishchess.org/tests/view/6505ce9072620bc881ea9086
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 52116 W: 13294 L: 13113 D: 25709
Ptnml(0-2): 26, 5176, 15471, 5361, 24

No functional change