### PR TITLE
Early Exit in Bitboards::sliding_attack()

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -124,8 +124,12 @@ Bitboard sliding_attack(PieceType pt, Square sq, Bitboard occupied) {
     for (Direction d : (pt == ROOK ? RookDirections : BishopDirections))
     {
         Square s = sq;
-        while (safe_destination(s, d) && !(occupied & s))
+        while (safe_destination(s, d)) {
             attacks |= (s += d);
+            if (occupied & s) {
+                break;
+      }
+     }
     }
 
     return attacks;


### PR DESCRIPTION
The original code checks for occupancy within the loop condition. By moving this check inside the loop and adding an early exit condition, we can avoid unnecessary iterations if a blocking piece is encountered.

Passed stc:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 127200 W: 33129 L: 32700 D: 61371
Ptnml(0-2): 424, 13243, 35826, 13694, 413
https://tests.stockfishchess.org/tests/view/664646006dcff0d1d6b05bca

No functional change:
bench: 1991750