### PR TITLE
Symmetrize optimism

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -372,8 +372,8 @@ void Thread::search() {
             beta      = std::min(avg + delta, VALUE_INFINITE);
 
             // Adjust optimism based on root move's averageScore (~4 Elo)
-            optimism[us]  = 103 * avg / (std::abs(avg) + 119);
-            optimism[~us] = -116 * avg / (std::abs(avg) + 123);
+            optimism[us]  = 110 * avg / (std::abs(avg) + 121);
+            optimism[~us] = -optimism[us];
 
             // Start with a small aspiration window and, in the case of a fail
             // high/low, re-search with a bigger window until we don't fail


### PR DESCRIPTION
removes some additional parameters,
making the term more logical at the same time.

passed STC:
https://tests.stockfishchess.org/tests/view/6550e896136acbc5735328ed
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 271104 W: 68441 L: 68480 D: 134183
Ptnml(0-2): 827, 32590, 68816, 32433, 886

passed LTC:
https://tests.stockfishchess.org/tests/view/65523858136acbc5735344f7
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 198954 W: 49250 L: 49211 D: 100493
Ptnml(0-2): 93, 22565, 54117, 22614, 88

Bench: 1292164