### PR TITLE
update WDL model and normalize eval dynamically

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -218,11 +218,11 @@ std::string Eval::trace(Position& pos) {
     Value v;
     v = NNUE::evaluate(pos, false);
     v = pos.side_to_move() == WHITE ? v : -v;
-    ss << "NNUE evaluation        " << 0.01 * UCI::to_cp(v) << " (white side)\n";
+    ss << "NNUE evaluation        " << 0.01 * UCI::to_cp(v, pos.game_ply()) << " (white side)\n";
 
     v = evaluate(pos);
     v = pos.side_to_move() == WHITE ? v : -v;
-    ss << "Final evaluation       " << 0.01 * UCI::to_cp(v) << " (white side)";
+    ss << "Final evaluation       " << 0.01 * UCI::to_cp(v, pos.game_ply()) << " (white side)";
     ss << " [with scaled NNUE, ...]";
     ss << "\n";
 

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -235,11 +235,11 @@ constexpr std::string_view PieceToChar(" PNBRQK  pnbrqk");
 
 // Converts a Value into (centi)pawns and writes it in a buffer.
 // The buffer must have capacity for at least 5 chars.
-static void format_cp_compact(Value v, char* buffer) {
+static void format_cp_compact(Value v, char* buffer, int ply) {
 
     buffer[0] = (v < 0 ? '-' : v > 0 ? '+' : ' ');
 
-    int cp = std::abs(UCI::to_cp(v));
+    int cp = std::abs(UCI::to_cp(v, ply));
     if (cp >= 10000)
     {
         buffer[1] = '0' + cp / 10000;
@@ -271,9 +271,9 @@ static void format_cp_compact(Value v, char* buffer) {
 
 
 // Converts a Value into pawns, always keeping two decimals
-static void format_cp_aligned_dot(Value v, std::stringstream& stream) {
+static void format_cp_aligned_dot(Value v, std::stringstream& stream, int ply) {
 
-    const double pawns = std::abs(0.01 * UCI::to_cp(v));
+    const double pawns = std::abs(0.01 * UCI::to_cp(v, ply));
 
     stream << (v < 0   ? '-'
                : v > 0 ? '+'
@@ -294,7 +294,7 @@ std::string trace(Position& pos) {
         board[row][8 * 8 + 1] = '\0';
 
     // A lambda to output one box of the board
-    auto writeSquare = [&board](File file, Rank rank, Piece pc, Value value) {
+    auto writeSquare = [&board, &pos](File file, Rank rank, Piece pc, Value value) {
         const int x = int(file) * 8;
         const int y = (7 - int(rank)) * 3;
         for (int i = 1; i < 8; ++i)
@@ -305,7 +305,7 @@ std::string trace(Position& pos) {
         if (pc != NO_PIECE)
             board[y + 1][x + 4] = PieceToChar[pc];
         if (value != VALUE_NONE)
-            format_cp_compact(value, &board[y + 2][x + 2]);
+            format_cp_compact(value, &board[y + 2][x + 2], pos.game_ply());
     };
 
     // We estimate the value of each piece by doing a differential evaluation from
@@ -358,13 +358,13 @@ std::string trace(Position& pos) {
     {
         ss << "|  " << bucket << "        ";
         ss << " |  ";
-        format_cp_aligned_dot(t.psqt[bucket], ss);
+        format_cp_aligned_dot(t.psqt[bucket], ss, pos.game_ply());
         ss << "  "
            << " |  ";
-        format_cp_aligned_dot(t.positional[bucket], ss);
+        format_cp_aligned_dot(t.positional[bucket], ss, pos.game_ply());
         ss << "  "
            << " |  ";
-        format_cp_aligned_dot(t.psqt[bucket] + t.positional[bucket], ss);
+        format_cp_aligned_dot(t.psqt[bucket] + t.positional[bucket], ss, pos.game_ply());
         ss << "  "
            << " |";
         if (bucket == t.correctBucket)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -223,7 +223,9 @@ void MainThread::search() {
     {
         rootMoves.emplace_back(MOVE_NONE);
         sync_cout << "info depth 0 score "
-                  << UCI::value(rootPos.checkers() ? -VALUE_MATE : VALUE_DRAW) << sync_endl;
+                  << UCI::to_score(rootPos.checkers() ? -VALUE_MATE : VALUE_DRAW,
+                                   rootPos.game_ply())
+                  << sync_endl;
     }
     else
     {
@@ -1874,7 +1876,7 @@ string UCI::pv(const Position& pos, Depth depth) {
 
         ss << "info"
            << " depth " << d << " seldepth " << rootMoves[i].selDepth << " multipv " << i + 1
-           << " score " << UCI::value(v);
+           << " score " << UCI::to_score(v, pos.game_ply());
 
         if (Options["UCI_ShowWDL"])
             ss << UCI::wdl(v, pos.game_ply());

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,6 +30,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "benchmark.h"

--- a/src/uci.h
+++ b/src/uci.h
@@ -32,13 +32,6 @@ class Position;
 
 namespace UCI {
 
-// Normalizes the internal value as reported by evaluate or search
-// to the UCI centipawn result used in output. This value is derived from
-// the win_rate_model() such that Stockfish outputs an advantage of
-// "100 centipawns" for a position if the engine has a 50% probability to win
-// from this position in self-play at fishtest LTC time control.
-const int NormalizeToPawnValue = 328;
-
 class Option;
 
 // Define a custom comparator, because the UCI options should be case-insensitive
@@ -76,10 +69,15 @@ class Option {
     OnChange    on_change;
 };
 
-void        init(OptionsMap&);
-void        loop(int argc, char* argv[]);
-int         to_cp(Value v);
-std::string value(Value v);
+void init(OptionsMap&);
+void loop(int argc, char* argv[]);
+// Normalizes the internal value as reported by evaluate or search
+// to the UCI centipawn result used in output. This value is derived from
+// the win_rate_model() such that Stockfish outputs an advantage of
+// "100 centipawns" for a position if the engine has a 50% probability to win
+// from this position in self-play at fishtest LTC time control.
+int         to_cp(Value v, int ply);
+std::string to_score(Value v, int ply);
 std::string square(Square s);
 std::string move(Move m, bool chess960);
 std::string pv(const Position& pos, Depth depth);


### PR DESCRIPTION
Ensure that an evaluation of 100 centipawns always corresponds to a 50% win probability at fishtest LTC, irrespective of the move number.

This PR is the culmination of recent work by @disservin, @vondele and myself on https://github.com/official-stockfish/WDL_model, as well as recent changes to https://github.com/official-stockfish/books and https://github.com/official-stockfish/fishtest.

The new model was fitted based on about 500M positions extracted from 7.9M fishtest LTC games from the last three weeks, involving SF versions from b59786e750a59d3d7cff2630cf284553f607ed29 to current master.

A summary of the changes to the WDL model itself:
- an incorrect 8-move shift in master's WDL model has been fixed
- the polynomials `p_a` and `p_b` are fitted over the move range [8, 120]
- the coefficients for `p_a` and `p_b` are optimized by maximizing the probability of predicting the observed outcome (credits to @vondele)

A summary of the changes to the SF code:
- the internal evalulation is no longer normalized by `p_a(32)` (aka `NormalizeToPawnValue`), but by `p_a(max(8, min(120, move)))` (credits to @vondele, see https://github.com/vondele/Stockfish/tree/wdlScore)
- the above means we can now retire `NormalizeToPawnValue` 
- in `win_rate_model()` we no longer clamp the internal eval to [-4000,4000]

This PR is in draft status for now, to allow for some discussion of the proposed changes.

No functional change.
