### PR TITLE
Simplify npm constants when adjusting eval

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -62,15 +62,13 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     Value nnue = smallNet ? networks.small.evaluate(pos, &caches.small, true, &nnueComplexity)
                           : networks.big.evaluate(pos, &caches.big, true, &nnueComplexity);
 
-    const auto adjustEval = [&](int nnueDiv, int pawnCountConstant, int pawnCountMul,
-                                int npmConstant, int evalDiv, int shufflingConstant) {
+    const auto adjustEval = [&](int nnueDiv, int pawnCountMul, int evalDiv, int shufflingConstant) {
         // Blend optimism and eval with nnue complexity and material imbalance
         optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 584;
         nnue -= nnue * (nnueComplexity * 5 / 3) / nnueDiv;
 
         int npm = pos.non_pawn_material() / 64;
-        v       = (nnue * (npm + pawnCountConstant + pawnCountMul * pos.count<PAWN>())
-             + optimism * (npmConstant + npm))
+        v       = (nnue * (npm + 943 + pawnCountMul * pos.count<PAWN>()) + optimism * (npm + 140))
           / evalDiv;
 
         // Damp down the evaluation linearly when shuffling
@@ -79,9 +77,9 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     };
 
     if (!smallNet)
-        adjustEval(32395, 942, 11, 139, 1058, 178);
+        adjustEval(32395, 11, 1058, 178);
     else
-        adjustEval(32793, 944, 9, 140, 1067, 206);
+        adjustEval(32793, 9, 1067, 206);
 
     // Guarantee evaluation does not hit the tablebase range
     v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);


### PR DESCRIPTION
Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/663d0c4f507ebe1c0e91ec8d
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 162784 W: 41987 L: 41906 D: 78891
Ptnml(0-2): 520, 19338, 41591, 19427, 516

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/663d20fd507ebe1c0e91f405
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 457242 W: 115022 L: 115250 D: 226970
Ptnml(0-2): 271, 51566, 125179, 51330, 275

bench 2566893