### PR TITLE
Adjust standpat return value in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1478,6 +1478,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
         // Stand pat. Return immediately if static value is at least beta
         if (bestValue >= beta)
         {
+            if (std::abs(bestValue) < VALUE_TB_WIN_IN_MAX_PLY && !PvNode)
+                bestValue = (3 * bestValue + beta) / 4;
             if (!ss->ttHit)
                 tte->save(posKey, value_to_tt(bestValue, ss->ply), false, BOUND_LOWER, DEPTH_NONE,
                           Move::none(), unadjustedStaticEval, tt.generation());


### PR DESCRIPTION
Instead of returning value itself return value between it and beta for non pv nodes - analogous to what we do after actual search there.
Passed STC:
https://tests.stockfishchess.org/tests/view/663cb1b4c0b75d7f7b98188e
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 131552 W: 34131 L: 33673 D: 63748
Ptnml(0-2): 420, 15446, 33600, 15876, 434 
Passed LTC:
https://tests.stockfishchess.org/tests/view/663cda5dc0b75d7f7b981c6f
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 282798 W: 71658 L: 70833 D: 140307
Ptnml(0-2): 112, 31187, 77979, 32006, 115 
bench 2751986