### PR TITLE
Standardize Comments

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -95,17 +95,17 @@ const std::vector<std::string> Defaults = {
 
 namespace Stockfish {
 
-/// setup_bench() builds a list of UCI commands to be run by bench. There
-/// are five parameters: TT size in MB, number of search threads that
-/// should be used, the limit value spent for each position, a file name
-/// where to look for positions in FEN format, and the type of the limit:
-/// depth, perft, nodes and movetime (in milliseconds). Examples:
-///
-/// bench                            : search default positions up to depth 13
-/// bench 64 1 15                    : search default positions up to depth 15 (TT = 64MB)
-/// bench 64 1 100000 default nodes  : search default positions for 100K nodes each
-/// bench 64 4 5000 current movetime : search current position with 4 threads for 5 sec
-/// bench 16 1 5 blah perft          : run a perft 5 on positions in file "blah"
+// setup_bench() builds a list of UCI commands to be run by bench. There
+// are five parameters: TT size in MB, number of search threads that
+// should be used, the limit value spent for each position, a file name
+// where to look for positions in FEN format, and the type of the limit:
+// depth, perft, nodes and movetime (in milliseconds). Examples:
+//
+// bench                            : search default positions up to depth 13
+// bench 64 1 15                    : search default positions up to depth 15 (TT = 64MB)
+// bench 64 1 100000 default nodes  : search default positions for 100K nodes each
+// bench 64 4 5000 current movetime : search current position with 4 threads for 5 sec
+// bench 16 1 5 blah perft          : run a perft 5 on positions in file "blah"
 
 std::vector<std::string> setup_bench(const Position& current, std::istream& is) {
 

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -46,8 +46,8 @@ namespace {
 
 }
 
-/// safe_destination() returns the bitboard of target square for the given step
-/// from the given square. If the step is off the board, returns empty bitboard.
+// safe_destination() returns the bitboard of target square for the given step
+// from the given square. If the step is off the board, returns empty bitboard.
 
 inline Bitboard safe_destination(Square s, int step) {
     Square to = Square(s + step);
@@ -55,8 +55,8 @@ inline Bitboard safe_destination(Square s, int step) {
 }
 
 
-/// Bitboards::pretty() returns an ASCII representation of a bitboard suitable
-/// to be printed to standard output. Useful for debugging.
+// Bitboards::pretty() returns an ASCII representation of a bitboard suitable
+// to be printed to standard output. Useful for debugging.
 
 std::string Bitboards::pretty(Bitboard b) {
 
@@ -75,8 +75,8 @@ std::string Bitboards::pretty(Bitboard b) {
 }
 
 
-/// Bitboards::init() initializes various bitboard tables. It is called at
-/// startup and relies on global objects to be already zero-initialized.
+// Bitboards::init() initializes various bitboard tables. It is called at
+// startup and relies on global objects to be already zero-initialized.
 
 void Bitboards::init() {
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -64,7 +64,7 @@ extern Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 extern Bitboard PawnAttacks[COLOR_NB][SQUARE_NB];
 
 
-/// Magic holds all magic bitboards relevant data for a single square
+// Magic holds all magic bitboards relevant data for a single square
 struct Magic {
   Bitboard  mask;
   Bitboard  magic;
@@ -95,8 +95,8 @@ inline Bitboard square_bb(Square s) {
 }
 
 
-/// Overloads of bitwise operators between a Bitboard and a Square for testing
-/// whether a given bit is set in a bitboard, and for setting and clearing bits.
+// Overloads of bitwise operators between a Bitboard and a Square for testing
+// whether a given bit is set in a bitboard, and for setting and clearing bits.
 
 inline Bitboard  operator&( Bitboard  b, Square s) { return b &  square_bb(s); }
 inline Bitboard  operator|( Bitboard  b, Square s) { return b |  square_bb(s); }
@@ -115,8 +115,8 @@ constexpr bool more_than_one(Bitboard b) {
 }
 
 
-/// rank_bb() and file_bb() return a bitboard representing all the squares on
-/// the given file or rank.
+// rank_bb() and file_bb() return a bitboard representing all the squares on
+// the given file or rank.
 
 constexpr Bitboard rank_bb(Rank r) {
   return Rank1BB << (8 * r);
@@ -135,7 +135,7 @@ constexpr Bitboard file_bb(Square s) {
 }
 
 
-/// shift() moves a bitboard one or two steps as specified by the direction D
+// shift() moves a bitboard one or two steps as specified by the direction D
 
 template<Direction D>
 constexpr Bitboard shift(Bitboard b) {
@@ -148,8 +148,8 @@ constexpr Bitboard shift(Bitboard b) {
 }
 
 
-/// pawn_attacks_bb() returns the squares attacked by pawns of the given color
-/// from the squares in the given bitboard.
+// pawn_attacks_bb() returns the squares attacked by pawns of the given color
+// from the squares in the given bitboard.
 
 template<Color C>
 constexpr Bitboard pawn_attacks_bb(Bitboard b) {
@@ -163,10 +163,10 @@ inline Bitboard pawn_attacks_bb(Color c, Square s) {
   return PawnAttacks[c][s];
 }
 
-/// line_bb() returns a bitboard representing an entire line (from board edge
-/// to board edge) that intersects the two given squares. If the given squares
-/// are not on a same file/rank/diagonal, the function returns 0. For instance,
-/// line_bb(SQ_C4, SQ_F7) will return a bitboard with the A2-G8 diagonal.
+// line_bb() returns a bitboard representing an entire line (from board edge
+// to board edge) that intersects the two given squares. If the given squares
+// are not on a same file/rank/diagonal, the function returns 0. For instance,
+// line_bb(SQ_C4, SQ_F7) will return a bitboard with the A2-G8 diagonal.
 
 inline Bitboard line_bb(Square s1, Square s2) {
 
@@ -176,13 +176,13 @@ inline Bitboard line_bb(Square s1, Square s2) {
 }
 
 
-/// between_bb(s1, s2) returns a bitboard representing the squares in the semi-open
-/// segment between the squares s1 and s2 (excluding s1 but including s2). If the
-/// given squares are not on a same file/rank/diagonal, it returns s2. For instance,
-/// between_bb(SQ_C4, SQ_F7) will return a bitboard with squares D5, E6 and F7, but
-/// between_bb(SQ_E6, SQ_F8) will return a bitboard with the square F8. This trick
-/// allows to generate non-king evasion moves faster: the defending piece must either
-/// interpose itself to cover the check or capture the checking piece.
+// between_bb(s1, s2) returns a bitboard representing the squares in the semi-open
+// segment between the squares s1 and s2 (excluding s1 but including s2). If the
+// given squares are not on a same file/rank/diagonal, it returns s2. For instance,
+// between_bb(SQ_C4, SQ_F7) will return a bitboard with squares D5, E6 and F7, but
+// between_bb(SQ_E6, SQ_F8) will return a bitboard with the square F8. This trick
+// allows to generate non-king evasion moves faster: the defending piece must either
+// interpose itself to cover the check or capture the checking piece.
 
 inline Bitboard between_bb(Square s1, Square s2) {
 
@@ -191,16 +191,16 @@ inline Bitboard between_bb(Square s1, Square s2) {
   return BetweenBB[s1][s2];
 }
 
-/// aligned() returns true if the squares s1, s2 and s3 are aligned either on a
-/// straight or on a diagonal line.
+// aligned() returns true if the squares s1, s2 and s3 are aligned either on a
+// straight or on a diagonal line.
 
 inline bool aligned(Square s1, Square s2, Square s3) {
   return line_bb(s1, s2) & s3;
 }
 
 
-/// distance() functions return the distance between x and y, defined as the
-/// number of steps for a king in x to reach y.
+// distance() functions return the distance between x and y, defined as the
+// number of steps for a king in x to reach y.
 
 template<typename T1 = Square> inline int distance(Square x, Square y);
 template<> inline int distance<File>(Square x, Square y) { return std::abs(file_of(x) - file_of(y)); }
@@ -209,8 +209,8 @@ template<> inline int distance<Square>(Square x, Square y) { return SquareDistan
 
 inline int edge_distance(File f) { return std::min(f, File(FILE_H - f)); }
 
-/// attacks_bb(Square) returns the pseudo attacks of the given piece type
-/// assuming an empty board.
+// attacks_bb(Square) returns the pseudo attacks of the given piece type
+// assuming an empty board.
 
 template<PieceType Pt>
 inline Bitboard attacks_bb(Square s) {
@@ -221,9 +221,9 @@ inline Bitboard attacks_bb(Square s) {
 }
 
 
-/// attacks_bb(Square, Bitboard) returns the attacks by the given piece
-/// assuming the board is occupied according to the passed Bitboard.
-/// Sliding piece attacks do not continue passed an occupied square.
+// attacks_bb(Square, Bitboard) returns the attacks by the given piece
+// assuming the board is occupied according to the passed Bitboard.
+// Sliding piece attacks do not continue passed an occupied square.
 
 template<PieceType Pt>
 inline Bitboard attacks_bb(Square s, Bitboard occupied) {
@@ -253,7 +253,7 @@ inline Bitboard attacks_bb(PieceType pt, Square s, Bitboard occupied) {
 }
 
 
-/// popcount() counts the number of non-zero bits in a bitboard
+// popcount() counts the number of non-zero bits in a bitboard
 
 inline int popcount(Bitboard b) {
 
@@ -274,7 +274,7 @@ inline int popcount(Bitboard b) {
 }
 
 
-/// lsb() and msb() return the least/most significant bit in a non-zero bitboard
+// lsb() and msb() return the least/most significant bit in a non-zero bitboard
 
 #if defined(__GNUC__)  // GCC, Clang, ICX
 
@@ -342,15 +342,15 @@ inline Square msb(Bitboard b) {
 
 #endif
 
-/// least_significant_square_bb() returns the bitboard of the least significant
-/// square of a non-zero bitboard. It is equivalent to square_bb(lsb(bb)).
+// least_significant_square_bb() returns the bitboard of the least significant
+// square of a non-zero bitboard. It is equivalent to square_bb(lsb(bb)).
 
 inline Bitboard least_significant_square_bb(Bitboard b) {
   assert(b);
   return b & -b;
 }
 
-/// pop_lsb() finds and clears the least significant bit in a non-zero bitboard
+// pop_lsb() finds and clears the least significant bit in a non-zero bitboard
 
 inline Square pop_lsb(Bitboard& b) {
   assert(b);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -57,13 +57,13 @@ namespace Eval {
 
   std::string currentEvalFileName = "None";
 
-  /// NNUE::init() tries to load a NNUE network at startup time, or when the engine
-  /// receives a UCI command "setoption name EvalFile value nn-[a-z0-9]{12}.nnue"
-  /// The name of the NNUE network is always retrieved from the EvalFile option.
-  /// We search the given network in three locations: internally (the default
-  /// network may be embedded in the binary), in the active working directory and
-  /// in the engine directory. Distro packagers may define the DEFAULT_NNUE_DIRECTORY
-  /// variable to have the engine search in a special directory in their distro.
+  // NNUE::init() tries to load a NNUE network at startup time, or when the engine
+  // receives a UCI command "setoption name EvalFile value nn-[a-z0-9]{12}.nnue"
+  // The name of the NNUE network is always retrieved from the EvalFile option.
+  // We search the given network in three locations: internally (the default
+  // network may be embedded in the binary), in the active working directory and
+  // in the engine directory. Distro packagers may define the DEFAULT_NNUE_DIRECTORY
+  // variable to have the engine search in a special directory in their distro.
 
   void NNUE::init() {
 
@@ -105,7 +105,7 @@ namespace Eval {
         }
   }
 
-  /// NNUE::verify() verifies that the last net used was loaded successfully
+  // NNUE::verify() verifies that the last net used was loaded successfully
   void NNUE::verify() {
 
     std::string eval_file = std::string(Options["EvalFile"]);
@@ -135,9 +135,9 @@ namespace Eval {
 }
 
 
-/// simple_eval() returns a static, purely materialistic evaluation of the position
-/// from the point of view of the given color. It can be divided by PawnValue to get
-/// an approximation of the material advantage on the board in terms of pawns.
+// simple_eval() returns a static, purely materialistic evaluation of the position
+// from the point of view of the given color. It can be divided by PawnValue to get
+// an approximation of the material advantage on the board in terms of pawns.
 
 Value Eval::simple_eval(const Position& pos, Color c) {
    return  PawnValue * (pos.count<PAWN>(c)       - pos.count<PAWN>(~c))
@@ -145,8 +145,8 @@ Value Eval::simple_eval(const Position& pos, Color c) {
 }
 
 
-/// evaluate() is the evaluator for the outer world. It returns a static evaluation
-/// of the position from the point of view of the side to move.
+// evaluate() is the evaluator for the outer world. It returns a static evaluation
+// of the position from the point of view of the side to move.
 
 Value Eval::evaluate(const Position& pos) {
 
@@ -189,10 +189,10 @@ Value Eval::evaluate(const Position& pos) {
   return v;
 }
 
-/// trace() is like evaluate(), but instead of returning a value, it returns
-/// a string (suitable for outputting to stdout) that contains the detailed
-/// descriptions and values of each evaluation term. Useful for debugging.
-/// Trace scores are from white's point of view
+// trace() is like evaluate(), but instead of returning a value, it returns
+// a string (suitable for outputting to stdout) that contains the detailed
+// descriptions and values of each evaluation term. Useful for debugging.
+// Trace scores are from white's point of view
 
 std::string Eval::trace(Position& pos) {
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -71,14 +71,14 @@ namespace Stockfish {
 
 namespace {
 
-/// Version number or dev.
+// Version number or dev.
 constexpr std::string_view version = "dev";
 
-/// Our fancy logging facility. The trick here is to replace cin.rdbuf() and
-/// cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We
-/// can toggle the logging of std::cout and std:cin at runtime whilst preserving
-/// usual I/O functionality, all without changing a single line of code!
-/// Idea from http://groups.google.com/group/comp.lang.c++/msg/1d941c0f26ea0d81
+// Our fancy logging facility. The trick here is to replace cin.rdbuf() and
+// cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We
+// can toggle the logging of std::cout and std:cin at runtime whilst preserving
+// usual I/O functionality, all without changing a single line of code!
+// Idea from http://groups.google.com/group/comp.lang.c++/msg/1d941c0f26ea0d81
 
 struct Tie: public std::streambuf { // MSVC requires split streambuf for cin and cout
 
@@ -141,15 +141,15 @@ public:
 } // namespace
 
 
-/// engine_info() returns the full name of the current Stockfish version.
-/// For local dev compiles we try to append the commit sha and commit date
-/// from git if that fails only the local compilation date is set and "nogit" is specified:
-/// Stockfish dev-YYYYMMDD-SHA
-/// or
-/// Stockfish dev-YYYYMMDD-nogit
-///
-/// For releases (non dev builds) we only include the version number:
-/// Stockfish version
+// engine_info() returns the full name of the current Stockfish version.
+// For local dev compiles we try to append the commit sha and commit date
+// from git if that fails only the local compilation date is set and "nogit" is specified:
+// Stockfish dev-YYYYMMDD-SHA
+// or
+// Stockfish dev-YYYYMMDD-nogit
+//
+// For releases (non-dev builds) we only include the version number:
+// Stockfish version
 
 std::string engine_info(bool to_uci) {
   std::stringstream ss;
@@ -185,20 +185,20 @@ std::string engine_info(bool to_uci) {
 }
 
 
-/// compiler_info() returns a string trying to describe the compiler we use
+// compiler_info() returns a string trying to describe the compiler we use
 
 std::string compiler_info() {
 
   #define make_version_string(major, minor, patch) stringify(major) "." stringify(minor) "." stringify(patch)
 
-/// Predefined macros hell:
-///
-/// __GNUC__                Compiler is GCC, Clang or ICX
-/// __clang__               Compiler is Clang or ICX
-/// __INTEL_LLVM_COMPILER   Compiler is ICX
-/// _MSC_VER                Compiler is MSVC
-/// _WIN32                  Building on Windows (any)
-/// _WIN64                  Building on Windows 64 bit
+// Predefined macros hell:
+//
+// __GNUC__                Compiler is GCC, Clang or ICX
+// __clang__               Compiler is Clang or ICX
+// __INTEL_LLVM_COMPILER   Compiler is ICX
+// _MSC_VER                Compiler is MSVC
+// _WIN32                  Building on Windows (any)
+// _WIN64                  Building on Windows 64 bit
 
   std::string compiler = "\nCompiled by                : ";
 
@@ -308,7 +308,7 @@ std::string compiler_info() {
 }
 
 
-/// Debug functions used mainly to collect run-time statistics
+// Debug functions used mainly to collect run-time statistics
 constexpr int MaxDebugSlots = 32;
 
 namespace {
@@ -400,8 +400,8 @@ void dbg_print() {
 }
 
 
-/// Used to serialize access to std::cout to avoid multiple threads writing at
-/// the same time.
+// Used to serialize access to std::cout to avoid multiple threads writing at
+// the same time.
 
 std::ostream& operator<<(std::ostream& os, SyncCout sc) {
 
@@ -417,13 +417,13 @@ std::ostream& operator<<(std::ostream& os, SyncCout sc) {
 }
 
 
-/// Trampoline helper to avoid moving Logger to misc.h
+// Trampoline helper to avoid moving Logger to misc.h
 void start_logger(const std::string& fname) { Logger::start(fname); }
 
 
-/// prefetch() preloads the given address in L1/L2 cache. This is a non-blocking
-/// function that doesn't stall the CPU waiting for data to be loaded from memory,
-/// which can be quite slow.
+// prefetch() preloads the given address in L1/L2 cache. This is a non-blocking
+// function that doesn't stall the CPU waiting for data to be loaded from memory,
+// which can be quite slow.
 #ifdef NO_PREFETCH
 
 void prefetch(void*) {}
@@ -442,9 +442,9 @@ void prefetch(void* addr) {
 #endif
 
 
-/// std_aligned_alloc() is our wrapper for systems where the c++17 implementation
-/// does not guarantee the availability of aligned_alloc(). Memory allocated with
-/// std_aligned_alloc() must be freed with std_aligned_free().
+// std_aligned_alloc() is our wrapper for systems where the c++17 implementation
+// does not guarantee the availability of aligned_alloc(). Memory allocated with
+// std_aligned_alloc() must be freed with std_aligned_free().
 
 void* std_aligned_alloc(size_t alignment, size_t size) {
 
@@ -473,7 +473,7 @@ void std_aligned_free(void* ptr) {
 #endif
 }
 
-/// aligned_large_pages_alloc() will return suitably aligned memory, if possible using large pages.
+// aligned_large_pages_alloc() will return suitably aligned memory, if possible using large pages.
 
 #if defined(_WIN32)
 
@@ -553,7 +553,7 @@ void* aligned_large_pages_alloc(size_t allocSize) {
   // Try to allocate large pages
   void* mem = aligned_large_pages_alloc_windows(allocSize);
 
-  // Fall back to regular, page aligned, allocation if necessary
+  // Fall back to regular, page-aligned, allocation if necessary
   if (!mem)
       mem = VirtualAlloc(nullptr, allocSize, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
 
@@ -582,7 +582,7 @@ void* aligned_large_pages_alloc(size_t allocSize) {
 #endif
 
 
-/// aligned_large_pages_free() will free the previously allocated ttmem
+// aligned_large_pages_free() will free the previously allocated ttmem
 
 #if defined(_WIN32)
 
@@ -615,9 +615,9 @@ void bindThisThread(size_t) {}
 
 #else
 
-/// best_node() retrieves logical processor information using Windows specific
-/// API and returns the best node id for the thread with index idx. Original
-/// code from Texel by Peter Österlund.
+// best_node() retrieves logical processor information using Windows specific
+// API and returns the best node id for the thread with index idx. Original
+// code from Texel by Peter Österlund.
 
 static int best_node(size_t idx) {
 
@@ -669,8 +669,8 @@ static int best_node(size_t idx) {
 
   std::vector<int> groups;
 
-  // Run as many threads as possible on the same node until core limit is
-  // reached, then move on filling the next node.
+  // Run as many threads as possible on the same node until the core limit is
+  // reached, then move on to filling the next node.
   for (int n = 0; n < nodes; n++)
       for (int i = 0; i < cores / nodes; i++)
           groups.push_back(n);
@@ -687,7 +687,7 @@ static int best_node(size_t idx) {
 }
 
 
-/// bindThisThread() set the group affinity of the current thread
+// bindThisThread() sets the group affinity of the current thread
 
 void bindThisThread(size_t idx) {
 
@@ -754,7 +754,7 @@ void init([[maybe_unused]] int argc, char* argv[]) {
     pathSeparator = "\\";
   #ifdef _MSC_VER
     // Under windows argv[0] may not have the extension. Also _get_pgmptr() had
-    // issues in some windows 10 versions, so check returned values carefully.
+    // issues in some Windows 10 versions, so check returned values carefully.
     char* pgmptr = nullptr;
     if (!_get_pgmptr(&pgmptr) && pgmptr != nullptr && *pgmptr)
         argv0 = pgmptr;

--- a/src/misc.h
+++ b/src/misc.h
@@ -74,7 +74,7 @@ T* align_ptr_up(T* ptr)
 }
 
 
-// IsLittleEndian : true if and only if the binary is compiled on a little endian machine
+// IsLittleEndian : true if and only if the binary is compiled on a little-endian machine
 static inline const union { uint32_t i; char c[4]; } Le = { 0x01020304 };
 static inline const bool IsLittleEndian = (Le.c[0] == 4);
 
@@ -145,8 +145,8 @@ inline uint64_t mul_hi64(uint64_t a, uint64_t b) {
 }
 
 /// Under Windows it is not possible for a process to run on more than one
-/// logical processor group. This usually means to be limited to use max 64
-/// cores. To overcome this, some special platform specific API should be
+/// logical processor group. This usually means being limited to using max 64
+/// cores. To overcome this, some special platform-specific API should be
 /// called to set group affinity for each thread. Original code from Texel by
 /// Peter Österlund.
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -94,20 +94,20 @@ private:
 };
 
 
-/// xorshift64star Pseudo-Random Number Generator
-/// This class is based on original code written and dedicated
-/// to the public domain by Sebastiano Vigna (2014).
-/// It has the following characteristics:
-///
-///  -  Outputs 64-bit numbers
-///  -  Passes Dieharder and SmallCrush test batteries
-///  -  Does not require warm-up, no zeroland to escape
-///  -  Internal state is a single 64-bit integer
-///  -  Period is 2^64 - 1
-///  -  Speed: 1.60 ns/call (Core i7 @3.40GHz)
-///
-/// For further analysis see
-///   <http://vigna.di.unimi.it/ftp/papers/xorshift.pdf>
+// xorshift64star Pseudo-Random Number Generator
+// This class is based on original code written and dedicated
+// to the public domain by Sebastiano Vigna (2014).
+// It has the following characteristics:
+//
+//  -  Outputs 64-bit numbers
+//  -  Passes Dieharder and SmallCrush test batteries
+//  -  Does not require warm-up, no zeroland to escape
+//  -  Internal state is a single 64-bit integer
+//  -  Period is 2^64 - 1
+//  -  Speed: 1.60 ns/call (Core i7 @3.40GHz)
+//
+// For further analysis see
+//   <http://vigna.di.unimi.it/ftp/papers/xorshift.pdf>
 
 class PRNG {
 
@@ -124,8 +124,8 @@ public:
 
   template<typename T> T rand() { return T(rand64()); }
 
-  /// Special generator used to fast init magic numbers.
-  /// Output values only have 1/8th of their bits set on average.
+  // Special generator used to fast init magic numbers.
+  // Output values only have 1/8th of their bits set on average.
   template<typename T> T sparse_rand()
   { return T(rand64() & rand64() & rand64()); }
 };
@@ -144,11 +144,11 @@ inline uint64_t mul_hi64(uint64_t a, uint64_t b) {
 #endif
 }
 
-/// Under Windows it is not possible for a process to run on more than one
-/// logical processor group. This usually means being limited to using max 64
-/// cores. To overcome this, some special platform-specific API should be
-/// called to set group affinity for each thread. Original code from Texel by
-/// Peter Österlund.
+// Under Windows it is not possible for a process to run on more than one
+// logical processor group. This usually means being limited to using max 64
+// cores. To overcome this, some special platform-specific API should be
+// called to set group affinity for each thread. Original code from Texel by
+// Peter Österlund.
 
 namespace WinProcGroup {
   void bindThisThread(size_t idx);

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -234,13 +234,13 @@ namespace {
 } // namespace
 
 
-/// <CAPTURES>     Generates all pseudo-legal captures plus queen promotions
-/// <QUIETS>       Generates all pseudo-legal non-captures and underpromotions
-/// <EVASIONS>     Generates all pseudo-legal check evasions when the side to move is in check
-/// <QUIET_CHECKS> Generates all pseudo-legal non-captures giving check, except castling and promotions
-/// <NON_EVASIONS> Generates all pseudo-legal captures and non-captures
-///
-/// Returns a pointer to the end of the move list.
+// <CAPTURES>     Generates all pseudo-legal captures plus queen promotions
+// <QUIETS>       Generates all pseudo-legal non-captures and underpromotions
+// <EVASIONS>     Generates all pseudo-legal check evasions when the side to move is in check
+// <QUIET_CHECKS> Generates all pseudo-legal non-captures giving check, except castling and promotions
+// <NON_EVASIONS> Generates all pseudo-legal captures and non-captures
+//
+// Returns a pointer to the end of the move list.
 
 template<GenType Type>
 ExtMove* generate(const Position& pos, ExtMove* moveList) {
@@ -262,7 +262,7 @@ template ExtMove* generate<QUIET_CHECKS>(const Position&, ExtMove*);
 template ExtMove* generate<NON_EVASIONS>(const Position&, ExtMove*);
 
 
-/// generate<LEGAL> generates all the legal moves in the given position
+// generate<LEGAL> generates all the legal moves in the given position
 
 template<>
 ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -56,9 +56,9 @@ inline bool operator<(const ExtMove& f, const ExtMove& s) {
 template<GenType>
 ExtMove* generate(const Position& pos, ExtMove* moveList);
 
-/// The MoveList struct wraps the generate() function and returns a convenient
-/// list of moves. Using MoveList is sometimes preferable to directly calling
-/// the lower level generate() function.
+// The MoveList struct wraps the generate() function and returns a convenient
+// list of moves. Using MoveList is sometimes preferable to directly calling
+// the lower level generate() function.
 template<GenType T>
 struct MoveList {
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -55,13 +55,13 @@ namespace {
 } // namespace
 
 
-/// Constructors of the MovePicker class. As arguments, we pass information
-/// to help it return the (presumably) good moves first, to decide which
-/// moves to return (in the quiescence search, for instance, we only want to
-/// search captures, promotions, and some checks) and how important a good
-/// move ordering is at the current node.
+// Constructors of the MovePicker class. As arguments, we pass information
+// to help it return the (presumably) good moves first, to decide which
+// moves to return (in the quiescence search, for instance, we only want to
+// search captures, promotions, and some checks) and how important a good
+// move ordering is at the current node.
 
-/// MovePicker constructor for the main search
+// MovePicker constructor for the main search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
                                                              const CapturePieceToHistory* cph,
                                                              const PieceToHistory** ch,
@@ -76,7 +76,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
           !(ttm && pos.pseudo_legal(ttm));
 }
 
-/// MovePicker constructor for quiescence search
+// MovePicker constructor for quiescence search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh,
                                                              const CapturePieceToHistory* cph,
                                                              const PieceToHistory** ch,
@@ -90,8 +90,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
             && pos.pseudo_legal(ttm));
 }
 
-/// MovePicker constructor for ProbCut: we generate captures with SEE greater
-/// than or equal to the given threshold.
+// MovePicker constructor for ProbCut: we generate captures with SEE greater
+// than or equal to the given threshold.
 MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePieceToHistory* cph)
            : pos(p), captureHistory(cph), ttMove(ttm), threshold(th)
 {
@@ -102,9 +102,9 @@ MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePiece
                              && pos.see_ge(ttm, threshold));
 }
 
-/// MovePicker::score() assigns a numerical value to each move in a list, used
-/// for sorting. Captures are ordered by Most Valuable Victim (MVV), preferring
-/// captures with a good history. Quiets moves are ordered using the history tables.
+// MovePicker::score() assigns a numerical value to each move in a list, used
+// for sorting. Captures are ordered by Most Valuable Victim (MVV), preferring
+// captures with a good history. Quiets moves are ordered using the history tables.
 template<GenType Type>
 void MovePicker::score() {
 
@@ -179,8 +179,8 @@ void MovePicker::score() {
       }
 }
 
-/// MovePicker::select() returns the next move satisfying a predicate function.
-/// It never returns the TT move.
+// MovePicker::select() returns the next move satisfying a predicate function.
+// It never returns the TT move.
 template<MovePicker::PickType T, typename Pred>
 Move MovePicker::select(Pred filter) {
 
@@ -197,9 +197,9 @@ Move MovePicker::select(Pred filter) {
   return MOVE_NONE;
 }
 
-/// MovePicker::next_move() is the most important method of the MovePicker class. It
-/// returns a new pseudo-legal move every time it is called until there are no more
-/// moves left, picking the move with the highest score from a list of generated moves.
+// MovePicker::next_move() is the most important method of the MovePicker class. It
+// returns a new pseudo-legal move every time it is called until there are no more
+// moves left, picking the move with the highest score from a list of generated moves.
 Move MovePicker::next_move(bool skipQuiets) {
 
 top:

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -32,10 +32,10 @@
 namespace Stockfish {
 class Position;
 
-/// StatsEntry stores the stat table value. It is usually a number but could
-/// be a move or even a nested history. We use a class instead of naked value
-/// to directly call history update operator<<() on the entry so to use stats
-/// tables at caller sites as simple multi-dim arrays.
+// StatsEntry stores the stat table value. It is usually a number but could
+// be a move or even a nested history. We use a class instead of a naked value
+// to directly call history update operator<<() on the entry so to use stats
+// tables at caller sites as simple multi-dim arrays.
 template<typename T, int D>
 class StatsEntry {
 
@@ -57,11 +57,11 @@ public:
   }
 };
 
-/// Stats is a generic N-dimensional array used to store various statistics.
-/// The first template parameter T is the base type of the array, the second
-/// template parameter D limits the range of updates in [-D, D] when we update
-/// values with the << operator, while the last parameters (Size and Sizes)
-/// encode the dimensions of the array.
+// Stats is a generic N-dimensional array used to store various statistics.
+// The first template parameter T is the base type of the array, and the second
+// template parameter D limits the range of updates in [-D, D] when we update
+// values with the << operator, while the last parameters (Size and Sizes)
+// encode the dimensions of the array.
 template <typename T, int D, int Size, int... Sizes>
 struct Stats : public std::array<Stats<T, D, Sizes...>, Size>
 {
@@ -69,7 +69,7 @@ struct Stats : public std::array<Stats<T, D, Sizes...>, Size>
 
   void fill(const T& v) {
 
-    // For standard-layout 'this' points to first struct member
+    // For standard-layout 'this' points to the first struct member
     assert(std::is_standard_layout_v<stats>);
 
     using entry = StatsEntry<T, D>;
@@ -81,40 +81,40 @@ struct Stats : public std::array<Stats<T, D, Sizes...>, Size>
 template <typename T, int D, int Size>
 struct Stats<T, D, Size> : public std::array<StatsEntry<T, D>, Size> {};
 
-/// In stats table, D=0 means that the template parameter is not used
+// In stats table, D=0 means that the template parameter is not used
 enum StatsParams { NOT_USED = 0 };
 enum StatsType { NoCaptures, Captures };
 
-/// ButterflyHistory records how often quiet moves have been successful or
-/// unsuccessful during the current search, and is used for reduction and move
-/// ordering decisions. It uses 2 tables (one for each color) indexed by
-/// the move's from and to squares, see www.chessprogramming.org/Butterfly_Boards
-/// (~11 elo)
+// ButterflyHistory records how often quiet moves have been successful or
+// unsuccessful during the current search, and is used for reduction and move
+// ordering decisions. It uses 2 tables (one for each color) indexed by
+// the move's from and to squares, see www.chessprogramming.org/Butterfly_Boards
+// (~11 elo)
 using ButterflyHistory = Stats<int16_t, 7183, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)>;
 
-/// CounterMoveHistory stores counter moves indexed by [piece][to] of the previous
-/// move, see www.chessprogramming.org/Countermove_Heuristic
+// CounterMoveHistory stores counter moves indexed by [piece][to] of the previous
+// move, see www.chessprogramming.org/Countermove_Heuristic
 using CounterMoveHistory = Stats<Move, NOT_USED, PIECE_NB, SQUARE_NB>;
 
-/// CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
+// CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;
 
-/// PieceToHistory is like ButterflyHistory but is addressed by a move's [piece][to]
+// PieceToHistory is like ButterflyHistory but is addressed by a move's [piece][to]
 using PieceToHistory = Stats<int16_t, 29952, PIECE_NB, SQUARE_NB>;
 
-/// ContinuationHistory is the combined history of a given pair of moves, usually
-/// the current one given a previous one. The nested history table is based on
-/// PieceToHistory instead of ButterflyBoards.
-/// (~63 elo)
+// ContinuationHistory is the combined history of a given pair of moves, usually
+// the current one given a previous one. The nested history table is based on
+// PieceToHistory instead of ButterflyBoards.
+// (~63 elo)
 using ContinuationHistory = Stats<PieceToHistory, NOT_USED, PIECE_NB, SQUARE_NB>;
 
 
-/// MovePicker class is used to pick one pseudo-legal move at a time from the
-/// current position. The most important method is next_move(), which returns a
-/// new pseudo-legal move each time it is called, until there are no moves left,
-/// when MOVE_NONE is returned. In order to improve the efficiency of the
-/// alpha-beta algorithm, MovePicker attempts to return the moves which are most
-/// likely to get a cut-off first.
+// MovePicker class is used to pick one pseudo-legal move at a time from the
+// current position. The most important method is next_move(), which returns a
+// new pseudo-legal move each time it is called, until there are no moves left,
+// when MOVE_NONE is returned. In order to improve the efficiency of the
+// alpha-beta algorithm, MovePicker attempts to return the moves which are most
+// likely to get a cut-off first.
 class MovePicker {
 
   enum PickType { Next, Best };

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -375,7 +375,7 @@ namespace Stockfish::Eval::NNUE {
     return write_parameters(stream);
   }
 
-  /// Save eval, to a file given by its name
+  // Save eval, to a file given by its name
   bool save_eval(const std::optional<std::string>& filename) {
 
     std::string actualFilename;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -532,7 +532,7 @@ bool Position::legal(Move m) const {
           if (attackers_to(s) & pieces(~us))
               return false;
 
-      // In case of Chess960, verify if the Rook blocks some checks
+      // In case of Chess960, verify if the Rook blocks some checks.
       // For instance an enemy queen in SQ_A1 when castling rook is in SQ_B1.
       return !chess960 || !(blockers_for_king(us) & to_sq(m));
   }

--- a/src/position.h
+++ b/src/position.h
@@ -342,8 +342,8 @@ inline bool Position::capture(Move m) const {
           ||  type_of(m) == EN_PASSANT;
 }
 
-// returns true if a move is generated from the capture stage
-// having also queen promotions covered, i.e. consistency with the capture stage move generation
+// Returns true if a move is generated from the capture stage, having also
+// queen promotions covered, i.e. consistency with the capture stage move generation
 // is needed to avoid the generation of duplicate moves.
 inline bool Position::capture_stage(Move m) const {
   assert(is_ok(m));

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -169,7 +169,7 @@ namespace {
 } // namespace
 
 
-/// Search::init() is called at startup to initialize various lookup tables
+// Search::init() is called at startup to initialize various lookup tables
 
 void Search::init() {
 
@@ -178,7 +178,7 @@ void Search::init() {
 }
 
 
-/// Search::clear() resets search state to its initial value
+// Search::clear() resets search state to its initial value
 
 void Search::clear() {
 
@@ -191,8 +191,8 @@ void Search::clear() {
 }
 
 
-/// MainThread::search() is started when the program receives the UCI 'go'
-/// command. It searches from the root position and outputs the "bestmove".
+// MainThread::search() is started when the program receives the UCI 'go'
+// command. It searches from the root position and outputs the "bestmove".
 
 void MainThread::search() {
 
@@ -268,9 +268,9 @@ void MainThread::search() {
 }
 
 
-/// Thread::search() is the main iterative deepening loop. It calls search()
-/// repeatedly with increasing depth until the allocated thinking time has been
-/// consumed, the user stops the search, or the maximum search depth is reached.
+// Thread::search() is the main iterative deepening loop. It calls search()
+// repeatedly with increasing depth until the allocated thinking time has been
+// consumed, the user stops the search, or the maximum search depth is reached.
 
 void Thread::search() {
 
@@ -1835,8 +1835,8 @@ moves_loop: // When in check, search starts here
 } // namespace
 
 
-/// MainThread::check_time() is used to print debug info and, more importantly,
-/// to detect when we are out of available time and thus stop the search.
+// MainThread::check_time() is used to print debug info and, more importantly,
+// to detect when we are out of available time and thus stop the search.
 
 void MainThread::check_time() {
 
@@ -1868,8 +1868,8 @@ void MainThread::check_time() {
 }
 
 
-/// UCI::pv() formats PV information according to the UCI protocol. UCI requires
-/// that all (if any) unsearched PV lines are sent using a previous search score.
+// UCI::pv() formats PV information according to the UCI protocol. UCI requires
+// that all (if any) unsearched PV lines are sent using a previous search score.
 
 string UCI::pv(const Position& pos, Depth depth) {
 
@@ -1927,10 +1927,10 @@ string UCI::pv(const Position& pos, Depth depth) {
 }
 
 
-/// RootMove::extract_ponder_from_tt() is called in case we have no ponder move
-/// before exiting the search, for instance, in case we stop the search during a
-/// fail high at root. We try hard to have a ponder move to return to the GUI,
-/// otherwise in case of 'ponder on' we have nothing to think about.
+// RootMove::extract_ponder_from_tt() is called in case we have no ponder move
+// before exiting the search, for instance, in case we stop the search during a
+// fail high at root. We try hard to have a ponder move to return to the GUI,
+// otherwise in case of 'ponder on' we have nothing to think about.
 
 bool RootMove::extract_ponder_from_tt(Position& pos) {
 

--- a/src/search.h
+++ b/src/search.h
@@ -33,9 +33,9 @@ class Position;
 namespace Search {
 
 
-/// Stack struct keeps track of the information we need to remember from nodes
-/// shallower and deeper in the tree during the search. Each search thread has
-/// its own array of Stack objects, indexed by the current ply.
+// Stack struct keeps track of the information we need to remember from nodes
+// shallower and deeper in the tree during the search. Each search thread has
+// its own array of Stack objects, indexed by the current ply.
 
 struct Stack {
   Move* pv;
@@ -55,9 +55,9 @@ struct Stack {
 };
 
 
-/// RootMove struct is used for moves at the root of the tree. For each root move
-/// we store a score and a PV (really a refutation in the case of moves which
-/// fail low). Score is normally set at -VALUE_INFINITE for all non-pv moves.
+// RootMove struct is used for moves at the root of the tree. For each root move
+// we store a score and a PV (really a refutation in the case of moves which
+// fail low). Score is normally set at -VALUE_INFINITE for all non-pv moves.
 
 struct RootMove {
 
@@ -84,8 +84,8 @@ struct RootMove {
 using RootMoves = std::vector<RootMove>;
 
 
-/// LimitsType struct stores information sent by GUI about available time to
-/// search the current move, maximum depth/time, or if we are in analysis mode.
+// LimitsType struct stores information sent by GUI about available time to
+// search the current move, maximum depth/time, or if we are in analysis mode.
 
 struct LimitsType {
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1550,7 +1550,7 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
         {
             // In case a root move leads to a draw by repetition or 50-move rule,
             // we set dtz to zero. Note: since we are only 1 ply from the root,
-            //  this must be a true 3-fold repetition inside the game history.
+            // this must be a true 3-fold repetition inside the game history.
             dtz = 0;
         }
         else

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -139,7 +139,7 @@ template <typename T> int sign_of(T val) {
     return (T(0) < val) - (val < T(0));
 }
 
-// Numbers in little endian used by sparseIndex[] to point into blockLength[]
+// Numbers in little-endian used by sparseIndex[] to point into blockLength[]
 struct SparseEntry {
     char block[4];   // Number of block
     char offset[2];  // Offset within the block
@@ -153,7 +153,7 @@ struct LR {
     enum Side { Left, Right };
 
     uint8_t lr[3]; // The first 12 bits is the left-hand symbol, the second 12
-                   // bits is the right-hand symbol. If symbol has length 1,
+                   // bits is the right-hand symbol. If the symbol has length 1,
                    // then the left-hand symbol is the stored value.
     template<Side S>
     Sym get() {
@@ -301,9 +301,9 @@ public:
 
 std::string TBFile::Paths;
 
-// struct PairsData contains low level indexing information to access TB data.
-// There are 8, 4 or 2 PairsData records for each TBTable, according to type of
-// table and if positions have pawns or not. It is populated at first access.
+// struct PairsData contains low-level indexing information to access TB data.
+// There are 8, 4, or 2 PairsData records for each TBTable, according to the type
+// of table and if positions have pawns or not. It is populated at first access.
 struct PairsData {
     uint8_t flags;                 // Table flags, see enum TBFlag
     uint8_t maxSymLen;             // Maximum length in bits of the Huffman symbols
@@ -379,7 +379,7 @@ TBTable<WDL>::TBTable(const std::string& code) : TBTable() {
                 hasUniquePieces = true;
 
     // Set the leading color. In case both sides have pawns the leading color
-    // is the side with less pawns because this leads to better compression.
+    // is the side with fewer pawns because this leads to better compression.
     bool c =   !pos.count<PAWN>(BLACK)
             || (   pos.count<PAWN>(WHITE)
                 && pos.count<PAWN>(BLACK) >= pos.count<PAWN>(WHITE));
@@ -404,7 +404,7 @@ TBTable<DTZ>::TBTable(const TBTable<WDL>& wdl) : TBTable() {
 }
 
 // class TBTables creates and keeps ownership of the TBTable objects, one for
-// each TB file found. It supports a fast, hash based, table lookup. Populated
+// each TB file found. It supports a fast, hash-based, table lookup. Populated
 // at init time, accessed at probe time.
 class TBTables {
 
@@ -511,9 +511,9 @@ void TBTables::add(const std::vector<PieceType>& pieces) {
 // mostly-draw or mostly-win tables this can leave many 64-byte blocks only half-filled, so
 // in such cases blocks are 32 bytes long. The blocks of DTZ tables are up to 1024 bytes long.
 // The generator picks the size that leads to the smallest table. The "book" of symbols and
-// Huffman codes is the same for all blocks in the table. A non-symmetric pawnless TB file
+// Huffman codes are the same for all blocks in the table. A non-symmetric pawnless TB file
 // will have one table for wtm and one for btm, a TB file with pawns will have tables per
-// file a,b,c,d also in this case one set for wtm and one for btm.
+// file a,b,c,d also, in this case, one set for wtm and one for btm.
 int decompress_pairs(PairsData* d, uint64_t idx) {
 
     // Special case where all table positions store the same value
@@ -541,7 +541,7 @@ int decompress_pairs(PairsData* d, uint64_t idx) {
     uint32_t block = number<uint32_t, LittleEndian>(&d->sparseIndex[k].block);
     int offset     = number<uint16_t, LittleEndian>(&d->sparseIndex[k].offset);
 
-    // Now compute the difference idx - I(k). From definition of k we know that
+    // Now compute the difference idx - I(k). From the definition of k, we know that
     //
     //       idx = k * d->span + idx % d->span    (2)
     //
@@ -551,7 +551,7 @@ int decompress_pairs(PairsData* d, uint64_t idx) {
     // Sum the above to offset to find the offset corresponding to our idx
     offset += diff;
 
-    // Move to previous/next block, until we reach the correct block that contains idx,
+    // Move to the previous/next block, until we reach the correct block that contains idx,
     // that is when 0 <= offset <= d->blockLength[block]
     while (offset < 0)
         offset += d->blockLength[--block] + 1;
@@ -564,7 +564,7 @@ int decompress_pairs(PairsData* d, uint64_t idx) {
 
     // Read the first 64 bits in our block, this is a (truncated) sequence of
     // unknown number of symbols of unknown length but we know the first one
-    // is at the beginning of this 64 bits sequence.
+    // is at the beginning of this 64-bit sequence.
     uint64_t buf64 = number<uint64_t, BigEndian>(ptr); ptr += 2;
     int buf64Size = 64;
     Sym sym;
@@ -587,8 +587,8 @@ int decompress_pairs(PairsData* d, uint64_t idx) {
         // Now add the value of the lowest symbol of length len to get our symbol
         sym += number<Sym, LittleEndian>(&d->lowestSym[len]);
 
-        // If our offset is within the number of values represented by symbol sym
-        // we are done...
+        // If our offset is within the number of values represented by symbol sym,
+        // we are done.
         if (offset < d->symlen[sym] + 1)
             break;
 
@@ -604,7 +604,7 @@ int decompress_pairs(PairsData* d, uint64_t idx) {
         }
     }
 
-    // Ok, now we have our symbol that expands into d->symlen[sym] + 1 symbols.
+    // Now we have our symbol that expands into d->symlen[sym] + 1 symbols.
     // We binary-search for our value recursively expanding into the left and
     // right child symbols until we reach a leaf node where symlen[sym] + 1 == 1
     // that will store the value we need.
@@ -614,7 +614,7 @@ int decompress_pairs(PairsData* d, uint64_t idx) {
 
         // If a symbol contains 36 sub-symbols (d->symlen[sym] + 1 = 36) and
         // expands in a pair (d->symlen[left] = 23, d->symlen[right] = 11), then
-        // we know that, for instance the ten-th value (offset = 10) will be on
+        // we know that, for instance, the tenth value (offset = 10) will be on
         // the left side because in Recursive Pairing child symbols are adjacent.
         if (offset < d->symlen[left] + 1)
             sym = left;
@@ -639,7 +639,7 @@ bool check_dtz_stm(TBTable<DTZ>* entry, int stm, File f) {
 // DTZ scores are sorted by frequency of occurrence and then assigned the
 // values 0, 1, 2, ... in order of decreasing frequency. This is done for each
 // of the four WDLScore values. The mapping information necessary to reconstruct
-// the original values is stored in the TB file and read during map[] init.
+// the original values are stored in the TB file and read during map[] init.
 WDLScore map_score(TBTable<WDL>*, File, int value, WDLScore) { return WDLScore(value - 2); }
 
 int map_score(TBTable<DTZ>* entry, File f, int value, WDLScore wdl) {
@@ -658,7 +658,7 @@ int map_score(TBTable<DTZ>* entry, File f, int value, WDLScore wdl) {
     }
 
     // DTZ tables store distance to zero in number of moves or plies. We
-    // want to return plies, so we have convert to plies when needed.
+    // want to return plies, so we have to convert to plies when needed.
     if (   (wdl == WDLWin  && !(flags & TBFlag::WinPlies))
         || (wdl == WDLLoss && !(flags & TBFlag::LossPlies))
         ||  wdl == WDLCursedWin
@@ -669,7 +669,7 @@ int map_score(TBTable<DTZ>* entry, File f, int value, WDLScore wdl) {
 }
 
 // Compute a unique index out of a position and use it to probe the TB file. To
-// encode k pieces of same type and color, first sort the pieces by square in
+// encode k pieces of the same type and color, first sort the pieces by square in
 // ascending order s1 <= s2 <= ... <= sk then compute the unique index as:
 //
 //      idx = Binomial[1][s1] + Binomial[2][s2] + ... + Binomial[k][sk]
@@ -687,13 +687,13 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
 
     // A given TB entry like KRK has associated two material keys: KRvk and Kvkr.
     // If both sides have the same pieces keys are equal. In this case TB tables
-    // only store the 'white to move' case, so if the position to lookup has black
+    // only stores the 'white to move' case, so if the position to lookup has black
     // to move, we need to switch the color and flip the squares before to lookup.
     bool symmetricBlackToMove = (entry->key == entry->key2 && pos.side_to_move());
 
-    // TB files are calculated for white as stronger side. For instance we have
-    // KRvK, not KvKR. A position where stronger side is white will have its
-    // material key == entry->key, otherwise we have to switch the color and
+    // TB files are calculated for white as the stronger side. For instance, we
+    // have KRvK, not KvKR. A position where the stronger side is white will have
+    // its material key == entry->key, otherwise we have to switch the color and
     // flip the squares before to lookup.
     bool blackStronger = (pos.material_key() != entry->key);
 
@@ -816,7 +816,7 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
     // Rs "together" in 62 * 61 / 2 ways (we divide by 2 because rooks can be
     // swapped and still get the same position.)
     //
-    // In case we have at least 3 unique pieces (included kings) we encode them
+    // In case we have at least 3 unique pieces (including kings) we encode them
     // together.
     if (entry->hasUniquePieces) {
 
@@ -861,7 +861,7 @@ encode_remaining:
     idx *= d->groupIdx[0];
     Square* groupSq = squares + d->groupLen[0];
 
-    // Encode remaining pawns then pieces according to square, in ascending order
+    // Encode remaining pawns and then pieces according to square, in ascending order
     bool remainingPawns = entry->hasPawns && entry->pawnCount[1];
 
     while (d->groupLen[++next])
@@ -870,7 +870,7 @@ encode_remaining:
         uint64_t n = 0;
 
         // Map down a square if "comes later" than a square in the previous
-        // groups (similar to what done earlier for leading group pieces).
+        // groups (similar to what was done earlier for leading group pieces).
         for (int i = 0; i < d->groupLen[next]; ++i)
         {
             auto f = [&](Square s) { return groupSq[i] > s; };
@@ -888,7 +888,7 @@ encode_remaining:
 }
 
 // Group together pieces that will be encoded together. The general rule is that
-// a group contains pieces of same type and color. The exception is the leading
+// a group contains pieces of the same type and color. The exception is the leading
 // group that, in case of positions without pawns, can be formed by 3 different
 // pieces (default) or by the king pair when there is not a unique piece apart
 // from the kings. When there are pawns, pawns are always first in pieces[].
@@ -953,7 +953,7 @@ void set_groups(T& e, PairsData* d, int order[], File f) {
 
 // In Recursive Pairing each symbol represents a pair of children symbols. So
 // read d->btree[] symbols data and expand each one in his left and right child
-// symbol until reaching the leafs that represent the symbol value.
+// symbol until reaching the leaves that represent the symbol value.
 uint8_t set_symlen(PairsData* d, Sym s, std::vector<bool>& visited) {
 
     visited[s] = true; // We can set it now because tree is acyclic
@@ -1002,7 +1002,7 @@ uint8_t* set_sizes(PairsData* d, uint8_t* data) {
 
     // See https://en.wikipedia.org/wiki/Huffman_coding
     // The canonical code is ordered such that longer symbols (in terms of
-    // the number of bits of their Huffman code) have lower numeric value,
+    // the number of bits of their Huffman code) have a lower numeric value,
     // so that d->lowestSym[i] >= d->lowestSym[i+1] (when read as LittleEndian).
     // Starting from this we compute a base64[] table indexed by symbol length
     // and containing 64 bit values so that d->base64[i] >= d->base64[i+1].
@@ -1072,7 +1072,7 @@ uint8_t* set_dtz_map(TBTable<DTZ>& e, uint8_t* data, File maxFile) {
     return data += uintptr_t(data) & 1; // Word alignment
 }
 
-// Populate entry's PairsData records with data from the just memory mapped file.
+// Populate entry's PairsData records with data from the just memory-mapped file.
 // Called at first access.
 template<typename T>
 void set(T& e, uint8_t* data) {
@@ -1138,9 +1138,9 @@ void set(T& e, uint8_t* data) {
         }
 }
 
-// If the TB file corresponding to the given position is already memory mapped
-// then return its base address, otherwise try to memory map and init it. Called
-// at every probe, memory map and init only at first access. Function is thread
+// If the TB file corresponding to the given position is already memory-mapped
+// then return its base address, otherwise, try to memory map and init it. Called
+// at every probe, memory map, and init only at first access. Function is thread
 // safe and can be called concurrently.
 template<TBType Type>
 void* mapped(TBTable<Type>& e, const Position& pos) {
@@ -1191,7 +1191,7 @@ Ret probe_table(const Position& pos, ProbeState* result, WDLScore wdl = WDLDraw)
 }
 
 // For a position where the side to move has a winning capture it is not necessary
-// to store a winning value so the generator treats such positions as "don't cares"
+// to store a winning value so the generator treats such positions as "don't care"
 // and tries to assign to it a value that improves the compression ratio. Similarly,
 // if the side to move has a drawing capture, then the position is at least drawn.
 // If the position is won, then the TB needs to store a win value. But if the
@@ -1200,7 +1200,7 @@ Ret probe_table(const Position& pos, ProbeState* result, WDLScore wdl = WDLDraw)
 // their results and must probe the position itself. The "best" result of these
 // probes is the correct result for the position.
 // DTZ tables do not store values when a following move is a zeroing winning move
-// (winning capture or winning pawn move). Also DTZ store wrong values for positions
+// (winning capture or winning pawn move). Also, DTZ store wrong values for positions
 // where the best move is an ep-move (even if losing). So in all these cases set
 // the state to ZEROING_BEST_MOVE.
 template<bool CheckZeroingMoves>
@@ -1268,9 +1268,9 @@ WDLScore search(Position& pos, ProbeState* result) {
 } // namespace
 
 
-/// Tablebases::init() is called at startup and after every change to
-/// "SyzygyPath" UCI option to (re)create the various tables. It is not thread
-/// safe, nor it needs to be.
+// Tablebases::init() is called at startup and after every change to
+// "SyzygyPath" UCI option to (re)create the various tables. It is not thread
+// safe, nor it needs to be.
 void Tablebases::init(const std::string& paths) {
 
     TBTables.clear();
@@ -1302,7 +1302,7 @@ void Tablebases::init(const std::string& paths) {
 
     // MapKK[] encodes all the 462 possible legal positions of two kings where
     // the first is in the a1-d1-d4 triangle. If the first king is on the a1-d4
-    // diagonal, the other one shall not to be above the a1-h8 diagonal.
+    // diagonal, the other one shall not be above the a1-h8 diagonal.
     std::vector<std::pair<int, Square>> bothOnDiagonal;
     code = 0;
     for (int idx = 0; idx < 10; idx++)
@@ -1323,7 +1323,7 @@ void Tablebases::init(const std::string& paths) {
                         MapKK[idx][s2] = code++;
             }
 
-    // Legal positions with both kings on diagonal are encoded as last ones
+    // Legal positions with both kings on a diagonal are encoded as last ones
     for (auto p : bothOnDiagonal)
         MapKK[p.first][p.second] = code++;
 
@@ -1338,8 +1338,8 @@ void Tablebases::init(const std::string& paths) {
 
     // MapPawns[s] encodes squares a2-h7 to 0..47. This is the number of possible
     // available squares when the leading one is in 's'. Moreover the pawn with
-    // highest MapPawns[] is the leading pawn, the one nearest the edge and,
-    // among pawns with same file, the one with lowest rank.
+    // highest MapPawns[] is the leading pawn, the one nearest the edge, and
+    // among pawns with the same file, the one with the lowest rank.
     int availableSquares = 47; // Available squares when lead pawn is in a2
 
     // Init the tables for the encoding of leading pawns group: with 7-men TB we
@@ -1463,7 +1463,7 @@ int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
     if (*result == FAIL || wdl == WDLDraw) // DTZ tables don't store draws
         return 0;
 
-    // DTZ stores a 'don't care' value in this case, or even a plain wrong
+    // DTZ stores a 'don't care value in this case, or even a plain wrong
     // one as in case the best move is a losing ep, so it cannot be probed.
     if (*result == ZEROING_BEST_MOVE)
         return dtz_before_zeroing(wdl);
@@ -1490,7 +1490,7 @@ int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
         // For zeroing moves we want the dtz of the move _before_ doing it,
         // otherwise we will get the dtz of the next move sequence. Search the
         // position after the move to get the score sign (because even in a
-        // winning position we could make a losing capture or going for a draw).
+        // winning position we could make a losing capture or go for a draw).
         dtz = zeroing ? -dtz_before_zeroing(search<false>(pos, result))
                       : -probe_dtz(pos, result);
 
@@ -1548,10 +1548,9 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves) {
         }
         else if (pos.is_draw(1))
         {
-            // In case a root move leads to a draw by repetition or
-            // 50-move rule, we set dtz to zero. Note: since we are
-            // only 1 ply from the root, this must be a true 3-fold
-            // repetition inside the game history.
+            // In case a root move leads to a draw by repetition or 50-move rule,
+            // we set dtz to zero. Note: since we are only 1 ply from the root,
+            //  this must be a true 3-fold repetition inside the game history.
             dtz = 0;
         }
         else

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -40,8 +40,8 @@ namespace Stockfish {
 ThreadPool Threads; // Global object
 
 
-/// Thread constructor launches the thread and waits until it goes to sleep
-/// in idle_loop(). Note that 'searching' and 'exit' should be already set.
+// Thread constructor launches the thread and waits until it goes to sleep
+// in idle_loop(). Note that 'searching' and 'exit' should be already set.
 
 Thread::Thread(size_t n) : idx(n), stdThread(&Thread::idle_loop, this) {
 
@@ -49,8 +49,8 @@ Thread::Thread(size_t n) : idx(n), stdThread(&Thread::idle_loop, this) {
 }
 
 
-/// Thread destructor wakes up the thread in idle_loop() and waits
-/// for its termination. Thread should be already waiting.
+// Thread destructor wakes up the thread in idle_loop() and waits
+// for its termination. Thread should be already waiting.
 
 Thread::~Thread() {
 
@@ -62,7 +62,7 @@ Thread::~Thread() {
 }
 
 
-/// Thread::clear() reset histories, usually before a new game
+// Thread::clear() reset histories, usually before a new game
 
 void Thread::clear() {
 
@@ -78,7 +78,7 @@ void Thread::clear() {
 }
 
 
-/// Thread::start_searching() wakes up the thread that will start the search
+// Thread::start_searching() wakes up the thread that will start the search
 
 void Thread::start_searching() {
   mutex.lock();
@@ -88,8 +88,8 @@ void Thread::start_searching() {
 }
 
 
-/// Thread::wait_for_search_finished() blocks on the condition variable
-/// until the thread has finished searching.
+// Thread::wait_for_search_finished() blocks on the condition variable
+// until the thread has finished searching.
 
 void Thread::wait_for_search_finished() {
 
@@ -98,15 +98,15 @@ void Thread::wait_for_search_finished() {
 }
 
 
-/// Thread::idle_loop() is where the thread is parked, blocked on the
-/// condition variable, when it has no work to do.
+// Thread::idle_loop() is where the thread is parked, blocked on the
+// condition variable, when it has no work to do.
 
 void Thread::idle_loop() {
 
   // If OS already scheduled us on a different group than 0 then don't overwrite
   // the choice, eventually we are one of many one-threaded processes running on
   // some Windows NUMA hardware, for instance in fishtest. To make it simple,
-  // just check if running threads are below a threshold, in this case all this
+  // just check if running threads are below a threshold, in this case, all this
   // NUMA machinery is not needed.
   if (Options["Threads"] > 8)
       WinProcGroup::bindThisThread(idx);
@@ -127,9 +127,9 @@ void Thread::idle_loop() {
   }
 }
 
-/// ThreadPool::set() creates/destroys threads to match the requested number.
-/// Created and launched threads will immediately go to sleep in idle_loop.
-/// Upon resizing, threads are recreated to allow for binding if necessary.
+// ThreadPool::set() creates/destroys threads to match the requested number.
+// Created and launched threads will immediately go to sleep in idle_loop.
+// Upon resizing, threads are recreated to allow for binding if necessary.
 
 void ThreadPool::set(size_t requested) {
 
@@ -158,7 +158,7 @@ void ThreadPool::set(size_t requested) {
 }
 
 
-/// ThreadPool::clear() sets threadPool data to initial values
+// ThreadPool::clear() sets threadPool data to initial values
 
 void ThreadPool::clear() {
 
@@ -172,8 +172,8 @@ void ThreadPool::clear() {
 }
 
 
-/// ThreadPool::start_thinking() wakes up main thread waiting in idle_loop() and
-/// returns immediately. Main thread will wake up other threads and start the search.
+// ThreadPool::start_thinking() wakes up main thread waiting in idle_loop() and
+// returns immediately. Main thread will wake up other threads and start the search.
 
 void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
                                 const Search::LimitsType& limits, bool ponderMode) {
@@ -225,7 +225,7 @@ Thread* ThreadPool::get_best_thread() const {
     std::map<Move, int64_t> votes;
     Value minScore = VALUE_NONE;
 
-    // Find minimum score of all threads
+    // Find the minimum score of all threads
     for (Thread* th: threads)
         minScore = std::min(minScore, th->rootMoves[0].score);
 
@@ -256,7 +256,7 @@ Thread* ThreadPool::get_best_thread() const {
 }
 
 
-/// Start non-main threads
+// Start non-main threads
 
 void ThreadPool::start_searching() {
 
@@ -266,7 +266,7 @@ void ThreadPool::start_searching() {
 }
 
 
-/// Wait for non-main threads
+// Wait for non-main threads
 
 void ThreadPool::wait_for_search_finished() const {
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -34,10 +34,10 @@
 
 namespace Stockfish {
 
-/// Thread class keeps together all the thread-related stuff. We use
-/// per-thread pawn and material hash tables so that once we get a
-/// pointer to an entry its life time is unlimited and we don't have
-/// to care about someone changing the entry under our feet.
+// Thread class keeps together all the thread-related stuff. We use
+// per-thread pawn and material hash tables so that once we get a
+// pointer to an entry its lifetime is unlimited and we don't have
+// to care about someone changing the entry under our feet.
 
 class Thread {
 
@@ -75,7 +75,7 @@ public:
 };
 
 
-/// MainThread is a derived class specific for main thread
+// MainThread is a derived class specific for main thread
 
 struct MainThread : public Thread {
 
@@ -94,9 +94,9 @@ struct MainThread : public Thread {
 };
 
 
-/// ThreadPool struct handles all the threads-related stuff like init, starting,
-/// parking and, most importantly, launching a thread. All the access to threads
-/// is done through this class.
+// ThreadPool struct handles all the threads-related stuff like init, starting,
+// parking and, most importantly, launching a thread. All the access to threads
+// is done through this class.
 
 struct ThreadPool {
 

--- a/src/thread_win32_osx.h
+++ b/src/thread_win32_osx.h
@@ -21,11 +21,11 @@
 
 #include <thread>
 
-/// On OSX threads other than the main thread are created with a reduced stack
-/// size of 512KB by default, this is too low for deep searches, which require
-/// somewhat more than 1MB stack, so adjust it to TH_STACK_SIZE.
-/// The implementation calls pthread_create() with the stack size parameter
-/// equal to the linux 8MB default, on platforms that support it.
+// On OSX threads other than the main thread are created with a reduced stack
+// size of 512KB by default, this is too low for deep searches, which require
+// somewhat more than 1MB stack, so adjust it to TH_STACK_SIZE.
+// The implementation calls pthread_create() with the stack size parameter
+// equal to the Linux 8MB default, on platforms that support it.
 
 #if defined(__APPLE__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(USE_PTHREADS)
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -29,14 +29,14 @@ namespace Stockfish {
 TimeManagement Time; // Our global time management object
 
 
-/// TimeManagement::init() is called at the beginning of the search and calculates
-/// the bounds of time allowed for the current game ply. We currently support:
+// TimeManagement::init() is called at the beginning of the search and calculates
+// the bounds of time allowed for the current game ply. We currently support:
 //      1) x basetime (+ z increment)
 //      2) x moves in y seconds (+ z increment)
 
 void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
 
-  // if we have no time, no need to initialize TM, except for the start time,
+  // If we have no time, no need to initialize TM, except for the start time,
   // which is used by movetime.
   startTime = limits.startTime;
   if (limits.time[us] == 0)

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -28,8 +28,8 @@
 
 namespace Stockfish {
 
-/// The TimeManagement class computes the optimal time to think depending on
-/// the maximum available time, the game move number and other parameters.
+// The TimeManagement class computes the optimal time to think depending on
+// the maximum available time, the game move number, and other parameters.
 
 class TimeManagement {
 public:

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -33,8 +33,8 @@ namespace Stockfish {
 
 TranspositionTable TT; // Our global transposition table
 
-/// TTEntry::save() populates the TTEntry with a new node's data, possibly
-/// overwriting an old position. Update is not atomic and can be racy.
+// TTEntry::save() populates the TTEntry with a new node's data, possibly
+// overwriting an old position. The update is not atomic and can be racy.
 
 void TTEntry::save(Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev) {
 
@@ -59,9 +59,9 @@ void TTEntry::save(Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev) 
 }
 
 
-/// TranspositionTable::resize() sets the size of the transposition table,
-/// measured in megabytes. Transposition table consists of a power of 2 number
-/// of clusters and each cluster consists of ClusterSize number of TTEntry.
+// TranspositionTable::resize() sets the size of the transposition table,
+// measured in megabytes. Transposition table consists of a power of 2 number
+// of clusters and each cluster consists of ClusterSize number of TTEntry.
 
 void TranspositionTable::resize(size_t mbSize) {
 
@@ -83,7 +83,7 @@ void TranspositionTable::resize(size_t mbSize) {
 }
 
 
-/// TranspositionTable::clear() initializes the entire transposition table to zero,
+// TranspositionTable::clear() initializes the entire transposition table to zero,
 //  in a multi-threaded way.
 
 void TranspositionTable::clear() {
@@ -113,12 +113,12 @@ void TranspositionTable::clear() {
 }
 
 
-/// TranspositionTable::probe() looks up the current position in the transposition
-/// table. It returns true and a pointer to the TTEntry if the position is found.
-/// Otherwise, it returns false and a pointer to an empty or least valuable TTEntry
-/// to be replaced later. The replace value of an entry is calculated as its depth
-/// minus 8 times its relative age. TTEntry t1 is considered more valuable than
-/// TTEntry t2 if its replace value is greater than that of t2.
+// TranspositionTable::probe() looks up the current position in the transposition
+// table. It returns true and a pointer to the TTEntry if the position is found.
+// Otherwise, it returns false and a pointer to an empty or least valuable TTEntry
+// to be replaced later. The replace value of an entry is calculated as its depth
+// minus 8 times its relative age. TTEntry t1 is considered more valuable than
+// TTEntry t2 if its replace value is greater than that of t2.
 
 TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 
@@ -149,8 +149,8 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 }
 
 
-/// TranspositionTable::hashfull() returns an approximation of the hashtable
-/// occupation during a search. The hash is x permill full, as per UCI protocol.
+// TranspositionTable::hashfull() returns an approximation of the hashtable
+// occupation during a search. The hash is x permill full, as per UCI protocol.
 
 int TranspositionTable::hashfull() const {
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -27,16 +27,16 @@
 
 namespace Stockfish {
 
-/// TTEntry struct is the 10 bytes transposition table entry, defined as below:
-///
-/// key        16 bit
-/// depth       8 bit
-/// generation  5 bit
-/// pv node     1 bit
-/// bound type  2 bit
-/// move       16 bit
-/// value      16 bit
-/// eval value 16 bit
+// TTEntry struct is the 10 bytes transposition table entry, defined as below:
+//
+// key        16 bit
+// depth       8 bit
+// generation  5 bit
+// pv node     1 bit
+// bound type  2 bit
+// move       16 bit
+// value      16 bit
+// eval value 16 bit
 
 struct TTEntry {
 
@@ -60,11 +60,11 @@ private:
 };
 
 
-/// A TranspositionTable is an array of Cluster, of size clusterCount. Each
-/// cluster consists of ClusterSize number of TTEntry. Each non-empty TTEntry
-/// contains information on exactly one position. The size of a Cluster should
-/// divide the size of a cache line for best performance, as the cacheline is
-/// prefetched when possible.
+// A TranspositionTable is an array of Cluster, of size clusterCount. Each
+// cluster consists of ClusterSize number of TTEntry. Each non-empty TTEntry
+// contains information on exactly one position. The size of a Cluster should
+// divide the size of a cache line for best performance, as the cacheline is
+// prefetched when possible.
 
 class TranspositionTable {
 

--- a/src/tune.h
+++ b/src/tune.h
@@ -49,31 +49,30 @@ struct SetRange {
 #define SetDefaultRange SetRange(default_range)
 
 
-/// Tune class implements the 'magic' code that makes the setup of a fishtest
-/// tuning session as easy as it can be. Mainly you have just to remove const
-/// qualifiers from the variables you want to tune and flag them for tuning, so
-/// if you have:
-///
-///   const Value myValue[][2] = { { V(100), V(20) }, { V(7), V(78) } };
-///
-/// If you have a my_post_update() function to run after values have been updated,
-/// and a my_range() function to set custom Option's min-max values, then you just
-/// remove the 'const' qualifiers and write somewhere below in the file:
-///
-///   TUNE(SetRange(my_range), myValue, my_post_update);
-///
-/// You can also set the range directly, and restore the default at the end
-///
-///   TUNE(SetRange(-100, 100), myValue, SetDefaultRange);
-///
-/// In case update function is slow and you have many parameters, you can add:
-///
-///   UPDATE_ON_LAST();
-///
-/// And the values update, including post update function call, will be done only
-/// once, after the engine receives the last UCI option, that is the one defined
-/// and created as the last one, so the GUI should send the options in the same
-/// order in which have been defined.
+// Tune class implements the 'magic' code that makes the setup of a fishtest tuning
+// session as easy as it can be. Mainly you have just to remove const qualifiers
+// from the variables you want to tune and flag them for tuning, so if you have:
+//
+//   const Value myValue[][2] = { { V(100), V(20) }, { V(7), V(78) } };
+//
+// If you have a my_post_update() function to run after values have been updated,
+// and a my_range() function to set custom Option's min-max values, then you just
+// remove the 'const' qualifiers and write somewhere below in the file:
+//
+//   TUNE(SetRange(my_range), myValue, my_post_update);
+//
+// You can also set the range directly, and restore the default at the end
+//
+//   TUNE(SetRange(-100, 100), myValue, SetDefaultRange);
+//
+// In case update function is slow and you have many parameters, you can add:
+//
+//   UPDATE_ON_LAST();
+//
+// And the values update, including post update function call, will be done only
+// once, after the engine receives the last UCI option, that is the one defined
+// and created as the last one, so the GUI should send the options in the same
+// order in which have been defined.
 
 class Tune {
 
@@ -151,7 +150,7 @@ public:
   static bool update_on_last;
 };
 
-// Some macro magic :-) we define a dummy int variable that compiler initializes calling Tune::add()
+// Some macro magic :-) we define a dummy int variable that the compiler initializes calling Tune::add()
 #define STRINGIFY(x) #x
 #define UNIQUE2(x, y) x ## y
 #define UNIQUE(x, y) UNIQUE2(x, y) // Two indirection levels to expand __LINE__

--- a/src/types.h
+++ b/src/types.h
@@ -19,22 +19,22 @@
 #ifndef TYPES_H_INCLUDED
 #define TYPES_H_INCLUDED
 
-/// When compiling with provided Makefile (e.g. for Linux and OSX), configuration
-/// is done automatically. To get started type 'make help'.
-///
-/// When Makefile is not used (e.g. with Microsoft Visual Studio) some switches
-/// need to be set manually:
-///
-/// -DNDEBUG      | Disable debugging mode. Always use this for release.
-///
-/// -DNO_PREFETCH | Disable use of prefetch asm-instruction. You may need this to
-///               | run on some very old machines.
-///
-/// -DUSE_POPCNT  | Add runtime support for use of popcnt asm-instruction. Works
-///               | only in 64-bit mode and requires hardware with popcnt support.
-///
-/// -DUSE_PEXT    | Add runtime support for use of pext asm-instruction. Works
-///               | only in 64-bit mode and requires hardware with pext support.
+// When compiling with provided Makefile (e.g. for Linux and OSX), configuration
+// is done automatically. To get started type 'make help'.
+//
+// When Makefile is not used (e.g. with Microsoft Visual Studio) some switches
+// need to be set manually:
+//
+// -DNDEBUG      | Disable debugging mode. Always use this for release.
+//
+// -DNO_PREFETCH | Disable use of prefetch asm-instruction. You may need this to
+//               | run on some very old machines.
+//
+// -DUSE_POPCNT  | Add runtime support for use of popcnt asm-instruction. Works
+//               | only in 64-bit mode and requires hardware with popcnt support.
+//
+// -DUSE_PEXT    | Add runtime support for use of pext asm-instruction. Works
+//               | only in 64-bit mode and requires hardware with pext support.
 
 #include <cassert>
 #include <cstdint>
@@ -46,14 +46,14 @@
 #pragma warning(disable: 4800) // Forcing value to bool 'true' or 'false'
 #endif
 
-/// Predefined macros hell:
-///
-/// __GNUC__                Compiler is GCC, Clang or ICX
-/// __clang__               Compiler is Clang or ICX
-/// __INTEL_LLVM_COMPILER   Compiler is ICX
-/// _MSC_VER                Compiler is MSVC
-/// _WIN32                  Building on Windows (any)
-/// _WIN64                  Building on Windows 64 bit
+// Predefined macros hell:
+//
+// __GNUC__                Compiler is GCC, Clang or ICX
+// __clang__               Compiler is Clang or ICX
+// __INTEL_LLVM_COMPILER   Compiler is ICX
+// _MSC_VER                Compiler is MSVC
+// _WIN32                  Building on Windows (any)
+// _WIN64                  Building on Windows 64 bit
 
 #if defined(__GNUC__ ) && (__GNUC__ < 9 || (__GNUC__ == 9 && __GNUC_MINOR__ <= 2)) && defined(_WIN32) && !defined(__clang__)
 #define ALIGNAS_ON_STACK_VARIABLES_BROKEN
@@ -107,17 +107,17 @@ using Bitboard = uint64_t;
 constexpr int MAX_MOVES = 256;
 constexpr int MAX_PLY   = 246;
 
-/// A move needs 16 bits to be stored
-///
-/// bit  0- 5: destination square (from 0 to 63)
-/// bit  6-11: origin square (from 0 to 63)
-/// bit 12-13: promotion piece type - 2 (from KNIGHT-2 to QUEEN-2)
-/// bit 14-15: special move flag: promotion (1), en passant (2), castling (3)
-/// NOTE: en passant bit is set only when a pawn can be captured
-///
-/// Special cases are MOVE_NONE and MOVE_NULL. We can sneak these in because in
-/// any normal move destination square is always different from origin square
-/// while MOVE_NONE and MOVE_NULL have the same origin and destination square.
+// A move needs 16 bits to be stored
+//
+// bit  0- 5: destination square (from 0 to 63)
+// bit  6-11: origin square (from 0 to 63)
+// bit 12-13: promotion piece type - 2 (from KNIGHT-2 to QUEEN-2)
+// bit 14-15: special move flag: promotion (1), en passant (2), castling (3)
+// NOTE: en passant bit is set only when a pawn can be captured
+//
+// Special cases are MOVE_NONE and MOVE_NULL. We can sneak these in because in
+// any normal move destination square is always different from origin square
+// while MOVE_NONE and MOVE_NULL have the same origin and destination square.
 
 enum Move : int {
   MOVE_NONE,
@@ -291,7 +291,7 @@ ENABLE_INCR_OPERATORS_ON(Rank)
 #undef ENABLE_INCR_OPERATORS_ON
 #undef ENABLE_BASE_OPERATORS_ON
 
-/// Additional operators to add a Direction to a Square
+// Additional operators to add a Direction to a Square
 constexpr Square operator+(Square s, Direction d) { return Square(int(s) + int(d)); }
 constexpr Square operator-(Square s, Direction d) { return Square(int(s) - int(d)); }
 inline Square& operator+=(Square& s, Direction d) { return s = s + d; }
@@ -405,7 +405,7 @@ constexpr Move make(Square from, Square to, PieceType pt = KNIGHT) {
   return Move(T + ((pt - KNIGHT) << 12) + (from << 6) + to);
 }
 
-/// Based on a congruential pseudo-random number generator
+// Based on a congruential pseudo-random number generator
 constexpr Key make_key(uint64_t seed) {
   return seed * 6364136223846793005ULL + 1442695040888963407ULL;
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -233,11 +233,11 @@ namespace {
 } // namespace
 
 
-/// UCI::loop() waits for a command from the stdin, parses it, and then calls the appropriate
-/// function. It also intercepts an end-of-file (EOF) indication from the stdin to ensure a
-/// graceful exit if the GUI dies unexpectedly. When called with some command-line arguments,
-/// like running 'bench', the function returns immediately after the command is executed.
-/// In addition to the UCI ones, some additional debug commands are also supported.
+// UCI::loop() waits for a command from the stdin, parses it, and then calls the appropriate
+// function. It also intercepts an end-of-file (EOF) indication from the stdin to ensure a
+// graceful exit if the GUI dies unexpectedly. When called with some command-line arguments,
+// like running 'bench', the function returns immediately after the command is executed.
+// In addition to the UCI ones, some additional debug commands are also supported.
 
 void UCI::loop(int argc, char* argv[]) {
 
@@ -310,18 +310,18 @@ void UCI::loop(int argc, char* argv[]) {
 }
 
 
-/// Turns a Value to an integer centipawn number,
-/// without treatment of mate and similar special scores.
+// Turns a Value to an integer centipawn number,
+// without treatment of mate and similar special scores.
 int UCI::to_cp(Value v) {
 
   return 100 * v / UCI::NormalizeToPawnValue;
 }
 
-/// UCI::value() converts a Value to a string by adhering to the UCI protocol specification:
-///
-/// cp <x>    The score from the engine's point of view in centipawns.
-/// mate <y>  Mate in 'y' moves (not plies). If the engine is getting mated,
-///           uses negative values for 'y'.
+// UCI::value() converts a Value to a string by adhering to the UCI protocol specification:
+//
+// cp <x>    The score from the engine's point of view in centipawns.
+// mate <y>  Mate in 'y' moves (not plies). If the engine is getting mated,
+//           uses negative values for 'y'.
 
 std::string UCI::value(Value v) {
 
@@ -343,8 +343,8 @@ std::string UCI::value(Value v) {
 }
 
 
-/// UCI::wdl() reports the win-draw-loss (WDL) statistics given an evaluation
-/// and a game ply based on the data gathered for fishtest LTC games.
+// UCI::wdl() reports the win-draw-loss (WDL) statistics given an evaluation
+// and a game ply based on the data gathered for fishtest LTC games.
 
 std::string UCI::wdl(Value v, int ply) {
 
@@ -359,17 +359,17 @@ std::string UCI::wdl(Value v, int ply) {
 }
 
 
-/// UCI::square() converts a Square to a string in algebraic notation (g1, a7, etc.)
+// UCI::square() converts a Square to a string in algebraic notation (g1, a7, etc.)
 
 std::string UCI::square(Square s) {
   return std::string{ char('a' + file_of(s)), char('1' + rank_of(s)) };
 }
 
 
-/// UCI::move() converts a Move to a string in coordinate notation (g1f3, a7a8q).
-/// The only special case is castling where the e1g1 notation is printed in
-/// standard chess mode and in e1h1 notation it is printed in Chess960 mode.
-/// Internally, all castling moves are always encoded as 'king captures rook'.
+// UCI::move() converts a Move to a string in coordinate notation (g1f3, a7a8q).
+// The only special case is castling where the e1g1 notation is printed in
+// standard chess mode and in e1h1 notation it is printed in Chess960 mode.
+// Internally, all castling moves are always encoded as 'king captures rook'.
 
 std::string UCI::move(Move m, bool chess960) {
 
@@ -394,8 +394,8 @@ std::string UCI::move(Move m, bool chess960) {
 }
 
 
-/// UCI::to_move() converts a string representing a move in coordinate notation
-/// (g1f3, a7a8q) to the corresponding legal Move, if any.
+// UCI::to_move() converts a string representing a move in coordinate notation
+// (g1f3, a7a8q) to the corresponding legal Move, if any.
 
 Move UCI::to_move(const Position& pos, std::string& str) {
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -41,15 +41,15 @@ const int NormalizeToPawnValue = 328;
 
 class Option;
 
-/// Define a custom comparator, because the UCI options should be case-insensitive
+// Define a custom comparator, because the UCI options should be case-insensitive
 struct CaseInsensitiveLess {
   bool operator() (const std::string&, const std::string&) const;
 };
 
-/// The options container is defined as a std::map
+// The options container is defined as a std::map
 using OptionsMap = std::map<std::string, Option, CaseInsensitiveLess>;
 
-/// The Option class implements each option as specified by the UCI protocol
+// The Option class implements each option as specified by the UCI protocol
 class Option {
 
   using OnChange = void (*)(const Option&);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -44,7 +44,7 @@ UCI::OptionsMap Options; // Global object
 
 namespace UCI {
 
-/// 'On change' actions, triggered by an option's value change
+// 'On change' actions, triggered by an option's value change
 static void on_clear_hash(const Option&) { Search::clear(); }
 static void on_hash_size(const Option& o) { TT.resize(size_t(o)); }
 static void on_logger(const Option& o) { start_logger(o); }
@@ -52,7 +52,7 @@ static void on_threads(const Option& o) { Threads.set(size_t(o)); }
 static void on_tb_path(const Option& o) { Tablebases::init(o); }
 static void on_eval_file(const Option&) { Eval::NNUE::init(); }
 
-/// Our case insensitive less() function as required by UCI protocol
+// Our case insensitive less() function as required by UCI protocol
 bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const {
 
   return std::lexicographical_compare(s1.begin(), s1.end(), s2.begin(), s2.end(),
@@ -60,7 +60,7 @@ bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const 
 }
 
 
-/// UCI::init() initializes the UCI options to their hard-coded default values
+// UCI::init() initializes the UCI options to their hard-coded default values
 
 void init(OptionsMap& o) {
 
@@ -89,8 +89,8 @@ void init(OptionsMap& o) {
 }
 
 
-/// operator<<() is used to print all the options default values in chronological
-/// insertion order (the idx field) and in the format defined by the UCI protocol.
+// operator<<() is used to print all the options default values in chronological
+// insertion order (the idx field) and in the format defined by the UCI protocol.
 
 std::ostream& operator<<(std::ostream& os, const OptionsMap& om) {
 
@@ -116,7 +116,7 @@ std::ostream& operator<<(std::ostream& os, const OptionsMap& om) {
 }
 
 
-/// Option class constructors and conversion operators
+// Option class constructors and conversion operators
 
 Option::Option(const char* v, OnChange f) : type("string"), min(0), max(0), on_change(f)
 { defaultValue = currentValue = v; }
@@ -150,7 +150,7 @@ bool Option::operator==(const char* s) const {
 }
 
 
-/// operator<<() inits options and assigns idx in the correct printing order
+// operator<<() inits options and assigns idx in the correct printing order
 
 void Option::operator<<(const Option& o) {
 
@@ -161,9 +161,9 @@ void Option::operator<<(const Option& o) {
 }
 
 
-/// operator=() updates currentValue and triggers on_change() action. It's up to
-/// the GUI to check for option's limits, but we could receive the new value
-/// from the user by console window, so let's check the bounds anyway.
+// operator=() updates currentValue and triggers on_change() action. It's up to
+// the GUI to check for option's limits, but we could receive the new value
+// from the user by console window, so let's check the bounds anyway.
 
 Option& Option::operator=(const string& v) {
 


### PR DESCRIPTION
Comments improvement, mainly, I've noticed a mix of comment styles in our chess engine code: double slashes (//) and triple slashes (///). To enhance code consistency and readability, I propose we standardize on double slashes (//) for comments for better consistency and clarity.
Non-Functional change.