### PR TITLE
Tweak continuation history bonus dependent on ply.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1779,6 +1779,8 @@ void update_all_stats(const Position& pos,
 // by moves at ply -1, -2, -3, -4, and -6 with current move.
 void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
 
+    bonus = bonus * (112 * ss->ply + 136) / (159 * ss->ply + 124);
+
     for (int i : {1, 2, 3, 4, 6})
     {
         // Only update the first 2 continuation histories if we are in check


### PR DESCRIPTION
This patch is based on following tuning https://tests.stockfishchess.org/tests/view/6648b2eb308cceea45533abe by only using the tuned factors for the continuation history.

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 99904 W: 25865 L: 25457 D: 48582
Ptnml(0-2): 281, 11705, 25578, 12101, 287
https://tests.stockfishchess.org/tests/view/6648c136308cceea45533af8

Passed LTC:
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 36402 W: 9362 L: 9039 D: 18001
Ptnml(0-2): 20, 3952, 9951, 4241, 37
https://tests.stockfishchess.org/tests/view/6648ee3cb8fa20e74c39f3fd

Bench: 1917762