### PR TITLE
Remove doEvenDeeperSearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1190,12 +1190,9 @@ moves_loop:  // When in check, search starts here
                 // Adjust full-depth search based on LMR results - if the result
                 // was good enough search deeper, if it was bad enough search shallower.
                 const bool doDeeperSearch     = value > (bestValue + 51 + 10 * (newDepth - d));
-                const bool doEvenDeeperSearch = value > alpha + 700 && ss->doubleExtensions <= 6;
                 const bool doShallowerSearch  = value < bestValue + newDepth;
 
-                ss->doubleExtensions = ss->doubleExtensions + doEvenDeeperSearch;
-
-                newDepth += doDeeperSearch - doShallowerSearch + doEvenDeeperSearch;
+                newDepth += doDeeperSearch - doShallowerSearch;
 
                 if (newDepth > d)
                     value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, newDepth, !cutNode);


### PR DESCRIPTION
Remove doEvenDeeperSearch

Passed STC:
LLR: 2.98 (-2.94,2.94) <-1.75,0.25>
Total: 51040 W: 13014 L: 12804 D: 25222
Ptnml(0-2): 166, 6032, 12917, 6236, 169
https://tests.stockfishchess.org/tests/view/65525aa1136acbc573534801

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 165168 W: 40863 L: 40789 D: 83516
Ptnml(0-2): 73, 18783, 44792, 18869, 67
https://tests.stockfishchess.org/tests/view/65535af5136acbc573535c84

bench: 1477007