### PR TITLE
Respell Move::None and Move::Null to reflect that they're constants

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -109,7 +109,7 @@ void Engine::set_position(const std::string& fen, const std::vector<std::string>
     {
         auto m = UCIEngine::to_move(pos, move);
 
-        if (m == Move::none())
+        if (m == Move::None())
             break;
 
         states->emplace_back();

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -233,7 +233,7 @@ Move MovePicker::select(Pred filter) {
 
         cur++;
     }
-    return Move::none();
+    return Move::None();
 }
 
 // Most important method of the MovePicker class. It
@@ -286,7 +286,7 @@ top:
 
     case REFUTATION :
         if (select<Next>([&]() {
-                return *cur != Move::none() && !pos.capture_stage(*cur) && pos.pseudo_legal(*cur);
+                return *cur != Move::None() && !pos.capture_stage(*cur) && pos.pseudo_legal(*cur);
             }))
             return *(cur - 1);
         ++stage;
@@ -341,7 +341,7 @@ top:
                 return *cur != refutations[0] && *cur != refutations[1] && *cur != refutations[2];
             });
 
-        return Move::none();
+        return Move::None();
 
     case EVASION_INIT :
         cur      = moves;
@@ -363,7 +363,7 @@ top:
 
         // If we did not find any move and we do not try checks, we have finished
         if (depth != DEPTH_QS_CHECKS)
-            return Move::none();
+            return Move::None();
 
         ++stage;
         [[fallthrough]];
@@ -380,7 +380,7 @@ top:
     }
 
     assert(false);
-    return Move::none();  // Silence warning
+    return Move::None();  // Silence warning
 }
 
 }  // namespace Stockfish

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -144,7 +144,7 @@ using CorrectionHistory =
 // MovePicker class is used to pick one pseudo-legal move at a time from the
 // current position. The most important method is next_move(), which returns a
 // new pseudo-legal move each time it is called, until there are no moves left,
