### PR TITLE
Update correction history in case of successful null move pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -802,7 +802,14 @@ Value Search::Worker::search(
         if (nullValue >= beta && nullValue < VALUE_TB_WIN_IN_MAX_PLY)
         {
             if (thisThread->nmpMinPly || depth < 16)
+            {
+                if (nullValue >= ss->staticEval)
+                {
+                    auto bonus = std::min(int(nullValue - ss->staticEval) * depth / 32, CORRECTION_HISTORY_LIMIT / 16);
+                    thisThread->correctionHistory[us][pawn_structure_index<Correction>(pos)] << bonus;
+                }
                 return nullValue;
+            }
 
             assert(!thisThread->nmpMinPly);  // Recursive verification is not allowed
 


### PR DESCRIPTION
Since null move pruning uses the same position it makes some sense to try to update correction history there in case of fail high.
Update value is 4 times less than normal update.
Passed STC:
https://tests.stockfishchess.org/tests/view/664a011cae57c1758ac5b4dd
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 419360 W: 108390 L: 107505 D: 203465
Ptnml(0-2): 1416, 49603, 106724, 50554, 1383 
Passed LTC:
https://tests.stockfishchess.org/tests/view/664a53d95fc7b70b8817c65b
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 193518 W: 49076 L: 48434 D: 96008
Ptnml(0-2): 89, 21335, 53263, 21989, 83 
bench 1092995