### PR TITLE
Simplify away eval - beta >= 0 assert in null move search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -772,8 +772,6 @@ Value Search::Worker::search(
         && !excludedMove && pos.non_pawn_material(us) && ss->ply >= thisThread->nmpMinPly
         && beta > VALUE_TB_LOSS_IN_MAX_PLY)
     {
-        assert(eval - beta >= 0);
-
         // Null move dynamic reduction based on depth and eval
         Depth R = std::min(int(eval - beta) / 154, 6) + depth / 3 + 4;
 


### PR DESCRIPTION
In the if-condition for null move search it is written as one of the conditions: `eval >= beta`. Therefore `eval - beta >= 0` will trivially always be true, rendering the assert pointless.

No functional change