### PR TITLE
Simplification of partial_insertion_sort formula

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -300,7 +300,7 @@ top:
             endMoves = generate<QUIETS>(pos, cur);
 
             score<QUIETS>();
-            partial_insertion_sort(cur, endMoves, -1960 - 3130 * depth);
+            partial_insertion_sort(cur, endMoves, -3330 * depth);
         }
 
         ++stage;


### PR DESCRIPTION
Simplification of partial_insertion_sort formula.

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 134880 W: 34468 L: 34355 D: 66057
Ptnml(0-2): 476, 16060, 34220, 16243, 441
https://tests.stockfishchess.org/tests/view/6590110879aa8af82b9562e9

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 60780 W: 15179 L: 14996 D: 30605
Ptnml(0-2): 27, 6847, 16464, 7020, 32
https://tests.stockfishchess.org/tests/view/659156ca79aa8af82b957f07

bench: 1338331