### PR TITLE
Remove istringstream and ostringstream from Position

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -86,8 +86,8 @@ class Position {
     Position& operator=(const Position&) = delete;
 
     // FEN string input/output
-    Position&   set(const std::string& fenStr, bool isChess960, StateInfo* si);
-    Position&   set(const std::string& code, Color c, StateInfo* si);
+    Position&   set(const char* fenStr, bool isChess960, StateInfo* si);
+    Position&   set(const char* code, Color c, StateInfo* si);
     std::string fen() const;
 
     // Position representation


### PR DESCRIPTION
The idea of removing **(**`istringstream`**,**`ostringstream`**)** was taken from **Ronald de Man** on Cfish repository.

There were three patterns as follows:


- **string& -> char\***

```diff
- string& fenStr

+ char* fenStr
```

- **Remove istringstream**

```diff
- ss >> token;

+ token = *fenStr++; 
```

- **Remove ostringstream**

```diff
- ss << 'Q';

+ *str++ = ('Q');
```

The flip() function is the only thing left! And i'll do it soon, too.