### PR TITLE
Simplify shuffling and optimism divisors to constants

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -64,11 +64,10 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
                  ? networks.small.evaluate(pos, &caches.small, true, &nnueComplexity, psqtOnly)
                  : networks.big.evaluate(pos, &caches.big, true, &nnueComplexity, false);
 
-    const auto adjustEval = [&](int optDiv, int nnueDiv, int pawnCountConstant, int pawnCountMul,
-                                int npmConstant, int evalDiv, int shufflingConstant,
-                                int shufflingDiv) {
+    const auto adjustEval = [&](int nnueDiv, int pawnCountConstant, int pawnCountMul,
+                                int npmConstant, int evalDiv, int shufflingConstant) {
         // Blend optimism and eval with nnue complexity and material imbalance
-        optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / optDiv;
+        optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 584;
         nnue -= nnue * (nnueComplexity * 5 / 3) / nnueDiv;
 
         int npm = pos.non_pawn_material() / 64;
@@ -78,15 +77,15 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 
         // Damp down the evaluation linearly when shuffling
         int shuffling = pos.rule50_count();
-        v             = v * (shufflingConstant - shuffling) / shufflingDiv;
+        v             = v * (shufflingConstant - shuffling) / 207;
     };
 
     if (!smallNet)
-        adjustEval(524, 32395, 942, 11, 139, 1058, 178, 204);
+        adjustEval(32395, 942, 11, 139, 1058, 178);
     else if (psqtOnly)
-        adjustEval(517, 32857, 908, 7, 155, 1006, 224, 238);
+        adjustEval(32857, 908, 7, 155, 1006, 224);
     else
-        adjustEval(515, 32793, 944, 9, 140, 1067, 206, 206);
+        adjustEval(32793, 944, 9, 140, 1067, 206);
 
     // Guarantee evaluation does not hit the tablebase range
     v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);


### PR DESCRIPTION
Simplify shuffling and optimism divisors to constants

Shuffling divisor and Optimism divisors passed STC & LTC separately:
shuf STC: https://tests.stockfishchess.org/tests/view/66356316b4e9bdbc7228b995
shuf LTC: https://tests.stockfishchess.org/tests/view/6635815a73559a8aa857c1dc
opt STC: https://tests.stockfishchess.org/tests/view/66356326b4e9bdbc7228b9a0
opt LTC: https://tests.stockfishchess.org/tests/view/663615c673559a8aa8589f8a

And then passed LTC together:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 178278 W: 45039 L: 44979 D: 88260
Ptnml(0-2): 43, 19776, 49460, 19798, 62
https://tests.stockfishchess.org/tests/view/66363f19cdb7cf5da64e22a3

bench: 1479180