### PR TITLE
Lower smallnet threshold with updated eval divisors

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -46,7 +46,7 @@ int Eval::simple_eval(const Position& pos, Color c) {
 
 bool Eval::use_smallnet(const Position& pos) {
     int simpleEval = simple_eval(pos, pos.side_to_move());
-    return std::abs(simpleEval) > 1126 + 6 * pos.count<PAWN>();
+    return std::abs(simpleEval) > 1076 + 5 * pos.count<PAWN>();
 }
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
@@ -73,8 +73,8 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     }
 
     // Blend optimism and eval with nnue complexity and material imbalance
-    optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 584;
-    nnue -= nnue * (nnueComplexity * 5 / 3) / 32395;
+    optimism += optimism * (nnueComplexity + std::abs(simpleEval - nnue)) / 658;
+    nnue -= nnue * (nnueComplexity * 5 / 3) / 31582;
 
     v = (nnue
            * (32961 + 381 * pos.count<PAWN>() + 349 * pos.count<KNIGHT>()
@@ -82,7 +82,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
          + optimism
              * (4835 + 136 * pos.count<PAWN>() + 375 * pos.count<KNIGHT>()
                 + 403 * pos.count<BISHOP>() + 628 * pos.count<ROOK>() + 1124 * pos.count<QUEEN>()))
-      / 32768;
+      / 34813;
 
     // Damp down the evaluation linearly when shuffling
     v = v * (204 - pos.rule50_count()) / 208;


### PR DESCRIPTION
Params found after 10k spsa games at 60+0.6, with initial values from 64k spsa games at 45+0.45

First spsa with 64k / 120k games at 45+0.45:
https://tests.stockfishchess.org/tests/view/664a561b5fc7b70b8817c663 https://tests.stockfishchess.org/tests/view/664ae88e830eb9f8866146f9

Second spsa with 10k / 120k games at 60+0.6:
https://tests.stockfishchess.org/tests/view/664be227830eb9f886615a36

Passed STC:
https://tests.stockfishchess.org/tests/view/664bf4bd830eb9f886615a72
LLR: 2.99 (-2.94,2.94) <0.00,2.00>
Total: 48864 W: 12742 L: 12403 D: 23719
Ptnml(0-2): 146, 5659, 12516, 5932, 179

Passed LTC:
https://tests.stockfishchess.org/tests/view/664c0905830eb9f886615abf
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 64884 W: 16543 L: 16161 D: 32180
Ptnml(0-2): 46, 7156, 17671, 7508, 61

bench 1340812