### PR TITLE
Lower smallnet threshold with tuned eval params

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -77,13 +77,13 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     optimism += optimism * nnueComplexity / 512;
     nnue -= nnue * (nnueComplexity * 5 / 3) / 32082;
 
-    v = (nnue
-           * (32961 + 381 * pos.count<PAWN>() + 349 * pos.count<KNIGHT>()
-              + 392 * pos.count<BISHOP>() + 649 * pos.count<ROOK>() + 1211 * pos.count<QUEEN>())
-         + optimism
-             * (4835 + 136 * pos.count<PAWN>() + 375 * pos.count<KNIGHT>()
-                + 403 * pos.count<BISHOP>() + 628 * pos.count<ROOK>() + 1124 * pos.count<QUEEN>()))
-      / 36860;
+    int material = 200 * pos.count<PAWN>()
+                 + 350 * pos.count<KNIGHT>()
+                 + 400 * pos.count<BISHOP>()
+                 + 640 * pos.count<ROOK>()
+                 + 1200 * pos.count<QUEEN>();
+
+    v = (nnue * (34000 + material) + optimism * (4400 + material)) / 36860;
 
     // Damp down the evaluation linearly when shuffling
     v = v * (204 - pos.rule50_count()) / 208;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -46,7 +46,7 @@ int Eval::simple_eval(const Position& pos, Color c) {
 
 bool Eval::use_smallnet(const Position& pos) {
     int simpleEval = simple_eval(pos, pos.side_to_move());
-    return std::abs(simpleEval) > 1018 + 5 * pos.count<PAWN>();
+    return std::abs(simpleEval) > 992 + 6 * pos.count<PAWN>();
 }
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
@@ -74,16 +74,15 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     }
 
     // Blend optimism and eval with nnue complexity
-    optimism += optimism * nnueComplexity / 512;
-    nnue -= nnue * (nnueComplexity * 5 / 3) / 32082;
+    optimism += optimism * nnueComplexity / 470;
+    nnue -= nnue * (nnueComplexity * 5 / 3) / 32621;
 
-    int material = 200 * pos.count<PAWN>()
-                 + 350 * pos.count<KNIGHT>()
-                 + 400 * pos.count<BISHOP>()
-                 + 640 * pos.count<ROOK>()
-                 + 1200 * pos.count<QUEEN>();
+    int material = 200 * pos.count<PAWN>() + 350 * pos.count<KNIGHT>() + 400 * pos.count<BISHOP>()
+                 + 640 * pos.count<ROOK>() + 1200 * pos.count<QUEEN>();
 
-    v = (nnue * (34000 + material) + optimism * (4400 + material)) / 36860;
+    v = (nnue * (34000 + material + 135 * pos.count<PAWN>())
+         + optimism * (4400 + material + 99 * pos.count<PAWN>()))
+      / 35967;
 
     // Damp down the evaluation linearly when shuffling
     v = v * (204 - pos.rule50_count()) / 208;


### PR DESCRIPTION
The smallnet threshold is now below the training data range of
the current smallnet (simple eval diff > 1k, nn-baff1edelf90.nnue)
when no pawns are on the board.

Params found with spsa at 93k / 120k games at 60+06:
https://tests.stockfishchess.org/tests/view/664fa166a86388d5e27d7d6b

Tuned on top of: https://github.com/official-stockfish/Stockfish/pull/5287

Passed STC:
https://tests.stockfishchess.org/tests/view/664fc8b7a86388d5e27d8dac
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 64672 W: 16731 L: 16371 D: 31570
Ptnml(0-2): 239, 7463, 16517, 7933, 184

Passed LTC:
https://tests.stockfishchess.org/tests/view/664fd5f9a86388d5e27d8dfe
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 210648 W: 53489 L: 52813 D: 104346
Ptnml(0-2): 102, 23129, 58164, 23849, 80

bench 1717838