### PR TITLE
Remove UCI_AnalyseMode option

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -76,7 +76,6 @@ void init(OptionsMap& o) {
     o["Slow Mover"] << Option(100, 10, 1000);
     o["nodestime"] << Option(0, 0, 10000);
     o["UCI_Chess960"] << Option(false);
-    o["UCI_AnalyseMode"] << Option(false);
     o["UCI_LimitStrength"] << Option(false);
     o["UCI_Elo"] << Option(1320, 1320, 3190);
     o["UCI_ShowWDL"] << Option(false);


### PR DESCRIPTION
Simplify away the useless option, as documented: "An option handled by your GUI. This currently doesn't do anything."

The option was originally added with the introduction of contempt: commit e9aeaad. But it is now deprecated.

No functional change