### PR TITLE
Reordering the reduction formulas

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1140,26 +1140,26 @@ moves_loop:  // When in check, search starts here
         if (ttCapture)
             r++;
 
-        // Decrease reduction for PvNodes (~2 Elo)
-        if (PvNode)
-            r--;
-
         // Decrease reduction if a quiet ttMove has been singularly extended (~1 Elo)
         if (singularQuietLMR)
             r--;
-
-        // Increase reduction on repetition (~1 Elo)
-        if (move == (ss - 4)->currentMove && pos.has_repeated())
-            r += 2;
 
         // Increase reduction if next ply has a lot of fail high (~5 Elo)
         if ((ss + 1)->cutoffCnt > 3)
             r++;
 
         // Set reduction to 0 for first picked move (ttMove) (~2 Elo)
-        // Nullifies all previous reduction adjustments to ttMove and leaves only history to do them
+        // Nullifies all previous reduction adjustments to ttMove
         else if (move == ttMove)
             r = 0;
+
+        // Decrease reduction for PvNodes (~2 Elo)
+        if (PvNode)
+            r--;
+
+        // Increase reduction on repetition (~1 Elo)
+        if (move == (ss - 4)->currentMove && pos.has_repeated())
+            r += 2;
 
         ss->statScore = 2 * thisThread->mainHistory[us][from_to(move)]
                       + (*contHist[0])[movedPiece][to_sq(move)]


### PR DESCRIPTION
Reordering the reduction formulas.

Specifically, moving the adjustments related to PvNodes and repetition after the formula that nullifies all previous reductions.
From my POV it improves the clarity of the code and makes the logic more straightforward.

Non-Functional (Checked up to bench 26)
master bench 26: 143700122
this patch bench 26: 143700122