### PR TITLE
Simplifying the verification rule

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -794,7 +794,7 @@ Value Search::Worker::search(
 
             // Do verification search at high depths, with null move pruning disabled
             // until ply exceeds nmpMinPly.
-            thisThread->nmpMinPly = ss->ply + 3 * (depth - R) / 4;
+            thisThread->nmpMinPly = ss->ply + depth - R;
 
             Value v = search<NonPV>(pos, ss, beta - 1, beta, depth - R, false);
 


### PR DESCRIPTION
Simplifying the verification rule by removing two operations.

Passed STC non-reg:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 46368 W: 12124 L: 11914 D: 22330
Ptnml(0-2): 198, 5170, 12210, 5436, 170
https://tests.stockfishchess.org/tests/view/65bf71fcc865510db027e1ff

Passed LTC non-reg:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 214764 W: 53946 L: 53924 D: 106894
Ptnml(0-2): 116, 23288, 60560, 23294, 124
https://tests.stockfishchess.org/tests/view/65bfbcabc865510db027e8f9

Here are the results of the zugzwang test suite, filled by personally observing each position until the patch was able to find the correct evaluation (fail high in most of the positions, and draw in a single position (pos.20).
Engines were set to use only one core, and a maximum time of 120 sec.

![image](https://github.com/official-stockfish/Stockfish/assets/11150271/b36cdeea-1008-4d52-b478-ab9dd5472fe9)


So in conclusion I didn't observe any regression in detecting zugzwang positions, the only position that took a little longer was pos. 17, but since in other positions the new patch sometimes took less time to find the solution, I don't think it's relevant.
Also, for the positions in which the patches took longer than 2 seconds to solve, I ran them twice, and got always very similar results.

Test Suite used: https://github.com/official-stockfish/Stockfish/files/1558563/Zugzwang-Allgeuer.zip

bench: 1478189