### PR TITLE
Simplify `perft()`.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -164,7 +164,7 @@ uint64_t perft(Position& pos, Depth depth) {
 
     for (const auto& m : MoveList<LEGAL>(pos))
     {
-        if (Root && depth <= 1)
+        if (depth <= 1)
             cnt = 1, nodes++;
         else
         {


### PR DESCRIPTION
When perft is called on any depth, it recurses with decreasing depth until `depth == 2`, at which point it counts legal moves and returns. This means it can never reach `depth <= 1` unless it's at root and `depth == 1`. (If it's called at depth 1 and `Root == false`, this patch would also stop the function from breaking.)

Not a particularly important simplification as `Root` is a generic parameter anyway, but it's a simplification regardless.

No functional change.