### PR TITLE
Refactor Futility Margin Formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -57,7 +57,8 @@ namespace {
 // Futility margin
 Value futility_margin(Depth d, bool noTtCutNode, bool improving) {
     Value futilityMult = 117 - 44 * noTtCutNode;
-    return (futilityMult * d - 3 * futilityMult / 2 * improving);
+    return (improving? futilityMult * d - 3 * futilityMult / 2
+                      :futilityMult * d);
 }
 
 constexpr int futility_move_count(bool improving, Depth depth) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -57,7 +57,7 @@ namespace {
 // Futility margin
 Value futility_margin(Depth d, bool noTtCutNode, bool improving) {
     Value futilityMult = 117 - 44 * noTtCutNode;
-    return (futilityMult * d) - ((3 * futilityMult / 2) * improving);
+    return futilityMult * d - 3 * futilityMult * improving / 2;
 }
 
 constexpr int futility_move_count(bool improving, Depth depth) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -57,8 +57,7 @@ namespace {
 // Futility margin
 Value futility_margin(Depth d, bool noTtCutNode, bool improving) {
     Value futilityMult = 117 - 44 * noTtCutNode;
-    return (improving? futilityMult * d - 3 * futilityMult / 2
-                      :futilityMult * d);
+    return (futilityMult * d) - ((3 * futilityMult / 2) * improving);
 }
 
 constexpr int futility_move_count(bool improving, Depth depth) {


### PR DESCRIPTION
In the current implementation, the formula involves several consecutive multiplications and divisors. Making it challenging to understand the order of operations.

Refactor Futility Margin Formula, to make it easier to understand.
~~Since using ternary operator, the logic, and order of operations become more apparent.~~
Removed the parentheses and moved the improving multiply before the divide for easier-to-read operator precedence (Thanks to @mstembera for this solution idea).


Non Functional