### PR TITLE
Merge pawn count terms using their average

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -77,12 +77,10 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     optimism += optimism * nnueComplexity / 470;
     nnue -= nnue * (nnueComplexity * 5 / 3) / 32621;
 
-    int material = 200 * pos.count<PAWN>() + 350 * pos.count<KNIGHT>() + 400 * pos.count<BISHOP>()
+    int material = 300 * pos.count<PAWN>() + 350 * pos.count<KNIGHT>() + 400 * pos.count<BISHOP>()
                  + 640 * pos.count<ROOK>() + 1200 * pos.count<QUEEN>();
 
-    v = (nnue * (34000 + material + 135 * pos.count<PAWN>())
-         + optimism * (4400 + material + 99 * pos.count<PAWN>()))
-      / 35967;
+    v = (nnue * (34300 + material) + optimism * (4400 + material)) / 35967;
 
     // Damp down the evaluation linearly when shuffling
     v = v * (204 - pos.rule50_count()) / 208;


### PR DESCRIPTION
This simplification patch merges the pawn count terms in the eval formula with the material term, updating the offset constant for the nnue part of the formula from 34000 to 34300 because the average pawn count in middlegame positions evaluated during search is around 8.

STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 138240 W: 35834 L: 35723 D: 66683
Ptnml(0-2): 527, 16587, 34817, 16626, 563
https://tests.stockfishchess.org/tests/view/6653f474a86388d5e27daaac

LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 454272 W: 114787 L: 115012 D: 224473
Ptnml(0-2): 246, 51168, 124553, 50903, 266
https://tests.stockfishchess.org/tests/view/6654f256a86388d5e27db131

closes https://github.com/official-stockfish/Stockfish/pull/5303

bench: 1287067