### PR TITLE
Promote Jörg Oster To Stockfish Founders

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@ Tord Romstad (romstad)
 Marco Costalba (mcostalba)
 Joona Kiiski (zamar)
 Gary Linscott (glinscott)
+Jörg Oster (joergoster)
 
 # Authors and inventors of NNUE, training, and NNUE port
 Yu Nasu (ynasu87)

--- a/AUTHORS
+++ b/AUTHORS
@@ -114,7 +114,6 @@ Jonathan McDermid (jonathanmcdermid)
 Joost VandeVondele (vondele)
 Joseph Ellis (jhellis3)
 Joseph R. Prostko
-Jörg Oster (joergoster)
 Julian Willemer (NightlyKing)
 jundery
 Justin Blanchard (UncombedCoconut)


### PR DESCRIPTION
@joergoster has been contributing to Stockfish for more than 10 years, so he can be included in the list of founders.

![image](https://github.com/official-stockfish/Stockfish/assets/79460792/6e56d99b-c572-4051-91dd-cc9efe821300)

No functional change.