### PR TITLE
If verification search fails low, return beta

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -816,6 +816,8 @@ Value Search::Worker::search(
 
             if (v >= beta)
                 return nullValue;
+            else
+                return v;
         }
     }
 


### PR DESCRIPTION
Same bench as master:
bench: 1441794

The original code checks if v >= beta after the verification search. However, if the verification search fails low (v < beta), it still returns nullValue.
With this change,  if we can't beat beta, we return v, so we don't completly render the verification search useless.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 675040 W: 173934 L: 172755 D: 328351
Ptnml(0-2): 1813, 70154, 192463, 71221, 1869
https://tests.stockfishchess.org/tests/view/664739006dcff0d1d6b05cb9

*Let me know if an LTC test is needed.

bench: 1441794