### PR TITLE
Remove recaptures stage in qsearch

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -112,15 +112,13 @@ MovePicker::MovePicker(const Position&              p,
                        const ButterflyHistory*      mh,
                        const CapturePieceToHistory* cph,
                        const PieceToHistory**       ch,
-                       const PawnHistory*           ph,
-                       Square                       rs) :
+                       const PawnHistory*           ph) :
     pos(p),
     mainHistory(mh),
     captureHistory(cph),
     continuationHistory(ch),
     pawnHistory(ph),
     ttMove(ttm),
-    recaptureSquare(rs),
     depth(d) {
     assert(d <= 0);
 
@@ -340,8 +338,7 @@ top:
         return select<Next>([&]() { return pos.see_ge(*cur, threshold); });
 
     case QCAPTURE :
-        if (select<Next>(
-              [&]() { return depth > DEPTH_QS_RECAPTURES || to_sq(*cur) == recaptureSquare; }))
+        if (select<Next>([]() { return true; }))
             return *(cur - 1);
 
         // If we did not find any move and we do not try checks, we have finished

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -152,8 +152,7 @@ class MovePicker {
                const ButterflyHistory*,
                const CapturePieceToHistory*,
                const PieceToHistory**,
-               const PawnHistory*,
-               Square);
+               const PawnHistory*);
     MovePicker(const Position&, Move, Value, const CapturePieceToHistory*);
     Move next_move(bool skipQuiets = false);
 
@@ -173,7 +172,6 @@ class MovePicker {
     Move                         ttMove;
     ExtMove                      refutations[3], *cur, *endMoves, *endBadCaptures;
     int                          stage;
-    Square                       recaptureSquare;
     Value                        threshold;
     Depth                        depth;
     ExtMove                      moves[MAX_MOVES];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1488,7 +1488,7 @@ Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth) {
     // will be generated.
     Square     prevSq = is_ok((ss - 1)->currentMove) ? to_sq((ss - 1)->currentMove) : SQ_NONE;
     MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory, &thisThread->captureHistory,
-                  contHist, &thisThread->pawnHistory, prevSq);
+                  contHist, &thisThread->pawnHistory);
 
     int quietCheckEvasions = 0;
 

--- a/src/types.h
+++ b/src/types.h
@@ -205,9 +205,8 @@ constexpr Value PieceValue[PIECE_NB] = {
 using Depth = int;
 
 enum : int {
-    DEPTH_QS_CHECKS     = 0,
-    DEPTH_QS_NO_CHECKS  = -1,
-    DEPTH_QS_RECAPTURES = -5,
+    DEPTH_QS_CHECKS    = 0,
+    DEPTH_QS_NO_CHECKS = -1,
 
     DEPTH_NONE = -6,
 


### PR DESCRIPTION
Simplify an old commit github.com/official-stockfish/Stockfish/commit/72760c05c64d1fb2bb71c2ac54acfbeecf513b87. 

Search is not stuck on the test position given r1n1n1b1/1P1P1P1P/1N1N1N2/2RnQrRq/2pKp3/3BNQbQ/k7/4Bq2 w - - 0 1

Passed STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 236160 W: 59475 L: 59475 D: 117210
Ptnml(0-2): 841, 28266, 59816, 28366, 791
https://tests.stockfishchess.org/tests/view/6567050d136acbc573550919

Passed LTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 201690 W: 49630 L: 49593 D: 102467
Ptnml(0-2): 128, 23214, 54122, 23255, 126
https://tests.stockfishchess.org/tests/view/6567d133136acbc573551c78

Bench: 1199035