### PR TITLE
timeman - use divide instead of log10() for optConstant

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -29,7 +29,7 @@
 namespace Stockfish {
 
 //auto f1 = [](int m){return Range(m / 2, m * 3 / 2);};
-int A=1028, B=1005, C=1020;
+int A=1000, B=1000, C=1000;
 TUNE(A, B, C);
 
 TimePoint TimeManagement::optimum() const { return optimumTime; }
@@ -101,7 +101,7 @@ void TimeManagement::init(Search::LimitsType& limits,
         double optExtra = limits.inc[us] < 500 ? 1.0 : 1.13;
 
         // Calculate time constants based on current time left.
-        double optConstant = A*0.000004 - B*0.09 / (limits.time[us] + C*75);
+        double optConstant = A*0.0000046 - B*0.13 / (limits.time[us] + C*77.69);
         double maxConstant = std::max(3.39 + 3.01 * std::log10(limits.time[us] / 1000.0), 2.93);
 
         optScale = std::min(0.0122 + std::pow(ply + 2.95, 0.462) * optConstant,

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -97,9 +97,13 @@ void TimeManagement::init(Search::LimitsType& limits,
         double optExtra = limits.inc[us] < 500 ? 1.0 : 1.13;
 
         // Calculate time constants based on current time left.
-        double optConstant =
-          std::min(0.00278 + 0.000307 * (3.71 - 283300.0 / (limits.time[us] + 75516.0)), 0.00506);
+        double optConstant = 0.004111 - 90.46 / (limits.time[us] + 76477.0);
         double maxConstant = std::max(3.39 + 3.01 * std::log10(limits.time[us] / 1000.0), 2.93);
+        sync_cout << "info optConstant " << optConstant << sync_endl;
+        //           stc 0.003399 ltc 0.00364723
+        // 270/(+80)     0.0034       0.00374079
+        // 278+307*      0.00290193   0.00327718
+        // 4111-90.46*   0.00306494   0.00344818
 
         optScale = std::min(0.0122 + std::pow(ply + 2.95, 0.462) * optConstant,
                             0.213 * limits.time[us] / double(timeLeft))

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -28,10 +28,6 @@
 
 namespace Stockfish {
 
-auto f1 = [](int m){return Range(m / 2, m * 3 / 2);};
-int A=308, B=319, C=400, D=270, E=400, F=320, G=506;
-TUNE(SetRange(f1),A,B,C,D,E,F,G);
-
 TimePoint TimeManagement::optimum() const { return optimumTime; }
 TimePoint TimeManagement::maximum() const { return maximumTime; }
 TimePoint TimeManagement::elapsed(size_t nodes) const {
@@ -102,12 +98,9 @@ void TimeManagement::init(Search::LimitsType& limits,
 
         // Calculate time constants based on current time left.
         double optConstant =
-          std::clamp(A/100000.0 + (B/1000000.0) * (C/100.0 - D*1000.0 / (limits.time[us] + E*200.0)),
-                     F/100000.0, G/100000.0);
+          std::clamp(0.00288 + 0.000318 * (3.83 - 279700.0 / (limits.time[us] + 76572.0)),
+                     0.003136, 0.005013);
         double maxConstant = std::max(3.39 + 3.01 * std::log10(limits.time[us] / 1000.0), 2.93);
-        //sync_cout << "info optConstant " << optConstant << sync_endl;
-        //           stc 0.003399 ltc 0.00364723
-        // 270/(+80)     0.0034       0.00374079
 
         optScale = std::min(0.0122 + std::pow(ply + 2.95, 0.462) * optConstant,
                             0.213 * limits.time[us] / double(timeLeft))

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -28,6 +28,10 @@
 
 namespace Stockfish {
 
+auto f1 = [](int m){return Range(m / 2, m * 3 / 2);};
+int A=287, B=319, C=384, D=280, E=384, G=249;
+TUNE(SetRange(f1),A,B,C,D,E,G);
+
 TimePoint TimeManagement::optimum() const { return optimumTime; }
 TimePoint TimeManagement::maximum() const { return maximumTime; }
 TimePoint TimeManagement::elapsed(size_t nodes) const {
@@ -98,8 +102,10 @@ void TimeManagement::init(Search::LimitsType& limits,
 
         // Calculate time constants based on current time left.
         double optConstant =
-          std::min(0.00288 + 0.000318 * (3.83 - 279700.0 / (limits.time[us] + 76572.0)), 0.005013);
+          std::min(A/100000.0 + (B/1000000.0) * (C/100.0 - D*1000.0 / (limits.time[us] + E*200.0)),
+                   G/50000.0);
         double maxConstant = std::max(3.39 + 3.01 * std::log10(limits.time[us] / 1000.0), 2.93);
+        //sync_cout << "info optConstant " << optConstant << sync_endl;
 
         optScale = std::min(0.0122 + std::pow(ply + 2.95, 0.462) * optConstant,
                             0.213 * limits.time[us] / double(timeLeft))

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -28,10 +28,6 @@
 
 namespace Stockfish {
 
-auto f1 = [](int m){return Range(m / 2, m * 3 / 2);};
-int A=287, B=319, C=384, D=280, E=384, G=249;
-TUNE(SetRange(f1),A,B,C,D,E,G);
-
 TimePoint TimeManagement::optimum() const { return optimumTime; }
 TimePoint TimeManagement::maximum() const { return maximumTime; }
 TimePoint TimeManagement::elapsed(size_t nodes) const {
@@ -102,10 +98,8 @@ void TimeManagement::init(Search::LimitsType& limits,
 
         // Calculate time constants based on current time left.
         double optConstant =
-          std::min(A/100000.0 + (B/1000000.0) * (C/100.0 - D*1000.0 / (limits.time[us] + E*200.0)),
-                   G/50000.0);
+          std::min(0.00278 + 0.000307 * (3.71 - 283300.0 / (limits.time[us] + 75516.0)), 0.00506);
         double maxConstant = std::max(3.39 + 3.01 * std::log10(limits.time[us] / 1000.0), 2.93);
-        //sync_cout << "info optConstant " << optConstant << sync_endl;
 
         optScale = std::min(0.0122 + std::pow(ply + 2.95, 0.462) * optConstant,
                             0.213 * limits.time[us] / double(timeLeft))

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -99,7 +99,7 @@ void TimeManagement::init(Search::LimitsType& limits,
         // Calculate time constants based on current time left.
         double optConstant = 0.004111 - 90.46 / (limits.time[us] + 76477.0);
         double maxConstant = std::max(3.39 + 3.01 * std::log10(limits.time[us] / 1000.0), 2.93);
-        sync_cout << "info optConstant " << optConstant << sync_endl;
+        //sync_cout << "info optConstant " << optConstant << sync_endl;
         //           stc 0.003399 ltc 0.00364723
         // 270/(+80)     0.0034       0.00374079
         // 278+307*      0.00290193   0.00327718

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -97,13 +97,8 @@ void TimeManagement::init(Search::LimitsType& limits,
         double optExtra = limits.inc[us] < 500 ? 1.0 : 1.13;
 
         // Calculate time constants based on current time left.
-        double optConstant = 0.004111 - 90.46 / (limits.time[us] + 76477.0);
+        double optConstant = 0.003919 - 86.97 / (limits.time[us] + 75516.0);
         double maxConstant = std::max(3.39 + 3.01 * std::log10(limits.time[us] / 1000.0), 2.93);
-        //sync_cout << "info optConstant " << optConstant << sync_endl;
-        //           stc 0.003399 ltc 0.00364723
-        // 270/(+80)     0.0034       0.00374079
-        // 278+307*      0.00290193   0.00327718
-        // 4111-90.46*   0.00306494   0.00344818
 
         optScale = std::min(0.0122 + std::pow(ply + 2.95, 0.462) * optConstant,
                             0.213 * limits.time[us] / double(timeLeft))

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -98,8 +98,7 @@ void TimeManagement::init(Search::LimitsType& limits,
 
         // Calculate time constants based on current time left.
         double optConstant =
-          std::clamp(0.00288 + 0.000318 * (3.83 - 279700.0 / (limits.time[us] + 76572.0)),
-                     0.003136, 0.005013);
+          std::min(0.00288 + 0.000318 * (3.83 - 279700.0 / (limits.time[us] + 76572.0)), 0.005013);
         double maxConstant = std::max(3.39 + 3.01 * std::log10(limits.time[us] / 1000.0), 2.93);
 
         optScale = std::min(0.0122 + std::pow(ply + 2.95, 0.462) * optConstant,

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -28,6 +28,10 @@
 
 namespace Stockfish {
 
+//auto f1 = [](int m){return Range(m / 2, m * 3 / 2);};
+int A=1028, B=1005, C=1020;
+TUNE(A, B, C);
+
 TimePoint TimeManagement::optimum() const { return optimumTime; }
 TimePoint TimeManagement::maximum() const { return maximumTime; }
 TimePoint TimeManagement::elapsed(size_t nodes) const {
@@ -97,7 +101,7 @@ void TimeManagement::init(Search::LimitsType& limits,
         double optExtra = limits.inc[us] < 500 ? 1.0 : 1.13;
 
         // Calculate time constants based on current time left.
-        double optConstant = 0.003919 - 86.97 / (limits.time[us] + 75516.0);
+        double optConstant = A*0.000004 - B*0.09 / (limits.time[us] + C*75);
         double maxConstant = std::max(3.39 + 3.01 * std::log10(limits.time[us] / 1000.0), 2.93);
 
         optScale = std::min(0.0122 + std::pow(ply + 2.95, 0.462) * optConstant,

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -98,8 +98,9 @@ void TimeManagement::init(Search::LimitsType& limits,
 
         // Calculate time constants based on current time left.
         double optConstant =
-          std::min(0.00308 + 0.000319 * std::log10(limits.time[us] / 1000.0), 0.00506);
+          std::clamp(0.00308 + 0.000319 * (4.0 - 150000.0 / (limits.time[us] + 40000.0)), 0.003399, 0.00506);
         double maxConstant = std::max(3.39 + 3.01 * std::log10(limits.time[us] / 1000.0), 2.93);
+        //sync_cout << "info optConstant " << optConstant << sync_endl;
 
         optScale = std::min(0.0122 + std::pow(ply + 2.95, 0.462) * optConstant,
                             0.213 * limits.time[us] / double(timeLeft))

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -28,6 +28,10 @@
 
 namespace Stockfish {
 
+auto f1 = [](int m){return Range(m / 2, m * 3 / 2);};
+int A=308, B=319, C=400, D=270, E=400, F=320, G=506;
+TUNE(SetRange(f1),A,B,C,D,E,F,G);
+
 TimePoint TimeManagement::optimum() const { return optimumTime; }
 TimePoint TimeManagement::maximum() const { return maximumTime; }
 TimePoint TimeManagement::elapsed(size_t nodes) const {
@@ -98,9 +102,12 @@ void TimeManagement::init(Search::LimitsType& limits,
 
         // Calculate time constants based on current time left.
         double optConstant =
-          std::clamp(0.00308 + 0.000319 * (4.0 - 150000.0 / (limits.time[us] + 40000.0)), 0.003399, 0.00506);
+          std::clamp(A/100000.0 + (B/1000000.0) * (C/100.0 - D*1000.0 / (limits.time[us] + E*200.0)),
+                     F/100000.0, G/100000.0);
         double maxConstant = std::max(3.39 + 3.01 * std::log10(limits.time[us] / 1000.0), 2.93);
         //sync_cout << "info optConstant " << optConstant << sync_endl;
+        //           stc 0.003399 ltc 0.00364723
+        // 270/(+80)     0.0034       0.00374079
 
         optScale = std::min(0.0122 + std::pow(ply + 2.95, 0.462) * optConstant,
                             0.213 * limits.time[us] / double(timeLeft))

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -28,10 +28,6 @@
 
 namespace Stockfish {
 
-//auto f1 = [](int m){return Range(m / 2, m * 3 / 2);};
-int A=1000, B=1000, C=1000;
-TUNE(A, B, C);
-
 TimePoint TimeManagement::optimum() const { return optimumTime; }
 TimePoint TimeManagement::maximum() const { return maximumTime; }
 TimePoint TimeManagement::elapsed(size_t nodes) const {
@@ -101,7 +97,7 @@ void TimeManagement::init(Search::LimitsType& limits,
         double optExtra = limits.inc[us] < 500 ? 1.0 : 1.13;
 
         // Calculate time constants based on current time left.
-        double optConstant = A*0.0000046 - B*0.13 / (limits.time[us] + C*77.69);
+        double optConstant = 0.004427 - 126.0 / (limits.time[us] + 76393);
         double maxConstant = std::max(3.39 + 3.01 * std::log10(limits.time[us] / 1000.0), 2.93);
 
         optScale = std::min(0.0122 + std::pow(ply + 2.95, 0.462) * optConstant,


### PR DESCRIPTION
Use divide instead of log10() for optConstant as a simplification. Regression tests:

VSTC: 3+0.03
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 25546 W: 7152 L: 6877 D: 11517
Ptnml(0-2): 388, 2918, 5908, 3149, 410
https://tests.stockfishchess.org/tests/live_elo/65f219550ec64f0526c47daf

VSTC: 5+0
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 17280 W: 4728 L: 4434 D: 8118
Ptnml(0-2): 288, 1922, 3956, 2156, 318
https://tests.stockfishchess.org/tests/live_elo/65f219dc0ec64f0526c47db7

STC: 10+0.1
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 39232 W: 10230 L: 10012 D: 18990
Ptnml(0-2): 126, 4394, 10389, 4550, 157
https://tests.stockfishchess.org/tests/view/65f0de580ec64f0526c46bcf

LTC: 60+0.6
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 121128 W: 30434 L: 30315 D: 60379
Ptnml(0-2): 93, 12890, 34467, 13033, 81
https://tests.stockfishchess.org/tests/live_elo/65f147ee0ec64f0526c4725e

