### PR TITLE
Fix mates from probCut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -854,7 +854,7 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
       // So effective depth is equal to depth - 3
       && !(tte->depth() >= depth - 3 && ttValue != VALUE_NONE && ttValue < probCutBeta))
     {
-        assert(probCutBeta < VALUE_INFINITE);
+        assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
         MovePicker mp(pos, ttMove, probCutBeta - ss->staticEval, &captureHistory);
 
@@ -888,7 +888,8 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
                     // Save ProbCut data into transposition table
                     tte->save(posKey, value_to_tt(value, ss->ply), ss->ttPv, BOUND_LOWER, depth - 3,
                               move, ss->staticEval);
-                    return value - (probCutBeta - beta);
+                    return std::abs(value) < VALUE_TB_WIN_IN_MAX_PLY ? value - (probCutBeta - beta)
+                                                                     : value;
                 }
             }
 
@@ -1613,7 +1614,7 @@ Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth) {
         return mated_in(ss->ply);  // Plies to mate from the root
     }
 
-    if (abs(bestValue) < VALUE_TB_WIN_IN_MAX_PLY)
+    if (std::abs(bestValue) < VALUE_TB_WIN_IN_MAX_PLY)
         bestValue = bestValue >= beta ? (3 * bestValue + beta) / 4 : bestValue;
 
     // Save gathered info in transposition table


### PR DESCRIPTION
This fixes returning wrong mated-in scores, or losing a proven mate-in score from probCut after recent tweaks. The issue reported by @cj5716 on discord

passed non-reg STC:
https://tests.stockfishchess.org/tests/view/6583c36b5457644dc9843afe
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 295936 W: 75011 L: 75075 D: 145850
Ptnml(0-2): 978, 33947, 78146, 33955, 942

passed non-reg LTC:
https://tests.stockfishchess.org/tests/view/658513075457644dc98451cd
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 55932 W: 13970 L: 13786 D: 28176
Ptnml(0-2): 33, 5933, 15837, 6143, 20

bench: 1308739