### PR TITLE
Simplify Away Quadruple Extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1066,11 +1066,9 @@ moves_loop:  // When in check, search starts here
                 {
                     int doubleMargin = 304 * PvNode - 203 * !ttCapture;
                     int tripleMargin = 117 + 259 * PvNode - 296 * !ttCapture + 97 * ss->ttPv;
-                    int quadMargin   = 486 + 343 * PvNode - 273 * !ttCapture + 232 * ss->ttPv;
 
                     extension = 1 + (value < singularBeta - doubleMargin)
-                              + (value < singularBeta - tripleMargin)
-                              + (value < singularBeta - quadMargin);
+                              + (value < singularBeta - tripleMargin);
 
                     depth += ((!PvNode) && (depth < 16));
                 }


### PR DESCRIPTION
Passed non-regression VVLTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 90792 W: 23155 L: 23018 D: 44619
Ptnml(0-2): 6, 8406, 28432, 8549, 3 
https://tests.stockfishchess.org/tests/view/664ffa4ca86388d5e27d8e7a

Passed non-regression VLTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 288136 W: 72608 L: 72659 D: 142869
Ptnml(0-2): 38, 30258, 83525, 30211, 36
https://tests.stockfishchess.org/tests/view/66551609a86388d5e27db9ae

bench 1501735