### PR TITLE
Split uci class, into engine and uci classes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ PGOBENCH = $(WINE_PATH) ./$(EXE) bench
 SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
 	misc.cpp movegen.cpp movepick.cpp position.cpp \
 	search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp \
-	nnue/nnue_misc.cpp nnue/features/half_ka_v2_hm.cpp nnue/network.cpp
+	nnue/nnue_misc.cpp nnue/features/half_ka_v2_hm.cpp nnue/network.cpp engine.cpp
 
 HEADERS = benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.h \
 		nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/layers/affine_transform.h \
@@ -63,7 +63,7 @@ HEADERS = benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.h \
 		nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h nnue/nnue_architecture.h \
 		nnue/nnue_common.h nnue/nnue_feature_transformer.h position.h \
 		search.h syzygy/tbprobe.h thread.h thread_win32_osx.h timeman.h \
-		tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h
+		tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h engine.h
 
 OBJS = $(notdir $(SRCS:.cpp=.o))
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1,0 +1,153 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2024 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "engine.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <deque>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <vector>
+
+#include "benchmark.h"
+#include "evaluate.h"
+#include "movegen.h"
+#include "nnue/network.h"
+#include "nnue/nnue_common.h"
+#include "perft.h"
+#include "position.h"
+#include "search.h"
+#include "syzygy/tbprobe.h"
+#include "types.h"
+#include "ucioption.h"
+
+namespace Stockfish {
+
+namespace NN = Eval::NNUE;
+
+constexpr auto StartFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+Engine::Engine(std::string path) :
+    binaryDirectory(CommandLine::get_binary_directory(path)),
+    states(new std::deque<StateInfo>(1)),
+    networks(NN::Networks(
+      NN::NetworkBig({EvalFileDefaultNameBig, "None", ""}, NN::EmbeddedNNUEType::BIG),
+      NN::NetworkSmall({EvalFileDefaultNameSmall, "None", ""}, NN::EmbeddedNNUEType::SMALL))) {
+    Tune::init(options);
+    pos.set(StartFEN, false, &states->back());
+}
+
+void Engine::go(const Search::LimitsType& limits) {
+    verify_networks();
+
+    if (limits.perft)
+    {
+        perft(pos.fen(), limits.perft, options["UCI_Chess960"]);
+        return;
+    }
+
+    threads.start_thinking(options, pos, states, limits);
+}
+void Engine::stop() { threads.stop = true; }
+
+void Engine::search_clear() {
+    wait_for_search_finished();
+
+    tt.clear(options["Threads"]);
+    threads.clear();
+
+    // @TODO wont work multiple instances
+    Tablebases::init(options["SyzygyPath"]);  // Free mapped files
+}
+
+void Engine::wait_for_search_finished() { threads.main_thread()->wait_for_search_finished(); }
+
+void Engine::set_position(const std::string& fen, const std::vector<std::string>& moves) {
+    // Drop the old state and create a new one
+    states = StateListPtr(new std::deque<StateInfo>(1));
+    pos.set(fen, options["UCI_Chess960"], &states->back());
+
+    for (const auto& move : moves)
+    {
+        auto m = UCI::to_move(pos, move);
+
+        if (m == Move::none())
+            break;
+
+        states->emplace_back();
+        pos.do_move(m, states->back());
+    }
+}
+
+// modifiers
+
+void Engine::resize_threads() { threads.set({options, threads, tt, networks}); }
+
+void Engine::set_tt_size(size_t mb) {
+    wait_for_search_finished();
+    tt.resize(mb, options["Threads"]);
+}
+
+void Engine::set_ponderhit(bool b) { threads.main_manager()->ponder = b; }
+
+// network related
+
+void Engine::verify_networks() {
+    networks.big.verify(options["EvalFile"]);
+    networks.small.verify(options["EvalFileSmall"]);
+}
+
+void Engine::load_networks() {
+    networks.big.load(binaryDirectory, options["EvalFile"]);
+    networks.small.load(binaryDirectory, options["EvalFileSmall"]);
+}
+
+void Engine::load_big_network(const std::string& file) { networks.big.load(binaryDirectory, file); }
+
+void Engine::load_small_network(const std::string& file) {
+    networks.small.load(binaryDirectory, file);
+}
+
+void Engine::save_network(const std::pair<std::optional<std::string>, std::string> files[2]) {
+    networks.big.save(files[0].first);
+    networks.small.save(files[1].first);
+}
+
+// utility functions
+
+OptionsMap& Engine::get_options() { return options; }
+
+uint64_t Engine::nodes_searched() const { return threads.nodes_searched(); }
+
+void Engine::trace_eval() {
+    StateListPtr trace_states(new std::deque<StateInfo>(1));
+    Position     p;
+    p.set(pos.fen(), options["UCI_Chess960"], &trace_states->back());
+
+    verify_networks();
+
+    sync_cout << "\n" << Eval::trace(p, networks) << sync_endl;
+}
+
+}

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -18,7 +18,6 @@
 
 #include "engine.h"
 
