### PR TITLE
Skip LMR for 2nd move at the root only

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1171,7 +1171,7 @@ moves_loop:  // When in check, search starts here
         // We use various heuristics for the sons of a node after the first son has
         // been searched. In general, we would like to reduce them, but there are many
         // cases where we extend a son if it has good chances to be "interesting".
-        if (depth >= 2 && moveCount > 1 + (PvNode && ss->ply <= 1)
+        if (depth >= 2 && moveCount > 1 + rootNode
             && (!ss->ttPv || !capture || (cutNode && (ss - 1)->moveCount > 1)))
         {
             // In general we want to cap the LMR depth search at newDepth, but when


### PR DESCRIPTION
This patch reverts commit by Vizvezdenec: https://github.com/official-stockfish/Stockfish/commit/27139dedac14af400f5b18e2ab50aca3f8cf0e33.

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 301952 W: 76271 L: 76344 D: 149337
Ptnml(0-2): 1053, 36293, 76348, 36238, 1044
https://tests.stockfishchess.org/tests/view/65660b4a136acbc57354f13d

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 25050 W: 6283 L: 6063 D: 12704
Ptnml(0-2): 10, 2756, 6775, 2972, 12
https://tests.stockfishchess.org/tests/view/656738ab136acbc573550e39

bench: 1482524