### PR TITLE
Remove razoring history update.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -764,18 +764,7 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
     {
         value = qsearch<NonPV>(pos, ss, alpha - 1, alpha);
         if (value < alpha)
-        {
-            if (!priorCapture && prevSq != SQ_NONE)
-            {
-                int bonus = (depth > 6) + (PvNode || cutNode) + (value < alpha - 658)
-                          + ((ss - 1)->moveCount > 11);
-                update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
-                                              stat_bonus(depth) * bonus);
-                thisThread->mainHistory[~us][from_to((ss - 1)->currentMove)]
-                  << stat_bonus(depth) * bonus * 57 / 100;
-            }
             return value;
-        }
     }
 
     // Step 8. Futility pruning: child node (~40 Elo)


### PR DESCRIPTION
The recently commit 'Rewarding Quiet Moves that Enable Razoring' add a history update if razoring. But its contains also many tuned values all over the search. Following tests shows that the tuned values and not the added history update is responsible for the elo gain. So remove later.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 29376 W: 7641 L: 7410 D: 14325
Ptnml(0-2): 100, 3411, 7451, 3610, 116
https://tests.stockfishchess.org/tests/view/653c9fe1cc309ae839562070

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 242922 W: 59879 L: 59885 D: 123158
Ptnml(0-2): 129, 27764, 65688, 27744, 136
https://tests.stockfishchess.org/tests/view/653d06cbcc309ae839562735

Bench: 1356706