-// when Move::none() is returned. In order to improve the efficiency of the
+// when Move::None() is returned. In order to improve the efficiency of the
 // alpha-beta algorithm, MovePicker attempts to return the moves which are most
 // likely to get a cut-off first.
 class MovePicker {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -131,7 +131,7 @@ void Position::init() {
 
     // Prepare the cuckoo tables
     cuckoo.fill(0);
-    cuckooMove.fill(Move::none());
+    cuckooMove.fill(Move::None());
     [[maybe_unused]] int count = 0;
     for (Piece pc : Pieces)
         for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
@@ -145,7 +145,7 @@ void Position::init() {
                     {
                         std::swap(cuckoo[i], key);
                         std::swap(cuckooMove[i], move);
-                        if (move == Move::none())  // Arrived at empty slot?
+                        if (move == Move::None())  // Arrived at empty slot?
                             break;
                         i = (i == H1(key)) ? H2(key) : H1(key);  // Push victim to alternative slot
                     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -107,7 +107,7 @@ struct Skill {
     Move pick_best(const RootMoves&, size_t multiPV);
 
     double level;
-    Move   best = Move::none();
+    Move   best = Move::None();
 };
 
 Value value_to_tt(Value v, int ply);
@@ -159,7 +159,7 @@ void Search::Worker::start_searching() {
 
     if (rootMoves.empty())
     {
-        rootMoves.emplace_back(Move::none());
+        rootMoves.emplace_back(Move::None());
         main_manager()->updates.onUpdateNoMoves(
           {0, {rootPos.checkers() ? -VALUE_MATE : VALUE_DRAW, rootPos}});
     }
@@ -195,7 +195,7 @@ void Search::Worker::start_searching() {
       Skill(options["Skill Level"], options["UCI_LimitStrength"] ? int(options["UCI_Elo"]) : 0);
 
     if (int(options["MultiPV"]) == 1 && !limits.depth && !limits.mate && !skill.enabled()
-        && rootMoves[0].pv[0] != Move::none())
+        && rootMoves[0].pv[0] != Move::None())
         bestThread = threads.get_best_thread()->worker.get();
 
     main_manager()->bestPreviousScore        = bestThread->rootMoves[0].score;
@@ -226,7 +226,7 @@ void Search::Worker::iterative_deepening() {
 
     Depth lastBestMoveDepth = 0;
     Value lastBestScore     = -VALUE_INFINITE;
-    auto  lastBestPV        = std::vector{Move::none()};
+    auto  lastBestPV        = std::vector{Move::None()};
 
     Value  alpha, beta;
     Value  bestValue     = -VALUE_INFINITE;
@@ -489,7 +489,7 @@ void Search::Worker::iterative_deepening() {
 }
 
 void Search::Worker::clear() {
-    counterMoves.fill(Move::none());
+    counterMoves.fill(Move::None());
     mainHistory.fill(0);
     captureHistory.fill(0);
     pawnHistory.fill(0);
@@ -590,8 +590,8 @@ Value Search::Worker::search(
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
-    bestMove             = Move::none();
-    (ss + 2)->killers[0] = (ss + 2)->killers[1] = Move::none();
+    bestMove             = Move::None();
+    (ss + 2)->killers[0] = (ss + 2)->killers[1] = Move::None();
     (ss + 2)->cutoffCnt                         = 0;
     ss->multipleExtensions                      = (ss - 1)->multipleExtensions;
     Square prevSq = ((ss - 1)->currentMove).is_ok() ? ((ss - 1)->currentMove).to_sq() : SQ_NONE;
@@ -604,7 +604,7 @@ Value Search::Worker::search(
     ttValue   = ss->ttHit ? value_from_tt(tte->value(), ss->ply, pos.rule50_count()) : VALUE_NONE;
     ttMove    = rootNode  ? thisThread->rootMoves[thisThread->pvIdx].pv[0]
               : ss->ttHit ? tte->move()
-                          : Move::none();
+                          : Move::None();
     ttCapture = ttMove && pos.capture_stage(ttMove);
 
     // At this point, if excluded, skip straight to step 6, static eval. However,
@@ -675,7 +675,7 @@ Value Search::Worker::search(
                 if (b == BOUND_EXACT || (b == BOUND_LOWER ? value >= beta : value <= alpha))
                 {
                     tte->save(posKey, value_to_tt(value, ss->ply), ss->ttPv, b,
-                              std::min(MAX_PLY - 1, depth + 6), Move::none(), VALUE_NONE,
+                              std::min(MAX_PLY - 1, depth + 6), Move::None(), VALUE_NONE,
                               tt.generation());
 
                     return value;
@@ -729,7 +729,7 @@ Value Search::Worker::search(
         ss->staticEval = eval = to_corrected_static_eval(unadjustedStaticEval, *thisThread, pos);
 
         // Static evaluation is saved as it was before adjustment by correction history
-        tte->save(posKey, VALUE_NONE, ss->ttPv, BOUND_NONE, DEPTH_NONE, Move::none(),
+        tte->save(posKey, VALUE_NONE, ss->ttPv, BOUND_NONE, DEPTH_NONE, Move::None(),
                   unadjustedStaticEval, tt.generation());
     }
 
@@ -776,7 +776,7 @@ Value Search::Worker::search(
         return beta > VALUE_TB_LOSS_IN_MAX_PLY ? (eval + beta) / 2 : eval;
 
     // Step 9. Null move search with verification search (~35 Elo)
-    if (!PvNode && (ss - 1)->currentMove != Move::null() && (ss - 1)->statScore < 18001
+    if (!PvNode && (ss - 1)->currentMove != Move::Null() && (ss - 1)->statScore < 18001
         && eval >= beta && ss->staticEval >= beta - 21 * depth + 312 && !excludedMove
         && pos.non_pawn_material(us) && ss->ply >= thisThread->nmpMinPly
         && beta > VALUE_TB_LOSS_IN_MAX_PLY)
@@ -786,7 +786,7 @@ Value Search::Worker::search(
         // Null move dynamic reduction based on depth and eval
         Depth R = std::min(int(eval - beta) / 152, 6) + depth / 3 + 4;
 
-        ss->currentMove         = Move::null();
+        ss->currentMove         = Move::Null();
         ss->continuationHistory = &thisThread->continuationHistory[0][0][NO_PIECE][0];
 
         pos.do_null_move(st, tt);
@@ -846,7 +846,7 @@ Value Search::Worker::search(
 
         MovePicker mp(pos, ttMove, probCutBeta - ss->staticEval, &thisThread->captureHistory);
 
-        while ((move = mp.next_move()) != Move::none())
+        while ((move = mp.next_move()) != Move::None())
             if (move != excludedMove && pos.legal(move))
             {
                 assert(pos.capture_stage(move));
@@ -902,7 +902,7 @@ moves_loop:  // When in check, search starts here
                                         (ss - 6)->continuationHistory};
 
     Move countermove =
-      prevSq != SQ_NONE ? thisThread->counterMoves[pos.piece_on(prevSq)][prevSq] : Move::none();
+      prevSq != SQ_NONE ? thisThread->counterMoves[pos.piece_on(prevSq)][prevSq] : Move::None();
 
     MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory, &thisThread->captureHistory,
                   contHist, &thisThread->pawnHistory, countermove, ss->killers);
@@ -912,7 +912,7 @@ moves_loop:  // When in check, search starts here
 
     // Step 13. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
-    while ((move = mp.next_move(moveCountPruning)) != Move::none())
+    while ((move = mp.next_move(moveCountPruning)) != Move::None())
     {
         assert(move.is_ok());
 
@@ -1045,7 +1045,7 @@ moves_loop:  // When in check, search starts here
                 ss->excludedMove = move;
                 value =
                   search<NonPV>(pos, ss, singularBeta - 1, singularBeta, singularDepth, cutNode);
-                ss->excludedMove = Move::none();
+                ss->excludedMove = Move::None();
 
                 if (value < singularBeta)
                 {
@@ -1206,7 +1206,7 @@ moves_loop:  // When in check, search starts here
         if (PvNode && (moveCount == 1 || value > alpha))
         {
             (ss + 1)->pv    = pv;
-            (ss + 1)->pv[0] = Move::none();
+            (ss + 1)->pv[0] = Move::None();
 
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);
         }
@@ -1255,7 +1255,7 @@ moves_loop:  // When in check, search starts here
 
                 assert((ss + 1)->pv);
 
-                for (Move* m = (ss + 1)->pv; *m != Move::none(); ++m)
+                for (Move* m = (ss + 1)->pv; *m != Move::None(); ++m)
                     rm.pv.push_back(*m);
 
                 // We record how often the best move has been changed in each iteration.
@@ -1415,11 +1415,11 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
     if (PvNode)
     {
         (ss + 1)->pv = pv;
-        ss->pv[0]    = Move::none();
+        ss->pv[0]    = Move::None();
     }
 
     Worker* thisThread = this;
-    bestMove           = Move::none();
+    bestMove           = Move::None();
     ss->inCheck        = pos.checkers();
     moveCount          = 0;
 
@@ -1442,7 +1442,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
     posKey  = pos.key();
     tte     = tt.probe(posKey, ss->ttHit);
     ttValue = ss->ttHit ? value_from_tt(tte->value(), ss->ply, pos.rule50_count()) : VALUE_NONE;
-    ttMove  = ss->ttHit ? tte->move() : Move::none();
+    ttMove  = ss->ttHit ? tte->move() : Move::None();
     pvHit   = ss->ttHit && tte->is_pv();
 
     // At non-PV nodes we check for an early TT cutoff
@@ -1475,7 +1475,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
         else
         {
             // In case of null move search, use previous static eval with a different sign
-            unadjustedStaticEval = (ss - 1)->currentMove != Move::null()
+            unadjustedStaticEval = (ss - 1)->currentMove != Move::Null()
                                    ? evaluate(networks, pos, refreshTable, thisThread->optimism[us])
                                    : -(ss - 1)->staticEval;
             ss->staticEval       = bestValue =
@@ -1487,7 +1487,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
         {
             if (!ss->ttHit)
                 tte->save(posKey, value_to_tt(bestValue, ss->ply), false, BOUND_LOWER, DEPTH_NONE,
-                          Move::none(), unadjustedStaticEval, tt.generation());
+                          Move::None(), unadjustedStaticEval, tt.generation());
 
             return bestValue;
         }
@@ -1513,7 +1513,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
 
     // Step 5. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
-    while ((move = mp.next_move()) != Move::none())
+    while ((move = mp.next_move()) != Move::None())
     {
         assert(move.is_ok());
 
@@ -1707,9 +1707,9 @@ Value value_from_tt(Value v, int ply, int r50c) {
 // Adds current move and appends child pv[]
 void update_pv(Move* pv, Move move, const Move* childPv) {
 
-    for (*pv++ = move; childPv && *childPv != Move::none();)
+    for (*pv++ = move; childPv && *childPv != Move::None();)
         *pv++ = *childPv++;
-    *pv = Move::none();
+    *pv = Move::None();
 }
 
 
@@ -1964,7 +1964,7 @@ bool RootMove::extract_ponder_from_tt(const TranspositionTable& tt, Position& po
     bool ttHit;
 
     assert(pv.size() == 1);
-    if (pv[0] == Move::none())
+    if (pv[0] == Move::None())
         return false;
 
     pos.do_move(pv[0], st);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -415,10 +415,10 @@ std::string UCIEngine::square(Square s) {
 }
 
 std::string UCIEngine::move(Move m, bool chess960) {
-    if (m == Move::none())
+    if (m == Move::None())
         return "(none)";
 
-    if (m == Move::null())
+    if (m == Move::Null())
         return "0000";
 
     Square from = m.from_sq();
@@ -449,7 +449,7 @@ Move UCIEngine::to_move(const Position& pos, std::string str) {
         if (str == move(m, pos.is_chess960()))
             return m;
 
-    return Move::none();
+    return Move::None();
 }
 
 void UCIEngine::on_update_no_moves(const Engine::InfoShort& info) {


### PR DESCRIPTION
…not functions

Despite the syntax, these are compiletime singleton constants, or rather they *would* be if such syntax was permitted:
```
static constexpr Move None = Move(0);
static constexpr Move Null = Move(65);
```
...but this syntax not permitted. In some ways this is a flaw of the language, but that's offtopic (and a gigantic can of worms best left sealed). So function syntax is what we're stuck with, but we can respell them to reflect that they really are just constants.

Also move MoveType under its explanatory comments and remove some blank lines

No functional change