### PR TITLE
Simplifying improving and worsening deduction formulas

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -60,8 +60,8 @@ static constexpr double EvalLevel[10] = {0.981, 0.956, 0.895, 0.949, 0.913,
 // Futility margin
 Value futility_margin(Depth d, bool noTtCutNode, bool improving, bool oppWorsening) {
     Value futilityMult       = 131 - 48 * noTtCutNode;
-    Value improvingDeduction = 57 * improving * futilityMult / 32;
-    Value worseningDeduction = (309 + 52 * improving) * oppWorsening * futilityMult / 1024;
+    Value improvingDeduction = 2 * improving * futilityMult;
+    Value worseningDeduction = 330 * oppWorsening * futilityMult / 1024;
 
     return futilityMult * d - improvingDeduction - worseningDeduction;
 }


### PR DESCRIPTION
Simplifying improving and worsening deduction formulas
I have some ideas on top of this which I will experiment with as soon as this gets merged.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 77696 W: 20052 L: 19878 D: 37766
Ptnml(0-2): 222, 9124, 19994, 9274, 234
https://tests.stockfishchess.org/tests/view/66440032bc537f561945171e

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 234414 W: 58874 L: 58871 D: 116669
Ptnml(0-2): 96, 26147, 64742, 26102, 120
https://tests.stockfishchess.org/tests/view/6644094cbc537f5619451735


bench: 1651630