### PR TITLE
Extend by two if the side to move has only one legal move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1333,7 +1333,7 @@ moves_loop:  // When in check, search starts here
     assert(moveCount || !ss->inCheck || excludedMove || !MoveList<LEGAL>(pos).size());
 
     if (!moveCount)
-        bestValue = excludedMove ? alpha : ss->inCheck ? mated_in(ss->ply) : VALUE_DRAW;
+        bestValue = excludedMove || ss->inCheck ? mated_in(ss->ply) : VALUE_DRAW;
 
     // If there is a move that produces search value greater than alpha we update the stats of searched moves
     else if (bestMove)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1328,7 +1328,7 @@ moves_loop:  // When in check, search starts here
     // Step 21. Check for mate and stalemate
     // All legal moves have been searched and if there are no legal moves, it
     // must be a mate or a stalemate. If we are in a singular extension search then
-    // return a fail low score.
+    // return a mate score to trigger double extension.
 
     assert(moveCount || !ss->inCheck || excludedMove || !MoveList<LEGAL>(pos).size());
 


### PR DESCRIPTION
This patch returns mate score instead of alpha in singular search.

Passed STC:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 56576 W: 14374 L: 14172 D: 28030
Ptnml(0-2): 171, 6646, 14472, 6808, 191
https://tests.stockfishchess.org/tests/view/6564e3ab136acbc57354d443

Passed LTC:
LLR: 3.13 (-2.94,2.94) <-1.75,0.25>
Total: 103782 W: 25524 L: 25370 D: 52888
Ptnml(0-2): 58, 11753, 28118, 11901, 61
https://tests.stockfishchess.org/tests/view/6565e4c8136acbc57354ed23

bench: 1451915