### PR TITLE
Sudden Death - Improve TM

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -84,6 +84,12 @@ void TimeManagement::init(Search::LimitsType& limits,
     // Maximum move horizon of 50 moves
     int mtg = limits.movestogo ? std::min(limits.movestogo, 50) : 50;
 
+    // if less than one second, gradually reduce mtg
+    if (limits.time[us] < 1000 && (double(mtg) / limits.time[us] > 0.05))
+    {
+        mtg = limits.time[us] * 0.05;
+    }
+
     // Make sure timeLeft is > 0 since we may use it as a divisor
     TimePoint timeLeft = std::max(TimePoint(1), limits.time[us] + limits.inc[us] * (mtg - 1)
                                                   - moveOverhead * (2 + mtg));


### PR DESCRIPTION
Due to the 50 estimated move horizon, once a sudden death game got below 1 second, the time allocation for optimumTime would go into the negative and SF would start instamoving.

to counter this, once limits.time is below 1 second, the move horizon will start decreasing, at a rate of 1 move per 20ms. This was just what seemed a reasonable rate of decay.

Fishtest sudden death TC 5+0
https://tests.stockfishchess.org/tests/live_elo/65ee2cdf0ec64f0526c43bbb
LLR: 2.99 (-2.94,2.94) <0.00,2.00>
Total: 3348 W: 1070 L: 727 D:1551
Ptnml(0-2): 46, 277, 738, 514, 99

Fishtest SD TC 10+0
https://tests.stockfishchess.org/tests/live_elo/65ee401e0ec64f0526c43cf7
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 3780 W: 1097 L: 808 D: 1875
Ptnml(0-2): 11, 353, 919, 550, 57

Neutral Non-Regression STC 10+0.1
https://tests.stockfishchess.org/tests/live_elo/65ee45ff0ec64f0526c43d68
LLR: 2.95 (-2.94,2.94) <-1.75, 0.25>
Total: 123616 W: 32054 L: 31927 D:59635
Ptnml(0-2): 493, 14323, 32105, 14338, 549

neutral Non-Regression LTC 60+0.6
https://tests.stockfishchess.org/tests/live_elo/65ef1eec0ec64f0526c44bc4
LLR: 2.95 (-2.94,2.94) <-1.75, 0.25>
Total: 130482 W: 32961 L: 32855 D:64666
Ptnml(0-2): 88, 13412, 38123, 13542, 76