### PR TITLE
Simplify IIR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -808,10 +808,11 @@ Value Search::Worker::search(
     }
 
     // Step 10. Internal iterative reductions (~9 Elo)
-    // For PV nodes without a ttMove, we decrease depth by 3
+    // For PV nodes without a ttMove, we decrease depth by 3.
     if (PvNode && !ttMove)
         depth -= 3;
 
+    // Use qsearch if depth <= 0.
     if (depth <= 0)
         return qsearch<PV>(pos, ss, alpha, beta);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -808,12 +808,9 @@ Value Search::Worker::search(
     }
 
     // Step 10. Internal iterative reductions (~9 Elo)
-    // For PV nodes without a ttMove, we decrease depth by 2,
-    // or by 4 if the current position is present in the TT and
-    // the stored depth is greater than or equal to the current depth.
-    // Use qsearch if depth <= 0.
+    // For PV nodes without a ttMove, we decrease depth by 3
     if (PvNode && !ttMove)
-        depth -= 2 + 2 * (ss->ttHit && tte->depth() >= depth);
+        depth -= 3;
 
     if (depth <= 0)
         return qsearch<PV>(pos, ss, alpha, beta);


### PR DESCRIPTION
Simplified depth reduction for PV nodes without a ttMove to 3.

Passed STC non-reg:
https://tests.stockfishchess.org/tests/view/65d1a90a1d8e83c78bfd855a
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 363168 W: 93648 L: 93791 D: 175729
Ptnml(0-2): 1557, 43692, 91221, 43565, 1549

Passed LTC non-reg:
https://tests.stockfishchess.org/tests/view/65d5612d1d8e83c78bfdc8e2
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 58818 W: 14946 L: 14761 D: 29111
Ptnml(0-2): 36, 6595, 15962, 6780, 36

Bench: 1615965