### PR TITLE
Time Management Parameter Improvement

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -471,12 +471,12 @@ void Thread::search() {
         {
             double fallingEval = (66 + 14 * (mainThread->bestPreviousAverageScore - bestValue)
                                   + 6 * (mainThread->iterValue[iterIdx] - bestValue))
-                               / 583.0;
-            fallingEval = std::clamp(fallingEval, 0.5, 1.5);
+                               / 616.6;
+            fallingEval = std::clamp(fallingEval, 0.51, 1.51);
 
             // If the bestMove is stable over several iterations, reduce time accordingly
             timeReduction    = lastBestMoveDepth + 8 < completedDepth ? 1.56 : 0.69;
-            double reduction = (1.4 + mainThread->previousTimeReduction) / (2.03 * timeReduction);
+            double reduction = (1.4 + mainThread->previousTimeReduction) / (2.17 * timeReduction);
             double bestMoveInstability = 1 + 1.79 * totBestMoveChanges / Threads.size();
 
             double totalTime = Time.optimum() * fallingEval * reduction * bestMoveInstability;

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -71,21 +71,21 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
                                                   - moveOverhead * (2 + mtg));
 
     // Use extra time with larger increments
-    double optExtra = std::clamp(1.0 + 12.5 * limits.inc[us] / limits.time[us], 1.0, 1.12);
+    double optExtra = std::clamp(1.0 + 12.5 * limits.inc[us] / limits.time[us], 1.0, 1.11);
 
     // Calculate time constants based on current time left.
-    double optConstant = std::min(0.00335 + 0.0003 * std::log10(limits.time[us] / 1000.0), 0.0048);
-    double maxConstant = std::max(3.6 + 3.0 * std::log10(limits.time[us] / 1000.0), 2.7);
+    double optConstant = std::min(0.00334 + 0.0003 * std::log10(limits.time[us] / 1000.0), 0.0049);
+    double maxConstant = std::max(3.4 + 3.0 * std::log10(limits.time[us] / 1000.0), 2.76);
 
     // x basetime (+ z increment)
     // If there is a healthy increment, timeLeft can exceed actual available
     // game time for the current move, so also cap to 20% of available game time.
     if (limits.movestogo == 0)
     {
-        optScale = std::min(0.0120 + std::pow(ply + 3.3, 0.44) * optConstant,
-                            0.2 * limits.time[us] / double(timeLeft))
+        optScale = std::min(0.0120 + std::pow(ply + 3.1, 0.44) * optConstant,
+                            0.21 * limits.time[us] / double(timeLeft))
                  * optExtra;
-        maxScale = std::min(6.8, maxConstant + ply / 12.2);
+        maxScale = std::min(6.9, maxConstant + ply / 12.2);
     }
 
     // x moves in y seconds (+ z increment)


### PR DESCRIPTION
 Improvement for Time Management Parameter.

Passed STC (~2.5 Elo):
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 44672 W: 11354 L: 11030 D: 22288
Ptnml(0-2): 140, 5033, 11685, 5319, 159
https://tests.stockfishchess.org/tests/view/6579c5574d789acf40aaf914


Passed LTC (~2.5 Elo):
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 40932 W: 10275 L: 9950 D: 20707
Ptnml(0-2): 21, 4316, 11473, 4629, 27
https://tests.stockfishchess.org/tests/view/657ad7f44d789acf40ab105e

Passed non-regression Sudden death 10+0 (~4 Elo):
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 21384 W: 5171 L: 4925 D: 11288
Ptnml(0-2): 112, 2420, 5409, 2612, 139
https://tests.stockfishchess.org/tests/view/657b9b9e393ac02e7911f1a8