### PR TITLE
Small speedup for movecount pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -984,7 +984,8 @@ moves_loop: // When in check, search starts here
           && bestValue > VALUE_TB_LOSS_IN_MAX_PLY)
       {
           // Skip quiet moves if movecount exceeds our FutilityMoveCount threshold (~8 Elo)
-          moveCountPruning = moveCount >= futility_move_count(improving, depth);
+          if (!moveCountPruning)
+              moveCountPruning = moveCount >= futility_move_count(improving, depth);
 
           // Reduced depth of the next LMR search
           int lmrDepth = newDepth - r;


### PR DESCRIPTION
In search, when moveCountPruning becomes true, it can never turn false again.

Passed STC https://tests.stockfishchess.org/tests/view/652075ceac57711436728aac
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 136448 W: 34923 L: 34472 D: 67053
Ptnml(0-2): 420, 15094, 36767, 15501, 442

Non functional change