### PR TITLE
Simplifying the lazy formula in evaluate

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -164,7 +164,7 @@ Value Eval::evaluate(const Position& pos) {
     int   shuffling  = pos.rule50_count();
     int   simpleEval = simple_eval(pos, stm) + (int(pos.key() & 7) - 3);
 
-    bool lazy = abs(simpleEval) >= RookValue + KnightValue + 16 * shuffling * shuffling
+    bool lazy = abs(simpleEval) >= RookValue + KnightValue + shuffling * shuffling
                                      + abs(pos.this_thread()->bestValue)
                                      + abs(pos.this_thread()->rootSimpleEval);
 


### PR DESCRIPTION
Simplifying the lazy formula in evaluate, by removing one multiplication operation.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 44320 W: 11342 L: 11132 D: 21846
Ptnml(0-2): 163, 4947, 11731, 5155, 164
https://tests.stockfishchess.org/tests/view/654ab7f0136acbc57352aba7

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 53268 W: 13292 L: 13102 D: 26874
Ptnml(0-2): 35, 5908, 14556, 6102, 33
https://tests.stockfishchess.org/tests/view/654b6863136acbc57352b9c3

Passed also the test with adj=OFF:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 91776 W: 23436 L: 23276 D: 45064
Ptnml(0-2): 344, 10619, 23818, 10747, 360
https://tests.stockfishchess.org/tests/view/654e31c5136acbc57352f2e8


bench: 1484225