### PR TITLE
Update 5 search params for pruning at shallow depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -973,7 +973,7 @@ moves_loop:  // When in check, search starts here
             {
                 // Futility pruning for captures (~2 Elo)
                 if (!givesCheck && lmrDepth < 7 && !ss->inCheck
-                    && ss->staticEval + 188 + 206 * lmrDepth + PieceValue[pos.piece_on(to_sq(move))]
+                    && ss->staticEval + 239 + 291 * lmrDepth + PieceValue[pos.piece_on(to_sq(move))]
                            + captureHistory[movedPiece][to_sq(move)]
                                            [type_of(pos.piece_on(to_sq(move)))]
                                / 7
@@ -991,16 +991,16 @@ moves_loop:  // When in check, search starts here
                             + (*contHist[3])[movedPiece][to_sq(move)];
 
                 // Continuation history based pruning (~2 Elo)
-                if (lmrDepth < 6 && history < -3232 * depth)
+                if (lmrDepth < 6 && history < -3498 * depth)
                     continue;
 
                 history += 2 * thisThread->mainHistory[us][from_to(move)];
 
-                lmrDepth += history / 5793;
+                lmrDepth += history / 7815;
                 lmrDepth = std::max(lmrDepth, -2);
 
                 // Futility pruning: parent node (~13 Elo)
-                if (!ss->inCheck && lmrDepth < 13 && ss->staticEval + 115 + 122 * lmrDepth <= alpha)
+                if (!ss->inCheck && lmrDepth < 13 && ss->staticEval + 80 + 122 * lmrDepth <= alpha)
                     continue;
 
                 lmrDepth = std::max(lmrDepth, 0);


### PR DESCRIPTION
Found by spsa tuning at 45+0.45 with:

```c++
int fpcEvalOffset = 188;
int fpcLmrDepthMult = 206;
int histDepthMult = -3232;
int histDenom = 5793;
int fpEvalOffset = 115;
int negSeeDepthMultSq = -27;
TUNE(SetRange(0, 394), fpcEvalOffset);
TUNE(SetRange(0, 412), fpcLmrDepthMult);
TUNE(SetRange(-6464, -1616), histDepthMult);
TUNE(SetRange(2896, 11586), histDenom);
TUNE(SetRange(0, 230), fpEvalOffset);
TUNE(SetRange(-54, 0), negSeeDepthMultSq);
```

Passed STC:
https://tests.stockfishchess.org/tests/view/6535551de746e058e6c0165d
LLR: 2.98 (-2.94,2.94) <0.00,2.00>
Total: 109056 W: 28025 L: 27599 D: 53432
Ptnml(0-2): 357, 12669, 28038, 13119, 345

Passed LTC:
https://tests.stockfishchess.org/tests/view/65364c6ff127f3553505175d
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 61290 W: 15316 L: 14941 D: 31033
Ptnml(0-2): 34, 6849, 16498, 7236, 28

bench 1167412