### PR TITLE
Remove threatenedRook ByPawn

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -203,7 +203,7 @@ void MovePicker::score() {
                 ? (pt == QUEEN
                      ? bool(to & threatenedByRook) * 50000 + bool(to & threatenedByMinor) * 10000
                    : pt == ROOK
-                     ? bool(to & threatenedByMinor) * 25000 + bool(to & threatenedByPawn) * 10000
+                     ? bool(to & threatenedByMinor) * 25000
                    : pt != PAWN ? bool(to & threatenedByPawn) * 15000
                                 : 0)
                 : 0;


### PR DESCRIPTION
Remove a part of the formula (threatenedRook ByPawn) that doesn't bring any benefit in terms of Elo.

Passed STC:
LLR: 2.92 (-2.94,2.94) <-1.75,0.25>
Total: 30592 W: 7903 L: 7674 D: 15015
Ptnml(0-2): 96, 3590, 7711, 3787, 112
https://tests.stockfishchess.org/tests/view/65a3fa4179aa8af82b96face

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 73656 W: 18382 L: 18212 D: 37062
Ptnml(0-2): 47, 8287, 19981, 8475, 38
https://tests.stockfishchess.org/tests/view/65a42b9a79aa8af82b96fe88