### PR TITLE
Simplify history update formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1029,7 +1029,7 @@ moves_loop:  // When in check, search starts here
                 if (lmrDepth < 6 && history < -4195 * depth)
                     continue;
 
-                history += 69 * thisThread->mainHistory[us][move.from_to()] / 32;
+                history += 2 * thisThread->mainHistory[us][move.from_to()];
 
                 lmrDepth += history / 6992;
                 lmrDepth = std::max(lmrDepth, -1);


### PR DESCRIPTION
Simplify history update formula

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 161376 W: 41582 L: 41498 D: 78296
Ptnml(0-2): 633, 19354, 40611, 19476, 614
https://tests.stockfishchess.org/tests/view/65ad08b179aa8af82b979dd1

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 116526 W: 29269 L: 29143 D: 58114
Ptnml(0-2): 71, 13252, 31509, 13342, 89
https://tests.stockfishchess.org/tests/view/65af966fc865510db026c0f0
