### PR TITLE
Fix dotprod detection

### DIFF
--- a/scripts/get_native_properties.sh
+++ b/scripts/get_native_properties.sh
@@ -79,7 +79,7 @@ case $uname_s in
       'aarch64')
         file_os='android'
         true_arch='armv8'
-        if check_flags 'dotprod'; then
+        if check_flags 'asimddp'; then
           true_arch="$true_arch-dotprod"
         fi
         ;;


### PR DESCRIPTION
This fixes the detection of dotprod capable CPUs.
Previously it looked for the `dotprod` flag,
but this does not exist (https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/arch/arm64/kernel/cpuinfo.c#n50). The correct flag that specifies the dotprod capability is the `asimddp` flag.

fixes #4931