### PR TITLE
Introduce asymmetric optimism

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -364,14 +364,13 @@ void Thread::search() {
 
             // Reset aspiration window starting size
             Value avg = rootMoves[pvIdx].averageScore;
-            delta     = Value(10) + int(avg) * avg / 17470;
+            delta     = Value(10) + int(avg) * avg / 15335;
             alpha     = std::max(avg - delta, -VALUE_INFINITE);
             beta      = std::min(avg + delta, VALUE_INFINITE);
 
             // Adjust optimism based on root move's averageScore (~4 Elo)
-            int opt       = 113 * avg / (std::abs(avg) + 109);
-            optimism[us]  = Value(opt);
-            optimism[~us] = -optimism[us];
+            optimism[us]  = 103 * (avg + 33) / (std::abs(avg + 34) + 119);
+            optimism[~us] = -116 * (avg + 40) / (std::abs(avg + 12) + 123);
 
             // Start with a small aspiration window and, in the case of a fail
             // high/low, re-search with a bigger window until we don't fail


### PR DESCRIPTION
Introduce asymmetric optimism for both side to move and opponent. Parameter tuning was done with 200k LTC games.

STC: https://tests.stockfishchess.org/tests/view/653cc08fcc309ae8395622b3
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 98336 W: 25074 L: 24661 D: 48601
Ptnml(0-2): 339, 11612, 24890, 11951, 376 

LTC: https://tests.stockfishchess.org/tests/view/653db595cc309ae839563140
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 83244 W: 20760 L: 20339 D: 42145
Ptnml(0-2): 51, 9306, 22498, 9705, 62 

Bench: 1371690