### PR TITLE
update the WDL model

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -330,8 +330,8 @@ WinRateParams win_rate_params(const Position& pos) {
     double m = std::clamp(material, 10, 78) / 58.0;
 
     // Return a = p_a(material) and b = p_b(material), see github.com/official-stockfish/WDL_model
-    constexpr double as[] = {-132.62669598, 351.91690697, -290.67933842, 403.61346073};
-    constexpr double bs[] = {63.49574536, -90.82470531, 43.77506173, 49.50973166};
+    constexpr double as[] = {-150.77043883, 394.96159472, -321.73403766, 406.15850091};
+    constexpr double bs[] = {62.33245393, -91.02264855, 45.88486850, 51.63461272};
 
     double a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
     double b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -330,8 +330,8 @@ WinRateParams win_rate_params(const Position& pos) {
     double m = std::clamp(material, 10, 78) / 58.0;
 
     // Return a = p_a(material) and b = p_b(material), see github.com/official-stockfish/WDL_model
-    constexpr double as[] = {-185.71965483, 504.85014385, -438.58295743, 474.04604627};
-    constexpr double bs[] = {89.23542728, -137.02141296, 73.28669021, 47.53376190};
+    constexpr double as[] = {-132.62669598, 351.91690697, -290.67933842, 403.61346073};
+    constexpr double bs[] = {63.49574536, -90.82470531, 43.77506173, 49.50973166};
 
     double a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
     double b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];


### PR DESCRIPTION
This PR updates the internal WDL model, taking into account that the normalizing constant has dropped significantly since the commit 1adf8e1ae662f2eecc5d652ece7b9f53014cf057 (from 355 to 329).

```
> ./updateWDL.sh --firstrev 1adf8e1ae662f2eecc5d652ece7b9f53014cf057
Running: ./updateWDL.sh --firstrev=1adf8e1ae662f2eecc5d652ece7b9f53014cf057 --lasttrev=HEAD --materialMin=10
started at:  Sun 21 Apr 13:49:37 CEST 2024
Look recursively in directory pgns for games from SPRT tests using books matching "UHO_Lichess_4852_v..epd" for SF revisions between 1adf8e1ae662f2eecc5d652ece7b9f53014cf057 (from 2024-04-11 22:23:52 +0200) and HEAD (from 2024-04-13 22:05:19 +0200).
Based on 105111912 positions from 1798371 games, NormalizeToPawnValue should change from 355 to 329.
ended at:  Sun 21 Apr 13:51:46 CEST 2024
```

```
> cat scoreWDL.log 
Converting evals with NormalizeData = {'momType': 'material', 'momMin': 10, 'momMax': 78, 'momTarget': 58, 'as': [-185.71965483, 504.85014385, -438.58295743, 474.04604627]}.
Reading eval stats from updateWDL.json.
Retained (W,D,L) = (25548026, 53489841, 26074045) positions.
Saved distribution plot to updateWDLdistro.png.
Fit WDL model based on material.
Initial objective function:  0.33922554547182054
Final objective function:    0.3392222751671758
Optimization terminated successfully.
const int NormalizeToPawnValue = 329;
Corresponding spread = 69;
Corresponding normalized spread = 0.20945226758880028;
Draw rate at 0.0 eval at material 58 = 0.9832543768223896;
Parameters in internal value units: 
p_a = ((-150.770 * x / 58 + 394.962) * x / 58 + -321.734) * x / 58 + 406.159
p_b = ((62.332 * x / 58 + -91.023) * x / 58 + 45.885) * x / 58 + 51.635
    constexpr double as[] = {-150.77043883, 394.96159472, -321.73403766, 406.15850091};
    constexpr double bs[] = {62.33245393, -91.02264855, 45.88486850, 51.63461272};
Preparing plots.
Saved graphics to updateWDL.png.
Total elapsed time = 70.18s.
```

The patch only changes the displayed `cp` and `wdl` values.

No bench change.