### PR TITLE
Remove handcrafted MMX code

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -674,7 +674,6 @@ ifeq ($(sse2),yes)
 endif
 
 ifeq ($(mmx),yes)
-	CXXFLAGS += -DUSE_MMX
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
 		CXXFLAGS += -mmmx
 	endif
@@ -794,11 +793,11 @@ help:
 	@echo "x86-64-sse41-popcnt     > x86 64-bit with sse41 and popcnt support"
 	@echo "x86-64-modern           > deprecated, currently x86-64-sse41-popcnt"
 	@echo "x86-64-ssse3            > x86 64-bit with ssse3 support"
-	@echo "x86-64-sse3-popcnt      > x86 64-bit with sse3 and popcnt support"
+	@echo "x86-64-sse3-popcnt      > x86 64-bit with sse3 compile and popcnt support"
 	@echo "x86-64                  > x86 64-bit generic (with sse2 support)"
 	@echo "x86-32-sse41-popcnt     > x86 32-bit with sse41 and popcnt support"
 	@echo "x86-32-sse2             > x86 32-bit with sse2 support"
-	@echo "x86-32                  > x86 32-bit generic (with mmx and sse support)"
+	@echo "x86-32                  > x86 32-bit generic (with mmx compile support)"
 	@echo "ppc-64                  > PPC 64-bit"
 	@echo "ppc-32                  > PPC 32-bit"
 	@echo "armv7                   > ARMv7 32-bit"

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -282,9 +282,6 @@ std::string compiler_info() {
     compiler += " SSE2";
   #endif
   compiler += (HasPopCnt ? " POPCNT" : "");
-  #if defined(USE_MMX)
-    compiler += " MMX";
-  #endif
   #if defined(USE_NEON_DOTPROD)
     compiler += " NEON_DOTPROD";
   #elif defined(USE_NEON)

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -135,24 +135,6 @@ namespace Stockfish::Eval::NNUE::Layers {
       }
       constexpr IndexType Start = NumChunks * SimdWidth;
 
-  #elif defined(USE_MMX)
-      constexpr IndexType NumChunks = InputDimensions / SimdWidth;
-      const __m64 k0x80s = _mm_set1_pi8(-128);
-      const auto in = reinterpret_cast<const __m64*>(input);
-      const auto out = reinterpret_cast<__m64*>(output);
-      for (IndexType i = 0; i < NumChunks; ++i) {
-        const __m64 words0 = _mm_srai_pi16(
-            _mm_packs_pi32(in[i * 4 + 0], in[i * 4 + 1]),
-            WeightScaleBits);
-        const __m64 words1 = _mm_srai_pi16(
-            _mm_packs_pi32(in[i * 4 + 2], in[i * 4 + 3]),
-            WeightScaleBits);
-        const __m64 packedbytes = _mm_packs_pi16(words0, words1);
-        out[i] = _mm_subs_pi8(_mm_adds_pi8(packedbytes, k0x80s), k0x80s);
-      }
-      _mm_empty();
-      constexpr IndexType Start = NumChunks * SimdWidth;
-
   #elif defined(USE_NEON)
       constexpr IndexType NumChunks = InputDimensions / (SimdWidth / 2);
       const int8x8_t Zero = {0};

--- a/src/nnue/layers/simd.h
+++ b/src/nnue/layers/simd.h
@@ -31,9 +31,6 @@
 #elif defined(USE_SSE2)
 # include <emmintrin.h>
 
-#elif defined(USE_MMX)
-# include <mmintrin.h>
-
 #elif defined(USE_NEON)
 # include <arm_neon.h>
 #endif

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -42,9 +42,6 @@
 #elif defined(USE_SSE2)
 #include <emmintrin.h>
 
-#elif defined(USE_MMX)
-#include <mmintrin.h>
-
 #elif defined(USE_NEON)
 #include <arm_neon.h>
 #endif
@@ -70,9 +67,6 @@ namespace Stockfish::Eval::NNUE {
 
   #elif defined(USE_SSE2)
   constexpr std::size_t SimdWidth = 16;
-
-  #elif defined(USE_MMX)
-  constexpr std::size_t SimdWidth = 8;
 
   #elif defined(USE_NEON)
   constexpr std::size_t SimdWidth = 16;

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -117,34 +117,6 @@ namespace Stockfish::Eval::NNUE {
   #define NumRegistersSIMD (Is64Bit ? 16 : 8)
   #define MaxChunkSize 16
 
-  #elif USE_MMX
-  using vec_t = __m64;
-  using psqt_vec_t = __m64;
-  #define vec_load(a) (*(a))
-  #define vec_store(a,b) *(a)=(b)
-  #define vec_add_16(a,b) _mm_add_pi16(a,b)
-  #define vec_sub_16(a,b) _mm_sub_pi16(a,b)
-  #define vec_mul_16(a,b) _mm_mullo_pi16(a,b)
-  #define vec_zero() _mm_setzero_si64()
-  #define vec_set_16(a) _mm_set1_pi16(a)
-  inline vec_t vec_max_16(vec_t a,vec_t b){
-    vec_t comparison = _mm_cmpgt_pi16(a,b);
-    return _mm_or_si64(_mm_and_si64(comparison, a), _mm_andnot_si64(comparison, b));
-  }
-  inline vec_t vec_min_16(vec_t a,vec_t b){
-    vec_t comparison = _mm_cmpgt_pi16(a,b);
-    return _mm_or_si64(_mm_and_si64(comparison, b), _mm_andnot_si64(comparison, a));
-  }
-  #define vec_msb_pack_16(a,b) _mm_packs_pi16(_mm_srli_pi16(a,7),_mm_srli_pi16(b,7))
-  #define vec_load_psqt(a) (*(a))
-  #define vec_store_psqt(a,b) *(a)=(b)
-  #define vec_add_psqt_32(a,b) _mm_add_pi32(a,b)
-  #define vec_sub_psqt_32(a,b) _mm_sub_pi32(a,b)
-  #define vec_zero_psqt() _mm_setzero_si64()
-  #define vec_cleanup() _mm_empty()
-  #define NumRegistersSIMD 8
-  #define MaxChunkSize 8
-
   #elif USE_NEON
   using vec_t = int16x8_t;
   using psqt_vec_t = int32x4_t;
@@ -334,10 +306,6 @@ namespace Stockfish::Eval::NNUE {
 
 #endif
       }
-
-#if defined(vec_cleanup)
-      vec_cleanup();
-#endif
 
       return psqt;
     } // end of function transform()
@@ -529,10 +497,6 @@ namespace Stockfish::Eval::NNUE {
         }
       }
 #endif
-
-  #if defined(USE_MMX)
-      _mm_empty();
-  #endif
     }
 
     template<Color Perspective>
@@ -613,10 +577,6 @@ namespace Stockfish::Eval::NNUE {
           accumulator.psqtAccumulation[Perspective][k] += psqtWeights[index * PSQTBuckets + k];
       }
 #endif
-
-  #if defined(USE_MMX)
-      _mm_empty();
-  #endif
     }
 
     template<Color Perspective>


### PR DESCRIPTION
This removes the handcrafted MMX code as discussed here https://github.com/official-stockfish/Stockfish/pull/4786#issuecomment-1716907435

It also fixes a Makefile bug (line 157) where we claimed sse support for x86-32 but didn't actually enable it.

Finally I tried making it more explicit that we have two different kinds of "architecture support".  In some cases we have custom handcrafted code using intrinsics.  In other cases we simply enable the appropriate -m compiler flag allowing the compiler to emit advanced instructions on its own.

As @vondele pointed out maybe some CI stuff should be looked at.

No functional change
bench: 1246812