### PR TITLE
combine pawn count multipliers

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -77,12 +77,10 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     optimism += optimism * nnueComplexity / 470;
     nnue -= nnue * (nnueComplexity * 5 / 3) / 32621;
 
-    int material = 200 * pos.count<PAWN>() + 350 * pos.count<KNIGHT>() + 400 * pos.count<BISHOP>()
-                 + 640 * pos.count<ROOK>() + 1200 * pos.count<QUEEN>();
+    int material = 335 * pos.count<PAWN>() + 350 * pos.count<KNIGHT>() + 400 * pos.count<BISHOP>()
+                 + 739 * pos.count<ROOK>() + 1200 * pos.count<QUEEN>();
 
-    v = (nnue * (34000 + material + 135 * pos.count<PAWN>())
-         + optimism * (4400 + material + 99 * pos.count<PAWN>()))
-      / 35967;
+    v = (nnue * (34000 + material) + optimism * (4400 + material) / 35967;
 
     // Damp down the evaluation linearly when shuffling
     v = v * (204 - pos.rule50_count()) / 208;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -80,7 +80,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     int material = 335 * pos.count<PAWN>() + 350 * pos.count<KNIGHT>() + 400 * pos.count<BISHOP>()
                  + 739 * pos.count<ROOK>() + 1200 * pos.count<QUEEN>();
 
-    v = (nnue * (34000 + material) + optimism * (4400 + material) / 35967;
+    v = (nnue * (34000 + material) + optimism * (4400 + material)) / 35967;
 
     // Damp down the evaluation linearly when shuffling
     v = v * (204 - pos.rule50_count()) / 208;


### PR DESCRIPTION
combine the pos.countPAWN to remove redundant operation.

non-functional change 

Bench: 1717838