### PR TITLE
Simplify Time Management

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -94,7 +94,7 @@ void TimeManagement::init(Search::LimitsType& limits,
     if (limits.movestogo == 0)
     {
         // Use extra time with larger increments
-        double optExtra = std::clamp(1.0 + 12.5 * limits.inc[us] / limits.time[us], 1.0, 1.11);
+        double optExtra = limits.inc[us] < 500 ? 1.0 : 1.1;
 
         // Calculate time constants based on current time left.
         double optConstant =


### PR DESCRIPTION
Simplify Time Management

Instead of having a formula for using extra time with larger increments.
Simply set it to 1 when the increment is lower than 0.5s and to 1.1 when the increment is higher.

The values can later on be further improved.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 27488 W: 7077 L: 6848 D: 13563
Ptnml(0-2): 96, 3041, 7267, 3218, 122
https://tests.stockfishchess.org/tests/view/65d25d3c1d8e83c78bfd9293

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 137568 W: 34612 L: 34512 D: 68444
Ptnml(0-2): 60, 14672, 39221, 14770, 61
https://tests.stockfishchess.org/tests/view/65d2a72c1d8e83c78bfd97fa

Passed VLTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 139650 W: 35229 L: 35134 D: 69287
Ptnml(0-2): 33, 14227, 41218, 14306, 41
https://tests.stockfishchess.org/tests/view/65d7d7d39b2da0226a5a205b

Passed also the TCEC TC style suggested by vondele:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 134150 W: 34278 L: 34163 D: 65709
Ptnml(0-2): 561, 15727, 34444, 15722, 621
https://tests.stockfishchess.org/tests/view/65e4ca73416ecd92c162a57d
