### PR TITLE
Tweaking quiet move bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -748,7 +748,7 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
     // Use static evaluation difference to improve quiet move ordering (~4 Elo)
     if (is_ok((ss - 1)->currentMove) && !(ss - 1)->inCheck && !priorCapture)
     {
-        int bonus = std::clamp(-13 * int((ss - 1)->staticEval + ss->staticEval), -1555, 1452);
+        int bonus = std::clamp(-13 * int((ss - 1)->staticEval + ss->staticEval), -1652, 1546);
         thisThread->mainHistory[~us][from_to((ss - 1)->currentMove)] << bonus;
         if (type_of(pos.piece_on(prevSq)) != PAWN && type_of((ss - 1)->currentMove) != PROMOTION)
             thisThread->pawnHistory[pawn_structure(pos)][pos.piece_on(prevSq)][prevSq] << bonus / 4;
@@ -1344,7 +1344,7 @@ moves_loop:  // When in check, search starts here
     // Bonus for prior countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
     {
-        int bonus = (depth > 6) + (PvNode || cutNode) + (bestValue < alpha - 656)
+        int bonus = (depth > 6) + (PvNode || cutNode) + ((ss - 1)->statScore < -18782)
                   + ((ss - 1)->moveCount > 10);
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       stat_bonus(depth) * bonus);


### PR DESCRIPTION
Inspiration came from @locutus2

Tweaking and improving quiet move bonus by replacing bestvalue and alpha comparison, with checking the statScore of the previous search step instead.


Passed STC:
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 51296 W: 13121 L: 12774 D: 25401
Ptnml(0-2): 225, 5986, 12868, 6355, 214
https://tests.stockfishchess.org/tests/view/657f22fb893104ee25b614e8

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 82758 W: 20606 L: 20189 D: 41963
Ptnml(0-2): 51, 9149, 22555, 9580, 44
https://tests.stockfishchess.org/tests/view/658024a2893104ee25b62587