### PR TITLE
Modify ttPv Reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -946,11 +946,6 @@ moves_loop:  // When in check, search starts here
     value            = bestValue;
     moveCountPruning = singularQuietLMR = false;
 
-    // Indicate PvNodes that will probably fail low if the node was searched
-    // at a depth equal to or greater than the current depth, and the result
-    // of this search was a fail low.
-    bool likelyFailLow = PvNode && ttMove && (tte->bound() & BOUND_UPPER) && tte->depth() >= depth;
-
     // Step 13. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
     while ((move = mp.next_move(moveCountPruning)) != Move::none())
@@ -1155,9 +1150,10 @@ moves_loop:  // When in check, search starts here
         thisThread->nodes.fetch_add(1, std::memory_order_relaxed);
         pos.do_move(move, st, givesCheck);
 
-        // Decrease reduction if position is or has been on the PV (~4 Elo)
-        if (ss->ttPv && !likelyFailLow)
-            r -= 1 + (cutNode && tte->depth() >= depth) + (ttValue > alpha);
+        // Decrease reduction if position is or has been on the PV (~7 Elo)
+        if (ss->ttPv)
+            r -= !(tte->bound() == BOUND_UPPER && PvNode) + (cutNode && tte->depth() >= depth)
+               + (ttValue > alpha) + (ttValue > beta && tte->depth() >= depth);
 
         // Decrease reduction if opponent's move count is high (~1 Elo)
         if ((ss - 1)->moveCount > 7)


### PR DESCRIPTION
This patch allows a partial reduction decrease when a node is likely to fail low, and increases the reduction decrease when a node has failed high.

Passed STC:
https://tests.stockfishchess.org/tests/view/65a626e779aa8af82b9722bc
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 157824 W: 40332 L: 39835 D: 77657
Ptnml(0-2): 543, 18617, 40098, 19108, 546

Passed LTC:
https://tests.stockfishchess.org/tests/view/65a7290279aa8af82b97328a
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 57228 W: 14475 L: 14111 D: 28642
Ptnml(0-2): 34, 6278, 15633, 6628, 41

Bench: 1376648