### PR TITLE
Remove unneeded operator overload macros

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -264,36 +264,19 @@ struct DirtyPiece {
     Square to[3];
 };
 
-    #define ENABLE_BASE_OPERATORS_ON(T) \
-        constexpr T operator+(T d1, int d2) { return T(int(d1) + d2); } \
-        constexpr T operator-(T d1, int d2) { return T(int(d1) - d2); } \
-        constexpr T operator-(T d) { return T(-int(d)); } \
-        inline T&   operator+=(T& d1, int d2) { return d1 = d1 + d2; } \
-        inline T&   operator-=(T& d1, int d2) { return d1 = d1 - d2; }
-
     #define ENABLE_INCR_OPERATORS_ON(T) \
         inline T& operator++(T& d) { return d = T(int(d) + 1); } \
         inline T& operator--(T& d) { return d = T(int(d) - 1); }
-
-    #define ENABLE_FULL_OPERATORS_ON(T) \
-        ENABLE_BASE_OPERATORS_ON(T) \
-        constexpr T   operator*(int i, T d) { return T(i * int(d)); } \
-        constexpr T   operator*(T d, int i) { return T(int(d) * i); } \
-        constexpr T   operator/(T d, int i) { return T(int(d) / i); } \
-        constexpr int operator/(T d1, T d2) { return int(d1) / int(d2); } \
-        inline T&     operator*=(T& d, int i) { return d = T(int(d) * i); } \
-        inline T&     operator/=(T& d, int i) { return d = T(int(d) / i); }
-
-ENABLE_FULL_OPERATORS_ON(Direction)
 
 ENABLE_INCR_OPERATORS_ON(PieceType)
 ENABLE_INCR_OPERATORS_ON(Square)
 ENABLE_INCR_OPERATORS_ON(File)
 ENABLE_INCR_OPERATORS_ON(Rank)
 
-    #undef ENABLE_FULL_OPERATORS_ON
     #undef ENABLE_INCR_OPERATORS_ON
-    #undef ENABLE_BASE_OPERATORS_ON
+
+constexpr Direction operator+(Direction d1, Direction d2) { return Direction(int(d1) + int(d2)); }
+constexpr Direction operator*(int i, Direction d) { return Direction(i * int(d)); }
 
 // Additional operators to add a Direction to a Square
 constexpr Square operator+(Square s, Direction d) { return Square(int(s) + int(d)); }


### PR DESCRIPTION
Only Direction type is using two of the enable overload macros. Aside from this, only two of the overloads are even being used.

Therefore, we can just define the needed overloads and remove the macros.

No functional change.