### PR TITLE
Tune14f pr

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -206,11 +206,11 @@ Value Eval::evaluate(const Position& pos, int optimism) {
     nnue -= nnue * (nnueComplexity + std::abs(simpleEval - nnue)) / 32768;
 
     int npm = pos.non_pawn_material() / 64;
-    int v   = (nnue * (915 + npm + 9 * pos.count<PAWN>()) + optimism * (154 + npm)) / 1024;
+    int v   = (nnue * (936 + npm + 9 * pos.count<PAWN>()) + optimism * (154 + npm)) / 1024;
 
     // Damp down the evaluation linearly when shuffling
     int shuffling = pos.rule50_count();
-    v             = v * (200 - shuffling) / 214;
+    v             = v * (200 - shuffling) / 225;
 
     // Guarantee evaluation does not hit the tablebase range
     v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -190,18 +190,18 @@ void MovePicker::score() {
             m.value += bool(pos.check_squares(pt) & to) * 16384;
 
             // bonus for escaping from capture
-            m.value += threatenedPieces & from ? (pt == QUEEN && !(to & threatenedByRook)   ? 50000
-                                                  : pt == ROOK && !(to & threatenedByMinor) ? 25000
-                                                  : !(to & threatenedByPawn)                ? 15000
+            m.value += threatenedPieces & from ? (pt == QUEEN && !(to & threatenedByRook)   ? 51000
+                                                  : pt == ROOK && !(to & threatenedByMinor) ? 24950
+                                                  : !(to & threatenedByPawn)                ? 14450
                                                                                             : 0)
                                                : 0;
 
             // malus for putting piece en prise
             m.value -= !(threatenedPieces & from)
-                       ? (pt == QUEEN ? bool(to & threatenedByRook) * 50000
-                                          + bool(to & threatenedByMinor) * 10000
-                          : pt == ROOK ? bool(to & threatenedByMinor) * 25000
-                          : pt != PAWN ? bool(to & threatenedByPawn) * 15000
+                       ? (pt == QUEEN ? bool(to & threatenedByRook) * 48150
+                                          + bool(to & threatenedByMinor) * 10650
+                          : pt == ROOK ? bool(to & threatenedByMinor) * 24500
+                          : pt != PAWN ? bool(to & threatenedByPawn) * 14950
                                        : 0)
                        : 0;
         }
@@ -241,7 +241,7 @@ Move MovePicker::select(Pred filter) {
 // moves left, picking the move with the highest score from a list of generated moves.
 Move MovePicker::next_move(bool skipQuiets) {
 
-    auto quiet_threshold = [](Depth d) { return -3330 * d; };
+    auto quiet_threshold = [](Depth d) { return -3550 * d; };
 
 top:
     switch (stage)


### PR DESCRIPTION
The original idea started from @TarasVuk with his patch: https://tests.stockfishchess.org/tests/view/6516b3a8b3e74811c8af4203
And the tune was done on top of it: https://tests.stockfishchess.org/tests/view/65db923b90f639b028a53875
and: https://tests.stockfishchess.org/tests/view/65db923390f639b028a53873

The razoring patch by itself does not pass:
https://tests.stockfishchess.org/tests/view/65e9da8b0ec64f0526c3ff71

The tuning patch by itself does not pass:
https://tests.stockfishchess.org/tests/view/65e74d230ec64f0526c3d5c5

While the combination of them passed both tests.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 50496 W: 13211 L: 12868 D: 24417
Ptnml(0-2): 208, 5931, 12627, 6274, 208
https://tests.stockfishchess.org/tests/view/65e656dbb6345c1b93486281

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 78552 W: 20101 L: 19692 D: 38759
Ptnml(0-2): 45, 8690, 21395, 9103, 43
https://tests.stockfishchess.org/tests/view/65e74d140ec64f0526c3d5c3

