### PR TITLE
More reduction at cut nodes which are not a former PV node.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1117,6 +1117,9 @@ moves_loop:  // When in check, search starts here
         if (ss->ttPv)
             r -= 1 + (ttValue > alpha) + (tte->depth() >= depth);
 
+        else if (cutNode && move != ttMove && move != ss->killers[0])
+            r++;
+
         // Increase reduction for cut nodes (~4 Elo)
         if (cutNode)
             r += 2 - (tte->depth() >= depth && ss->ttPv);


### PR DESCRIPTION
But the tt move and first killer are excluded.

This idea is based on following LMR condition tuning https://tests.stockfishchess.org/tests/view/66228bed3fe04ce4cefc0c71 by using only the two largest terms P[0] and P[1].

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 173248 W: 45091 L: 44565 D: 83592
Ptnml(0-2): 693, 20534, 43673, 21002, 722
https://tests.stockfishchess.org/tests/view/6629603b3fe04ce4cefc7d37

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 722394 W: 183231 L: 181487 D: 357676
Ptnml(0-2): 462, 80650, 197252, 82348, 485
https://tests.stockfishchess.org/tests/view/662cbe45d46f72253dcff7bf

Bench: 1545107