### PR TITLE
Simplify bad quiets

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -312,19 +312,11 @@ top:
                 return *cur != refutations[0] && *cur != refutations[1] && *cur != refutations[2];
             }))
         {
-            Move tmp = *(cur - 1);
-            if ((cur - 1)->value < -7500 && (cur - 1)->value > quiet_threshold(depth))
-            {
-                // Remaining quiets are bad
-                beginBadQuiets = cur;
-
-                // Prepare the pointers to loop over the bad captures
-                cur      = moves;
-                endMoves = endBadCaptures;
-
-                ++stage;
-            }
-            return tmp;
+            if ((cur - 1)->value > -8000 || (cur - 1)->value <= quiet_threshold(depth))
+                return *(cur - 1);
+            
+            // Remaining quiets are bad
+            beginBadQuiets = cur - 1;
         }
 
         // Prepare the pointers to loop over the bad captures


### PR DESCRIPTION
The main difference is that instead of returning the first bad quiet as a good one we fall through.  This is actually more correct and simpler to implement.

STC https://tests.stockfishchess.org/tests/view/659bbb3479aa8af82b964ec7
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 150944 W: 38399 L: 38305 D: 74240
Ptnml(0-2): 485, 18042, 38298, 18188, 459 
LTC https://tests.stockfishchess.org/tests/view/659c6e6279aa8af82b9660eb
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 192060 W: 47871 L: 47823 D: 96366
Ptnml(0-2): 144, 21912, 51845, 22010, 119 

The cutoff is now -8K instead of -7.5K.  I tried w/ -7.5K but it failed.
https://tests.stockfishchess.org/tests/view/659a1f4b79aa8af82b962a0e
I believe this was likely a false negative because the only difference is what I explained above.

bench: 1308279