### PR TITLE
Allow tt cutoffs for shallower depths in certain conditions.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -618,7 +618,7 @@ Value Search::Worker::search(
         ss->ttPv = PvNode || (ss->ttHit && tte->is_pv());
 
     // At non-PV nodes we check for an early TT cutoff
-    if (!PvNode && !excludedMove && tte->depth() > depth
+    if (!PvNode && !excludedMove && tte->depth() > depth - (ttValue <= beta)
         && ttValue != VALUE_NONE  // Possible in case of TT access race or if !ttHit
         && (tte->bound() & (ttValue >= beta ? BOUND_LOWER : BOUND_UPPER)))
     {


### PR DESCRIPTION
Current master allows tt cutoffs only when depth from tt is strictly greater than current node depth.
This patch also allows them when it's equal and if tt value is lower or equal to beta.
Passed STC:
https://tests.stockfishchess.org/tests/view/66578e2e6b0e318cefa8d447
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 26592 W: 6944 L: 6645 D: 13003
Ptnml(0-2): 67, 3039, 6795, 3318, 77 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6657f46b6b0e318cefa8d7e9
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 142572 W: 36315 L: 35776 D: 70481
Ptnml(0-2): 70, 15666, 39288, 16179, 83 
bench 1368486