### PR TITLE
Fix a couple of inefficiencies with std::unordered_map used for voting.

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -210,10 +210,9 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
 
 Thread* ThreadPool::get_best_thread() const {
 
-    std::unordered_map<Move, int64_t, Move::MoveHash> votes;
-
     Thread* bestThread = threads.front();
     Value   minScore   = VALUE_NONE;
+    std::unordered_map<Move, int64_t, Move::MoveHash> votes(2 * std::min(size(), bestThread->worker->rootMoves.size())); 
 
     // Find the minimum score of all threads
     for (Thread* th : threads)
@@ -232,12 +231,11 @@ Thread* ThreadPool::get_best_thread() const {
         const auto bestThreadScore = bestThread->worker->rootMoves[0].score;
         const auto newThreadScore  = th->worker->rootMoves[0].score;
 
-        const auto bestThreadPV = bestThread->worker->rootMoves[0].pv;
-        const auto newThreadPV  = th->worker->rootMoves[0].pv;
+        const auto& bestThreadPV = bestThread->worker->rootMoves[0].pv;
+        const auto& newThreadPV  = th->worker->rootMoves[0].pv;
 
         const auto bestThreadMoveVote = votes[bestThreadPV[0]];
         const auto newThreadMoveVote  = votes[newThreadPV[0]];
-
 
         const bool bestThreadInProvenWin = bestThreadScore >= VALUE_TB_WIN_IN_MAX_PLY;
         const bool newThreadInProvenWin  = newThreadScore >= VALUE_TB_WIN_IN_MAX_PLY;

--- a/src/types.h
+++ b/src/types.h
@@ -397,7 +397,7 @@ class Move {
     constexpr std::uint16_t raw() const { return data; }
 
     struct MoveHash {
-        std::size_t operator()(const Move& m) const { return m.data; }
+        std::size_t operator()(const Move& m) const { return make_key(m.data); }
     };
 
    protected:


### PR DESCRIPTION
Initialize the unordered map to a reasonable number of buckets.  Make move hashes well distributed.  For more see https://github.com/official-stockfish/Stockfish/pull/4958#issuecomment-1937351190
Also make bestThreadPV and newThreadPV references so we don't copy entire vectors.

No functional change
bench: 1116591