### PR TITLE
Revert "Simplify Away Quadruple Extensions"

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1053,9 +1053,11 @@ moves_loop:  // When in check, search starts here
                     int doubleMargin = 298 * PvNode - 209 * !ttCapture;
                     int tripleMargin =
                       117 + 252 * PvNode - 270 * !ttCapture + 111 * (ss->ttPv || !ttCapture);
+                    int quadMargin = 471 + 343 * PvNode - 281 * !ttCapture + 217 * ss->ttPv;
 
                     extension = 1 + (value < singularBeta - doubleMargin)
-                              + (value < singularBeta - tripleMargin);
+                              + (value < singularBeta - tripleMargin)
+                              + (value < singularBeta - quadMargin);
 
                     depth += ((!PvNode) && (depth < 15));
                 }


### PR DESCRIPTION
Calamitous blunder: This reverts commit 4edd1a3

The unusual result of (combined) +12.0 +- 3.7 in the 2 VVLTC simplification SPRTs ran was the result of base having only 64MB of hash instead of 512MB (Asymmetric hash). @Vizvezdenec was the one to notice this.

On a positive note, this has lead to the development of a new fishtest warning system to prevent such occurences in the future.

bench 1404295