### PR TITLE
Time management simplification

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -75,7 +75,7 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
 
     // Calculate time constants based on current time left.
     double optConstant = std::min(0.00334 + 0.0003 * std::log10(limits.time[us] / 1000.0), 0.0049);
-    double maxConstant = std::max(3.4 + 3.0 * std::log10(limits.time[us] / 1000.0), 2.76);
+    double maxConstant = 3.4 + 3.0 * std::log10(limits.time[us] / 1000.0);
 
     // x basetime (+ z increment)
     // If there is a healthy increment, timeLeft can exceed actual available


### PR DESCRIPTION
Time management simplification
std::max is not needed in this formula for higher time controls.
But it seems it regresses a little bit for shorter time control (less than 10+0.1)

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 68640 W: 17473 L: 17288 D: 33879
Ptnml(0-2): 272, 7874, 17784, 8177, 213
https://tests.stockfishchess.org/tests/view/658ae98179aa8af82b950cd7

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 57354 W: 14189 L: 14008 D: 29157
Ptnml(0-2): 31, 6054, 16314, 6259, 19
https://tests.stockfishchess.org/tests/view/658c014d79aa8af82b951b2b

Failed Sudden death (10+0):
LLR: -2.94 (-2.94,2.94) <-1.75,0.25>
Total: 235278 W: 55207 L: 55742 D: 124329
Ptnml(0-2): 1292, 27618, 60280, 27231, 1218
https://tests.stockfishchess.org/tests/view/658d9b2979aa8af82b95334b