### PR TITLE
Introduce double extensions for PV nodes.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1038,6 +1038,8 @@ moves_loop:  // When in check, search starts here
                         extension = 2 + (value < singularBeta - 78 && !ttCapture);
                         depth += depth < 16;
                     }
+                    if (PvNode && !ttCapture && ss->multipleExtensions <= 5 && value < singularBeta - 50)
+                        extension = 2;
                 }
 
                 // Multi-cut pruning


### PR DESCRIPTION
Our double/triple extensions were allowed only for non-pv nodes.
This patch allows them to be done for PV nodes, with some stricter conditions.
Passed STC:
https://tests.stockfishchess.org/tests/view/65d657ec1d8e83c78bfddab8
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 339424 W: 88097 L: 87318 D: 164009
Ptnml(0-2): 1573, 39935, 85729, 41090, 1385 
Passed LTC:
https://tests.stockfishchess.org/tests/view/65dd63824b19edc854ebc433
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 459564 W: 115812 L: 114614 D: 229138
Ptnml(0-2): 248, 51441, 125173, 52705, 215 
bench 1942991