### PR TITLE
Prove mated-in scores

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -257,15 +257,16 @@ void Search::Worker::iterative_deepening() {
     // Allocate stack with extra size to allow access from (ss - 7) to (ss + 2):
     // (ss - 7) is needed for update_continuation_histories(ss - 1) which accesses (ss - 6),
     // (ss + 2) is needed for initialization of cutOffCnt and killers.
-    Stack          stack[MAX_PLY + 10], *ss = stack + 7;
-    Move           pv[MAX_PLY + 1];
-    Value          alpha, beta;
-    Move           lastBestMove      = Move::none();
-    Depth          lastBestMoveDepth = 0;
-    SearchManager* mainThread        = (thread_idx == 0 ? main_manager() : nullptr);
-    double         timeReduction = 1, totBestMoveChanges = 0;
-    Color          us = rootPos.side_to_move();
-    int            delta, iterIdx = 0;
+    Stack             stack[MAX_PLY + 10], *ss = stack + 7;
+    Move              pv[MAX_PLY + 1];
+    Value             alpha, beta;
+    Value             lastBestScore     = -VALUE_INFINITE;
+    std::vector<Move> lastBestPV        = {Move::none()};
+    Depth             lastBestMoveDepth = 0;
+    SearchManager*    mainThread        = (thread_idx == 0 ? main_manager() : nullptr);
+    double            timeReduction = 1, totBestMoveChanges = 0;
+    Color             us = rootPos.side_to_move();
+    int               delta, iterIdx = 0;
 
     std::memset(ss - 7, 0, 10 * sizeof(Stack));
     for (int i = 7; i > 0; --i)
@@ -411,7 +412,12 @@ void Search::Worker::iterative_deepening() {
 
             if (mainThread
                 && (threads.stop || pvIdx + 1 == multiPV
-                    || mainThread->tm.elapsed(threads.nodes_searched()) > 3000))
+                    || mainThread->tm.elapsed(threads.nodes_searched()) > 3000)
+                // A thread that aborted search can have mated-in/TB-loss PV and score
+                // that cannot be trusted, i.e. it can be delayed or refuted if we would have
+                // had time to fully search other root-moves. Thus we suppress this output and
+                // below pick a proven score/PV for this thread (from the previous iteration).
+                && !(threads.abortedSearch && rootMoves[0].uciScore <= VALUE_TB_LOSS_IN_MAX_PLY))
                 sync_cout << UCI::pv(*this, mainThread->tm.elapsed(threads.nodes_searched()),
                                      threads.nodes_searched(), threads.tb_hits(), tt.hashfull(),
                                      TB::RootInTB)
