### PR TITLE
Fix missing initialization of AccumulatorCaches in Eval::trace

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -99,7 +99,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 // Trace scores are from white's point of view
 std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
 
-    auto caches = std::make_unique<Eval::NNUE::AccumulatorCaches>();
+    auto caches = std::make_unique<Eval::NNUE::AccumulatorCaches>(networks);
 
     if (pos.checkers())
         return "Final evaluation: none (in check)";

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -50,6 +50,11 @@ struct alignas(CacheLineSize) Accumulator {
 // is commonly referred to as "Finny Tables".
 struct AccumulatorCaches {
 
+    template<typename Networks>
+    AccumulatorCaches(const Networks& networks) {
+        clear(networks);
+    }
+
     template<IndexType Size>
     struct alignas(CacheLineSize) Cache {
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -137,11 +137,11 @@ Search::Worker::Worker(SharedState&                    sharedState,
     // Unpack the SharedState struct into member variables
     thread_idx(thread_id),
     manager(std::move(sm)),
-    refreshTable(),
     options(sharedState.options),
     threads(sharedState.threads),
     tt(sharedState.tt),
-    networks(sharedState.networks) {
+    networks(sharedState.networks),
+    refreshTable(networks) {
     clear();
 }
 

--- a/src/search.h
+++ b/src/search.h
@@ -302,14 +302,13 @@ class Worker {
 
     Tablebases::Config tbConfig;
 
-    // Used by NNUE
-
-    Eval::NNUE::AccumulatorCaches refreshTable;
-
     const OptionsMap&           options;
     ThreadPool&                 threads;
     TranspositionTable&         tt;
     const Eval::NNUE::Networks& networks;
+
+    // Used by NNUE
+    Eval::NNUE::AccumulatorCaches refreshTable;
 
     friend class Stockfish::ThreadPool;
     friend class SearchManager;


### PR DESCRIPTION
Add a constructor to `AccumulatorCaches` instead of just calling `clear(networks)` to prevent similar issues from appearing in the future.

fixes https://github.com/official-stockfish/Stockfish/issues/5190

No functional change