### PR TITLE
Simplify away check extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1071,10 +1071,6 @@ moves_loop:  // When in check, search starts here
                     extension = -1;
             }
 
-            // Check extensions (~1 Elo)
-            else if (givesCheck && depth > 10)
-                extension = 1;
-
             // Quiet ttMove extensions (~1 Elo)
             else if (PvNode && move == ttMove && move == ss->killers[0]
                      && (*contHist[0])[movedPiece][move.to_sq()] >= 4339)


### PR DESCRIPTION
Remove check extension.

Passed simplification STC: https://tests.stockfishchess.org/tests/view/65c38d2ac865510db02836cf
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 52288 W: 13578 L: 13371 D: 25339
Ptnml(0-2): 197, 6171, 13265, 6250, 261 

Passed simplification LTC: https://tests.stockfishchess.org/tests/view/65c4470ec865510db0284473
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 44958 W: 11255 L: 11055 D: 22648
Ptnml(0-2): 37, 4962, 12274, 5176, 30 

Bench: 1592260