### PR TITLE
Use ttPv in depth condition of singular extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1064,7 +1064,7 @@ moves_loop:  // When in check, search starts here
             // so changing them requires tests at these types of time controls.
             // Recursive singular search is avoided.
             if (!rootNode && move == ttMove && !excludedMove
-                && depth >= 4 - (thisThread->completedDepth > 31) + 2 * (PvNode && tte->is_pv())
+                && depth >= 4 - (thisThread->completedDepth > 31) + ss->ttPv
                 && std::abs(ttValue) < VALUE_TB_WIN_IN_MAX_PLY && (tte->bound() & BOUND_LOWER)
                 && tte->depth() >= depth - 3)
             {


### PR DESCRIPTION
This replaces the PvNode condition and tte Pv call previously with using the precomputed ttPv, and also removes the multiplier of 2.  This new depth condition occurs with approximately equal frequency (47%) to the old depth condition (measured when the other conditions in the if are true), so non-linear scaling behaviour isn't expected.

Passed STC:
https://tests.stockfishchess.org/tests/view/65b0e132c865510db026da27
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 243232 W: 62432 L: 62437 D: 118363
Ptnml(0-2): 910, 28937, 61900, 28986, 883

Passed LTC:
https://tests.stockfishchess.org/tests/view/65b2053bc865510db026eea1
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 190596 W: 47666 L: 47618 D: 95312
Ptnml(0-2): 115, 21710, 51596, 21766, 111

bench 1287565