### PR TITLE
Scale down stat bonus

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -51,7 +51,7 @@ public:
     assert(abs(bonus) <= D); // Ensure range is [-D, D]
     static_assert(D <= std::numeric_limits<T>::max(), "D overflows T");
 
-    entry += bonus - entry * abs(bonus) / D;
+    entry += (bonus * D - entry * abs(bonus)) / (D * 5 / 4);
 
     assert(abs(entry) <= D);
   }


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/652eff58de6d262d08d33353
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 88224 W: 22618 L: 22228 D: 43378
Ptnml(0-2): 282, 10177, 22783, 10609, 261 

LTC https://tests.stockfishchess.org/tests/view/652fd13bde6d262d08d3481a
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 143508 W: 36674 L: 36142 D: 70692
Ptnml(0-2): 92, 15240, 40534, 15820, 68 

Reduces the stat bonus by 20%.  Maybe future patches can tune the actual bonus calculations for different histories.

bench: 1248132