### PR TITLE
Initialize constexpr variable to get rid of clang compiler warning

### DIFF
--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -229,7 +229,7 @@ class FeatureTransformer {
 
     static constexpr void order_packs([[maybe_unused]] uint64_t* v) {
 #if defined(USE_AVX512)  // _mm512_packs_epi16 ordering
-        uint64_t tmp0, tmp1;
+        uint64_t tmp0 = 0, tmp1 = 0;
         tmp0 = v[2], tmp1 = v[3];
         v[2] = v[8], v[3] = v[9];
         v[8] = v[4], v[9] = v[5];
@@ -246,7 +246,7 @@ class FeatureTransformer {
 
     static constexpr void inverse_order_packs([[maybe_unused]] uint64_t* v) {
 #if defined(USE_AVX512)  // Inverse _mm512_packs_epi16 ordering
-        uint64_t tmp0, tmp1;
+        uint64_t tmp0 = 0, tmp1 = 0;
         tmp0 = v[2], tmp1 = v[3];
         v[2] = v[4], v[3] = v[5];
         v[4] = v[8], v[5] = v[9];

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -229,7 +229,7 @@ class FeatureTransformer {
 
     static constexpr void order_packs([[maybe_unused]] uint64_t* v) {
 #if defined(USE_AVX512)  // _mm512_packs_epi16 ordering
-        uint64_t tmp0 = 0, tmp1 = 1;
+        uint64_t tmp0 = 0, tmp1 = 0;
         tmp0 = v[2], tmp1 = v[3];
         v[2] = v[8], v[3] = v[9];
         v[8] = v[4], v[9] = v[5];

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -229,7 +229,7 @@ class FeatureTransformer {
 
     static constexpr void order_packs([[maybe_unused]] uint64_t* v) {
 #if defined(USE_AVX512)  // _mm512_packs_epi16 ordering
-        uint64_t tmp0 = 0, tmp1 = 0;
+        uint64_t tmp0 = 0, tmp1 = 1;
         tmp0 = v[2], tmp1 = v[3];
         v[2] = v[8], v[3] = v[9];
         v[8] = v[4], v[9] = v[5];


### PR DESCRIPTION
Non-functional change