### PR TITLE
Tweak stand pat usage in qsearch.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1462,14 +1462,19 @@ Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth) {
             ss->staticEval = bestValue =
               (ss - 1)->currentMove != MOVE_NULL ? evaluate(pos) : -(ss - 1)->staticEval;
 
-        // Stand pat. Return immediately if static value is at least beta
+        // Stand pat. Return immediately if static value is at least beta for non-Pv nodes
+        // for PvNodes make bestValue between alpha and beta instead
         if (bestValue >= beta)
         {
-            if (!ss->ttHit)
-                tte->save(posKey, value_to_tt(bestValue, ss->ply), false, BOUND_LOWER, DEPTH_NONE,
+            if (!PvNode)
+            {
+                if (!ss->ttHit)
+                    tte->save(posKey, value_to_tt(bestValue, ss->ply), false, BOUND_LOWER, DEPTH_NONE,
                           MOVE_NONE, ss->staticEval);
 
-            return bestValue;
+                return bestValue;
+            }
+            bestValue = (alpha + beta) / 2;
         }
 
         if (bestValue > alpha)


### PR DESCRIPTION
Instead of immediately returning a fail high do this only at non-pv nodes, for pv nodes adjust bestValue to (alpha+beta)/2 and continue searching.
Passed STC:
https://tests.stockfishchess.org/tests/view/65739b0af09ce1261f122f33
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 189216 W: 48142 L: 47598 D: 93476
Ptnml(0-2): 584, 22463, 48051, 22845, 665 
Passed LTC:
https://tests.stockfishchess.org/tests/view/657701214d789acf40aac194
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 82506 W: 20689 L: 20269 D: 41548
Ptnml(0-2): 56, 9236, 22268, 9618, 75 
bench 1042346