### PR TITLE
Update Makefile for Android x86-64 Builds

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -211,10 +211,10 @@ Stéphane Nicolet (snicolet)
 Stephen Touset (stouset)
 Syine Mineta (MinetaS)
 Taras Vuk (TarasVuk)
-Tobias Steinmann
 Thanar2
 thaspel
 theo77186
+Tobias Steinmann
 Tomasz Sobczyk (Sopel97)
 Tom Truscott
 Tom Vijlbrief (tomtor)

--- a/AUTHORS
+++ b/AUTHORS
@@ -211,6 +211,7 @@ Stéphane Nicolet (snicolet)
 Stephen Touset (stouset)
 Syine Mineta (MinetaS)
 Taras Vuk (TarasVuk)
+Tobias Steinmann
 Thanar2
 thaspel
 theo77186

--- a/src/Makefile
+++ b/src/Makefile
@@ -521,6 +521,14 @@ ifeq ($(COMP),ndk)
 			STRIP=llvm-strip
 		endif
 	endif
+	ifeq ($(arch),x86_64)
+		CXX=x86_64-linux-android21-clang++
+		ifneq ($(shell which x86_64-linux-android-strip 2>/dev/null),)
+			STRIP=x86_64-linux-android-strip
+		else
+			STRIP=llvm-strip
+		endif
+	endif
 	LDFLAGS += -static-libstdc++ -pie -lm -latomic
 endif
 


### PR DESCRIPTION
For developing an Android GUI it can be helpful to use the Emulator on Windows. Therefor an android_x86-64 library of Stockfish is needed. It would be nice to compile it "out-of-the-box".

This change is originally suggested by Craftyawesome

https://github.com/Craftyawesome/Stockfish/commit/bd997a22b57e04ba5a3293db014d037b1af9b24a