### PR TITLE
Use same nnue divisor for both nets

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -68,10 +68,10 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
         smallNet = false;
     }
 
-    const auto adjustEval = [&](int nnueDiv, int pawnCountMul, int shufflingConstant) {
+    const auto adjustEval = [&](int pawnCountMul, int shufflingConstant) {
         // Blend optimism and eval with nnue complexity and material imbalance
         optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 584;
-        nnue -= nnue * (nnueComplexity * 5 / 3) / nnueDiv;
+        nnue -= nnue * (nnueComplexity * 5 / 3) / 32395;
 
         int npm = pos.non_pawn_material() / 64;
         v = (nnue * (npm + 943 + pawnCountMul * pos.count<PAWN>()) + optimism * (npm + 140)) / 1058;
@@ -82,9 +82,9 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     };
 
     if (!smallNet)
-        adjustEval(32395, 11, 178);
+        adjustEval(11, 178);
     else
-        adjustEval(32793, 9, 206);
+        adjustEval(9, 206);
 
     // Guarantee evaluation does not hit the tablebase range
     v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);


### PR DESCRIPTION
Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/6643ceeabc537f56194506f6
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 224800 W: 57910 L: 57896 D: 108994
Ptnml(0-2): 673, 26790, 57519, 26686, 732

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/6643ff15bc537f5619451719
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 347658 W: 87574 L: 87688 D: 172396
Ptnml(0-2): 207, 39004, 95488, 38956, 174

bench 1804704