### PR TITLE
Remove penalty for quiet ttMove that fails low

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -610,13 +610,6 @@ Value Search::Worker::search(
                     update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                                   -stat_malus(depth + 1));
             }
-            // Penalty for a quiet ttMove that fails low (~1 Elo)
-            else if (!ttCapture)
-            {
-                int penalty = -stat_malus(depth);
-                thisThread->mainHistory[us][ttMove.from_to()] << penalty;
-                update_continuation_histories(ss, pos.moved_piece(ttMove), ttMove.to_sq(), penalty);
-            }
         }
 
         // Partial workaround for the graph history interaction problem


### PR DESCRIPTION
Remove penalty for quiet ttMove that fails low.

Passed STC non-reg:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 234336 W: 60258 L: 60255 D: 113823
Ptnml(0-2): 966, 28141, 58918, 28210, 933
https://tests.stockfishchess.org/tests/view/65c691a7c865510db0286e6e

Passed LTC non-reg:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 235206 W: 59134 L: 59132 D: 116940
Ptnml(0-2): 135, 26908, 63517, 26906, 137
https://tests.stockfishchess.org/tests/view/65c8d0d31d8e83c78bfcd4a6

bench 1287996