### PR TITLE
Remove threatenedQueen ByPawn 

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -201,7 +201,6 @@ void MovePicker::score() {
             m.value -= !(threatenedPieces & from)
                        ? (pt == QUEEN ? bool(to & threatenedByRook) * 50000
                                           + bool(to & threatenedByMinor) * 10000
-                                          + bool(to & threatenedByPawn) * 20000
                           : pt == ROOK ? bool(to & threatenedByMinor) * 25000
                                            + bool(to & threatenedByPawn) * 10000
                           : pt != PAWN ? bool(to & threatenedByPawn) * 15000


### PR DESCRIPTION
Remove a part of the formula (threatenedQueen ByPawn) that doesn't bring any benefit in terms of Elo.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 151776 W: 38690 L: 38597 D: 74489
Ptnml(0-2): 522, 17841, 39015, 18042, 468
https://tests.stockfishchess.org/tests/view/659d614c79aa8af82b9677d0

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 91908 W: 23075 L: 22924 D: 45909
Ptnml(0-2): 70, 10311, 25037, 10470, 66
https://tests.stockfishchess.org/tests/view/659d94d379aa8af82b967cb2