### PR TITLE
Remove the dependency on a Worker from evaluate

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -35,7 +35,6 @@
 #include "nnue/evaluate_nnue.h"
 #include "nnue/nnue_architecture.h"
 #include "position.h"
-#include "search.h"
 #include "types.h"
 #include "uci.h"
 #include "ucioption.h"

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -196,7 +196,7 @@ int Eval::simple_eval(const Position& pos, Color c) {
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
 // of the position from the point of view of the side to move.
-Value Eval::evaluate(const Position& pos, const Search::Worker& workerThread) {
+Value Eval::evaluate(const Position& pos, int optimism) {
 
     assert(!pos.checkers());
 
@@ -216,8 +216,6 @@ Value Eval::evaluate(const Position& pos, const Search::Worker& workerThread) {
 
         Value nnue = smallNet ? NNUE::evaluate<NNUE::Small>(pos, true, &nnueComplexity)
                               : NNUE::evaluate<NNUE::Big>(pos, true, &nnueComplexity);
-
-        int optimism = workerThread.optimism[stm];
 
         // Blend optimism and eval with nnue complexity and material imbalance
         optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 512;
@@ -240,16 +238,10 @@ Value Eval::evaluate(const Position& pos, const Search::Worker& workerThread) {
 // a string (suitable for outputting to stdout) that contains the detailed
 // descriptions and values of each evaluation term. Useful for debugging.
 // Trace scores are from white's point of view
-std::string Eval::trace(Position& pos, Search::Worker& workerThread) {
+std::string Eval::trace(Position& pos) {
 
     if (pos.checkers())
         return "Final evaluation: none (in check)";
-
-    // Reset any global variable used in eval
-    workerThread.iterBestValue   = VALUE_ZERO;
-    workerThread.rootSimpleEval  = VALUE_ZERO;
-    workerThread.optimism[WHITE] = VALUE_ZERO;
-    workerThread.optimism[BLACK] = VALUE_ZERO;
 
     std::stringstream ss;
     ss << std::showpoint << std::noshowpos << std::fixed << std::setprecision(2);
@@ -262,7 +254,7 @@ std::string Eval::trace(Position& pos, Search::Worker& workerThread) {
     v = pos.side_to_move() == WHITE ? v : -v;
     ss << "NNUE evaluation        " << 0.01 * UCI::to_cp(v) << " (white side)\n";
 
-    v = evaluate(pos, workerThread);
+    v = evaluate(pos, VALUE_ZERO);
     v = pos.side_to_move() == WHITE ? v : -v;
     ss << "Final evaluation       " << 0.01 * UCI::to_cp(v) << " (white side)";
     ss << " [with scaled NNUE, ...]";

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,10 +35,10 @@ class Worker;
 
 namespace Eval {
 
-std::string trace(Position& pos, Search::Worker& workerThread);
+std::string trace(Position& pos);
 
 int   simple_eval(const Position& pos, Color c);
-Value evaluate(const Position& pos, const Search::Worker& workerThread);
+Value evaluate(const Position& pos, int optimism);
 
 // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
 // for the build process (profile-build and fishtest) to work. Do not change the

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -29,10 +29,6 @@ namespace Stockfish {
 class Position;
 class OptionsMap;
 
-namespace Search {
-class Worker;
-}
-
 namespace Eval {
 
 std::string trace(Position& pos);

--- a/src/search.h
+++ b/src/search.h
@@ -185,10 +185,6 @@ class Worker {
 
     bool is_mainthread() const { return thread_idx == 0; }
 
-    // Public because evaluate uses this
-    Value iterBestValue, optimism[COLOR_NB];
-    Value rootSimpleEval;
-
     // Public because they need to be updatable by the stats
     CounterMoveHistory    counterMoves;
     ButterflyHistory      mainHistory;
@@ -226,6 +222,9 @@ class Worker {
     size_t                pvIdx, pvLast;
     std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;
     int                   selDepth, nmpMinPly;
+
+    Value optimism[COLOR_NB];
+    Value iterBestValue;
 
     Position  rootPos;
     StateInfo rootState;

--- a/src/search.h
+++ b/src/search.h
@@ -224,7 +224,6 @@ class Worker {
     int                   selDepth, nmpMinPly;
 
     Value optimism[COLOR_NB];
-    Value iterBestValue;
 
     Position  rootPos;
     StateInfo rootState;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -27,7 +27,6 @@
 #include <unordered_map>
 #include <utility>
 
-#include "evaluate.h"
 #include "misc.h"
 #include "movegen.h"
 #include "search.h"

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -206,7 +206,6 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
         th->worker->rootMoves                              = rootMoves;
         th->worker->rootPos.set(pos.fen(), pos.is_chess960(), &th->worker->rootState);
         th->worker->rootState      = setupStates->back();
-        th->worker->rootSimpleEval = Eval::simple_eval(pos, pos.side_to_move());
     }
 
     main_thread()->start_searching();

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -205,7 +205,7 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
         th->worker->rootDepth = th->worker->completedDepth = 0;
         th->worker->rootMoves                              = rootMoves;
         th->worker->rootPos.set(pos.fen(), pos.is_chess960(), &th->worker->rootState);
-        th->worker->rootState      = setupStates->back();
+        th->worker->rootState = setupStates->back();
     }
 
     main_thread()->start_searching();

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -270,7 +270,7 @@ void UCI::trace_eval(Position& pos) {
 
     Eval::NNUE::verify(options, evalFiles);
 
-    sync_cout << "\n" << Eval::trace(p, *threads.main_thread()->worker.get()) << sync_endl;
+    sync_cout << "\n" << Eval::trace(p) << sync_endl;
 }
 
 void UCI::search_clear() {


### PR DESCRIPTION
Also remove dead code, `rootSimpleEval` is no longer used since the introduction of dual net.  
`iterBestValue` is also no longer used in evaluate and can be reduced to a local variable.

No functional change