### PR TITLE
fix go mate x behaviour for mated-in positions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -398,8 +398,10 @@ void Search::Worker::iterative_deepening() {
         }
 
         // Have we found a "mate in x"?
-        if (limits.mate && bestValue >= VALUE_MATE_IN_MAX_PLY
-            && VALUE_MATE - bestValue <= 2 * limits.mate)
+        if (limits.mate
+            && ((bestValue >= VALUE_MATE_IN_MAX_PLY && VALUE_MATE - bestValue <= 2 * limits.mate)
+                || (bestValue != -VALUE_INFINITE && bestValue <= VALUE_TB_LOSS_IN_MAX_PLY
+                    && VALUE_MATE + bestValue <= 2 * limits.mate)))
             threads.stop = true;
 
         if (!mainThread)


### PR DESCRIPTION
Since the merge of https://github.com/official-stockfish/Stockfish/pull/4990 we can also trust `mate -x` scores, and so use these to stop search when asked to `go mate x` in losing positions.

Note that the UCI protocols assumes that `go mate x` is for `x` always positive: `search for a mate in x moves`, see [uci](https://www.wbec-ridderkerk.nl/html/UCIProtocol.html).  This is also what's implemented in [python-chess](https://python-chess.readthedocs.io/en/latest/_modules/chess/engine.html#Limit).

Master: 
```
position fen 8/8/3K1p1p/2N2pbr/2B1k2p/2P2p1P/2P2P2/8 b - -
go mate 2
info string NNUE evaluation using nn-baff1ede1f90.nnue
info string NNUE evaluation using nn-b1a57edbea57.nnue
info depth 1 seldepth 2 multipv 1 score cp 93 nodes 1 nps 1000 hashfull 0 tbhits 0 time 1 pv e4f4
info depth 2 seldepth 2 multipv 1 score cp 93 nodes 2 nps 2000 hashfull 0 tbhits 0 time 1 pv e4f4
<snip>
info depth 244 seldepth 5 multipv 1 score mate -2 nodes 9056 nps 905600 hashfull 0 tbhits 0 time 10 pv e4f4 c5d3 f4e4 c4d5
info depth 245 seldepth 5 multipv 1 score mate -2 nodes 9096 nps 909600 hashfull 0 tbhits 0 time 10 pv e4f4 c5d3 f4e4 c4d5
bestmove e4f4 ponder c5d3
```

Patch:
```
position fen 8/8/3K1p1p/2N2pbr/2B1k2p/2P2p1P/2P2P2/8 b - -
go mate 2
info string NNUE evaluation using nn-baff1ede1f90.nnue
info string NNUE evaluation using nn-b1a57edbea57.nnue
info depth 1 seldepth 2 multipv 1 score cp 93 nodes 1 nps 500 hashfull 0 tbhits 0 time 2 pv e4f4
info depth 2 seldepth 2 multipv 1 score cp 93 nodes 2 nps 1000 hashfull 0 tbhits 0 time 2 pv e4f4
info depth 3 seldepth 2 multipv 1 score cp 93 nodes 3 nps 1500 hashfull 0 tbhits 0 time 2 pv e4f4
info depth 4 seldepth 4 multipv 1 score cp 92 nodes 10 nps 5000 hashfull 0 tbhits 0 time 2 pv e4f4 c5d3 f4e4
info depth 5 seldepth 4 multipv 1 score cp 92 nodes 18 nps 9000 hashfull 0 tbhits 0 time 2 pv e4f4 c5d3 f4e4
info depth 6 seldepth 5 multipv 1 score mate -2 nodes 42 nps 14000 hashfull 0 tbhits 0 time 3 pv e4f4 c5d3 f4e4 c4d5
bestmove e4f4 ponder c5d3
```

The patch only affects the behaviour after `go mate x`.

No functional change.
