### PR TITLE
Reduce When TTValue is Above Alpha

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -42,6 +42,7 @@
 #include "thread.h"
 #include "timeman.h"
 #include "tt.h"
+#include "types.h"
 #include "uci.h"
 #include "ucioption.h"
 
@@ -824,9 +825,12 @@ Value Search::Worker::search(
     if (PvNode && !ttMove)
         depth -= 3;
 
+    if (!PvNode && ss->ttHit && (tte->bound() & BOUND_UPPER) && ttValue > alpha)
+        depth--;
+
     // Use qsearch if depth <= 0.
     if (depth <= 0)
-        return qsearch<PV>(pos, ss, alpha, beta);
+        return qsearch < PvNode ? PV : NonPV > (pos, ss, alpha, beta);
 
     // For cutNodes without a ttMove, we decrease depth by 2 if depth is high enough.
     if (cutNode && depth >= 8 && (!ttMove || tte->bound() == BOUND_UPPER))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -825,7 +825,7 @@ Value Search::Worker::search(
     if (PvNode && !ttMove)
         depth -= 3;
 
-    if (!PvNode && ss->ttHit && (tte->bound() & BOUND_UPPER) && ttValue > alpha)
+    if (!PvNode && ss->ttHit && (tte->bound() & BOUND_UPPER) && ttValue > alpha + 3 * depth)
         depth--;
 
     // Use qsearch if depth <= 0.

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -825,7 +825,7 @@ Value Search::Worker::search(
     if (PvNode && !ttMove)
         depth -= 3;
 
-    if (!PvNode && ss->ttHit && (tte->bound() & BOUND_UPPER) && ttValue > alpha + 3 * depth)
+    if (!PvNode && ss->ttHit && (tte->bound() & BOUND_UPPER) && ttValue > alpha + 5 * depth)
         depth--;
 
     // Use qsearch if depth <= 0.


### PR DESCRIPTION
Reduce depth by one in NonPV nodes when TT entry bound is not lower bound and ttValue is greater than alpha by some margin.

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 53376 W: 13818 L: 13476 D: 26082
Ptnml(0-2): 156, 6212, 13626, 6522, 172 
https://tests.stockfishchess.org/tests/live_elo/664aa261830eb9f8866145e5

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 393444 W: 100096 L: 99042 D: 194306
Ptnml(0-2): 191, 43516, 108248, 44582, 185 
https://tests.stockfishchess.org/tests/live_elo/664ab54f830eb9f88661463c

bench 1297561