### PR TITLE
Simplify collection of bad moves for history updates.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -546,7 +546,7 @@ namespace {
     assert(0 < depth && depth < MAX_PLY);
     assert(!(PvNode && cutNode));
 
-    Move pv[MAX_PLY+1], capturesSearched[32], quietsSearched[64];
+    Move pv[MAX_PLY+1], capturesSearched[32], quietsSearched[32];
     StateInfo st;
     ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
 
@@ -1329,12 +1329,12 @@ moves_loop: // When in check, search starts here
 
 
       // If the move is worse than some previously searched move, remember it, to update its stats later
-      if (move != bestMove)
+      if (move != bestMove && moveCount <= 32)
       {
-          if (capture && captureCount < 32)
+          if (capture)
               capturesSearched[captureCount++] = move;
 
-          else if (!capture && quietCount < 64)
+          else
               quietsSearched[quietCount++] = move;
       }
     }


### PR DESCRIPTION
1. collect only the first 32 moves searched and ignore the rest. So late bad moves get no further negative history updates.
2. collect now for quiet moves also at most 32 bad moves

STC:
https://tests.stockfishchess.org/tests/view/6517b3aeb3e74811c8af5651
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 51168 W: 13013 L: 12810 D: 25345
Ptnml(0-2): 120, 6006, 13186, 6095, 177

LTC:
https://tests.stockfishchess.org/tests/view/651adafecff46e538ee02734
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 109866 W: 27786 L: 27656 D: 54424
Ptnml(0-2): 52, 11816, 31069, 11942, 54

Bench: 1338617