### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# .git-blame-ignore-revs
+# Ignore commit which added clang-format
+2d0237db3f0e596fb06e3ffbadba84dcc4e018f6
+
+# Post commit formatting fixes
+0fca5605fa2e5e7240fde5e1aae50952b2612231
+08ed4c90db31959521b7ef3186c026edd1e90307


### PR DESCRIPTION
Add a `.git-blame-ignore-revs` file which can be used to skip specified commits when blaming, this is useful to ignore formatting commits, like clang-format #4790.

Github blame automatically supports this file format, as well as other third party tools.
Git itself needs to be told about the file name to work, the following command will add it
to the current git repo.
`git config blame.ignoreRevsFile .git-blame-ignore-revs`, alternatively one has to specify
it with every blame.
`git blame --ignore-revs-file .git-blame-ignore-revs search.cpp`

Supported since git 2.23.

No functional change