### PR TITLE
Cleanup Evalfile handling

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -20,6 +20,7 @@
 #define EVALUATE_H_INCLUDED
 
 #include <string>
+#include <unordered_map>
 
 #include "types.h"
 
@@ -34,8 +35,6 @@ std::string trace(Position& pos);
 int   simple_eval(const Position& pos, Color c);
 Value evaluate(const Position& pos);
 
-extern std::string currentEvalFileName[2];
-
 // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro, as it is used in the Makefile.
@@ -44,10 +43,20 @@ extern std::string currentEvalFileName[2];
 
 namespace NNUE {
 
+enum NetSize : int;
+
 void init();
 void verify();
 
 }  // namespace NNUE
+
+struct EvalFile {
+    std::string option_name;
+    std::string default_name;
+    std::string selected_name;
+};
+
+extern std::unordered_map<NNUE::NetSize, EvalFile> EvalFiles;
 
 }  // namespace Eval
 

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <sstream>
 #include <string_view>
+#include <unordered_map>
 
 #include "../evaluate.h"
 #include "../misc.h"
@@ -449,7 +450,7 @@ bool save_eval(const std::optional<std::string>& filename, NetSize netSize) {
         actualFilename = filename.value();
     else
     {
-        if (currentEvalFileName[netSize]
+        if (EvalFiles.at(netSize).selected_name
             != (netSize == Small ? EvalFileDefaultNameSmall : EvalFileDefaultNameBig))
         {
             msg = "Failed to export a net. "

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -37,7 +37,7 @@ namespace Stockfish::Eval::NNUE {
 // Input features used in evaluation function
 using FeatureSet = Features::HalfKAv2_hm;
 
-enum NetSize {
+enum NetSize : int {
     Big,
     Small
 };


### PR DESCRIPTION
This cleans up the EvalFile handling after the merge of #4915, 
which has become a bit confusing on what it is actually doing.

No functional change