### PR TITLE
Do more aggressive pawn history updates.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -496,7 +496,7 @@ void Search::Worker::clear() {
     counterMoves.fill(Move::none());
     mainHistory.fill(0);
     captureHistory.fill(0);
-    pawnHistory.fill(-900);
+    pawnHistory.fill(-1100);
     correctionHistory.fill(0);
 
     for (bool inCheck : {false, true})
@@ -1339,7 +1339,7 @@ moves_loop:  // When in check, search starts here
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
             thisThread->pawnHistory[pawn_structure_index(pos)][pos.piece_on(prevSq)][prevSq]
-              << stat_bonus(depth) * bonus * 2;
+              << stat_bonus(depth) * bonus * 4;
     }
 
     if (PvNode)


### PR DESCRIPTION
Tweak of recent patch that made pawn history to update for move that caused a fail low - and setting up default value of it to -900.
This patch makes it more aggressive - twice bigger updates and default value -1100.
Passed STC:
https://tests.stockfishchess.org/tests/view/6648c5d4308cceea45533b5d
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 235200 W: 61090 L: 60476 D: 113634
Ptnml(0-2): 763, 27952, 59651, 28376, 858 
Passed LTC:
https://tests.stockfishchess.org/tests/view/664a1008ae57c1758ac5b523
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 20076 W: 5193 L: 4908 D: 9975
Ptnml(0-2): 7, 2105, 5534, 2380, 12 
bench 1383066