### PR TITLE
Simplifying DOD

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1189,7 +1189,7 @@ moves_loop:  // When in check, search starts here
                 // Adjust full-depth search based on LMR results - if the result
                 // was good enough search deeper, if it was bad enough search shallower.
                 const bool doDeeperSearch =
-                  value > (bestValue + 50 + 3 * newDepth);             // (~1 Elo)
+                  value > (bestValue + 50 + 2 * newDepth);             // (~1 Elo)
                 const bool doShallowerSearch = value < bestValue + newDepth;  // (~2 Elo)
 
                 newDepth += doDeeperSearch - doShallowerSearch;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1189,7 +1189,7 @@ moves_loop:  // When in check, search starts here
                 // Adjust full-depth search based on LMR results - if the result
                 // was good enough search deeper, if it was bad enough search shallower.
                 const bool doDeeperSearch =
-                  value > (bestValue + 51 + 10 * (newDepth - d));             // (~1 Elo)
+                  value > (bestValue + 50 + 3 * newDepth);             // (~1 Elo)
                 const bool doShallowerSearch = value < bestValue + newDepth;  // (~2 Elo)
 
                 newDepth += doDeeperSearch - doShallowerSearch;


### PR DESCRIPTION
Removing dependence on d simplifies the doDeeperSearch formula and eliminates a variable that is not necessary in this context.
The change might also come with some small Elo gain

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 37440 W: 9558 L: 9334 D: 18548
Ptnml(0-2): 127, 4439, 9375, 4641, 138
https://tests.stockfishchess.org/tests/view/65647980136acbc57354c9f6

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 113946 W: 27993 L: 27864 D: 58089
Ptnml(0-2): 67, 12975, 30783, 13058, 90
https://tests.stockfishchess.org/tests/view/6564c3f0136acbc57354d126

*P.S: This is the first time I opened a PR without first adding the bench number in my commit, let's see if it works.
If not I might close this one and open a new one.

Bench: 1535946