### PR TITLE
Different eval parameters for smallnet and psqtOnly

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -59,39 +59,39 @@ Value Eval::evaluate(const Eval::NNUE::Networks& networks, const Position& pos, 
                           : networks.big.evaluate(pos, true, &nnueComplexity, false);
     if (!smallNet){
         // Blend optimism and eval with nnue complexity and material imbalance
-        optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 524;
-        nnue -= nnue * (nnueComplexity + std::abs(simpleEval - nnue)) / 31950;
+        optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 513;
+        nnue -= nnue * (nnueComplexity + std::abs(simpleEval - nnue)) / 32395;
 
         npm = pos.non_pawn_material() / 64;
-        v   = (nnue * (927 + npm + 9 * pos.count<PAWN>()) + optimism * (159 + npm)) / 1000;
+        v   = (nnue * (919 + npm + 11 * pos.count<PAWN>()) + optimism * (145 + npm)) / 1036;
 
         // Damp down the evaluation linearly when shuffling
         shuffling = pos.rule50_count();
-        v             = v * (195 - shuffling) / 228;
+        v             = v * (178 - shuffling) / 204;
     }
     else if (psqtOnly){
         // Blend optimism and eval with nnue complexity and material imbalance
-        optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 524;
-        nnue -= nnue * (nnueComplexity + std::abs(simpleEval - nnue)) / 31950;
+        optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 517;
+        nnue -= nnue * (nnueComplexity + std::abs(simpleEval - nnue)) / 32857;
 
         npm = pos.non_pawn_material() / 64;
-        v   = (nnue * (927 + npm + 9 * pos.count<PAWN>()) + optimism * (159 + npm)) / 1000;
+        v   = (nnue * (908 + npm + 7 * pos.count<PAWN>()) + optimism * (155 + npm)) / 1019;
 
         // Damp down the evaluation linearly when shuffling
         shuffling = pos.rule50_count();
-        v             = v * (195 - shuffling) / 228;
+        v             = v * (224 - shuffling) / 238;
     }
-    else{
+    else {
         // Blend optimism and eval with nnue complexity and material imbalance
-        optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 524;
-        nnue -= nnue * (nnueComplexity + std::abs(simpleEval - nnue)) / 31950;
+        optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 499;
+        nnue -= nnue * (nnueComplexity + std::abs(simpleEval - nnue)) / 32793;
 
         npm = pos.non_pawn_material() / 64;
-        v   = (nnue * (927 + npm + 9 * pos.count<PAWN>()) + optimism * (159 + npm)) / 1000;
+        v   = (nnue * (903 + npm + 9 * pos.count<PAWN>()) + optimism * (147 + npm)) / 1067;
 
         // Damp down the evaluation linearly when shuffling
         shuffling = pos.rule50_count();
-        v             = v * (195 - shuffling) / 228;
+        v             = v * (208 - shuffling) / 211;
     }
   
     // Guarantee evaluation does not hit the tablebase range

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -53,7 +53,8 @@ Value Eval::evaluate(const Eval::NNUE::Networks& networks, const Position& pos, 
     bool smallNet   = std::abs(simpleEval) > SmallNetThreshold;
     bool psqtOnly   = std::abs(simpleEval) > PsqtOnlyThreshold;
     int nnueComplexity;
-
+    int v;
+  
     Value nnue = smallNet ? networks.small.evaluate(pos, true, &nnueComplexity, psqtOnly)
                           : networks.big.evaluate(pos, true, &nnueComplexity, false);
   
@@ -65,7 +66,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks& networks, const Position& pos, 
         nnue -= nnue * (nnueComplexity + std::abs(simpleEval - nnue)) / nnueDiv;
 
         int npm = pos.non_pawn_material() / 64;
-        int v   = (nnue * (pawnCountConstant + npm + pawnCountMul * pos.count<PAWN>())
+        v   = (nnue * (pawnCountConstant + npm + pawnCountMul * pos.count<PAWN>())
              + optimism * (npmConstant + npm))
           / evalDiv;
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -61,7 +61,9 @@ Value Eval::evaluate(const Eval::NNUE::Networks& networks, const Position& pos, 
     int evalDiv[3] = {1036, 1067, 1019};
     int shufflingConstant[3] = {178, 208, 224};
     int shufflingDiv[3] = {204, 211, 238};
-    int netIndex = smallNet + psqtOnly;
+    int netIndex = 0;
+    netIndex += smallNet;
+    netIndex += psqtOnly;
       
     Value nnue = smallNet ? networks.small.evaluate(pos, true, &nnueComplexity, psqtOnly)
                           : networks.big.evaluate(pos, true, &nnueComplexity, false);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -61,9 +61,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks& networks, const Position& pos, 
     int evalDiv[3] = {1036, 1067, 1019};
     int shufflingConstant[3] = {178, 208, 224};
     int shufflingDiv[3] = {204, 211, 238};
-    int netIndex = 0;
-    netIndex += smallNet;
-    netIndex += psqtOnly;
+    int netIndex = smallNet + psqtOnly;
       
     Value nnue = smallNet ? networks.small.evaluate(pos, true, &nnueComplexity, psqtOnly)
                           : networks.big.evaluate(pos, true, &nnueComplexity, false);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -53,6 +53,9 @@ Value Eval::evaluate(const Eval::NNUE::Networks& networks, const Position& pos, 
     bool smallNet   = std::abs(simpleEval) > SmallNetThreshold;
     bool psqtOnly   = std::abs(simpleEval) > PsqtOnlyThreshold;
     int nnueComplexity;
+
+    Value nnue = smallNet ? networks.small.evaluate(pos, true, &nnueComplexity, psqtOnly)
+                          : networks.big.evaluate(pos, true, &nnueComplexity, false);
   
     const auto adjustEval = [&](int optDiv, int nnueDiv, int pawnCountConstant, int pawnCountMul,
                                 int npmConstant, int evalDiv, int shufflingConstant,
@@ -61,13 +64,13 @@ Value Eval::evaluate(const Eval::NNUE::Networks& networks, const Position& pos, 
         optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / optDiv;
         nnue -= nnue * (nnueComplexity + std::abs(simpleEval - nnue)) / nnueDiv;
 
-        npm = pos.non_pawn_material() / 64;
-        v   = (nnue * (pawnCountConstant + npm + pawnCountMul * pos.count<PAWN>())
+        int npm = pos.non_pawn_material() / 64;
+        int v   = (nnue * (pawnCountConstant + npm + pawnCountMul * pos.count<PAWN>())
              + optimism * (npmConstant + npm))
           / evalDiv;
 
         // Damp down the evaluation linearly when shuffling
-        shuffling = pos.rule50_count();
+        int shuffling = pos.rule50_count();
         v         = v * (shufflingConstant - shuffling) / shufflingDiv;
     };
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -53,14 +53,14 @@ Value Eval::evaluate(const Eval::NNUE::Networks& networks, const Position& pos, 
     bool smallNet   = std::abs(simpleEval) > SmallNetThreshold;
     bool psqtOnly   = std::abs(simpleEval) > PsqtOnlyThreshold;
     int nnueComplexity;
-    int optDiv[3] = {513, 499, 517};
-    int nnueDiv[3] = {32395, 32793, 32857};
-    int pawnCountConstant[3] = {919, 903, 908};
-    int pawnCountMul[3] = {11, 9, 7};
-    int npmConstant[3] = {145, 147, 155};
-    int evalDiv[3] = {1036, 1067, 1019};
-    int shufflingConstant[3] = {178, 208, 224};
-    int shufflingDiv[3] = {204, 211, 238};
+    constexpr int optDiv[3] = {513, 499, 517};
+    constexpr int nnueDiv[3] = {32395, 32793, 32857};
+    constexpr int pawnCountConstant[3] = {919, 903, 908};
+    constexpr int pawnCountMul[3] = {11, 9, 7};
+    constexpr int npmConstant[3] = {145, 147, 155};
+    constexpr int evalDiv[3] = {1036, 1067, 1019};
+    constexpr int shufflingConstant[3] = {178, 208, 224};
+    constexpr int shufflingDiv[3] = {204, 211, 238};
     int netIndex = smallNet + psqtOnly;
       
     Value nnue = smallNet ? networks.small.evaluate(pos, true, &nnueComplexity, psqtOnly)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -66,7 +66,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks& networks, const Position& pos, 
         nnue -= nnue * (nnueComplexity + std::abs(simpleEval - nnue)) / nnueDiv;
 
         int npm = pos.non_pawn_material() / 64;
-        v   = (nnue * (pawnCountConstant + npm + pawnCountMul * pos.count<PAWN>())
+        v   = (nnue * (npm + pawnCountConstant + pawnCountMul * pos.count<PAWN>())
              + optimism * (npmConstant + npm))
           / evalDiv;
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -29,7 +29,7 @@ class Position;
 
 namespace Eval {
 
-constexpr inline int SmallNetThreshold = 1136, PsqtOnlyThreshold = 2656;
+constexpr inline int SmallNetThreshold = 1050, PsqtOnlyThreshold = 2500;
 
 // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
 // for the build process (profile-build and fishtest) to work. Do not change the


### PR DESCRIPTION
Gives different eval scaling parameters for the three different nets (bignet, smallnet, psqtOnly smallnet).

Edit: Special thanks to maintainer @Disservin for making the code more easily readable by refactoring the code to use lambda functions.

Passed STC: 
https://tests.stockfishchess.org/tests/view/65f4b0020ec64f0526c4a3bd
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 168064 W: 43507 L: 42987 D: 81570
Ptnml(0-2): 662, 19871, 42445, 20393, 661

Passed LTC:
https://tests.stockfishchess.org/tests/view/65f6be1a0ec64f0526c4c361
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 162564 W: 41188 L: 40604 D: 80772
Ptnml(0-2): 120, 18112, 44216, 18732, 102

Bench: 2113576