### PR TITLE
Simplify Away Quiet Check Evasions Pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1502,8 +1502,6 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
     MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory, &thisThread->captureHistory,
                   contHist, &thisThread->pawnHistory);
 
-    int quietCheckEvasions = 0;
-
     // Step 5. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
     while ((move = mp.next_move()) != Move::none())
@@ -1556,12 +1554,6 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
                 }
             }
 
-            // We prune after the second quiet check evasion move, where being 'in check' is
-            // implicitly checked through the counter, and being a 'quiet move' apart from
-            // being a tt move is assumed after an increment because captures are pushed ahead.
-            if (quietCheckEvasions > 1)
-                break;
-
             // Continuation history based pruning (~3 Elo)
             if (!capture
                 && (*contHist[0])[pos.moved_piece(move)][move.to_sq()]
@@ -1584,8 +1576,6 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
         ss->continuationHistory =
           &thisThread
              ->continuationHistory[ss->inCheck][capture][pos.moved_piece(move)][move.to_sq()];
-
-        quietCheckEvasions += !capture && ss->inCheck;
 
         // Step 7. Make and search the move
         thisThread->nodes.fetch_add(1, std::memory_order_relaxed);


### PR DESCRIPTION
This patch simplifies away the pruning of quiet evasion moves in quiescent search.

Passed STC:
LLR: 2.98 (-2.94,2.94) <-1.75,0.25>
Total: 343520 W: 88356 L: 88470 D: 166694
Ptnml(0-2): 1061, 40073, 89706, 39759, 1161 
https://tests.stockfishchess.org/tests/view/663c7ddfc0b75d7f7b980f3b

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 168744 W: 42454 L: 42384 D: 83906
Ptnml(0-2): 75, 18678, 46782, 18776, 61 
https://tests.stockfishchess.org/tests/view/663ce34fc0b75d7f7b981ed9

bench 3681552