### PR TITLE
don't create and destroy an unused accumulator cache when calling Eval::trace in check

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -100,10 +100,10 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 // Trace scores are from white's point of view
 std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
 
-    auto caches = std::make_unique<Eval::NNUE::AccumulatorCaches>(networks);
-
     if (pos.checkers())
         return "Final evaluation: none (in check)";
+
+    auto caches = std::make_unique<Eval::NNUE::AccumulatorCaches>(networks);
 
     std::stringstream ss;
     ss << std::showpoint << std::noshowpos << std::fixed << std::setprecision(2);


### PR DESCRIPTION
saves a (currently) 800 KB allocation and deallocation when running `eval`, not particularly significant and zero impact on play but not necessary either

No functional change