### PR TITLE
Explicitly invoke shell

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -108,7 +108,7 @@ ifeq ($(ARCH),)
 endif
 
 ifeq ($(ARCH), native)
-   override ARCH = $(shell ../scripts/get_native_properties.sh | cut -d " " -f 1)
+   override ARCH = $(shell $(SHELL) ../scripts/get_native_properties.sh | cut -d " " -f 1)
 endif
 
 # explicitly check for the list of supported architectures (as listed with make help),


### PR DESCRIPTION
in some cases the permission on the script might be incorrect (zip downloads?). Explicitly invoke the shell

No functional change