### PR TITLE
Fix scores from reverse futility pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -784,7 +784,7 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
              >= beta
         && eval >= beta && eval < 29008  // smaller than TB wins
         && (!ttMove || ttCapture))
-        return (eval + beta) / 2;
+        return beta > VALUE_TB_LOSS_IN_MAX_PLY ? (eval + beta) / 2 : eval;
 
     // Step 9. Null move search with verification search (~35 Elo)
     if (!PvNode && (ss - 1)->currentMove != MOVE_NULL && (ss - 1)->statScore < 17496 && eval >= beta


### PR DESCRIPTION
This fixes futility pruning return values after recent tweaks, `eval` is guaranteed to be less than the mate-in range but it can be as low value such that the average between eval and beta can still fall in the mated-in range when beta is as low in mated range. i.e. (eval + beta) / 2 being at mated-range which can break mates.

Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/658f3eed79aa8af82b955139
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 117408 W: 29891 L: 29761 D: 57756
Ptnml(0-2): 386, 13355, 31120, 13429, 414

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/658f8b7a79aa8af82b9557bd
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 60240 W: 14962 L: 14786 D: 30492
Ptnml(0-2): 22, 6257, 17390, 6425, 26

changes signature at higher depth e.g. `128 1 15`

bench: 1304666