### PR TITLE
Update default net to nn-0000000000a0.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-ac1dbea57aa3.nnue"
+  #define EvalFileDefaultName   "nn-0000000000a0.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
This is a later epoch from the same experiment that led to the previous master net. In training stage 6, max-epoch was raised to 1,200 near the end of the first 1,000 epochs.

For more details, see https://github.com/official-stockfish/Stockfish/pull/4795

Local elo at 25k nodes per move (vs. L1-2048 nn-1ee1aba5ed4c.nnue):
ep1079 : 15.6 +/- 1.2

Passed STC:
https://tests.stockfishchess.org/tests/view/651503b3b3e74811c8af1e2a
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 29408 W: 7607 L: 7304 D: 14497
Ptnml(0-2): 97, 3277, 7650, 3586, 94

Passed LTC:
https://tests.stockfishchess.org/tests/view/651585ceb3e74811c8af2a5f
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 73164 W: 18828 L: 18440 D: 35896
Ptnml(0-2): 30, 7749, 20644, 8121, 38

bench 1306282