### PR TITLE
Tweak the "history and stats update bonus, based on depth" formulas

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -74,10 +74,10 @@ Value to_corrected_static_eval(Value v, const Worker& w, const Position& pos) {
 }
 
 // History and stats update bonus, based on depth
-int stat_bonus(Depth d) { return std::min(223 * d - 332, 1258); }
+int stat_bonus(Depth d) { return (d == 1 ? 0 : d < 7 ? 245 * d - 320 : 1296); }
 
 // History and stats update malus, based on depth
-int stat_malus(Depth d) { return std::min(536 * d - 299, 1353); }
+int stat_malus(Depth d) { return (d < 4 ? 554 * d - 303 : 1203); }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
 Value value_draw(size_t nodes) { return VALUE_DRAW - 1 + Value(nodes & 0x2); }
@@ -1709,7 +1709,7 @@ void update_all_stats(const Position& pos,
 
     if (!pos.capture_stage(bestMove))
     {
-        int bestMoveBonus = bestValue > beta + 173 ? quietMoveBonus      // larger bonus
+        int bestMoveBonus = bestValue > beta + 168 ? quietMoveBonus      // larger bonus
                                                    : stat_bonus(depth);  // smaller bonus
 
         // Increase stats for the best move in case it was a quiet move

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -74,7 +74,7 @@ Value to_corrected_static_eval(Value v, const Worker& w, const Position& pos) {
 }
 
 // History and stats update bonus, based on depth
-int stat_bonus(Depth d) { return (d == 1 ? 0 : d < 7 ? 245 * d - 320 : 1296); }
+int stat_bonus(Depth d) { return std::clamp(245 * d - 320, 0, 1296); }
 
 // History and stats update malus, based on depth
 int stat_malus(Depth d) { return (d < 4 ? 554 * d - 303 : 1203); }


### PR DESCRIPTION
Tweak the "history and stats update bonus, based on depth" formulas.
Assigning a formula just for the lower values, and assigning a fixed value for higher depths.
Now for depth 1 we don't have a negative score anymore (@peregrineshahin should be happy about this 😄 )

P.s: I changed the formula from (d == 1 ? 0 : d < 7 ? 245 * d - 320 : 1296) to the equivalent std::clamp(245 * d - 320, 0, 1296) based on vondele's request.


Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 117120 W: 30468 L: 30023 D: 56629
Ptnml(0-2): 526, 13759, 29539, 14216, 520
https://tests.stockfishchess.org/tests/view/65fb055c0ec64f0526c5024f

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 54816 W: 13955 L: 13595 D: 27266
Ptnml(0-2): 30, 6046, 14897, 6404, 31
https://tests.stockfishchess.org/tests/view/65fdca4b0ec64f0526c5293f

bench: 1876428