### PR TITLE
Simplify TT aging

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -134,8 +134,8 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
     // Find an entry to be replaced according to the replacement strategy
     TTEntry* replace = tte;
     for (int i = 1; i < ClusterSize; ++i)
-        if (replace->depth8 - replace->relative_age(generation8) * 2
-            > tte[i].depth8 - tte[i].relative_age(generation8) * 2)
+        if (replace->depth8 - replace->relative_age(generation8)
+            > tte[i].depth8 - tte[i].relative_age(generation8))
             replace = &tte[i];
 
     return found = false, replace;


### PR DESCRIPTION
Simplify away extra multiplication operation in TT aging code.

Passed STC: 
https://tests.stockfishchess.org/tests/view/65fa74cc0ec64f0526c4f9c7
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 106208 W: 27465 L: 27319 D: 51424
Ptnml(0-2): 401, 12336, 27538, 12374, 455

Passed LTC: 
https://tests.stockfishchess.org/tests/view/65fb67b60ec64f0526c507ce
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 46314 W: 11711 L: 11516 D: 23087
Ptnml(0-2): 32, 4962, 12981, 5143, 39

Failed STC w/ 2MB Hash
https://tests.stockfishchess.org/tests/view/65fca1580ec64f0526c518b4
LLR: -2.94 (-2.94,2.94) <-1.75,0.25>
Total: 165408 W: 42423 L: 42873 D: 80112
Ptnml(0-2): 746, 19529, 42541, 19205, 683

Bench: 2074516