### PR TITLE
Simplify NMP Condition

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -204,6 +204,7 @@ sf-x
 Shahin M. Shahin (peregrine)
 Shane Booth (shane31)
 Shawn Varghese (xXH4CKST3RXx)
+Shawn Xu (xu-shawn)
 Siad Daboul (Topologist)
 Stefan Geschwentner (locutus2)
 Stefano Cardanobile (Stefano80)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -770,8 +770,8 @@ Value Search::Worker::search(
 
     // Step 9. Null move search with verification search (~35 Elo)
     if (!PvNode && (ss - 1)->currentMove != Move::null() && (ss - 1)->statScore < 16878
-        && eval >= beta && eval >= ss->staticEval && ss->staticEval >= beta - 20 * depth + 314
-        && !excludedMove && pos.non_pawn_material(us) && ss->ply >= thisThread->nmpMinPly
+        && eval >= beta && ss->staticEval >= beta - 20 * depth + 314 && !excludedMove
+        && pos.non_pawn_material(us) && ss->ply >= thisThread->nmpMinPly
         && beta > VALUE_TB_LOSS_IN_MAX_PLY)
     {
         assert(eval - beta >= 0);


### PR DESCRIPTION
Remove `eval >= ss->staticEval` condition for Null Move Pruning.

Passed non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 44000 W: 11420 L: 11202 D: 21378
Ptnml(0-2): 174, 5243, 10978, 5401, 204 
https://tests.stockfishchess.org/tests/live_elo/6603ee490ec64f0526c57984

Passed non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 82956 W: 20978 L: 20818 D: 41160
Ptnml(0-2): 54, 9353, 22499, 9523, 49
https://tests.stockfishchess.org/tests/live_elo/660464b50ec64f0526c5804d

Bench 1814311