### PR TITLE
Remove rootDelta branch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -330,6 +330,7 @@ void Search::Worker::iterative_deepening() {
                 // for every four searchAgain steps (see issue #2717).
                 Depth adjustedDepth =
                   std::max(1, rootDepth - failedHighCnt - 3 * (searchAgainCounter + 1) / 4);
+                rootDelta = beta - alpha;
                 bestValue = search<Root>(rootPos, ss, alpha, beta, adjustedDepth, false);
 
                 // Bring the best move to the front. It is critical that sorting
@@ -590,8 +591,6 @@ Value Search::Worker::search(
         if (alpha >= beta)
             return alpha;
     }
-    else
-        thisThread->rootDelta = beta - alpha;
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 


### PR DESCRIPTION
This makes rootDelta logic easier to understand, recalculating the value where it belongs so removes an unnecessary branch

Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/664fc147a86388d5e27d8d8e
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 206016 W: 53120 L: 53089 D: 99807
Ptnml(0-2): 591, 20928, 59888, 21061, 540

No functional change