### PR TITLE
Use a simple depth instead of depth + 1

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1688,7 +1688,7 @@ void update_all_stats(const Position& pos,
     PieceType              captured;
 
     int quietMoveBonus = stat_bonus(depth + 1);
-    int quietMoveMalus = stat_malus(depth + 1);
+    int quietMoveMalus = stat_malus(depth);
 
     if (!pos.capture_stage(bestMove))
     {
@@ -1899,9 +1899,9 @@ string UCI::pv(const Position& pos, Depth depth) {
 }
 
 
-// Called in case we have no ponder move
-// before exiting the search, for instance, in case we stop the search during a
-// fail high at root. We try hard to have a ponder move to return to the GUI,
+// Called in case we have no ponder move before exiting the search,
+// for instance, in case we stop the search during a fail high at root.
+// We try hard to have a ponder move to return to the GUI,
 // otherwise in case of 'ponder on' we have nothing to think about.
 bool RootMove::extract_ponder_from_tt(Position& pos) {
 


### PR DESCRIPTION
Use a simple depth instead of depth + 1 in the quietMoveMalus formula.

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 105248 W: 26680 L: 26532 D: 52036
Ptnml(0-2): 409, 12590, 26481, 12732, 412
https://tests.stockfishchess.org/tests/view/65636bf0136acbc57354b662

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 204204 W: 50200 L: 50166 D: 103838
Ptnml(0-2): 123, 23331, 55145, 23395, 108
https://tests.stockfishchess.org/tests/view/6563b5db136acbc57354bcab

bench: 1406183