### PR TITLE
Do not do moves-loop pruning in qsearch if we have only pawns

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1426,6 +1426,7 @@ moves_loop: // When in check, search starts here
     Value bestValue, value, ttValue, futilityValue, futilityBase;
     bool pvHit, givesCheck, capture;
     int moveCount;
+    Color us = pos.side_to_move();
 
     // Step 1. Initialize node
     if (PvNode)
@@ -1536,7 +1537,7 @@ moves_loop: // When in check, search starts here
         moveCount++;
 
         // Step 6. Pruning.
-        if (bestValue > VALUE_TB_LOSS_IN_MAX_PLY)
+        if (bestValue > VALUE_TB_LOSS_IN_MAX_PLY && pos.non_pawn_material(us))
         {
             // Futility pruning and moveCount pruning (~10 Elo)
             if (   !givesCheck


### PR DESCRIPTION
At first my idea was only to cover movecount and futility pruning, but @peregrineshahin suggested to test it on all moves-loop pruning and it worked.

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 167968 W: 42970 L: 42480 D: 82518
Ptnml(0-2): 444, 18324, 46002, 18726, 488
https://tests.stockfishchess.org/tests/view/6511181a55b420c569d0d54c

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 40794 W: 10496 L: 10182 D: 20116
Ptnml(0-2): 12, 4021, 12025, 4319, 20
https://tests.stockfishchess.org/tests/view/6512ccc4b3e74811c8aee86c

closes #4809

Bench: 1273573