### PR TITLE
psqtOnly finny cache bug fix

### DIFF
--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -59,31 +59,27 @@ struct AccumulatorCaches {
     struct alignas(CacheLineSize) Cache {
 
         struct alignas(CacheLineSize) Entry {
-            BiasType       accumulation[COLOR_NB][Size];
-            PSQTWeightType psqtAccumulation[COLOR_NB][PSQTBuckets];
-            Bitboard       byColorBB[COLOR_NB][COLOR_NB];
-            Bitboard       byTypeBB[COLOR_NB][PIECE_TYPE_NB];
+            BiasType       accumulation[Size];
+            PSQTWeightType psqtAccumulation[PSQTBuckets];
+            Bitboard       byColorBB[COLOR_NB];
+            Bitboard       byTypeBB[PIECE_TYPE_NB];
             bool           psqtOnly;
 
             // To initialize a refresh entry, we set all its bitboards empty,
             // so we put the biases in the accumulation, without any weights on top
             void clear(const BiasType* biases) {
 
-                std::memset(byColorBB, 0, sizeof(byColorBB));
-                std::memset(byTypeBB, 0, sizeof(byTypeBB));
-                psqtOnly = false;
-
-                std::memcpy(accumulation[WHITE], biases, Size * sizeof(BiasType));
-                std::memcpy(accumulation[BLACK], biases, Size * sizeof(BiasType));
-
-                std::memset(psqtAccumulation, 0, sizeof(psqtAccumulation));
+                std::memcpy(accumulation, biases, sizeof(accumulation));
+                std::memset((uint8_t*)this + offsetof(Entry, psqtAccumulation),
+                            0, sizeof(Entry) - offsetof(Entry, psqtAccumulation));
             }
         };
 
         template<typename Network>
         void clear(const Network& network) {
-            for (auto& entry : entries)
-                entry.clear(network.featureTransformer->biases);
+            for (auto& entries1D : entries)
+                for (auto& entry : entries1D)
+                    entry.clear(network.featureTransformer->biases);
         }
 
         void clear(const BiasType* biases) {
@@ -91,9 +87,9 @@ struct AccumulatorCaches {
                 entry.clear(biases);
         }
 
-        Entry& operator[](Square sq) { return entries[sq]; }
+        std::array<Entry, COLOR_NB>& operator[](Square sq) { return entries[sq]; }
 
-        std::array<Entry, SQUARE_NB> entries;
+        std::array<std::array<Entry, COLOR_NB>, SQUARE_NB> entries;
     };
 
     template<typename Networks>

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -147,9 +147,6 @@ Search::Worker::Worker(SharedState&                    sharedState,
 
 void Search::Worker::start_searching() {
 
-    // Initialize accumulator refresh entries
-    refreshTable.clear(networks);
-
     // Non-main threads go directly to iterative_deepening()
     if (!is_mainthread())
     {
@@ -506,6 +503,8 @@ void Search::Worker::clear() {
 
     for (size_t i = 1; i < reductions.size(); ++i)
         reductions[i] = int((20.14 + std::log(size_t(options["Threads"])) / 2) * std::log(i));
+
+    refreshTable.clear(networks);
 }
 
 


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/663068913a05f1bf7a511dc2
LLR: 2.98 (-2.94,2.94) <-1.75,0.25>
Total: 70304 W: 18211 L: 18026 D: 34067
Ptnml(0-2): 232, 7966, 18582, 8129, 243 

1) Fixes a bug introduced by me in https://github.com/official-stockfish/Stockfish/pull/5194
Only one psqtOnly flag was used for two perspectives which was causing wrong entries to be cleared and marked.
2) The finny caches should be cleared like histories and not at the start of every search.

No functional change
bench: 1619613

@vondele also pointed out here https://github.com/mstembera/Stockfish/commit/402864351698ce2a5798cfa07bc1eeca55dd3723#r141503821 that we should probably also clear the caches when a new net is loaded.  I agree but the caches are stored in the Worker class so I'm not sure how to trigger their clearing when a new net is loaded.  If someone knows how to code it up I can either add it to this PR or please open a separate PR.

