### PR TITLE
Add Apple Silicon Runners to CI

### DIFF
--- a/.github/workflows/stockfish_binaries.yml
+++ b/.github/workflows/stockfish_binaries.yml
@@ -31,6 +31,13 @@ jobs:
             comp: clang
             shell: bash
             archive_ext: tar
+          - name: MacOS 14 Apple Clang M1
+            os: macos-14
+            simple_name: macos-m1
+            compiler: clang++
+            comp: clang
+            shell: bash
+            archive_ext: tar
           - name: Windows 2022 Mingw-w64 GCC x86_64
             os: windows-2022
             simple_name: windows
@@ -51,9 +58,32 @@ jobs:
           - x86-64-avx512
           - x86-64-vnni256
           - x86-64-vnni512
+          - apple-silicon
         exclude:
+          # Apple M1
+          - binaries: x86-64
+            config: { os: macos-14 }
+          - binaries: x86-64-sse41-popcnt
+            config: { os: macos-14 }
+          - binaries: x86-64-avx2
+            config: { os: macos-14 }
+          - binaries: x86-64-bmi2
+            config: { os: macos-14 }
+          - binaries: x86-64-avxvnni
+            config: { os: macos-14 }
+          - binaries: x86-64-avxvnni
+            config: { os: macos-14 }
+          - binaries: x86-64-avx512
+            config: { os: macos-14 }
+          - binaries: x86-64-vnni256
+            config: { os: macos-14 }
+          - binaries: x86-64-vnni512
+            config: { os: macos-14 }
+
           - binaries: x86-64-avxvnni
             config: { ubuntu-20.04 }
+
+          # Apple x86_64 (no sde)
           - binaries: x86-64-avxvnni
             config: { os: macos-13 }
           - binaries: x86-64-avx512
@@ -62,6 +92,14 @@ jobs:
             config: { os: macos-13 }
           - binaries: x86-64-vnni512
             config: { os: macos-13 }
+
+          # Apple silicon from windows, macos-13 and ubuntu
+          - binaries: apple-silicon
+            config: { os: windows-2022 }
+          - binaries: apple-silicon
+            config: { os: macos-13 }
+          - binaries: apple-silicon
+            config: { os: ubuntu-20.04 }
     defaults:
       run:
         working-directory: src
@@ -77,7 +115,7 @@ jobs:
 
       - name: Install fixed GCC on Linux
         if: runner.os == 'Linux'
-        uses: egor-tensin/setup-gcc@eaa888eb19115a521fa72b65cd94fe1f25bbcaac  # @v1.3
+        uses: egor-tensin/setup-gcc@eaa888eb19115a521fa72b65cd94fe1f25bbcaac # @v1.3
         with:
           version: 11
 
@@ -90,7 +128,7 @@ jobs:
 
       - name: Download SDE package
         if: runner.os == 'Linux' || runner.os == 'Windows'
-        uses: petarpetrovt/setup-sde@91a1a03434384e064706634125a15f7446d2aafb  # @v2.3
+        uses: petarpetrovt/setup-sde@91a1a03434384e064706634125a15f7446d2aafb # @v2.3
         with:
           environmentVariableName: SDE_DIR
           sdeVersion: 9.27.0
@@ -183,7 +221,7 @@ jobs:
 
       - name: Release
         if: startsWith(github.ref_name, 'sf_') && github.ref_type == 'tag'
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # @v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # @v1
         with:
           files: stockfish-${{ matrix.config.simple_name }}-${{ matrix.binaries }}.${{ matrix.config.archive_ext }}
 
@@ -206,7 +244,7 @@ jobs:
       - name: Prerelease
         if: github.ref_name == 'master' && env.CHANGES == '0'
         continue-on-error: true
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # @v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # @v1
         with:
           name: Stockfish dev-${{ env.COMMIT_DATE }}-${{ env.COMMIT_SHA }}
           tag_name: stockfish-dev-${{ env.COMMIT_DATE }}-${{ env.COMMIT_SHA }}

--- a/.github/workflows/stockfish_compile_test.yml
+++ b/.github/workflows/stockfish_compile_test.yml
@@ -26,6 +26,12 @@ jobs:
             compiler: clang++
             comp: clang
             shell: bash
+          - name: MacOS 14 Apple Clang M1
+            os: macos-14
+            compiler: clang++
+            comp: clang
+            shell: bash
+            m1: true
           - name: MacOS 13 GCC 11
             os: macos-13
             compiler: g++-11
@@ -75,26 +81,37 @@ jobs:
       # x86-64 with newer extensions tests
 
       - name: Compile x86-64-avx2 build
+        if: ${{ ! matrix.config.m1 }}
         run: |
           make clean
           make -j2 ARCH=x86-64-avx2 build
 
       - name: Compile x86-64-bmi2 build
+        if: ${{ ! matrix.config.m1 }}
         run: |
           make clean
           make -j2 ARCH=x86-64-bmi2 build
 
       - name: Compile x86-64-avx512 build
+        if: ${{ ! matrix.config.m1 }}
         run: |
           make clean
           make -j2 ARCH=x86-64-avx512 build
 
       - name: Compile x86-64-vnni512 build
+        if: ${{ ! matrix.config.m1 }}
         run: |
           make clean
           make -j2 ARCH=x86-64-vnni512 build
 
       - name: Compile x86-64-vnni256 build
+        if: ${{ ! matrix.config.m1 }}
         run: |
           make clean
           make -j2 ARCH=x86-64-vnni256 build
+
+      - name: Compile apple-silicon build
+        if: matrix.config.m1
+        run: |
+          make clean
+          make -j2 ARCH=apple-silicon build

--- a/.github/workflows/stockfish_test.yml
+++ b/.github/workflows/stockfish_test.yml
@@ -43,22 +43,29 @@ jobs:
             compiler: g++
             comp: gcc
             run_riscv64_tests: true
-            base_image: 'riscv64/alpine:edge'
-            platform: linux/riscv64          
+            base_image: "riscv64/alpine:edge"
+            platform: linux/riscv64
             shell: bash
           - name: Linux GCC ppc64
             os: ubuntu-22.04
             compiler: g++
             comp: gcc
             run_ppc64_tests: true
-            base_image: 'ppc64le/alpine:latest'
-            platform: linux/ppc64le          
+            base_image: "ppc64le/alpine:latest"
+            platform: linux/ppc64le
             shell: bash
           - name: MacOS 13 Apple Clang
             os: macos-13
             compiler: clang++
             comp: clang
             run_64bit_tests: true
+            shell: bash
+          - name: MacOS 14 Apple Clang M1
+            os: macos-14
+            compiler: clang++
+            comp: clang
+            run_64bit_tests: false
+            run_m1_tests: true
             shell: bash
           - name: MacOS 13 GCC 11
             os: macos-13
@@ -279,6 +286,13 @@ jobs:
         run: |
           make clean
           make -j2 ARCH=general-64 build
+          ../tests/signature.sh $benchref
+
+      - name: Test apple-silicon build
+        if: matrix.config.run_m1_tests
+        run: |
+          make clean
+          make -j2 ARCH=apple-silicon build
           ../tests/signature.sh $benchref
 
       # armv8 tests


### PR DESCRIPTION
Since yesterday (January 30, 2024), GitHub CI runners are available for macOS 14.
These runners are using apple silicon chips (M1).

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

No functional change