### PR TITLE
Setting the reduction of move == ttMove to 0

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1142,7 +1142,7 @@ moves_loop:  // When in check, search starts here
 
         // Decrease reduction for first generated move (ttMove)
         else if (move == ttMove)
-            r--;
+            r = 0;
 
         ss->statScore = 2 * thisThread->mainHistory[us][from_to(move)]
                       + (*contHist[0])[movedPiece][to_sq(move)]

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1141,7 +1141,7 @@ moves_loop:  // When in check, search starts here
             r++;
 
         // Set reduction to 0 for first generated move (ttMove)
-        // Nullifyies all previous reduction adjustments to ttMove and leaves only history to do them
+        // Nullifies all previous reduction adjustments to ttMove and leaves only history to do them
         else if (move == ttMove)
             r = 0;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1140,7 +1140,8 @@ moves_loop:  // When in check, search starts here
         if ((ss + 1)->cutoffCnt > 3)
             r++;
 
-        // Decrease reduction for first generated move (ttMove)
+        // Set reduction to 0 for first generated move (ttMove)
+        // Nullifyies all previous reduction adjustments to ttMove and leaves only history to do them
         else if (move == ttMove)
             r = 0;
 


### PR DESCRIPTION
The reduction formula currently decreases by 1 if the move is a TT move. This PR simplifies this by just setting the reduction to 0 instead.

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 83136 W: 21145 L: 20758 D: 41233
Ptnml(0-2): 279, 9772, 21090, 10137, 290
https://tests.stockfishchess.org/tests/view/653c0fbacc309ae839561584

Passed LTC:
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 273150 W: 67987 L: 67171 D: 137992
Ptnml(0-2): 155, 30730, 73966, 31592, 132
https://tests.stockfishchess.org/tests/view/653d9d02cc309ae839562fdf

bench: 1110556