### PR TITLE
Removal of SlowMover Option

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -42,7 +42,6 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
         return;
 
     TimePoint moveOverhead = TimePoint(Options["Move Overhead"]);
-    TimePoint slowMover    = TimePoint(Options["Slow Mover"]);
     TimePoint npmsec       = TimePoint(Options["nodestime"]);
 
     // optScale is a percentage of available time to use for the current move.
@@ -77,10 +76,6 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
     // Calculate time constants based on current time left.
     double optConstant = std::min(0.00335 + 0.0003 * std::log10(limits.time[us] / 1000.0), 0.0048);
     double maxConstant = std::max(3.6 + 3.0 * std::log10(limits.time[us] / 1000.0), 2.7);
-
-    // A user may scale time usage by setting UCI option "Slow Mover"
-    // Default is 100 and changing this value will probably lose elo.
-    timeLeft = slowMover * timeLeft / 100;
 
     // x basetime (+ z increment)
     // If there is a healthy increment, timeLeft can exceed actual available

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -73,7 +73,6 @@ void init(OptionsMap& o) {
     o["MultiPV"] << Option(1, 1, 500);
     o["Skill Level"] << Option(20, 0, 20);
     o["Move Overhead"] << Option(10, 0, 5000);
-    o["Slow Mover"] << Option(100, 10, 1000);
     o["nodestime"] << Option(0, 0, 10000);
     o["UCI_Chess960"] << Option(false);
     o["UCI_AnalyseMode"] << Option(false);


### PR DESCRIPTION
Removing the SlowMover for simplicity.

The SlowMover option allows users to modify the timeLeft variant, impacting the engine's time management. However, this feature, while theoretically flexible, doesn't offer substantial benefits. Instead, it introduces the risk of non-experienced users altering values without a clear understanding of the effects, potentially leading to a weaker engine.

I believe that the vast majority of SF users don't use it anyway, and based on tests conducted by me several months ago suggest that changing would only lose Elo.

Examples:
https://tests.stockfishchess.org/tests/view/651f309bac57711436726bba
https://tests.stockfishchess.org/tests/view/651fea29ac57711436727d85
https://tests.stockfishchess.org/tests/view/65257c343125598fc7eb68a1
https://tests.stockfishchess.org/tests/view/652296c83125598fc7eb2ad7
Tune: https://tests.stockfishchess.org/tests/view/652a70313125598fc7ebd706 (keeping the value at 100, zz2)

Non-Functional
Bench: 1283323