### PR TITLE
Simplify recently introduced generalized non-pawn material divisor back to a constant.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -63,14 +63,14 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     Value nnue = smallNet ? networks.small.evaluate(pos, nullptr, true, &nnueComplexity, psqtOnly)
                           : networks.big.evaluate(pos, &caches.big, true, &nnueComplexity, false);
 
-    const auto adjustEval = [&](int optDiv, int nnueDiv, int npmDiv, int pawnCountConstant,
-                                int pawnCountMul, int npmConstant, int evalDiv,
-                                int shufflingConstant, int shufflingDiv) {
+    const auto adjustEval = [&](int optDiv, int nnueDiv, int pawnCountConstant, int pawnCountMul,
+                                int npmConstant, int evalDiv, int shufflingConstant,
+                                int shufflingDiv) {
         // Blend optimism and eval with nnue complexity and material imbalance
         optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / optDiv;
         nnue -= nnue * (nnueComplexity * 5 / 3) / nnueDiv;
 
-        int npm = pos.non_pawn_material() / npmDiv;
+        int npm = pos.non_pawn_material() / 64;
         v       = (nnue * (npm + pawnCountConstant + pawnCountMul * pos.count<PAWN>())
              + optimism * (npmConstant + npm))
           / evalDiv;
@@ -81,11 +81,11 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     };
 
     if (!smallNet)
-        adjustEval(524, 32395, 66, 942, 11, 139, 1058, 178, 204);
+        adjustEval(524, 32395, 942, 11, 139, 1058, 178, 204);
     else if (psqtOnly)
-        adjustEval(517, 32857, 65, 908, 7, 155, 1006, 224, 238);
+        adjustEval(517, 32857, 908, 7, 155, 1006, 224, 238);
     else
-        adjustEval(515, 32793, 63, 944, 9, 140, 1067, 206, 206);
+        adjustEval(515, 32793, 944, 9, 140, 1067, 206, 206);
 
     // Guarantee evaluation does not hit the tablebase range
     v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);


### PR DESCRIPTION

Because the generalized divisor was introduced together with a large search parameter optimization, there is always the risk that the success is only due to the optimization itself. That is why I checked whether it made a significant contribution to the ELO increase.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 272832 W: 70456 L: 70497 D: 131879
Ptnml(0-2): 1020, 32619, 69154, 32628, 995
https://tests.stockfishchess.org/tests/view/662942603fe04ce4cefc7aba

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 100254 W: 25446 L: 25303 D: 49505
Ptnml(0-2): 121, 11292, 27166, 11419, 129
https://tests.stockfishchess.org/tests/view/662dfe3b6115ff6764c829eb

Bench: 1774427