### PR TITLE
Simplifying the malus for putting piece en prise formula

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -199,8 +199,7 @@ void MovePicker::score() {
             // malus for putting piece en prise
             m.value -= (pt == QUEEN  ? bool(to & threatenedByRook) * 49000
                         : pt == ROOK ? bool(to & threatenedByMinor) * 24335
-                        : pt != PAWN ? bool(to & threatenedByPawn) * 14950
-                                     : 0);
+                        : bool(to & threatenedByPawn) * 14900);
         }
 
         else  // Type == EVASIONS


### PR DESCRIPTION
Simplifying the malus for putting piece en prise formula by merging the minor pieces and pawns (removing the pawn exclusion from the formula).

Passed STC:
LLR: 2.99 (-2.94,2.94) <-1.75,0.25>
Total: 314272 W: 80705 L: 80786 D: 152781
Ptnml(0-2): 873, 37577, 80366, 37398, 922
https://tests.stockfishchess.org/tests/view/66578d9c6b0e318cefa8d441

Passed LTC (before rebasing):
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 117000 W: 29447 L: 29324 D: 58229
Ptnml(0-2): 47, 12877, 32535, 12988, 53
https://tests.stockfishchess.org/tests/view/6657b5ee6b0e318cefa8d6ab

Passed LTC (also after rebasing):
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 244992 W: 61807 L: 61814 D: 121371
Ptnml(0-2): 125, 27420, 67414, 27411, 126
https://tests.stockfishchess.org/tests/view/6658803d6b0e318cefa8fd99

bench: 1324783