### PR TITLE
Remove cutoffCnt margin adjustment in razoring

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -761,8 +761,7 @@ Value Search::Worker::search(
     // Step 7. Razoring (~1 Elo)
     // If eval is really low check with qsearch if it can exceed alpha, if it can't,
     // return a fail low.
-    // Adjust razor margin according to cutoffCnt. (~1 Elo)
-    if (eval < alpha - 474 - (326 - 139 * ((ss + 1)->cutoffCnt > 3)) * depth * depth)
+    if (eval < alpha - 474 - 324 * depth * depth)
     {
         value = qsearch<NonPV>(pos, ss, alpha - 1, alpha);
         if (value < alpha)


### PR DESCRIPTION
Passed non-regression STC (master 2d32581):
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 65344 W: 16767 L: 16578 D: 31999
Ptnml(0-2): 198, 7557, 16987, 7718, 212
https://tests.stockfishchess.org/tests/view/664bd895830eb9f886615a26

Passed non-regression LTC (master 2d32581):
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 35214 W: 8999 L: 8791 D: 17424
Ptnml(0-2): 16, 3804, 9760, 4010, 17
https://tests.stockfishchess.org/tests/view/664bead5830eb9f886615a52

Bench: 1441095