### PR TITLE
Remove Cstdlib

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -23,7 +23,6 @@
 #include <cassert>
 #include <cmath>
 #include <cstdint>
-#include <cstdlib>
 #include <string>
 
 #include "types.h"

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -22,7 +22,6 @@
 #include <array>
 #include <cassert>
 #include <cstdint>
-#include <cstdlib>
 #include <limits>
 #include <type_traits>
 

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -21,7 +21,6 @@
 #include "evaluate_nnue.h"
 
 #include <cmath>
-#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <iomanip>

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -23,7 +23,6 @@
 #include <atomic>
 #include <cassert>
 #include <cmath>
-#include <cstdlib>
 #include <cstring>
 #include <initializer_list>
 #include <iostream>

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -23,7 +23,6 @@
 #include <atomic>
 #include <cassert>
 #include <cstdint>
-#include <cstdlib>
 #include <cstring>
 #include <deque>
 #include <fstream>

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -20,7 +20,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cstdlib>
 #include <deque>
 #include <initializer_list>
 #include <map>

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -19,7 +19,6 @@
 #include "tt.h"
 
 #include <cassert>
-#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <thread>


### PR DESCRIPTION
It seems that none of the functions or features from the C Standard Library provided by cstdlib are being used in the following parts.

So we can safely remove them without causing any compilation issues or affecting the functionality of the code.

Non-Functional