### PR TITLE
Move ALSR change to Workflow file

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -55,6 +55,14 @@ jobs:
       - name: Check git
         run: git --version
 
+      # Since Linux Kernel 6.5 we are getting false positives from the ci,
+      # lower the ALSR entropy to disable ALSR, which works as a temporary workaround.
+      # https://github.com/google/sanitizers/issues/1716
+      # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2056762
+
+      - name: Lower ALSR entropy
+        run: sudo sysctl -w vm.mmap_rnd_bits=28
+
       # Sanitizers
 
       - name: ${{ matrix.sanitizers.name }}

--- a/tests/instrumented.sh
+++ b/tests/instrumented.sh
@@ -8,13 +8,6 @@ error()
 }
 trap 'error ${LINENO}' ERR
 
-# Since Linux Kernel 6.5 we are getting false positives from the ci,
-# lower the ALSR entropy to disable ALSR, which works as a temporary workaround.
-# https://github.com/google/sanitizers/issues/1716
-# https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2056762
-sudo sysctl -w vm.mmap_rnd_bits=28
-
-
 # define suitable post and prefixes for testing options
 case $1 in
   --valgrind)


### PR DESCRIPTION
It makes more sense to not (potentially) change the developers alsr entropy setting to make the test run through. This should be an active choice even if the test then might fail locally for them.

No functional change