### PR TITLE
Adjust value returned after TT cutoff.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -653,7 +653,7 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
         // Partial workaround for the graph history interaction problem
         // For high rule50 counts don't produce transposition table cutoffs.
         if (pos.rule50_count() < 90)
-            return ttValue >= beta && abs(ttValue) < VALUE_TB_WIN_IN_MAX_PLY ? (ttValue * 3 + beta) / 4 : ttValue;
+            return ttValue >= beta && std::abs(ttValue) < VALUE_TB_WIN_IN_MAX_PLY ? (ttValue * 3 + beta) / 4 : ttValue;
     }
 
     // Step 5. Tablebases probe

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -653,7 +653,7 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
         // Partial workaround for the graph history interaction problem
         // For high rule50 counts don't produce transposition table cutoffs.
         if (pos.rule50_count() < 90)
-            return ttValue;
+            return ttValue >= beta && abs(ttValue) < VALUE_TB_WIN_IN_MAX_PLY ? (ttValue * 3 + beta) / 4 : ttValue;
     }
 
     // Step 5. Tablebases probe


### PR DESCRIPTION
Instead of returning value from tt in case of a fail high return mix between it and beta.
Passed STC:
https://tests.stockfishchess.org/tests/view/658465395457644dc98446c7
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 220704 W: 56404 L: 55811 D: 108489
Ptnml(0-2): 750, 26214, 55921, 26627, 840 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6585c3f55457644dc9845db9
LLR: 2.97 (-2.94,2.94) <0.50,2.50>
Total: 124980 W: 31169 L: 30658 D: 63153
Ptnml(0-2): 57, 14147, 33603, 14594, 89 
bench 1222986