### PR TITLE
More reduction if position is improving but value from TT doesn't exceeds alpha.

### DIFF
--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -666,8 +666,7 @@ class FeatureTransformer {
         {
             auto accTile =
               reinterpret_cast<vec_t*>(&accumulator.accumulation[Perspective][j * TileHeight]);
-            auto entryTile =
-              reinterpret_cast<vec_t*>(&entry.accumulation[j * TileHeight]);
+            auto entryTile = reinterpret_cast<vec_t*>(&entry.accumulation[j * TileHeight]);
 
             for (IndexType k = 0; k < NumRegs; ++k)
                 acc[k] = entryTile[k];
@@ -714,9 +713,9 @@ class FeatureTransformer {
         {
             auto accTilePsqt = reinterpret_cast<psqt_vec_t*>(
               &accumulator.psqtAccumulation[Perspective][j * PsqtTileHeight]);
-            auto entryTilePsqt = reinterpret_cast<psqt_vec_t*>(
-              &entry.psqtAccumulation[j * PsqtTileHeight]);
-            
+            auto entryTilePsqt =
+              reinterpret_cast<psqt_vec_t*>(&entry.psqtAccumulation[j * PsqtTileHeight]);
+
             for (std::size_t k = 0; k < NumPsqtRegs; ++k)
                 psqt[k] = entryTilePsqt[k];
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1133,6 +1133,9 @@ moves_loop:  // When in check, search starts here
         if (PvNode)
             r--;
 
+        if (improving && ttValue <= alpha && move != ttMove)
+            r++;
+
         // Increase reduction if next ply has a lot of fail high (~5 Elo)
         if ((ss + 1)->cutoffCnt > 3)
             r++;


### PR DESCRIPTION

But the tt move is excluded.

This idea is based on following LMR condition tuning https://tests.stockfishchess.org/tests/view/66423a1bf9f4e8fc783cba37 by using only three of the four largest terms P[3], P[18] and P[12].

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 27840 W: 7309 L: 7004 D: 13527
Ptnml(0-2): 85, 3219, 7018, 3502, 96
https://tests.stockfishchess.org/tests/view/6643dc1cbc537f56194508ba

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 191280 W: 48656 L: 48020 D: 94604
Ptnml(0-2): 78, 20979, 52903, 21589, 91
https://tests.stockfishchess.org/tests/view/6643e543bc537f5619451683

Bench: 1652409