### PR TITLE
VLTC time management tune

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -423,15 +423,15 @@ void Search::Worker::iterative_deepening() {
             int  nodesEffort = effort[bestmove.from_sq()][bestmove.to_sq()] * 100
                             / std::max(size_t(1), size_t(nodes));
 
-            double fallingEval = (66 + 14 * (mainThread->bestPreviousAverageScore - bestValue)
-                                  + 6 * (mainThread->iterValue[iterIdx] - bestValue))
-                               / 616.6;
-            fallingEval = std::clamp(fallingEval, 0.51, 1.51);
+            double fallingEval = (1067 + 223 * (mainThread->bestPreviousAverageScore - bestValue)
+                                  + 97 * (mainThread->iterValue[iterIdx] - bestValue))
+                               / 10000.0;
+            fallingEval = std::clamp(fallingEval, 0.580, 1.667);
 
             // If the bestMove is stable over several iterations, reduce time accordingly
-            timeReduction    = lastBestMoveDepth + 8 < completedDepth ? 1.56 : 0.69;
-            double reduction = (1.4 + mainThread->previousTimeReduction) / (2.17 * timeReduction);
-            double bestMoveInstability = 1 + 1.79 * totBestMoveChanges / threads.size();
+            timeReduction    = lastBestMoveDepth + 8 < completedDepth ? 1.495 : 0.687;
+            double reduction = (1.48 + mainThread->previousTimeReduction) / (2.17 * timeReduction);
+            double bestMoveInstability = 1 + 1.88 * totBestMoveChanges / threads.size();
 
             double totalTime =
               mainThread->tm.optimum() * fallingEval * reduction * bestMoveInstability;
@@ -440,8 +440,8 @@ void Search::Worker::iterative_deepening() {
             if (rootMoves.size() == 1)
                 totalTime = std::min(500.0, totalTime);
 
-            if (completedDepth >= 10 && nodesEffort >= 95
-                && mainThread->tm.elapsed(threads.nodes_searched()) > totalTime * 3 / 4
+            if (completedDepth >= 10 && nodesEffort >= 97
+                && mainThread->tm.elapsed(threads.nodes_searched()) > totalTime * 0.739
                 && !mainThread->ponder)
             {
                 threads.stop = true;
@@ -458,7 +458,7 @@ void Search::Worker::iterative_deepening() {
                     threads.stop = true;
             }
             else if (!mainThread->ponder
-                     && mainThread->tm.elapsed(threads.nodes_searched()) > totalTime * 0.50)
+                     && mainThread->tm.elapsed(threads.nodes_searched()) > totalTime * 0.506)
                 threads.increaseDepth = false;
             else
                 threads.increaseDepth = true;

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -94,17 +94,17 @@ void TimeManagement::init(Search::LimitsType& limits,
     if (limits.movestogo == 0)
     {
         // Use extra time with larger increments
-        double optExtra = std::clamp(1.0 + 12.5 * limits.inc[us] / limits.time[us], 1.0, 1.11);
+        double optExtra = limits.inc[us] < 500 ? 1.0 : 1.13;
 
         // Calculate time constants based on current time left.
         double optConstant =
-          std::min(0.00334 + 0.0003 * std::log10(limits.time[us] / 1000.0), 0.0049);
-        double maxConstant = std::max(3.4 + 3.0 * std::log10(limits.time[us] / 1000.0), 2.76);
+          std::min(0.00308 + 0.000319 * std::log10(limits.time[us] / 1000.0), 0.00506);
+        double maxConstant = std::max(3.39 + 3.01 * std::log10(limits.time[us] / 1000.0), 2.93);
 
-        optScale = std::min(0.0120 + std::pow(ply + 3.1, 0.44) * optConstant,
-                            0.21 * limits.time[us] / double(timeLeft))
+        optScale = std::min(0.0122 + std::pow(ply + 2.95, 0.462) * optConstant,
+                            0.213 * limits.time[us] / double(timeLeft))
                  * optExtra;
-        maxScale = std::min(6.9, maxConstant + ply / 12.2);
+        maxScale = std::min(6.64, maxConstant + ply / 12.0);
     }
 
     // x moves in y seconds (+ z increment)
@@ -117,7 +117,7 @@ void TimeManagement::init(Search::LimitsType& limits,
     // Limit the maximum possible time for this move
     optimumTime = TimePoint(optScale * timeLeft);
     maximumTime =
-      TimePoint(std::min(0.84 * limits.time[us] - moveOverhead, maxScale * optimumTime)) - 10;
+      TimePoint(std::min(0.825 * limits.time[us] - moveOverhead, maxScale * optimumTime)) - 10;
 
     if (options["Ponder"])
         optimumTime += optimumTime / 4;


### PR DESCRIPTION
Result of 35k games of SPSA tuning at 180+1.8. Tuning attempt can be found here: https://tests.stockfishchess.org/tests/view/65e40599f2ef6c733362b03b

Passed VLTC 180+1.8: https://tests.stockfishchess.org/tests/view/65e5a6f5416ecd92c162b5d4
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 31950 W: 8225 L: 7949 D: 15776
Ptnml(0-2): 3, 3195, 9309, 3459, 9 

Passed VLTC 240+2.4: https://tests.stockfishchess.org/tests/view/65e714de0ec64f0526c3d1f1
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 65108 W: 16558 L: 16202 D: 32348
Ptnml(0-2): 7, 6366, 19449, 6728, 4 

STC Elo estimate: https://tests.stockfishchess.org/tests/view/65e9bfa40ec64f0526c3fe0c

No functional change