### PR TITLE
Use more continuation histories.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -141,6 +141,7 @@ void MovePicker::score() {
           m.value =  2 * (*mainHistory)[pos.side_to_move()][from_to(m)];
           m.value += 2 * (*continuationHistory[0])[pc][to];
           m.value +=     (*continuationHistory[1])[pc][to];
+          m.value +=     (*continuationHistory[2])[pc][to] / 4;
           m.value +=     (*continuationHistory[3])[pc][to];
           m.value +=     (*continuationHistory[5])[pc][to];
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -918,7 +918,7 @@ moves_loop: // When in check, search starts here
         return probCutBeta;
 
     const PieceToHistory* contHist[] = { (ss-1)->continuationHistory, (ss-2)->continuationHistory,
-                                          nullptr                   , (ss-4)->continuationHistory,
+                                         (ss-3)->continuationHistory, (ss-4)->continuationHistory,
                                           nullptr                   , (ss-6)->continuationHistory };
 
     Move countermove = prevSq != SQ_NONE ? thisThread->counterMoves[pos.piece_on(prevSq)][prevSq] : MOVE_NONE;
@@ -1511,7 +1511,7 @@ moves_loop: // When in check, search starts here
     }
 
     const PieceToHistory* contHist[] = { (ss-1)->continuationHistory, (ss-2)->continuationHistory,
-                                          nullptr                   , (ss-4)->continuationHistory,
+                                         (ss-3)->continuationHistory, (ss-4)->continuationHistory,
                                           nullptr                   , (ss-6)->continuationHistory };
 
     // Initialize a MovePicker object for the current position, and prepare
@@ -1768,13 +1768,13 @@ moves_loop: // When in check, search starts here
 
   void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
 
-    for (int i : {1, 2, 4, 6})
+    for (int i : {1, 2, 3, 4, 6})
     {
         // Only update the first 2 continuation histories if we are in check
         if (ss->inCheck && i > 2)
             break;
         if (is_ok((ss-i)->currentMove))
-            (*(ss-i)->continuationHistory)[pc][to] << bonus;
+            (*(ss-i)->continuationHistory)[pc][to] << bonus / (1 + 3 * (i == 3));
     }
   }
 


### PR DESCRIPTION
This patch allows stats updates and movepicker bonuses for continuation history 3 plies deep - so counter counter move. 
Updates and movepicker usage are done with 1/4 multiplier compared to other histories. 
Passed STC:
https://tests.stockfishchess.org/tests/view/6528f28d3125598fc7ebb5a3
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 161344 W: 41369 L: 40868 D: 79107
Ptnml(0-2): 535, 18720, 41679, 19185, 553 
Passed LTC:
https://tests.stockfishchess.org/tests/view/652a397a3125598fc7ebd1d6
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 48564 W: 12556 L: 12215 D: 23793
Ptnml(0-2): 25, 5149, 13595, 5486, 27 
bench 1327410