### PR TITLE
Simplification of TM declaration of timeLeft, and improvement of timeleft max() function

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -82,12 +82,12 @@ void TimeManagement::init(Search::LimitsType& limits,
         limits.npmsec = npmsec;
     }
 
-    // Maximum move horizon of 50 moves
+    // Maximum and default move horizon of 50 moves
     int mtg = limits.movestogo ? std::min(limits.movestogo, 50) : 50;
 
-    // Make sure timeLeft is > 0 since we may use it as a divisor
-    TimePoint timeLeft = std::max(TimePoint(1), limits.time[us] + limits.inc[us] * (mtg - 1)
-                                                  - moveOverhead * (2 + mtg));
+    // Make sure timeLeft is > 0 since we use it as a divisor
+    double timeLeft =
+      std::max(limits.time[us], limits.time[us] + limits.inc[us] * (mtg - 1) - moveOverhead * mtg);
 
     // Use extra time with larger increments
     double optExtra = std::clamp(1.0 + 12.5 * limits.inc[us] / limits.time[us], 1.0, 1.11);
@@ -97,12 +97,12 @@ void TimeManagement::init(Search::LimitsType& limits,
     double maxConstant = std::max(3.4 + 3.0 * std::log10(limits.time[us] / 1000.0), 2.76);
 
     // x basetime (+ z increment)
-    // If there is a healthy increment, timeLeft can exceed actual available
+    // If there is a healthy increment and low mtg, timeLeft can exceed actual available
     // game time for the current move, so also cap to 20% of available game time.
     if (limits.movestogo == 0)
     {
         optScale = std::min(0.0120 + std::pow(ply + 3.1, 0.44) * optConstant,
-                            0.21 * limits.time[us] / double(timeLeft))
+                            0.21 * limits.time[us] / timeLeft)
                  * optExtra;
         maxScale = std::min(6.9, maxConstant + ply / 12.2);
     }
@@ -110,7 +110,7 @@ void TimeManagement::init(Search::LimitsType& limits,
     // x moves in y seconds (+ z increment)
     else
     {
-        optScale = std::min((0.88 + ply / 116.4) / mtg, 0.88 * limits.time[us] / double(timeLeft));
+        optScale = std::min((0.88 + ply / 116.4) / mtg, 0.88 * limits.time[us] / timeLeft);
         maxScale = std::min(6.3, 1.5 + 0.11 * mtg);
     }
 


### PR DESCRIPTION
Declared timeLeft as a double, as it was always casting to a double anyway. and instead of defaulting timeleft to '1' in the scenario where
`limits.time[us] + limits.inc[us] * (mtg - 1) - moveOverhead * mtg)`
was less than 0, default to remaining time.

passed STC regression
https://tests.stockfishchess.org/tests/view/65d283751d8e83c78bfd9534

LTC regression
https://tests.stockfishchess.org/tests/view/65d32d7f1d8e83c78bfda1a2

and made a significant improvement in Sudden Death 10 sec.
https://tests.stockfishchess.org/tests/live_elo/65d65c061d8e83c78bfddb1a