### PR TITLE
5% less time on first move.

### DIFF
--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -666,8 +666,7 @@ class FeatureTransformer {
         {
             auto accTile =
               reinterpret_cast<vec_t*>(&accumulator.accumulation[Perspective][j * TileHeight]);
-            auto entryTile =
-              reinterpret_cast<vec_t*>(&entry.accumulation[j * TileHeight]);
+            auto entryTile = reinterpret_cast<vec_t*>(&entry.accumulation[j * TileHeight]);
 
             for (IndexType k = 0; k < NumRegs; ++k)
                 acc[k] = entryTile[k];
@@ -714,9 +713,9 @@ class FeatureTransformer {
         {
             auto accTilePsqt = reinterpret_cast<psqt_vec_t*>(
               &accumulator.psqtAccumulation[Perspective][j * PsqtTileHeight]);
-            auto entryTilePsqt = reinterpret_cast<psqt_vec_t*>(
-              &entry.psqtAccumulation[j * PsqtTileHeight]);
-            
+            auto entryTilePsqt =
+              reinterpret_cast<psqt_vec_t*>(&entry.psqtAccumulation[j * PsqtTileHeight]);
+
             for (std::size_t k = 0; k < NumPsqtRegs; ++k)
                 psqt[k] = entryTilePsqt[k];
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -157,7 +157,8 @@ void Search::Worker::start_searching() {
         return;
     }
 
-    main_manager()->tm.init(limits, rootPos.side_to_move(), rootPos.game_ply(), options);
+    main_manager()->tm.init(limits, rootPos.side_to_move(), rootPos.game_ply(), options,
+                            main_manager()->originalPly);
     tt.new_search();
 
     if (rootMoves.empty())

--- a/src/search.h
+++ b/src/search.h
@@ -210,6 +210,7 @@ class SearchManager: public ISearchManager {
             Depth                     depth) const;
 
     Stockfish::TimeManagement tm;
+    int                       originalPly;
     int                       callsCnt;
     std::atomic_bool          ponder;
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -167,6 +167,7 @@ void ThreadPool::clear() {
     main_manager()->callsCnt                 = 0;
     main_manager()->bestPreviousScore        = VALUE_INFINITE;
     main_manager()->bestPreviousAverageScore = VALUE_INFINITE;
+    main_manager()->originalPly              = -1;
     main_manager()->previousTimeReduction    = 1.0;
     main_manager()->tm.clear();
 }

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -44,10 +44,8 @@ void TimeManagement::advance_nodes_time(std::int64_t nodes) {
 // the bounds of time allowed for the current game ply. We currently support:
 //      1) x basetime (+ z increment)
 //      2) x moves in y seconds (+ z increment)
-void TimeManagement::init(Search::LimitsType& limits,
-                          Color               us,
-                          int                 ply,
-                          const OptionsMap&   options) {
+void TimeManagement::init(
+  Search::LimitsType& limits, Color us, int ply, const OptionsMap& options, int& originalPly) {
     TimePoint npmsec = TimePoint(options["nodestime"]);
 
     // If we have no time, we don't need to fully initialize TM.
@@ -57,6 +55,9 @@ void TimeManagement::init(Search::LimitsType& limits,
 
     if (limits.time[us] == 0)
         return;
+
+    if (originalPly == -1)
+        originalPly = ply;
 
     TimePoint moveOverhead = TimePoint(options["Move Overhead"]);
 
@@ -106,6 +107,8 @@ void TimeManagement::init(Search::LimitsType& limits,
     {
         // Use extra time with larger increments
         double optExtra = scaledInc < 500 ? 1.0 : 1.13;
+        if (ply - originalPly < 2)
+            optExtra *= 0.95;
 
         // Calculate time constants based on current time left.
         double logTimeInSec = std::log10(scaledTime / 1000.0);

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -36,7 +36,8 @@ struct LimitsType;
 // the maximum available time, the game move number, and other parameters.
 class TimeManagement {
    public:
-    void init(Search::LimitsType& limits, Color us, int ply, const OptionsMap& options);
+    void init(
+      Search::LimitsType& limits, Color us, int ply, const OptionsMap& options, int& originalPly);
 
     TimePoint optimum() const;
     TimePoint maximum() const;


### PR DESCRIPTION
Stockfish appears to take too much time on the first move of a game and then not enough on moves 2,3,4... Probably caused by most of the factors that increase time usually applying on the first move.

Attempts to give more time to the subsequent moves have not worked so far, but this change to simply reduce first move time by 5% worked.

STC 10+0.1 :
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 78496 W: 20516 L: 20135 D: 37845
Ptnml(0-2): 340, 8859, 20456, 9266, 327
https://tests.stockfishchess.org/tests/view/663d47bf507ebe1c0e9200ba

LTC 60+0.6 :
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 94872 W: 24179 L: 23751 D: 46942
Ptnml(0-2): 61, 9743, 27405, 10161, 66
https://tests.stockfishchess.org/tests/view/663e779cbb28828150dd9089

Bench 1876282