### PR TITLE
Simplify LMR condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1161,8 +1161,7 @@ moves_loop:  // When in check, search starts here
         // We use various heuristics for the sons of a node after the first son has
         // been searched. In general, we would like to reduce them, but there are many
         // cases where we extend a son if it has good chances to be "interesting".
-        if (depth >= 2 && moveCount > 1 + rootNode
-            && (!ss->ttPv || !capture || (cutNode && (ss - 1)->moveCount > 1)))
+        if (depth >= 2 && moveCount > 1 + rootNode)
         {
             // In general we want to cap the LMR depth search at newDepth, but when
             // reduction is negative, we allow this move a limited search extension


### PR DESCRIPTION
Apply LMR on captures the same way it is applied on quiets

Passed Non-Reg STC:
https://tests.stockfishchess.org/tests/view/65bbf39bc865510db027a14a
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 77152 W: 19970 L: 19791 D: 37391
Ptnml(0-2): 304, 9159, 19496, 9288, 329

Passed Non-Reg LTC:
https://tests.stockfishchess.org/tests/view/65bc8889c865510db027ac9e
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 103230 W: 25997 L: 25858 D: 51375
Ptnml(0-2): 71, 11687, 27958, 11830, 69

Hit rate of removed condition `(!ss->ttPv || !capture || (cutNode && (ss - 1)->moveCount > 1))`
Total 1253801 Hits 1228904 Hit Rate (%) 98.0143

Hit rate of previous LMR `(depth >= 2 && moveCount > 1 + rootNode && ...)`
Total 1253801 Hits 727234 Hit Rate (%) 58.0023

Hit rate of simplified LMR `(depth >= 2 && moveCount > 1 + rootNode)`
Total 1201839 Hits 713540 Hit Rate (%) 59.3707

Bench: 1420480