### PR TITLE
Prefetch TT entries in probcut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -869,6 +869,9 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
             {
                 assert(pos.capture_stage(move));
 
+                // Prefetch the TT entry for the resulting position
+                prefetch(TT.first_entry(pos.key_after(move)));
+
                 ss->currentMove = move;
                 ss->continuationHistory =
                   &thisThread


### PR DESCRIPTION
Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 101344 W: 25893 L: 25491 D: 49960
Ptnml(0-2): 303, 11350, 26991, 11698, 330
https://tests.stockfishchess.org/tests/view/6540daa6cc309ae83956669b

No functional change