### PR TITLE
Bad Quiets

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -37,8 +37,9 @@ enum Stages {
     GOOD_CAPTURE,
     REFUTATION,
     QUIET_INIT,
-    QUIET,
+    GOOD_QUIET,
     BAD_CAPTURE,
+    BAD_QUIET,
 
     // generate evasion moves
     EVASION_TT,
@@ -243,6 +244,8 @@ Move MovePicker::select(Pred filter) {
 // moves left, picking the move with the highest score from a list of generated moves.
 Move MovePicker::next_move(bool skipQuiets) {
 
+    auto quiet_threshold = [](Depth d) { return -3330 * d; };
+
 top:
     switch (stage)
     {
@@ -295,21 +298,35 @@ top:
         if (!skipQuiets)
         {
             cur      = endBadCaptures;
-            endMoves = generate<QUIETS>(pos, cur);
+            endMoves = beginBadQuiets = endBadQuiets = generate<QUIETS>(pos, cur);
 
             score<QUIETS>();
-            partial_insertion_sort(cur, endMoves, -3330 * depth);
+            partial_insertion_sort(cur, endMoves, quiet_threshold(depth));
         }
 
         ++stage;
         [[fallthrough]];
 
-    case QUIET :
+    case GOOD_QUIET :
         if (!skipQuiets && select<Next>([&]() {
                 return *cur != refutations[0] && *cur != refutations[1] && *cur != refutations[2];
             }))
-            return *(cur - 1);
+        {
+            Move tmp = *(cur - 1);
+            if ((cur - 1)->value < -7500 && (cur - 1)->value > quiet_threshold(depth))
+            {
+                // Remaining quiets are bad
+                beginBadQuiets = cur;
 
+                // Prepare the pointers to loop over the bad captures
+                cur            = moves;
+                endMoves       = endBadCaptures;
+
+                ++stage;
+            }
+            return tmp;
+        }
+        
         // Prepare the pointers to loop over the bad captures
         cur      = moves;
         endMoves = endBadCaptures;
@@ -318,7 +335,23 @@ top:
         [[fallthrough]];
 
     case BAD_CAPTURE :
-        return select<Next>([]() { return true; });
+        if (select<Next>([]() { return true; }))
+            return *(cur - 1);
+        
+        // Prepare the pointers to loop over the bad quiets
+        cur      = beginBadQuiets;
+        endMoves = endBadQuiets;
+
+        ++stage;
+        [[fallthrough]];
+
+    case BAD_QUIET :
+        if (!skipQuiets)
+            return select<Next>([&]() {
+                return *cur != refutations[0] && *cur != refutations[1] && *cur != refutations[2];
+            });
+
+        return Move::none();
 
     case EVASION_INIT :
         cur      = moves;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -188,7 +188,7 @@ class MovePicker {
     const PieceToHistory**       continuationHistory;
     const PawnHistory*           pawnHistory;
     Move                         ttMove;
-    ExtMove                      refutations[3], *cur, *endMoves, *endBadCaptures;
+    ExtMove                      refutations[3], *cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
     int                          stage;
     int                          threshold;
     Depth                        depth;


### PR DESCRIPTION
Split quiets into good and bad as we do with captures.   When we find the first quiet move below a certain threshold that has been sorted we consider all subsequent quiets bad.  Inspired by @locutus2 idea to skip bad captures.

STC https://tests.stockfishchess.org/tests/view/6597759f79aa8af82b95fa17
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 138688 W: 35566 L: 35096 D: 68026
Ptnml(0-2): 476, 16367, 35183, 16847, 471 

LTC https://tests.stockfishchess.org/tests/view/6598583c79aa8af82b960ad0
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 84108 W: 21468 L: 21048 D: 41592
Ptnml(0-2): 38, 9355, 22858, 9755, 48 

bench: 1351755