### PR TITLE
Remove global TB variables from search 

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -44,15 +44,13 @@ Bitboard BishopTable[0x1480];  // To store bishop attacks
 
 void init_magics(PieceType pt, Bitboard table[], Magic magics[]);
 
-}
-
 // Returns the bitboard of target square for the given step
 // from the given square. If the step is off the board, returns empty bitboard.
-inline Bitboard safe_destination(Square s, int step) {
+Bitboard safe_destination(Square s, int step) {
     Square to = Square(s + step);
     return is_ok(to) && distance(s, to) <= 2 ? square_bb(to) : Bitboard(0);
 }
-
+}
 
 // Returns an ASCII representation of a bitboard suitable
 // to be printed to standard output. Useful for debugging.

--- a/src/search.h
+++ b/src/search.h
@@ -29,6 +29,7 @@
 #include "misc.h"
 #include "movepick.h"
 #include "position.h"
+#include "syzygy/tbprobe.h"
 #include "timeman.h"
 #include "types.h"
 
@@ -47,7 +48,6 @@ class OptionsMap;
 class UCI;
 
 namespace Search {
-
 
 // Stack struct keeps track of the information we need to remember from nodes
 // shallower and deeper in the tree during the search. Each search thread has
@@ -237,6 +237,8 @@ class Worker {
 
     // The main thread has a SearchManager, the others have a NullSearchManager
     std::unique_ptr<ISearchManager> manager;
+
+    Tablebases::Config tbConfig;
 
     const OptionsMap&   options;
     ThreadPool&         threads;

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -18,7 +18,6 @@
 
 #include "tbprobe.h"
 
-#include <sys/stat.h>
 #include <algorithm>
 #include <atomic>
 #include <cassert>
@@ -32,6 +31,7 @@
 #include <mutex>
 #include <sstream>
 #include <string_view>
+#include <sys/stat.h>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -42,6 +42,7 @@
 #include "../position.h"
 #include "../search.h"
 #include "../types.h"
+#include "../ucioption.h"
 
 #ifndef _WIN32
     #include <fcntl.h>
@@ -1680,4 +1681,60 @@ bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, boo
     return true;
 }
 
+Config Tablebases::rank_root_moves(const OptionsMap&  options,
+                                   Position&          pos,
+                                   Search::RootMoves& rootMoves) {
+    Config config;
+
+    if (rootMoves.empty())
+        return config;
+
+    config.rootInTB    = false;
+    config.useRule50   = bool(options["Syzygy50MoveRule"]);
+    config.probeDepth  = int(options["SyzygyProbeDepth"]);
+    config.cardinality = int(options["SyzygyProbeLimit"]);
+
+    bool dtz_available = true;
+
+    // Tables with fewer pieces than SyzygyProbeLimit are searched with
+    // probeDepth == DEPTH_ZERO
+    if (config.cardinality > MaxCardinality)
+    {
+        config.cardinality = MaxCardinality;
+        config.probeDepth  = 0;
+    }
+
+    if (config.cardinality >= popcount(pos.pieces()) && !pos.can_castle(ANY_CASTLING))
+    {
+        // Rank moves using DTZ tables
+        config.rootInTB = root_probe(pos, rootMoves, options["Syzygy50MoveRule"]);
+
+        if (!config.rootInTB)
+        {
+            // DTZ tables are missing; try to rank moves using WDL tables
+            dtz_available   = false;
+            config.rootInTB = root_probe_wdl(pos, rootMoves, options["Syzygy50MoveRule"]);
+        }
+    }
+
+    if (config.rootInTB)
+    {
+        // Sort moves according to TB rank
+        std::stable_sort(
+          rootMoves.begin(), rootMoves.end(),
+          [](const Search::RootMove& a, const Search::RootMove& b) { return a.tbRank > b.tbRank; });
+
+        // Probe during search only if DTZ is not available and we are winning
+        if (dtz_available || rootMoves[0].tbScore <= VALUE_DRAW)
+            config.cardinality = 0;
+    }
+    else
+    {
+        // Clean up if root_probe() and root_probe_wdl() have failed
+        for (auto& m : rootMoves)
+            m.tbRank = 0;
+    }
+
+    return config;
+}
 }  // namespace Stockfish

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -20,15 +20,29 @@
 #define TBPROBE_H
 
 #include <string>
+#include <vector>
 
-#include "../search.h"
 
 namespace Stockfish {
 class Position;
 class OptionsMap;
+
+using Depth = int;
+
+namespace Search {
+struct RootMove;
+using RootMoves = std::vector<RootMove>;
+}
 }
 
 namespace Stockfish::Tablebases {
+
+struct Config {
+    int   cardinality = 0;
+    bool  rootInTB    = false;
+    bool  useRule50   = false;
+    Depth probeDepth  = 0;
+};
 
 enum WDLScore {
     WDLLoss        = -2,  // Loss
@@ -54,7 +68,7 @@ WDLScore probe_wdl(Position& pos, ProbeState* result);
 int      probe_dtz(Position& pos, ProbeState* result);
 bool     root_probe(Position& pos, Search::RootMoves& rootMoves, bool rule50);
 bool     root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, bool rule50);
-void     rank_root_moves(const OptionsMap& options, Position& pos, Search::RootMoves& rootMoves);
+Config   rank_root_moves(const OptionsMap& options, Position& pos, Search::RootMoves& rootMoves);
 
 }  // namespace Stockfish::Tablebases
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -181,8 +181,7 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
             || std::count(limits.searchmoves.begin(), limits.searchmoves.end(), m))
             rootMoves.emplace_back(m);
 
-    if (!rootMoves.empty())
-        Tablebases::rank_root_moves(options, pos, rootMoves);
+    Tablebases::Config tbConfig = Tablebases::rank_root_moves(options, pos, rootMoves);
 
     // After ownership transfer 'states' becomes empty, so if we stop the search
     // and call 'go' again without setting a new position states.get() == nullptr.
@@ -205,6 +204,7 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
         th->worker->rootMoves                              = rootMoves;
         th->worker->rootPos.set(pos.fen(), pos.is_chess960(), &th->worker->rootState);
         th->worker->rootState = setupStates->back();
+        th->worker->tbConfig  = tbConfig;
     }
 
     main_thread()->start_searching();


### PR DESCRIPTION
Follow up cleanup of #4968, removes the global variables from search and instead uses a dedicated tb config.

No functional change