### PR TITLE
Add extra bonuses to some moves that forced a fail low.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1336,7 +1336,8 @@ moves_loop:  // When in check, search starts here
     {
         int bonus = (depth > 5) + (PvNode || cutNode) + ((ss - 1)->statScore < -14761)
                   + ((ss - 1)->moveCount > 11)
-                  + (!ss->inCheck && bestValue <= ss->staticEval - 142);
+                  + (!ss->inCheck && bestValue <= ss->staticEval - 142)
+                  + (!(ss-1)->inCheck && bestValue <= -(ss-1)->staticEval - 77);
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       stat_bonus(depth) * bonus);
         thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()]


### PR DESCRIPTION
My previous patch on this idea was giving bonuses to this moves if best value of search is far below current static evaluation.
This patch does similar thing but adds extra bonus when best value of search is far below static evaluation before previous move.
Passed STC:
https://tests.stockfishchess.org/tests/view/66355fc819566d64b481d6a4
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 454144 W: 116575 L: 115656 D: 221913
Ptnml(0-2): 1060, 53410, 117215, 54325, 1062 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6635c61a73559a8aa858012d
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 136578 W: 34858 L: 34335 D: 67385
Ptnml(0-2): 46, 14914, 37864, 15401, 64 
bench 1600075