### PR TITLE
Subtract the margin from the value returned by ProbCut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -896,7 +896,7 @@ namespace {
                 {
                     // Save ProbCut data into transposition table
                     tte->save(posKey, value_to_tt(value, ss->ply), ss->ttPv, BOUND_LOWER, depth - 3, move, ss->staticEval);
-                    return value;
+                    return value - (probCutBeta - beta);
                 }
             }
 


### PR DESCRIPTION
This patch subtracts the margin from the value returned by ProbCut.

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 46112 W: 11940 L: 11610 D: 22562
Ptnml(0-2): 131, 5318, 11842, 5620, 145
https://tests.stockfishchess.org/tests/view/652ea42ade6d262d08d329dd

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 86880 W: 22192 L: 21776 D: 42912
Ptnml(0-2): 43, 9213, 24510, 9633, 41
https://tests.stockfishchess.org/tests/view/652f70ffde6d262d08d33e8d

bench: 1161104