### PR TITLE
Adding #include <cassert> to misc.cpp

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -47,6 +47,7 @@ using fun8_t = bool(*)(HANDLE, BOOL, PTOKEN_PRIVILEGES, DWORD, PTOKEN_PRIVILEGES
 #endif
 
 #include <atomic>
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <fstream>


### PR DESCRIPTION
Including cassert when we have an assert in the code is a best practice in C++ development.
Non-Functional