### PR TITLE
Simplify opponentWorsening condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -748,7 +748,7 @@ Value Search::Worker::search(
                 ? ss->staticEval > (ss - 2)->staticEval
                 : (ss - 4)->staticEval != VALUE_NONE && ss->staticEval > (ss - 4)->staticEval;
 
-    opponentWorsening = ss->staticEval + (ss - 1)->staticEval > 2 && (depth != 2 || !improving);
+    opponentWorsening = ss->staticEval + (ss - 1)->staticEval > 2;
 
     // Step 7. Razoring (~1 Elo)
     // If eval is really low check with qsearch if it can exceed alpha, if it can't,


### PR DESCRIPTION
Passed non-reg STC:
https://tests.stockfishchess.org/tests/view/65ea18650ec64f0526c4033a
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 226624 W: 58601 L: 58589 D: 109434
Ptnml(0-2): 1030, 27193, 56819, 27275, 995
Passed non-reg LTC:
https://tests.stockfishchess.org/tests/view/65eb7a220ec64f0526c4161a
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 243882 W: 61462 L: 61469 D: 120951
Ptnml(0-2): 197, 27559, 66419, 27586, 180

Bench: 1605883