### PR TITLE
Use same eval divisor for both nets

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -65,14 +65,13 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     if (smallNet && (nnue * simpleEval < 0 || std::abs(nnue) < 500))
         nnue = networks.big.evaluate(pos, &caches.big, true, &nnueComplexity);
 
-    const auto adjustEval = [&](int nnueDiv, int pawnCountMul, int evalDiv, int shufflingConstant) {
+    const auto adjustEval = [&](int nnueDiv, int pawnCountMul, int shufflingConstant) {
         // Blend optimism and eval with nnue complexity and material imbalance
         optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 584;
         nnue -= nnue * (nnueComplexity * 5 / 3) / nnueDiv;
 
         int npm = pos.non_pawn_material() / 64;
-        v       = (nnue * (npm + 943 + pawnCountMul * pos.count<PAWN>()) + optimism * (npm + 140))
-          / evalDiv;
+        v = (nnue * (npm + 943 + pawnCountMul * pos.count<PAWN>()) + optimism * (npm + 140)) / 1058;
 
         // Damp down the evaluation linearly when shuffling
         int shuffling = pos.rule50_count();
@@ -80,9 +79,9 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     };
 
     if (!smallNet)
-        adjustEval(32395, 11, 1058, 178);
+        adjustEval(32395, 11, 178);
     else
-        adjustEval(32793, 9, 1067, 206);
+        adjustEval(32793, 9, 206);
 
     // Guarantee evaluation does not hit the tablebase range
     v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);


### PR DESCRIPTION
Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/66428f146577e9d2c8a29cf8
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 241024 W: 62173 L: 62177 D: 116674
Ptnml(0-2): 904, 28648, 61407, 28654, 899

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/6643ae6f1f32a966da74977b
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 193710 W: 48762 L: 48717 D: 96231
Ptnml(0-2): 70, 21599, 53481, 21626, 79

bench 1539355