### PR TITLE
Simplifying two formulas by eliminating two multiplication operations

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -772,7 +772,7 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
                 update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                               stat_bonus(depth) * bonus);
                 thisThread->mainHistory[~us][from_to((ss - 1)->currentMove)]
-                  << stat_bonus(depth) * bonus * 57 / 100;
+                  << stat_bonus(depth) * bonus / 2;
             }
             return value;
         }
@@ -1336,7 +1336,7 @@ moves_loop:  // When in check, search starts here
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       stat_bonus(depth) * bonus);
         thisThread->mainHistory[~us][from_to((ss - 1)->currentMove)]
-          << stat_bonus(depth) * bonus * 61 / 100;
+          << stat_bonus(depth) * bonus / 2;
     }
 
     if (PvNode)


### PR DESCRIPTION
Simplifying two formulas by eliminating two multiplication operations.

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 60000 W: 15193 L: 14996 D: 29811
Ptnml(0-2): 199, 7100, 15215, 7277, 209
https://tests.stockfishchess.org/tests/view/653beb69cc309ae83956129d

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 122910 W: 30471 L: 30353 D: 62086
Ptnml(0-2): 68, 13961, 33271, 14095, 60
https://tests.stockfishchess.org/tests/view/653c5848cc309ae839561ae7

bench: 1216779