### PR TITLE
Update default main net to nn-c721dfca8cd3.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,7 +35,7 @@ constexpr inline int SmallNetThreshold = 1126;
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-ae6a388e4a1a.nnue"
+#define EvalFileDefaultNameBig "nn-c721dfca8cd3.nnue"
 #define EvalFileDefaultNameSmall "nn-baff1ede1f90.nnue"
 
 namespace NNUE {


### PR DESCRIPTION
Created by first retraining the spsa-tuned main net `nn-ae6a388e4a1a.nnue` with:
- using v6-dd data without bestmove captures removed
- addition of T80 mar2024 data
- increasing loss by 20% when Q is too high
- torch.compile changes for marginal training speed gains

And then SPSA tuning weights of epoch 899 following methods described in:
https://github.com/official-stockfish/Stockfish/pull/5149

This net was reached at 92k out of 120k steps in this 70+0.7 th 7 SPSA tuning run: https://tests.stockfishchess.org/tests/view/66413b7df9f4e8fc783c9bbb

Thanks to @Viren6 for suggesting usage of:
- c value 4 for the weights
- c value 128 for the biases

Scripts for automating applying fishtest spsa params to exporting tuned .nnue are in:
https://github.com/linrock/nnue-tools/tree/master/spsa

Before spsa tuning, epoch 899 was nn-f85738aefa84.nnue https://tests.stockfishchess.org/tests/view/663e5c893a2f9702074bc167

After initially training with max-epoch 800, training was resumed with max-epoch 1000.

```yaml
experiment-name: 3072--S11--more-data-v6-dd-t80-mar2024--see-ge0-20p-more-loss-high-q-sk28-l8
nnue-pytorch-branch: linrock/nnue-pytorch/3072-r21-skip-more-wdl-see-ge0-20p-more-loss-high-q-torch-compile-more

start-from-engine-test-net: False
start-from-model: /data/config/apr2024-3072/nn-ae6a388e4a1a.nnue

early-fen-skipping: 28
training-dataset:
  /data/S11-mar2024/:
    - leela96.v2.min.binpack

    - test60-2021-11-12-novdec-12tb7p.v6-dd.min.binpack
    - test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack

    - test80-2022-06-jun-16tb7p.v6-dd.min.binpack

    - test80-2022-08-aug-16tb7p.v6-dd.min.binpack
    - test80-2022-09-sep-16tb7p.v6-dd.min.binpack

    - test80-2023-01-jan-16tb7p.v6-sk20.min.binpack
    - test80-2023-02-feb-16tb7p.v6-sk20.min.binpack
    - test80-2023-03-mar-2tb7p.v6-sk16.min.binpack
    - test80-2023-04-apr-2tb7p.v6-sk16.min.binpack
    - test80-2023-05-may-2tb7p.v6.min.binpack

    # https://github.com/official-stockfish/Stockfish/pull/4782
    - test80-2023-06-jun-2tb7p.binpack
    - test80-2023-07-jul-2tb7p.binpack

    # https://github.com/official-stockfish/Stockfish/pull/4972
    - test80-2023-08-aug-2tb7p.v6.min.binpack
    - test80-2023-09-sep-2tb7p.binpack
    - test80-2023-10-oct-2tb7p.binpack

    # S9 new data: https://github.com/official-stockfish/Stockfish/pull/5056
    - test80-2023-11-nov-2tb7p.binpack
    - test80-2023-12-dec-2tb7p.binpack

    # S10 new data: https://github.com/official-stockfish/Stockfish/pull/5149
    - test80-2024-01-jan-2tb7p.binpack
    - test80-2024-02-feb-2tb7p.binpack

    # S11 new data
    - test80-2024-03-mar-2tb7p.binpack

  /data/filt-v6-dd/:
    - test77-dec2021-16tb7p-filter-v6-dd.binpack
    - test78-juntosep2022-16tb7p-filter-v6-dd.binpack
    - test79-apr2022-16tb7p-filter-v6-dd.binpack
    - test79-may2022-16tb7p-filter-v6-dd.binpack
    - test80-jul2022-16tb7p-filter-v6-dd.binpack
    - test80-oct2022-16tb7p-filter-v6-dd.binpack
    - test80-nov2022-16tb7p-filter-v6-dd.binpack

num-epochs: 1000

lr: 4.375e-4
gamma: 0.995
start-lambda: 0.8
end-lambda: 0.7
```

Training data can be found at:
https://robotmoon.com/nnue-training-data/

Local elo at 25k nodes per move:
nn-epoch899.nnue : 4.6 +/- 1.4

Passed STC:
https://tests.stockfishchess.org/tests/view/6645454893ce6da3e93b31ae
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 95232 W: 24598 L: 24194 D: 46440
Ptnml(0-2): 294, 11215, 24180, 11647, 280

Passed LTC:
https://tests.stockfishchess.org/tests/view/6645522d93ce6da3e93b31df
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 320544 W: 81432 L: 80524 D: 158588
Ptnml(0-2): 164, 35659, 87696, 36611, 142

bench 1995552