### PR TITLE
Fix MSVC NUMA compile issues

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -77,6 +77,8 @@ using AlignedPtr = std::unique_ptr<T, AlignedDeleter<T>>;
 template<typename T>
 using LargePagePtr = std::unique_ptr<T, LargePageDeleter<T>>;
 
+#if defined(__linux__)
+
 struct PipeDeleter {
     void operator()(FILE* file) const {
         if (file != nullptr)
@@ -85,8 +87,6 @@ struct PipeDeleter {
         }
     }
 };
-
-#if defined(__linux__)
 
 inline std::optional<std::string> get_system_command_output(const std::string& command) {
     std::unique_ptr<FILE, PipeDeleter> pipe(popen(command.c_str(), "r"));

--- a/src/numa.h
+++ b/src/numa.h
@@ -51,6 +51,9 @@ static constexpr size_t WIN_PROCESSOR_GROUP_SIZE = 64;
         #define NOMINMAX
     #endif
     #include <windows.h>
+    #if defined small
+        #undef small
+    #endif
 
 // https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadselectedcpusetmasks
 using SetThreadSelectedCpuSetMasks_t = BOOL (*)(HANDLE, PGROUP_AFFINITY, USHORT);
@@ -562,7 +565,7 @@ class NumaConfig {
         {
             // Only available on Windows 11 and Windows Server 2022 onwards.
             const USHORT numProcGroups =
-              ((highestCpuIndex + 1) + WIN_PROCESSOR_GROUP_SIZE - 1) / WIN_PROCESSOR_GROUP_SIZE;
+              USHORT(((highestCpuIndex + 1) + WIN_PROCESSOR_GROUP_SIZE - 1) / WIN_PROCESSOR_GROUP_SIZE);
             auto groupAffinities = std::make_unique<GROUP_AFFINITY[]>(numProcGroups);
             std::memset(groupAffinities.get(), 0, sizeof(GROUP_AFFINITY) * numProcGroups);
             for (WORD i = 0; i < numProcGroups; ++i)


### PR DESCRIPTION
No functional change
bench: 1856147

Additionally there is a handful of preexisting MSVC warnings about possible loss of data throughout the code base where we implicitly convert doubles to ints or size_t to int.  Would it be ok if I fixed those as well?