### PR TITLE
sample fewer hash table entries to speedup hashfull calculation

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -137,16 +137,14 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 
 // Returns an approximation of the hashtable
 // occupation during a search. The hash is x permill full, as per UCI protocol.
-
 int TranspositionTable::hashfull() const {
-
     int cnt = 0;
-    for (int i = 0; i < 1000; ++i)
+    for (int i = 0; i < 1000 / ClusterSize; ++i)
         for (int j = 0; j < ClusterSize; ++j)
             cnt += table[i].entry[j].depth8
                 && (table[i].entry[j].genBound8 & GENERATION_MASK) == generation8;
 
-    return cnt / ClusterSize;
+    return cnt;
 }
 
 }  // namespace Stockfish


### PR DESCRIPTION
This PR reduces the number of sampled hash table entries for the hashfull calculation to 999. Before it was 3000. This should speed up the calculation.

No bench change.