### PR TITLE
Remove COMPILER from Make

### DIFF
--- a/.github/workflows/arm_compilation.yml
+++ b/.github/workflows/arm_compilation.yml
@@ -10,7 +10,7 @@ jobs:
     name: ${{ matrix.config.name }} ${{ matrix.binaries }}
     runs-on: ${{ matrix.config.os }}
     env:
-      COMPILER: ${{ matrix.config.compiler }}
+      COMPCXX: ${{ matrix.config.compiler }}
       COMP: ${{ matrix.config.comp }}
       EMU: ${{ matrix.config.emu }}
       EXT: ${{ matrix.config.ext }}
@@ -62,7 +62,7 @@ jobs:
           if [ $COMP == ndk ]; then
             export PATH=${{ env.ANDROID_NDK_BIN }}:$PATH
           fi
-          $COMPILER -v
+          $COMPCXX -v
 
       - name: Test help target
         run: make help

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -10,7 +10,7 @@ jobs:
     name: ${{ matrix.config.name }} ${{ matrix.binaries }}
     runs-on: ${{ matrix.config.os }}
     env:
-      COMPILER: ${{ matrix.config.compiler }}
+      COMPCXX: ${{ matrix.config.compiler }}
       COMP: ${{ matrix.config.comp }}
       EXT: ${{ matrix.config.ext }}
       NAME: ${{ matrix.config.simple_name }}
@@ -50,7 +50,7 @@ jobs:
         run: make net
 
       - name: Check compiler
-        run: $COMPILER -v
+        run: $COMPCXX -v
 
       - name: Test help target
         run: make help
@@ -59,7 +59,7 @@ jobs:
         run: git --version
 
       - name: Check compiler
-        run: $COMPILER -v
+        run: $COMPCXX -v
 
       - name: Show g++ cpu info
         if: runner.os != 'macOS'

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -6,7 +6,7 @@ jobs:
     name: ${{ matrix.sanitizers.name }}
     runs-on: ${{ matrix.config.os }}
     env:
-      COMPILER: ${{ matrix.config.compiler }}
+      COMPCXX: ${{ matrix.config.compiler }}
       COMP: ${{ matrix.config.comp }}
       CXXFLAGS: "-Werror"
     strategy:
@@ -47,7 +47,7 @@ jobs:
         run: make net
 
       - name: Check compiler
-        run: $COMPILER -v
+        run: $COMPCXX -v
 
       - name: Test help target
         run: make help

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     env:
-      COMPILER: ${{ matrix.config.compiler }}
+      COMPCXX: ${{ matrix.config.compiler }}
       COMP: ${{ matrix.config.comp }}
       CXXFLAGS: "-Werror"
     strategy:
@@ -172,9 +172,9 @@ jobs:
             if [ $COMP == ndk ]; then
               export PATH=${{ env.ANDROID_NDK_BIN }}:$PATH
             fi
-            $COMPILER -v
+            $COMPCXX -v
           else
-            echo "$COMPILER -v" > script.sh
+            echo "$COMPCXX -v" > script.sh
             docker run --rm --platform ${{ matrix.config.platform }} -v ${{ github.workspace }}/src:/app sf_builder
           fi
 

--- a/.github/workflows/upload_binaries.yml
+++ b/.github/workflows/upload_binaries.yml
@@ -11,7 +11,7 @@ jobs:
     name: ${{ matrix.config.name }} ${{ matrix.binaries }}
     runs-on: ${{ matrix.config.os }}
     env:
-      COMPILER: ${{ matrix.config.compiler }}
+      COMPCXX: ${{ matrix.config.compiler }}
       COMP: ${{ matrix.config.comp }}
       EXT: ${{ matrix.config.ext }}
       NAME: ${{ matrix.config.simple_name }}

--- a/src/Makefile
+++ b/src/Makefile
@@ -546,11 +546,6 @@ else
 	endif
 endif
 
-### Travis CI script uses COMPILER to overwrite CXX
-ifdef COMPILER
-	COMPCXX=$(COMPILER)
-endif
-
 ### Allow overwriting CXX from command line
 ifdef COMPCXX
 	CXX=$(COMPCXX)


### PR DESCRIPTION
Remove `COMPILER` from Makefile. The same functionality is available by using `COMPCXX` and having another variable which does the same is just confusing.  
There was only one mention on Stockfish Wiki about this which has been changed to `COMPCXX`.

No functional change