### PR TITLE
Use one nnue pawn count multiplier

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -68,13 +68,13 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
         smallNet = false;
     }
 
-    const auto adjustEval = [&](int pawnCountMul, int shufflingConstant) {
+    const auto adjustEval = [&](int shufflingConstant) {
         // Blend optimism and eval with nnue complexity and material imbalance
         optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 584;
         nnue -= nnue * (nnueComplexity * 5 / 3) / 32395;
 
         int npm = pos.non_pawn_material() / 64;
-        v = (nnue * (npm + 943 + pawnCountMul * pos.count<PAWN>()) + optimism * (npm + 140)) / 1058;
+        v       = (nnue * (npm + 943 + 11 * pos.count<PAWN>()) + optimism * (npm + 140)) / 1058;
 
         // Damp down the evaluation linearly when shuffling
         int shuffling = pos.rule50_count();
@@ -82,9 +82,9 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     };
 
     if (!smallNet)
-        adjustEval(11, 178);
+        adjustEval(178);
     else
-        adjustEval(9, 206);
+        adjustEval(206);
 
     // Guarantee evaluation does not hit the tablebase range
     v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);


### PR DESCRIPTION
Switch to the value used by the main net.

Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/6647e8096dcff0d1d6b05e96
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 51040 W: 13249 L: 13044 D: 24747
Ptnml(0-2): 139, 6029, 13016, 6160, 176

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/6647f4a46dcff0d1d6b05eea
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 20460 W: 5195 L: 4972 D: 10293
Ptnml(0-2): 8, 2178, 5637, 2397, 10

bench 1978177