### PR TITLE
Simplify away conthist 3 from statscore.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1150,8 +1150,7 @@ moves_loop:  // When in check, search starts here
 
         ss->statScore = 2 * thisThread->mainHistory[us][move.from_to()]
                       + (*contHist[0])[movedPiece][move.to_sq()]
-                      + (*contHist[1])[movedPiece][move.to_sq()]
-                      + (*contHist[3])[movedPiece][move.to_sq()] - 5078;
+                      + (*contHist[1])[movedPiece][move.to_sq()] - 5078;
 
         // Decrease/increase reduction for moves with a good/bad history (~8 Elo)
         r -= ss->statScore / 12076;


### PR DESCRIPTION
Following previous elo gainer that gained by making conthist 3 less important in pruning this patch simplifies away this history from calculation of statscore.
Passed STC:
https://tests.stockfishchess.org/tests/view/6637aa7e9819650825aa93e0
LLR: 3.00 (-2.94,2.94) <-1.75,0.25>
Total: 35392 W: 9352 L: 9120 D: 16920
Ptnml(0-2): 141, 4145, 8888, 4385, 137 
Passed LTC:
https://tests.stockfishchess.org/tests/view/66383cd8493aaaf4b7ea90c5
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 33948 W: 8714 L: 8503 D: 16731
Ptnml(0-2): 39, 3701, 9270, 3938, 26
Passed LTC simplification on top of fauzi PR:
https://tests.stockfishchess.org/tests/view/663bdf15ca93dad645f7efa7
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 172254 W: 43482 L: 43416 D: 85356
Ptnml(0-2): 69, 19076, 47779, 19126, 77 
bench 2580316