### PR TITLE
Simplify history update.

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -58,7 +58,7 @@ class StatsEntry {
         assert(abs(bonus) <= D);  // Ensure range is [-D, D]
         static_assert(D <= std::numeric_limits<T>::max(), "D overflows T");
 
-        entry += (bonus * D - entry * abs(bonus)) / (D * 5 / 4);
+        entry += bonus - entry * abs(bonus) / D;
 
         assert(abs(entry) <= D);
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -94,10 +94,10 @@ constexpr int futility_move_count(bool improving, Depth depth) {
 }
 
 // History and stats update bonus, based on depth
-int stat_bonus(Depth d) { return std::min(364 * d - 438, 1501); }
+int stat_bonus(Depth d) { return std::min(291 * d - 350, 1200); }
 
 // History and stats update malus, based on depth
-int stat_malus(Depth d) { return std::min(452 * d - 452, 1478); }
+int stat_malus(Depth d) { return std::min(361 * d - 361, 1182); }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
 Value value_draw(const Thread* thisThread) {
@@ -746,7 +746,7 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
     // Use static evaluation difference to improve quiet move ordering (~4 Elo)
     if (is_ok((ss - 1)->currentMove) && !(ss - 1)->inCheck && !priorCapture)
     {
-        int bonus = std::clamp(-18 * int((ss - 1)->staticEval + ss->staticEval), -1812, 1812);
+        int bonus = std::clamp(-14 * int((ss - 1)->staticEval + ss->staticEval), -1449, 1449);
         thisThread->mainHistory[~us][from_to((ss - 1)->currentMove)] << bonus;
         if (type_of(pos.piece_on(prevSq)) != PAWN && type_of((ss - 1)->currentMove) != PROMOTION)
             thisThread->pawnHistory[pawn_structure(pos)][pos.piece_on(prevSq)][prevSq] << bonus / 4;


### PR DESCRIPTION
Removal of the slowdown factor from the history update formula with corresponding adjustment of the stat bonus used in the search.

Passed STC:
https://tests.stockfishchess.org/tests/view/655e1079136acbc573544744
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 128096 W: 32355 L: 32235 D: 63506
Ptnml(0-2): 466, 15187, 32573, 15405, 417

Passed LTC:
https://tests.stockfishchess.org/tests/view/655f4e60136acbc573546266
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 50652 W: 12653 L: 12459 D: 25540
Ptnml(0-2): 28, 5666, 13751, 5846, 35

Bench: 1303857