### PR TITLE
Tweak first picked move (ttMove) reduction rule.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1152,7 +1152,7 @@ moves_loop:  // When in check, search starts here
         // Set reduction to 0 for first picked move (ttMove) if it's less than 2
         // Otherwise, reduce by 2 (~3 Elo)
         else if (move == ttMove)
-            (r < 2) ? r = 0: r -= 2;
+            r = std::max(0, r - 2);
 
         ss->statScore = 2 * thisThread->mainHistory[us][move.from_to()]
                       + (*contHist[0])[movedPiece][move.to_sq()]

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1149,8 +1149,8 @@ moves_loop:  // When in check, search starts here
         if ((ss + 1)->cutoffCnt > 3)
             r++;
 
-        // Set reduction to 0 for first picked move (ttMove) if it's less than 2
-        // Otherwise, reduce by 2 (~3 Elo)
+        // For first picked move (ttMove) reduce reduction
+        // but never allow it to go below 0 (~3 Elo)
         else if (move == ttMove)
             r = std::max(0, r - 2);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1150,7 +1150,7 @@ moves_loop:  // When in check, search starts here
             r++;
 
         // Set reduction to 0 for first picked move (ttMove) if it's less than 2
-        // Otherwise, reduce by 2 (~2 Elo)
+        // Otherwise, reduce by 2 (~3 Elo)
         else if (move == ttMove)
             (r < 2) ? r = 0: r -= 2;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1149,10 +1149,10 @@ moves_loop:  // When in check, search starts here
         if ((ss + 1)->cutoffCnt > 3)
             r++;
 
-        // Set reduction to 0 for first picked move (ttMove) (~2 Elo)
-        // Nullifies all previous reduction adjustments to ttMove and leaves only history to do them
+        // Set reduction to 0 for first picked move (ttMove) if it's less than 2
+        // Otherwise, reduce by 2 (~2 Elo)
         else if (move == ttMove)
-            r = 0;
+            (r < 2) ? r = 0: r -= 2;
 
         ss->statScore = 2 * thisThread->mainHistory[us][move.from_to()]
                       + (*contHist[0])[movedPiece][move.to_sq()]


### PR DESCRIPTION
Tweak first picked move (ttMove) reduction rule:

Instead of always resetting the reduction to 0, we now only do so if the current reduction is less than 2.
If the current reduction is 2 or more, we decrease it by 2 instead.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 109504 W: 28340 L: 27919 D: 53245
Ptnml(0-2): 305, 12848, 28028, 13263, 308
https://tests.stockfishchess.org/tests/view/6658c2fa6b0e318cefa900c2

Passed LTC:
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 130410 W: 33248 L: 32738 D: 64424
Ptnml(0-2): 53, 14139, 36328, 14615, 70
https://tests.stockfishchess.org/tests/view/6658dd8a6b0e318cefa90173

bench: 1130149