### PR TITLE
Simplify TT PV reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1105,9 +1105,9 @@ moves_loop:  // When in check, search starts here
         thisThread->nodes.fetch_add(1, std::memory_order_relaxed);
         pos.do_move(move, st, givesCheck);
 
-        // Decrease reduction if position is or has been on the PV (~5 Elo)
+        // Decrease reduction if position is or has been on the PV (~7 Elo)
         if (ss->ttPv)
-            r -= 1 + (ttValue > alpha) + (ttValue > beta && tte->depth() >= depth);
+            r -= 1 + (ttValue > alpha) + (tte->depth() >= depth);
 
         // Increase reduction for cut nodes (~4 Elo)
         if (cutNode)


### PR DESCRIPTION
This also removes some incorrect fail-high logic.

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 87968 W: 22634 L: 22468 D: 42866
Ptnml(0-2): 315, 10436, 22323, 10588, 322
https://tests.stockfishchess.org/tests/view/65cb3b641d8e83c78bfd04a9

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 70794 W: 17846 L: 17672 D: 35276
Ptnml(0-2): 44, 7980, 19189, 8126, 58
https://tests.stockfishchess.org/tests/view/65cccee21d8e83c78bfd222c

closes #5055

Bench 1203823