### PR TITLE
Simplify depth formula based on score improvement

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1291,7 +1291,7 @@ moves_loop:  // When in check, search starts here
                 else
                 {
                     // Reduce other moves if we have found at least one score improvement (~2 Elo)
-                    if (depth > 2 && depth < 13 && beta < 15868 && value > -14630)
+                    if (depth > 2 && depth < 13 && abs(value) < VALUE_TB_WIN_IN_MAX_PLY)
                         depth -= 2;
 
                     assert(depth > 0);


### PR DESCRIPTION
Simplify depth formula based on score improvement.
This idea was first tried by @cj5716 (Please add him as co-author of this PR if possible).

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 347104 W: 89683 L: 89804 D: 167617
Ptnml(0-2): 1357, 38824, 93307, 38711, 1353
https://tests.stockfishchess.org/tests/view/66378edf9819650825aa75d0

Passed LTC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 63000 W: 15851 L: 15694 D: 31455
Ptnml(0-2): 22, 5396, 20499, 5569, 14
https://tests.stockfishchess.org/tests/view/663c04e5c0b75d7f7b97d461

bench: 2180675