### PR TITLE
tweak and update the WDL model

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -382,12 +382,12 @@ WinRateParams win_rate_params(const Position& pos) {
     int material = pos.count<PAWN>() + 3 * pos.count<KNIGHT>() + 3 * pos.count<BISHOP>()
                  + 5 * pos.count<ROOK>() + 9 * pos.count<QUEEN>();
 
-    // The fitted model only uses data for material counts in [10, 78], and is anchored at count 58.
-    double m = std::clamp(material, 10, 78) / 58.0;
+    // The fitted model only uses data for material counts in [17, 78], and is anchored at count 58.
+    double m = std::clamp(material, 17, 78) / 58.0;
 
     // Return a = p_a(material) and b = p_b(material), see github.com/official-stockfish/WDL_model
-    constexpr double as[] = {-150.77043883, 394.96159472, -321.73403766, 406.15850091};
-    constexpr double bs[] = {62.33245393, -91.02264855, 45.88486850, 51.63461272};
+    constexpr double as[] = {-41.25712052, 121.47473115, -124.46958843, 411.84490997};
+    constexpr double bs[] = {84.92998051, -143.66658718, 80.09988253, 49.80869370};
 
     double a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
     double b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];
@@ -428,8 +428,8 @@ std::string UCIEngine::format_score(const Score& s) {
 // without treatment of mate and similar special scores.
 int UCIEngine::to_cp(Value v, const Position& pos) {
 
-    // In general, the score can be defined via the the WDL as
-    // (log(1/L - 1) - log(1/W - 1)) / ((log(1/L - 1) + log(1/W - 1))
+    // In general, the score can be defined via the WDL as
+    // (log(1/L - 1) - log(1/W - 1)) / (log(1/L - 1) + log(1/W - 1)).
     // Based on our win_rate_model, this simply yields v / a.
 
     auto [a, b] = win_rate_params(pos);


### PR DESCRIPTION
This PR updates the internal WDL model, using data from 2.5M games played by SF-dev (3c62ad7e077a5ed0ea7b55422e03e7316dcbce7e). Note that the normalizing constant has increased from 329 to 368.

Changes to the fitting procedure:
* the value for `--materialMin` was increased from 10 to 17: data with less material on the board is noisy and sparse, and including it in the fitted model leads to less accuracy for larger material count values
* the data was filtered to only include single thread LTC games at 60+0.6
* the data was filtered to only include games from master against patches that are (approximatively) within 5 nElo of master, see https://github.com/official-stockfish/WDL_model/pull/193  (incidentally, for the games at hand, none were filtered out due to nElo being outside the window)

Changes to SF code:
* updated coefficients in `as[]` and `bs[]`
* changed lower material count limit from `10` to `17`
* fixed two typos, one was previously noted in https://github.com/official-stockfish/Stockfish/pull/5192

```
> ./updateWDL.sh --firstrev 3c62ad7e077a5ed0ea7b55422e03e7316dcbce7e
Running: ./updateWDL.sh --firstrev 3c62ad7e077a5ed0ea7b55422e03e7316dcbce7e --lasttrev HEAD --materialMin 17 --EloDiffMax 5
started at:  Thu 30 May 08:03:26 CEST 2024
Look recursively in directory pgns for games with max nElo difference 5 using books matching "UHO_Lichess_4852_v..epd" for SF revisions between 3c62ad7e077a5ed0ea7b55422e03e7316dcbce7e (from 2024-05-29 19:04:57 +0200) and HEAD (from 2024-05-29 19:04:57 +0200).
Based on 128752154 positions from 2455916 games, NormalizeToPawnValue should change from 329 to 368.
ended at:  Thu 30 May 08:05:47 CEST 2024
```

```
> cat scoreWDL.log
Converting evals with NormalizeData = {'momType': 'material', 'momMin': 10, 'momMax': 78, 'momTarget': 58, 'as': [-150.77043883, 394.96159472, -321.73403766, 406.15850091]}.
Reading eval stats from updateWDL.json.
Retained (W,D,L) = (30598053, 66815803, 31338298) positions.
Saved distribution plot to updateWDLdistro.png.
Fit WDL model based on material.
Initial objective function:  0.3685738334172546
Final objective function:    0.3685721660041207
Optimization terminated successfully.
const int NormalizeToPawnValue = 368;
Corresponding spread = 71;
Corresponding normalized spread = 0.19361626228752915;
Draw rate at 0.0 eval at material 58 = 0.9886371481877294;
Parameters in internal value units: 
p_a = ((-41.257 * x / 58 + 121.475) * x / 58 + -124.470) * x / 58 + 411.845
p_b = ((84.930 * x / 58 + -143.667) * x / 58 + 80.100) * x / 58 + 49.809
    constexpr double as[] = {-41.25712052, 121.47473115, -124.46958843, 411.84490997};
    constexpr double bs[] = {84.92998051, -143.66658718, 80.09988253, 49.80869370};
Preparing plots.
Saved graphics to updateWDL.png.
Total elapsed time = 71.86s.
```

The patch only changes the displayed cp and wdl values.

Closes #5309.

No bench change.