### PR TITLE
Simplify Away History Updates in Multicut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1080,12 +1080,7 @@ moves_loop:  // When in check, search starts here
                 // we assume this expected cut-node is not singular (multiple moves fail high),
                 // and we can prune the whole subtree by returning a softbound.
                 else if (singularBeta >= beta)
-                {
-                    if (!ttCapture)
-                        update_quiet_histories(pos, ss, *this, ttMove, -stat_malus(depth));
-
                     return singularBeta;
-                }
 
                 // Negative extensions
                 // If other moves failed high over (ttValue - margin) without the ttMove on a reduced search,


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 44896 W: 11600 L: 11388 D: 21908
Ptnml(0-2): 140, 5230, 11532, 5370, 176
https://tests.stockfishchess.org/tests/view/664cee31830eb9f886616a80

Passed Non-regression LTC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 56832 W: 14421 L: 14234 D: 28177
Ptnml(0-2): 37, 6251, 15643, 6458, 27 
https://tests.stockfishchess.org/tests/view/664cfd4e830eb9f886616aa6

bench 1415522