### PR TITLE
Simplify move history reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1165,7 +1165,7 @@ moves_loop:  // When in check, search starts here
                       + (*contHist[3])[movedPiece][to_sq(move)] - 3848;
 
         // Decrease/increase reduction for moves with a good/bad history (~25 Elo)
-        r -= ss->statScore / (10216 + 3855 * (depth > 5 && depth < 23));
+        r -= ss->statScore / 14200;
 
         // Step 17. Late moves reduction / extension (LMR, ~117 Elo)
         // We use various heuristics for the sons of a node after the first son has


### PR DESCRIPTION
Recent VLTC search tuning has suggested that the depth limit can be increased by a lot. This patch simplifies away the depth-based bonus from statScore reduction, making the divisor a constant. 

Simplification STC: https://tests.stockfishchess.org/tests/view/656201f5136acbc573549791
LLR: 2.96 (-2.94,2.94) <-1.75,0.25> 
Total: 91520 W: 23130 L: 22967 D: 45423 
Ptnml(0-2): 282, 10947, 23141, 11106, 284

Simplification LTC: https://tests.stockfishchess.org/tests/view/6562b43a136acbc57354a581
LLR: 2.94 (-2.94,2.94) <-1.75,0.25> 
Total: 352902 W: 86796 L: 86917 D: 179189
Ptnml(0-2): 190, 40227, 95741, 40100, 193

Bench: 1543230