### PR TITLE
Simplify the extension formula in the case of `cutNode`

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1072,7 +1072,7 @@ moves_loop:  // When in check, search starts here
 
                 // If we are on a cutNode but the ttMove is not assumed to fail high over current beta (~1 Elo)
                 else if (cutNode)
-                    extension = depth < 20 ? -2 : -1;
+                    extension = -2;
 
                 // If the ttMove is assumed to fail low over the value of the reduced search (~1 Elo)
                 else if (ttValue <= value)


### PR DESCRIPTION
Simplify the extension formula in the case of `cutNode` by removing the depth condition and always setting `extension` to -2.

Passed STC:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 277280 W: 70760 L: 70802 D: 135718
Ptnml(0-2): 971, 31775, 73153, 31807, 934
https://tests.stockfishchess.org/tests/view/65ad08f779aa8af82b979dd6

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 452976 W: 112992 L: 113215 D: 226769
Ptnml(0-2): 266, 51041, 124112, 50788, 281
https://tests.stockfishchess.org/tests/view/65ae466fc865510db026a760