### PR TITLE
Simplification in the improving formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -761,9 +761,8 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
     // check at our previous move we look at static evaluation at move prior to it
     // and if we were in check at move prior to it flag is set to true) and is
     // false otherwise. The improving flag is used in various pruning heuristics.
-    improving = (ss - 2)->staticEval != VALUE_NONE ? ss->staticEval > (ss - 2)->staticEval
-              : (ss - 4)->staticEval != VALUE_NONE ? ss->staticEval > (ss - 4)->staticEval
-                                                   : true;
+    improving = (ss - 2)->staticEval != VALUE_NONE  ? ss->staticEval > (ss - 2)->staticEval
+              : (ss - 4)->staticEval != VALUE_NONE && ss->staticEval > (ss - 4)->staticEval;
 
     // Step 7. Razoring (~1 Elo)
     // If eval is really low check with qsearch if it can exceed alpha, if it can't,


### PR DESCRIPTION
Simplification in the improving flag formula.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 93408 W: 23747 L: 23587 D: 46074
Ptnml(0-2): 340, 11178, 23527, 11300, 359
https://tests.stockfishchess.org/tests/view/658ec29979aa8af82b9547f6

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 64026 W: 15984 L: 15806 D: 32236
Ptnml(0-2): 31, 7113, 17552, 7281, 36
https://tests.stockfishchess.org/tests/view/658f73e479aa8af82b9555b6


bench: 1143749