### PR TITLE
Expose EvalFileSmall option for small net

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -77,11 +77,7 @@ NNUE::EvalFiles NNUE::load_networks(const std::string& rootDirectory,
 
     for (auto& [netSize, evalFile] : evalFiles)
     {
-        // Replace with
-        // options[evalFile.optionName]
-        // once fishtest supports the uci option EvalFileSmall
-        std::string user_eval_file =
-          netSize == Small ? evalFile.defaultName : options[evalFile.optionName];
+        std::string user_eval_file = options[evalFile.optionName];
 
         if (user_eval_file.empty())
             user_eval_file = evalFile.defaultName;
@@ -149,11 +145,8 @@ void NNUE::verify(const OptionsMap&                                        optio
 
     for (const auto& [netSize, evalFile] : evalFiles)
     {
-        // Replace with
-        // options[evalFile.optionName]
-        // once fishtest supports the uci option EvalFileSmall
-        std::string user_eval_file =
-          netSize == Small ? evalFile.defaultName : options[evalFile.optionName];
+        std::string user_eval_file = options[evalFile.optionName];
+
         if (user_eval_file.empty())
             user_eval_file = evalFile.defaultName;
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -83,6 +83,9 @@ UCI::UCI(int argc, char** argv) :
     options["EvalFile"] << Option(EvalFileDefaultNameBig, [this](const Option&) {
         evalFiles = Eval::NNUE::load_networks(cli.binaryDirectory, options, evalFiles);
     });
+    options["EvalFileSmall"] << Option(EvalFileDefaultNameSmall, [this](const Option&) {
+        evalFiles = Eval::NNUE::load_networks(cli.binaryDirectory, options, evalFiles);
+    });
 
     threads.set({options, threads, tt});
 


### PR DESCRIPTION
Since https://github.com/official-stockfish/fishtest/pull/1870 has been merged
it's time for this update.

5k Fixed Games showed no problems.
https://tests.stockfishchess.org/tests/view/65d9cc274c0e22b904f574d7

No functional change 