### PR TITLE
Slight speedup to NNUE inference

### DIFF
--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -256,6 +256,7 @@ class AffineTransform {
     #undef vec_setzero
     #undef vec_set_32
     #undef vec_add_dpbusd_32
+    #undef vec_add_dpbusd_32x2
     #undef vec_hadd
         }
         else if constexpr (OutputDimensions == 1)

--- a/src/nnue/layers/simd.h
+++ b/src/nnue/layers/simd.h
@@ -175,6 +175,13 @@ dotprod_m128_add_dpbusd_epi32(int32x4_t& acc, int8x16_t a, int8x16_t b) {
 
     acc = vdotq_s32(acc, a, b);
 }
+
+[[maybe_unused]] static void dotprod_m128_add_dpbusd_epi32x2(
+  int32x4_t& acc, int8x16_t a, int8x16_t b, int8x16_t c, int8x16_t d) {
+
+    acc = vdotq_s32(acc, a, b);
+    acc = vdotq_s32(acc, c, d);
+}
 #endif
 
 #if defined(USE_NEON)
@@ -200,6 +207,13 @@ dotprod_m128_add_dpbusd_epi32(int32x4_t& acc, int8x16_t a, int8x16_t b) {
     int16x8_t product1 = vmull_high_s8(a, b);
     int16x8_t sum      = vpaddq_s16(product0, product1);
     acc                = vpadalq_s16(acc, sum);
+}
+
+[[maybe_unused]] static void
+neon_m128_add_dpbusd_epi32x2(int32x4_t& acc, int8x16_t a, int8x16_t b, int8x16_t c, int8x16_t d) {
+
+    neon_m128_add_dpbusd_epi32(acc, a, b);
+    neon_m128_add_dpbusd_epi32(acc, c, d);
 }
 #endif
 }

--- a/src/nnue/layers/simd.h
+++ b/src/nnue/layers/simd.h
@@ -87,6 +87,21 @@ m512_hadd128x16_interleave(__m512i sum0, __m512i sum1, __m512i sum2, __m512i sum
     #endif
 }
 
+[[maybe_unused]] static void
+m512_add_dpbusd_epi32x2(__m512i& acc, __m512i a, __m512i b, __m512i c, __m512i d) {
+
+    #if defined(USE_VNNI)
+    acc = _mm512_dpbusd_epi32(acc, a, b);
+    acc = _mm512_dpbusd_epi32(acc, c, d);
+    #else
+    __m512i product0 = _mm512_maddubs_epi16(a, b);
+    __m512i product1 = _mm512_maddubs_epi16(c, d);
+    product0         = _mm512_add_epi16(product0, product1);
+    product0         = _mm512_madd_epi16(product0, _mm512_set1_epi16(1));
+    acc              = _mm512_add_epi32(acc, product0);
+    #endif
+}
+
 #endif
 
 #if defined(USE_AVX2)
@@ -109,6 +124,21 @@ m512_hadd128x16_interleave(__m512i sum0, __m512i sum1, __m512i sum2, __m512i sum
     #endif
 }
 
+[[maybe_unused]] static void
+m256_add_dpbusd_epi32x2(__m256i& acc, __m256i a, __m256i b, __m256i c, __m256i d) {
+
+    #if defined(USE_VNNI)
+    acc = _mm256_dpbusd_epi32(acc, a, b);
+    acc = _mm256_dpbusd_epi32(acc, c, d);
+    #else
+    __m256i product0 = _mm256_maddubs_epi16(a, b);
+    __m256i product1 = _mm256_maddubs_epi16(c, d);
+    product0         = _mm256_add_epi16(product0, product1);
+    product0         = _mm256_madd_epi16(product0, _mm256_set1_epi16(1));
+    acc              = _mm256_add_epi32(acc, product0);
+    #endif
+}
+
 #endif
 
 #if defined(USE_SSSE3)
@@ -122,6 +152,16 @@ m512_hadd128x16_interleave(__m512i sum0, __m512i sum1, __m512i sum2, __m512i sum
 [[maybe_unused]] static void m128_add_dpbusd_epi32(__m128i& acc, __m128i a, __m128i b) {
 
     __m128i product0 = _mm_maddubs_epi16(a, b);
+    product0         = _mm_madd_epi16(product0, _mm_set1_epi16(1));
+    acc              = _mm_add_epi32(acc, product0);
+}
+
+[[maybe_unused]] static void
+m128_add_dpbusd_epi32x2(__m128i& acc, __m128i a, __m128i b, __m128i c, __m128i d) {
+
+    __m128i product0 = _mm_maddubs_epi16(a, b);
+    __m128i product1 = _mm_maddubs_epi16(c, d);
+    product0         = _mm_add_epi16(product0, product1);
     product0         = _mm_madd_epi16(product0, _mm_set1_epi16(1));
     acc              = _mm_add_epi32(acc, product0);
 }


### PR DESCRIPTION
This speedup is not applicable to vnni, dotprod or neon architectures.
It works by accumulating 2 maddubs operations per madd, and thus saves 1 madd operation for every 2 dpbusd.
~The sum of the 2 maddubs operations will not overflow because the unsigned vector (input vector) is clamped to [0, 127]. This ensures that the range of each maddubs operation is [-16256, 16129], and thus the range of the sum of 2 maddubs operations will be [-32512, 32258] which is within the range of an int16 [-32768, 32767].~
Edit: It seems overflow will indeed happen

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 49216 W: 12888 L: 12556 D: 23772
Ptnml(0-2): 179, 5461, 13007, 5771, 190
https://tests.stockfishchess.org/tests/view/65f517270ec64f0526c4a9dd

closes #5117

No functional change