### PR TITLE
Implement accumulator refresh table

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -59,8 +59,9 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     int  nnueComplexity;
     int  v;
 
-    Value nnue = smallNet ? networks.small.evaluate(pos, cache, true, &nnueComplexity, psqtOnly)
-                          : networks.big.evaluate(pos, cache, true, &nnueComplexity, false);
+    Value nnue = smallNet
+                 ? networks.small.evaluate(pos, cache.small, true, &nnueComplexity, psqtOnly)
+                 : networks.big.evaluate(pos, cache.big, true, &nnueComplexity, false);
 
     const auto adjustEval = [&](int optDiv, int nnueDiv, int pawnCountConstant, int pawnCountMul,
                                 int npmConstant, int evalDiv, int shufflingConstant,
@@ -109,7 +110,7 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
 
     ss << std::showpoint << std::showpos << std::fixed << std::setprecision(2) << std::setw(15);
 
-    Value v = networks.big.evaluate(pos, *cache, false);
+    Value v = networks.big.evaluate(pos, cache->big, false);
     v       = pos.side_to_move() == WHITE ? v : -v;
     ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)\n";
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -45,7 +45,10 @@ int Eval::simple_eval(const Position& pos, Color c) {
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
 // of the position from the point of view of the side to move.
-Value Eval::evaluate(const Eval::NNUE::Networks& networks, const Position& pos, int optimism) {
+Value Eval::evaluate(const Eval::NNUE::Networks&   networks,
+                     const Position&               pos,
+                     Eval::NNUE::AccumulatorCache& cache,
+                     int                           optimism) {
 
     assert(!pos.checkers());
 
@@ -55,8 +58,8 @@ Value Eval::evaluate(const Eval::NNUE::Networks& networks, const Position& pos, 
     int  nnueComplexity;
     int  v;
 
-    Value nnue = smallNet ? networks.small.evaluate(pos, true, &nnueComplexity, psqtOnly)
-                          : networks.big.evaluate(pos, true, &nnueComplexity, false);
+    Value nnue = smallNet ? networks.small.evaluate(pos, cache, true, &nnueComplexity, psqtOnly)
+                          : networks.big.evaluate(pos, cache, true, &nnueComplexity, false);
 
     const auto adjustEval = [&](int optDiv, int nnueDiv, int pawnCountConstant, int pawnCountMul,
                                 int npmConstant, int evalDiv, int shufflingConstant,
@@ -94,20 +97,22 @@ Value Eval::evaluate(const Eval::NNUE::Networks& networks, const Position& pos, 
 // Trace scores are from white's point of view
 std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
 
+    auto cache = std::make_unique<Eval::NNUE::AccumulatorCache>();
+
     if (pos.checkers())
         return "Final evaluation: none (in check)";
 
     std::stringstream ss;
     ss << std::showpoint << std::noshowpos << std::fixed << std::setprecision(2);
-    ss << '\n' << NNUE::trace(pos, networks) << '\n';
+    ss << '\n' << NNUE::trace(pos, networks, *cache) << '\n';
 
     ss << std::showpoint << std::showpos << std::fixed << std::setprecision(2) << std::setw(15);
 
-    Value v = networks.big.evaluate(pos, false);
+    Value v = networks.big.evaluate(pos, *cache, false);
     v       = pos.side_to_move() == WHITE ? v : -v;
     ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)\n";
 
-    v = evaluate(networks, pos, VALUE_ZERO);
+    v = evaluate(networks, pos, *cache, VALUE_ZERO);
     v = pos.side_to_move() == WHITE ? v : -v;
     ss << "Final evaluation       " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)";
     ss << " [with scaled NNUE, ...]";

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -48,7 +48,7 @@ int Eval::simple_eval(const Position& pos, Color c) {
 // of the position from the point of view of the side to move.
 Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
                      const Position&                pos,
-                     Eval::NNUE::AccumulatorCaches& cache,
+                     Eval::NNUE::AccumulatorCaches& caches,
                      int                            optimism) {
 
     assert(!pos.checkers());
@@ -60,7 +60,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     int  v;
 
     Value nnue = smallNet ? networks.small.evaluate(pos, nullptr, true, &nnueComplexity, psqtOnly)
-                          : networks.big.evaluate(pos, &cache.big, true, &nnueComplexity, false);
+                          : networks.big.evaluate(pos, &caches.big, true, &nnueComplexity, false);
 
     const auto adjustEval = [&](int optDiv, int nnueDiv, int pawnCountConstant, int pawnCountMul,
                                 int npmConstant, int evalDiv, int shufflingConstant,

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -32,6 +32,7 @@
 #include "position.h"
 #include "types.h"
 #include "uci.h"
+#include "nnue/nnue_accumulator.h"
 
 namespace Stockfish {
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -59,9 +59,8 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     int  nnueComplexity;
     int  v;
 
-    Value nnue = smallNet
-                 ? networks.small.evaluate(pos, cache.small, true, &nnueComplexity, psqtOnly)
-                 : networks.big.evaluate(pos, cache.big, true, &nnueComplexity, false);
+    Value nnue = smallNet ? networks.small.evaluate(pos, nullptr, true, &nnueComplexity, psqtOnly)
+                          : networks.big.evaluate(pos, &cache.big, true, &nnueComplexity, false);
 
     const auto adjustEval = [&](int optDiv, int nnueDiv, int pawnCountConstant, int pawnCountMul,
                                 int npmConstant, int evalDiv, int shufflingConstant,
@@ -110,7 +109,7 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
 
     ss << std::showpoint << std::showpos << std::fixed << std::setprecision(2) << std::setw(15);
 
-    Value v = networks.big.evaluate(pos, cache->big, false);
+    Value v = networks.big.evaluate(pos, &cache->big, false);
     v       = pos.side_to_move() == WHITE ? v : -v;
     ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)\n";
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -46,10 +46,10 @@ int Eval::simple_eval(const Position& pos, Color c) {
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
 // of the position from the point of view of the side to move.
-Value Eval::evaluate(const Eval::NNUE::Networks&   networks,
-                     const Position&               pos,
-                     Eval::NNUE::AccumulatorCache& cache,
-                     int                           optimism) {
+Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
+                     const Position&                pos,
+                     Eval::NNUE::AccumulatorCaches& cache,
+                     int                            optimism) {
 
     assert(!pos.checkers());
 
@@ -98,7 +98,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&   networks,
 // Trace scores are from white's point of view
 std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
 
-    auto cache = std::make_unique<Eval::NNUE::AccumulatorCache>();
+    auto cache = std::make_unique<Eval::NNUE::AccumulatorCaches>();
 
     if (pos.checkers())
         return "Final evaluation: none (in check)";

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -98,22 +98,22 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 // Trace scores are from white's point of view
 std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
 
-    auto cache = std::make_unique<Eval::NNUE::AccumulatorCaches>();
+    auto caches = std::make_unique<Eval::NNUE::AccumulatorCaches>();
 
     if (pos.checkers())
         return "Final evaluation: none (in check)";
 
     std::stringstream ss;
     ss << std::showpoint << std::noshowpos << std::fixed << std::setprecision(2);
-    ss << '\n' << NNUE::trace(pos, networks, *cache) << '\n';
+    ss << '\n' << NNUE::trace(pos, networks, *caches) << '\n';
 
     ss << std::showpoint << std::showpos << std::fixed << std::setprecision(2) << std::setw(15);
 
-    Value v = networks.big.evaluate(pos, &cache->big, false);
+    Value v = networks.big.evaluate(pos, &caches->big, false);
     v       = pos.side_to_move() == WHITE ? v : -v;
     ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)\n";
 
-    v = evaluate(networks, pos, *cache, VALUE_ZERO);
+    v = evaluate(networks, pos, *caches, VALUE_ZERO);
     v = pos.side_to_move() == WHITE ? v : -v;
     ss << "Final evaluation       " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)";
     ss << " [with scaled NNUE, ...]";

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -25,6 +25,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <memory>
 
 #include "nnue/network.h"
 #include "nnue/nnue_misc.h"

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -40,12 +40,17 @@ constexpr inline int SmallNetThreshold = 1274, PsqtOnlyThreshold = 2389;
 
 namespace NNUE {
 struct Networks;
+struct AccumulatorRefreshEntry;
+using AccumulatorCache = std::array<AccumulatorRefreshEntry, SQUARE_NB>;
 }
 
 std::string trace(Position& pos, const Eval::NNUE::Networks& networks);
 
 int   simple_eval(const Position& pos, Color c);
-Value evaluate(const NNUE::Networks& networks, const Position& pos, int optimism);
+Value evaluate(const NNUE::Networks&         networks,
+               const Position&               pos,
+               Eval::NNUE::AccumulatorCache& cache,
+               int                           optimism);
 
 
 }  // namespace Eval

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -21,7 +21,6 @@
 
 #include <string>
 
-#include "nnue/nnue_accumulator.h"
 #include "types.h"
 
 namespace Stockfish {
@@ -41,6 +40,7 @@ constexpr inline int SmallNetThreshold = 1274, PsqtOnlyThreshold = 2389;
 
 namespace NNUE {
 struct Networks;
+struct AccumulatorCaches;
 }
 
 std::string trace(Position& pos, const Eval::NNUE::Networks& networks);

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -48,7 +48,7 @@ std::string trace(Position& pos, const Eval::NNUE::Networks& networks);
 int   simple_eval(const Position& pos, Color c);
 Value evaluate(const NNUE::Networks&          networks,
                const Position&                pos,
-               Eval::NNUE::AccumulatorCaches& cache,
+               Eval::NNUE::AccumulatorCaches& caches,
                int                            optimism);
 }  // namespace Eval
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -46,10 +46,10 @@ struct Networks;
 std::string trace(Position& pos, const Eval::NNUE::Networks& networks);
 
 int   simple_eval(const Position& pos, Color c);
-Value evaluate(const NNUE::Networks&         networks,
-               const Position&               pos,
-               Eval::NNUE::AccumulatorCache& cache,
-               int                           optimism);
+Value evaluate(const NNUE::Networks&          networks,
+               const Position&                pos,
+               Eval::NNUE::AccumulatorCaches& cache,
+               int                            optimism);
 }  // namespace Eval
 
 }  // namespace Stockfish

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -20,7 +20,9 @@
 #define EVALUATE_H_INCLUDED
 
 #include <string>
+#include <array>
 
+#include "nnue/nnue_accumulator.h"
 #include "types.h"
 
 namespace Stockfish {
@@ -40,8 +42,6 @@ constexpr inline int SmallNetThreshold = 1274, PsqtOnlyThreshold = 2389;
 
 namespace NNUE {
 struct Networks;
-struct AccumulatorRefreshEntry;
-using AccumulatorCache = std::array<AccumulatorRefreshEntry, SQUARE_NB>;
 }
 
 std::string trace(Position& pos, const Eval::NNUE::Networks& networks);

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -20,7 +20,6 @@
 #define EVALUATE_H_INCLUDED
 
 #include <string>
-#include <array>
 
 #include "nnue/nnue_accumulator.h"
 #include "types.h"
@@ -51,8 +50,6 @@ Value evaluate(const NNUE::Networks&         networks,
                const Position&               pos,
                Eval::NNUE::AccumulatorCache& cache,
                int                           optimism);
-
-
 }  // namespace Eval
 
 }  // namespace Stockfish

--- a/src/nnue/features/half_ka_v2_hm.cpp
+++ b/src/nnue/features/half_ka_v2_hm.cpp
@@ -49,6 +49,8 @@ void HalfKAv2_hm::append_active_indices(const Position& pos, IndexList& active) 
 // Explicit template instantiations
 template void HalfKAv2_hm::append_active_indices<WHITE>(const Position& pos, IndexList& active);
 template void HalfKAv2_hm::append_active_indices<BLACK>(const Position& pos, IndexList& active);
+template IndexType HalfKAv2_hm::make_index<WHITE>(Square s, Piece pc, Square ksq);
+template IndexType HalfKAv2_hm::make_index<BLACK>(Square s, Piece pc, Square ksq);
 
 // Get a list of indices for recently changed features
 template<Color Perspective>

--- a/src/nnue/features/half_ka_v2_hm.cpp
+++ b/src/nnue/features/half_ka_v2_hm.cpp
@@ -23,7 +23,7 @@
 #include "../../bitboard.h"
 #include "../../position.h"
 #include "../../types.h"
-#include "../nnue_common.h"
+#include "../nnue_accumulator.h"
 
 namespace Stockfish::Eval::NNUE::Features {
 

--- a/src/nnue/features/half_ka_v2_hm.h
+++ b/src/nnue/features/half_ka_v2_hm.h
@@ -63,10 +63,6 @@ class HalfKAv2_hm {
       {PS_NONE, PS_B_PAWN, PS_B_KNIGHT, PS_B_BISHOP, PS_B_ROOK, PS_B_QUEEN, PS_KING, PS_NONE,
        PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_KING, PS_NONE}};
 
-    // Index of a feature for a given king position and another piece on some square
-    template<Color Perspective>
-    static IndexType make_index(Square s, Piece pc, Square ksq);
-
    public:
     // Feature name
     static constexpr const char* Name = "HalfKAv2_hm(Friend)";
@@ -125,6 +121,10 @@ class HalfKAv2_hm {
     // Maximum number of simultaneously active features.
     static constexpr IndexType MaxActiveDimensions = 32;
     using IndexList                                = ValueList<IndexType, MaxActiveDimensions>;
+
+    // Index of a feature for a given king position and another piece on some square
+    template<Color Perspective>
+    static IndexType make_index(Square s, Piece pc, Square ksq);
 
     // Get a list of indices for active features
     template<Color Perspective>

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -187,11 +187,11 @@ bool Network<Arch, Transformer>::save(const std::optional<std::string>& filename
 
 template<typename Arch, typename Transformer>
 Value Network<Arch, Transformer>::evaluate(
-  const Position&                                        pos,
-  AccumulatorCaches::Cache<Transformer::HalfDimensions>& cache,
-  bool                                                   adjusted,
-  int*                                                   complexity,
-  bool                                                   psqtOnly) const {
+  const Position&                                            pos,
+  AccumulatorCaches::CacheType<Transformer::HalfDimensions>& cache,
+  bool                                                       adjusted,
+  int*                                                       complexity,
+  bool                                                       psqtOnly) const {
     // We manually align the arrays on the stack because with gcc < 9.3
     // overaligning stack variables with alignas() doesn't work correctly.
 
@@ -259,15 +259,15 @@ void Network<Arch, Transformer>::verify(std::string evalfilePath) const {
 
 template<typename Arch, typename Transformer>
 void Network<Arch, Transformer>::hint_common_access(
-  const Position&                                        pos,
-  AccumulatorCaches::Cache<Transformer::HalfDimensions>& cache,
-  bool                                                   psqtOnl) const {
+  const Position&                                            pos,
+  AccumulatorCaches::CacheType<Transformer::HalfDimensions>& cache,
+  bool                                                       psqtOnl) const {
     featureTransformer->hint_common_access(pos, cache, psqtOnl);
 }
 
 template<typename Arch, typename Transformer>
 NnueEvalTrace Network<Arch, Transformer>::trace_evaluate(
-  const Position& pos, AccumulatorCaches::Cache<Transformer::HalfDimensions>& entry) const {
+  const Position& pos, AccumulatorCaches::CacheType<Transformer::HalfDimensions>& entry) const {
     // We manually align the arrays on the stack because with gcc < 9.3
     // overaligning stack variables with alignas() doesn't work correctly.
     constexpr uint64_t alignment = CacheLineSize;

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -264,12 +264,6 @@ void Network<Arch, Transformer>::hint_common_access(const Position&   pos,
 }
 
 template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::init_refresh_entry(AccumulatorRefreshEntry& entry) const {
-    featureTransformer->init_refresh_entry(entry);
-}
-
-
-template<typename Arch, typename Transformer>
 NnueEvalTrace Network<Arch, Transformer>::trace_evaluate(const Position&   pos,
                                                          AccumulatorCache& entry) const {
     // We manually align the arrays on the stack because with gcc < 9.3

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -186,12 +186,11 @@ bool Network<Arch, Transformer>::save(const std::optional<std::string>& filename
 
 
 template<typename Arch, typename Transformer>
-Value Network<Arch, Transformer>::evaluate(
-  const Position&                                        pos,
-  AccumulatorCaches::Cache<Transformer::HalfDimensions>* cache,
-  bool                                                   adjusted,
-  int*                                                   complexity,
-  bool                                                   psqtOnly) const {
+Value Network<Arch, Transformer>::evaluate(const Position&                         pos,
+                                           AccumulatorCaches::Cache<FTDimensions>* cache,
+                                           bool                                    adjusted,
+                                           int*                                    complexity,
+                                           bool                                    psqtOnly) const {
     // We manually align the arrays on the stack because with gcc < 9.3
     // overaligning stack variables with alignas() doesn't work correctly.
 
@@ -199,14 +198,14 @@ Value Network<Arch, Transformer>::evaluate(
     constexpr int      delta     = 24;
 
 #if defined(ALIGNAS_ON_STACK_VARIABLES_BROKEN)
-    TransformedFeatureType transformedFeaturesUnaligned
-      [FeatureTransformer<Arch::TransformedFeatureDimensions, nullptr>::BufferSize
-       + alignment / sizeof(TransformedFeatureType)];
+    TransformedFeatureType
+      transformedFeaturesUnaligned[FeatureTransformer<FTDimensions, nullptr>::BufferSize
+                                   + alignment / sizeof(TransformedFeatureType)];
 
     auto* transformedFeatures = align_ptr_up<alignment>(&transformedFeaturesUnaligned[0]);
 #else
-    alignas(alignment) TransformedFeatureType transformedFeatures
-      [FeatureTransformer<Arch::TransformedFeatureDimensions, nullptr>::BufferSize];
+    alignas(alignment) TransformedFeatureType
+      transformedFeatures[FeatureTransformer<FTDimensions, nullptr>::BufferSize];
 #endif
 
     ASSERT_ALIGNED(transformedFeatures, alignment);
@@ -258,29 +257,29 @@ void Network<Arch, Transformer>::verify(std::string evalfilePath) const {
 
 
 template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::hint_common_access(
-  const Position&                                        pos,
-  AccumulatorCaches::Cache<Transformer::HalfDimensions>* cache,
-  bool                                                   psqtOnl) const {
+void Network<Arch, Transformer>::hint_common_access(const Position&                         pos,
+                                                    AccumulatorCaches::Cache<FTDimensions>* cache,
+                                                    bool psqtOnl) const {
     featureTransformer->hint_common_access(pos, cache, psqtOnl);
 }
 
 template<typename Arch, typename Transformer>
-NnueEvalTrace Network<Arch, Transformer>::trace_evaluate(
-  const Position& pos, AccumulatorCaches::Cache<Transformer::HalfDimensions>* cache) const {
+NnueEvalTrace
+Network<Arch, Transformer>::trace_evaluate(const Position&                         pos,
+                                           AccumulatorCaches::Cache<FTDimensions>* cache) const {
     // We manually align the arrays on the stack because with gcc < 9.3
     // overaligning stack variables with alignas() doesn't work correctly.
     constexpr uint64_t alignment = CacheLineSize;
 
 #if defined(ALIGNAS_ON_STACK_VARIABLES_BROKEN)
-    TransformedFeatureType transformedFeaturesUnaligned
-      [FeatureTransformer<Arch::TransformedFeatureDimensions, nullptr>::BufferSize
-       + alignment / sizeof(TransformedFeatureType)];
+    TransformedFeatureType
+      transformedFeaturesUnaligned[FeatureTransformer<FTDimensions, nullptr>::BufferSize
+                                   + alignment / sizeof(TransformedFeatureType)];
 
     auto* transformedFeatures = align_ptr_up<alignment>(&transformedFeaturesUnaligned[0]);
 #else
-    alignas(alignment) TransformedFeatureType transformedFeatures
-      [FeatureTransformer<Arch::TransformedFeatureDimensions, nullptr>::BufferSize];
+    alignas(alignment) TransformedFeatureType
+      transformedFeatures[FeatureTransformer<FTDimensions, nullptr>::BufferSize];
 #endif
 
     ASSERT_ALIGNED(transformedFeatures, alignment);

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -186,11 +186,11 @@ bool Network<Arch, Transformer>::save(const std::optional<std::string>& filename
 
 
 template<typename Arch, typename Transformer>
-Value Network<Arch, Transformer>::evaluate(const Position&   pos,
-                                           AccumulatorCache& cache,
-                                           bool              adjusted,
-                                           int*              complexity,
-                                           bool              psqtOnly) const {
+Value Network<Arch, Transformer>::evaluate(const Position&    pos,
+                                           AccumulatorCaches& cache,
+                                           bool               adjusted,
+                                           int*               complexity,
+                                           bool               psqtOnly) const {
     // We manually align the arrays on the stack because with gcc < 9.3
     // overaligning stack variables with alignas() doesn't work correctly.
 
@@ -257,15 +257,15 @@ void Network<Arch, Transformer>::verify(std::string evalfilePath) const {
 
 
 template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::hint_common_access(const Position&   pos,
-                                                    AccumulatorCache& cache,
-                                                    bool              psqtOnl) const {
+void Network<Arch, Transformer>::hint_common_access(const Position&    pos,
+                                                    AccumulatorCaches& cache,
+                                                    bool               psqtOnl) const {
     featureTransformer->hint_common_access(pos, cache, psqtOnl);
 }
 
 template<typename Arch, typename Transformer>
-NnueEvalTrace Network<Arch, Transformer>::trace_evaluate(const Position&   pos,
-                                                         AccumulatorCache& entry) const {
+NnueEvalTrace Network<Arch, Transformer>::trace_evaluate(const Position&    pos,
+                                                         AccumulatorCaches& entry) const {
     // We manually align the arrays on the stack because with gcc < 9.3
     // overaligning stack variables with alignas() doesn't work correctly.
     constexpr uint64_t alignment = CacheLineSize;

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -186,11 +186,12 @@ bool Network<Arch, Transformer>::save(const std::optional<std::string>& filename
 
 
 template<typename Arch, typename Transformer>
-Value Network<Arch, Transformer>::evaluate(const Position&    pos,
-                                           AccumulatorCaches& cache,
-                                           bool               adjusted,
-                                           int*               complexity,
-                                           bool               psqtOnly) const {
+Value Network<Arch, Transformer>::evaluate(
+  const Position&                                        pos,
+  AccumulatorCaches::Cache<Transformer::HalfDimensions>& cache,
+  bool                                                   adjusted,
+  int*                                                   complexity,
+  bool                                                   psqtOnly) const {
     // We manually align the arrays on the stack because with gcc < 9.3
     // overaligning stack variables with alignas() doesn't work correctly.
 
@@ -257,15 +258,16 @@ void Network<Arch, Transformer>::verify(std::string evalfilePath) const {
 
 
 template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::hint_common_access(const Position&    pos,
-                                                    AccumulatorCaches& cache,
-                                                    bool               psqtOnl) const {
+void Network<Arch, Transformer>::hint_common_access(
+  const Position&                                        pos,
+  AccumulatorCaches::Cache<Transformer::HalfDimensions>& cache,
+  bool                                                   psqtOnl) const {
     featureTransformer->hint_common_access(pos, cache, psqtOnl);
 }
 
 template<typename Arch, typename Transformer>
-NnueEvalTrace Network<Arch, Transformer>::trace_evaluate(const Position&    pos,
-                                                         AccumulatorCaches& entry) const {
+NnueEvalTrace Network<Arch, Transformer>::trace_evaluate(
+  const Position& pos, AccumulatorCaches::Cache<Transformer::HalfDimensions>& entry) const {
     // We manually align the arrays on the stack because with gcc < 9.3
     // overaligning stack variables with alignas() doesn't work correctly.
     constexpr uint64_t alignment = CacheLineSize;

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -259,6 +259,11 @@ void Network<Arch, Transformer>::hint_common_access(const Position& pos, bool ps
     featureTransformer->hint_common_access(pos, psqtOnl);
 }
 
+template<typename Arch, typename Transformer>
+void Network<Arch, Transformer>::init_refresh_entry(AccumulatorRefreshEntry& entry) const {
+    featureTransformer->init_refresh_entry(entry);
+}
+
 
 template<typename Arch, typename Transformer>
 NnueEvalTrace Network<Arch, Transformer>::trace_evaluate(const Position& pos) const {

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -187,11 +187,11 @@ bool Network<Arch, Transformer>::save(const std::optional<std::string>& filename
 
 template<typename Arch, typename Transformer>
 Value Network<Arch, Transformer>::evaluate(
-  const Position&                                            pos,
-  AccumulatorCaches::CacheType<Transformer::HalfDimensions>& cache,
-  bool                                                       adjusted,
-  int*                                                       complexity,
-  bool                                                       psqtOnly) const {
+  const Position&                                        pos,
+  AccumulatorCaches::Cache<Transformer::HalfDimensions>* cache,
+  bool                                                   adjusted,
+  int*                                                   complexity,
+  bool                                                   psqtOnly) const {
     // We manually align the arrays on the stack because with gcc < 9.3
     // overaligning stack variables with alignas() doesn't work correctly.
 
@@ -259,15 +259,15 @@ void Network<Arch, Transformer>::verify(std::string evalfilePath) const {
 
 template<typename Arch, typename Transformer>
 void Network<Arch, Transformer>::hint_common_access(
-  const Position&                                            pos,
-  AccumulatorCaches::CacheType<Transformer::HalfDimensions>& cache,
-  bool                                                       psqtOnl) const {
+  const Position&                                        pos,
+  AccumulatorCaches::Cache<Transformer::HalfDimensions>* cache,
+  bool                                                   psqtOnl) const {
     featureTransformer->hint_common_access(pos, cache, psqtOnl);
 }
 
 template<typename Arch, typename Transformer>
 NnueEvalTrace Network<Arch, Transformer>::trace_evaluate(
-  const Position& pos, AccumulatorCaches::CacheType<Transformer::HalfDimensions>& entry) const {
+  const Position& pos, AccumulatorCaches::Cache<Transformer::HalfDimensions>* cache) const {
     // We manually align the arrays on the stack because with gcc < 9.3
     // overaligning stack variables with alignas() doesn't work correctly.
     constexpr uint64_t alignment = CacheLineSize;
@@ -290,7 +290,7 @@ NnueEvalTrace Network<Arch, Transformer>::trace_evaluate(
     for (IndexType bucket = 0; bucket < LayerStacks; ++bucket)
     {
         const auto materialist =
-          featureTransformer->transform(pos, entry, transformedFeatures, bucket, false);
+          featureTransformer->transform(pos, cache, transformedFeatures, bucket, false);
         const auto positional = network[bucket]->propagate(transformedFeatures);
 
         t.psqt[bucket]       = static_cast<Value>(materialist / OutputScale);

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -60,8 +60,6 @@ class Network {
 
     void hint_common_access(const Position& pos, AccumulatorCache& cache, bool psqtOnl) const;
 
-    void init_refresh_entry(AccumulatorRefreshEntry& entry) const;
-
     void          verify(std::string evalfilePath) const;
     NnueEvalTrace trace_evaluate(const Position& pos, AccumulatorCache& entry) const;
 
@@ -91,6 +89,8 @@ class Network {
 
     // Hash value of evaluation function structure
     static constexpr std::uint32_t hash = Transformer::get_hash_value() ^ Arch::get_hash_value();
+
+    friend struct AccumulatorCache;
 };
 
 // Definitions of the network types

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -51,21 +51,21 @@ class Network {
     void load(const std::string& rootDirectory, std::string evalfilePath);
     bool save(const std::optional<std::string>& filename) const;
 
-    Value evaluate(const Position&                                        pos,
-                   AccumulatorCaches::Cache<Transformer::HalfDimensions>& cache,
-                   bool                                                   adjusted   = false,
-                   int*                                                   complexity = nullptr,
-                   bool                                                   psqtOnly   = false) const;
+    Value evaluate(const Position&                                            pos,
+                   AccumulatorCaches::CacheType<Transformer::HalfDimensions>& cache,
+                   bool                                                       adjusted   = false,
+                   int*                                                       complexity = nullptr,
+                   bool psqtOnly = false) const;
 
 
-    void hint_common_access(const Position&                                        pos,
-                            AccumulatorCaches::Cache<Transformer::HalfDimensions>& cache,
-                            bool                                                   psqtOnl) const;
+    void hint_common_access(const Position&                                            pos,
+                            AccumulatorCaches::CacheType<Transformer::HalfDimensions>& cache,
+                            bool psqtOnl) const;
 
     void verify(std::string evalfilePath) const;
     NnueEvalTrace
-    trace_evaluate(const Position&                                        pos,
-                   AccumulatorCaches::Cache<Transformer::HalfDimensions>& entry) const;
+    trace_evaluate(const Position&                                            pos,
+                   AccumulatorCaches::CacheType<Transformer::HalfDimensions>& entry) const;
 
    private:
     void load_user_net(const std::string&, const std::string&);

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -51,21 +51,21 @@ class Network {
     void load(const std::string& rootDirectory, std::string evalfilePath);
     bool save(const std::optional<std::string>& filename) const;
 
-    Value evaluate(const Position&                                            pos,
-                   AccumulatorCaches::CacheType<Transformer::HalfDimensions>& cache,
-                   bool                                                       adjusted   = false,
-                   int*                                                       complexity = nullptr,
-                   bool psqtOnly = false) const;
+    Value evaluate(const Position&                                        pos,
+                   AccumulatorCaches::Cache<Transformer::HalfDimensions>* cache,
+                   bool                                                   adjusted   = false,
+                   int*                                                   complexity = nullptr,
+                   bool                                                   psqtOnly   = false) const;
 
 
-    void hint_common_access(const Position&                                            pos,
-                            AccumulatorCaches::CacheType<Transformer::HalfDimensions>& cache,
-                            bool psqtOnl) const;
+    void hint_common_access(const Position&                                        pos,
+                            AccumulatorCaches::Cache<Transformer::HalfDimensions>* cache,
+                            bool                                                   psqtOnl) const;
 
     void verify(std::string evalfilePath) const;
     NnueEvalTrace
-    trace_evaluate(const Position&                                            pos,
-                   AccumulatorCaches::CacheType<Transformer::HalfDimensions>& entry) const;
+    trace_evaluate(const Position&                                        pos,
+                   AccumulatorCaches::Cache<Transformer::HalfDimensions>* cache) const;
 
    private:
     void load_user_net(const std::string&, const std::string&);

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -43,6 +43,8 @@ enum class EmbeddedNNUEType {
 
 template<typename Arch, typename Transformer>
 class Network {
+    static constexpr IndexType FTDimensions = Arch::TransformedFeatureDimensions;
+
    public:
     Network(EvalFile file, EmbeddedNNUEType type) :
         evalFile(file),
@@ -51,21 +53,20 @@ class Network {
     void load(const std::string& rootDirectory, std::string evalfilePath);
     bool save(const std::optional<std::string>& filename) const;
 
-    Value evaluate(const Position&                                        pos,
-                   AccumulatorCaches::Cache<Transformer::HalfDimensions>* cache,
-                   bool                                                   adjusted   = false,
-                   int*                                                   complexity = nullptr,
-                   bool                                                   psqtOnly   = false) const;
+    Value evaluate(const Position&                         pos,
+                   AccumulatorCaches::Cache<FTDimensions>* cache,
+                   bool                                    adjusted   = false,
+                   int*                                    complexity = nullptr,
+                   bool                                    psqtOnly   = false) const;
 
 
-    void hint_common_access(const Position&                                        pos,
-                            AccumulatorCaches::Cache<Transformer::HalfDimensions>* cache,
-                            bool                                                   psqtOnl) const;
+    void hint_common_access(const Position&                         pos,
+                            AccumulatorCaches::Cache<FTDimensions>* cache,
+                            bool                                    psqtOnl) const;
 
-    void verify(std::string evalfilePath) const;
-    NnueEvalTrace
-    trace_evaluate(const Position&                                        pos,
-                   AccumulatorCaches::Cache<Transformer::HalfDimensions>* cache) const;
+    void          verify(std::string evalfilePath) const;
+    NnueEvalTrace trace_evaluate(const Position&                         pos,
+                                 AccumulatorCaches::Cache<FTDimensions>* cache) const;
 
    private:
     void load_user_net(const std::string&, const std::string&);

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -34,6 +34,7 @@
 
 namespace Stockfish::Eval::NNUE {
 
+struct AccumulatorRefreshEntry;
 
 enum class EmbeddedNNUEType {
     BIG,
@@ -51,7 +52,6 @@ class Network {
     void load(const std::string& rootDirectory, std::string evalfilePath);
     bool save(const std::optional<std::string>& filename) const;
 
-
     Value evaluate(const Position& pos,
                    bool            adjusted   = false,
                    int*            complexity = nullptr,
@@ -59,6 +59,8 @@ class Network {
 
 
     void hint_common_access(const Position& pos, bool psqtOnl) const;
+
+    void init_refresh_entry(AccumulatorRefreshEntry& entry) const;
 
     void          verify(std::string evalfilePath) const;
     NnueEvalTrace trace_evaluate(const Position& pos) const;

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -31,10 +31,9 @@
 #include "nnue_architecture.h"
 #include "nnue_feature_transformer.h"
 #include "nnue_misc.h"
+#include "nnue_accumulator.h"
 
 namespace Stockfish::Eval::NNUE {
-
-struct AccumulatorRefreshEntry;
 
 enum class EmbeddedNNUEType {
     BIG,

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -51,17 +51,17 @@ class Network {
     void load(const std::string& rootDirectory, std::string evalfilePath);
     bool save(const std::optional<std::string>& filename) const;
 
-    Value evaluate(const Position&   pos,
-                   AccumulatorCache& cache,
-                   bool              adjusted   = false,
-                   int*              complexity = nullptr,
-                   bool              psqtOnly   = false) const;
+    Value evaluate(const Position&    pos,
+                   AccumulatorCaches& cache,
+                   bool               adjusted   = false,
+                   int*               complexity = nullptr,
+                   bool               psqtOnly   = false) const;
 
 
-    void hint_common_access(const Position& pos, AccumulatorCache& cache, bool psqtOnl) const;
+    void hint_common_access(const Position& pos, AccumulatorCaches& cache, bool psqtOnl) const;
 
     void          verify(std::string evalfilePath) const;
-    NnueEvalTrace trace_evaluate(const Position& pos, AccumulatorCache& entry) const;
+    NnueEvalTrace trace_evaluate(const Position& pos, AccumulatorCaches& entry) const;
 
    private:
     void load_user_net(const std::string&, const std::string&);
@@ -90,7 +90,8 @@ class Network {
     // Hash value of evaluation function structure
     static constexpr std::uint32_t hash = Transformer::get_hash_value() ^ Arch::get_hash_value();
 
-    friend struct AccumulatorCache;
+    template<IndexType Size>
+    friend struct AccumulatorCaches::Cache;
 };
 
 // Definitions of the network types

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -51,17 +51,21 @@ class Network {
     void load(const std::string& rootDirectory, std::string evalfilePath);
     bool save(const std::optional<std::string>& filename) const;
 
-    Value evaluate(const Position&    pos,
-                   AccumulatorCaches& cache,
-                   bool               adjusted   = false,
-                   int*               complexity = nullptr,
-                   bool               psqtOnly   = false) const;
+    Value evaluate(const Position&                                        pos,
+                   AccumulatorCaches::Cache<Transformer::HalfDimensions>& cache,
+                   bool                                                   adjusted   = false,
+                   int*                                                   complexity = nullptr,
+                   bool                                                   psqtOnly   = false) const;
 
 
-    void hint_common_access(const Position& pos, AccumulatorCaches& cache, bool psqtOnl) const;
+    void hint_common_access(const Position&                                        pos,
+                            AccumulatorCaches::Cache<Transformer::HalfDimensions>& cache,
+                            bool                                                   psqtOnl) const;
 
-    void          verify(std::string evalfilePath) const;
-    NnueEvalTrace trace_evaluate(const Position& pos, AccumulatorCaches& entry) const;
+    void verify(std::string evalfilePath) const;
+    NnueEvalTrace
+    trace_evaluate(const Position&                                        pos,
+                   AccumulatorCaches::Cache<Transformer::HalfDimensions>& entry) const;
 
    private:
     void load_user_net(const std::string&, const std::string&);

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -52,18 +52,19 @@ class Network {
     void load(const std::string& rootDirectory, std::string evalfilePath);
     bool save(const std::optional<std::string>& filename) const;
 
-    Value evaluate(const Position& pos,
-                   bool            adjusted   = false,
-                   int*            complexity = nullptr,
-                   bool            psqtOnly   = false) const;
+    Value evaluate(const Position&   pos,
+                   AccumulatorCache& cache,
+                   bool              adjusted   = false,
+                   int*              complexity = nullptr,
+                   bool              psqtOnly   = false) const;
 
 
-    void hint_common_access(const Position& pos, bool psqtOnl) const;
+    void hint_common_access(const Position& pos, AccumulatorCache& cache, bool psqtOnl) const;
 
     void init_refresh_entry(AccumulatorRefreshEntry& entry) const;
 
     void          verify(std::string evalfilePath) const;
-    NnueEvalTrace trace_evaluate(const Position& pos) const;
+    NnueEvalTrace trace_evaluate(const Position& pos, AccumulatorCache& entry) const;
 
    private:
     void load_user_net(const std::string&, const std::string&);

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -38,8 +38,8 @@ struct alignas(CacheLineSize) Accumulator {
 };
 
 struct AccumulatorRefreshEntry {
-    Bitboard                                     byColorBB[2][2];
-    Bitboard                                     byTypeBB[2][8];
+    Bitboard                                     byColorBB[COLOR_NB][COLOR_NB];
+    Bitboard                                     byTypeBB[COLOR_NB][PIECE_TYPE_NB];
     Accumulator<TransformedFeatureDimensionsBig> acc;
 };
 

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -42,6 +42,13 @@ struct alignas(CacheLineSize) Accumulator {
     bool         computedPSQT[2];
 };
 
+
+// AccumulatorCaches struct provides per-thread accumulator caches, where each
+// cache contains multiple entries for each of the possible king squares.
+// When the accumulator needs to be refreshed, the cached entry is used to more
+// efficiently update the accumulator, instead of rebuilding it from scratch.
+// This idea, was first described by Luecx (author of Koivisto) and
+// is commonly referred to as "Finny Tables".
 struct AccumulatorCaches {
 
     template<IndexType Size>
@@ -79,7 +86,6 @@ struct AccumulatorCaches {
         }
 
         Entry& operator[](Square sq) { return entries[sq]; }
-        Entry& operator[](int sq) { return entries[sq]; }
 
         std::array<Entry, SQUARE_NB> entries;
     };

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -56,8 +56,8 @@ struct AccumulatorCaches {
             // so we put the biases in the accumulation, without any weights on top
             void clear(const BiasType* biases) {
 
-                std::memset(byColorBB, 0, 2 * 2 * sizeof(Bitboard));
-                std::memset(byTypeBB, 0, 2 * 8 * sizeof(Bitboard));
+                std::memset(byColorBB, 0, sizeof(byColorBB));
+                std::memset(byTypeBB, 0, sizeof(byTypeBB));
 
                 std::memcpy(accumulation[WHITE], biases,
                             TransformedFeatureDimensionsBig * sizeof(BiasType));

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -89,6 +89,8 @@ struct AccumulatorCaches {
         big.clear(networks.big);
     }
 
+    // When adding a new cache for a network, i.e. the smallnet
+    // the appropriate condition must be added to FeatureTransformer::update_accumulator_refresh.
     Cache<TransformedFeatureDimensionsBig> big;
 };
 

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -44,18 +44,6 @@ struct alignas(CacheLineSize) Accumulator {
 
 struct AccumulatorCaches {
 
-    enum Initializer {
-        INIT_SMALL = 1,
-        INIT_BIG   = 2,
-    };
-
-    explicit AccumulatorCaches(Initializer init = Initializer(INIT_BIG)) {
-        if (init & INIT_SMALL)
-            small.emplace();
-        if (init & INIT_BIG)
-            big.emplace();
-    }
-
     template<IndexType Size>
     struct alignas(CacheLineSize) Cache {
 
@@ -98,17 +86,10 @@ struct AccumulatorCaches {
 
     template<typename Networks>
     void clear(const Networks& networks) {
-        if (big)
-            big->clear(networks.big);
-        if (small)
-            small->clear(networks.small);
+        big.clear(networks.big);
     }
 
-    template<IndexType Size>
-    using CacheType = std::optional<Cache<Size>>;
-
-    std::optional<Cache<TransformedFeatureDimensionsBig>>   big;
-    std::optional<Cache<TransformedFeatureDimensionsSmall>> small;
+    Cache<TransformedFeatureDimensionsBig> big;
 };
 
 }  // namespace Stockfish::Eval::NNUE

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -38,10 +38,12 @@ struct alignas(CacheLineSize) Accumulator {
 };
 
 struct AccumulatorRefreshEntry {
-  Bitboard byColorBB[2][2];
-  Bitboard byTypeBB[2][8];
-  Accumulator<TransformedFeatureDimensionsBig> acc;
+    Bitboard                                     byColorBB[2][2];
+    Bitboard                                     byTypeBB[2][8];
+    Accumulator<TransformedFeatureDimensionsBig> acc;
 };
+
+using AccumulatorCache = std::array<Eval::NNUE::AccumulatorRefreshEntry, SQUARE_NB>;
 
 }  // namespace Stockfish::Eval::NNUE
 

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -37,6 +37,12 @@ struct alignas(CacheLineSize) Accumulator {
     bool         computedPSQT[2];
 };
 
+struct AccumulatorRefreshEntry {
+  Bitboard byColorBB[2][2];
+  Bitboard byTypeBB[2][8];
+  Accumulator<TransformedFeatureDimensionsBig> acc;
+};
+
 }  // namespace Stockfish::Eval::NNUE
 
 #endif  // NNUE_ACCUMULATOR_H_INCLUDED

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -37,10 +37,11 @@ struct alignas(CacheLineSize) Accumulator {
     bool         computedPSQT[2];
 };
 
-struct AccumulatorRefreshEntry {
-    Bitboard                                     byColorBB[COLOR_NB][COLOR_NB];
-    Bitboard                                     byTypeBB[COLOR_NB][PIECE_TYPE_NB];
-    Accumulator<TransformedFeatureDimensionsBig> acc;
+struct alignas(CacheLineSize) AccumulatorRefreshEntry {
+    std::int16_t accumulation[2][TransformedFeatureDimensionsBig];
+    std::int32_t psqtAccumulation[2][PSQTBuckets];
+    Bitboard     byColorBB[COLOR_NB][COLOR_NB];
+    Bitboard     byTypeBB[COLOR_NB][PIECE_TYPE_NB];
 };
 
 using AccumulatorCache = std::array<Eval::NNUE::AccumulatorRefreshEntry, SQUARE_NB>;

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -39,15 +39,12 @@ struct alignas(CacheLineSize) Accumulator {
 
 
 struct alignas(CacheLineSize) AccumulatorRefreshEntry {
-    std::int16_t accumulation[2][TransformedFeatureDimensionsBig];
-    // using Acc = std::array<std::array<std::int16_t, TransformedFeatureDimensionsBig>, 2>;
-    // Acc          accumulation;
-    std::int32_t psqtAccumulation[2][PSQTBuckets];
-    Bitboard     byColorBB[COLOR_NB][COLOR_NB];
-    Bitboard     byTypeBB[COLOR_NB][PIECE_TYPE_NB];
+    BiasType       accumulation[2][TransformedFeatureDimensionsBig];
+    PSQTWeightType psqtAccumulation[2][PSQTBuckets];
+    Bitboard       byColorBB[COLOR_NB][COLOR_NB];
+    Bitboard       byTypeBB[COLOR_NB][PIECE_TYPE_NB];
 
-    // todo use BiasType
-    void clear(const std::int16_t* biases) {
+    void clear(const BiasType* biases) {
         // To initialize a refresh entry, we set all its bitboards empty,
         // so we put the biases in the accumulation, without any weights on top
 
@@ -55,9 +52,9 @@ struct alignas(CacheLineSize) AccumulatorRefreshEntry {
         std::memset(byTypeBB, 0, 2 * 8 * sizeof(Bitboard));
 
         std::memcpy(accumulation[WHITE], biases,
-                    TransformedFeatureDimensionsBig * sizeof(std::int16_t));
+                    TransformedFeatureDimensionsBig * sizeof(BiasType));
         std::memcpy(accumulation[BLACK], biases,
-                    TransformedFeatureDimensionsBig * sizeof(std::int16_t));
+                    TransformedFeatureDimensionsBig * sizeof(BiasType));
 
         std::memset(psqtAccumulation, 0, sizeof(psqtAccumulation));
     }

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -22,7 +22,6 @@
 #define NNUE_ACCUMULATOR_H_INCLUDED
 
 #include <cstdint>
-#include <optional>
 
 #include "nnue_architecture.h"
 #include "nnue_common.h"

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -35,10 +35,10 @@ using IndexType      = std::uint32_t;
 // Class that holds the result of affine transformation of input features
 template<IndexType Size>
 struct alignas(CacheLineSize) Accumulator {
-    std::int16_t accumulation[2][Size];
-    std::int32_t psqtAccumulation[2][PSQTBuckets];
-    bool         computed[2];
-    bool         computedPSQT[2];
+    std::int16_t accumulation[COLOR_NB][Size];
+    std::int32_t psqtAccumulation[COLOR_NB][PSQTBuckets];
+    bool         computed[COLOR_NB];
+    bool         computedPSQT[COLOR_NB];
 };
 
 
@@ -54,8 +54,8 @@ struct AccumulatorCaches {
     struct alignas(CacheLineSize) Cache {
 
         struct alignas(CacheLineSize) Entry {
-            BiasType       accumulation[2][Size];
-            PSQTWeightType psqtAccumulation[2][PSQTBuckets];
+            BiasType       accumulation[COLOR_NB][Size];
+            PSQTWeightType psqtAccumulation[COLOR_NB][PSQTBuckets];
             Bitboard       byColorBB[COLOR_NB][COLOR_NB];
             Bitboard       byTypeBB[COLOR_NB][PIECE_TYPE_NB];
 

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -79,7 +79,7 @@ struct AccumulatorCaches {
                 entry.clear(network.featureTransformer->biases);
         }
 
-        void clear(const std::int16_t* biases) {
+        void clear(const BiasType* biases) {
             for (auto& entry : entries)
                 entry.clear(biases);
         }

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -59,10 +59,8 @@ struct AccumulatorCaches {
                 std::memset(byColorBB, 0, sizeof(byColorBB));
                 std::memset(byTypeBB, 0, sizeof(byTypeBB));
 
-                std::memcpy(accumulation[WHITE], biases,
-                            TransformedFeatureDimensionsBig * sizeof(BiasType));
-                std::memcpy(accumulation[BLACK], biases,
-                            TransformedFeatureDimensionsBig * sizeof(BiasType));
+                std::memcpy(accumulation[WHITE], biases, Size * sizeof(BiasType));
+                std::memcpy(accumulation[BLACK], biases, Size * sizeof(BiasType));
 
                 std::memset(psqtAccumulation, 0, sizeof(psqtAccumulation));
             }
@@ -86,6 +84,8 @@ struct AccumulatorCaches {
     };
 
     Cache<TransformedFeatureDimensionsBig> big;
+
+    Cache<TransformedFeatureDimensionsSmall> small;
 };
 
 }  // namespace Stockfish::Eval::NNUE

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -194,7 +194,7 @@ static constexpr int BestRegisterCount() {
 template<IndexType                                 TransformedFeatureDimensions,
          Accumulator<TransformedFeatureDimensions> StateInfo::*accPtr>
 class FeatureTransformer {
-   public:
+
     // Number of output dimensions for one side
     static constexpr IndexType HalfDimensions = TransformedFeatureDimensions;
 

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -306,11 +306,11 @@ class FeatureTransformer {
     }
 
     // Convert input features
-    std::int32_t transform(const Position&                           pos,
-                           AccumulatorCaches::Cache<HalfDimensions>& cache,
-                           OutputType*                               output,
-                           int                                       bucket,
-                           bool                                      psqtOnly) const {
+    std::int32_t transform(const Position&                               pos,
+                           AccumulatorCaches::CacheType<HalfDimensions>& cache,
+                           OutputType*                                   output,
+                           int                                           bucket,
+                           bool                                          psqtOnly) const {
         update_accumulator<WHITE>(pos, cache, psqtOnly);
         update_accumulator<BLACK>(pos, cache, psqtOnly);
 
@@ -374,9 +374,9 @@ class FeatureTransformer {
         return psqt;
     }  // end of function transform()
 
-    void hint_common_access(const Position&                           pos,
-                            AccumulatorCaches::Cache<HalfDimensions>& cache,
-                            bool                                      psqtOnly) const {
+    void hint_common_access(const Position&                               pos,
+                            AccumulatorCaches::CacheType<HalfDimensions>& cache,
+                            bool                                          psqtOnly) const {
         hint_common_access_for_perspective<WHITE>(pos, cache, psqtOnly);
         hint_common_access_for_perspective<BLACK>(pos, cache, psqtOnly);
     }
@@ -655,13 +655,13 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void update_accumulator_refresh_cache(const Position&                           pos,
-                                          AccumulatorCaches::Cache<HalfDimensions>& cache) const {
+    void
+    update_accumulator_refresh_cache(const Position&                               pos,
+                                     AccumulatorCaches::CacheType<HalfDimensions>& cache) const {
 
-        // assert(HalfDimensions == TransformedFeatureDimensionsBig);
+        Square ksq = pos.square<KING>(Perspective);
 
-        Square ksq   = pos.square<KING>(Perspective);
-        auto&  entry = cache[ksq];
+        auto& entry = (*cache)[ksq];
 
         auto& accumulator                     = pos.state()->*accPtr;
         accumulator.computed[Perspective]     = true;
@@ -796,17 +796,18 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void update_accumulator_refresh(const Position&                           pos,
-                                    AccumulatorCaches::Cache<HalfDimensions>& cache,
-                                    bool                                      psqtOnly) const {
+    void update_accumulator_refresh(const Position&                               pos,
+                                    AccumulatorCaches::CacheType<HalfDimensions>& cache,
+                                    bool                                          psqtOnly) const {
 
         // When we are refreshing the accumulator of the big net,
-        // redirect to the version of refresh that uses the refresh table
-        // if (HalfDimensions == Eval::NNUE::TransformedFeatureDimensionsBig)
-        // {
-        update_accumulator_refresh_cache<Perspective>(pos, cache);
-        return;
-        // }
+        // redirect to the version of refresh that uses the refresh table.
+        // Using the cache for the small net is not beneficial.
+        if (HalfDimensions == Eval::NNUE::TransformedFeatureDimensionsBig)
+        {
+            update_accumulator_refresh_cache<Perspective>(pos, cache);
+            return;
+        }
 
 #ifdef VECTOR
         // Gcc-10.2 unnecessarily spills AVX2 registers if this array
@@ -921,8 +922,8 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void hint_common_access_for_perspective(const Position&                           pos,
-                                            AccumulatorCaches::Cache<HalfDimensions>& cache,
+    void hint_common_access_for_perspective(const Position&                               pos,
+                                            AccumulatorCaches::CacheType<HalfDimensions>& cache,
                                             bool psqtOnly) const {
 
         // Works like update_accumulator, but performs less work.
@@ -950,9 +951,9 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void update_accumulator(const Position&                           pos,
-                            AccumulatorCaches::Cache<HalfDimensions>& cache,
-                            bool                                      psqtOnly) const {
+    void update_accumulator(const Position&                               pos,
+                            AccumulatorCaches::CacheType<HalfDimensions>& cache,
+                            bool                                          psqtOnly) const {
 
         auto [oldest_st, next] = try_find_computed_accumulator<Perspective>(pos, psqtOnly);
 

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -802,7 +802,7 @@ class FeatureTransformer {
         // When we are refreshing the accumulator of the big net,
         // redirect to the version of refresh that uses the refresh table.
         // Using the cache for the small net is not beneficial.
-        if (HalfDimensions == Eval::NNUE::TransformedFeatureDimensionsBig)
+        if constexpr (HalfDimensions == Eval::NNUE::TransformedFeatureDimensionsBig)
         {
             update_accumulator_refresh_cache<Perspective>(pos, cache);
             return;

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -795,9 +795,10 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void update_accumulator_refresh(const Position&                           pos,
-                                    AccumulatorCaches::Cache<HalfDimensions>* cache,
-                                    bool                                      psqtOnly) const {
+    void
+    update_accumulator_refresh(const Position&                                            pos,
+                               [[maybe_unused]] AccumulatorCaches::Cache<HalfDimensions>* cache,
+                               bool psqtOnly) const {
 
         // When we are refreshing the accumulator of the big net,
         // redirect to the version of refresh that uses the refresh table.

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -306,11 +306,11 @@ class FeatureTransformer {
     }
 
     // Convert input features
-    std::int32_t transform(const Position&   pos,
-                           AccumulatorCache& cache,
-                           OutputType*       output,
-                           int               bucket,
-                           bool              psqtOnly) const {
+    std::int32_t transform(const Position&    pos,
+                           AccumulatorCaches& cache,
+                           OutputType*        output,
+                           int                bucket,
+                           bool               psqtOnly) const {
         update_accumulator<WHITE>(pos, cache, psqtOnly);
         update_accumulator<BLACK>(pos, cache, psqtOnly);
 
@@ -374,7 +374,7 @@ class FeatureTransformer {
         return psqt;
     }  // end of function transform()
 
-    void hint_common_access(const Position& pos, AccumulatorCache& cache, bool psqtOnly) const {
+    void hint_common_access(const Position& pos, AccumulatorCaches& cache, bool psqtOnly) const {
         hint_common_access_for_perspective<WHITE>(pos, cache, psqtOnly);
         hint_common_access_for_perspective<BLACK>(pos, cache, psqtOnly);
     }
@@ -653,12 +653,12 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void update_accumulator_refresh_cache(const Position& pos, AccumulatorCache& cache) const {
+    void update_accumulator_refresh_cache(const Position& pos, AccumulatorCaches& cache) const {
 
         assert(HalfDimensions == TransformedFeatureDimensionsBig);
 
-        Square                   ksq   = pos.square<KING>(Perspective);
-        AccumulatorRefreshEntry& entry = cache[ksq];
+        Square ksq   = pos.square<KING>(Perspective);
+        auto&  entry = cache.big[ksq];
 
         auto& accumulator                     = pos.state()->*accPtr;
         accumulator.computed[Perspective]     = true;
@@ -794,7 +794,7 @@ class FeatureTransformer {
 
     template<Color Perspective>
     void
-    update_accumulator_refresh(const Position& pos, AccumulatorCache& cache, bool psqtOnly) const {
+    update_accumulator_refresh(const Position& pos, AccumulatorCaches& cache, bool psqtOnly) const {
 
         // When we are refreshing the accumulator of the big net,
         // redirect to the version of refresh that uses the refresh table
@@ -917,9 +917,9 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void hint_common_access_for_perspective(const Position&   pos,
-                                            AccumulatorCache& cache,
-                                            bool              psqtOnly) const {
+    void hint_common_access_for_perspective(const Position&    pos,
+                                            AccumulatorCaches& cache,
+                                            bool               psqtOnly) const {
 
         // Works like update_accumulator, but performs less work.
         // Updates ONLY the accumulator for pos.
@@ -946,7 +946,7 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void update_accumulator(const Position& pos, AccumulatorCache& cache, bool psqtOnly) const {
+    void update_accumulator(const Position& pos, AccumulatorCaches& cache, bool psqtOnly) const {
 
         auto [oldest_st, next] = try_find_computed_accumulator<Perspective>(pos, psqtOnly);
 
@@ -971,7 +971,8 @@ class FeatureTransformer {
             update_accumulator_refresh<Perspective>(pos, cache, psqtOnly);
     }
 
-    friend struct AccumulatorCache;
+    template<IndexType Size>
+    friend struct AccumulatorCaches::Cache;
 
     alignas(CacheLineSize) BiasType biases[HalfDimensions];
     alignas(CacheLineSize) WeightType weights[HalfDimensions * InputDimensions];

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -306,11 +306,11 @@ class FeatureTransformer {
     }
 
     // Convert input features
-    std::int32_t transform(const Position&                               pos,
-                           AccumulatorCaches::CacheType<HalfDimensions>& cache,
-                           OutputType*                                   output,
-                           int                                           bucket,
-                           bool                                          psqtOnly) const {
+    std::int32_t transform(const Position&                           pos,
+                           AccumulatorCaches::Cache<HalfDimensions>* cache,
+                           OutputType*                               output,
+                           int                                       bucket,
+                           bool                                      psqtOnly) const {
         update_accumulator<WHITE>(pos, cache, psqtOnly);
         update_accumulator<BLACK>(pos, cache, psqtOnly);
 
@@ -374,9 +374,9 @@ class FeatureTransformer {
         return psqt;
     }  // end of function transform()
 
-    void hint_common_access(const Position&                               pos,
-                            AccumulatorCaches::CacheType<HalfDimensions>& cache,
-                            bool                                          psqtOnly) const {
+    void hint_common_access(const Position&                           pos,
+                            AccumulatorCaches::Cache<HalfDimensions>* cache,
+                            bool                                      psqtOnly) const {
         hint_common_access_for_perspective<WHITE>(pos, cache, psqtOnly);
         hint_common_access_for_perspective<BLACK>(pos, cache, psqtOnly);
     }
@@ -655,9 +655,8 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void
-    update_accumulator_refresh_cache(const Position&                               pos,
-                                     AccumulatorCaches::CacheType<HalfDimensions>& cache) const {
+    void update_accumulator_refresh_cache(const Position&                           pos,
+                                          AccumulatorCaches::Cache<HalfDimensions>* cache) const {
 
         Square ksq = pos.square<KING>(Perspective);
 
@@ -796,9 +795,9 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void update_accumulator_refresh(const Position&                               pos,
-                                    AccumulatorCaches::CacheType<HalfDimensions>& cache,
-                                    bool                                          psqtOnly) const {
+    void update_accumulator_refresh(const Position&                           pos,
+                                    AccumulatorCaches::Cache<HalfDimensions>* cache,
+                                    bool                                      psqtOnly) const {
 
         // When we are refreshing the accumulator of the big net,
         // redirect to the version of refresh that uses the refresh table.
@@ -922,8 +921,8 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void hint_common_access_for_perspective(const Position&                               pos,
-                                            AccumulatorCaches::CacheType<HalfDimensions>& cache,
+    void hint_common_access_for_perspective(const Position&                           pos,
+                                            AccumulatorCaches::Cache<HalfDimensions>* cache,
                                             bool psqtOnly) const {
 
         // Works like update_accumulator, but performs less work.
@@ -951,9 +950,9 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void update_accumulator(const Position&                               pos,
-                            AccumulatorCaches::CacheType<HalfDimensions>& cache,
-                            bool                                          psqtOnly) const {
+    void update_accumulator(const Position&                           pos,
+                            AccumulatorCaches::Cache<HalfDimensions>* cache,
+                            bool                                      psqtOnly) const {
 
         auto [oldest_st, next] = try_find_computed_accumulator<Perspective>(pos, psqtOnly);
 

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -194,11 +194,11 @@ static constexpr int BestRegisterCount() {
 template<IndexType                                 TransformedFeatureDimensions,
          Accumulator<TransformedFeatureDimensions> StateInfo::*accPtr>
 class FeatureTransformer {
-
-   private:
+   public:
     // Number of output dimensions for one side
     static constexpr IndexType HalfDimensions = TransformedFeatureDimensions;
 
+   private:
 #ifdef VECTOR
     static constexpr int NumRegs =
       BestRegisterCount<vec_t, WeightType, TransformedFeatureDimensions, NumRegistersSIMD>();
@@ -306,11 +306,11 @@ class FeatureTransformer {
     }
 
     // Convert input features
-    std::int32_t transform(const Position&    pos,
-                           AccumulatorCaches& cache,
-                           OutputType*        output,
-                           int                bucket,
-                           bool               psqtOnly) const {
+    std::int32_t transform(const Position&                           pos,
+                           AccumulatorCaches::Cache<HalfDimensions>& cache,
+                           OutputType*                               output,
+                           int                                       bucket,
+                           bool                                      psqtOnly) const {
         update_accumulator<WHITE>(pos, cache, psqtOnly);
         update_accumulator<BLACK>(pos, cache, psqtOnly);
 
@@ -374,7 +374,9 @@ class FeatureTransformer {
         return psqt;
     }  // end of function transform()
 
-    void hint_common_access(const Position& pos, AccumulatorCaches& cache, bool psqtOnly) const {
+    void hint_common_access(const Position&                           pos,
+                            AccumulatorCaches::Cache<HalfDimensions>& cache,
+                            bool                                      psqtOnly) const {
         hint_common_access_for_perspective<WHITE>(pos, cache, psqtOnly);
         hint_common_access_for_perspective<BLACK>(pos, cache, psqtOnly);
     }
@@ -653,12 +655,13 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void update_accumulator_refresh_cache(const Position& pos, AccumulatorCaches& cache) const {
+    void update_accumulator_refresh_cache(const Position&                           pos,
+                                          AccumulatorCaches::Cache<HalfDimensions>& cache) const {
 
-        assert(HalfDimensions == TransformedFeatureDimensionsBig);
+        // assert(HalfDimensions == TransformedFeatureDimensionsBig);
 
         Square ksq   = pos.square<KING>(Perspective);
-        auto&  entry = cache.big[ksq];
+        auto&  entry = cache[ksq];
 
         auto& accumulator                     = pos.state()->*accPtr;
         accumulator.computed[Perspective]     = true;
@@ -793,16 +796,17 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void
-    update_accumulator_refresh(const Position& pos, AccumulatorCaches& cache, bool psqtOnly) const {
+    void update_accumulator_refresh(const Position&                           pos,
+                                    AccumulatorCaches::Cache<HalfDimensions>& cache,
+                                    bool                                      psqtOnly) const {
 
         // When we are refreshing the accumulator of the big net,
         // redirect to the version of refresh that uses the refresh table
-        if (HalfDimensions == Eval::NNUE::TransformedFeatureDimensionsBig)
-        {
-            update_accumulator_refresh_cache<Perspective>(pos, cache);
-            return;
-        }
+        // if (HalfDimensions == Eval::NNUE::TransformedFeatureDimensionsBig)
+        // {
+        update_accumulator_refresh_cache<Perspective>(pos, cache);
+        return;
+        // }
 
 #ifdef VECTOR
         // Gcc-10.2 unnecessarily spills AVX2 registers if this array
@@ -917,9 +921,9 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void hint_common_access_for_perspective(const Position&    pos,
-                                            AccumulatorCaches& cache,
-                                            bool               psqtOnly) const {
+    void hint_common_access_for_perspective(const Position&                           pos,
+                                            AccumulatorCaches::Cache<HalfDimensions>& cache,
+                                            bool psqtOnly) const {
 
         // Works like update_accumulator, but performs less work.
         // Updates ONLY the accumulator for pos.
@@ -946,7 +950,9 @@ class FeatureTransformer {
     }
 
     template<Color Perspective>
-    void update_accumulator(const Position& pos, AccumulatorCaches& cache, bool psqtOnly) const {
+    void update_accumulator(const Position&                           pos,
+                            AccumulatorCaches::Cache<HalfDimensions>& cache,
+                            bool                                      psqtOnly) const {
 
         auto [oldest_st, next] = try_find_computed_accumulator<Perspective>(pos, psqtOnly);
 

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -657,6 +657,7 @@ class FeatureTransformer {
     template<Color Perspective>
     void update_accumulator_refresh_cache(const Position&                           pos,
                                           AccumulatorCaches::Cache<HalfDimensions>* cache) const {
+        assert(cache != nullptr);
 
         Square ksq = pos.square<KING>(Perspective);
 

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -679,7 +679,7 @@ class FeatureTransformer {
         accumulator.computedPSQT[Perspective] = true;
 
         FeatureSet::IndexList removed, added;
-        for (Color c = WHITE; c <= BLACK; c = Color(int(c) + 1))
+        for (Color c : {WHITE, BLACK})
         {
             for (PieceType pt = PAWN; pt <= KING; ++pt)
             {
@@ -801,11 +801,11 @@ class FeatureTransformer {
         std::memcpy(accumulator.accumulation[Perspective], entry.acc.accumulation[Perspective],
                     sizeof(int16_t) * HalfDimensions);
 
-        for (int i = WHITE; i <= BLACK; i++)
-            entry.byColorBB[Perspective][i] = pos.pieces(Color(i));
+        for (Color c : {WHITE, BLACK})
+            entry.byColorBB[Perspective][c] = pos.pieces(c);
 
-        for (int i = PAWN; i <= KING; i++)
-            entry.byTypeBB[Perspective][i] = pos.pieces(PieceType(i));
+        for (PieceType pt = PAWN; pt <= KING; ++pt)
+            entry.byTypeBB[Perspective][pt] = pos.pieces(pt);
     }
 
     template<Color Perspective>
@@ -816,7 +816,6 @@ class FeatureTransformer {
         // redirect to the version of refresh that uses the refresh table
         if (HalfDimensions == Eval::NNUE::TransformedFeatureDimensionsBig)
         {
-            // TODO: find a better solution than const_casting the position
             update_accumulator_refresh_cache<Perspective>(pos, cache);
             return;
         }

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -48,10 +48,9 @@ void hint_common_parent_position(const Position&    pos,
 
     int simpleEvalAbs = std::abs(simple_eval(pos, pos.side_to_move()));
     if (simpleEvalAbs > Eval::SmallNetThreshold)
-        networks.small.hint_common_access(pos, cache.small,
-                                          simpleEvalAbs > Eval::PsqtOnlyThreshold);
+        networks.small.hint_common_access(pos, nullptr, simpleEvalAbs > Eval::PsqtOnlyThreshold);
     else
-        networks.big.hint_common_access(pos, cache.big, false);
+        networks.big.hint_common_access(pos, &cache.big, false);
 }
 
 namespace {
@@ -134,7 +133,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
 
     // We estimate the value of each piece by doing a differential evaluation from
     // the current base eval, simulating the removal of the piece from its square.
-    Value base = networks.big.evaluate(pos, cache.big);
+    Value base = networks.big.evaluate(pos, &cache.big);
     base       = pos.side_to_move() == WHITE ? base : -base;
 
     for (File f = FILE_A; f <= FILE_H; ++f)
@@ -153,7 +152,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
                   st->accumulatorBig.computedPSQT[WHITE] = st->accumulatorBig.computedPSQT[BLACK] =
                     false;
 
-                Value eval = networks.big.evaluate(pos, cache.big);
+                Value eval = networks.big.evaluate(pos, &cache.big);
                 eval       = pos.side_to_move() == WHITE ? eval : -eval;
                 v          = base - eval;
 
@@ -171,7 +170,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
         ss << board[row] << '\n';
     ss << '\n';
 
-    auto t = networks.big.trace_evaluate(pos, cache.big);
+    auto t = networks.big.trace_evaluate(pos, &cache.big);
 
     ss << " NNUE network contributions "
        << (pos.side_to_move() == WHITE ? "(White to move)" : "(Black to move)") << std::endl

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -42,13 +42,15 @@ namespace Stockfish::Eval::NNUE {
 constexpr std::string_view PieceToChar(" PNBRQK  pnbrqk");
 
 
-void hint_common_parent_position(const Position& pos, const Networks& networks) {
+void hint_common_parent_position(const Position&   pos,
+                                 const Networks&   networks,
+                                 AccumulatorCache& cache) {
 
     int simpleEvalAbs = std::abs(simple_eval(pos, pos.side_to_move()));
     if (simpleEvalAbs > Eval::SmallNetThreshold)
-        networks.small.hint_common_access(pos, simpleEvalAbs > Eval::PsqtOnlyThreshold);
+        networks.small.hint_common_access(pos, cache, simpleEvalAbs > Eval::PsqtOnlyThreshold);
     else
-        networks.big.hint_common_access(pos, false);
+        networks.big.hint_common_access(pos, cache, false);
 }
 
 namespace {
@@ -104,7 +106,8 @@ void format_cp_aligned_dot(Value v, std::stringstream& stream, const Position& p
 
 // Returns a string with the value of each piece on a board,
 // and a table for (PSQT, Layers) values bucket by bucket.
-std::string trace(Position& pos, const Eval::NNUE::Networks& networks) {
+std::string
+trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::AccumulatorCache& cache) {
 
     std::stringstream ss;
 
@@ -130,7 +133,7 @@ std::string trace(Position& pos, const Eval::NNUE::Networks& networks) {
 
     // We estimate the value of each piece by doing a differential evaluation from
     // the current base eval, simulating the removal of the piece from its square.
-    Value base = networks.big.evaluate(pos);
+    Value base = networks.big.evaluate(pos, cache);
     base       = pos.side_to_move() == WHITE ? base : -base;
 
     for (File f = FILE_A; f <= FILE_H; ++f)
@@ -149,7 +152,7 @@ std::string trace(Position& pos, const Eval::NNUE::Networks& networks) {
                   st->accumulatorBig.computedPSQT[WHITE] = st->accumulatorBig.computedPSQT[BLACK] =
                     false;
 
-                Value eval = networks.big.evaluate(pos);
+                Value eval = networks.big.evaluate(pos, cache);
                 eval       = pos.side_to_move() == WHITE ? eval : -eval;
                 v          = base - eval;
 
@@ -167,7 +170,7 @@ std::string trace(Position& pos, const Eval::NNUE::Networks& networks) {
         ss << board[row] << '\n';
     ss << '\n';
 
-    auto t = networks.big.trace_evaluate(pos);
+    auto t = networks.big.trace_evaluate(pos, cache);
 
     ss << " NNUE network contributions "
        << (pos.side_to_move() == WHITE ? "(White to move)" : "(Black to move)") << std::endl

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -48,9 +48,10 @@ void hint_common_parent_position(const Position&    pos,
 
     int simpleEvalAbs = std::abs(simple_eval(pos, pos.side_to_move()));
     if (simpleEvalAbs > Eval::SmallNetThreshold)
-        networks.small.hint_common_access(pos, cache, simpleEvalAbs > Eval::PsqtOnlyThreshold);
+        networks.small.hint_common_access(pos, cache.small,
+                                          simpleEvalAbs > Eval::PsqtOnlyThreshold);
     else
-        networks.big.hint_common_access(pos, cache, false);
+        networks.big.hint_common_access(pos, cache.big, false);
 }
 
 namespace {
@@ -133,7 +134,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
 
     // We estimate the value of each piece by doing a differential evaluation from
     // the current base eval, simulating the removal of the piece from its square.
-    Value base = networks.big.evaluate(pos, cache);
+    Value base = networks.big.evaluate(pos, cache.big);
     base       = pos.side_to_move() == WHITE ? base : -base;
 
     for (File f = FILE_A; f <= FILE_H; ++f)
@@ -152,7 +153,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
                   st->accumulatorBig.computedPSQT[WHITE] = st->accumulatorBig.computedPSQT[BLACK] =
                     false;
 
-                Value eval = networks.big.evaluate(pos, cache);
+                Value eval = networks.big.evaluate(pos, cache.big);
                 eval       = pos.side_to_move() == WHITE ? eval : -eval;
                 v          = base - eval;
 
@@ -170,7 +171,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
         ss << board[row] << '\n';
     ss << '\n';
 
-    auto t = networks.big.trace_evaluate(pos, cache);
+    auto t = networks.big.trace_evaluate(pos, cache.big);
 
     ss << " NNUE network contributions "
        << (pos.side_to_move() == WHITE ? "(White to move)" : "(Black to move)") << std::endl

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -42,9 +42,9 @@ namespace Stockfish::Eval::NNUE {
 constexpr std::string_view PieceToChar(" PNBRQK  pnbrqk");
 
 
-void hint_common_parent_position(const Position&   pos,
-                                 const Networks&   networks,
-                                 AccumulatorCache& cache) {
+void hint_common_parent_position(const Position&    pos,
+                                 const Networks&    networks,
+                                 AccumulatorCaches& cache) {
 
     int simpleEvalAbs = std::abs(simple_eval(pos, pos.side_to_move()));
     if (simpleEvalAbs > Eval::SmallNetThreshold)
@@ -107,7 +107,7 @@ void format_cp_aligned_dot(Value v, std::stringstream& stream, const Position& p
 // Returns a string with the value of each piece on a board,
 // and a table for (PSQT, Layers) values bucket by bucket.
 std::string
-trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::AccumulatorCache& cache) {
+trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::AccumulatorCaches& cache) {
 
     std::stringstream ss;
 

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -44,13 +44,13 @@ constexpr std::string_view PieceToChar(" PNBRQK  pnbrqk");
 
 void hint_common_parent_position(const Position&    pos,
                                  const Networks&    networks,
-                                 AccumulatorCaches& cache) {
+                                 AccumulatorCaches& caches) {
 
     int simpleEvalAbs = std::abs(simple_eval(pos, pos.side_to_move()));
     if (simpleEvalAbs > Eval::SmallNetThreshold)
         networks.small.hint_common_access(pos, nullptr, simpleEvalAbs > Eval::PsqtOnlyThreshold);
     else
-        networks.big.hint_common_access(pos, &cache.big, false);
+        networks.big.hint_common_access(pos, &caches.big, false);
 }
 
 namespace {
@@ -107,7 +107,7 @@ void format_cp_aligned_dot(Value v, std::stringstream& stream, const Position& p
 // Returns a string with the value of each piece on a board,
 // and a table for (PSQT, Layers) values bucket by bucket.
 std::string
-trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::AccumulatorCaches& cache) {
+trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::AccumulatorCaches& caches) {
 
     std::stringstream ss;
 
@@ -133,7 +133,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
 
     // We estimate the value of each piece by doing a differential evaluation from
     // the current base eval, simulating the removal of the piece from its square.
-    Value base = networks.big.evaluate(pos, &cache.big);
+    Value base = networks.big.evaluate(pos, &caches.big);
     base       = pos.side_to_move() == WHITE ? base : -base;
 
     for (File f = FILE_A; f <= FILE_H; ++f)
@@ -152,7 +152,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
                   st->accumulatorBig.computedPSQT[WHITE] = st->accumulatorBig.computedPSQT[BLACK] =
                     false;
 
-                Value eval = networks.big.evaluate(pos, &cache.big);
+                Value eval = networks.big.evaluate(pos, &caches.big);
                 eval       = pos.side_to_move() == WHITE ? eval : -eval;
                 v          = base - eval;
 
@@ -170,7 +170,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
         ss << board[row] << '\n';
     ss << '\n';
 
-    auto t = networks.big.trace_evaluate(pos, &cache.big);
+    auto t = networks.big.trace_evaluate(pos, &caches.big);
 
     ss << " NNUE network contributions "
        << (pos.side_to_move() == WHITE ? "(White to move)" : "(Black to move)") << std::endl

--- a/src/nnue/nnue_misc.h
+++ b/src/nnue/nnue_misc.h
@@ -22,7 +22,6 @@
 #include <cstddef>
 #include <string>
 
-#include "nnue_accumulator.h"
 #include "../types.h"
 #include "nnue_architecture.h"
 
@@ -52,6 +51,7 @@ struct NnueEvalTrace {
 };
 
 struct Networks;
+struct AccumulatorCaches;
 
 std::string trace(Position& pos, const Networks& networks, AccumulatorCaches& caches);
 void        hint_common_parent_position(const Position&    pos,

--- a/src/nnue/nnue_misc.h
+++ b/src/nnue/nnue_misc.h
@@ -52,10 +52,14 @@ struct NnueEvalTrace {
 
 
 struct Networks;
+struct AccumulatorRefreshEntry;
 
+using AccumulatorCache = std::array<AccumulatorRefreshEntry, SQUARE_NB>;
 
-std::string trace(Position& pos, const Networks& networks);
-void        hint_common_parent_position(const Position& pos, const Networks& networks);
+std::string trace(Position& pos, const Networks& networks, AccumulatorCache& cache);
+void        hint_common_parent_position(const Position&   pos,
+                                        const Networks&   networks,
+                                        AccumulatorCache& cache);
 
 }  // namespace Stockfish::Eval::NNUE
 }  // namespace Stockfish

--- a/src/nnue/nnue_misc.h
+++ b/src/nnue/nnue_misc.h
@@ -22,6 +22,7 @@
 #include <cstddef>
 #include <string>
 
+#include "nnue_accumulator.h"
 #include "../types.h"
 #include "nnue_architecture.h"
 
@@ -50,11 +51,7 @@ struct NnueEvalTrace {
     std::size_t correctBucket;
 };
 
-
 struct Networks;
-struct AccumulatorRefreshEntry;
-
-using AccumulatorCache = std::array<AccumulatorRefreshEntry, SQUARE_NB>;
 
 std::string trace(Position& pos, const Networks& networks, AccumulatorCache& cache);
 void        hint_common_parent_position(const Position&   pos,

--- a/src/nnue/nnue_misc.h
+++ b/src/nnue/nnue_misc.h
@@ -53,10 +53,10 @@ struct NnueEvalTrace {
 
 struct Networks;
 
-std::string trace(Position& pos, const Networks& networks, AccumulatorCache& cache);
-void        hint_common_parent_position(const Position&   pos,
-                                        const Networks&   networks,
-                                        AccumulatorCache& cache);
+std::string trace(Position& pos, const Networks& networks, AccumulatorCaches& cache);
+void        hint_common_parent_position(const Position&    pos,
+                                        const Networks&    networks,
+                                        AccumulatorCaches& cache);
 
 }  // namespace Stockfish::Eval::NNUE
 }  // namespace Stockfish

--- a/src/nnue/nnue_misc.h
+++ b/src/nnue/nnue_misc.h
@@ -53,10 +53,10 @@ struct NnueEvalTrace {
 
 struct Networks;
 
-std::string trace(Position& pos, const Networks& networks, AccumulatorCaches& cache);
+std::string trace(Position& pos, const Networks& networks, AccumulatorCaches& caches);
 void        hint_common_parent_position(const Position&    pos,
                                         const Networks&    networks,
-                                        AccumulatorCaches& cache);
+                                        AccumulatorCaches& caches);
 
 }  // namespace Stockfish::Eval::NNUE
 }  // namespace Stockfish

--- a/src/position.h
+++ b/src/position.h
@@ -172,6 +172,9 @@ class Position {
     void put_piece(Piece pc, Square s);
     void remove_piece(Square s);
 
+    // Used by NNUE
+    Eval::NNUE::AccumulatorRefreshEntry refreshTable[SQUARE_NB];
+
    private:
     // Initialization helpers (used while setting up a position)
     void set_castling_right(Color c, Square rfrom);

--- a/src/position.h
+++ b/src/position.h
@@ -172,9 +172,6 @@ class Position {
     void put_piece(Piece pc, Square s);
     void remove_piece(Square s);
 
-    // Used by NNUE
-    Eval::NNUE::AccumulatorRefreshEntry refreshTable[SQUARE_NB];
-
    private:
     // Initialization helpers (used while setting up a position)
     void set_castling_right(Color c, Square rfrom);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -148,6 +148,7 @@ void Search::Worker::start_searching() {
 
     // Initialize accumulator refresh entries
     refreshTable.big.clear(networks.big);
+    refreshTable.small.clear(networks.small);
 
     // Non-main threads go directly to iterative_deepening()
     if (!is_mainthread())

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -147,8 +147,7 @@ Search::Worker::Worker(SharedState&                    sharedState,
 void Search::Worker::start_searching() {
 
     // Initialize accumulator refresh entries
-    for (int i = 0; i < SQUARE_NB; i++)
-        networks.big.init_refresh_entry(refreshTable[i]);
+    refreshTable.clear(networks.big);
 
     // Non-main threads go directly to iterative_deepening()
     if (!is_mainthread())

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -137,6 +137,7 @@ Search::Worker::Worker(SharedState&                    sharedState,
     // Unpack the SharedState struct into member variables
     thread_idx(thread_id),
     manager(std::move(sm)),
+    refreshTable(),
     options(sharedState.options),
     threads(sharedState.threads),
     tt(sharedState.tt),
@@ -147,8 +148,7 @@ Search::Worker::Worker(SharedState&                    sharedState,
 void Search::Worker::start_searching() {
 
     // Initialize accumulator refresh entries
-    refreshTable.big.clear(networks.big);
-    refreshTable.small.clear(networks.small);
+    refreshTable.clear(networks);
 
     // Non-main threads go directly to iterative_deepening()
     if (!is_mainthread())

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -147,7 +147,7 @@ Search::Worker::Worker(SharedState&                    sharedState,
 void Search::Worker::start_searching() {
 
     // Initialize accumulator refresh entries
-    refreshTable.clear(networks.big);
+    refreshTable.big.clear(networks.big);
 
     // Non-main threads go directly to iterative_deepening()
     if (!is_mainthread())

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -148,7 +148,7 @@ void Search::Worker::start_searching() {
 
     // Initialize accumulator refresh entries
     for (int i = 0; i < SQUARE_NB; i++)
-        networks.big.init_refresh_entry(rootPos.refreshTable[i]);
+        networks.big.init_refresh_entry(refreshTable[i]);
 
     // Non-main threads go directly to iterative_deepening()
     if (!is_mainthread())
@@ -571,7 +571,7 @@ Value Search::Worker::search(
         if (threads.stop.load(std::memory_order_relaxed) || pos.is_draw(ss->ply)
             || ss->ply >= MAX_PLY)
             return (ss->ply >= MAX_PLY && !ss->inCheck)
-                   ? evaluate(networks, pos, thisThread->optimism[us])
+                   ? evaluate(networks, pos, refreshTable, thisThread->optimism[us])
                    : value_draw(thisThread->nodes);
 
         // Step 3. Mate distance pruning. Even if we mate at the next move our score
@@ -705,7 +705,7 @@ Value Search::Worker::search(
     {
         // Providing the hint that this node's accumulator will be used often
         // brings significant Elo gain (~13 Elo).
-        Eval::NNUE::hint_common_parent_position(pos, networks);
+        Eval::NNUE::hint_common_parent_position(pos, networks, refreshTable);
         unadjustedStaticEval = eval = ss->staticEval;
     }
     else if (ss->ttHit)
@@ -713,9 +713,9 @@ Value Search::Worker::search(
         // Never assume anything about values stored in TT
         unadjustedStaticEval = tte->eval();
         if (unadjustedStaticEval == VALUE_NONE)
-            unadjustedStaticEval = evaluate(networks, pos, thisThread->optimism[us]);
+            unadjustedStaticEval = evaluate(networks, pos, refreshTable, thisThread->optimism[us]);
         else if (PvNode)
-            Eval::NNUE::hint_common_parent_position(pos, networks);
+            Eval::NNUE::hint_common_parent_position(pos, networks, refreshTable);
 
         ss->staticEval = eval = to_corrected_static_eval(unadjustedStaticEval, *thisThread, pos);
 
@@ -725,7 +725,7 @@ Value Search::Worker::search(
     }
     else
     {
-        unadjustedStaticEval = evaluate(networks, pos, thisThread->optimism[us]);
+        unadjustedStaticEval = evaluate(networks, pos, refreshTable, thisThread->optimism[us]);
         ss->staticEval = eval = to_corrected_static_eval(unadjustedStaticEval, *thisThread, pos);
 
         // Static evaluation is saved as it was before adjustment by correction history
@@ -882,7 +882,7 @@ Value Search::Worker::search(
                 }
             }
 
-        Eval::NNUE::hint_common_parent_position(pos, networks);
+        Eval::NNUE::hint_common_parent_position(pos, networks, refreshTable);
     }
 
 moves_loop:  // When in check, search starts here
@@ -1420,7 +1420,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
     // Step 2. Check for an immediate draw or maximum ply reached
     if (pos.is_draw(ss->ply) || ss->ply >= MAX_PLY)
         return (ss->ply >= MAX_PLY && !ss->inCheck)
-               ? evaluate(networks, pos, thisThread->optimism[us])
+               ? evaluate(networks, pos, refreshTable, thisThread->optimism[us])
                : VALUE_DRAW;
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
@@ -1452,7 +1452,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
             // Never assume anything about values stored in TT
             unadjustedStaticEval = tte->eval();
             if (unadjustedStaticEval == VALUE_NONE)
-                unadjustedStaticEval = evaluate(networks, pos, thisThread->optimism[us]);
+                unadjustedStaticEval =
+                  evaluate(networks, pos, refreshTable, thisThread->optimism[us]);
             ss->staticEval = bestValue =
               to_corrected_static_eval(unadjustedStaticEval, *thisThread, pos);
 
@@ -1465,7 +1466,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
         {
             // In case of null move search, use previous static eval with a different sign
             unadjustedStaticEval = (ss - 1)->currentMove != Move::null()
-                                   ? evaluate(networks, pos, thisThread->optimism[us])
+                                   ? evaluate(networks, pos, refreshTable, thisThread->optimism[us])
                                    : -(ss - 1)->staticEval;
             ss->staticEval       = bestValue =
               to_corrected_static_eval(unadjustedStaticEval, *thisThread, pos);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -33,6 +33,8 @@
 #include "misc.h"
 #include "movegen.h"
 #include "movepick.h"
+#include "nnue/network.h"
+#include "nnue/nnue_accumulator.h"
 #include "nnue/nnue_common.h"
 #include "nnue/nnue_misc.h"
 #include "position.h"
@@ -143,6 +145,11 @@ Search::Worker::Worker(SharedState&                    sharedState,
 }
 
 void Search::Worker::start_searching() {
+
+    // Initialize accumulator refresh entries
+    for (int i = 0; i < SQUARE_NB; i++)
+        networks.big.init_refresh_entry(rootPos.refreshTable[i]);
+
     // Non-main threads go directly to iterative_deepening()
     if (!is_mainthread())
     {

--- a/src/search.h
+++ b/src/search.h
@@ -258,7 +258,7 @@ class Worker {
 
     // Used by NNUE
 
-    Eval::NNUE::AccumulatorCache refreshTable;
+    Eval::NNUE::AccumulatorCaches refreshTable;
 
    private:
     void iterative_deepening();

--- a/src/search.h
+++ b/src/search.h
@@ -256,9 +256,6 @@ class Worker {
     PawnHistory           pawnHistory;
     CorrectionHistory     correctionHistory;
 
-    // Used by NNUE
-
-    Eval::NNUE::AccumulatorCaches refreshTable;
 
    private:
     void iterative_deepening();
@@ -305,6 +302,10 @@ class Worker {
     std::unique_ptr<ISearchManager> manager;
 
     Tablebases::Config tbConfig;
+
+    // Used by NNUE
+
+    Eval::NNUE::AccumulatorCaches refreshTable;
 
     const OptionsMap&           options;
     ThreadPool&                 threads;

--- a/src/search.h
+++ b/src/search.h
@@ -258,7 +258,7 @@ class Worker {
 
     // Used by NNUE
 
-    std::array<Eval::NNUE::AccumulatorRefreshEntry, SQUARE_NB> refreshTable;
+    Eval::NNUE::AccumulatorCache refreshTable;
 
    private:
     void iterative_deepening();

--- a/src/search.h
+++ b/src/search.h
@@ -37,6 +37,7 @@
 #include "syzygy/tbprobe.h"
 #include "timeman.h"
 #include "types.h"
+#include "nnue/nnue_accumulator.h"
 
 namespace Stockfish {
 

--- a/src/search.h
+++ b/src/search.h
@@ -26,9 +26,9 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <string>
 #include <string_view>
 #include <vector>
-#include <string>
 
 #include "misc.h"
 #include "movepick.h"
@@ -254,6 +254,10 @@ class Worker {
     ContinuationHistory   continuationHistory[2][2];
     PawnHistory           pawnHistory;
     CorrectionHistory     correctionHistory;
+
+    // Used by NNUE
+
+    std::array<Eval::NNUE::AccumulatorRefreshEntry, SQUARE_NB> refreshTable;
 
    private:
     void iterative_deepening();

--- a/src/search.h
+++ b/src/search.h
@@ -256,7 +256,6 @@ class Worker {
     PawnHistory           pawnHistory;
     CorrectionHistory     correctionHistory;
 
-
    private:
     void iterative_deepening();
 


### PR DESCRIPTION
For each thread, keep a list of `AccumulatorRefreshEntry`, one for each possible king square.
An `AccumulatorRefreshEntry` contains the bitboards to represent the pieces of a position, and an accumulator.
When the accumulator needs to be refreshed, instead of filling it with biases and adding every piece from scratch, we...

1. Take the `AccumulatorRefreshEntry` associated with the new king bucket
2. Calculate the features to activate and deactivate 
        (from differences between bitboards in the entry and bitboards of the actual position)
3. Apply the updates on the refresh entry
4. Copy the content of the refresh entry accumulator to the accumulator we were refreshing
5. Copy the bitboards from the position to the refresh entry, to match the newly updated accumulator

I believe the structure of this new feature isn't implemented very well and needs a refactoring.

Credits to Luecx/Finny, who originally came up with this idea.

Results at STC:
https://tests.stockfishchess.org/tests/live_elo/662301573fe04ce4cefc1386

No functional change