### PR TITLE
Temporarily disable CI include checks

### DIFF
--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -33,8 +33,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  Analyzers:
-    uses: ./.github/workflows/stockfish_analyzers.yml
+  # The include checks currently fail because of broken LLVM nightly packages: https://github.com/llvm/llvm-project/issues/73402
+  #Analyzers:
+  #  uses: ./.github/workflows/stockfish_analyzers.yml
   Sanitizers:
     uses: ./.github/workflows/stockfish_sanitizers.yml
   Tests:


### PR DESCRIPTION
The include checks currently fail because of broken LLVM nightly packages: https://github.com/llvm/llvm-project/issues/73402.

No functional change