### PR TITLE
Revert "Temporarily disable CI include checks"

### DIFF
--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -33,9 +33,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # The include checks currently fail because of broken LLVM nightly packages: https://github.com/llvm/llvm-project/issues/73402
-  #Analyzers:
-  #  uses: ./.github/workflows/stockfish_analyzers.yml
+  Analyzers:
+    uses: ./.github/workflows/stockfish_analyzers.yml
   Sanitizers:
     uses: ./.github/workflows/stockfish_sanitizers.yml
   Tests:


### PR DESCRIPTION
This reverts commit 8f65953583a2abc34041b087120a378e22d0509d.

No functional change.