### PR TITLE
Tweak TT aging and replacement strategies

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -40,7 +40,8 @@ void TTEntry::save(
         move16 = m;
 
     // Overwrite less valuable entries (cheapest checks first)
-    if (b == BOUND_EXACT || uint16_t(k) != key16 || d - DEPTH_OFFSET + 2 * pv > depth8 - 4)
+    if (b == BOUND_EXACT || uint16_t(k) != key16 || d - DEPTH_OFFSET + 2 * pv > depth8 - 4
+        || relative_age(generation8))
     {
         assert(d > DEPTH_OFFSET);
         assert(d < 256 + DEPTH_OFFSET);
@@ -123,13 +124,7 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
 
     for (int i = 0; i < ClusterSize; ++i)
         if (tte[i].key16 == key16 || !tte[i].depth8)
-        {
-            constexpr uint8_t lowerBits = GENERATION_DELTA - 1;
-
-            // Refresh with new generation, keeping the lower bits the same.
-            tte[i].genBound8 = uint8_t(generation8 | (tte[i].genBound8 & lowerBits));
-            return found     = bool(tte[i].depth8), &tte[i];
-        }
+            return found = bool(tte[i].depth8), &tte[i];
 
     // Find an entry to be replaced according to the replacement strategy
     TTEntry* replace = tte;


### PR DESCRIPTION
We change the definition of "age" from "age of this position" to "age of this TT entry".
In this way, despite being on the same position, when we save into TT, we always prefer the new entry as compared to the old one.

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 152256 W: 39597 L: 39110 D: 73549
Ptnml(0-2): 556, 17562, 39398, 18063, 549
https://tests.stockfishchess.org/tests/view/6620faee3fe04ce4cefbf215

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 51564 W: 13242 L: 12895 D: 25427
Ptnml(0-2): 24, 5464, 14463, 5803, 28
https://tests.stockfishchess.org/tests/view/66231ab53fe04ce4cefc153e

closes #5184

Bench 1479416