### PR TITLE
Re-eval only if smallnet output flips from simple eval

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -66,7 +66,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     Value nnue = smallNet ? networks.small.evaluate(pos, &caches.small, true, &nnueComplexity)
                           : networks.big.evaluate(pos, &caches.big, true, &nnueComplexity);
 
-    if (smallNet && (nnue * simpleEval < 0 || std::abs(nnue) < 500))
+    if (smallNet && nnue * simpleEval < 0)
     {
         nnue     = networks.big.evaluate(pos, &caches.big, true, &nnueComplexity);
         smallNet = false;


### PR DESCRIPTION
Recent attempts to change the smallnet nnue re-eval threshold did not show much elo difference:
https://tests.stockfishchess.org/tests/view/664a29bb25a9058c4d21d53c https://tests.stockfishchess.org/tests/view/664a299925a9058c4d21d53a

Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/664a3ea95fc7b70b8817aee2
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 22304 W: 5905 L: 5664 D: 10735
Ptnml(0-2): 67, 2602, 5603, 2783, 97

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/664a43d35fc7b70b8817aef4
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 37536 W: 9667 L: 9460 D: 18409
Ptnml(0-2): 25, 4090, 10321, 4317, 15

bench 1194630