### PR TITLE
Introduce Quadruple Extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -593,7 +593,6 @@ Value Search::Worker::search(
     bestMove             = Move::none();
     (ss + 2)->killers[0] = (ss + 2)->killers[1] = Move::none();
     (ss + 2)->cutoffCnt                         = 0;
-    ss->multipleExtensions                      = (ss - 1)->multipleExtensions;
     Square prevSq = ((ss - 1)->currentMove).is_ok() ? ((ss - 1)->currentMove).to_sq() : SQ_NONE;
     ss->statScore = 0;
 
@@ -1049,17 +1048,15 @@ moves_loop:  // When in check, search starts here
 
                 if (value < singularBeta)
                 {
-                    extension = 1;
+                        int doubleMargin =       251 * PvNode - 241 * !ttCapture;
+                        int tripleMargin = 135 + 234 * PvNode - 248 * !ttCapture + 124 * (ss->ttPv || !ttCapture);
+                        int quadMargin   = 447 + 354 * PvNode - 300 * !ttCapture + 206 * ss->ttPv;
 
-                    // We make sure to limit the extensions in some way to avoid a search explosion
-                    if (!PvNode && ss->multipleExtensions <= 16)
-                    {
-                        extension = 2 + (value < singularBeta - 11 && !ttCapture);
-                        depth += depth < 14;
-                    }
-                    if (PvNode && !ttCapture && ss->multipleExtensions <= 5
-                        && value < singularBeta - 38)
-                        extension = 2;
+                        extension    = 1 + (value < singularBeta - doubleMargin) 
+                                         + (value < singularBeta - tripleMargin)
+                                         + (value < singularBeta - quadMargin);
+
+                        depth += ((!PvNode) && (depth < 14));
                 }
 
                 // Multi-cut pruning
@@ -1104,7 +1101,6 @@ moves_loop:  // When in check, search starts here
 
         // Add extension to new depth
         newDepth += extension;
-        ss->multipleExtensions = (ss - 1)->multipleExtensions + (extension >= 2);
 
         // Speculative prefetch as early as possible
         prefetch(tt.first_entry(pos.key_after(move)));

--- a/src/search.h
+++ b/src/search.h
@@ -74,7 +74,6 @@ struct Stack {
     bool            inCheck;
     bool            ttPv;
     bool            ttHit;
-    int             multipleExtensions;
     int             cutoffCnt;
 };
 


### PR DESCRIPTION
This patch introduces quadruple extensions, with the new condition of not ttPv. It also generalises all margins, so that extensions can still occur if conditions are only partially fulfilled, but with a stricter margin.

Failed STC:
LLR: -2.94 (-2.94,2.94) <0.00,2.00>
Total: 16096 W: 3984 L: 4228 D: 7884
Ptnml(0-2): 72, 2067, 4002, 1847, 60
https://tests.stockfishchess.org/tests/view/66316422d01fb9ac9bcdbdcd

Passed VVLTC 1: 
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 96660 W: 24550 L: 24210 D: 47900
Ptnml(0-2): 5, 8776, 30426, 9120, 3
https://tests.stockfishchess.org/tests/view/66361f2c74fa3f41ef2ee091

Passed VVLTC 2:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 80546 W: 20495 L: 20120 D: 39931
Ptnml(0-2): 6, 7477, 24929, 7858, 3
https://tests.stockfishchess.org/tests/view/66350cf739ba8e443112b3fa

bench 2233743