### PR TITLE
Silence security alert warning about infinite loop

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1074,7 +1074,7 @@ uint8_t* set_sizes(PairsData* d, uint8_t* data) {
     // See https://web.archive.org/web/20201106232444/http://www.larsson.dogma.net/dcc99.pdf
     std::vector<bool> visited(d->symlen.size());
 
-    for (Sym sym = 0; sym < d->symlen.size(); ++sym)
+    for (std::size_t sym = 0; sym < d->symlen.size(); ++sym)
         if (!visited[sym])
             d->symlen[sym] = set_symlen(d, sym, visited);
 


### PR DESCRIPTION
As some have noticed, a security alert has been complaining about a for loop in our TB code for quite some time now. 
However, it was never really an issue.

A few lines earlier the symlen vector is resized
https://github.com/official-stockfish/Stockfish/blob/master/src/syzygy/tbprobe.cpp#L1066
`d->symlen.resize(number<uint16_t, LittleEndian>(data));` 
while this code seems odd at first, it resizes the array to at most `(2 << 16) - 1 ` aka `uint16_t` elements, basically making the infinite loop issue impossible.

No functional change