### PR TITLE
Remove Queen threatenedByMinor

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -197,8 +197,7 @@ void MovePicker::score() {
                                                : 0;
 
             // malus for putting piece en prise
-            m.value -= (pt == QUEEN ? bool(to & threatenedByRook) * 48150
-                                        + bool(to & threatenedByMinor) * 10650
+            m.value -= (pt == QUEEN ? bool(to & threatenedByRook) * 49000
                         : pt == ROOK ? bool(to & threatenedByMinor) * 24335
                         : pt != PAWN ? bool(to & threatenedByPawn) * 14950
                                      : 0);


### PR DESCRIPTION
Remove Queen threatenedByMinor from movepick

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 54432 W: 14053 L: 13855 D: 26524
Ptnml(0-2): 124, 6347, 14090, 6517, 138
https://tests.stockfishchess.org/tests/view/66578d036b0e318cefa8d43d

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 198168 W: 49979 L: 49940 D: 98249
Ptnml(0-2): 84, 21824, 55236, 21849, 91
https://tests.stockfishchess.org/tests/view/66579cf86b0e318cefa8d5b1

bench: 1430842