### PR TITLE
Parameters Tune

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -58,14 +58,14 @@ Value Eval::evaluate(const Eval::NNUE::Networks& networks, const Position& pos, 
     Value nnue = smallNet ? networks.small.evaluate(pos, true, &nnueComplexity, psqtOnly)
                           : networks.big.evaluate(pos, true, &nnueComplexity, false);
 
-    const auto adjustEval = [&](int optDiv, int nnueDiv, int pawnCountConstant, int pawnCountMul,
-                                int npmConstant, int evalDiv, int shufflingConstant,
-                                int shufflingDiv) {
+    const auto adjustEval = [&](int optDiv, int nnueDiv, int npmDiv, int pawnCountConstant,
+                                int pawnCountMul, int npmConstant, int evalDiv,
+                                int shufflingConstant, int shufflingDiv) {
         // Blend optimism and eval with nnue complexity and material imbalance
         optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / optDiv;
-        nnue -= nnue * (nnueComplexity * 5 / 3) / nnueDiv;
+        nnue -= nnue * (nnueComplexity * 486 / 300) / nnueDiv;
 
-        int npm = pos.non_pawn_material() / 64;
+        int npm = pos.non_pawn_material() / npmDiv;
         v       = (nnue * (npm + pawnCountConstant + pawnCountMul * pos.count<PAWN>())
              + optimism * (npmConstant + npm))
           / evalDiv;
@@ -76,11 +76,11 @@ Value Eval::evaluate(const Eval::NNUE::Networks& networks, const Position& pos, 
     };
 
     if (!smallNet)
-        adjustEval(513, 32395, 919, 11, 145, 1036, 178, 204);
+        adjustEval(552, 32395, 66, 936, 12, 140, 1068, 178, 206);
     else if (psqtOnly)
-        adjustEval(517, 32857, 908, 7, 155, 1019, 224, 238);
+        adjustEval(517, 32900, 64, 908, 8, 173, 1018, 223, 240);
     else
-        adjustEval(499, 32793, 903, 9, 147, 1067, 208, 211);
+        adjustEval(499, 32793, 63, 964, 9, 147, 1067, 208, 208);
 
     // Guarantee evaluation does not hit the tablebase range
     v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -29,7 +29,7 @@ class Position;
 
 namespace Eval {
 
-constexpr inline int SmallNetThreshold = 1274, PsqtOnlyThreshold = 2389;
+constexpr inline int SmallNetThreshold = 1274, PsqtOnlyThreshold = 2440;
 
 // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
 // for the build process (profile-build and fishtest) to work. Do not change the

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -187,7 +187,7 @@ void MovePicker::score() {
             m.value += (*continuationHistory[5])[pc][to];
 
             // bonus for checks
-            m.value += bool(pos.check_squares(pt) & to) * 16384;
+            m.value += bool(pos.check_squares(pt) & to) * 16200;
 
             // bonus for escaping from capture
             m.value += threatenedPieces & from ? (pt == QUEEN && !(to & threatenedByRook)   ? 51000
@@ -199,7 +199,7 @@ void MovePicker::score() {
             // malus for putting piece en prise
             m.value -= !(threatenedPieces & from)
                        ? (pt == QUEEN ? bool(to & threatenedByRook) * 48150
-                                          + bool(to & threatenedByMinor) * 10650
+                                          + bool(to & threatenedByMinor) * 11000
                           : pt == ROOK ? bool(to & threatenedByMinor) * 24500
                           : pt != PAWN ? bool(to & threatenedByPawn) * 14950
                                        : 0)


### PR DESCRIPTION
Parameters Tune, adding also another tunable parameter (npmDiv) to be variable for different nets (bignet, smallnet, psqtOnly smallnet).
P.s: The changed values are only the parameters where there is agreement among the different time controls, so in other words, the tunings are telling us that changing these specific values to this specific direction is good in all time controls, so there shouldn't be a high risk of regressing at longer time controls.

Passed STC:
LLR: 2.92 (-2.94,2.94) <0.00,2.00>
Total: 11040 W: 3018 L: 2732 D: 5290
Ptnml(0-2): 43, 1221, 2718, 1483, 55
https://tests.stockfishchess.org/tests/view/661afb09bd68065432a07b95

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 30606 W: 7908 L: 7598 D: 15100
Ptnml(0-2): 18, 3298, 8369, 3592, 26
https://tests.stockfishchess.org/tests/view/661b1ad8bd68065432a07d54

If an extra VVLTC test is needed, please let me know at what bounds.

bench: 1540110