### PR TITLE
Modify ttPV Reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1152,7 +1152,7 @@ moves_loop:  // When in check, search starts here
 
         // Decrease reduction if position is or has been on the PV (~4 Elo)
         if (ss->ttPv && !likelyFailLow)
-            r -= cutNode && tte->depth() >= depth ? 3 : 2;
+            r -= 1 + (cutNode && tte->depth() >= depth) + (ttValue > alpha); 
 
         // Decrease reduction if opponent's move count is high (~1 Elo)
         if ((ss - 1)->moveCount > 7)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1152,7 +1152,7 @@ moves_loop:  // When in check, search starts here
 
         // Decrease reduction if position is or has been on the PV (~4 Elo)
         if (ss->ttPv && !likelyFailLow)
-            r -= 1 + (cutNode && tte->depth() >= depth) + (ttValue > alpha); 
+            r -= 1 + (cutNode && tte->depth() >= depth) + (ttValue > alpha);
 
         // Decrease reduction if opponent's move count is high (~1 Elo)
         if ((ss - 1)->moveCount > 7)


### PR DESCRIPTION
This patch modifies ttPV reduction by reducing 1 more unless ttValue is above alpha.

Inspired from @pb00068 https://tests.stockfishchess.org/tests/view/658060796a3b4f6202215f1f

Passed STC:
https://tests.stockfishchess.org/tests/view/6591867679aa8af82b958328
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 37856 W: 9727 L: 9407 D: 18722
Ptnml(0-2): 99, 4444, 9568, 4672, 145

Passed LTC:
https://tests.stockfishchess.org/tests/view/6591d9b679aa8af82b958a6c
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 128256 W: 32152 L: 31639 D: 64465
Ptnml(0-2): 64, 14364, 34772, 14851, 77

Bench: 1151646
