### PR TITLE
Use capture history to better judge which sacrifices to explore

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -967,20 +967,21 @@ moves_loop:  // When in check, search starts here
 
             if (capture || givesCheck)
             {
+                Piece capturedPiece = pos.piece_on(move.to_sq());
+                int captHist = thisThread->captureHistory[movedPiece][move.to_sq()][type_of(capturedPiece)];
+
                 // Futility pruning for captures (~2 Elo)
                 if (!givesCheck && lmrDepth < 7 && !ss->inCheck)
                 {
-                    Piece capturedPiece = pos.piece_on(move.to_sq());
                     Value futilityValue =
-                      ss->staticEval + 285 + 277 * lmrDepth + PieceValue[capturedPiece]
-                      + thisThread->captureHistory[movedPiece][move.to_sq()][type_of(capturedPiece)]
-                          / 7;
+                      ss->staticEval + 285 + 277 * lmrDepth + PieceValue[capturedPiece] + captHist / 7;
                     if (futilityValue <= alpha)
                         continue;
                 }
 
                 // SEE based pruning for captures and checks (~11 Elo)
-                if (!pos.see_ge(move, -203 * depth))
+                int seeHist = std::clamp(captHist / 32, -199 * depth, 199 * depth);
+                if (!pos.see_ge(move, -203 * depth - seeHist))
                     continue;
             }
             else


### PR DESCRIPTION
This idea has been bouncing around a while. @Vizvezdenec tried it a couple years ago in Stockfish without results, but its recent arrival in Ethereal inspired him and thence me to try it afresh in Stockfish.

My thanks to fishtest contributors for letting me throw more than 5 tests as this.

(Also factor out the now-common code with futpruning for captures.)

STC: https://tests.stockfishchess.org/tests/view/662355bc3fe04ce4cefc18ac
LLR: 2.92 (-2.94,2.94) <0.00,2.00>
Total: 45760 W: 11970 L: 11640 D: 22150
Ptnml(0-2): 124, 5371, 11625, 5571, 189

LTC: https://tests.stockfishchess.org/tests/view/662dda396115ff6764c817c9
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 243828 W: 62042 L: 61287 D: 120499
Ptnml(0-2): 211, 27202, 66329, 27965, 207

bench 1480008