-#include <cstdint>
 #include <deque>
 #include <memory>
 #include <ostream>
@@ -33,7 +32,6 @@
 #include "position.h"
 #include "search.h"
 #include "syzygy/tbprobe.h"
-#include "tune.h"
 #include "types.h"
 #include "uci.h"
 #include "ucioption.h"
@@ -50,7 +48,6 @@ Engine::Engine(std::string path) :
     networks(NN::Networks(
       NN::NetworkBig({EvalFileDefaultNameBig, "None", ""}, NN::EmbeddedNNUEType::BIG),
       NN::NetworkSmall({EvalFileDefaultNameSmall, "None", ""}, NN::EmbeddedNNUEType::SMALL))) {
-    Tune::init(options);
     pos.set(StartFEN, false, &states->back());
 }
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -18,28 +18,24 @@
 
 #include "engine.h"
 
-#include <algorithm>
-#include <cassert>
-#include <cctype>
-#include <cmath>
 #include <cstdint>
-#include <cstdlib>
 #include <deque>
 #include <memory>
-#include <optional>
-#include <sstream>
+#include <ostream>
+#include <utility>
 #include <vector>
 
-#include "benchmark.h"
 #include "evaluate.h"
-#include "movegen.h"
+#include "misc.h"
 #include "nnue/network.h"
 #include "nnue/nnue_common.h"
 #include "perft.h"
 #include "position.h"
 #include "search.h"
 #include "syzygy/tbprobe.h"
+#include "tune.h"
 #include "types.h"
