### PR TITLE
Refine Evaluation Scaling with Piece-Specific Weights

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -76,8 +76,10 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 584;
     nnue -= nnue * (nnueComplexity * 5 / 3) / 32395;
 
-    int npm = pos.non_pawn_material() / 64;
-    v       = (nnue * (npm + 943 + 11 * pos.count<PAWN>()) + optimism * (npm + 140)) / 1058;
+    v = (nnue * (32961 + 381 * pos.count<PAWN>() + 349 * pos.count<KNIGHT>()
+      + 392 * pos.count<BISHOP>()+ 649 * pos.count<ROOK>() + 1211 * pos.count<QUEEN>())
+      + optimism * (4835 + 136 * pos.count<PAWN>() + 375 * pos.count<KNIGHT>()
+      + 403 * pos.count<BISHOP>() + 628 * pos.count<ROOK>() + 1124 * pos.count<QUEEN>())) / 32768;
 
     // Damp down the evaluation linearly when shuffling
     v = v * ((smallNet ? 206 : 178) - pos.rule50_count()) / 207;


### PR DESCRIPTION
Refine Evaluation Scaling with Piece-Specific Weights, instead of the simplified npm method.
I took the initial idea from @Viren6 , as he worked on it in September of last year.
I worked on it, and tuned it, and now it passed both tests.

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 95712 W: 24731 L: 24325 D: 46656
Ptnml(0-2): 363, 11152, 24357, 11684, 300
https://tests.stockfishchess.org/tests/view/664b5493830eb9f886614af3

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 204480 W: 52167 L: 51501 D: 100812
Ptnml(0-2): 114, 22579, 56166, 23289, 92
https://tests.stockfishchess.org/tests/view/664b75dd830eb9f886614b44

bench: 1084999