### PR TITLE
Adjust returned value in qsearch at fail high.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1613,6 +1613,9 @@ Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth) {
         return mated_in(ss->ply);  // Plies to mate from the root
     }
 
+    if (abs(bestValue) < VALUE_TB_WIN_IN_MAX_PLY)
+        bestValue = bestValue >= beta ? (3 * bestValue + beta) / 4 : bestValue;
+
     // Save gathered info in transposition table
     tte->save(posKey, value_to_tt(bestValue, ss->ply), pvHit,
               bestValue >= beta ? BOUND_LOWER : BOUND_UPPER, ttDepth, bestMove, ss->staticEval);


### PR DESCRIPTION
Instead of returning strict fail soft fail high return value between value from search and beta (somewhat by analogy to futility pruning and probcut). Note - this seems to be somewhat depth sensitive heuristic which performed much worse at LTC while performing much better at STC if it is more aggressive, passed version is the least aggressive one.
Passed STC:
https://tests.stockfishchess.org/tests/view/657b06414d789acf40ab1475
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 212352 W: 53900 L: 53315 D: 105137
Ptnml(0-2): 809, 25236, 53520, 25783, 828 
Passed LTC:
https://tests.stockfishchess.org/tests/view/657ce36f393ac02e79120a7c
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 319362 W: 79541 L: 78630 D: 161191
Ptnml(0-2): 202, 35839, 86709, 36708, 223 
bench 1249544