### PR TITLE
Tweak return value in futility pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -780,7 +780,7 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
              >= beta
         && eval >= beta && eval < 29462  // smaller than TB wins
         && (!ttMove || ttCapture))
-        return eval;
+        return (eval + beta) / 2;
 
     // Step 9. Null move search with verification search (~35 Elo)
     if (!PvNode && (ss - 1)->currentMove != MOVE_NULL && (ss - 1)->statScore < 17257 && eval >= beta


### PR DESCRIPTION
In futility pruning, return the average between eval and beta.

Passed STC:
https://tests.stockfishchess.org/tests/view/65680bb6136acbc5735521d7
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 15200 W: 3926 L: 3642 D: 7632
Ptnml(0-2): 36, 1699, 3867, 1941, 57

Passed LTC:
https://tests.stockfishchess.org/tests/view/656817fc136acbc573552304
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 200376 W: 49700 L: 49036 D: 101640
Ptnml(0-2): 110, 22584, 54137, 23246, 111

Bench: 1119702