### PR TITLE
Prove mated-in scores.

### DIFF
--- a/src/thread.h
+++ b/src/thread.h
@@ -81,7 +81,7 @@ struct MainThread: public Thread {
     using Thread::Thread;
 
     void search() override;
-    void check_time();
+    void check_time(Depth completed);
 
     double           previousTimeReduction;
     Value            bestPreviousScore;
@@ -109,7 +109,7 @@ struct ThreadPool {
     void        start_searching();
     void        wait_for_search_finished() const;
 
-    std::atomic_bool stop, increaseDepth;
+    std::atomic_bool stop, abortedSearch, increaseDepth;
 
     auto cbegin() const noexcept { return threads.cbegin(); }
     auto begin() noexcept { return threads.begin(); }


### PR DESCRIPTION
This fixes the issue that Stockfish can output non-proven mated scores if the search has been prematurely stopped with Time control or Nodes searched before exploring other possibilities that the mated score could have been delayed or refuted.

The fix also replaces staving off from proven mated scores in multithread environment.

Issue reported on mate tracker repo by and this PR is co-authored with @robertnurnberg
Special thanks to @AndyGrant for outlining that a fix is eventually possible.

Passed Adj off SMP STC:
https://tests.stockfishchess.org/tests/view/659d8c1b79aa8af82b967bc9
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 143064 W: 35747 L: 35647 D: 71670
Ptnml(0-2): 182, 16500, 38091, 16554, 205

Passed Adj off SMP LTC:
https://tests.stockfishchess.org/tests/view/659e3b6179aa8af82b968c9e
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 106678 W: 26449 L: 26318 D: 53911
Ptnml(0-2): 24, 11410, 30344, 11533, 28

Passed all tests in mate tracker without any better mate for opponent found in 1t and multithreads.

bench: 1219824