### PR TITLE
Adjust history usage in moves loop pruning.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -989,7 +989,7 @@ moves_loop:  // When in check, search starts here
                 int history =
                   (*contHist[0])[movedPiece][move.to_sq()]
                   + (*contHist[1])[movedPiece][move.to_sq()]
-                  + (*contHist[3])[movedPiece][move.to_sq()]
+                  + (*contHist[3])[movedPiece][move.to_sq()] / 2
                   + thisThread->pawnHistory[pawn_structure_index(pos)][movedPiece][move.to_sq()];
 
                 // Continuation history based pruning (~2 Elo)


### PR DESCRIPTION
After my experiments with conthist 5 addition failed really bad I tried to adjust conthist 3 weights for lower values, divions by 2 passed as a gainer.
Passed STC:
https://tests.stockfishchess.org/tests/view/6636d7114b68b70d858035ce
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 35936 W: 9287 L: 8976 D: 17673
Ptnml(0-2): 81, 4129, 9234, 4446, 78 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6636ddb64b68b70d858040a8
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 82428 W: 21035 L: 20622 D: 40771
Ptnml(0-2): 29, 8985, 22775, 9394, 31 
bench 1615863