### PR TITLE
Penalise the TT move in multicut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1066,7 +1066,12 @@ moves_loop:  // When in check, search starts here
                 // we assume this expected cut-node is not singular (multiple moves fail high),
                 // and we can prune the whole subtree by returning a softbound.
                 else if (singularBeta >= beta)
+                {
+                    if (!ttCapture)
+                        update_quiet_stats(pos, ss, *this, ttMove, -stat_malus(depth));
+
                     return singularBeta;
+                }
 
                 // Negative extensions
                 // If other moves failed high over (ttValue - margin) without the ttMove on a reduced search,


### PR DESCRIPTION
Passed STC:
LLR: 2.99 (-2.94,2.94) <0.00,2.00>
Total: 185504 W: 48079 L: 47533 D: 89892
Ptnml(0-2): 716, 21866, 46988, 22520, 662
https://tests.stockfishchess.org/tests/view/662d9e1d6115ff6764c7f83d

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 75612 W: 19351 L: 18948 D: 37313
Ptnml(0-2): 46, 8363, 20592, 8752, 53
https://tests.stockfishchess.org/tests/view/662dc9dc6115ff6764c80fea

closes #5195

Bench 1415435