### PR TITLE
Introduce static evaluation correction history.

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -34,11 +34,14 @@
 namespace Stockfish {
 
 constexpr int PAWN_HISTORY_SIZE = 512;  // has to be a power of 2
+constexpr int CORRECTION_HISTORY_SIZE = 131072;  // has to be a power of 2
+constexpr int CORRECTION_HISTORY_LIMIT = 512;
 
 static_assert((PAWN_HISTORY_SIZE & (PAWN_HISTORY_SIZE - 1)) == 0,
               "PAWN_HISTORY_SIZE has to be a power of 2");
 
 inline int pawn_structure(const Position& pos) { return pos.pawn_key() & (PAWN_HISTORY_SIZE - 1); }
+inline int correction_pawn_structure(const Position& pos) { return pos.pawn_key() & (CORRECTION_HISTORY_SIZE - 1); }
 
 // StatsEntry stores the stat table value. It is usually a number but could
 // be a move or even a nested history. We use a class instead of a naked value
@@ -121,6 +124,9 @@ using ContinuationHistory = Stats<PieceToHistory, NOT_USED, PIECE_NB, SQUARE_NB>
 
 // PawnHistory is addressed by the pawn structure and a move's [piece][to]
 using PawnHistory = Stats<int16_t, 8192, PAWN_HISTORY_SIZE, PIECE_NB, SQUARE_NB>;
+
+// CorrectionHistory is addressed by color and pawn structure
+using CorrectionHistory = Stats<int16_t, CORRECTION_HISTORY_LIMIT, 2, CORRECTION_HISTORY_SIZE>;
 
 // MovePicker class is used to pick one pseudo-legal move at a time from the
 // current position. The most important method is next_move(), which returns a

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -70,6 +70,7 @@ void Thread::clear() {
     mainHistory.fill(0);
     captureHistory.fill(0);
     pawnHistory.fill(0);
+    correctionHistory.fill(0);
 
     for (bool inCheck : {false, true})
         for (StatsType c : {NoCaptures, Captures})

--- a/src/thread.h
+++ b/src/thread.h
@@ -69,6 +69,7 @@ class Thread {
     CapturePieceToHistory captureHistory;
     ContinuationHistory   continuationHistory[2][2];
     PawnHistory           pawnHistory;
+    CorrectionHistory     correctionHistory;
 };
 
 


### PR DESCRIPTION
Idea from Caissa chess engine.
With given pawn structure collect data with how often search result and by how much it was better / worse than static evalution of position and use it to adjust static evaluation of positions with given pawn structure.
Details:
1) excludes positions with fail highs and moves producing it being a capture;
2) update value is function of not only difference between best value and static evaluation but also is multiplied by linear function of depth;
3) maximum update value is maximum value of correction history divided by 2;
4) correction history itself is divided by 16 when applied so maximum value of static evaluation adjustment is 32 internal units.
Passed STC:
https://tests.stockfishchess.org/tests/view/658f24ad79aa8af82b954f3c
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 99392 W: 25371 L: 24955 D: 49066
Ptnml(0-2): 332, 11870, 24938, 12162, 394 
Passed LTC:
https://tests.stockfishchess.org/tests/view/658fc0ae79aa8af82b955bf3
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 40272 W: 10182 L: 9850 D: 20240
Ptnml(0-2): 33, 4419, 10899, 4753, 32 
bench 1379865