### PR TITLE
Lower smallnet threshold linearly as pawn count decreases

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -55,7 +55,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     assert(!pos.checkers());
 
     int  simpleEval = simple_eval(pos, pos.side_to_move());
-    bool smallNet   = std::abs(simpleEval) > SmallNetThreshold;
+    bool smallNet   = std::abs(simpleEval) > SmallNetThreshold + 6 * pos.count<PAWN>();
     int  nnueComplexity;
     int  v;
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -29,7 +29,7 @@ class Position;
 
 namespace Eval {
 
-constexpr inline int SmallNetThreshold = 1174;
+constexpr inline int SmallNetThreshold = 1126;
 
 // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
 // for the build process (profile-build and fishtest) to work. Do not change the

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -47,7 +47,7 @@ void hint_common_parent_position(const Position&    pos,
                                  AccumulatorCaches& caches) {
 
     int simpleEvalAbs = std::abs(simple_eval(pos, pos.side_to_move()));
-    if (simpleEvalAbs > Eval::SmallNetThreshold)
+    if (simpleEvalAbs > Eval::SmallNetThreshold + 6 * pos.count<PAWN>())
         networks.small.hint_common_access(pos, &caches.small);
     else
         networks.big.hint_common_access(pos, &caches.big);


### PR DESCRIPTION
Passed STC:
https://tests.stockfishchess.org/tests/view/6644f677324e96f42f89d894
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 377920 W: 97135 L: 96322 D: 184463
Ptnml(0-2): 1044, 44259, 97588, 44978, 1091

Passed LTC:
https://tests.stockfishchess.org/tests/view/664548af93ce6da3e93b31b3
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 169056 W: 42901 L: 42312 D: 83843
Ptnml(0-2): 58, 18538, 46753, 19115, 64

bench 1495338