### PR TITLE
Fix go mate in multithreading

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -398,8 +398,10 @@ void Search::Worker::iterative_deepening() {
         }
 
         // Have we found a "mate in x"?
-        if (limits.mate && bestValue >= VALUE_MATE_IN_MAX_PLY
-            && VALUE_MATE - bestValue <= 2 * limits.mate)
+        if (limits.mate && rootMoves[0].uciScore >= VALUE_MATE_IN_MAX_PLY
+            && rootMoves[0].score >= VALUE_MATE_IN_MAX_PLY
+            && VALUE_MATE - rootMoves[0].uciScore <= 2 * limits.mate
+            && VALUE_MATE - rootMoves[0].score <= 2 * limits.mate)
             threads.stop = true;
 
         if (!mainThread)


### PR DESCRIPTION
To actually have consistency one cannot use bestValue as it can propagate the aborted scores and more importantly out of the bound scores that we do not accept in outputting (thus we use uciScore) and label them as lowerbound/upperbound .

The extra checks for `.score` is needed in voting because we use .score not .uciScore this renders only the thread that can actually be picked as best to be the one printing the mate.

No functional change