### PR TITLE
Simplify pawn count in evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -177,7 +177,7 @@ Value Eval::evaluate(const Position& pos) {
 
       int npm = pos.non_pawn_material() / 64;
       v = (  nnue     * (915 + npm + 9 * pos.count<PAWN>())
-           + optimism * (154 + npm +     pos.count<PAWN>())) / 1024;
+           + optimism * (154 + npm                       )) / 1024;
   }
 
   // Damp down the evaluation linearly when shuffling


### PR DESCRIPTION
This simplifies the evaluation by removing the unnecessary pawn count term when combining nnue and optimism values.
bench: 1514579

Passed STC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 61472 W: 15748 L: 15554 D: 30170
Ptnml(0-2): 191, 7123, 15933, 7279, 210
https://tests.stockfishchess.org/tests/view/650c34cf7ca0d3f7bbf264ff

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 81264 W: 20657 L: 20500 D: 40107
Ptnml(0-2): 30, 8713, 22997, 8854, 38
https://tests.stockfishchess.org/tests/view/650cc30efb151d43ae6d5987