### PR TITLE
Tweak usage of correction history.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -745,7 +745,8 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
 
         Value newEval =
           ss->staticEval
-          + thisThread->correctionHistory[us][pawn_structure_index<Correction>(pos)] / 32;
+          + thisThread->correctionHistory[us][pawn_structure_index<Correction>(pos)] * 
+            std::abs(thisThread->correctionHistory[us][pawn_structure_index<Correction>(pos)]) / 16384;
 
         ss->staticEval = eval = to_static_eval(newEval);
 
@@ -759,7 +760,8 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
 
         Value newEval =
           ss->staticEval
-          + thisThread->correctionHistory[us][pawn_structure_index<Correction>(pos)] / 32;
+          + thisThread->correctionHistory[us][pawn_structure_index<Correction>(pos)] * 
+            std::abs(thisThread->correctionHistory[us][pawn_structure_index<Correction>(pos)]) / 16384;
 
         ss->staticEval = eval = to_static_eval(newEval);
 
@@ -1502,7 +1504,8 @@ Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth) {
 
             Value newEval =
               ss->staticEval
-              + thisThread->correctionHistory[us][pawn_structure_index<Correction>(pos)] / 32;
+              + thisThread->correctionHistory[us][pawn_structure_index<Correction>(pos)] * 
+              std::abs(thisThread->correctionHistory[us][pawn_structure_index<Correction>(pos)]) / 16384;
 
             ss->staticEval = bestValue = to_static_eval(newEval);
 
@@ -1519,7 +1522,8 @@ Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth) {
 
             Value newEval =
               ss->staticEval
-              + thisThread->correctionHistory[us][pawn_structure_index<Correction>(pos)] / 32;
+              + thisThread->correctionHistory[us][pawn_structure_index<Correction>(pos)] * 
+              std::abs(thisThread->correctionHistory[us][pawn_structure_index<Correction>(pos)]) / 16384;
 
             ss->staticEval = bestValue = to_static_eval(newEval);
         }


### PR DESCRIPTION
Instead of using linear formula use quadratic one.
Maximum impact of correction history is doubled this way, it breaks even with previous formula on half of maximum value.
Passed STC:
https://tests.stockfishchess.org/tests/view/659591e579aa8af82b95d7e8
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 225216 W: 57616 L: 57019 D: 110581
Ptnml(0-2): 747, 26677, 57201, 27198, 785 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6596ee0b79aa8af82b95f08a
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 73314 W: 18524 L: 18125 D: 36665
Ptnml(0-2): 41, 8159, 19875, 8524, 58 
bench 1464785