### PR TITLE
Improve prerelease creation workflow

### DIFF
--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -16,6 +16,8 @@ jobs:
     if: github.repository == 'official-stockfish/Stockfish' && (github.ref == 'refs/heads/master' || (startsWith(github.ref_name, 'sf_') && github.ref_type == 'tag'))
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       # returns null if no pre-release exists
       - name: Get Commit SHA of Latest Pre-release
         run: |
@@ -23,14 +25,40 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y curl jq
 
-          echo "COMMIT_SHA=$(jq -r 'map(select(.prerelease)) | first | .tag_name' <<< $(curl -s https://api.github.com/repos/${{ github.repository_owner }}/Stockfish/releases))" >> $GITHUB_ENV
+          echo "COMMIT_SHA_TAG=$(jq -r 'map(select(.prerelease)) | first | .tag_name' <<< $(curl -s https://api.github.com/repos/${{ github.repository_owner }}/Stockfish/releases))" >> $GITHUB_ENV
 
-        # delete old previous pre-release and tag
-      - uses: actions/checkout@v4
-      - run: gh release delete ${{ env.COMMIT_SHA }} --cleanup-tag
-        if: env.COMMIT_SHA != 'null'
+      # delete old previous pre-release and tag
+      - run: gh release delete ${{ env.COMMIT_SHA_TAG }} --cleanup-tag
+        if: env.COMMIT_SHA_TAG != 'null'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Make sure that an old ci that still runs on master doesn't recreate a prerelease
+      - name: Check Pullable Commits
+        id: check_commits
+        run: |
+          git fetch
+          CHANGES=$(git rev-list HEAD..origin/master --count)
+          echo "CHANGES=$CHANGES" >> $GITHUB_ENV
+
+      - name: Get last commit SHA
+        id: last_commit
+        run: echo "COMMIT_SHA=$(git rev-parse HEAD | cut -c 1-8)" >> $GITHUB_ENV
+
+      - name: Get commit date
+        id: commit_date
+        run: echo "COMMIT_DATE=$(git show -s --date=format:'%Y%m%d' --format=%cd HEAD)" >> $GITHUB_ENV
+
+      # Create a new pre-release, the other upload_binaries.yml will upload the binaries
+      # to this pre-release.
+      - name: Create Prerelease
+        if: github.ref_name == 'master' && env.CHANGES == '0'
+        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
+        with:
+          name: Stockfish dev-${{ env.COMMIT_DATE }}-${{ env.COMMIT_SHA }}
+          tag_name: stockfish-dev-${{ env.COMMIT_DATE }}-${{ env.COMMIT_SHA }}
+          prerelease: true
+
   Matrix:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
In the last couple of months we sometimes saw duplicated prereleases uploaded to GitHub, possibly due to some racy behavior when concurrent jobs create a prerelease. This now creates an empty prerelease at the beginning of the CI and the binaries are later just attached to this one.

No functional change