### PR TITLE
Tweak return value in futility pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -775,7 +775,7 @@ Value Search::Worker::search(
                - (ss - 1)->statScore / 248
              >= beta
         && eval >= beta && eval < VALUE_TB_WIN_IN_MAX_PLY && (!ttMove || ttCapture))
-        return beta > VALUE_TB_LOSS_IN_MAX_PLY ? (eval + beta) / 2 : eval;
+        return beta > VALUE_TB_LOSS_IN_MAX_PLY ? beta + (eval - beta) / 3 : eval;
 
     // Step 9. Null move search with verification search (~35 Elo)
     if (!PvNode && (ss - 1)->currentMove != Move::null() && (ss - 1)->statScore < 13999


### PR DESCRIPTION
Tweak the return value formula in futility pruning.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 60544 W: 15791 L: 15440 D: 29313
Ptnml(0-2): 193, 7024, 15520, 7309, 226
https://tests.stockfishchess.org/tests/view/6654ef22a86388d5e27db122

Passed LTC:
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 126426 W: 32317 L: 31812 D: 62297
Ptnml(0-2): 55, 13871, 34869, 14350, 68
https://tests.stockfishchess.org/tests/view/66550644a86388d5e27db649

bench: 1307505