### PR TITLE
remove quiet ttMove extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1071,11 +1071,6 @@ moves_loop:  // When in check, search starts here
                     extension = -1;
             }
 
-            // Quiet ttMove extensions (~1 Elo)
-            else if (PvNode && move == ttMove && move == ss->killers[0]
-                     && (*contHist[0])[movedPiece][move.to_sq()] >= 4339)
-                extension = 1;
-
             // Recapture extensions (~1 Elo)
             else if (PvNode && move == ttMove && move.to_sq() == prevSq
                      && thisThread->captureHistory[movedPiece][move.to_sq()]


### PR DESCRIPTION
remove quiet ttMove extensions.

Passed STC:
https://tests.stockfishchess.org/tests/view/65c6934cc865510db0286e90
LLR: 2.99 (-2.94,2.94) <-1.75,0.25>
Total: 54016 W: 14065 L: 13854 D: 26097
Ptnml(0-2): 231, 6381, 13581, 6576, 239

Passed LTC:
https://tests.stockfishchess.org/tests/view/65c72b91c865510db0287a1a
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 55098 W: 13850 L: 13658 D: 27590
Ptnml(0-2): 37, 6257, 14777, 6433, 45

Bench 1091284