### PR TITLE
Double weight of pawn history for quiet move ordering.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -183,6 +183,7 @@ void MovePicker::score() {
 
             // histories
             m.value = 2 * (*mainHistory)[pos.side_to_move()][from_to(m)];
+            m.value += 2 * pawnHistory[pawn_structure(pos)][pc][to];
             m.value += 2 * (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
             m.value += (*continuationHistory[2])[pc][to] / 4;
@@ -209,8 +210,6 @@ void MovePicker::score() {
                           : pt != PAWN ? bool(to & threatenedByPawn) * 15000
                                        : 0)
                        : 0;
-
-            m.value += pawnHistory[pawn_structure(pos)][pc][to];
         }
 
         else  // Type == EVASIONS
@@ -305,7 +304,7 @@ top:
             endMoves = generate<QUIETS>(pos, cur);
 
             score<QUIETS>();
-            partial_insertion_sort(cur, endMoves, -3000 * depth);
+            partial_insertion_sort(cur, endMoves, -1960 - 3130 * depth);
         }
 
         ++stage;


### PR DESCRIPTION
I measured on my 1000 position bench the average additional added pawn history per depth. This shows on average negative value with even smaller values with increaing depth.

A linear regression against depth get following formula:

-1960 - 130 * depth

For compensation add this to the used sort limit to maintain roughly the same proportion of sorted quiet moves.

Remarks:
1. using no compensation failed here https://tests.stockfishchess.org/tests/view/6547664f136acbc5735265f0
2. using only the compensation failed at LTC:
    passed STC: https://tests.stockfishchess.org/tests/view/65477457136acbc5735266f8
    failed LTC: https://tests.stockfishchess.org/tests/view/65487fc8136acbc573527d1c

STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 98528 W: 25109 L: 24699 D: 48720
Ptnml(0-2): 334, 11586, 25009, 12006, 329
https://tests.stockfishchess.org/tests/view/65475873136acbc5735264f7

LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 69726 W: 17467 L: 17073 D: 35186
Ptnml(0-2): 39, 7814, 18769, 8196, 45
https://tests.stockfishchess.org/tests/view/6547e759136acbc573527071

Bench: 1379422