### PR TITLE
Tweak stand pat usage in qsearch.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1468,14 +1468,19 @@ Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth) {
             ss->staticEval = bestValue =
               (ss - 1)->currentMove != MOVE_NULL ? evaluate(pos) : -(ss - 1)->staticEval;
 
-        // Stand pat. Return immediately if static value is at least beta
+        // Stand pat. Return immediately if bestValue is at least beta at non-Pv nodes.
+        // At PvNodes set bestValue between alpha and beta instead
         if (bestValue >= beta)
         {
-            if (!ss->ttHit)
-                tte->save(posKey, value_to_tt(bestValue, ss->ply), false, BOUND_LOWER, DEPTH_NONE,
-                          MOVE_NONE, ss->staticEval);
+            if (!PvNode || abs(bestValue) >= VALUE_TB_WIN_IN_MAX_PLY)
+            {
+                if (!ss->ttHit)
+                    tte->save(posKey, value_to_tt(bestValue, ss->ply), false, BOUND_LOWER, DEPTH_NONE,
+                            MOVE_NONE, ss->staticEval);
 
-            return bestValue;
+                return bestValue;
+            }
+            bestValue = std::min((alpha + beta) / 2, beta - 1);
         }
 
         if (bestValue > alpha)


### PR DESCRIPTION
Instead of immediately returning a fail high do this only at non-pv nodes, for pv nodes adjust bestValue to value between alpha and beta and continue searching.
Idea is to do it the same way as it's done in search where we don't return positive beta cutoffs after ttHits / zero window search at PvNodes and instead fully search lines.
Co-authored by @XInTheDark and @peregrineshahin 
Passed STC:
https://tests.stockfishchess.org/tests/view/65739b0af09ce1261f122f33
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 189216 W: 48142 L: 47598 D: 93476
Ptnml(0-2): 584, 22463, 48051, 22845, 665
Passed LTC:
https://tests.stockfishchess.org/tests/view/657701214d789acf40aac194
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 82506 W: 20689 L: 20269 D: 41548
Ptnml(0-2): 56, 9236, 22268, 9618, 75
But had two problems - 
1) in rare cases it set alpha to the same value as beta and thus broke some asserts;
2) messed up with returning tb win values.
Fix passed non-regression LTC vs this patch:
https://tests.stockfishchess.org/tests/view/6578113b4d789acf40aad544
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 277308 W: 68839 L: 68880 D: 139589
Ptnml(0-2): 167, 31580, 75212, 31517, 178 
bench 1069503