### PR TITLE
Closing the file stream after saving the evaluation data

### DIFF
--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -418,6 +418,7 @@ bool save_eval(const std::optional<std::string>& filename) {
 
     std::ofstream stream(actualFilename, std::ios_base::binary);
     bool          saved = save_eval(stream);
+    stream.close();  // Close the file stream
 
     msg = saved ? "Network saved successfully to " + actualFilename : "Failed to export a net";
 


### PR DESCRIPTION
Closing the file stream after saving the evaluation data to avoid resource leaks.

When we open a file stream (e.g., using std::ofstream), the operating system allocates resources to handle the file. These resources may include file handles, buffers, and other data structures.
If we don't explicitly close the file stream after you're done with it, the file remains open, and its associated resources are not released.

Closing a file stream is a best practice for resource management. It ensures that data is written to the file, and prevents resource exhaustion, data loss, and file-locking issues.

No functional change, bench: 1241996