### PR TITLE
Simplify the depth-dependent part of the best value adjustment formula in main search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1308,7 +1308,7 @@ moves_loop:  // When in check, search starts here
     // Adjust best value for fail high cases at non-pv nodes
     if (!PvNode && bestValue >= beta && std::abs(bestValue) < VALUE_TB_WIN_IN_MAX_PLY
         && std::abs(beta) < VALUE_TB_WIN_IN_MAX_PLY && std::abs(alpha) < VALUE_TB_WIN_IN_MAX_PLY)
-        bestValue = (bestValue * (depth + 2) + beta) / (depth + 3);
+        bestValue = (bestValue * depth + beta) / (depth + 1);
 
     if (!moveCount)
         bestValue = excludedMove ? alpha : ss->inCheck ? mated_in(ss->ply) : VALUE_DRAW;


### PR DESCRIPTION
Simplify the depth-dependent part of the best value adjustment formula in the main search.

Passed STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 139648 W: 36171 L: 36061 D: 67416
Ptnml(0-2): 545, 16685, 35282, 16739, 573
https://tests.stockfishchess.org/tests/view/660d953b8ff4a059828d625d

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 222894 W: 56519 L: 56505 D: 109870
Ptnml(0-2): 112, 25145, 60971, 25055, 164
https://tests.stockfishchess.org/tests/view/660fd4afbfeb43334bf7d558


bench: 1907981