### PR TITLE
Update pawn history based on static eval difference.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -745,6 +745,8 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
     {
         int bonus = std::clamp(-18 * int((ss - 1)->staticEval + ss->staticEval), -1812, 1812);
         thisThread->mainHistory[~us][from_to((ss - 1)->currentMove)] << bonus;
+        if (type_of(pos.piece_on(prevSq)) != PAWN && type_of((ss - 1)->currentMove) != PROMOTION)
+            thisThread->pawnHistory[pawn_structure(pos)][pos.piece_on(prevSq)][prevSq] << bonus / 4;
     }
 
     // Set up the improving flag, which is true if current static evaluation is


### PR DESCRIPTION
Use the same logic as in main history but with 1/4 multiplier.
Passed STC: 
https://tests.stockfishchess.org/tests/view/653c1282cc309ae8395615bf
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 306624 W: 77811 L: 77094 D: 151719
Ptnml(0-2): 975, 36411, 77830, 37114, 982 
Passed LTC:
https://tests.stockfishchess.org/tests/view/654258e2cc309ae83956818d
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 99150 W: 24681 L: 24228 D: 50241
Ptnml(0-2): 56, 11107, 26792, 11568, 52 
bench 1202750