### PR TITLE
Simplifying razoring formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -751,7 +751,7 @@ Value Search::Worker::search(
     // If eval is really low check with qsearch if it can exceed alpha, if it can't,
     // return a fail low.
     // Adjust razor margin according to cutoffCnt. (~1 Elo)
-    if (eval < alpha - 462 - (296 - 145 * ((ss + 1)->cutoffCnt > 3)) * depth * depth)
+    if (eval < alpha - 462 - (296 - 145 * ((ss + 1)->cutoffCnt > 3)) * depth)
     {
         value = qsearch<NonPV>(pos, ss, alpha - 1, alpha);
         if (value < alpha)


### PR DESCRIPTION
Simplifying razoring formula, using only depth for calculation instead of depth squared.
This simplification showed no regression by leaving the parameters as they initially were. I assume that tuning them after this change, and compensating for this change, might give even better results.

Passed STC:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 124064 W: 32154 L: 32024 D: 59886
Ptnml(0-2): 555, 14876, 31026, 15034, 541
https://tests.stockfishchess.org/tests/view/65f087ef0ec64f0526c464fd

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 179568 W: 45175 L: 45116 D: 89277
Ptnml(0-2): 142, 20080, 49268, 20165, 129
https://tests.stockfishchess.org/tests/view/65f241950ec64f0526c47fdf

bench: 1900221