### PR TITLE
Simplify opponent movecount reduction

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -78,6 +78,7 @@ Fauzi Akram Dabat (fauzi2)
 Felix Wittmann
 gamander
 Gabriele Lombardo (gabe)
+Gahtan Nahdi
 Gary Heckman (gheckman)
 George Sobala (gsobala)
 gguliash

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1108,10 +1108,6 @@ moves_loop:  // When in check, search starts here
         if (ss->ttPv)
             r -= 1 + (ttValue > alpha) + (ttValue > beta && tte->depth() >= depth);
 
-        // Decrease reduction if opponent's move count is high (~1 Elo)
-        if ((ss - 1)->moveCount > 7)
-            r--;
-
         // Increase reduction for cut nodes (~4 Elo)
         if (cutNode)
             r += 2 - (tte->depth() >= depth && ss->ttPv);


### PR DESCRIPTION
This removes the reduction decrease that occured when the previous ply had a movecount greater than 7

Passed STC:
https://tests.stockfishchess.org/tests/view/65c3f6dac865510db0283ef6
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 11968 W: 3205 L: 2953 D: 5810
Ptnml(0-2): 38, 1310, 3064, 1506, 66

Passed LTC:
https://tests.stockfishchess.org/tests/view/65c42377c865510db0284217
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 35676 W: 9113 L: 8905 D: 17658
Ptnml(0-2): 22, 3893, 9802, 4097, 24

Bench 1205830