### PR TITLE
Simplify Away Quadruple Extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1053,11 +1053,9 @@ moves_loop:  // When in check, search starts here
                     int doubleMargin = 285 * PvNode - 228 * !ttCapture;
                     int tripleMargin =
                       121 + 238 * PvNode - 259 * !ttCapture + 117 * (ss->ttPv || !ttCapture);
-                    int quadMargin = 471 + 343 * PvNode - 281 * !ttCapture + 217 * ss->ttPv;
 
                     extension = 1 + (value < singularBeta - doubleMargin)
-                              + (value < singularBeta - tripleMargin)
-                              + (value < singularBeta - quadMargin);
+                              + (value < singularBeta - tripleMargin);
 
                     depth += ((!PvNode) && (depth < 14));
                 }


### PR DESCRIPTION
Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 95472 W: 24176 L: 24031 D: 47265
Ptnml(0-2): 52, 10533, 26414, 10692, 45 
https://tests.stockfishchess.org/tests/live_elo/6647fa596dcff0d1d6b05efa

Passed VVLTC 70+7 th 7:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 6772 W: 1793 L: 1583 D: 3396
Ptnml(0-2): 0, 502, 2172, 712, 0
https://tests.stockfishchess.org/tests/live_elo/6648277a6dcff0d1d6b05ffb

Passed VVLTC 70+7 th 7 (2x):
https://tests.stockfishchess.org/tests/view/66484c896dcff0d1d6b0619d
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 5424 W: 1469 L: 1254 D: 2701
Ptnml(0-2): 0, 394, 1710, 607, 1

bench 1497842