### PR TITLE
Fix viewer experience patch in thread voting

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -270,9 +270,9 @@ Thread* ThreadPool::get_best_thread() const {
           newThreadScore != -VALUE_INFINITE && newThreadScore <= VALUE_TB_LOSS_IN_MAX_PLY;
 
         // Note that we make sure not to pick a thread with truncated-PV for better viewer experience.
-        const bool betterVotingValue =
-          thread_voting_value(th) * int(newThreadPV.size() > 2)
-          > thread_voting_value(bestThread) * int(bestThreadPV.size() > 2);
+        const bool betterVotingValue = thread_voting_value(th) > thread_voting_value(bestThread)
+                                    || (newThreadPV[0] == bestThreadPV[0] && newThreadPV.size() > 2
+                                        && bestThreadPV.size() <= 2);
 
         if (bestThreadInProvenWin)
         {


### PR DESCRIPTION
https://github.com/official-stockfish/Stockfish/commit/310928e985a6d87bdd73542e2109f93c31e2cc41 was introduced to enhance viewer experience in tournaments and it was supposed to be non-functional this implements the intended and fixes the edge case where the patch can be functional if  `votes[th->rootMoves[0].pv[0]] == votes[bestThread->rootMoves[0].pv[0]]` is true but `th->rootMoves[0].pv[0] == bestThread->rootMoves[0].pv[0]` is not, leading to changing the move played.

Passed non-reg SMP STC:
https://tests.stockfishchess.org/tests/view/6640f6f970e85e1f2ce32460
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 135096 W: 34589 L: 34482 D: 66025
Ptnml(0-2): 219, 15267, 36455, 15402, 205

Passed non-reg SMP LTC:
https://tests.stockfishchess.org/tests/view/66417145f9f4e8fc783c9d26
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 142906 W: 36093 L: 35999 D: 70814
Ptnml(0-2): 29, 15050, 41198, 15150, 26

No functional change