### PR TITLE
Assorted cleanups

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,6 @@
 */
 
 #include <iostream>
-#include <unordered_map>
 
 #include "bitboard.h"
 #include "evaluate.h"
@@ -40,7 +39,7 @@ int main(int argc, char* argv[]) {
 
     Tune::init(uci.options);
 
-    uci.evalFiles = Eval::NNUE::load_networks(uci.workingDirectory(), uci.options, uci.evalFiles);
+    uci.evalFiles = Eval::NNUE::load_networks(uci.working_directory(), uci.options, uci.evalFiles);
 
     uci.loop();
 

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -452,9 +452,9 @@ bool save_eval(std::ostream&      stream,
 }
 
 // Save eval, to a file given by its name
-bool save_eval(const std::optional<std::string>&                              filename,
-               NetSize                                                        netSize,
-               const std::unordered_map<Eval::NNUE::NetSize, Eval::EvalFile>& evalFiles) {
+bool save_eval(const std::optional<std::string>& filename,
+               NetSize                           netSize,
+               const EvalFiles&                  evalFiles) {
 
     std::string actualFilename;
     std::string msg;

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -30,7 +30,6 @@
 #include <sstream>
 #include <string_view>
 #include <type_traits>
-#include <unordered_map>
 
 #include "../evaluate.h"
 #include "../misc.h"

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -26,7 +26,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 #include "../evaluate.h"
 #include "../misc.h"
@@ -36,11 +35,6 @@
 
 namespace Stockfish {
 class Position;
-
-namespace Eval {
-struct EvalFile;
-}
-
 }
 
 namespace Stockfish::Eval::NNUE {

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "../evaluate.h"
 #include "../misc.h"
 #include "../types.h"
 #include "nnue_architecture.h"
@@ -87,9 +88,7 @@ bool                       save_eval(std::ostream&      stream,
                                      NetSize            netSize,
                                      const std::string& name,
                                      const std::string& netDescription);
-bool                       save_eval(const std::optional<std::string>& filename,
-                                     NetSize                           netSize,
-                                     const std::unordered_map<Eval::NNUE::NetSize, Eval::EvalFile>&);
+bool save_eval(const std::optional<std::string>& filename, NetSize netSize, const EvalFiles&);
 
 }  // namespace Stockfish::Eval::NNUE
 

--- a/src/search.h
+++ b/src/search.h
@@ -109,6 +109,7 @@ struct LimitsType {
         time[WHITE] = time[BLACK] = inc[WHITE] = inc[BLACK] = npmsec = movetime = TimePoint(0);
         movestogo = depth = mate = perft = infinite = 0;
         nodes                                       = 0;
+        ponderMode                                  = false;
     }
 
     bool use_time_management() const { return time[WHITE] || time[BLACK]; }
@@ -117,6 +118,7 @@ struct LimitsType {
     TimePoint         time[COLOR_NB], inc[COLOR_NB], npmsec, movetime, startTime;
     int               movestogo, depth, mate, perft, infinite;
     uint64_t          nodes;
+    bool              ponderMode;
 };
 
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -163,13 +163,12 @@ void ThreadPool::clear() {
 void ThreadPool::start_thinking(const OptionsMap&  options,
                                 Position&          pos,
                                 StateListPtr&      states,
-                                Search::LimitsType limits,
-                                bool               ponderMode) {
+                                Search::LimitsType limits) {
 
     main_thread()->wait_for_search_finished();
 
     main_manager()->stopOnPonderhit = stop = abortedSearch = false;
-    main_manager()->ponder                                 = ponderMode;
+    main_manager()->ponder                                 = limits.ponderMode;
 
     increaseDepth = true;
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -79,8 +79,7 @@ class ThreadPool {
         }
     }
 
-    void
-    start_thinking(const OptionsMap&, Position&, StateListPtr&, Search::LimitsType, bool = false);
+    void start_thinking(const OptionsMap&, Position&, StateListPtr&, Search::LimitsType);
     void clear();
     void set(Search::SharedState);
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -175,11 +175,9 @@ void UCI::loop() {
     } while (token != "quit" && cli.argc == 1);  // The command-line arguments are one-shot
 }
 
-void UCI::go(Position& pos, std::istringstream& is, StateListPtr& states) {
-
+Search::LimitsType UCI::parse_limits(const Position& pos, std::istream& is) {
     Search::LimitsType limits;
     std::string        token;
-    bool               ponderMode = false;
 
     limits.startTime = now();  // The search starts as early as possible
 
@@ -211,7 +209,14 @@ void UCI::go(Position& pos, std::istringstream& is, StateListPtr& states) {
         else if (token == "infinite")
             limits.infinite = 1;
         else if (token == "ponder")
-            ponderMode = true;
+            limits.ponderMode = true;
+
+    return limits;
+}
+
+void UCI::go(Position& pos, std::istringstream& is, StateListPtr& states) {
+
+    Search::LimitsType limits = parse_limits(pos, is);
 
     Eval::NNUE::verify(options, evalFiles);
 
@@ -221,7 +226,7 @@ void UCI::go(Position& pos, std::istringstream& is, StateListPtr& states) {
         return;
     }
 
-    threads.start_thinking(options, pos, states, limits, ponderMode);
+    threads.start_thinking(options, pos, states, limits);
 }
 
 void UCI::bench(Position& pos, std::istream& args, StateListPtr& states) {

--- a/src/uci.h
+++ b/src/uci.h
@@ -55,9 +55,8 @@ class UCI {
 
     const std::string& workingDirectory() const { return cli.workingDirectory; }
 
-    OptionsMap options;
-
-    std::unordered_map<Eval::NNUE::NetSize, Eval::EvalFile> evalFiles;
+    OptionsMap            options;
+    Eval::NNUE::EvalFiles evalFiles;
 
    private:
     TranspositionTable tt;

--- a/src/uci.h
+++ b/src/uci.h
@@ -21,7 +21,6 @@
 
 #include <iostream>
 #include <string>
-#include <unordered_map>
 
 #include "evaluate.h"
 #include "misc.h"
@@ -29,12 +28,9 @@
 #include "thread.h"
 #include "tt.h"
 #include "ucioption.h"
+#include "search.h"
 
 namespace Stockfish {
-
-namespace Eval::NNUE {
-enum NetSize : int;
-}
 
 class Move;
 enum Square : int;
@@ -53,7 +49,9 @@ class UCI {
     static std::string wdl(Value v, int ply);
     static Move        to_move(const Position& pos, std::string& str);
 
-    const std::string& workingDirectory() const { return cli.workingDirectory; }
+    static Search::LimitsType parse_limits(const Position& pos, std::istream& is);
+
+    const std::string& working_directory() const { return cli.workingDirectory; }
 
     OptionsMap            options;
     Eval::NNUE::EvalFiles evalFiles;


### PR DESCRIPTION
- fix naming convention for `workingDirectory`
- use type alias for `EvalFiles` everywhere
- move `ponderMode` into `LimitsType`
- move limits parsing into standalone static function

No functional change