### PR TITLE
Simplify the recently introduced ply-based cmh bonus factor.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1779,6 +1779,8 @@ void update_all_stats(const Position& pos,
 // by moves at ply -1, -2, -3, -4, and -6 with current move.
 void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
 
+    bonus = bonus * 45 / 64;
+
     for (int i : {1, 2, 3, 4, 6})
     {
         // Only update the first 2 continuation histories if we are in check


### PR DESCRIPTION
Replace it with a constant which is an approximation of the limit of the factor.

STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 120064 W: 30967 L: 30836 D: 58261
Ptnml(0-2): 421, 14238, 30608, 14319, 446
https://tests.stockfishchess.org/tests/view/6649d146b8fa20e74c39f4ad

LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 53856 W: 13719 L: 13530 D: 26607
Ptnml(0-2): 31, 5879, 14922, 6062, 34
https://tests.stockfishchess.org/tests/view/664a027fae57c1758ac5b4ee

Bench: 1496307