### PR TITLE
Simplify array initializations

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -19,6 +19,7 @@
 #include "position.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cctype>
 #include <cstddef>
@@ -107,9 +108,8 @@ inline int H1(Key h) { return h & 0x1fff; }
 inline int H2(Key h) { return (h >> 16) & 0x1fff; }
 
 // Cuckoo tables with Zobrist hashes of valid reversible moves, and the moves themselves
-Key  cuckoo[8192];
-Move cuckooMove[8192];
-
+std::array<Key, 8192>  cuckoo;
+std::array<Move, 8192> cuckooMove;
 
 // Initializes at startup the various arrays used to compute hash keys
 void Position::init() {
@@ -130,8 +130,8 @@ void Position::init() {
     Zobrist::noPawns = rng.rand<Key>();
 
     // Prepare the cuckoo tables
-    std::memset(cuckoo, 0, sizeof(cuckoo));
-    std::memset(cuckooMove, 0, sizeof(cuckooMove));
+    cuckoo.fill(0);
+    cuckooMove.fill(Move::none());
     [[maybe_unused]] int count = 0;
     for (Piece pc : Pieces)
         for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)

--- a/src/search.h
+++ b/src/search.h
@@ -19,6 +19,7 @@
 #ifndef SEARCH_H_INCLUDED
 #define SEARCH_H_INCLUDED
 
+#include <array>
 #include <atomic>
 #include <cassert>
 #include <cstddef>
@@ -153,11 +154,11 @@ class SearchManager: public ISearchManager {
     int                       callsCnt;
     std::atomic_bool          ponder;
 
-    double previousTimeReduction;
-    Value  bestPreviousScore;
-    Value  bestPreviousAverageScore;
-    Value  iterValue[4];
-    bool   stopOnPonderhit;
+    std::array<Value, 4> iterValue;
+    double               previousTimeReduction;
+    Value                bestPreviousScore;
+    Value                bestPreviousAverageScore;
+    bool                 stopOnPonderhit;
 
     size_t id;
 };
@@ -233,7 +234,7 @@ class Worker {
     size_t thread_idx;
 
     // Reductions lookup table initialized at startup
-    int reductions[MAX_MOVES];  // [depth or moveNumber]
+    std::array<int, MAX_MOVES> reductions;  // [depth or moveNumber]
 
     // The main thread has a SearchManager, the others have a NullSearchManager
     std::unique_ptr<ISearchManager> manager;


### PR DESCRIPTION
Simplify a few array initializations, also retire a few `std::memset` calls.

Passed non-regresion STC:
https://tests.stockfishchess.org/tests/view/65b8e162c865510db0276901
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 97504 W: 25294 L: 25140 D: 47070
Ptnml(0-2): 378, 11102, 25667, 11198, 407 

No functional change