### PR TITLE
ReEval fix

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -63,7 +63,10 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
                           : networks.big.evaluate(pos, &caches.big, true, &nnueComplexity);
 
     if (smallNet && (nnue * simpleEval < 0 || std::abs(nnue) < 500))
-        nnue = networks.big.evaluate(pos, &caches.big, true, &nnueComplexity);
+    {
+        nnue     = networks.big.evaluate(pos, &caches.big, true, &nnueComplexity);
+        smallNet = false;
+    }
 
     const auto adjustEval = [&](int nnueDiv, int pawnCountMul, int evalDiv, int shufflingConstant) {
         // Blend optimism and eval with nnue complexity and material imbalance


### PR DESCRIPTION
Set smallNet to false after rescoring so we call adjustEval() w/ correct parameters.

STC https://tests.stockfishchess.org/tests/view/664308687134c82f3f7a4003
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 146912 W: 37856 L: 37756 D: 71300
Ptnml(0-2): 566, 17562, 37122, 17618, 588 

LTC https://tests.stockfishchess.org/tests/view/6643a0821f32a966da7485d6
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 390414 W: 98015 L: 98173 D: 194226
Ptnml(0-2): 162, 43555, 107929, 43401, 160 

bench: 1766019