### PR TITLE
Depth dependent statscore based reductions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1154,7 +1154,7 @@ moves_loop:  // When in check, search starts here
                       + (*contHist[3])[movedPiece][move.to_sq()] - 5078;
 
         // Decrease/increase reduction for moves with a good/bad history (~8 Elo)
-        r -= ss->statScore / 12076;
+        r -= ss->statScore / (17662 - std::min(depth, 16) * 105);
 
         // Step 17. Late moves reduction / extension (LMR, ~117 Elo)
         if (depth >= 2 && moveCount > 1 + rootNode)


### PR DESCRIPTION
Test a modification of Fawzi's PR #5223, against that PR.

parameters locally tuned with nevergrad4sf.

passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 1047424 W: 271478 L: 269649 D: 506297
Ptnml(0-2): 3851, 124543, 265290, 125982, 4046
https://tests.stockfishchess.org/tests/view/663b0889ca93dad645f7c58c

passed LTC:
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 796236 W: 201712 L: 199825 D: 394699
Ptnml(0-2): 361, 88381, 218778, 90206, 392
https://tests.stockfishchess.org/tests/view/663be6adca93dad645f7f509

Bench: 3346224