### PR TITLE
Do more double extensions.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1082,7 +1082,7 @@ moves_loop:  // When in check, search starts here
                     singularQuietLMR = !ttCapture;
 
                     // Avoid search explosion by limiting the number of double extensions
-                    if (!PvNode && value < singularBeta - 16 && ss->doubleExtensions <= 12)
+                    if (!PvNode && value < singularBeta - 2 && ss->doubleExtensions <= 12)
                     {
                         extension = 2;
                         depth += depth < 15;


### PR DESCRIPTION
Parameter tweak from Black Marlin chess engine.
Instead of master value take and extremely low value that makes it trigger in 95% of cases instead of 84% of cases in usual bench run.
Failed STC really fast:
https://tests.stockfishchess.org/tests/view/65b11d05c865510db026df7b
LLR: -2.94 (-2.94,2.94) <0.00,2.00>
Total: 13216 W: 3242 L: 3485 D: 6489
Ptnml(0-2): 50, 1682, 3371, 1471, 34 
Was reasonable at LTC:
https://tests.stockfishchess.org/tests/view/65b13e20c865510db026e210
Elo: 1.18 ± 1.5 (95%) LOS: 94.3%
Total: 50000 W: 12517 L: 12347 D: 25136
Ptnml(0-2): 31, 5598, 13579, 5754, 38
nElo: 2.45 ± 3.0 (95%) PairsRatio: 1.03 
Passed VLTC with STC bounds:
https://tests.stockfishchess.org/tests/view/65b18870c865510db026e769
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 30456 W: 7726 L: 7448 D: 15282
Ptnml(0-2): 6, 3111, 8717, 3387, 7 
Passed VVLTC with LTC bounds:
https://tests.stockfishchess.org/tests/view/65b20b95c865510db026eef0
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 36134 W: 9158 L: 8859 D: 18117
Ptnml(0-2): 3, 3455, 10850, 3758, 1 
bench 1384766