### PR TITLE
Simplify aborting search in TM

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -463,11 +463,8 @@ void Search::Worker::iterative_deepening() {
                 else
                     threads.stop = true;
             }
-            else if (!mainThread->ponder
-                     && mainThread->tm.elapsed(threads.nodes_searched()) > totalTime * 0.506)
-                threads.increaseDepth = false;
             else
-                threads.increaseDepth = true;
+                threads.increaseDepth = mainThread->ponder || mainThread->tm.elapsed(threads.nodes_searched()) <= totalTime * 0.506;
         }
 
         mainThread->iterValue[iterIdx] = bestValue;


### PR DESCRIPTION
Non-functional Simplification, maintaining the same logic as before.
Big thanks to @peregrineshahin for helping with the code.

Passed non-regression bounds:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 101088 W: 26196 L: 26047 D: 48845
Ptnml(0-2): 405, 11580, 26473, 11633, 453
https://tests.stockfishchess.org/tests/view/65ec93860ec64f0526c42375