### PR TITLE
Simplify PV node reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1118,7 +1118,7 @@ moves_loop:  // When in check, search starts here
             r++;
 
         // Decrease reduction for PvNodes (~3 Elo)
-        if (PvNode && tte->bound() != BOUND_UPPER)
+        if (PvNode)
             r--;
 
         // Increase reduction on repetition (~1 Elo)


### PR DESCRIPTION
Reduce less on PV nodes even with an upperbound TT entry.

Passed STC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 118752 W: 30441 L: 30307 D: 58004
Ptnml(0-2): 476, 14179, 29921, 14335, 465
https://tests.stockfishchess.org/tests/view/65cb3a861d8e83c78bfd0497

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 155058 W: 38549 L: 38464 D: 78045
Ptnml(0-2): 85, 17521, 42219, 17632, 72
https://tests.stockfishchess.org/tests/view/65cd3b951d8e83c78bfd2b0d

closes #5057

Bench 1283134