### PR TITLE
Remove cutNode condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1207,8 +1207,8 @@ moves_loop:  // When in check, search starts here
         // Step 18. Full-depth search when LMR is skipped
         else if (!PvNode || moveCount > 1)
         {
-            // Increase reduction for cut nodes without ttMove (~1 Elo)
-            if (!ttMove && cutNode)
+            // Increase reduction for not ttMove (~1 Elo)
+            if (!ttMove)
                 r += 2;
 
             // Note that if expected reduction is high, we reduce search depth by 1 here


### PR DESCRIPTION
cutNode condition here seems irrelevant. Remove it.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 24224 W: 6206 L: 5970 D: 12048
Ptnml(0-2): 69, 2818, 6122, 3014, 89
https://tests.stockfishchess.org/tests/view/65686910136acbc5735529ec

Passed LTC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 236538 W: 58624 L: 58622 D: 119292
Ptnml(0-2): 136, 26955, 64091, 26945, 142
https://tests.stockfishchess.org/tests/view/6568925a136acbc573552d8f

bench: 1244386