### PR TITLE
Tweaking the futility pruning formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1009,7 +1009,7 @@ moves_loop:  // When in check, search starts here
                 lmrDepth = std::max(lmrDepth, -1);
 
                 // Futility pruning: parent node (~13 Elo)
-                if (!ss->inCheck && lmrDepth < 13 && ss->staticEval + 77 + 124 * lmrDepth <= alpha)
+                if (!ss->inCheck && lmrDepth < 13 && ss->staticEval + (bestValue < ss->staticEval - 62 ? 123 : 77) + 127 * lmrDepth <= alpha)
                     continue;
 
                 lmrDepth = std::max(lmrDepth, 0);


### PR DESCRIPTION
Huge credit goes also to @candirufish , as the idea was first tried by him, and then tuned by me at multiple phases.

Tweaking the futility pruning formula to be a bit more selective about when pruning is applied.
Adjust the value added to the static eval based on the bestValue relative to ss->staticEval. If bestValue is significantly lower, we add a larger value.

Passed STC:
LLR: 2.98 (-2.94,2.94) <0.00,2.00>
Total: 37120 W: 9590 L: 9266 D: 18264
Ptnml(0-2): 130, 4301, 9385, 4603, 141
https://tests.stockfishchess.org/tests/view/6544cf90136acbc573523247

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 49632 W: 12381 L: 12033 D: 25218
Ptnml(0-2): 30, 5429, 13549, 5779, 29
https://tests.stockfishchess.org/tests/view/65453bc1136acbc573523a3c

bench: 1107118