### PR TITLE
Remove redundant operator

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -51,7 +51,6 @@ class StatsEntry {
    public:
     void operator=(const T& v) { entry = v; }
     T*   operator&() { return &entry; }
-    T*   operator->() { return &entry; }
     operator const T&() const { return entry; }
 
     void operator<<(int bonus) {

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -74,7 +74,7 @@ void Thread::clear() {
         for (StatsType c : {NoCaptures, Captures})
             for (auto& to : continuationHistory[inCheck][c])
                 for (auto& h : to)
-                    h->fill(-71);
+                    (&h)->fill(-71);
 }
 
 


### PR DESCRIPTION
We don't need two separate operators returning T*
No functional change
bench: 1371690