### PR TITLE
Simplify Away Negative Extension When TT Value Is Below the Value of Reduced Search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1089,10 +1089,6 @@ moves_loop:  // When in check, search starts here
                 // If we are on a cutNode but the ttMove is not assumed to fail high over current beta (~1 Elo)
                 else if (cutNode)
                     extension = -2;
-
-                // If the ttMove is assumed to fail low over the value of the reduced search (~1 Elo)
-                else if (ttValue <= value)
-                    extension = -1;
             }
 
             // Extension for capturing the previous moved piece (~0 Elo on STC, ~1 Elo on LTC)


### PR DESCRIPTION
This patch simplifies away the negative extension applied when the value returned by the transposition table is assumed to fail low over the value of reduced search.

Passed STC:
LLR: 2.99 (-2.94,2.94) <-1.75,0.25>
Total: 248736 W: 64293 L: 64302 D: 120141
Ptnml(0-2): 925, 29833, 62831, 29884, 895
https://tests.stockfishchess.org/tests/view/663bee3bca93dad645f7f64a

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 254970 W: 64289 L: 64308 D: 126373
Ptnml(0-2): 110, 28428, 70422, 28421, 104 
https://tests.stockfishchess.org/tests/view/663c11f0c0b75d7f7b97d4bb

bench 2563206