### PR TITLE
Make sure stats updates are never bigger than maximum value of stats.

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -21,7 +21,6 @@
 
 #include <array>
 #include <cassert>
-#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <limits>

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -19,6 +19,7 @@
 #ifndef MOVEPICK_H_INCLUDED
 #define MOVEPICK_H_INCLUDED
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cstdint>

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -69,10 +69,10 @@ class StatsEntry {
     operator const T&() const { return entry; }
 
     void operator<<(int bonus) {
-        assert(std::abs(bonus) <= D);  // Ensure range is [-D, D]
         static_assert(D <= std::numeric_limits<T>::max(), "D overflows T");
+        T truncatedBonus = std::clamp(bonus, -D, D); // Make sure that bonus isn't overflowing D
 
-        entry += bonus - entry * std::abs(bonus) / D;
+        entry += truncatedBonus - entry * std::abs(truncatedBonus) / D;
 
         assert(std::abs(entry) <= D);
     }


### PR DESCRIPTION
In current master you always need to keep track if you may update stats with values too big for them.
This patch makes sure that even if you pass such update it would be lowered to value low enough, so is a QoL change.
Passed non-regression bounds :
https://tests.stockfishchess.org/tests/view/65ef2af40ec64f0526c44cbc
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 179232 W: 46513 L: 46450 D: 86269
Ptnml(0-2): 716, 20323, 47452, 20432, 693 
non-functional change