### PR TITLE
Fix a crash bug when allocating an aligned transformer buffer.

### DIFF
--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -198,18 +198,17 @@ Value evaluate(const Position& pos, bool adjusted, int* complexity) {
 
 #if defined(ALIGNAS_ON_STACK_VARIABLES_BROKEN)
     TransformedFeatureType
-      transformedFeaturesUnaligned[FeatureTransformer < Small ? TransformedFeatureDimensionsSmall
-                                                              : TransformedFeatureDimensionsBig,
-                                   nullptr
-                                     > ::BufferSize + alignment / sizeof(TransformedFeatureType)];
+      transformedFeaturesUnaligned[FeatureTransformer<Net_Size == Small ? TransformedFeatureDimensionsSmall
+                                                                        : TransformedFeatureDimensionsBig,
+                                   nullptr>::BufferSize + alignment / sizeof(TransformedFeatureType)];
 
     auto* transformedFeatures = align_ptr_up<alignment>(&transformedFeaturesUnaligned[0]);
 #else
 
     alignas(alignment) TransformedFeatureType
-      transformedFeatures[FeatureTransformer < Net_Size == Small ? TransformedFeatureDimensionsSmall
-                                                                 : TransformedFeatureDimensionsBig,
-                          nullptr > ::BufferSize];
+      transformedFeatures[FeatureTransformer<Net_Size == Small ? TransformedFeatureDimensionsSmall
+                                                               : TransformedFeatureDimensionsBig,
+                          nullptr>::BufferSize];
 #endif
 
     ASSERT_ALIGNED(transformedFeatures, alignment);


### PR DESCRIPTION
Thanks to @cj5716 and @peregrineshahin https://github.com/official-stockfish/Stockfish/commit/584d9efedcde330eeb96a99215552ddfb06f52ba#r138417600 for spotting this!  I also removed some spaces so that the < at the start of the template parameters doesn't look like the less than symbol.

No functional change
bench: 1478189