### PR TITLE
Removed a restriction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1032,7 +1032,6 @@ moves_loop:  // When in check, search starts here
                 history += 69 * thisThread->mainHistory[us][move.from_to()] / 32;
 
                 lmrDepth += history / 6992;
-                lmrDepth = std::max(lmrDepth, -1);
 
                 // Futility pruning: parent node (~13 Elo)
                 if (!ss->inCheck && lmrDepth < 15


### PR DESCRIPTION
Removed a restriction that prohibited history heuristics sum in futility pruning to exceed some negative value.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 279040 W: 71095 L: 71143 D: 136802
Ptnml(0-2): 949, 33574, 70474, 33622, 901
https://tests.stockfishchess.org/tests/view/65aaef4c79aa8af82b977631

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 75156 W: 18884 L: 18715 D: 37557
Ptnml(0-2): 52, 8445, 20408, 8628, 45
https://tests.stockfishchess.org/tests/view/65ae7ef3c865510db026abf5
