### PR TITLE
Simplify NMP Formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -787,7 +787,7 @@ Value Search::Worker::search(
         assert(eval - beta >= 0);
 
         // Null move dynamic reduction based on depth and eval
-        Depth R = std::min(int(eval - beta) / 152, 6) + depth / 3 + 5;
+        Depth R = (eval - beta) / 152 + depth / 3 + 5;
 
         ss->currentMove         = Move::null();
         ss->continuationHistory = &thisThread->continuationHistory[0][0][NO_PIECE][0];


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 120608 W: 31018 L: 30892 D: 58698
Ptnml(0-2): 394, 13828, 31688, 14046, 348 
https://tests.stockfishchess.org/tests/view/664aa795830eb9f8866145fe

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 132060 W: 33588 L: 33481 D: 64991
Ptnml(0-2): 39, 14604, 36662, 14661, 64 
https://tests.stockfishchess.org/tests/view/664adca9830eb9f8866146df

bench 1289514