### PR TITLE
Simplify material weights in evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -77,13 +77,13 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     optimism += optimism * nnueComplexity / 512;
     nnue -= nnue * (nnueComplexity * 5 / 3) / 32082;
 
-    v = (nnue
-           * (32961 + 381 * pos.count<PAWN>() + 349 * pos.count<KNIGHT>()
-              + 392 * pos.count<BISHOP>() + 649 * pos.count<ROOK>() + 1211 * pos.count<QUEEN>())
-         + optimism
-             * (4835 + 136 * pos.count<PAWN>() + 375 * pos.count<KNIGHT>()
-                + 403 * pos.count<BISHOP>() + 628 * pos.count<ROOK>() + 1124 * pos.count<QUEEN>()))
-      / 36860;
+    int material = 200 * pos.count<PAWN>()
+                 + 350 * pos.count<KNIGHT>()
+                 + 400 * pos.count<BISHOP>()
+                 + 640 * pos.count<ROOK>()
+                 + 1200 * pos.count<QUEEN>();
+
+    v = (nnue * (34000 + material) + optimism * (4400 + material)) / 36860;
 
     // Damp down the evaluation linearly when shuffling
     v = v * (204 - pos.rule50_count()) / 208;


### PR DESCRIPTION
This patch uses the same material weights for the nnue amplification term and the optimism term in evaluate()

STC:
LLR: 2.99 (-2.94,2.94) <-1.75,0.25>
Total: 83360 W: 21489 L: 21313 D: 40558
Ptnml(0-2): 303, 9934, 21056, 10058, 329
https://tests.stockfishchess.org/tests/view/664eee69928b1fb18de500d9

LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 192648 W: 48675 L: 48630 D: 95343
Ptnml(0-2): 82, 21484, 53161, 21501, 96
https://tests.stockfishchess.org/tests/view/664fa17aa86388d5e27d7d6e

closes https://github.com/official-stockfish/Stockfish/pull/5287

bench: 1495602