### PR TITLE
Adjust best value after a pruned quiet move.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -991,12 +991,18 @@ moves_loop:  // When in check, search starts here
 
                 lmrDepth += history / 5637;
 
+                Value futilityValue = ss->staticEval + (bestValue < ss->staticEval - 59 ? 141 : 58)
+                           + 125 * lmrDepth;
+
                 // Futility pruning: parent node (~13 Elo)
                 if (!ss->inCheck && lmrDepth < 15
-                    && ss->staticEval + (bestValue < ss->staticEval - 59 ? 141 : 58)
-                           + 125 * lmrDepth
+                    && futilityValue
                          <= alpha)
+                {
+                    if (bestValue <= futilityValue && abs(bestValue) < VALUE_TB_WIN_IN_MAX_PLY && futilityValue < VALUE_TB_WIN_IN_MAX_PLY)
+                        bestValue = (bestValue + futilityValue * 3) / 4;
                     continue;
+                }
 
                 lmrDepth = std::max(lmrDepth, 0);
 


### PR DESCRIPTION
Logic somewhat similar to how we adjust best value after pruned captures in qsearch, but in search this patch does it after pruned quiet moves and also to not full scale of futility value but to smth in between best value and futility value.
Passed STC:
https://tests.stockfishchess.org/tests/view/6601cf900ec64f0526c55c30
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 59936 W: 15722 L: 15369 D: 28845
Ptnml(0-2): 182, 7097, 15112, 7340, 237 
Passed LTC:
https://tests.stockfishchess.org/tests/view/66029b2d0ec64f0526c566f1
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 118362 W: 29953 L: 29460 D: 58949
Ptnml(0-2): 68, 13159, 32249, 13622, 83 
bench 1726806