### PR TITLE
Remove conthist 3 from moves loop pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -991,7 +991,6 @@ moves_loop:  // When in check, search starts here
                 int history =
                   (*contHist[0])[movedPiece][move.to_sq()]
                   + (*contHist[1])[movedPiece][move.to_sq()]
-                  + (*contHist[3])[movedPiece][move.to_sq()] / 2
                   + thisThread->pawnHistory[pawn_structure_index(pos)][movedPiece][move.to_sq()];
 
                 // Continuation history based pruning (~2 Elo)


### PR DESCRIPTION
Followup to previous gainer that made it twice less impactful there - this patch removes it entirely as a simplification.
Passed STC:
https://tests.stockfishchess.org/tests/view/6637aa7e9819650825aa93e0
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 26208 W: 6930 L: 6694 D: 12584
Ptnml(0-2): 113, 2997, 6652, 3225, 117 
Passed LTC:
https://tests.stockfishchess.org/tests/view/66383cba493aaaf4b7ea90c2
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 67866 W: 17294 L: 17118 D: 33454
Ptnml(0-2): 46, 7627, 18415, 7795, 50 
bench 2106211