### PR TITLE
Remove dev/null from sanitizer action

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -61,5 +61,5 @@ jobs:
         run: |
           export CXXFLAGS="-O1 -fno-inline"
           make clean
-          make -j4 ARCH=x86-64-sse41-popcnt ${{ matrix.sanitizers.make_option }} debug=yes optimize=no build > /dev/null
+          make -j4 ARCH=x86-64-sse41-popcnt ${{ matrix.sanitizers.make_option }} debug=yes optimize=no build
           ../tests/instrumented.sh --${{ matrix.sanitizers.instrumented_option }}

--- a/tests/instrumented.sh
+++ b/tests/instrumented.sh
@@ -97,6 +97,8 @@ do
 
 done
 
+./stockfish uci
+
 # verify the generated net equals the base net
 network=`./stockfish uci | grep 'option name EvalFile type string default' | awk '{print $NF}'`
 echo "Comparing $network to the written verify.nnue"


### PR DESCRIPTION
Remove the redirection to dev/null to print the compilation output to the action logs.
Makes it easier to debug if something already went wrong during compilation.

closes https://github.com/official-stockfish/Stockfish/pull/5107

No functional change