+#include "uci.h"
 #include "ucioption.h"
 
 namespace Stockfish {
@@ -77,8 +73,24 @@ void Engine::search_clear() {
     tt.clear(options["Threads"]);
     threads.clear();
 
-    // @TODO wont work multiple instances
+    // @TODO wont work with multiple instances
     Tablebases::init(options["SyzygyPath"]);  // Free mapped files
+}
+
+void Engine::set_on_update_short(std::function<void(const Engine::InfoShort&)> f) {
+    updateContext.onUpdateShort = std::move(f);
+}
+
+void Engine::set_on_update_full(std::function<void(const Engine::InfoFull&)> f) {
+    updateContext.onUpdateFull = std::move(f);
+}
+
+void Engine::set_on_iter(std::function<void(const Engine::InfoIter&)> f) {
+    updateContext.onIter = std::move(f);
+}
+
+void Engine::set_on_bestmove(std::function<void(const std::string&, const std::string&)> f) {
+    updateContext.onBestmove = std::move(f);
 }
 
 void Engine::wait_for_search_finished() { threads.main_thread()->wait_for_search_finished(); }
@@ -102,7 +114,7 @@ void Engine::set_position(const std::string& fen, const std::vector<std::string>
 
 // modifiers
 
-void Engine::resize_threads() { threads.set({options, threads, tt, networks}); }
+void Engine::resize_threads() { threads.set({options, threads, tt, networks}, updateContext); }
 
 void Engine::set_tt_size(size_t mb) {
     wait_for_search_finished();
@@ -113,7 +125,7 @@ void Engine::set_ponderhit(bool b) { threads.main_manager()->ponder = b; }
 
 // network related
 
-void Engine::verify_networks() {
+void Engine::verify_networks() const {
     networks.big.verify(options["EvalFile"]);
     networks.small.verify(options["EvalFileSmall"]);
 }
@@ -138,9 +150,7 @@ void Engine::save_network(const std::pair<std::optional<std::string>, std::strin
 
 OptionsMap& Engine::get_options() { return options; }
 
-uint64_t Engine::nodes_searched() const { return threads.nodes_searched(); }
-
-void Engine::trace_eval() {
+void Engine::trace_eval() const {
     StateListPtr trace_states(new std::deque<StateInfo>(1));
     Position     p;
     p.set(pos.fen(), options["UCI_Chess960"], &trace_states->back());

--- a/src/engine.h
+++ b/src/engine.h
@@ -19,7 +19,12 @@
 #ifndef STOCKFISH_H_INCLUDED
 #define STOCKFISH_H_INCLUDED
 
-#include "misc.h"
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
 #include "nnue/network.h"
 #include "position.h"
 #include "search.h"
@@ -31,6 +36,10 @@ namespace Stockfish {
 
 class Engine {
    public:
+    using InfoShort = Search::InfoShort;
+    using InfoFull  = Search::InfoFull;
+    using InfoIter  = Search::InfoIteration;
+
     Engine(std::string path = "");
     ~Engine() { wait_for_search_finished(); }
 
@@ -52,9 +61,14 @@ class Engine {
     // clears the search
     void search_clear();
 
+    void set_on_update_short(std::function<void(const InfoShort&)>);
+    void set_on_update_full(std::function<void(const InfoFull&)>);
+    void set_on_iter(std::function<void(const InfoIter&)>);
+    void set_on_bestmove(std::function<void(const std::string&, const std::string&)>);
+
     // network related
 
-    void verify_networks();
+    void verify_networks() const;
     void load_networks();
     void load_big_network(const std::string& file);
     void load_small_network(const std::string& file);
@@ -62,9 +76,7 @@ class Engine {
 
     // utility functions
 
-    void trace_eval();
-    // nodes since last search clear
-    uint64_t    nodes_searched() const;
+    void        trace_eval() const;
     OptionsMap& get_options();
 
    private:
@@ -77,6 +89,8 @@ class Engine {
     ThreadPool           threads;
     TranspositionTable   tt;
     Eval::NNUE::Networks networks;
+
+    Search::SearchManager::UpdateContext updateContext;
 };
 
 }  // namespace Stockfish

--- a/src/engine.h
+++ b/src/engine.h
@@ -1,0 +1,85 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2024 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef STOCKFISH_H_INCLUDED
+#define STOCKFISH_H_INCLUDED
+
+#include "misc.h"
+#include "nnue/network.h"
+#include "position.h"
+#include "search.h"
+#include "thread.h"
+#include "tt.h"
+#include "ucioption.h"
+
+namespace Stockfish {
+
+class Engine {
+   public:
+    Engine(std::string path = "");
+    ~Engine() { wait_for_search_finished(); }
+
+    // non blocking call to start searching
+    void go(const Search::LimitsType&);
+    // non blocking call to stop searching
+    void stop();
+
+    // blocking call to wait for search to finish
+    void wait_for_search_finished();
+    // set a new position
+    void set_position(const std::string& fen, const std::vector<std::string>& moves);
+
+    // modifiers
+
+    void resize_threads();
+    void set_tt_size(size_t mb);
+    void set_ponderhit(bool);
+    // clears the search
+    void search_clear();
+
+    // network related
+
+    void verify_networks();
+    void load_networks();
+    void load_big_network(const std::string& file);
+    void load_small_network(const std::string& file);
+    void save_network(const std::pair<std::optional<std::string>, std::string> files[2]);
+
+    // utility functions
+
+    void trace_eval();
+    // nodes since last search clear
+    uint64_t    nodes_searched() const;
+    OptionsMap& get_options();
+
+   private:
+    const std::string binaryDirectory;
+
+    Position     pos;
+    StateListPtr states;
+
+    OptionsMap           options;
+    ThreadPool           threads;
+    TranspositionTable   tt;
+    Eval::NNUE::Networks networks;
+};
+
+}  // namespace Stockfish
+
+
+#endif  // #ifndef STOCKFISH_H_INCLUDED

--- a/src/engine.h
+++ b/src/engine.h
@@ -16,14 +16,15 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef STOCKFISH_H_INCLUDED
-#define STOCKFISH_H_INCLUDED
+#ifndef ENGINE_H_INCLUDED
+#define ENGINE_H_INCLUDED
 
 #include <cstddef>
-#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
+#include <optional>
+#include <utility>
 
 #include "nnue/network.h"
 #include "position.h"
@@ -96,4 +97,4 @@ class Engine {
 }  // namespace Stockfish
 
 
-#endif  // #ifndef STOCKFISH_H_INCLUDED
+#endif  // #ifndef ENGINE_H_INCLUDED

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "position.h"
 #include "types.h"
 #include "uci.h"
+#include "tune.h"
 
 using namespace Stockfish;
 
@@ -34,6 +35,9 @@ int main(int argc, char* argv[]) {
     Position::init();
 
     UCI uci(argc, argv);
+
+    Tune::init(uci.engine_options());
+
     uci.loop();
 
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,6 @@
 #include "bitboard.h"
 #include "misc.h"
 #include "position.h"
-#include "tune.h"
 #include "types.h"
 #include "uci.h"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,9 +35,6 @@ int main(int argc, char* argv[]) {
     Position::init();
 
     UCI uci(argc, argv);
-
-    Tune::init(uci.options);
-
     uci.loop();
 
     return 0;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -723,13 +723,9 @@ void bind_this_thread(size_t idx) {
     #define GETCWD getcwd
 #endif
 
-CommandLine::CommandLine(int _argc, char** _argv) :
-    argc(_argc),
-    argv(_argv) {
-    std::string pathSeparator;
 
-    // Extract the path+name of the executable binary
-    std::string argv0 = argv[0];
+std::string CommandLine::get_binary_directory(std::string argv0) {
+    std::string pathSeparator;
 
 #ifdef _WIN32
     pathSeparator = "\\";
@@ -745,15 +741,11 @@ CommandLine::CommandLine(int _argc, char** _argv) :
 #endif
 
     // Extract the working directory
-    workingDirectory = "";
-    char  buff[40000];
-    char* cwd = GETCWD(buff, 40000);
-    if (cwd)
-        workingDirectory = cwd;
+    auto workingDirectory = CommandLine::get_working_directory();
 
     // Extract the binary directory path from argv0
-    binaryDirectory = argv0;
-    size_t pos      = binaryDirectory.find_last_of("\\/");
+    auto   binaryDirectory = argv0;
+    size_t pos             = binaryDirectory.find_last_of("\\/");
     if (pos == std::string::npos)
         binaryDirectory = "." + pathSeparator;
     else
@@ -762,6 +754,19 @@ CommandLine::CommandLine(int _argc, char** _argv) :
     // Pattern replacement: "./" at the start of path is replaced by the working directory
     if (binaryDirectory.find("." + pathSeparator) == 0)
         binaryDirectory.replace(0, 1, workingDirectory);
+
+    return binaryDirectory;
 }
+
+std::string CommandLine::get_working_directory() {
+    std::string workingDirectory = "";
+    char        buff[40000];
+    char*       cwd = GETCWD(buff, 40000);
+    if (cwd)
+        workingDirectory = cwd;
+
+    return workingDirectory;
+}
+
 
 }  // namespace Stockfish

--- a/src/misc.h
+++ b/src/misc.h
@@ -206,13 +206,15 @@ void bind_this_thread(size_t idx);
 
 struct CommandLine {
    public:
-    CommandLine(int, char**);
+    CommandLine(int _argc, char** _argv) :
+        argc(_argc),
+        argv(_argv) {}
+
+    static std::string get_binary_directory(std::string argv0);
+    static std::string get_working_directory();
 
     int    argc;
     char** argv;
-
-    std::string binaryDirectory;   // path of the executable directory
-    std::string workingDirectory;  // path of the working directory
 };
 
 namespace Utility {

--- a/src/search.h
+++ b/src/search.h
@@ -24,6 +24,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -139,7 +140,6 @@ struct SharedState {
         tt(transpositionTable),
         networks(nets) {}
 
-
     const OptionsMap&           options;
     ThreadPool&                 threads;
     TranspositionTable&         tt;
@@ -156,16 +156,56 @@ class ISearchManager {
     virtual void check_time(Search::Worker&) = 0;
 };
 
+struct InfoShort {
+    int         depth;
+    std::string score;
+};
+
+struct InfoFull: InfoShort {
+    int         selDepth;
+    size_t      multiPV;
+    std::string wdl;
+    std::string bound;
+    size_t      timeMs;
+    size_t      nodes;
+    size_t      nps;
+    size_t      tbHits;
+    std::string pv;
+    int         hashfull;
+};
+
+struct InfoIteration {
+    int         depth;
+    std::string currmove;
+    size_t      currmovenumber;
+};
+
 // SearchManager manages the search from the main thread. It is responsible for
 // keeping track of the time, and storing data strictly related to the main thread.
 class SearchManager: public ISearchManager {
    public:
+    using UpdateShort    = std::function<void(const InfoShort&)>;
+    using UpdateFull     = std::function<void(const InfoFull&)>;
+    using UpdateIter     = std::function<void(const InfoIteration&)>;
+    using UpdateBestmove = std::function<void(const std::string&, const std::string&)>;
+
+    struct UpdateContext {
+        UpdateShort    onUpdateShort;
+        UpdateFull     onUpdateFull;
+        UpdateIter     onIter;
+        UpdateBestmove onBestmove;
+    };
+
+
+    SearchManager(const UpdateContext& updateContext) :
+        updates(updateContext) {}
+
     void check_time(Search::Worker& worker) override;
 
-    std::string pv(const Search::Worker&     worker,
-                   const ThreadPool&         threads,
-                   const TranspositionTable& tt,
-                   Depth                     depth) const;
+    void pv(const Search::Worker&     worker,
+            const ThreadPool&         threads,
+            const TranspositionTable& tt,
+            Depth                     depth) const;
 
     Stockfish::TimeManagement tm;
     int                       callsCnt;
@@ -178,6 +218,8 @@ class SearchManager: public ISearchManager {
     bool                 stopOnPonderhit;
 
     size_t id;
+
+    const UpdateContext& updates;
 };
 
 class NullSearchManager: public ISearchManager {

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -119,7 +119,8 @@ uint64_t ThreadPool::tb_hits() const { return accumulate(&Search::Worker::tbHits
 // Creates/destroys threads to match the requested number.
 // Created and launched threads will immediately go to sleep in idle_loop.
 // Upon resizing, threads are recreated to allow for binding if necessary.
-void ThreadPool::set(Search::SharedState sharedState) {
+void ThreadPool::set(Search::SharedState                         sharedState,
+                     const Search::SearchManager::UpdateContext& updateContext) {
 
     if (threads.size() > 0)  // destroy any existing thread(s)
     {
@@ -133,14 +134,15 @@ void ThreadPool::set(Search::SharedState sharedState) {
 
     if (requested > 0)  // create new thread(s)
     {
-        threads.push_back(new Thread(
-          sharedState, std::unique_ptr<Search::ISearchManager>(new Search::SearchManager()), 0));
-
+        auto manager = std::make_unique<Search::SearchManager>(updateContext);
+        threads.push_back(new Thread(sharedState, std::move(manager), 0));
 
         while (threads.size() < requested)
-            threads.push_back(new Thread(
-              sharedState, std::unique_ptr<Search::ISearchManager>(new Search::NullSearchManager()),
-              threads.size()));
+        {
+            auto null_manager = std::make_unique<Search::NullSearchManager>();
+            threads.push_back(new Thread(sharedState, std::move(null_manager), threads.size()));
+        }
+
         clear();
 
         main_thread()->wait_for_search_finished();

--- a/src/thread.h
+++ b/src/thread.h
@@ -82,7 +82,7 @@ class ThreadPool {
 
     void start_thinking(const OptionsMap&, Position&, StateListPtr&, Search::LimitsType);
     void clear();
-    void set(Search::SharedState);
+    void set(Search::SharedState, const Search::SearchManager::UpdateContext&);
 
     Search::SearchManager* main_manager();
     Thread*                main_thread() const { return threads.front(); }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -35,9 +35,6 @@
 #include "engine.h"
 #include "evaluate.h"
 #include "movegen.h"
-#include "nnue/network.h"
-#include "nnue/nnue_common.h"
-#include "perft.h"
 #include "position.h"
 #include "search.h"
 #include "syzygy/tbprobe.h"
@@ -80,6 +77,12 @@ UCI::UCI(int argc, char** argv) :
                                   [this](const Option& o) { engine.load_big_network(o); });
     options["EvalFileSmall"] << Option(EvalFileDefaultNameSmall,
                                        [this](const Option& o) { engine.load_small_network(o); });
+
+
+    engine.set_on_iter([](const auto& i) { on_iter(i); });
+    engine.set_on_update_short([](const auto& i) { on_update_short(i); });
+    engine.set_on_update_full([&](const auto& i) { on_update_full(i, options["UCI_ShowWDL"]); });
+    engine.set_on_bestmove([](const auto& bm, const auto& p) { on_bestmove(bm, p); });
 
     engine.load_networks();
     engine.resize_threads();
@@ -221,6 +224,13 @@ void UCI::go(Position& pos, std::istringstream& is) {
 void UCI::bench(Position& pos, std::istream& args) {
     std::string token;
     uint64_t    num, nodes = 0, cnt = 1;
+    uint64_t    nodesSearched = 0;
+    const auto& options       = engine.get_options();
+
+    engine.set_on_update_full([&](const auto& i) {
+        nodesSearched = i.nodes;
+        on_update_full(i, options["UCI_ShowWDL"]);
+    });
 
     std::vector<std::string> list = setup_bench(pos, args);
 
@@ -242,7 +252,8 @@ void UCI::bench(Position& pos, std::istream& args) {
             {
                 go(pos, is);
                 engine.wait_for_search_finished();
-                nodes += engine.nodes_searched();
+                nodes += nodesSearched;
+                nodesSearched = 0;
             }
             else
                 engine.trace_eval();
@@ -265,6 +276,9 @@ void UCI::bench(Position& pos, std::istream& args) {
     std::cerr << "\n==========================="
               << "\nTotal time (ms) : " << elapsed << "\nNodes searched  : " << nodes
               << "\nNodes/second    : " << 1000 * nodes / elapsed << std::endl;
+
+    // reset callback, to not capture a dangling reference to nodesSearched
+    engine.set_on_update_full([&](const auto& i) { on_update_full(i, options["UCI_ShowWDL"]); });
 }
 
 
@@ -412,6 +426,51 @@ Move UCI::to_move(const Position& pos, std::string str) {
             return m;
 
     return Move::none();
+}
+
+void UCI::on_update_short(const Engine::InfoShort& info) {
+    sync_cout << "info depth" << info.depth << " score " << info.score << sync_endl;
+}
+
+void UCI::on_update_full(const Engine::InfoFull& info, bool showWDL) {
+    std::stringstream ss;
+
+    ss << "info";
+    ss << " depth " << info.depth        //
+       << " seldepth " << info.selDepth  //
+       << " multiPV " << info.multiPV    //
+       << " score " << info.score;       //
+
+    if (showWDL)
+        ss << " wdl " << info.wdl;
+
+    ss << info.bound                     //
+       << " nodes " << info.nodes        //
+       << " nps " << info.nps            //
+       << " hashfull " << info.hashfull  //
+       << " tbhits " << info.tbHits      //
+       << " time " << info.timeMs        //
+       << " pv " << info.pv;             //
+
+    sync_cout << ss.str() << sync_endl;
+}
+
+void UCI::on_iter(const Engine::InfoIter& info) {
+    std::stringstream ss;
+
+    ss << "info";
+    ss << " depth " << info.depth                     //
+       << " currmove " << info.currmove               //
+       << " currmovenumber " << info.currmovenumber;  //
+
+    sync_cout << ss.str() << sync_endl;
+}
+
+void UCI::on_bestmove(const std::string& bestmove, const std::string& ponder) {
+    sync_cout << "bestmove " << bestmove;
+    if (!ponder.empty())
+        std::cout << " ponder " << ponder;
+    std::cout << sync_endl;
 }
 
 }  // namespace Stockfish

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 
 #include "benchmark.h"
+#include "engine.h"
 #include "evaluate.h"
 #include "movegen.h"
 #include "nnue/network.h"
@@ -49,27 +50,19 @@ constexpr auto StartFEN  = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -
 constexpr int  MaxHashMB = Is64Bit ? 33554432 : 2048;
 
 
-namespace NN = Eval::NNUE;
-
-
 UCI::UCI(int argc, char** argv) :
-    networks(NN::Networks(
-      NN::NetworkBig({EvalFileDefaultNameBig, "None", ""}, NN::EmbeddedNNUEType::BIG),
-      NN::NetworkSmall({EvalFileDefaultNameSmall, "None", ""}, NN::EmbeddedNNUEType::SMALL))),
+    engine(argv[0]),
     cli(argc, argv) {
+
+    auto& options = engine.get_options();
 
     options["Debug Log File"] << Option("", [](const Option& o) { start_logger(o); });
 
-    options["Threads"] << Option(1, 1, 1024, [this](const Option&) {
-        threads.set({options, threads, tt, networks});
-    });
+    options["Threads"] << Option(1, 1, 1024, [this](const Option&) { engine.resize_threads(); });
 
-    options["Hash"] << Option(16, 1, MaxHashMB, [this](const Option& o) {
-        threads.main_thread()->wait_for_search_finished();
-        tt.resize(o, options["Threads"]);
-    });
+    options["Hash"] << Option(16, 1, MaxHashMB, [this](const Option& o) { engine.set_tt_size(o); });
 
-    options["Clear Hash"] << Option([this](const Option&) { search_clear(); });
+    options["Clear Hash"] << Option([this](const Option&) { engine.search_clear(); });
     options["Ponder"] << Option(false);
     options["MultiPV"] << Option(1, 1, MAX_MOVES);
     options["Skill Level"] << Option(20, 0, 20);
@@ -83,19 +76,14 @@ UCI::UCI(int argc, char** argv) :
     options["SyzygyProbeDepth"] << Option(1, 1, 100);
     options["Syzygy50MoveRule"] << Option(true);
     options["SyzygyProbeLimit"] << Option(7, 0, 7);
-    options["EvalFile"] << Option(EvalFileDefaultNameBig, [this](const Option& o) {
-        networks.big.load(cli.binaryDirectory, o);
-    });
-    options["EvalFileSmall"] << Option(EvalFileDefaultNameSmall, [this](const Option& o) {
-        networks.small.load(cli.binaryDirectory, o);
-    });
+    options["EvalFile"] << Option(EvalFileDefaultNameBig,
+                                  [this](const Option& o) { engine.load_big_network(o); });
+    options["EvalFileSmall"] << Option(EvalFileDefaultNameSmall,
+                                       [this](const Option& o) { engine.load_small_network(o); });
 
-    networks.big.load(cli.binaryDirectory, options["EvalFile"]);
-    networks.small.load(cli.binaryDirectory, options["EvalFileSmall"]);
-
-    threads.set({options, threads, tt, networks});
-
-    search_clear();  // After threads are up
+    engine.load_networks();
+    engine.resize_threads();
+    engine.search_clear();  // After threads are up
 }
 
 void UCI::loop() {
@@ -121,27 +109,27 @@ void UCI::loop() {
         is >> std::skipws >> token;
 
         if (token == "quit" || token == "stop")
-            threads.stop = true;
+            engine.stop();
 
         // The GUI sends 'ponderhit' to tell that the user has played the expected move.
         // So, 'ponderhit' is sent if pondering was done on the same move that the user
         // has played. The search should continue, but should also switch from pondering
         // to the normal search.
         else if (token == "ponderhit")
-            threads.main_manager()->ponder = false;  // Switch to the normal search
+            engine.set_ponderhit(false);
 
         else if (token == "uci")
             sync_cout << "id name " << engine_info(true) << "\n"
-                      << options << "\nuciok" << sync_endl;
+                      << engine.get_options() << "\nuciok" << sync_endl;
 
         else if (token == "setoption")
             setoption(is);
         else if (token == "go")
-            go(pos, is, states);
+            go(pos, is);
         else if (token == "position")
-            position(pos, is, states);
+            position(is);
         else if (token == "ucinewgame")
-            search_clear();
+            engine.search_clear();
         else if (token == "isready")
             sync_cout << "readyok" << sync_endl;
 
@@ -150,11 +138,11 @@ void UCI::loop() {
         else if (token == "flip")
             pos.flip();
         else if (token == "bench")
-            bench(pos, is, states);
+            bench(pos, is);
         else if (token == "d")
             sync_cout << pos << sync_endl;
         else if (token == "eval")
-            trace_eval(pos);
+            engine.trace_eval();
         else if (token == "compiler")
             sync_cout << compiler_info() << sync_endl;
         else if (token == "export_net")
@@ -167,8 +155,7 @@ void UCI::loop() {
             if (is >> std::skipws >> files[1].second)
                 files[1].first = files[1].second;
 
-            networks.big.save(files[0].first);
-            networks.small.save(files[1].first);
+            engine.save_network(files);
         }
         else if (token == "--help" || token == "help" || token == "--license" || token == "license")
             sync_cout
@@ -225,23 +212,13 @@ Search::LimitsType UCI::parse_limits(const Position& pos, std::istream& is) {
     return limits;
 }
 
-void UCI::go(Position& pos, std::istringstream& is, StateListPtr& states) {
+void UCI::go(Position& pos, std::istringstream& is) {
 
     Search::LimitsType limits = parse_limits(pos, is);
-
-    networks.big.verify(options["EvalFile"]);
-    networks.small.verify(options["EvalFileSmall"]);
-
-    if (limits.perft)
-    {
-        perft(pos.fen(), limits.perft, options["UCI_Chess960"]);
-        return;
-    }
-
-    threads.start_thinking(options, pos, states, limits);
+    engine.go(limits);
 }
 
-void UCI::bench(Position& pos, std::istream& args, StateListPtr& states) {
+void UCI::bench(Position& pos, std::istream& args) {
     std::string token;
     uint64_t    num, nodes = 0, cnt = 1;
 
@@ -263,20 +240,20 @@ void UCI::bench(Position& pos, std::istream& args, StateListPtr& states) {
                       << std::endl;
             if (token == "go")
             {
-                go(pos, is, states);
-                threads.main_thread()->wait_for_search_finished();
-                nodes += threads.nodes_searched();
+                go(pos, is);
+                engine.wait_for_search_finished();
+                nodes += engine.nodes_searched();
             }
             else
-                trace_eval(pos);
+                engine.trace_eval();
         }
         else if (token == "setoption")
             setoption(is);
         else if (token == "position")
-            position(pos, is, states);
+            position(is);
         else if (token == "ucinewgame")
         {
-            search_clear();  // Search::clear() may take a while
+            engine.search_clear();  // search_clear may take a while
             elapsed = now();
         }
     }
@@ -290,33 +267,13 @@ void UCI::bench(Position& pos, std::istream& args, StateListPtr& states) {
               << "\nNodes/second    : " << 1000 * nodes / elapsed << std::endl;
 }
 
-void UCI::trace_eval(Position& pos) {
-    StateListPtr states(new std::deque<StateInfo>(1));
-    Position     p;
-    p.set(pos.fen(), options["UCI_Chess960"], &states->back());
-
-    networks.big.verify(options["EvalFile"]);
-    networks.small.verify(options["EvalFileSmall"]);
-
-
-    sync_cout << "\n" << Eval::trace(p, networks) << sync_endl;
-}
-
-void UCI::search_clear() {
-    threads.main_thread()->wait_for_search_finished();
-
-    tt.clear(options["Threads"]);
-    threads.clear();
-    Tablebases::init(options["SyzygyPath"]);  // Free mapped files
-}
 
 void UCI::setoption(std::istringstream& is) {
-    threads.main_thread()->wait_for_search_finished();
-    options.setoption(is);
+    engine.wait_for_search_finished();
+    engine.get_options().setoption(is);
 }
 
-void UCI::position(Position& pos, std::istringstream& is, StateListPtr& states) {
-    Move        m;
+void UCI::position(std::istringstream& is) {
     std::string token, fen;
 
     is >> token;
@@ -332,15 +289,14 @@ void UCI::position(Position& pos, std::istringstream& is, StateListPtr& states) 
     else
         return;
 
-    states = StateListPtr(new std::deque<StateInfo>(1));  // Drop the old state and create a new one
-    pos.set(fen, options["UCI_Chess960"], &states->back());
+    std::vector<std::string> moves;
 
-    // Parse the move list, if any
-    while (is >> token && (m = to_move(pos, token)) != Move::none())
+    while (is >> token)
     {
-        states->emplace_back();
-        pos.do_move(m, states->back());
+        moves.push_back(token);
     }
+
+    engine.set_position(fen, moves);
 }
 
 namespace {
@@ -447,7 +403,7 @@ std::string UCI::move(Move m, bool chess960) {
 }
 
 
-Move UCI::to_move(const Position& pos, std::string& str) {
+Move UCI::to_move(const Position& pos, std::string str) {
     if (str.length() == 5)
         str[4] = char(tolower(str[4]));  // The promotion piece character must be lowercased
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -438,7 +438,7 @@ void UCI::on_update_full(const Engine::InfoFull& info, bool showWDL) {
     ss << "info";
     ss << " depth " << info.depth        //
        << " seldepth " << info.selDepth  //
-       << " multiPV " << info.multiPV    //
+       << " multipv " << info.multiPV    //
        << " score " << info.score;       //
 
     if (showWDL)

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <string>
 
+#include "engine.h"
 #include "misc.h"
 #include "nnue/network.h"
 #include "position.h"
@@ -47,25 +48,17 @@ class UCI {
     static std::string square(Square s);
     static std::string move(Move m, bool chess960);
     static std::string wdl(Value v, const Position& pos);
-    static Move        to_move(const Position& pos, std::string& str);
+    static Move        to_move(const Position& pos, std::string str);
 
     static Search::LimitsType parse_limits(const Position& pos, std::istream& is);
 
-    const std::string& working_directory() const { return cli.workingDirectory; }
-
-    OptionsMap           options;
-    Eval::NNUE::Networks networks;
-
    private:
-    TranspositionTable tt;
-    ThreadPool         threads;
-    CommandLine        cli;
+    Engine      engine;
+    CommandLine cli;
 
-    void go(Position& pos, std::istringstream& is, StateListPtr& states);
-    void bench(Position& pos, std::istream& args, StateListPtr& states);
-    void position(Position& pos, std::istringstream& is, StateListPtr& states);
-    void trace_eval(Position& pos);
-    void search_clear();
+    void go(Position& pos, std::istringstream& is);
+    void bench(Position& pos, std::istream& args);
+    void position(std::istringstream& is);
     void setoption(std::istringstream& is);
 };
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -24,15 +24,11 @@
 
 #include "engine.h"
 #include "misc.h"
-#include "nnue/network.h"
-#include "position.h"
 #include "search.h"
-#include "thread.h"
-#include "tt.h"
-#include "ucioption.h"
 
 namespace Stockfish {
 
+class Position;
 class Move;
 enum Square : int;
 using Value = int;
@@ -60,6 +56,11 @@ class UCI {
     void bench(Position& pos, std::istream& args);
     void position(std::istringstream& is);
     void setoption(std::istringstream& is);
+
+    static void on_update_short(const Engine::InfoShort& info);
+    static void on_update_full(const Engine::InfoFull& info, bool showWDL);
+    static void on_iter(const Engine::InfoIter& info);
+    static void on_bestmove(const std::string& bestmove, const std::string& ponder);
 };
 
 }  // namespace Stockfish

--- a/src/uci.h
+++ b/src/uci.h
@@ -48,6 +48,8 @@ class UCI {
 
     static Search::LimitsType parse_limits(const Position& pos, std::istream& is);
 
+    auto& engine_options() { return engine.get_options(); }
+
    private:
     Engine      engine;
     CommandLine cli;


### PR DESCRIPTION
This is another refactor which aims to decouple uci from stockfish. A new engine class manages all engine related logic and uci is a "small" wrapper around it. 
UCI creates function callbacks for search to use when an update should occur. The benching in uci.cpp for example does this to extract the total nodes searched.

Non Regression STC:
https://tests.stockfishchess.org/tests/view/660006370ec64f0526c546e3
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 164064 W: 42514 L: 42434 D: 79116
Ptnml(0-2): 683, 18653, 43253, 18787, 656

Note:
I am currently not entirely happen with some of the names..
- InfoShort/InfoFull, these should maybe be one.
- updateContext

In the future we should also try to remove the need for the Position object in the uci and replace the options with an actual options struct instead of using a map.

closes https://github.com/official-stockfish/Stockfish/pull/5146

No functional change