### PR TITLE
Removing the bad history condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -782,8 +782,7 @@ namespace {
         &&  eval >= beta
         &&  eval < 29462 // smaller than TB wins
         && !(  !ttCapture
-             && ttMove
-             && thisThread->mainHistory[us][from_to(ttMove)] < 989))
+             && ttMove))
         return eval;
 
     // Step 9. Null move search with verification search (~35 Elo)


### PR DESCRIPTION
Removing the bad history condition from the skip futility pruning formula.

bench: 1110579

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 142688 W: 36420 L: 36317 D: 69951
Ptnml(0-2): 481, 16653, 36970, 16762, 478
https://tests.stockfishchess.org/tests/view/65270a663125598fc7eb8c67

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 435378 W: 110723 L: 110925 D: 213730
Ptnml(0-2): 278, 47251, 122788, 47139, 233
https://tests.stockfishchess.org/tests/view/6528595f3125598fc7eba8f5
