### PR TITLE
Reduce SIMD register count from 32 to 16 for avx512 and vnni512 archs

### DIFF
--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -69,7 +69,7 @@ namespace Stockfish::Eval::NNUE {
   #define vec_add_psqt_32(a,b) _mm256_add_epi32(a,b)
   #define vec_sub_psqt_32(a,b) _mm256_sub_epi32(a,b)
   #define vec_zero_psqt() _mm256_setzero_si256()
-  #define NumRegistersSIMD 32
+  #define NumRegistersSIMD 16
   #define MaxChunkSize 64
 
   #elif USE_AVX2


### PR DESCRIPTION
I measure a 13.3% speedup for avx512 on i9-7980XE

```
Results for 100 tests for each version:

            Base      Test      Diff      
    Mean    610584    691547    -80963    
    StDev   50399     58052     85603     

p-value: 0.828
speedup: 0.133
```

and a 12.6% speedup for vnni512 on i7-11800H
```
Results for 50 tests for each version:

            Base      Test      Diff      
    Mean    1040148   1171320   -131172   
    StDev   46468     50886     24687     

p-value: 1
speedup: 0.126
```

No functional change
bench: 1603079