### PR TITLE
Remove some outdated SIMD functions

### DIFF
--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -200,21 +200,18 @@ class AffineTransform {
         #define vec_setzero _mm512_setzero_si512
         #define vec_set_32 _mm512_set1_epi32
         #define vec_add_dpbusd_32 Simd::m512_add_dpbusd_epi32
-        #define vec_add_dpbusd_32x2 Simd::m512_add_dpbusd_epi32x2
         #define vec_hadd Simd::m512_hadd
     #elif defined(USE_AVX2)
             using vec_t = __m256i;
         #define vec_setzero _mm256_setzero_si256
         #define vec_set_32 _mm256_set1_epi32
         #define vec_add_dpbusd_32 Simd::m256_add_dpbusd_epi32
-        #define vec_add_dpbusd_32x2 Simd::m256_add_dpbusd_epi32x2
         #define vec_hadd Simd::m256_hadd
     #elif defined(USE_SSSE3)
             using vec_t = __m128i;
         #define vec_setzero _mm_setzero_si128
         #define vec_set_32 _mm_set1_epi32
         #define vec_add_dpbusd_32 Simd::m128_add_dpbusd_epi32
-        #define vec_add_dpbusd_32x2 Simd::m128_add_dpbusd_epi32x2
         #define vec_hadd Simd::m128_hadd
     #endif
 
@@ -231,16 +228,14 @@ class AffineTransform {
             for (IndexType k = 0; k < NumRegs; ++k)
                 acc[k] = biasvec[k];
 
-            for (IndexType i = 0; i < NumChunks; i += 2)
+            for (IndexType i = 0; i < NumChunks; ++i)
             {
-                const vec_t in0 = vec_set_32(input32[i + 0]);
-                const vec_t in1 = vec_set_32(input32[i + 1]);
+                const vec_t in0 = vec_set_32(input32[i]);
                 const auto  col0 =
-                  reinterpret_cast<const vec_t*>(&weights[(i + 0) * OutputDimensions * 4]);
-                const auto col1 =
-                  reinterpret_cast<const vec_t*>(&weights[(i + 1) * OutputDimensions * 4]);
+                  reinterpret_cast<const vec_t*>(&weights[i * OutputDimensions * 4]);
+
                 for (IndexType k = 0; k < NumRegs; ++k)
-                    vec_add_dpbusd_32x2(acc[k], in0, col0[k], in1, col1[k]);
+                    vec_add_dpbusd_32(acc[k], in0, col0[k]);
             }
 
             vec_t* outptr = reinterpret_cast<vec_t*>(output);
@@ -250,7 +245,6 @@ class AffineTransform {
     #undef vec_setzero
     #undef vec_set_32
     #undef vec_add_dpbusd_32
-    #undef vec_add_dpbusd_32x2
     #undef vec_hadd
         }
         else if constexpr (OutputDimensions == 1)
@@ -263,14 +257,12 @@ class AffineTransform {
         #define vec_setzero _mm256_setzero_si256
         #define vec_set_32 _mm256_set1_epi32
         #define vec_add_dpbusd_32 Simd::m256_add_dpbusd_epi32
-        #define vec_add_dpbusd_32x2 Simd::m256_add_dpbusd_epi32x2
         #define vec_hadd Simd::m256_hadd
     #elif defined(USE_SSSE3)
             using vec_t = __m128i;
         #define vec_setzero _mm_setzero_si128
         #define vec_set_32 _mm_set1_epi32
         #define vec_add_dpbusd_32 Simd::m128_add_dpbusd_epi32
-        #define vec_add_dpbusd_32x2 Simd::m128_add_dpbusd_epi32x2
         #define vec_hadd Simd::m128_hadd
     #endif
 
@@ -294,7 +286,6 @@ class AffineTransform {
     #undef vec_setzero
     #undef vec_set_32
     #undef vec_add_dpbusd_32
-    #undef vec_add_dpbusd_32x2
     #undef vec_hadd
         }
 #else

--- a/src/nnue/layers/simd.h
+++ b/src/nnue/layers/simd.h
@@ -87,21 +87,6 @@ m512_hadd128x16_interleave(__m512i sum0, __m512i sum1, __m512i sum2, __m512i sum
     #endif
 }
 
-[[maybe_unused]] static void
-m512_add_dpbusd_epi32x2(__m512i& acc, __m512i a0, __m512i b0, __m512i a1, __m512i b1) {
-
-    #if defined(USE_VNNI)
-    acc = _mm512_dpbusd_epi32(acc, a0, b0);
-    acc = _mm512_dpbusd_epi32(acc, a1, b1);
-    #else
-    __m512i product0 = _mm512_maddubs_epi16(a0, b0);
-    __m512i product1 = _mm512_maddubs_epi16(a1, b1);
-    product0         = _mm512_madd_epi16(product0, _mm512_set1_epi16(1));
-    product1         = _mm512_madd_epi16(product1, _mm512_set1_epi16(1));
-    acc              = _mm512_add_epi32(acc, _mm512_add_epi32(product0, product1));
-    #endif
-}
-
 #endif
 
 #if defined(USE_AVX2)
@@ -124,21 +109,6 @@ m512_add_dpbusd_epi32x2(__m512i& acc, __m512i a0, __m512i b0, __m512i a1, __m512
     #endif
 }
 
-[[maybe_unused]] static void
-m256_add_dpbusd_epi32x2(__m256i& acc, __m256i a0, __m256i b0, __m256i a1, __m256i b1) {
-
-    #if defined(USE_VNNI)
-    acc = _mm256_dpbusd_epi32(acc, a0, b0);
-    acc = _mm256_dpbusd_epi32(acc, a1, b1);
-    #else
-    __m256i product0 = _mm256_maddubs_epi16(a0, b0);
-    __m256i product1 = _mm256_maddubs_epi16(a1, b1);
-    product0         = _mm256_madd_epi16(product0, _mm256_set1_epi16(1));
-    product1         = _mm256_madd_epi16(product1, _mm256_set1_epi16(1));
-    acc              = _mm256_add_epi32(acc, _mm256_add_epi32(product0, product1));
-    #endif
-}
-
 #endif
 
 #if defined(USE_SSSE3)
@@ -156,26 +126,9 @@ m256_add_dpbusd_epi32x2(__m256i& acc, __m256i a0, __m256i b0, __m256i a1, __m256
     acc              = _mm_add_epi32(acc, product0);
 }
 
-[[maybe_unused]] static void
-m128_add_dpbusd_epi32x2(__m128i& acc, __m128i a0, __m128i b0, __m128i a1, __m128i b1) {
-
-    __m128i product0 = _mm_maddubs_epi16(a0, b0);
-    __m128i product1 = _mm_maddubs_epi16(a1, b1);
-    product0         = _mm_madd_epi16(product0, _mm_set1_epi16(1));
-    product1         = _mm_madd_epi16(product1, _mm_set1_epi16(1));
-    acc              = _mm_add_epi32(acc, _mm_add_epi32(product0, product1));
-}
-
 #endif
 
 #if defined(USE_NEON_DOTPROD)
-
-[[maybe_unused]] static void dotprod_m128_add_dpbusd_epi32x2(
-  int32x4_t& acc, int8x16_t a0, int8x16_t b0, int8x16_t a1, int8x16_t b1) {
-
-    acc = vdotq_s32(acc, a0, b0);
-    acc = vdotq_s32(acc, a1, b1);
-}
 
 [[maybe_unused]] static void
 dotprod_m128_add_dpbusd_epi32(int32x4_t& acc, int8x16_t a, int8x16_t b) {
@@ -198,13 +151,6 @@ dotprod_m128_add_dpbusd_epi32(int32x4_t& acc, int8x16_t a, int8x16_t b) {
     return neon_m128_reduce_add_epi32(sum) + bias;
 }
 
-[[maybe_unused]] static void
-neon_m128_add_dpbusd_epi32x2(int32x4_t& acc, int8x8_t a0, int8x8_t b0, int8x8_t a1, int8x8_t b1) {
-
-    int16x8_t product = vmull_s8(a0, b0);
-    product           = vmlal_s8(product, a1, b1);
-    acc               = vpadalq_s16(acc, product);
-}
 #endif
 
 #if USE_NEON >= 8


### PR DESCRIPTION
Since https://github.com/official-stockfish/Stockfish/pull/4391 the x2 SIMD functions no longer serve any useful purpose.

STC https://tests.stockfishchess.org/tests/view/659cf42579aa8af82b966d55
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 67392 W: 17222 L: 17037 D: 33133
Ptnml(0-2): 207, 7668, 17762, 7851, 208 

No functional change
bench: 1219824