### PR TITLE
Vary time use with eval.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -53,6 +53,9 @@ using namespace Search;
 
 namespace {
 
+static constexpr double EvalLevel[10] = {1.043, 1.017, 0.952, 1.009, 0.971,
+                                         1.002, 0.992, 0.947, 1.046, 1.001};
+
 // Futility margin
 Value futility_margin(Depth d, bool noTtCutNode, bool improving, bool oppWorsening) {
     Value futilityMult       = 118 - 44 * noTtCutNode;
@@ -438,9 +441,10 @@ void Search::Worker::iterative_deepening() {
             timeReduction    = lastBestMoveDepth + 8 < completedDepth ? 1.495 : 0.687;
             double reduction = (1.48 + mainThread->previousTimeReduction) / (2.17 * timeReduction);
             double bestMoveInstability = 1 + 1.88 * totBestMoveChanges / threads.size();
+            int    el                  = std::clamp((bestValue + 750) / 150, 0, 9);
 
-            double totalTime =
-              mainThread->tm.optimum() * fallingEval * reduction * bestMoveInstability;
+            double totalTime = mainThread->tm.optimum() * fallingEval * reduction
+                             * bestMoveInstability * EvalLevel[el];
 
             // Cap used time in case of a single legal move for a better viewer experience
             if (rootMoves.size() == 1)


### PR DESCRIPTION
Adjust time use depending on the current eval.

Passed STC :
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 101696 W: 26651 L: 26238 D: 48807
Ptnml(0-2): 400, 11602, 26459, 11959, 428
https://tests.stockfishchess.org/tests/live_elo/660187a50ec64f0526c557f6

Passed LTC :
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 60648 W: 15550 L: 15187 D: 29911
Ptnml(0-2): 40, 6356, 17171, 6715, 42
https://tests.stockfishchess.org/tests/live_elo/660298ed0ec64f0526c566d0

Values were found using two tunes with the final values taken from the ltc tune after 62k games :
stc - https://tests.stockfishchess.org/tests/view/65fb526b0ec64f0526c50694
ltc - https://tests.stockfishchess.org/tests/view/65fd36e60ec64f0526c5214b

Ideas for future work;
- tune these values with the other TM adjustments
- try narrower bands
- calculate adjustment for exact eval by interpolation

Bench 2103324