### PR TITLE
Explicitly use the LLD linker with Clang

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -464,6 +464,10 @@ ifeq ($(COMP),clang)
 	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-prototypes \
 	            -Wconditional-uninitialized
 
+	ifneq ($(KERNEL),Darwin)
+		LDFLAGS += -fuse-ld=lld
+	endif
+
 	ifeq ($(filter $(KERNEL),Darwin OpenBSD FreeBSD),)
 	ifeq ($(target_windows),)
 	ifneq ($(RTLIB),compiler-rt)
@@ -759,9 +763,6 @@ ifeq ($(debug), no)
 		ifeq ($(comp),icx)
 			CXXFLAGS += -fwhole-program-vtables
                 endif
-		ifeq ($(target_windows),yes)
-			CXXFLAGS += -fuse-ld=lld
-		endif
 		LDFLAGS += $(CXXFLAGS)
 
 # GCC and CLANG use different methods for parallelizing LTO and CLANG pretends to be


### PR DESCRIPTION
On Ubuntu 22.04, the compilation process using the Clang/LLVM distribution from LLVM (https://apt.llvm.org/) began to fail during the linking step.

To resolve this, add the `-fuse-ld=lld` flag for all operating systems except Darwin, see https://lld.llvm.org/#using-lld

closes https://github.com/official-stockfish/Stockfish/pull/5150

No functional change