### PR TITLE
Re-evaluate some small net positions for more accurate evals

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -62,6 +62,9 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     Value nnue = smallNet ? networks.small.evaluate(pos, &caches.small, true, &nnueComplexity)
                           : networks.big.evaluate(pos, &caches.big, true, &nnueComplexity);
 
+    if (smallNet && (nnue * simpleEval < 0 || std::abs(nnue) < 500))
+        nnue = networks.big.evaluate(pos, &caches.big, true, &nnueComplexity);
+
     const auto adjustEval = [&](int nnueDiv, int pawnCountConstant, int pawnCountMul,
                                 int npmConstant, int evalDiv, int shufflingConstant) {
         // Blend optimism and eval with nnue complexity and material imbalance

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -29,7 +29,7 @@ class Position;
 
 namespace Eval {
 
-constexpr inline int SmallNetThreshold = 1274;
+constexpr inline int SmallNetThreshold = 1174;
 
 // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
 // for the build process (profile-build and fishtest) to work. Do not change the


### PR DESCRIPTION
Use main net evals when small net evals hint that higher eval
accuracy may be worth the slower eval speeds. With Finny caches,
re-evals with the main net are less expensive than before.

Original idea by @mstembera who I've added as co-author to this PR.

Based on reEval tests by @mstembera:
https://tests.stockfishchess.org/tests/view/65e69187b6345c1b934866e5 https://tests.stockfishchess.org/tests/view/65e863aa0ec64f0526c3e991

A few variants of this patch also passed LTC:
https://tests.stockfishchess.org/tests/view/663d2108507ebe1c0e91f407 https://tests.stockfishchess.org/tests/view/663e388c3a2f9702074bc152

Passed STC:
https://tests.stockfishchess.org/tests/view/663dadbd1a61d6377f190e2c
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 92320 W: 23941 L: 23531 D: 44848
Ptnml(0-2): 430, 10993, 22931, 11349, 457

Passed LTC:
https://tests.stockfishchess.org/tests/view/663ef48b2948bf9aa698690c
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 98934 W: 24907 L: 24457 D: 49570
Ptnml(0-2): 48, 10952, 27027, 11382, 58

bench 2955600