### PR TITLE
Fix wrong sign for 200 TB score

### DIFF
--- a/src/score.cpp
+++ b/src/score.cpp
@@ -36,7 +36,7 @@ Score::Score(Value v, const Position& pos) {
     else if (std::abs(v) <= VALUE_TB)
     {
         auto distance = VALUE_TB - std::abs(v);
-        score         = (v > 0) ? TBWin{distance} : TBWin{-distance};
+        score         = (v > 0) ? Tablebase{distance, true} : Tablebase{-distance, false};
     }
     else
     {

--- a/src/score.h
+++ b/src/score.h
@@ -34,8 +34,9 @@ class Score {
         int plies;
     };
 
-    struct TBWin {
-        int plies;
+    struct Tablebase {
+        int  plies;
+        bool win;
     };
 
     struct InternalUnits {
@@ -61,7 +62,7 @@ class Score {
     }
 
    private:
-    std::variant<Mate, TBWin, InternalUnits> score;
+    std::variant<Mate, Tablebase, InternalUnits> score;
 };
 
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -357,9 +357,9 @@ std::string UCIEngine::format_score(const Score& s) {
                    auto m = (mate.plies > 0 ? (mate.plies + 1) : mate.plies) / 2;
                    return std::string("mate ") + std::to_string(m);
                },
-               [](Score::TBWin tb) -> std::string {
+               [](Score::Tablebase tb) -> std::string {
                    return std::string("cp ")
-                        + std::to_string((tb.plies > 0 ? TB_CP - tb.plies : -TB_CP - tb.plies));
+                        + std::to_string((tb.win ? TB_CP - tb.plies : -TB_CP - tb.plies));
                },
                [](Score::InternalUnits units) -> std::string {
                    return std::string("cp ") + std::to_string(units.value);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -435,7 +435,7 @@ Move UCIEngine::to_move(const Position& pos, std::string str) {
 }
 
 void UCIEngine::on_update_no_moves(const Engine::InfoShort& info) {
-    sync_cout << "info depth" << info.depth << " score " << format_score(info.score) << sync_endl;
+    sync_cout << "info depth " << info.depth << " score " << format_score(info.score) << sync_endl;
 }
 
 void UCIEngine::on_update_full(const Engine::InfoFull& info, bool showWDL) {


### PR DESCRIPTION
- TB values can have a distance of 0, mainly when we are in a tb position but haven't found mate.
- Add a missing whitespace to UCIEngine::on_update_no_moves()

Reproduction:
```
./stockfish

setoption name SyzygyPath value /home/disservin/syzygy
position fen 1k6/8/8/8/8/8/2B1N3/3K4 w - - 0 1
go
info string NNUE evaluation using nn-ae6a388e4a1a.nnue
info string NNUE evaluation using nn-baff1ede1f90.nnue
info depth 1 seldepth 2 multipv 1 score cp -20000 nodes 17 nps 17000 hashfull 0 tbhits 17 time 1 pv c2g6
```