### PR TITLE
Add seldepth update in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1419,6 +1419,10 @@ Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth) {
     ss->inCheck        = pos.checkers();
     moveCount          = 0;
 
+    // Used to send selDepth info to GUI (selDepth counts from 1, ply from 0)
+    if (PvNode && thisThread->selDepth < ss->ply + 1)
+        thisThread->selDepth = ss->ply + 1;
+
     // Step 2. Check for an immediate draw or maximum ply reached
     if (pos.is_draw(ss->ply) || ss->ply >= MAX_PLY)
         return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate(pos) : VALUE_DRAW;


### PR DESCRIPTION
Sometimes if we count the reported PV length, it turns out to be longer than the selective depth reported. This fixes this behavior by applying the selective depth to qsearch since we do report PVs from it as well.

Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/656cf5b66980e15f69c7499d

No functional change.