@@ -421,9 +427,23 @@ void Search::Worker::iterative_deepening() {
         if (!threads.stop)
             completedDepth = rootDepth;
 
-        if (rootMoves[0].pv[0] != lastBestMove)
+        // We make sure not to pick an unproven mated-in score,
+        // in case this thread prematurely stopped search (aborted-search).
+        if (threads.abortedSearch && rootMoves[0].score != -VALUE_INFINITE
+            && rootMoves[0].score <= VALUE_TB_LOSS_IN_MAX_PLY)
         {
-            lastBestMove      = rootMoves[0].pv[0];
+            // Bring the last best move to the front for best thread selection.
+            std::sort(rootMoves.begin(), rootMoves.end(),
+                      [lastBestPV](const RootMove& rootMove, const RootMove&) {
+                          return rootMove == lastBestPV[0];
+                      });
+            rootMoves[0].pv    = lastBestPV;
+            rootMoves[0].score = rootMoves[0].uciScore = lastBestScore;
+        }
+        else if (rootMoves[0].pv[0] != lastBestPV[0])
+        {
+            lastBestPV        = rootMoves[0].pv;
+            lastBestScore     = rootMoves[0].score;
             lastBestMoveDepth = rootDepth;
         }
 
@@ -1923,10 +1943,14 @@ void SearchManager::check_time(Search::Worker& worker) {
     if (ponder)
         return;
 
-    if ((worker.limits.use_time_management() && (elapsed > tm.maximum() || stopOnPonderhit))
-        || (worker.limits.movetime && elapsed >= worker.limits.movetime)
-        || (worker.limits.nodes
-            && worker.threads.nodes_searched() >= uint64_t(worker.limits.nodes)))
+    if (
+      // Later we rely on the fact that we can at least use the mainthread previous
+      // root-search score and PV in a multithreaded environment to prove mated-in scores.
+      worker.completedDepth >= 1
+      && ((worker.limits.use_time_management() && (elapsed > tm.maximum() || stopOnPonderhit))
+          || (worker.limits.movetime && elapsed >= worker.limits.movetime)
+          || (worker.limits.nodes
+              && worker.threads.nodes_searched() >= uint64_t(worker.limits.nodes))))
         worker.threads.stop = true;
 }
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -20,8 +20,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cmath>
-#include <cstdlib>
 #include <deque>
 #include <memory>
 #include <unordered_map>
@@ -170,8 +168,8 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
 
     main_thread()->wait_for_search_finished();
 
-    main_manager()->stopOnPonderhit = stop = false;
-    main_manager()->ponder                 = ponderMode;
+    main_manager()->stopOnPonderhit = stop = abortedSearch = false;
+    main_manager()->ponder                                 = ponderMode;
 
     increaseDepth = true;
 
@@ -231,13 +229,23 @@ Thread* ThreadPool::get_best_thread() const {
         votes[th->worker->rootMoves[0].pv[0]] += thread_value(th);
 
     for (Thread* th : threads)
-        if (std::abs(bestThread->worker->rootMoves[0].score) >= VALUE_TB_WIN_IN_MAX_PLY)
+        if (bestThread->worker->rootMoves[0].score >= VALUE_TB_WIN_IN_MAX_PLY)
         {
-            // Make sure we pick the shortest mate / TB conversion or stave off mate the longest
+            // Make sure we pick the shortest mate / TB conversion
             if (th->worker->rootMoves[0].score > bestThread->worker->rootMoves[0].score)
                 bestThread = th;
         }
+        else if (bestThread->worker->rootMoves[0].score != -VALUE_INFINITE
+                 && bestThread->worker->rootMoves[0].score <= VALUE_TB_LOSS_IN_MAX_PLY)
+        {
+            // Make sure we pick the shortest mated / TB conversion
+            if (th->worker->rootMoves[0].score != -VALUE_INFINITE
+                && th->worker->rootMoves[0].score < bestThread->worker->rootMoves[0].score)
+                bestThread = th;
+        }
         else if (th->worker->rootMoves[0].score >= VALUE_TB_WIN_IN_MAX_PLY
+                 || (th->worker->rootMoves[0].score != -VALUE_INFINITE
+                     && th->worker->rootMoves[0].score <= VALUE_TB_LOSS_IN_MAX_PLY)
                  || (th->worker->rootMoves[0].score > VALUE_TB_LOSS_IN_MAX_PLY
                      && (votes[th->worker->rootMoves[0].pv[0]]
                            > votes[bestThread->worker->rootMoves[0].pv[0]]

--- a/src/thread.h
+++ b/src/thread.h
@@ -94,7 +94,7 @@ class ThreadPool {
     void     start_searching();
     void     wait_for_search_finished() const;
 
-    std::atomic_bool stop, increaseDepth;
+    std::atomic_bool stop, abortedSearch, increaseDepth;
 
     auto cbegin() const noexcept { return threads.cbegin(); }
     auto begin() noexcept { return threads.begin(); }


### PR DESCRIPTION
This fixes the issue that Stockfish can output non-proven mated scores if the search has been prematurely stopped with Time control or Nodes searched before exploring other possibilities that the mated score could have been delayed or refuted.

The fix also replaces staving off from proven mated scores in a multithread environment making use of the threads instead of a negative effect with multithreads (1t was better in proving mated in scores than more threads).

Issue reported on mate tracker repo by and this PR is co-authored with @robertnurnberg Special thanks to @AndyGrant for outlining that a fix is eventually possible.

Passed Adj off SMP STC:
https://tests.stockfishchess.org/tests/view/65a125d779aa8af82b96c3eb
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 303256 W: 75823 L: 75892 D: 151541
Ptnml(0-2): 406, 35269, 80395, 35104, 454

Passed Adj off SMP LTC:
https://tests.stockfishchess.org/tests/view/65a37add79aa8af82b96f0f7
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 56056 W: 13951 L: 13770 D: 28335
Ptnml(0-2): 11, 5910, 16002, 6097, 8

Passed all tests in matetrack without any better mate for opponent found in 1t and multithreads.

Fixed bugs in https://github.com/official-stockfish/Stockfish/pull/4976

bench: 1308279