### PR TITLE
Update default main net to nn-ddcfb9224cdb.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-c721dfca8cd3.nnue"
+#define EvalFileDefaultNameBig "nn-ddcfb9224cdb.nnue"
 #define EvalFileDefaultNameSmall "nn-baff1ede1f90.nnue"
 
 namespace NNUE {


### PR DESCRIPTION
Created by further tuning the spsa-tuned main net `nn-c721dfca8cd3.nnue` with the same methods described in https://github.com/official-stockfish/Stockfish/pull/5254

This net was reached at 61k / 120k spsa games at 70+0.7 th 7: https://tests.stockfishchess.org/tests/view/665639d0a86388d5e27dd259

Passed STC:
https://tests.stockfishchess.org/tests/view/6657d44e6b0e318cefa8d771
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 114688 W: 29775 L: 29344 D: 55569
Ptnml(0-2): 274, 13633, 29149, 13964, 324

Passed LTC:
https://tests.stockfishchess.org/tests/view/6657e1e46b0e318cefa8d7a6
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 88152 W: 22412 L: 21988 D: 43752
Ptnml(0-2): 56, 9560, 24409, 10006, 45

Bench: 1288612