### PR TITLE
Rescale pawn history updates.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -496,7 +496,7 @@ void Search::Worker::clear() {
     counterMoves.fill(Move::none());
     mainHistory.fill(0);
     captureHistory.fill(0);
-    pawnHistory.fill(-900);
+    pawnHistory.fill(-1300);
     correctionHistory.fill(0);
 
     for (bool inCheck : {false, true})
@@ -1816,7 +1816,7 @@ void update_quiet_histories(
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus);
 
     int pIndex = pawn_structure_index(pos);
-    workerThread.pawnHistory[pIndex][pos.moved_piece(move)][move.to_sq()] << bonus;
+    workerThread.pawnHistory[pIndex][pos.moved_piece(move)][move.to_sq()] << bonus / 2;
 }
 
 // Updates move sorting heuristics


### PR DESCRIPTION
This patch is somewhat of a continuation of recent pawn history gainers.
It makes pawn history updates after search twice smaller. Since on average they make pawn history more negative offset is changed to lower value to remain average value approximately the same.
https://tests.stockfishchess.org/tests/view/664b3af9830eb9f886614aab
Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 170464 W: 44239 L: 43724 D: 82501
Ptnml(0-2): 523, 20278, 43128, 20767, 536 
Passed LTC against pending [PR ](https://github.com/official-stockfish/Stockfish/pull/5268):
https://tests.stockfishchess.org/tests/view/664b8c58830eb9f886614b64
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 98178 W: 25015 L: 24569 D: 48594
Ptnml(0-2): 48, 10769, 27005, 11223, 44 
bench 1329074
