### PR TITLE
Output some basic info about the networks used

### DIFF
--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -252,7 +252,11 @@ void Network<Arch, Transformer>::verify(std::string evalfilePath) const {
         exit(EXIT_FAILURE);
     }
 
-    sync_cout << "info string NNUE evaluation using " << evalfilePath << sync_endl;
+    size_t size = sizeof(*featureTransformer) + sizeof(*network) * LayerStacks;
+    sync_cout << "info string NNUE evaluation using " << evalfilePath << " ("
+              << size / (1024 * 1024) << "MiB, (" << featureTransformer->InputDimensions << ", "
+              << network[0]->TransformedFeatureDimensions << ", " << network[0]->FC_0_OUTPUTS
+              << ", " << network[0]->FC_1_OUTPUTS << ", 1))" << sync_endl;
 }
 
 


### PR DESCRIPTION
Adds size in memory as well as layer sizes as in

```
info string NNUE evaluation using nn-ae6a388e4a1a.nnue (132MiB, 22528 x 3072 x 15 x 32 x 1) 
info string NNUE evaluation using nn-baff1ede1f90.nnue (6MiB, 22528 x 128 x 15 x 32 x 1)
```

For example, the size in MiB is useful to keep the fishtest memory sizes up-to-date, the L1-L3 sizes give a useful hint about the architecture used.

No functional change