### PR TITLE
Give more bonuses to quiet move that caused a fail low.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1321,7 +1321,7 @@ moves_loop:  // When in check, search starts here
     else if (!priorCapture && prevSq != SQ_NONE)
     {
         int bonus = (depth > 5) + (PvNode || cutNode) + ((ss - 1)->statScore < -14446)
-                  + ((ss - 1)->moveCount > 10);
+                  + ((ss - 1)->moveCount > 11) + (!ss->inCheck && bestValue <= ss->staticEval - 150);
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       stat_bonus(depth) * bonus);
         thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()]


### PR DESCRIPTION
Give extra bonus if search result is far below static evaluation of position.
Passed STC:
https://tests.stockfishchess.org/tests/view/65edf1250ec64f0526c43787
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 90816 W: 23713 L: 23307 D: 43796
Ptnml(0-2): 401, 10725, 22742, 11147, 393 
Passed LTC:
https://tests.stockfishchess.org/tests/view/65ef5ed70ec64f0526c450af
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 66618 W: 16950 L: 16565 D: 33103
Ptnml(0-2): 35, 7372, 18139, 7699, 64 
bench 2002517