### PR TITLE
Cleanup / Rename Variable

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -571,7 +571,7 @@ Value Search::Worker::search(
     (ss + 1)->excludedMove = bestMove = Move::none();
     (ss + 2)->killers[0] = (ss + 2)->killers[1] = Move::none();
     (ss + 2)->cutoffCnt                         = 0;
-    ss->doubleExtensions                        = (ss - 1)->doubleExtensions;
+    ss->multipleExtensions                        = (ss - 1)->multipleExtensions;
     Square prevSq = ((ss - 1)->currentMove).is_ok() ? ((ss - 1)->currentMove).to_sq() : SQ_NONE;
     ss->statScore = 0;
 
@@ -1036,8 +1036,8 @@ moves_loop:  // When in check, search starts here
                 {
                     extension = 1;
 
-                    // Avoid search explosion by limiting the number of double extensions
-                    if (!PvNode && ss->doubleExtensions <= 16)
+                    // Avoid search explosion by limiting the number of multiple extensions
+                    if (!PvNode && ss->multipleExtensions <= 16)
                     {
                         extension = 2 + (value < singularBeta - 78 && !ttCapture);
                         depth += depth < 16;
@@ -1090,7 +1090,7 @@ moves_loop:  // When in check, search starts here
 
         // Add extension to new depth
         newDepth += extension;
-        ss->doubleExtensions = (ss - 1)->doubleExtensions + (extension >= 2);
+        ss->multipleExtensions = (ss - 1)->multipleExtensions + (extension >= 2);
 
         // Speculative prefetch as early as possible
         prefetch(tt.first_entry(pos.key_after(move)));
@@ -1142,7 +1142,7 @@ moves_loop:  // When in check, search starts here
                       + (*contHist[1])[movedPiece][move.to_sq()]
                       + (*contHist[3])[movedPiece][move.to_sq()] - 4409;
 
-        // Decrease/increase reduction for moves with a good/bad history (~25 Elo)
+        // Decrease/increase reduction for moves with a good/bad history (~8 Elo)
         r -= ss->statScore / 14894;
 
         // Step 17. Late moves reduction / extension (LMR, ~117 Elo)
@@ -1150,7 +1150,7 @@ moves_loop:  // When in check, search starts here
         {
             // In general we want to cap the LMR depth search at newDepth, but when
             // reduction is negative, we allow this move a limited search extension
-            // beyond the first move depth. This may lead to hidden double extensions.
+            // beyond the first move depth. This may lead to hidden multiple extensions.
             // To prevent problems when the max value is less than the min value,
             // std::clamp has been replaced by a more robust implementation.
             Depth d = std::max(1, std::min(newDepth - r, newDepth + 1));
@@ -1371,8 +1371,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
     assert(PvNode || (alpha == beta - 1));
     assert(depth <= 0);
 
-    // Check if we have an upcoming move that draws by repetition, or
-    // if the opponent had an alternative move earlier to this position.
+    // Check if we have an upcoming move that draws by repetition, or if
+    // the opponent had an alternative move earlier to this position. (~1 Elo)
     if (alpha < VALUE_DRAW && pos.has_game_cycle(ss->ply))
     {
         alpha = value_draw(this->nodes);
@@ -1520,7 +1520,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
                 futilityValue = futilityBase + PieceValue[pos.piece_on(move.to_sq())];
 
                 // If static eval + value of piece we are going to capture is much lower
-                // than alpha we can prune this move.
+                // than alpha we can prune this move. (~2 Elo)
                 if (futilityValue <= alpha)
                 {
                     bestValue = std::max(bestValue, futilityValue);
@@ -1528,7 +1528,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
                 }
 
                 // If static eval is much lower than alpha and move is not winning material
-                // we can prune this move.
+                // we can prune this move. (~2 Elo)
                 if (futilityBase <= alpha && !pos.see_ge(move, VALUE_ZERO + 1))
                 {
                     bestValue = std::max(bestValue, futilityBase);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1036,7 +1036,7 @@ moves_loop:  // When in check, search starts here
                 {
                     extension = 1;
 
-                    // Avoid search explosion by limiting the number of multiple extensions
+                    // We make sure to limit the extensions in some way to avoid a search explosion
                     if (!PvNode && ss->multipleExtensions <= 16)
                     {
                         extension = 2 + (value < singularBeta - 78 && !ttCapture);

--- a/src/search.h
+++ b/src/search.h
@@ -67,7 +67,7 @@ struct Stack {
     bool            inCheck;
     bool            ttPv;
     bool            ttHit;
-    int             doubleExtensions;
+    int             multiExtensions;
     int             cutoffCnt;
 };
 
@@ -136,9 +136,8 @@ struct SharedState {
 
 class Worker;
 
-// Null Object Pattern, implement a common interface
-// for the SearchManagers. A Null Object will be given to
-// non-mainthread workers.
+// Null Object Pattern, implement a common interface for the SearchManagers.
+// A Null Object will be given to non-mainthread workers.
 class ISearchManager {
    public:
     virtual ~ISearchManager() {}
@@ -185,8 +184,8 @@ class Worker {
     // Reset histories, usually before a new game
     void clear();
 
-    // Called when the program receives the UCI 'go'
-    // command. It searches from the root position and outputs the "bestmove".
+    // Called when the program receives the UCI 'go' command.
+    // It searches from the root position and outputs the "bestmove".
     void start_searching();
 
     bool is_mainthread() const { return thread_idx == 0; }


### PR DESCRIPTION
Renaming doubleExtensions variable to multiExtensions, since now we have also triple Extensions.
Updating some comments related to this.
Updating some Elo worth comments.

Recent tests used to do so:
https://tests.stockfishchess.org/tests/view/659fd0c379aa8af82b96abc3
https://tests.stockfishchess.org/tests/view/65a8f3da79aa8af82b9751e3
https://tests.stockfishchess.org/tests/view/65b51824c865510db0272740
https://tests.stockfishchess.org/tests/view/65b58fbfc865510db0272f5b

No functional