### PR TITLE
[RFC] [WIP] Dual net NNUE

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -798,7 +798,7 @@ help:
 	@echo "help                    > Display architecture details"
 	@echo "profile-build           > standard build with profile-guided optimization"
 	@echo "build                   > skip profile-guided optimization"
-	@echo "net                     > Download the default nnue net"
+	@echo "net                     > Download the default nnue nets"
 	@echo "strip                   > Strip executable"
 	@echo "install                 > Install executable"
 	@echo "clean                   > Clean up"
@@ -914,16 +914,7 @@ profileclean:
 	@rm -f stockfish.res
 	@rm -f ./-lstdc++.res
 
-# set up shell variables for the net stuff
-netvariables:
-	$(eval nnuenet := $(shell grep EvalFileDefaultName evaluate.h | grep define | sed 's/.*\(nn-[a-z0-9]\{12\}.nnue\).*/\1/'))
-	$(eval nnuedownloadurl1 := https://tests.stockfishchess.org/api/nn/$(nnuenet))
-	$(eval nnuedownloadurl2 := https://github.com/official-stockfish/networks/raw/master/$(nnuenet))
-	$(eval curl_or_wget := $(shell if hash curl 2>/dev/null; then echo "curl -skL"; elif hash wget 2>/dev/null; then echo "wget -qO-"; fi))
-	$(eval shasum_command := $(shell if hash shasum 2>/dev/null; then echo "shasum -a 256 "; elif hash sha256sum 2>/dev/null; then echo "sha256sum "; fi))
-
-# evaluation network (nnue)
-net: netvariables
+define evaluate_network
 	@echo "Default net: $(nnuenet)"
 	@if [ "x$(curl_or_wget)" = "x" ]; then \
 		echo "Neither curl nor wget is installed. Install one of these tools unless the net has been downloaded manually"; \
@@ -958,7 +949,24 @@ net: netvariables
 		if [ "$(nnuenet)" = "nn-"`$(shasum_command) $(nnuenet) | cut -c1-12`".nnue" ]; then \
 			echo "Network validated"; break; \
 		fi; \
-	fi; \
+	fi;
+endef
+
+# set up shell variables for the net stuff
+define netvariables
+$(eval nnuenet := $(shell grep $(1) evaluate.h | grep define | sed 's/.*\(nn-[a-z0-9]\{12\}.nnue\).*/\1/'))
+$(eval nnuedownloadurl1 := https://tests.stockfishchess.org/api/nn/$(nnuenet))
+$(eval nnuedownloadurl2 := https://github.com/official-stockfish/networks/raw/master/$(nnuenet))
+$(eval curl_or_wget := $(shell if hash curl 2>/dev/null; then echo "curl -skL"; elif hash wget 2>/dev/null; then echo "wget -qO-"; fi))
+$(eval shasum_command := $(shell if hash shasum 2>/dev/null; then echo "shasum -a 256 "; elif hash sha256sum 2>/dev/null; then echo "sha256sum "; fi))
+endef
+
+# evaluation network (nnue)
+net:
+	$(call netvariables, EvalFileDefaultNameBig)
+	$(call evaluate_network)
+	$(call netvariables, EvalFileDefaultNameSmall)
+	$(call evaluate_network)
 
 format:
 	$(CLANG-FORMAT) -i $(SRCS) $(HEADERS) -style=file

--- a/src/Makefile
+++ b/src/Makefile
@@ -914,7 +914,7 @@ profileclean:
 	@rm -f stockfish.res
 	@rm -f ./-lstdc++.res
 
-define evaluate_network
+define fetch_network
 	@echo "Default net: $(nnuenet)"
 	@if [ "x$(curl_or_wget)" = "x" ]; then \
 		echo "Neither curl nor wget is installed. Install one of these tools unless the net has been downloaded manually"; \
@@ -964,9 +964,9 @@ endef
 # evaluation network (nnue)
 net:
 	$(call netvariables, EvalFileDefaultNameBig)
-	$(call evaluate_network)
+	$(call fetch_network)
 	$(call netvariables, EvalFileDefaultNameSmall)
-	$(call evaluate_network)
+	$(call fetch_network)
 
 format:
 	$(CLANG-FORMAT) -i $(SRCS) $(HEADERS) -style=file

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -75,7 +75,8 @@ void NNUE::init() {
 
     for (bool small : {false, true})
     {
-        std::string eval_file = std::string(Options[EvFiles[small]]);
+        std::string eval_file =
+          std::string(small ? EvalFileDefaultNameSmall : Options[EvFiles[small]]);
         if (eval_file.empty())
             eval_file = EvFileNames[small];
 
@@ -129,7 +130,8 @@ void NNUE::verify() {
 
     for (bool small : {false, true})
     {
-        std::string eval_file = std::string(Options[EvFiles[small]]);
+        std::string eval_file =
+          std::string(small ? EvalFileDefaultNameSmall : Options[EvFiles[small]]);
         if (eval_file.empty())
             eval_file = EvFileNames[small];
 
@@ -170,15 +172,12 @@ Value Eval::evaluate(const Position& pos) {
     int   shuffling  = pos.rule50_count();
     int   simpleEval = pos.simple_eval();
 
-    int lazyThresholdSimpleEval = 2300;
-    int lazyThresholdSmallNet   = 1100;
-
-    bool lazy = abs(simpleEval) > lazyThresholdSimpleEval;
+    bool lazy = abs(simpleEval) > 2300;
     if (lazy)
         v = Value(simpleEval);
     else
     {
-        bool smallNet = abs(simpleEval) > lazyThresholdSmallNet;
+        bool smallNet = abs(simpleEval) > 1100;
 
         int nnueComplexity;
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -31,6 +31,7 @@
 #include "incbin/incbin.h"
 #include "misc.h"
 #include "nnue/evaluate_nnue.h"
+#include "nnue/nnue_architecture.h"
 #include "position.h"
 #include "thread.h"
 #include "types.h"

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -73,12 +73,12 @@ const std::string EvFileNames[2]         = {EvalFileDefaultNameBig, EvalFileDefa
 // variable to have the engine search in a special directory in their distro.
 void NNUE::init() {
 
-    for (bool small : {false, true})
+    for (NetSize netSize : {Big, Small})
     {
         std::string eval_file =
-          std::string(small ? EvalFileDefaultNameSmall : Options[EvFiles[small]]);
+          std::string(netSize == Small ? EvalFileDefaultNameSmall : Options[EvFiles[netSize]]);
         if (eval_file.empty())
-            eval_file = EvFileNames[small];
+            eval_file = EvFileNames[netSize];
 
 #if defined(DEFAULT_NNUE_DIRECTORY)
         std::vector<std::string> dirs = {"<internal>", "", CommandLine::binaryDirectory,
@@ -89,16 +89,16 @@ void NNUE::init() {
 
         for (const std::string& directory : dirs)
         {
-            if (currentEvalFileName[small] != eval_file)
+            if (currentEvalFileName[netSize] != eval_file)
             {
                 if (directory != "<internal>")
                 {
                     std::ifstream stream(directory + eval_file, std::ios::binary);
-                    if (NNUE::load_eval(eval_file, stream, small))
-                        currentEvalFileName[small] = eval_file;
+                    if (NNUE::load_eval(eval_file, stream, netSize))
+                        currentEvalFileName[netSize] = eval_file;
                 }
 
-                if (directory == "<internal>" && eval_file == EvFileNames[small])
+                if (directory == "<internal>" && eval_file == EvFileNames[netSize])
                 {
                     // C++ way to prepare a buffer for a memory stream
                     class MemoryBuffer: public std::basic_streambuf<char> {
@@ -111,14 +111,14 @@ void NNUE::init() {
 
                     MemoryBuffer buffer(
                       const_cast<char*>(reinterpret_cast<const char*>(
-                        small ? gEmbeddedNNUESmallData : gEmbeddedNNUEBigData)),
-                      size_t(small ? gEmbeddedNNUESmallSize : gEmbeddedNNUEBigSize));
+                        netSize == Small ? gEmbeddedNNUESmallData : gEmbeddedNNUEBigData)),
+                      size_t(netSize == Small ? gEmbeddedNNUESmallSize : gEmbeddedNNUEBigSize));
                     (void) gEmbeddedNNUEBigEnd;  // Silence warning on unused variable
                     (void) gEmbeddedNNUESmallEnd;
 
                     std::istream stream(&buffer);
-                    if (NNUE::load_eval(eval_file, stream, small))
-                        currentEvalFileName[small] = eval_file;
+                    if (NNUE::load_eval(eval_file, stream, netSize))
+                        currentEvalFileName[netSize] = eval_file;
                 }
             }
         }
@@ -128,14 +128,14 @@ void NNUE::init() {
 // Verifies that the last net used was loaded successfully
 void NNUE::verify() {
 
-    for (bool small : {false, true})
+    for (NetSize netSize : {Big, Small})
     {
         std::string eval_file =
-          std::string(small ? EvalFileDefaultNameSmall : Options[EvFiles[small]]);
+          std::string(netSize == Small ? EvalFileDefaultNameSmall : Options[EvFiles[netSize]]);
         if (eval_file.empty())
-            eval_file = EvFileNames[small];
+            eval_file = EvFileNames[netSize];
 
-        if (currentEvalFileName[small] != eval_file)
+        if (currentEvalFileName[netSize] != eval_file)
         {
             std::string msg1 =
               "Network evaluation parameters compatible with the engine must be available.";
@@ -144,7 +144,7 @@ void NNUE::verify() {
                                "including the directory name, to the network file.";
             std::string msg4 = "The default net can be downloaded from: "
                                "https://tests.stockfishchess.org/api/nn/"
-                             + std::string(EvFileNames[small]);
+                             + std::string(EvFileNames[netSize]);
             std::string msg5 = "The engine will be terminated now.";
 
             sync_cout << "info string ERROR: " << msg1 << sync_endl;
@@ -161,6 +161,15 @@ void NNUE::verify() {
 }
 }
 
+// Returns a static, purely materialistic evaluation of the position from
+// the point of view of the given color. It can be divided by PawnValue to get
+// an approximation of the material advantage on the board in terms of pawns.
+Value Eval::simple_eval(const Position& pos, Color c) {
+    return PawnValue * (pos.count<PAWN>(c) - pos.count<PAWN>(~c))
+         + (pos.non_pawn_material(c) - pos.non_pawn_material(~c));
+}
+
+
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
 // of the position from the point of view of the side to move.
 Value Eval::evaluate(const Position& pos) {
@@ -170,7 +179,7 @@ Value Eval::evaluate(const Position& pos) {
     Value v;
     Color stm        = pos.side_to_move();
     int   shuffling  = pos.rule50_count();
-    int   simpleEval = pos.simple_eval();
+    int   simpleEval = simple_eval(pos, stm);
 
     bool lazy = abs(simpleEval) > 2300;
     if (lazy)
@@ -181,8 +190,8 @@ Value Eval::evaluate(const Position& pos) {
 
         int nnueComplexity;
 
-        Value nnue = smallNet ? NNUE::evaluate<true>(pos, true, &nnueComplexity)
-                              : NNUE::evaluate<false>(pos, true, &nnueComplexity);
+        Value nnue = smallNet ? NNUE::evaluate<NNUE::Small>(pos, true, &nnueComplexity)
+                              : NNUE::evaluate<NNUE::Big>(pos, true, &nnueComplexity);
 
         Value optimism = pos.this_thread()->optimism[stm];
 
@@ -225,7 +234,7 @@ std::string Eval::trace(Position& pos) {
     ss << std::showpoint << std::showpos << std::fixed << std::setprecision(2) << std::setw(15);
 
     Value v;
-    v = NNUE::evaluate<false>(pos, false);
+    v = NNUE::evaluate<NNUE::Big>(pos, false);
     v = pos.side_to_move() == WHITE ? v : -v;
     ss << "NNUE evaluation        " << 0.01 * UCI::to_cp(v) << " (white side)\n";
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -21,25 +21,24 @@
 
 #include <string>
 
-#include "types.h"
-
 namespace Stockfish {
 
 class Position;
+enum Value : int;
 
 namespace Eval {
 
 std::string trace(Position& pos);
 
-Value simple_eval(const Position& pos, Color c);
 Value evaluate(const Position& pos);
 
-extern std::string currentEvalFileName;
+extern std::string currentEvalFileName[2];
 
 // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro, as it is used in the Makefile.
-#define EvalFileDefaultName "nn-0000000000a0.nnue"
+#define EvalFileDefaultNameBig "nn-0000000000a0.nnue"
+#define EvalFileDefaultNameSmall "nn-c01dc0ffeede.nnue"
 
 namespace NNUE {
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -21,15 +21,17 @@
 
 #include <string>
 
+#include "types.h"
+
 namespace Stockfish {
 
 class Position;
-enum Value : int;
 
 namespace Eval {
 
 std::string trace(Position& pos);
 
+Value simple_eval(const Position& pos, Color c);
 Value evaluate(const Position& pos);
 
 extern std::string currentEvalFileName[2];

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -93,9 +93,9 @@ bool write_parameters(std::ostream& stream, const T& reference) {
 
 
 // Initialize the evaluation function parameters
-static void initialize(bool small) {
+static void initialize(NetSize netSize) {
 
-    if (small)
+    if (netSize == Small)
     {
         Detail::initialize(featureTransformerSmall);
         for (std::size_t i = 0; i < LayerStacks; ++i)
@@ -133,41 +133,41 @@ static bool write_header(std::ostream& stream, std::uint32_t hashValue, const st
 }
 
 // Read network parameters
-static bool read_parameters(std::istream& stream, bool small) {
+static bool read_parameters(std::istream& stream, NetSize netSize) {
 
     std::uint32_t hashValue;
-    if (!read_header(stream, &hashValue, &netDescription[small]))
+    if (!read_header(stream, &hashValue, &netDescription[netSize]))
         return false;
-    if (hashValue != HashValue[small])
+    if (hashValue != HashValue[netSize])
         return false;
-    if (!small && !Detail::read_parameters(stream, *featureTransformerBig))
+    if (netSize == Big && !Detail::read_parameters(stream, *featureTransformerBig))
         return false;
-    if (small && !Detail::read_parameters(stream, *featureTransformerSmall))
+    if (netSize == Small && !Detail::read_parameters(stream, *featureTransformerSmall))
         return false;
     for (std::size_t i = 0; i < LayerStacks; ++i)
     {
-        if (!small && !Detail::read_parameters(stream, *(networkBig[i])))
+        if (netSize == Big && !Detail::read_parameters(stream, *(networkBig[i])))
             return false;
-        if (small && !Detail::read_parameters(stream, *(networkSmall[i])))
+        if (netSize == Small && !Detail::read_parameters(stream, *(networkSmall[i])))
             return false;
     }
     return stream && stream.peek() == std::ios::traits_type::eof();
 }
 
 // Write network parameters
-static bool write_parameters(std::ostream& stream, bool small) {
+static bool write_parameters(std::ostream& stream, NetSize netSize) {
 
-    if (!write_header(stream, HashValue[small], netDescription[small]))
+    if (!write_header(stream, HashValue[netSize], netDescription[netSize]))
         return false;
-    if (!small && !Detail::write_parameters(stream, *featureTransformerBig))
+    if (netSize == Big && !Detail::write_parameters(stream, *featureTransformerBig))
         return false;
-    if (small && !Detail::write_parameters(stream, *featureTransformerSmall))
+    if (netSize == Small && !Detail::write_parameters(stream, *featureTransformerSmall))
         return false;
     for (std::size_t i = 0; i < LayerStacks; ++i)
     {
-        if (!small && !Detail::write_parameters(stream, *(networkBig[i])))
+        if (netSize == Big && !Detail::write_parameters(stream, *(networkBig[i])))
             return false;
-        if (small && !Detail::write_parameters(stream, *(networkSmall[i])))
+        if (netSize == Small && !Detail::write_parameters(stream, *(networkSmall[i])))
             return false;
     }
     return bool(stream);
@@ -175,7 +175,7 @@ static bool write_parameters(std::ostream& stream, bool small) {
 
 void hint_common_parent_position(const Position& pos) {
 
-    int simpleEval = pos.simple_eval();
+    int simpleEval = simple_eval(pos, pos.side_to_move());
     if (abs(simpleEval) > 1100)
         featureTransformerSmall->hint_common_access(pos);
     else
@@ -183,7 +183,7 @@ void hint_common_parent_position(const Position& pos) {
 }
 
 // Evaluation function. Perform differential calculation.
-template<bool Small>
+template<NetSize Net_Size>
 Value evaluate(const Position& pos, bool adjusted, int* complexity) {
 
     // We manually align the arrays on the stack because with gcc < 9.3
@@ -202,7 +202,7 @@ Value evaluate(const Position& pos, bool adjusted, int* complexity) {
 #else
 
     alignas(alignment) TransformedFeatureType
-      transformedFeatures[FeatureTransformer < Small
+      transformedFeatures[FeatureTransformer < Net_Size == Small
                             ? TransformedFeatureDimensionsSmall
                             : TransformedFeatureDimensionsBig > ::BufferSize];
 #endif
@@ -210,10 +210,10 @@ Value evaluate(const Position& pos, bool adjusted, int* complexity) {
     ASSERT_ALIGNED(transformedFeatures, alignment);
 
     const int  bucket = (pos.count<ALL_PIECES>() - 1) / 4;
-    const auto psqt   = Small ? featureTransformerSmall->transform(pos, transformedFeatures, bucket)
-                              : featureTransformerBig->transform(pos, transformedFeatures, bucket);
-    const auto positional = Small ? networkSmall[bucket]->propagate(transformedFeatures)
-                                  : networkBig[bucket]->propagate(transformedFeatures);
+    const auto psqt   = Net_Size == Small ? featureTransformerSmall->transform(pos, transformedFeatures, bucket)
+                                          : featureTransformerBig->transform(pos, transformedFeatures, bucket);
+    const auto positional = Net_Size == Small ? networkSmall[bucket]->propagate(transformedFeatures)
+                                              : networkBig[bucket]->propagate(transformedFeatures);
 
     if (complexity)
         *complexity = abs(psqt - positional) / OutputScale;
@@ -226,8 +226,8 @@ Value evaluate(const Position& pos, bool adjusted, int* complexity) {
         return static_cast<Value>((psqt + positional) / OutputScale);
 }
 
-template Value evaluate<false>(const Position& pos, bool adjusted, int* complexity);
-template Value evaluate<true>(const Position& pos, bool adjusted, int* complexity);
+template Value evaluate<Big>(const Position& pos, bool adjusted, int* complexity);
+template Value evaluate<Small>(const Position& pos, bool adjusted, int* complexity);
 
 struct NnueEvalTrace {
     static_assert(LayerStacks == PSQTBuckets);
@@ -350,7 +350,7 @@ std::string trace(Position& pos) {
 
     // We estimate the value of each piece by doing a differential evaluation from
     // the current base eval, simulating the removal of the piece from its square.
-    Value base = evaluate<false>(pos);
+    Value base = evaluate<NNUE::Big>(pos);
     base       = pos.side_to_move() == WHITE ? base : -base;
 
     for (File f = FILE_A; f <= FILE_H; ++f)
@@ -368,7 +368,7 @@ std::string trace(Position& pos) {
                 st->accumulatorBig.computed[WHITE] = false;
                 st->accumulatorBig.computed[BLACK] = false;
 
-                Value eval = evaluate<false>(pos);
+                Value eval = evaluate<NNUE::Big>(pos);
                 eval       = pos.side_to_move() == WHITE ? eval : -eval;
                 v          = base - eval;
 
@@ -419,24 +419,24 @@ std::string trace(Position& pos) {
 
 
 // Load eval, from a file stream or a memory stream
-bool load_eval(const std::string name, std::istream& stream, bool small) {
+bool load_eval(const std::string name, std::istream& stream, NetSize netSize) {
 
-    initialize(small);
-    fileName[small] = name;
-    return read_parameters(stream, small);
+    initialize(netSize);
+    fileName[netSize] = name;
+    return read_parameters(stream, netSize);
 }
 
 // Save eval, to a file stream or a memory stream
-bool save_eval(std::ostream& stream, bool small) {
+bool save_eval(std::ostream& stream, NetSize netSize) {
 
-    if (fileName[small].empty())
+    if (fileName[netSize].empty())
         return false;
 
-    return write_parameters(stream, small);
+    return write_parameters(stream, netSize);
 }
 
 // Save eval, to a file given by its name
-bool save_eval(const std::optional<std::string>& filename, bool small) {
+bool save_eval(const std::optional<std::string>& filename, NetSize netSize) {
 
     std::string actualFilename;
     std::string msg;
@@ -445,8 +445,8 @@ bool save_eval(const std::optional<std::string>& filename, bool small) {
         actualFilename = filename.value();
     else
     {
-        if (currentEvalFileName[small]
-            != (small ? EvalFileDefaultNameSmall : EvalFileDefaultNameBig))
+        if (currentEvalFileName[netSize]
+            != (netSize == Small ? EvalFileDefaultNameSmall : EvalFileDefaultNameBig))
         {
             msg = "Failed to export a net. "
                   "A non-embedded net can only be saved if the filename is specified";
@@ -454,11 +454,11 @@ bool save_eval(const std::optional<std::string>& filename, bool small) {
             sync_cout << msg << sync_endl;
             return false;
         }
-        actualFilename = (small ? EvalFileDefaultNameSmall : EvalFileDefaultNameBig);
+        actualFilename = (netSize == Small ? EvalFileDefaultNameSmall : EvalFileDefaultNameBig);
     }
 
     std::ofstream stream(actualFilename, std::ios_base::binary);
-    bool          saved = save_eval(stream, small);
+    bool          saved = save_eval(stream, netSize);
 
     msg = saved ? "Network saved successfully to " + actualFilename : "Failed to export a net";
 

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -39,9 +39,11 @@ enum Value : int;
 namespace Stockfish::Eval::NNUE {
 
 // Hash value of evaluation function structure
-constexpr std::uint32_t HashValue =
-  FeatureTransformer::get_hash_value() ^ Network::get_hash_value();
-
+constexpr std::uint32_t HashValue[2] = {
+  FeatureTransformer<TransformedFeatureDimensionsBig>::get_hash_value()
+    ^ Network<TransformedFeatureDimensionsBig, L2Big, L3Big>::get_hash_value(),
+  FeatureTransformer<TransformedFeatureDimensionsSmall>::get_hash_value()
+    ^ Network<TransformedFeatureDimensionsSmall, L2Small, L3Small>::get_hash_value()};
 
 // Deleter for automating release of memory area
 template<typename T>
@@ -67,12 +69,13 @@ template<typename T>
 using LargePagePtr = std::unique_ptr<T, LargePageDeleter<T>>;
 
 std::string trace(Position& pos);
-Value       evaluate(const Position& pos, bool adjusted = false, int* complexity = nullptr);
-void        hint_common_parent_position(const Position& pos);
+template<bool Small>
+Value evaluate(const Position& pos, bool adjusted = false, int* complexity = nullptr);
+void  hint_common_parent_position(const Position& pos);
 
-bool load_eval(std::string name, std::istream& stream);
-bool save_eval(std::ostream& stream);
-bool save_eval(const std::optional<std::string>& filename);
+bool load_eval(const std::string name, std::istream& stream, bool small);
+bool save_eval(std::ostream& stream, bool small);
+bool save_eval(const std::optional<std::string>& filename, bool small);
 
 }  // namespace Stockfish::Eval::NNUE
 

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -38,16 +38,11 @@ enum Value : int;
 
 namespace Stockfish::Eval::NNUE {
 
-enum NetSize {
-    Big,
-    Small
-};
-
 // Hash value of evaluation function structure
 constexpr std::uint32_t HashValue[2] = {
-  FeatureTransformer<TransformedFeatureDimensionsBig>::get_hash_value()
+  FeatureTransformer<TransformedFeatureDimensionsBig, nullptr>::get_hash_value()
     ^ Network<TransformedFeatureDimensionsBig, L2Big, L3Big>::get_hash_value(),
-  FeatureTransformer<TransformedFeatureDimensionsSmall>::get_hash_value()
+  FeatureTransformer<TransformedFeatureDimensionsSmall, nullptr>::get_hash_value()
     ^ Network<TransformedFeatureDimensionsSmall, L2Small, L3Small>::get_hash_value()};
 
 // Deleter for automating release of memory area

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -38,6 +38,11 @@ enum Value : int;
 
 namespace Stockfish::Eval::NNUE {
 
+enum NetSize {
+    Big,
+    Small
+};
+
 // Hash value of evaluation function structure
 constexpr std::uint32_t HashValue[2] = {
   FeatureTransformer<TransformedFeatureDimensionsBig>::get_hash_value()
@@ -69,13 +74,13 @@ template<typename T>
 using LargePagePtr = std::unique_ptr<T, LargePageDeleter<T>>;
 
 std::string trace(Position& pos);
-template<bool Small>
+template<NetSize Net_Size>
 Value evaluate(const Position& pos, bool adjusted = false, int* complexity = nullptr);
 void  hint_common_parent_position(const Position& pos);
 
-bool load_eval(const std::string name, std::istream& stream, bool small);
-bool save_eval(std::ostream& stream, bool small);
-bool save_eval(const std::optional<std::string>& filename, bool small);
+bool load_eval(const std::string name, std::istream& stream, NetSize netSize);
+bool save_eval(std::ostream& stream, NetSize netSize);
+bool save_eval(const std::optional<std::string>& filename, NetSize netSize);
 
 }  // namespace Stockfish::Eval::NNUE
 

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -29,8 +29,10 @@
 namespace Stockfish::Eval::NNUE {
 
 // Class that holds the result of affine transformation of input features
+template<bool Small>
 struct alignas(CacheLineSize) Accumulator {
-    std::int16_t accumulation[2][TransformedFeatureDimensions];
+    std::int16_t
+      accumulation[2][Small ? TransformedFeatureDimensionsSmall : TransformedFeatureDimensionsBig];
     std::int32_t psqtAccumulation[2][PSQTBuckets];
     bool         computed[2];
 };

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -29,10 +29,9 @@
 namespace Stockfish::Eval::NNUE {
 
 // Class that holds the result of affine transformation of input features
-template<bool Small>
+template<IndexType Size>
 struct alignas(CacheLineSize) Accumulator {
-    std::int16_t
-      accumulation[2][Small ? TransformedFeatureDimensionsSmall : TransformedFeatureDimensionsBig];
+    std::int16_t accumulation[2][Size];
     std::int32_t psqtAccumulation[2][PSQTBuckets];
     bool         computed[2];
 };

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -38,13 +38,22 @@ namespace Stockfish::Eval::NNUE {
 using FeatureSet = Features::HalfKAv2_hm;
 
 // Number of input feature dimensions after conversion
-constexpr IndexType TransformedFeatureDimensions = 2560;
-constexpr IndexType PSQTBuckets                  = 8;
-constexpr IndexType LayerStacks                  = 8;
+constexpr IndexType TransformedFeatureDimensionsBig = 2560;
+constexpr int       L2Big                           = 15;
+constexpr int       L3Big                           = 32;
 
+constexpr IndexType TransformedFeatureDimensionsSmall = 128;
+constexpr int       L2Small                           = 15;
+constexpr int       L3Small                           = 32;
+
+constexpr IndexType PSQTBuckets = 8;
+constexpr IndexType LayerStacks = 8;
+
+template<IndexType L1, int L2, int L3>
 struct Network {
-    static constexpr int FC_0_OUTPUTS = 15;
-    static constexpr int FC_1_OUTPUTS = 32;
+    static constexpr IndexType TransformedFeatureDimensions = L1;
+    static constexpr int       FC_0_OUTPUTS                 = L2;
+    static constexpr int       FC_1_OUTPUTS                 = L3;
 
     Layers::AffineTransformSparseInput<TransformedFeatureDimensions, FC_0_OUTPUTS + 1> fc_0;
     Layers::SqrClippedReLU<FC_0_OUTPUTS + 1>                                           ac_sqr_0;
@@ -84,13 +93,13 @@ struct Network {
 
     std::int32_t propagate(const TransformedFeatureType* transformedFeatures) {
         struct alignas(CacheLineSize) Buffer {
-            alignas(CacheLineSize) decltype(fc_0)::OutputBuffer fc_0_out;
-            alignas(CacheLineSize) decltype(ac_sqr_0)::OutputType
+            alignas(CacheLineSize) typename decltype(fc_0)::OutputBuffer fc_0_out;
+            alignas(CacheLineSize) typename decltype(ac_sqr_0)::OutputType
               ac_sqr_0_out[ceil_to_multiple<IndexType>(FC_0_OUTPUTS * 2, 32)];
-            alignas(CacheLineSize) decltype(ac_0)::OutputBuffer ac_0_out;
-            alignas(CacheLineSize) decltype(fc_1)::OutputBuffer fc_1_out;
-            alignas(CacheLineSize) decltype(ac_1)::OutputBuffer ac_1_out;
-            alignas(CacheLineSize) decltype(fc_2)::OutputBuffer fc_2_out;
+            alignas(CacheLineSize) typename decltype(ac_0)::OutputBuffer ac_0_out;
+            alignas(CacheLineSize) typename decltype(fc_1)::OutputBuffer fc_1_out;
+            alignas(CacheLineSize) typename decltype(ac_1)::OutputBuffer ac_1_out;
+            alignas(CacheLineSize) typename decltype(fc_2)::OutputBuffer fc_2_out;
 
             Buffer() { std::memset(this, 0, sizeof(*this)); }
         };
@@ -108,7 +117,7 @@ struct Network {
         ac_sqr_0.propagate(buffer.fc_0_out, buffer.ac_sqr_0_out);
         ac_0.propagate(buffer.fc_0_out, buffer.ac_0_out);
         std::memcpy(buffer.ac_sqr_0_out + FC_0_OUTPUTS, buffer.ac_0_out,
-                    FC_0_OUTPUTS * sizeof(decltype(ac_0)::OutputType));
+                    FC_0_OUTPUTS * sizeof(typename decltype(ac_0)::OutputType));
         fc_1.propagate(buffer.ac_sqr_0_out, buffer.fc_1_out);
         ac_1.propagate(buffer.fc_1_out, buffer.ac_1_out);
         fc_2.propagate(buffer.ac_1_out, buffer.fc_2_out);

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -37,6 +37,11 @@ namespace Stockfish::Eval::NNUE {
 // Input features used in evaluation function
 using FeatureSet = Features::HalfKAv2_hm;
 
+enum NetSize {
+    Big,
+    Small
+};
+
 // Number of input feature dimensions after conversion
 constexpr IndexType TransformedFeatureDimensionsBig = 2560;
 constexpr int       L2Big                           = 15;

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -186,11 +186,6 @@ static constexpr int BestRegisterCount() {
 
     return 1;
 }
-
-static constexpr int NumRegs =
-  BestRegisterCount<vec_t, WeightType, TransformedFeatureDimensions, NumRegistersSIMD>();
-static constexpr int NumPsqtRegs =
-  BestRegisterCount<psqt_vec_t, PSQTWeightType, PSQTBuckets, NumRegistersSIMD>();
     #if defined(__GNUC__)
         #pragma GCC diagnostic pop
     #endif
@@ -198,13 +193,21 @@ static constexpr int NumPsqtRegs =
 
 
 // Input feature converter
+template<IndexType TransformedFeatureDimensions>
 class FeatureTransformer {
 
    private:
+    static constexpr bool Small = TransformedFeatureDimensions == TransformedFeatureDimensionsSmall;
+
     // Number of output dimensions for one side
     static constexpr IndexType HalfDimensions = TransformedFeatureDimensions;
 
 #ifdef VECTOR
+    static constexpr int NumRegs =
+      BestRegisterCount<vec_t, WeightType, TransformedFeatureDimensions, NumRegistersSIMD>();
+    static constexpr int NumPsqtRegs =
+      BestRegisterCount<psqt_vec_t, PSQTWeightType, PSQTBuckets, NumRegistersSIMD>();
+
     static constexpr IndexType TileHeight     = NumRegs * sizeof(vec_t) / 2;
     static constexpr IndexType PsqtTileHeight = NumPsqtRegs * sizeof(psqt_vec_t) / 4;
     static_assert(HalfDimensions % TileHeight == 0, "TileHeight must divide HalfDimensions");
@@ -247,14 +250,22 @@ class FeatureTransformer {
         return !stream.fail();
     }
 
+    // Cast a pointer to a 2 dimensional array of width D
+    template<int D, typename T>
+    static constexpr T (*cast_2D(T* pt))[D] {
+        return (T(*)[D]) pt;
+    }
+
     // Convert input features
     std::int32_t transform(const Position& pos, OutputType* output, int bucket) const {
         update_accumulator<WHITE>(pos);
         update_accumulator<BLACK>(pos);
 
-        const Color perspectives[2]  = {pos.side_to_move(), ~pos.side_to_move()};
-        const auto& accumulation     = pos.state()->accumulator.accumulation;
-        const auto& psqtAccumulation = pos.state()->accumulator.psqtAccumulation;
+        const Color perspectives[2] = {pos.side_to_move(), ~pos.side_to_move()};
+        const auto& accumulation =
+          cast_2D<TransformedFeatureDimensions>(pos.state()->template accumulation<Small>());
+        const auto& psqtAccumulation =
+          cast_2D<PSQTBuckets>(pos.state()->template psqt_accumulation<Small>());
 
         const auto psqt =
           (psqtAccumulation[perspectives[0]][bucket] - psqtAccumulation[perspectives[1]][bucket])
@@ -323,7 +334,7 @@ class FeatureTransformer {
         // of the estimated gain in terms of features to be added/subtracted.
         StateInfo *st = pos.state(), *next = nullptr;
         int        gain = FeatureSet::refresh_cost(pos);
-        while (st->previous && !st->accumulator.computed[Perspective])
+        while (st->previous && !st->template computed<Small>()[Perspective])
         {
             // This governs when a full feature refresh is needed and how many
             // updates are better than just one full refresh.
@@ -381,7 +392,7 @@ class FeatureTransformer {
 
             for (; i >= 0; --i)
             {
-                states_to_update[i]->accumulator.computed[Perspective] = true;
+                states_to_update[i]->template computed<Small>()[Perspective] = true;
 
                 const StateInfo* end_state = i == 0 ? computed_st : states_to_update[i - 1];
 
@@ -401,10 +412,10 @@ class FeatureTransformer {
         {
             assert(states_to_update[0]);
 
-            auto accIn =
-              reinterpret_cast<const vec_t*>(&st->accumulator.accumulation[Perspective][0]);
-            auto accOut = reinterpret_cast<vec_t*>(
-              &states_to_update[0]->accumulator.accumulation[Perspective][0]);
+            auto accIn  = reinterpret_cast<const vec_t*>(&cast_2D<TransformedFeatureDimensions>(
+              st->template accumulation<Small>())[Perspective][0]);
+            auto accOut = reinterpret_cast<vec_t*>(&cast_2D<TransformedFeatureDimensions>(
+              states_to_update[0]->template accumulation<Small>())[Perspective][0]);
 
             const IndexType offsetR0 = HalfDimensions * removed[0][0];
             auto            columnR0 = reinterpret_cast<const vec_t*>(&weights[offsetR0]);
@@ -429,9 +440,9 @@ class FeatureTransformer {
             }
 
             auto accPsqtIn = reinterpret_cast<const psqt_vec_t*>(
-              &st->accumulator.psqtAccumulation[Perspective][0]);
-            auto accPsqtOut = reinterpret_cast<psqt_vec_t*>(
-              &states_to_update[0]->accumulator.psqtAccumulation[Perspective][0]);
+              &cast_2D<PSQTBuckets>(st->template psqt_accumulation<Small>())[Perspective][0]);
+            auto accPsqtOut = reinterpret_cast<psqt_vec_t*>(&cast_2D<PSQTBuckets>(
+              states_to_update[0]->template psqt_accumulation<Small>())[Perspective][0]);
 
             const IndexType offsetPsqtR0 = PSQTBuckets * removed[0][0];
             auto columnPsqtR0 = reinterpret_cast<const psqt_vec_t*>(&psqtWeights[offsetPsqtR0]);
@@ -462,8 +473,9 @@ class FeatureTransformer {
             for (IndexType j = 0; j < HalfDimensions / TileHeight; ++j)
             {
                 // Load accumulator
-                auto accTileIn = reinterpret_cast<const vec_t*>(
-                  &st->accumulator.accumulation[Perspective][j * TileHeight]);
+                auto accTileIn =
+                  reinterpret_cast<const vec_t*>(&cast_2D<TransformedFeatureDimensions>(
+                    st->template accumulation<Small>())[Perspective][j * TileHeight]);
                 for (IndexType k = 0; k < NumRegs; ++k)
                     acc[k] = vec_load(&accTileIn[k]);
 
@@ -488,8 +500,10 @@ class FeatureTransformer {
                     }
 
                     // Store accumulator
-                    auto accTileOut = reinterpret_cast<vec_t*>(
-                      &states_to_update[i]->accumulator.accumulation[Perspective][j * TileHeight]);
+                    auto accTileOut =
+                      reinterpret_cast<vec_t*>(&cast_2D<TransformedFeatureDimensions>(
+                        states_to_update[i]
+                          ->template accumulation<Small>())[Perspective][j * TileHeight]);
                     for (IndexType k = 0; k < NumRegs; ++k)
                         vec_store(&accTileOut[k], acc[k]);
                 }
@@ -498,8 +512,8 @@ class FeatureTransformer {
             for (IndexType j = 0; j < PSQTBuckets / PsqtTileHeight; ++j)
             {
                 // Load accumulator
-                auto accTilePsqtIn = reinterpret_cast<const psqt_vec_t*>(
-                  &st->accumulator.psqtAccumulation[Perspective][j * PsqtTileHeight]);
+                auto accTilePsqtIn = reinterpret_cast<const psqt_vec_t*>(&cast_2D<PSQTBuckets>(
+                  st->template psqt_accumulation<Small>())[Perspective][j * PsqtTileHeight]);
                 for (std::size_t k = 0; k < NumPsqtRegs; ++k)
                     psqt[k] = vec_load_psqt(&accTilePsqtIn[k]);
 
@@ -524,9 +538,9 @@ class FeatureTransformer {
                     }
 
                     // Store accumulator
-                    auto accTilePsqtOut = reinterpret_cast<psqt_vec_t*>(
-                      &states_to_update[i]
-                         ->accumulator.psqtAccumulation[Perspective][j * PsqtTileHeight]);
+                    auto accTilePsqtOut = reinterpret_cast<psqt_vec_t*>(&cast_2D<PSQTBuckets>(
+                      states_to_update[i]
+                        ->template psqt_accumulation<Small>())[Perspective][j * PsqtTileHeight]);
                     for (std::size_t k = 0; k < NumPsqtRegs; ++k)
                         vec_store_psqt(&accTilePsqtOut[k], psqt[k]);
                 }
@@ -535,13 +549,16 @@ class FeatureTransformer {
 #else
         for (IndexType i = 0; states_to_update[i]; ++i)
         {
-            std::memcpy(states_to_update[i]->accumulator.accumulation[Perspective],
-                        st->accumulator.accumulation[Perspective],
+            std::memcpy(cast_2D<TransformedFeatureDimensions>(
+                          states_to_update[i]->template accumulation<Small>())[Perspective],
+                        cast_2D<TransformedFeatureDimensions>(
+                          st->template accumulation<Small>())[Perspective],
                         HalfDimensions * sizeof(BiasType));
 
             for (std::size_t k = 0; k < PSQTBuckets; ++k)
-                states_to_update[i]->accumulator.psqtAccumulation[Perspective][k] =
-                  st->accumulator.psqtAccumulation[Perspective][k];
+                cast_2D<PSQTBuckets>(
+                  states_to_update[i]->template psqt_accumulation<Small>())[Perspective][k] =
+                  cast_2D<PSQTBuckets>(st->template psqt_accumulation<Small>())[Perspective][k];
 
             st = states_to_update[i];
 
@@ -551,10 +568,11 @@ class FeatureTransformer {
                 const IndexType offset = HalfDimensions * index;
 
                 for (IndexType j = 0; j < HalfDimensions; ++j)
-                    st->accumulator.accumulation[Perspective][j] -= weights[offset + j];
+                    cast_2D<TransformedFeatureDimensions>(
+                      st->template accumulation<Small>())[Perspective][j] -= weights[offset + j];
 
                 for (std::size_t k = 0; k < PSQTBuckets; ++k)
-                    st->accumulator.psqtAccumulation[Perspective][k] -=
+                    cast_2D<PSQTBuckets>(st->template psqt_accumulation<Small>())[Perspective][k] -=
                       psqtWeights[index * PSQTBuckets + k];
             }
 
@@ -564,10 +582,11 @@ class FeatureTransformer {
                 const IndexType offset = HalfDimensions * index;
 
                 for (IndexType j = 0; j < HalfDimensions; ++j)
-                    st->accumulator.accumulation[Perspective][j] += weights[offset + j];
+                    cast_2D<TransformedFeatureDimensions>(
+                      st->template accumulation<Small>())[Perspective][j] += weights[offset + j];
 
                 for (std::size_t k = 0; k < PSQTBuckets; ++k)
-                    st->accumulator.psqtAccumulation[Perspective][k] +=
+                    cast_2D<PSQTBuckets>(st->template psqt_accumulation<Small>())[Perspective][k] +=
                       psqtWeights[index * PSQTBuckets + k];
             }
         }
@@ -586,8 +605,8 @@ class FeatureTransformer {
         // Refresh the accumulator
         // Could be extracted to a separate function because it's done in 2 places,
         // but it's unclear if compilers would correctly handle register allocation.
-        auto& accumulator                 = pos.state()->accumulator;
-        accumulator.computed[Perspective] = true;
+        StateInfo* st                               = pos.state();
+        st->template computed<Small>()[Perspective] = true;
         FeatureSet::IndexList active;
         FeatureSet::append_active_indices<Perspective>(pos, active);
 
@@ -607,8 +626,8 @@ class FeatureTransformer {
                     acc[k] = vec_add_16(acc[k], column[k]);
             }
 
-            auto accTile =
-              reinterpret_cast<vec_t*>(&accumulator.accumulation[Perspective][j * TileHeight]);
+            auto accTile = reinterpret_cast<vec_t*>(&cast_2D<TransformedFeatureDimensions>(
+              st->template accumulation<Small>())[Perspective][j * TileHeight]);
             for (unsigned k = 0; k < NumRegs; k++)
                 vec_store(&accTile[k], acc[k]);
         }
@@ -627,28 +646,30 @@ class FeatureTransformer {
                     psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
             }
 
-            auto accTilePsqt = reinterpret_cast<psqt_vec_t*>(
-              &accumulator.psqtAccumulation[Perspective][j * PsqtTileHeight]);
+            auto accTilePsqt = reinterpret_cast<psqt_vec_t*>(&cast_2D<PSQTBuckets>(
+              st->template psqt_accumulation<Small>())[Perspective][j * PsqtTileHeight]);
             for (std::size_t k = 0; k < NumPsqtRegs; ++k)
                 vec_store_psqt(&accTilePsqt[k], psqt[k]);
         }
 
 #else
-        std::memcpy(accumulator.accumulation[Perspective], biases,
-                    HalfDimensions * sizeof(BiasType));
+        std::memcpy(
+          cast_2D<TransformedFeatureDimensions>(st->template accumulation<Small>())[Perspective],
+          biases, HalfDimensions * sizeof(BiasType));
 
         for (std::size_t k = 0; k < PSQTBuckets; ++k)
-            accumulator.psqtAccumulation[Perspective][k] = 0;
+            cast_2D<PSQTBuckets>(st->template psqt_accumulation<Small>())[Perspective][k] = 0;
 
         for (const auto index : active)
         {
             const IndexType offset = HalfDimensions * index;
 
             for (IndexType j = 0; j < HalfDimensions; ++j)
-                accumulator.accumulation[Perspective][j] += weights[offset + j];
+                cast_2D<TransformedFeatureDimensions>(
+                  st->template accumulation<Small>())[Perspective][j] += weights[offset + j];
 
             for (std::size_t k = 0; k < PSQTBuckets; ++k)
-                accumulator.psqtAccumulation[Perspective][k] +=
+                cast_2D<PSQTBuckets>(st->template psqt_accumulation<Small>())[Perspective][k] +=
                   psqtWeights[index * PSQTBuckets + k];
         }
 #endif
@@ -663,12 +684,12 @@ class FeatureTransformer {
         // Look for a usable accumulator of an earlier position. We keep track
         // of the estimated gain in terms of features to be added/subtracted.
         // Fast early exit.
-        if (pos.state()->accumulator.computed[Perspective])
+        if (pos.state()->template computed<Small>()[Perspective])
             return;
 
         auto [oldest_st, _] = try_find_computed_accumulator<Perspective>(pos);
 
-        if (oldest_st->accumulator.computed[Perspective])
+        if (oldest_st->template computed<Small>()[Perspective])
         {
             // Only update current position accumulator to minimize work.
             StateInfo* states_to_update[2] = {pos.state(), nullptr};
@@ -685,7 +706,7 @@ class FeatureTransformer {
 
         auto [oldest_st, next] = try_find_computed_accumulator<Perspective>(pos);
 
-        if (oldest_st->accumulator.computed[Perspective])
+        if (oldest_st->template computed<Small>()[Perspective])
         {
             if (next == nullptr)
                 return;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -684,10 +684,10 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
     ++st->pliesFromNull;
 
     // Used by NNUE
-    st->accumulator.computed[WHITE] = false;
-    st->accumulator.computed[BLACK] = false;
-    auto& dp                        = st->dirtyPiece;
-    dp.dirty_num                    = 1;
+    st->accumulatorBig.computed[WHITE]     = st->accumulatorBig.computed[BLACK] =
+      st->accumulatorSmall.computed[WHITE] = st->accumulatorSmall.computed[BLACK] = false;
+    auto& dp                                                                      = st->dirtyPiece;
+    dp.dirty_num                                                                  = 1;
 
     Color  us       = sideToMove;
     Color  them     = ~us;
@@ -964,15 +964,15 @@ void Position::do_null_move(StateInfo& newSt) {
     assert(!checkers());
     assert(&newSt != st);
 
-    std::memcpy(&newSt, st, offsetof(StateInfo, accumulator));
+    std::memcpy(&newSt, st, offsetof(StateInfo, accumulatorBig));
 
     newSt.previous = st;
     st             = &newSt;
 
-    st->dirtyPiece.dirty_num        = 0;
-    st->dirtyPiece.piece[0]         = NO_PIECE;  // Avoid checks in UpdateAccumulator()
-    st->accumulator.computed[WHITE] = false;
-    st->accumulator.computed[BLACK] = false;
+    st->dirtyPiece.dirty_num               = 0;
+    st->dirtyPiece.piece[0]                = NO_PIECE;  // Avoid checks in UpdateAccumulator()
+    st->accumulatorBig.computed[WHITE]     = st->accumulatorBig.computed[BLACK] =
+      st->accumulatorSmall.computed[WHITE] = st->accumulatorSmall.computed[BLACK] = false;
 
     if (st->epSquare != SQ_NONE)
     {

--- a/src/position.h
+++ b/src/position.h
@@ -20,6 +20,7 @@
 #define POSITION_H_INCLUDED
 
 #include <cassert>
+#include <cstdint>
 #include <deque>
 #include <iosfwd>
 #include <memory>
@@ -57,8 +58,24 @@ struct StateInfo {
     int        repetition;
 
     // Used by NNUE
-    Eval::NNUE::Accumulator accumulator;
-    DirtyPiece              dirtyPiece;
+    Eval::NNUE::Accumulator<false> accumulatorBig;
+    Eval::NNUE::Accumulator<true>  accumulatorSmall;
+    DirtyPiece                     dirtyPiece;
+
+    template<bool Small>
+    constexpr std::int16_t* accumulation() {
+        return Small ? (std::int16_t*) accumulatorSmall.accumulation
+                     : (std::int16_t*) accumulatorBig.accumulation;
+    }
+    template<bool Small>
+    constexpr std::int32_t* psqt_accumulation() {
+        return Small ? (std::int32_t*) accumulatorSmall.psqtAccumulation
+                     : (std::int32_t*) accumulatorBig.psqtAccumulation;
+    }
+    template<bool Small>
+    constexpr bool* computed() {
+        return Small ? accumulatorSmall.computed : accumulatorBig.computed;
+    }
 };
 
 
@@ -160,6 +177,7 @@ class Position {
     int     rule50_count() const;
     Value   non_pawn_material(Color c) const;
     Value   non_pawn_material() const;
+    Value   simple_eval() const;
 
     // Position consistency check, for debugging
     bool pos_is_ok() const;
@@ -303,6 +321,11 @@ inline Value Position::non_pawn_material(Color c) const { return st->nonPawnMate
 
 inline Value Position::non_pawn_material() const {
     return non_pawn_material(WHITE) + non_pawn_material(BLACK);
+}
+
+inline Value Position::simple_eval() const {
+    return PawnValue * (count<PAWN>(sideToMove) - count<PAWN>(~sideToMove))
+         + (non_pawn_material(sideToMove) - non_pawn_material(~sideToMove));
 }
 
 inline int Position::game_ply() const { return gamePly; }

--- a/src/position.h
+++ b/src/position.h
@@ -323,6 +323,9 @@ inline Value Position::non_pawn_material() const {
     return non_pawn_material(WHITE) + non_pawn_material(BLACK);
 }
 
+// Returns a static, purely materialistic evaluation of the position from
+// the point of view of the given color. It can be divided by PawnValue to get
+// an approximation of the material advantage on the board in terms of pawns.
 inline Value Position::simple_eval() const {
     return PawnValue * (count<PAWN>(sideToMove) - count<PAWN>(~sideToMove))
          + (non_pawn_material(sideToMove) - non_pawn_material(~sideToMove));

--- a/src/position.h
+++ b/src/position.h
@@ -20,7 +20,6 @@
 #define POSITION_H_INCLUDED
 
 #include <cassert>
-#include <cstdint>
 #include <deque>
 #include <iosfwd>
 #include <memory>
@@ -28,6 +27,7 @@
 
 #include "bitboard.h"
 #include "nnue/nnue_accumulator.h"
+#include "nnue/nnue_architecture.h"
 #include "types.h"
 
 namespace Stockfish {
@@ -58,24 +58,9 @@ struct StateInfo {
     int        repetition;
 
     // Used by NNUE
-    Eval::NNUE::Accumulator<false> accumulatorBig;
-    Eval::NNUE::Accumulator<true>  accumulatorSmall;
-    DirtyPiece                     dirtyPiece;
-
-    template<bool Small>
-    constexpr std::int16_t* accumulation() {
-        return Small ? (std::int16_t*) accumulatorSmall.accumulation
-                     : (std::int16_t*) accumulatorBig.accumulation;
-    }
-    template<bool Small>
-    constexpr std::int32_t* psqt_accumulation() {
-        return Small ? (std::int32_t*) accumulatorSmall.psqtAccumulation
-                     : (std::int32_t*) accumulatorBig.psqtAccumulation;
-    }
-    template<bool Small>
-    constexpr bool* computed() {
-        return Small ? accumulatorSmall.computed : accumulatorBig.computed;
-    }
+    Eval::NNUE::Accumulator<Eval::NNUE::TransformedFeatureDimensionsBig>   accumulatorBig;
+    Eval::NNUE::Accumulator<Eval::NNUE::TransformedFeatureDimensionsSmall> accumulatorSmall;
+    DirtyPiece dirtyPiece;
 };
 
 

--- a/src/position.h
+++ b/src/position.h
@@ -177,7 +177,6 @@ class Position {
     int     rule50_count() const;
     Value   non_pawn_material(Color c) const;
     Value   non_pawn_material() const;
-    Value   simple_eval() const;
 
     // Position consistency check, for debugging
     bool pos_is_ok() const;
@@ -321,14 +320,6 @@ inline Value Position::non_pawn_material(Color c) const { return st->nonPawnMate
 
 inline Value Position::non_pawn_material() const {
     return non_pawn_material(WHITE) + non_pawn_material(BLACK);
-}
-
-// Returns a static, purely materialistic evaluation of the position from
-// the point of view of the given color. It can be divided by PawnValue to get
-// an approximation of the material advantage on the board in terms of pawns.
-inline Value Position::simple_eval() const {
-    return PawnValue * (count<PAWN>(sideToMove) - count<PAWN>(~sideToMove))
-         + (non_pawn_material(sideToMove) - non_pawn_material(~sideToMove));
 }
 
 inline int Position::game_ply() const { return gamePly; }

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -27,7 +27,6 @@
 #include <memory>
 #include <utility>
 
-#include "evaluate.h"
 #include "misc.h"
 #include "movegen.h"
 #include "search.h"
@@ -210,7 +209,7 @@ void ThreadPool::start_thinking(Position&                 pos,
         th->rootMoves                      = rootMoves;
         th->rootPos.set(pos.fen(), pos.is_chess960(), &th->rootState, th);
         th->rootState      = setupStates->back();
-        th->rootSimpleEval = Eval::simple_eval(pos, pos.side_to_move());
+        th->rootSimpleEval = pos.simple_eval();
     }
 
     main()->start_searching();

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <utility>
 
+#include "evaluate.h"
 #include "misc.h"
 #include "movegen.h"
 #include "search.h"
@@ -209,7 +210,7 @@ void ThreadPool::start_thinking(Position&                 pos,
         th->rootMoves                      = rootMoves;
         th->rootPos.set(pos.fen(), pos.is_chess960(), &th->rootState, th);
         th->rootState      = setupStates->back();
-        th->rootSimpleEval = pos.simple_eval();
+        th->rootSimpleEval = Eval::simple_eval(pos, pos.side_to_move());
     }
 
     main()->start_searching();

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -320,7 +320,7 @@ void UCI::loop(int argc, char* argv[]) {
             std::string                f;
             if (is >> std::skipws >> f)
                 filename = f;
-            Eval::NNUE::save_eval(filename);
+            Eval::NNUE::save_eval(filename, false);
         }
         else if (token == "--help" || token == "help" || token == "--license" || token == "license")
             sync_cout

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -320,7 +320,7 @@ void UCI::loop(int argc, char* argv[]) {
             std::string                f;
             if (is >> std::skipws >> f)
                 filename = f;
-            Eval::NNUE::save_eval(filename, false);
+            Eval::NNUE::save_eval(filename, Eval::NNUE::Big);
         }
         else if (token == "--help" || token == "help" || token == "--license" || token == "license")
             sync_cout

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -37,6 +37,7 @@
 #include "misc.h"
 #include "movegen.h"
 #include "nnue/evaluate_nnue.h"
+#include "nnue/nnue_architecture.h"
 #include "position.h"
 #include "search.h"
 #include "thread.h"

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -82,7 +82,8 @@ void init(OptionsMap& o) {
     o["SyzygyProbeDepth"] << Option(1, 1, 100);
     o["Syzygy50MoveRule"] << Option(true);
     o["SyzygyProbeLimit"] << Option(7, 0, 7);
-    o["EvalFile"] << Option(EvalFileDefaultName, on_eval_file);
+    o["EvalFile"] << Option(EvalFileDefaultNameBig, on_eval_file);
+    o["EvalFileSmall"] << Option(EvalFileDefaultNameSmall, on_eval_file);
 }
 
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -83,7 +83,6 @@ void init(OptionsMap& o) {
     o["Syzygy50MoveRule"] << Option(true);
     o["SyzygyProbeLimit"] << Option(7, 0, 7);
     o["EvalFile"] << Option(EvalFileDefaultNameBig, on_eval_file);
-    o["EvalFileSmall"] << Option(EvalFileDefaultNameSmall, on_eval_file);
 }
 
 


### PR DESCRIPTION
This allows SF to use two nets of different sizes.  The intention is that the second net will be smaller/faster and used to lazy evaluate positions w/ high scores.

I need help w/ two things:
1) I commented out the net download section of the Makefile because it doesn't handle multiple nets.  We need this before we can start testing on fishtest.  Could someone w/ the right skills please fix it?
2) The current small net is just a compressed version of the last L1=1024 wide master net.  This is way too big but even so local tests are close to elo neutral.  Could someone please train a very small net?  Maybe L1=256 L2=15 L3=16?  This net could also be trained on mostly(only) positions with high scores to make it even better.

Per @vondele this idea has been around so credit to whoever thought of it first.  Thanks in advance for any help and feedback.

bench: 1449578