### PR TITLE
Remove reduction increase on repetition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1116,10 +1116,6 @@ moves_loop:  // When in check, search starts here
         if (PvNode)
             r--;
 
-        // Increase reduction on repetition (~1 Elo)
-        if (move == (ss - 4)->currentMove && pos.has_repeated())
-            r += 2;
-
         // Increase reduction if next ply has a lot of fail high (~5 Elo)
         if ((ss + 1)->cutoffCnt > 3)
             r++;


### PR DESCRIPTION
Passed non-reg STC: 
https://tests.stockfishchess.org/tests/view/65f89ae30ec64f0526c4e0ff
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 173568 W: 45005 L: 44936 D: 83627
Ptnml(0-2): 684, 19878, 45628, 19873, 721

Passed non-reg LTC:
https://tests.stockfishchess.org/tests/view/65fa0f370ec64f0526c4f42d
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 21138 W: 5432 L: 5216 D: 10490
Ptnml(0-2): 13, 2107, 6112, 2325, 12

Bench: 1808273