### PR TITLE
Use type aliases instead of enums for Value types

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -148,7 +148,7 @@ void NNUE::verify() {
 // Returns a static, purely materialistic evaluation of the position from
 // the point of view of the given color. It can be divided by PawnValue to get
 // an approximation of the material advantage on the board in terms of pawns.
-Value Eval::simple_eval(const Position& pos, Color c) {
+int Eval::simple_eval(const Position& pos, Color c) {
     return PawnValue * (pos.count<PAWN>(c) - pos.count<PAWN>(~c))
          + (pos.non_pawn_material(c) - pos.non_pawn_material(~c));
 }
@@ -160,7 +160,7 @@ Value Eval::evaluate(const Position& pos) {
 
     assert(!pos.checkers());
 
-    Value v;
+    int   v;
     Color stm        = pos.side_to_move();
     int   shuffling  = pos.rule50_count();
     int   simpleEval = simple_eval(pos, stm) + (int(pos.key() & 7) - 3);
@@ -170,13 +170,13 @@ Value Eval::evaluate(const Position& pos) {
                                           + std::abs(pos.this_thread()->rootSimpleEval);
 
     if (lazy)
-        v = Value(simpleEval);
+        v = simpleEval;
     else
     {
         int   nnueComplexity;
         Value nnue = NNUE::evaluate(pos, true, &nnueComplexity);
 
-        Value optimism = pos.this_thread()->optimism[stm];
+        int optimism = pos.this_thread()->optimism[stm];
 
         // Blend optimism and eval with nnue complexity and material imbalance
         optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 512;
@@ -190,7 +190,7 @@ Value Eval::evaluate(const Position& pos) {
     v = v * (200 - shuffling) / 214;
 
     // Guarantee evaluation does not hit the tablebase range
-    v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
+    v = std::clamp(int(v), VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
 
     return v;
 }

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -31,7 +31,7 @@ namespace Eval {
 
 std::string trace(Position& pos);
 
-Value simple_eval(const Position& pos, Color c);
+int   simple_eval(const Position& pos, Color c);
 Value evaluate(const Position& pos);
 
 extern std::string currentEvalFileName;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -127,7 +127,7 @@ MovePicker::MovePicker(const Position&              p,
 
 // Constructor for ProbCut: we generate captures with SEE greater
 // than or equal to the given threshold.
-MovePicker::MovePicker(const Position& p, Move ttm, Value th, const CapturePieceToHistory* cph) :
+MovePicker::MovePicker(const Position& p, Move ttm, int th, const CapturePieceToHistory* cph) :
     pos(p),
     captureHistory(cph),
     ttMove(ttm),
@@ -211,8 +211,8 @@ void MovePicker::score() {
         else  // Type == EVASIONS
         {
             if (pos.capture_stage(m))
-                m.value = PieceValue[pos.piece_on(to_sq(m))] - Value(type_of(pos.moved_piece(m)))
-                        + (1 << 28);
+                m.value =
+                  PieceValue[pos.piece_on(to_sq(m))] - type_of(pos.moved_piece(m)) + (1 << 28);
             else
                 m.value = (*mainHistory)[pos.side_to_move()][from_to(m)]
                         + (*continuationHistory[0])[pos.moved_piece(m)][to_sq(m)]
@@ -268,8 +268,7 @@ top:
     case GOOD_CAPTURE :
         if (select<Next>([&]() {
                 // Move losing capture to endBadCaptures to be tried later
-                return pos.see_ge(*cur, Value(-cur->value)) ? true
-                                                            : (*endBadCaptures++ = *cur, false);
+                return pos.see_ge(*cur, -cur->value) ? true : (*endBadCaptures++ = *cur, false);
             }))
             return *(cur - 1);
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -171,7 +171,7 @@ class MovePicker {
                const CapturePieceToHistory*,
                const PieceToHistory**,
                const PawnHistory*);
-    MovePicker(const Position&, Move, Value, const CapturePieceToHistory*);
+    MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
     Move next_move(bool skipQuiets = false);
 
    private:
@@ -190,7 +190,7 @@ class MovePicker {
     Move                         ttMove;
     ExtMove                      refutations[3], *cur, *endMoves, *endBadCaptures;
     int                          stage;
-    Value                        threshold;
+    int                          threshold;
     Depth                        depth;
     ExtMove                      moves[MAX_MOVES];
 };

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -30,10 +30,10 @@
 #include "../misc.h"
 #include "nnue_architecture.h"
 #include "nnue_feature_transformer.h"
+#include "../types.h"
 
 namespace Stockfish {
 class Position;
-using Value = int;
 }
 
 namespace Stockfish::Eval::NNUE {

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -33,7 +33,7 @@
 
 namespace Stockfish {
 class Position;
-enum Value : int;
+using Value = int;
 }
 
 namespace Stockfish::Eval::NNUE {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1029,7 +1029,7 @@ Key Position::key_after(Move m) const {
 // Tests if the SEE (Static Exchange Evaluation)
 // value of move is greater or equal to the given threshold. We'll use an
 // algorithm similar to alpha-beta pruning with a null window.
-bool Position::see_ge(Move m, Value threshold) const {
+bool Position::see_ge(Move m, int threshold) const {
 
     assert(is_ok(m));
 

--- a/src/position.h
+++ b/src/position.h
@@ -141,7 +141,7 @@ class Position {
     void undo_null_move();
 
     // Static Exchange Evaluation
-    bool see_ge(Move m, Value threshold = VALUE_ZERO) const;
+    bool see_ge(Move m, int threshold = 0) const;
 
     // Accessing hash keys
     Key key() const;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -77,13 +77,13 @@ enum NodeType {
 
 // Futility margin
 Value futility_margin(Depth d, bool noTtCutNode, bool improving) {
-    return Value((116 - 44 * noTtCutNode) * (d - improving));
+    return ((116 - 44 * noTtCutNode) * (d - improving));
 }
 
 // Reductions lookup table initialized at startup
 int Reductions[MAX_MOVES];  // [depth or moveNumber]
 
-Depth reduction(bool i, Depth d, int mn, Value delta, Value rootDelta) {
+Depth reduction(bool i, Depth d, int mn, int delta, int rootDelta) {
     int reductionScale = Reductions[d] * Reductions[mn];
     return (reductionScale + 1346 - int(delta) * 896 / int(rootDelta)) / 1024
          + (!i && reductionScale > 880);
@@ -95,7 +95,7 @@ constexpr int futility_move_count(bool improving, Depth depth) {
 
 // Guarantee evaluation does not hit the tablebase range
 constexpr Value to_static_eval(const Value v) {
-    return std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
+    return std::clamp(int(v), VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
 }
 
 // History and stats update bonus, based on depth
@@ -292,13 +292,13 @@ void Thread::search() {
     // (ss + 2) is needed for initialization of cutOffCnt and killers.
     Stack       stack[MAX_PLY + 10], *ss = stack + 7;
     Move        pv[MAX_PLY + 1];
-    Value       alpha, beta, delta;
+    Value       alpha, beta;
     Move        lastBestMove      = MOVE_NONE;
     Depth       lastBestMoveDepth = 0;
     MainThread* mainThread        = (this == Threads.main() ? Threads.main() : nullptr);
     double      timeReduction = 1, totBestMoveChanges = 0;
-    Color       us      = rootPos.side_to_move();
-    int         iterIdx = 0;
+    Color       us = rootPos.side_to_move();
+    int         delta, iterIdx = 0;
 
     std::memset(ss - 7, 0, 10 * sizeof(Stack));
     for (int i = 7; i > 0; --i)
@@ -374,7 +374,7 @@ void Thread::search() {
             Value avg = rootMoves[pvIdx].averageScore;
             delta     = Value(9) + int(avg) * avg / 14847;
             alpha     = std::max(avg - delta, -VALUE_INFINITE);
-            beta      = std::min(avg + delta, VALUE_INFINITE);
+            beta      = std::min(avg + delta, int(VALUE_INFINITE));
 
             // Adjust optimism based on root move's averageScore (~4 Elo)
             optimism[us]  = 121 * avg / (std::abs(avg) + 109);
@@ -425,7 +425,7 @@ void Thread::search() {
                 }
                 else if (bestValue >= beta)
                 {
-                    beta = std::min(bestValue + delta, VALUE_INFINITE);
+                    beta = std::min(bestValue + delta, int(VALUE_INFINITE));
                     ++failedHighCnt;
                 }
                 else
@@ -989,7 +989,7 @@ moves_loop:  // When in check, search starts here
         // Calculate new depth for this move
         newDepth = depth - 1;
 
-        Value delta = beta - alpha;
+        int delta = beta - alpha;
 
         Depth r = reduction(improving, depth, moveCount, delta, thisThread->rootDelta);
 
@@ -1018,7 +1018,7 @@ moves_loop:  // When in check, search starts here
                 }
 
                 // SEE based pruning for captures and checks (~11 Elo)
-                if (!pos.see_ge(move, Value(-187) * depth))
+                if (!pos.see_ge(move, -187 * depth))
                     continue;
             }
             else
@@ -1047,7 +1047,7 @@ moves_loop:  // When in check, search starts here
                 lmrDepth = std::max(lmrDepth, 0);
 
                 // Prune moves with negative SEE (~4 Elo)
-                if (!pos.see_ge(move, Value(-26 * lmrDepth * lmrDepth)))
+                if (!pos.see_ge(move, -26 * lmrDepth * lmrDepth))
                     continue;
             }
         }
@@ -1615,7 +1615,7 @@ Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth) {
                 continue;
 
             // Do not search moves with bad enough SEE values (~5 Elo)
-            if (!pos.see_ge(move, Value(-77)))
+            if (!pos.see_ge(move, -77))
                 continue;
         }
 
@@ -1861,7 +1861,7 @@ Move Skill::pick_best(size_t multiPV) {
 
     // RootMoves are already sorted by score in descending order
     Value  topScore = rootMoves[0].score;
-    int    delta    = std::min(topScore - rootMoves[multiPV - 1].score, PawnValue);
+    int    delta    = std::min(topScore - rootMoves[multiPV - 1].score, int(PawnValue));
     int    maxScore = -VALUE_INFINITE;
     double weakness = 120 - 2 * level;
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -56,13 +56,15 @@ class Thread {
     size_t                pvIdx, pvLast;
     std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;
     int                   selDepth, nmpMinPly;
-    Value                 bestValue, optimism[COLOR_NB];
+    Value                 bestValue;
+
+    int optimism[COLOR_NB];
 
     Position              rootPos;
     StateInfo             rootState;
     Search::RootMoves     rootMoves;
     Depth                 rootDepth, completedDepth;
-    Value                 rootDelta;
+    int                   rootDelta;
     Value                 rootSimpleEval;
     CounterMoveHistory    counterMoves;
     ButterflyHistory      mainHistory;

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -25,7 +25,6 @@
 #include <string>
 
 #include "uci.h"
-#include "types.h"
 
 using std::string;
 

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -27,7 +27,7 @@
 #include "uci.h"
 
 namespace Stockfish {
-enum Value : int;
+using Value = int;
 }
 
 using std::string;
@@ -90,17 +90,6 @@ template<>
 void Tune::Entry<int>::read_option() {
     if (Options.count(name))
         value = int(Options[name]);
-}
-
-template<>
-void Tune::Entry<Value>::init_option() {
-    make_option(name, value, range);
-}
-
-template<>
-void Tune::Entry<Value>::read_option() {
-    if (Options.count(name))
-        value = Value(int(Options[name]));
 }
 
 // Instead of a variable here we have a PostUpdate function: just call it

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -25,10 +25,7 @@
 #include <string>
 
 #include "uci.h"
-
-namespace Stockfish {
-using Value = int;
-}
+#include "types.h"
 
 using std::string;
 

--- a/src/tune.h
+++ b/src/tune.h
@@ -27,7 +27,7 @@
 #include <vector>
 
 namespace Stockfish {
-enum Value : int;
+using Value = int;
 
 using Range    = std::pair<int, int>;  // Option's min-max values
 using RangeFun = Range(int);

--- a/src/tune.h
+++ b/src/tune.h
@@ -26,8 +26,6 @@
 #include <utility>
 #include <vector>
 
-#include "types.h"
-
 namespace Stockfish {
 
 using Range    = std::pair<int, int>;  // Option's min-max values
@@ -102,8 +100,7 @@ class Tune {
 
         static_assert(!std::is_const_v<T>, "Parameter cannot be const!");
 
-        static_assert(std::is_same_v<T, int> || std::is_same_v<T, Value>
-                        || std::is_same_v<T, PostUpdate>,
+        static_assert(std::is_same_v<T, int> || std::is_same_v<T, PostUpdate>,
                       "Parameter type not supported!");
 
         Entry(const std::string& n, T& v, const SetRange& r) :

--- a/src/tune.h
+++ b/src/tune.h
@@ -26,8 +26,9 @@
 #include <utility>
 #include <vector>
 
+#include "types.h"
+
 namespace Stockfish {
-using Value = int;
 
 using Range    = std::pair<int, int>;  // Option's min-max values
 using RangeFun = Range(int);

--- a/src/types.h
+++ b/src/types.h
@@ -161,29 +161,33 @@ enum Bound {
     BOUND_EXACT = BOUND_UPPER | BOUND_LOWER
 };
 
-enum Value : int {
-    VALUE_ZERO     = 0,
-    VALUE_DRAW     = 0,
-    VALUE_NONE     = 32002,
-    VALUE_INFINITE = 32001,
+// Value is used as an alias for int16_t, this is done to differentiate between
+// a search value and any other integer value. The values used in search are always
+// supposed to be in the range (-VALUE_NONE, VALUE_NONE] and should not exceed this range.
+using Value = int;
 
-    VALUE_MATE             = 32000,
-    VALUE_MATE_IN_MAX_PLY  = VALUE_MATE - MAX_PLY,
-    VALUE_MATED_IN_MAX_PLY = -VALUE_MATE_IN_MAX_PLY,
+constexpr Value VALUE_ZERO     = 0;
+constexpr Value VALUE_DRAW     = 0;
+constexpr Value VALUE_NONE     = 32002;
+constexpr Value VALUE_INFINITE = 32001;
 
-    VALUE_TB                 = VALUE_MATE_IN_MAX_PLY - 1,
-    VALUE_TB_WIN_IN_MAX_PLY  = VALUE_TB - MAX_PLY,
-    VALUE_TB_LOSS_IN_MAX_PLY = -VALUE_TB_WIN_IN_MAX_PLY,
+constexpr Value VALUE_MATE             = 32000;
+constexpr Value VALUE_MATE_IN_MAX_PLY  = VALUE_MATE - MAX_PLY;
+constexpr Value VALUE_MATED_IN_MAX_PLY = -VALUE_MATE_IN_MAX_PLY;
 
-    // In the code, we make the assumption that these values
-    // are such that non_pawn_material() can be used to uniquely
-    // identify the material on the board.
-    PawnValue   = 208,
-    KnightValue = 781,
-    BishopValue = 825,
-    RookValue   = 1276,
-    QueenValue  = 2538,
-};
+constexpr Value VALUE_TB                 = VALUE_MATE_IN_MAX_PLY - 1;
+constexpr Value VALUE_TB_WIN_IN_MAX_PLY  = VALUE_TB - MAX_PLY;
+constexpr Value VALUE_TB_LOSS_IN_MAX_PLY = -VALUE_TB_WIN_IN_MAX_PLY;
+
+// In the code, we make the assumption that these values
+// are such that non_pawn_material() can be used to uniquely
+// identify the material on the board.
+constexpr Value PawnValue   = 208;
+constexpr Value KnightValue = 781;
+constexpr Value BishopValue = 825;
+constexpr Value RookValue   = 1276;
+constexpr Value QueenValue  = 2538;
+
 
 // clang-format off
 enum PieceType {
@@ -304,7 +308,6 @@ struct DirtyPiece {
         inline T&     operator*=(T& d, int i) { return d = T(int(d) * i); } \
         inline T&     operator/=(T& d, int i) { return d = T(int(d) / i); }
 
-ENABLE_FULL_OPERATORS_ON(Value)
 ENABLE_FULL_OPERATORS_ON(Direction)
 
 ENABLE_INCR_OPERATORS_ON(PieceType)


### PR DESCRIPTION
The primary rationale behind this lies in the fact that enums were not originally designed to be employed in the manner we currently utilize them.

The Value enum was used like a type alias throughout the code and was often misused. Furthermore, changing the underlying size of the enum to int16_t broke everything, mostly because of the operator overloads for the Value enum, were causing data to be truncated. 
Since Value is now a type alias, the operator overloads are no longer required.

Passed Non-Regression STC:
https://tests.stockfishchess.org/tests/view/6593b8bb79aa8af82b95b401
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 235296 W: 59919 L: 59917 D: 115460
Ptnml(0-2): 743, 27085, 62054, 26959, 807

No functional change