### PR TITLE
Simplify away average score offset params in optimism

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -372,8 +372,8 @@ void Thread::search() {
             beta      = std::min(avg + delta, VALUE_INFINITE);
 
             // Adjust optimism based on root move's averageScore (~4 Elo)
-            optimism[us]  = 103 * (avg + 33) / (std::abs(avg + 34) + 119);
-            optimism[~us] = -116 * (avg + 40) / (std::abs(avg + 12) + 123);
+            optimism[us]  = 103 * avg / (std::abs(avg) + 119);
+            optimism[~us] = -116 * avg / (std::abs(avg) + 123);
 
             // Start with a small aspiration window and, in the case of a fail
             // high/low, re-search with a bigger window until we don't fail


### PR DESCRIPTION
Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/654abf6b136acbc57352ac4b
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 49664 W: 12687 L: 12477 D: 24500
Ptnml(0-2): 138, 5840, 12703, 5976, 175

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/654b638e136acbc57352b961
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 347166 W: 85561 L: 85676 D: 175929
Ptnml(0-2): 206, 39569, 94150, 39450, 208

bench 1257641