### PR TITLE
Simplifying malus for putting piece en prise formula

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -68,6 +68,7 @@ Douglas Matos Gomes (dsmsgms)
 Dubslow
 Eduardo Cáceres (eduherminio)
 Eelco de Groot (KingDefender)
+Ehsan Rashid (erashid)
 Elvin Liu (solarlight2)
 erbsenzaehler
 Ernesto Gatti

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -197,13 +197,11 @@ void MovePicker::score() {
                                                : 0;
 
             // malus for putting piece en prise
-            m.value -= !(threatenedPieces & from)
-                       ? (pt == QUEEN ? bool(to & threatenedByRook) * 48150
+            m.value -= (pt == QUEEN ? bool(to & threatenedByRook) * 48150
                                           + bool(to & threatenedByMinor) * 10650
                           : pt == ROOK ? bool(to & threatenedByMinor) * 24335
                           : pt != PAWN ? bool(to & threatenedByPawn) * 14950
-                                       : 0)
-                       : 0;
+                                       : 0);
         }
 
         else  // Type == EVASIONS


### PR DESCRIPTION
Simplifying malus for putting piece en prise formula.

Patch author: @ehsanrashid

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 116192 W: 30229 L: 30094 D: 55869
Ptnml(0-2): 451, 13880, 29351, 13911, 503
https://tests.stockfishchess.org/tests/view/66510a40a86388d5e27da936

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 441312 W: 111009 L: 111220 D: 219083
Ptnml(0-2): 217, 49390, 121659, 49167, 223
https://tests.stockfishchess.org/tests/view/66530696a86388d5e27da9e3

bench: 1987574