### PR TITLE
Introduce recapture extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1100,6 +1100,12 @@ moves_loop:  // When in check, search starts here
             else if (PvNode && move == ttMove && move == ss->killers[0]
                      && (*contHist[0])[movedPiece][to_sq(move)] >= 4194)
                 extension = 1;
+
+            // Recapture extensions (~1 Elo)
+            else if (PvNode && move == ttMove && to_sq(move) == prevSq
+                     && captureHistory[movedPiece][to_sq(move)][type_of(pos.piece_on(to_sq(move)))]
+                          > 4000)
+                extension = 1;
         }
 
         // Add extension to new depth


### PR DESCRIPTION
When in a PV-node this patch extends ttMove if it is a recapture and has a good history.

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 83840 W: 21560 L: 21166 D: 41114
Ptnml(0-2): 343, 9905, 21027, 10305, 340
https://tests.stockfishchess.org/tests/view/654f4b02136acbc5735308ab

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 165318 W: 41068 L: 40476 D: 83774
Ptnml(0-2): 98, 18670, 44517, 19290, 84
https://tests.stockfishchess.org/tests/view/654fde04136acbc5735314e0

bench: 1393911