### PR TITLE
Fix fishtest related issue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,8 +39,8 @@ Value evaluate(const Position& pos, int optimism);
 // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro, as it is used in the Makefile.
-#define EvalFileDefaultNameBig "nn-b1a57edbea57.nnue"
 #define EvalFileDefaultNameSmall "nn-baff1ede1f90.nnue"
+#define EvalFileDefaultNameBig "nn-b1a57edbea57.nnue"
 
 struct EvalFile {
     // UCI option name


### PR DESCRIPTION
This is a workaround for server NNUE files related issues, to not await on Fishtest indefinitely we can flip the order of the lines to match Fishtest regexes such that the big net is considered the main net instead of the small net so the new big nets appear in the repo as tested. and we fix test_view.

No functional change
