### PR TITLE
Update default hash size to 64MB

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -68,7 +68,7 @@ void init(OptionsMap& o) {
 
   o["Debug Log File"]        << Option("", on_logger);
   o["Threads"]               << Option(1, 1, 1024, on_threads);
-  o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
+  o["Hash"]                  << Option(64, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(false);
   o["MultiPV"]               << Option(1, 1, 500);


### PR DESCRIPTION
Our network alone takes about 64MB so it seems to makes sense to bump the default hash to at least a similar value.
bench: 1453057