### PR TITLE
Simplify Away TT Cutoff Return Value Adjustments

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -637,9 +637,7 @@ Value Search::Worker::search(
         // Partial workaround for the graph history interaction problem
         // For high rule50 counts don't produce transposition table cutoffs.
         if (pos.rule50_count() < 90)
-            return ttValue >= beta && std::abs(ttValue) < VALUE_TB_WIN_IN_MAX_PLY
-                   ? (ttValue * 3 + beta) / 4
-                   : ttValue;
+            return ttValue;
     }
 
     // Step 5. Tablebases probe


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 198432 W: 51161 L: 51119 D: 96152
Ptnml(0-2): 772, 23670, 50273, 23746, 755
https://tests.stockfishchess.org/tests/view/66517b9ea86388d5e27da966

Passed Non-regression LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 234150 W: 59200 L: 59197 D: 115753
Ptnml(0-2): 126, 26200, 64404, 26235, 110 
https://tests.stockfishchess.org/tests/view/6653a84da86388d5e27daa63

bench 1555200