### PR TITLE
Add extra bonus for high depth condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -738,7 +738,7 @@ Value Search::Worker::search(
     // Use static evaluation difference to improve quiet move ordering (~9 Elo)
     if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture)
     {
-        int bonus = std::clamp(-12 * int((ss - 1)->staticEval + ss->staticEval), -1749, 1602);
+        int bonus = std::clamp(-12 * int((ss - 1)->staticEval + ss->staticEval), -1749, 1584);
         bonus     = bonus > 0 ? 2 * bonus : bonus / 2;
         thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()] << bonus;
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
@@ -1327,8 +1327,8 @@ moves_loop:  // When in check, search starts here
     // Bonus for prior countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
     {
-        int bonus = (depth > 5) + (PvNode || cutNode) + ((ss - 1)->statScore < -14323)
-                  + ((ss - 1)->moveCount > 10) + (!ss->inCheck && bestValue <= ss->staticEval - 127)
+        int bonus = (depth > 4) + (depth > 5) + (PvNode || cutNode) + ((ss - 1)->statScore < -14323)
+                  + ((ss - 1)->moveCount > 10) + (!ss->inCheck && bestValue <= ss->staticEval - 120)
                   + (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 76);
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       stat_bonus(depth) * bonus);


### PR DESCRIPTION
Add extra bonus for high-depth condition
Tested against muzhen passed VLTC tune

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 54208 W: 14058 L: 13717 D: 26433
Ptnml(0-2): 166, 6277, 13885, 6602, 174
https://tests.stockfishchess.org/tests/view/664136d8f9f4e8fc783c9b82

Passed LTC:
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 112548 W: 28492 L: 28018 D: 56038
Ptnml(0-2): 53, 12186, 31318, 12668, 49
https://tests.stockfishchess.org/tests/view/664143fef9f4e8fc783c9bf6

bench: 1725980