### PR TITLE
Remove eval >= beta condition for null move search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -783,7 +783,7 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
         return eval;
 
     // Step 9. Null move search with verification search (~35 Elo)
-    if (!PvNode && (ss - 1)->currentMove != MOVE_NULL && (ss - 1)->statScore < 17257 && eval >= beta
+    if (!PvNode && (ss - 1)->currentMove != MOVE_NULL && (ss - 1)->statScore < 17257
         && eval >= ss->staticEval && ss->staticEval >= beta - 24 * depth + 281 && !excludedMove
         && pos.non_pawn_material(us) && ss->ply >= thisThread->nmpMinPly
         && beta > VALUE_TB_LOSS_IN_MAX_PLY)


### PR DESCRIPTION
Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/656a2447136acbc573555181
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 220480 W: 55820 L: 55801 D: 108859
Ptnml(0-2): 833, 26275, 55928, 26448, 756

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/656ac9b3136acbc573556137
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 402960 W: 99286 L: 99459 D: 204215
Ptnml(0-2): 232, 46237, 108732, 46030, 249

bench 1471517