### PR TITLE
Deduplicate pawn count expressions

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -77,12 +77,10 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     optimism += optimism * nnueComplexity / 470;
     nnue -= nnue * (nnueComplexity * 5 / 3) / 32621;
 
-    int material = 200 * pos.count<PAWN>() + 350 * pos.count<KNIGHT>() + 400 * pos.count<BISHOP>()
+    int material = 299 * pos.count<PAWN>() + 350 * pos.count<KNIGHT>() + 400 * pos.count<BISHOP>()
                  + 640 * pos.count<ROOK>() + 1200 * pos.count<QUEEN>();
 
-    v = (nnue * (34000 + material + 135 * pos.count<PAWN>())
-         + optimism * (4400 + material + 99 * pos.count<PAWN>()))
-      / 35967;
+    v = (nnue * (34000 + material + 36 * pos.count<PAWN>()) + optimism * (4400 + material)) / 35967;
 
     // Damp down the evaluation linearly when shuffling
     v = v * (204 - pos.rule50_count()) / 208;


### PR DESCRIPTION
Passed non-regression STC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 423936 W: 109589 L: 109780 D: 204567
Ptnml(0-2): 1331, 42899, 123695, 42716, 1327
https://tests.stockfishchess.org/tests/view/66566403a86388d5e27dd44a

Measured 0.1% speedup locally:
```
Result of 50 iterations (100 runs)
========================================
Base (.\stockfish-master.exe):    2116089 +/- 1467
Test (.\stockfish.exe       ):    2118495 +/- 1369
diff                         :      +2406 +/- 1356

ds        = +0.0011
P(ds > 0) = 99.9743%
```

No functional changes