### PR TITLE
Remove simple eval

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -204,25 +204,19 @@ Value Eval::evaluate(const Position& pos, int optimism) {
     int   shuffling  = pos.rule50_count();
     int   simpleEval = simple_eval(pos, stm);
 
-    bool lazy = std::abs(simpleEval) > 2550;
-    if (lazy)
-        v = simpleEval;
-    else
-    {
-        bool smallNet = std::abs(simpleEval) > 1050;
+    bool smallNet = std::abs(simpleEval) > 1050;
 
-        int nnueComplexity;
+    int nnueComplexity;
 
-        Value nnue = smallNet ? NNUE::evaluate<NNUE::Small>(pos, true, &nnueComplexity)
-                              : NNUE::evaluate<NNUE::Big>(pos, true, &nnueComplexity);
+    Value nnue = smallNet ? NNUE::evaluate<NNUE::Small>(pos, true, &nnueComplexity)
+                          : NNUE::evaluate<NNUE::Big>(pos, true, &nnueComplexity);
 
-        // Blend optimism and eval with nnue complexity and material imbalance
-        optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 512;
-        nnue -= nnue * (nnueComplexity + std::abs(simpleEval - nnue)) / 32768;
+    // Blend optimism and eval with nnue complexity and material imbalance
+    optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 512;
+    nnue -= nnue * (nnueComplexity + std::abs(simpleEval - nnue)) / 32768;
 
-        int npm = pos.non_pawn_material() / 64;
-        v       = (nnue * (915 + npm + 9 * pos.count<PAWN>()) + optimism * (154 + npm)) / 1024;
-    }
+    int npm = pos.non_pawn_material() / 64;
+    v       = (nnue * (915 + npm + 9 * pos.count<PAWN>()) + optimism * (154 + npm)) / 1024;
 
     // Damp down the evaluation linearly when shuffling
     v = v * (200 - shuffling) / 214;


### PR DESCRIPTION
With the recent introduction of the dual NNUE, the need for simple eval is no longer there.

Passed STC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 85312 W: 22009 L: 21837 D: 41466
Ptnml(0-2): 334, 10155, 21567, 10205, 395
https://tests.stockfishchess.org/tests/view/65c1f735c865510db0281652

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 49956 W: 12596 L: 12402 D: 24958
Ptnml(0-2): 28, 5553, 13624, 5743, 30
https://tests.stockfishchess.org/tests/view/65c2d64bc865510db0282810

closes https://github.com/official-stockfish/Stockfish/pull/5037

Bench 1427028