### PR TITLE
Comment about re-evaluating positions

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -66,6 +66,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     Value nnue = smallNet ? networks.small.evaluate(pos, &caches.small, true, &nnueComplexity)
                           : networks.big.evaluate(pos, &caches.big, true, &nnueComplexity);
 
+    // Re-evaluate the position when higher eval accuracy is worth the time spent
     if (smallNet && nnue * simpleEval < 0)
     {
         nnue     = networks.big.evaluate(pos, &caches.big, true, &nnueComplexity);


### PR DESCRIPTION
While the smallNet bool is no longer used as of now, setting it to false upon re-evaluation represents the correct eval state.

No functional change