### PR TITLE
Reduce less on larger window

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1132,7 +1132,7 @@ moves_loop:  // When in check, search starts here
 
         // Decrease reduction for PvNodes (~0 Elo on STC, ~2 Elo on LTC)
         if (PvNode)
-            r--;
+            r -= 1 + (beta - alpha > thisThread->rootDelta / 4);
 
         // These reduction adjustments have no proven non-linear scaling.
 


### PR DESCRIPTION
The idea is to reduce pv-nodes less as long as the window is bigger than 1/4 of the starting aspiration window the same functionality passed SPRT testing twice since `rootDelta` can't be smaller than our smallest aspiration window (i.e. 9 > 4) thus the node is a PvNode.
Patch author: @candirufish

Passed STC:
https://tests.stockfishchess.org/tests/view/664a2e4057cee176d5b88138
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 57376 W: 14948 L: 14600 D: 27828
Ptnml(0-2): 201, 6679, 14571, 7045, 192

Passed STC second time (same functionally):
https://tests.stockfishchess.org/tests/view/664e9d04928b1fb18de4e445
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 188160 W: 48744 L: 48204 D: 91212
Ptnml(0-2): 545, 22157, 48205, 22559, 614

Passed LTC:
https://tests.stockfishchess.org/tests/view/664a3d645fc7b70b8817aed6
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 46308 W: 11872 L: 11535 D: 22901
Ptnml(0-2): 14, 4969, 12861, 5286, 24

Passed LTC second time (same functionally):
https://tests.stockfishchess.org/tests/view/664e9d04928b1fb18de4e445
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 188160 W: 48744 L: 48204 D: 91212
Ptnml(0-2): 545, 22157, 48205, 22559, 614

bench: 1803488