### PR TITLE
Verification Formula Simplification

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -801,7 +801,7 @@ Value Search::Worker::search(
 
             // Do verification search at high depths, with null move pruning disabled
             // until ply exceeds nmpMinPly.
-            thisThread->nmpMinPly = ss->ply + 3 * (depth - R) / 4;
+            thisThread->nmpMinPly = ss->ply + depth / 4;
 
             Value v = search<NonPV>(pos, ss, beta - 1, beta, depth - R, false);
 


### PR DESCRIPTION
Simplifying the verification formula, which was added in order to better detect zugzwang positions.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 60160 W: 15529 L: 15336 D: 29295
Ptnml(0-2): 241, 6702, 16005, 6887, 245
https://tests.stockfishchess.org/tests/view/65b78dffc865510db027530e

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 159414 W: 39970 L: 39891 D: 79553
Ptnml(0-2): 95, 17369, 44694, 17460, 89
https://tests.stockfishchess.org/tests/view/65b80835c865510db0275b73

Benchmark with zugzwang-suite (see #1338 ), single core, max 45 secs per position:
Patch solves 31 out of 37 - (After the study that follows changed to 32 out of 37)
Master solves 32 out of 37

However, there is alot to be said about this epd suite after I studied it and our master and this patch interaction with it.

Below are the important notes that I was able to deduct.

Position #17: Both variations were able to solve it, but tbh master solved it much quicker than patch.
Position #18 : None of the two variations were able to solve it
Position #19 : None of the two variations were able to solve it
Position #21 :  The epd solution here is wrong, as it states that Ke3 and Kd3 are both valid solutions, but in reality, only Kd3 leads to white to win, while Ke3 leads only to draw, and by the way both master and patch didn't see the win, master opted for Ke3 with eval of 0.00 and patch opted for Nc3 also with eval 0.00, but none of them was able to see that Kd3 wins (And epd should be adjusted to remove Ke3 as a valid solution)
Position #28 : Both variations saw the win, but both of them opted to waste two extra plys with a repetition, opting for Nc3+ Kb4 Nd5+ Ka4, and then going for the valid solution with f4, and to be honest I don't see anything wrong with it, as long as the win was foreseen.
Position #33 : Both variations similarly opted for Kd7, which similarly to position 28, also leads to a win, but with a few extra plys, and both of them get stuck for a long time when analyzing this position (@peregrineshahin so, since you are investigating this SF issue, you can also use this position as testing material)
Position #36: Both engines similarly opted for Kb2, with fail high evaluations, and tbh even though I didn't do a deep study, I have the feeling that also here the epd solutions are not correct, as they only give Kb3 and Rf5 as valid solutions, but based on a quick check, it seems that also Kb2 is a valid solution after all.

Anyway in conclusion, I didn't observe huge differences in zugzwang detection for the proposed patch, the only two negative points I observed were:
1) Position number 17 slower solution
2) Position number 33 the patch version seems to me that it got stuck for a longer time than master, but I'm not sure also here.

Files:
[Analyses.log](https://github.com/official-stockfish/Stockfish/files/14118156/Analyses.log)
[Analyses.txt](https://github.com/official-stockfish/Stockfish/files/14118158/Analyses.txt)




