### PR TITLE
Move smallnet threshold logic into a function

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -44,6 +44,10 @@ int Eval::simple_eval(const Position& pos, Color c) {
          + (pos.non_pawn_material(c) - pos.non_pawn_material(~c));
 }
 
+bool Eval::use_smallnet(const Position& pos) {
+    int simpleEval = simple_eval(pos, pos.side_to_move());
+    return std::abs(simpleEval) > 1126 + 6 * pos.count<PAWN>();
+}
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
 // of the position from the point of view of the side to move.
@@ -55,7 +59,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     assert(!pos.checkers());
 
     int  simpleEval = simple_eval(pos, pos.side_to_move());
-    bool smallNet   = std::abs(simpleEval) > SmallNetThreshold + 6 * pos.count<PAWN>();
+    bool smallNet   = use_smallnet(pos);
     int  nnueComplexity;
     int  v;
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -29,8 +29,6 @@ class Position;
 
 namespace Eval {
 
-constexpr inline int SmallNetThreshold = 1126;
-
 // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
@@ -46,6 +44,7 @@ struct AccumulatorCaches;
 std::string trace(Position& pos, const Eval::NNUE::Networks& networks);
 
 int   simple_eval(const Position& pos, Color c);
+bool  use_smallnet(const Position& pos);
 Value evaluate(const NNUE::Networks&          networks,
                const Position&                pos,
                Eval::NNUE::AccumulatorCaches& caches,

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -45,9 +45,7 @@ constexpr std::string_view PieceToChar(" PNBRQK  pnbrqk");
 void hint_common_parent_position(const Position&    pos,
                                  const Networks&    networks,
                                  AccumulatorCaches& caches) {
-
-    int simpleEvalAbs = std::abs(simple_eval(pos, pos.side_to_move()));
-    if (simpleEvalAbs > Eval::SmallNetThreshold + 6 * pos.count<PAWN>())
+    if (Eval::use_smallnet(pos))
         networks.small.hint_common_access(pos, &caches.small);
     else
         networks.big.hint_common_access(pos, &caches.big);


### PR DESCRIPTION
Now that the smallnet threshold is no longer a constant, use a function to organize it with other eval code.

Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/66459fa093ce6da3e93b5ba2
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 217600 W: 56281 L: 56260 D: 105059
Ptnml(0-2): 756, 23787, 59729, 23736, 792

No functional change