### PR TITLE
Replace a `goto` with a loop.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -287,7 +287,8 @@ Move MovePicker::next_move(bool skipQuiets) {
 
         case REFUTATION :
             if (select<Next>([&]() {
-                    return *cur != Move::none() && !pos.capture_stage(*cur) && pos.pseudo_legal(*cur);
+                    return *cur != Move::none() && !pos.capture_stage(*cur)
+                        && pos.pseudo_legal(*cur);
                 }))
                 return *(cur - 1);
             ++stage;
@@ -308,7 +309,8 @@ Move MovePicker::next_move(bool skipQuiets) {
 
         case GOOD_QUIET :
             if (!skipQuiets && select<Next>([&]() {
-                    return *cur != refutations[0] && *cur != refutations[1] && *cur != refutations[2];
+                    return *cur != refutations[0] && *cur != refutations[1]
+                        && *cur != refutations[2];
                 }))
             {
                 if ((cur - 1)->value > -8000 || (cur - 1)->value <= quiet_threshold(depth))
@@ -339,7 +341,8 @@ Move MovePicker::next_move(bool skipQuiets) {
         case BAD_QUIET :
             if (!skipQuiets)
                 return select<Next>([&]() {
-                    return *cur != refutations[0] && *cur != refutations[1] && *cur != refutations[2];
+                    return *cur != refutations[0] && *cur != refutations[1]
+                        && *cur != refutations[2];
                 });
 
             return Move::none();


### PR DESCRIPTION
A switch-case used a `return` in all cases except one, which used a `goto` to the top of the switch. This replaces the label with a `while (true)` and `goto` with `continue`.

Passed non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 69440 W: 18120 L: 17934 D: 33386
Ptnml(0-2): 275, 7899, 18195, 8067, 284 
https://tests.stockfishchess.org/tests/view/660b48c601aaec5069f87957

No functional change.