### PR TITLE
Add extension condition to cutoffCnt

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1291,7 +1291,7 @@ moves_loop:  // When in check, search starts here
 
                 if (value >= beta)
                 {
-                    ss->cutoffCnt += 1 + !ttMove;
+                    ss->cutoffCnt += 1 + !ttMove - (extension >= 2);
                     assert(value >= beta);  // Fail high
                     break;
                 }


### PR DESCRIPTION
Decrease cutoffCnt increment by 1 if extension is 2 or greater.

Passed STC:
https://tests.stockfishchess.org/tests/view/66577a696b0e318cefa8d34d
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 99200 W: 25703 L: 25297 D: 48200
Ptnml(0-2): 253, 11660, 25390, 12022, 275

Passed LTC:
https://tests.stockfishchess.org/tests/view/665787ab6b0e318cefa8d411
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 124530 W: 31659 L: 31161 D: 61710
Ptnml(0-2): 58, 13578, 34489, 14088, 52

bench 1340462