### PR TITLE
Simplify futilityBase formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1502,7 +1502,7 @@ moves_loop: // When in check, search starts here
         if (bestValue > alpha)
             alpha = bestValue;
 
-        futilityBase = std::min(ss->staticEval, bestValue) + 200;
+        futilityBase = ss->staticEval + 200;
     }
 
     const PieceToHistory* contHist[] = {(ss-1)->continuationHistory, (ss-2)->continuationHistory};


### PR DESCRIPTION
This patch replaces std::min(ss->staticEval, bestValue) with ss->staticEval in the futilityBase formula.
Original idea by Vizvezdenec: https://tests.stockfishchess.org/tests/view/64ce66795b17f7c21c0d85f3

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 116928 W: 29925 L: 29793 D: 57210
Ptnml(0-2): 399, 13558, 30446, 13634, 427
https://tests.stockfishchess.org/tests/view/653285aade6d262d08d385dd

Passed LTC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 50868 W: 12947 L: 12757 D: 25164
Ptnml(0-2): 30, 5414, 14355, 5606, 29
https://tests.stockfishchess.org/tests/view/65336ffbde6d262d08d39ba0

bench: 1241996