### PR TITLE
Introduce Triple Extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -529,7 +529,7 @@ Value Search::Worker::search(
     Move     ttMove, move, excludedMove, bestMove;
     Depth    extension, newDepth;
     Value    bestValue, value, ttValue, eval, maxValue, probCutBeta;
-    bool     givesCheck, improving, priorCapture, singularQuietLMR;
+    bool     givesCheck, improving, priorCapture;
     bool     capture, moveCountPruning, ttCapture;
     Piece    movedPiece;
     int      moveCount, captureCount, quietCount;
@@ -907,7 +907,7 @@ moves_loop:  // When in check, search starts here
                   contHist, &thisThread->pawnHistory, countermove, ss->killers);
 
     value            = bestValue;
-    moveCountPruning = singularQuietLMR = false;
+    moveCountPruning = false;
 
     // Step 13. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
@@ -1042,12 +1042,11 @@ moves_loop:  // When in check, search starts here
                 if (value < singularBeta)
                 {
                     extension        = 1;
-                    singularQuietLMR = !ttCapture;
 
                     // Avoid search explosion by limiting the number of double extensions
                     if (!PvNode && value < singularBeta - 2 && ss->doubleExtensions <= 12)
                     {
-                        extension = 2;
+                        extension = 2 + (value < singularBeta - 200 && !ttCapture);
                         depth += depth < 15;
                     }
                 }
@@ -1098,7 +1097,7 @@ moves_loop:  // When in check, search starts here
 
         // Add extension to new depth
         newDepth += extension;
-        ss->doubleExtensions = (ss - 1)->doubleExtensions + (extension == 2);
+        ss->doubleExtensions = (ss - 1)->doubleExtensions + (extension >= 2);
 
         // Speculative prefetch as early as possible
         prefetch(tt.first_entry(pos.key_after(move)));
@@ -1130,10 +1129,6 @@ moves_loop:  // When in check, search starts here
 
         // Decrease reduction for PvNodes (~3 Elo)
         if (PvNode && tte->bound() != BOUND_UPPER)
-            r--;
-
-        // Decrease reduction if a quiet ttMove has been singularly extended (~1 Elo)
-        if (singularQuietLMR)
             r--;
 
         // Increase reduction on repetition (~1 Elo)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1044,7 +1044,7 @@ moves_loop:  // When in check, search starts here
                     extension        = 1;
 
                     // Avoid search explosion by limiting the number of double extensions
-                    if (!PvNode && value < singularBeta - 2 && ss->doubleExtensions <= 12)
+                    if (!PvNode && value < singularBeta - 2 && ss->doubleExtensions <= 15)
                     {
                         extension = 2 + (value < singularBeta - 200 && !ttCapture);
                         depth += depth < 15;


### PR DESCRIPTION
This replaces singularquietLMR with triple instead of double extending non-capture ttmoves that have value far below singularBeta. This threshold value is initially set to 200, there is scope for more scaling by reducing it as occured with double extensions.

Passed STC:
https://tests.stockfishchess.org/tests/view/65b683b8c865510db0274074
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 222912 W: 58141 L: 57535 D: 107236
Ptnml(0-2): 1063, 26244, 56154, 27014, 981

Passed LTC:
https://tests.stockfishchess.org/tests/view/65bae6d4c865510db0278eb5
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 66306 W: 16825 L: 16440 D: 33041
Ptnml(0-2): 40, 7374, 17952, 7735, 52

bench 1394701