### PR TITLE
Skip futility pruning if ttMove has bad history

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -210,6 +210,7 @@ Steinar Gunderson (sesse)
 Stéphane Nicolet (snicolet)
 Stephen Touset (stouset)
 Syine Mineta (MinetaS)
+Taras Vuk
 Thanar2
 thaspel
 theo77186

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -779,7 +779,10 @@ namespace {
         &&  depth < 9
         &&  eval - futility_margin(depth, cutNode && !ss->ttHit, improving) - (ss-1)->statScore / 306 >= beta
         &&  eval >= beta
-        &&  eval < 24923) // smaller than TB wins
+        &&  eval < 24923 // smaller than TB wins
+        && !(  !ttCapture
+             && ttMove
+             && thisThread->mainHistory[us][from_to(ttMove)] < 989))
         return eval;
 
     // Step 9. Null move search with verification search (~35 Elo)


### PR DESCRIPTION
Skip futility pruning if ttMove is quiet and has bad history.

Passed STC:
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 52416 W: 13465 L: 13128 D: 25823
Ptnml(0-2): 128, 6024, 13604, 6287, 165
https://tests.stockfishchess.org/tests/view/651fadd4ac577114367277bf

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 87348 W: 22234 L: 21818 D: 43296
Ptnml(0-2): 38, 9240, 24698, 9664, 34
https://tests.stockfishchess.org/tests/view/65201932ac57711436728218

bench: 1409152