### PR TITLE
Reduce futility_margin further when improving

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,6 +46,7 @@ candirufish
 Chess13234
 Chris Cain (ceebo)
 clefrks
+Clemens L. (rn5f107s2)
 Cody Ho (aesrentai)
 Dale Weiler (graphitemaster)
 Daniel Axtens (daxtens)
@@ -183,7 +184,6 @@ Raminder Singh
 renouve
 Reuven Peleg (R-Peleg)
 Richard Lloyd (Richard-Lloyd)
-rn5f107s2
 Robert Nürnberg (robertnurnberg)
 Rodrigo Exterckötter Tjäder
 Rodrigo Roim (roim)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -55,7 +55,8 @@ namespace {
 
 // Futility margin
 Value futility_margin(Depth d, bool noTtCutNode, bool improving) {
-    return ((116 - 44 * noTtCutNode) * (d - improving));
+    Value futilityMult = 116 - 44 * noTtCutNode;
+    return (futilityMult * d - 3 * futilityMult / 2 * improving);
 }
 
 constexpr int futility_move_count(bool improving, Depth depth) {


### PR DESCRIPTION
The idea of this is to unroll the futility_margin calculation to allow for the improving flag to have a greater effect on the futility margin. The current factor is 1.5 instead of the previos 1 resulting in a deduction of an extra margin/2 from futilit_margin if improving. The chosen value was not tuned, meaning that there is room for tweaking it. This patch is partially inspirde by @Vizvezdenec, who, although quite different in exectution, tested another idea where the futility_margin is lowered further when improving [1].

[1]: (first take) https://tests.stockfishchess.org/tests/view/65a56b1879aa8af82b97164b

--------

Passed STC:
https://tests.stockfishchess.org/tests/live_elo/65a8bfc179aa8af82b974e3c
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 161152 W: 41321 L: 40816 D: 79015
Ptnml(0-2): 559, 19030, 40921, 19479, 587

Passed rebased LTC:
https://tests.stockfishchess.org/tests/live_elo/65a8b9ef79aa8af82b974dc0
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 96024 W: 24172 L: 23728 D: 48124
Ptnml(0-2): 56, 10598, 26275, 11012, 71

-------

bench 1281703