### PR TITLE
Revert moveCountPruning alleged speedup

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -958,8 +958,7 @@ moves_loop:  // When in check, search starts here
         if (!rootNode && pos.non_pawn_material(us) && bestValue > VALUE_TB_LOSS_IN_MAX_PLY)
         {
             // Skip quiet moves if movecount exceeds our FutilityMoveCount threshold (~8 Elo)
-            if (!moveCountPruning)
-                moveCountPruning = moveCount >= futility_move_count(improving, depth);
+            moveCountPruning = moveCount >= futility_move_count(improving, depth);
 
             // Reduced depth of the next LMR search
             int lmrDepth = newDepth - r;


### PR DESCRIPTION
Non-Functional simplification, reverting #4823 which probably was a fluke, as many other devs theorized over time.

As it was originally tested with only an stc test, for now I ran only an stc non-reg test.
However, if an LTC is required/preferred please let me know.

Passed stc:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 88992 W: 22779 L: 22633 D: 43580
Ptnml(0-2): 137, 8706, 26681, 8818, 154
https://tests.stockfishchess.org/tests/view/6636c4844b68b70d85800dae


bench: 1480008