### PR TITLE
Change the improving logic

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -715,7 +715,7 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
     {
         // Skip early pruning when in check
         ss->staticEval = eval = VALUE_NONE;
-        improving             = false;
+        improving             = true;
         goto moves_loop;
     }
     else if (excludedMove)
@@ -759,9 +759,8 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
     // check at our previous move we look at static evaluation at move prior to it
     // and if we were in check at move prior to it flag is set to true) and is
     // false otherwise. The improving flag is used in various pruning heuristics.
-    improving = (ss - 2)->staticEval != VALUE_NONE ? ss->staticEval > (ss - 2)->staticEval
-              : (ss - 4)->staticEval != VALUE_NONE ? ss->staticEval > (ss - 4)->staticEval
-                                                   : true;
+    improving = (ss - 2)->staticEval != VALUE_NONE  ? ss->staticEval > (ss - 2)->staticEval
+              : (ss - 4)->staticEval != VALUE_NONE && ss->staticEval > (ss - 4)->staticEval;
 
     // Step 7. Razoring (~1 Elo)
     // If eval is really low check with qsearch if it can exceed alpha, if it can't,


### PR DESCRIPTION
The improving flag is currently initialized to false, this PR changes the initialization to true, and simplifies a later formula.
By initializing to true, we assume the position is improving until proven otherwise.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 65824 W: 16787 L: 16596 D: 32441
Ptnml(0-2): 240, 7833, 16573, 8028, 238
https://tests.stockfishchess.org/tests/view/658589ba5457644dc9845956

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 258906 W: 64064 L: 64087 D: 130755
Ptnml(0-2): 185, 29226, 70625, 29261, 156
https://tests.stockfishchess.org/tests/view/6585f8cb5457644dc98461d1


bench: 1237447