### PR TITLE
Use C++17 variable templates for type traits

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -24,7 +24,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <limits>
-#include <type_traits>
+#include <type_traits> // IWYU pragma: keep
 
 #include "movegen.h"
 #include "types.h"
@@ -70,7 +70,7 @@ struct Stats : public std::array<Stats<T, D, Sizes...>, Size>
   void fill(const T& v) {
 
     // For standard-layout 'this' points to first struct member
-    assert(std::is_standard_layout<stats>::value);
+    assert(std::is_standard_layout_v<stats>);
 
     using entry = StatsEntry<T, D>;
     entry* p = reinterpret_cast<entry*>(this);

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -103,7 +103,7 @@ namespace Stockfish::Eval::NNUE {
       else
       {
           std::uint8_t u[sizeof(IntType)];
-          typename std::make_unsigned<IntType>::type v = 0;
+          std::make_unsigned_t<IntType> v = 0;
 
           stream.read(reinterpret_cast<char*>(u), sizeof(IntType));
           for (std::size_t i = 0; i < sizeof(IntType); ++i)
@@ -128,7 +128,7 @@ namespace Stockfish::Eval::NNUE {
       else
       {
           std::uint8_t u[sizeof(IntType)];
-          typename std::make_unsigned<IntType>::type v = value;
+          std::make_unsigned_t<IntType> v = value;
 
           std::size_t i = 0;
           // if constexpr to silence the warning about shift by 8

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -102,7 +102,7 @@ constexpr Value WDL_to_value[] = {
 template<typename T, int Half = sizeof(T) / 2, int End = sizeof(T) - 1>
 inline void swap_endian(T& x)
 {
-    static_assert(std::is_unsigned<T>::value, "Argument of swap_endian not unsigned");
+    static_assert(std::is_unsigned_v<T>, "Argument of swap_endian not unsigned");
 
     uint8_t tmp, *c = (uint8_t*)&x;
     for (int i = 0; i < Half; ++i)
@@ -332,7 +332,7 @@ struct PairsData {
 // first access, when the corresponding file is memory mapped.
 template<TBType Type>
 struct TBTable {
-    using Ret = typename std::conditional<Type == WDL, WDLScore, int>::type;
+    using Ret = std::conditional_t<Type == WDL, WDLScore, int>;
 
     static constexpr int Sides = Type == WDL ? 2 : 1;
 

--- a/src/tune.h
+++ b/src/tune.h
@@ -22,7 +22,7 @@
 #include <cstddef>
 #include <memory>
 #include <string>
-#include <type_traits>
+#include <type_traits> // IWYU pragma: keep
 #include <utility>
 #include <vector>
 
@@ -96,11 +96,11 @@ class Tune {
   template<typename T>
   struct Entry : public EntryBase {
 
-    static_assert(!std::is_const<T>::value, "Parameter cannot be const!");
+    static_assert(!std::is_const_v<T>, "Parameter cannot be const!");
 
-    static_assert(   std::is_same<T,   int>::value
-                  || std::is_same<T, Value>::value
-                  || std::is_same<T, PostUpdate>::value, "Parameter type not supported!");
+    static_assert(   std::is_same_v<T, int>
+                  || std::is_same_v<T, Value>
+                  || std::is_same_v<T, PostUpdate>, "Parameter type not supported!");
 
     Entry(const std::string& n, T& v, const SetRange& r) : name(n), value(v), range(r) {}
     void operator=(const Entry&) = delete; // Because 'value' is a reference


### PR DESCRIPTION
The C++17 variable templates are slightly more readable and allow us to remove the typename keyword in a few cases.

No functional change