### PR TITLE
Revert "Reduce When TTValue is Above Alpha"

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -833,9 +833,6 @@ Value Search::Worker::search(
     if (PvNode && !ttMove)
         depth -= 3;
 
-    if (!PvNode && ss->ttHit && (tte->bound() & BOUND_UPPER) && ttValue > alpha + 5 * depth)
-        depth--;
-
     // Use qsearch if depth <= 0.
     if (depth <= 0)
         return qsearch < PvNode ? PV : NonPV > (pos, ss, alpha, beta);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -835,7 +835,7 @@ Value Search::Worker::search(
 
     // Use qsearch if depth <= 0.
     if (depth <= 0)
-        return qsearch < PvNode ? PV : NonPV > (pos, ss, alpha, beta);
+        return qsearch<PV>(pos, ss, alpha, beta);
 
     // For cutNodes without a ttMove, we decrease depth by 2 if depth is high enough.
     if (cutNode && depth >= 8 && (!ttMove || tte->bound() == BOUND_UPPER))


### PR DESCRIPTION
The patch regressed significantly at longer time controls. In particular, the `depth--` behavior was predicted to scale badly based on data from other variations of the patch.

Passed VVLTC 1st sprt: https://tests.stockfishchess.org/tests/view/664d45cf830eb9f886616c7d
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 51292 W: 13242 L: 12954 D: 25096
Ptnml(0-2): 5, 4724, 15896, 5020, 1 

Passed VVLTC 2nd sprt: https://tests.stockfishchess.org/tests/view/664e641a928b1fb18de4e385
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 41884 W: 10933 L: 10634 D: 20317
Ptnml(0-2): 1, 3759, 13125, 4054, 3 

Bench: 1468655