### PR TITLE
Remove an useless assignment

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -587,7 +587,7 @@ Value Search::Worker::search(
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
-    (ss + 1)->excludedMove = bestMove = Move::none();
+    bestMove = Move::none();
     (ss + 2)->killers[0] = (ss + 2)->killers[1] = Move::none();
     (ss + 2)->cutoffCnt                         = 0;
     ss->multipleExtensions                      = (ss - 1)->multipleExtensions;


### PR DESCRIPTION
The assignment `(ss + 1)->excludedMove = Move::none()` can be simplified away because when that line is reached, `(ss + 1)->excludedMove` is always already none. The only moment stack[x]->excludedMove is modified, is during singular search, but it is reset to none right after the singular search is finished.

No functional change
  
Bench 1823302