### PR TITLE
Simplify away the time reduction on first move

### DIFF
--- a/src/numa.h
+++ b/src/numa.h
@@ -42,6 +42,11 @@
     #include <sched.h>
 #elif defined(_WIN64)
 
+    #if _WIN32_WINNT < 0x0601
+        #undef _WIN32_WINNT
+        #define _WIN32_WINNT 0x0601  // Force to include needed API prototypes
+    #endif
+
 // On Windows each processor group can have up to 64 processors.
 // https://learn.microsoft.com/en-us/windows/win32/procthread/processor-groups
 static constexpr size_t WIN_PROCESSOR_GROUP_SIZE = 64;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -160,8 +160,7 @@ void Search::Worker::start_searching() {
         return;
     }
 
-    main_manager()->tm.init(limits, rootPos.side_to_move(), rootPos.game_ply(), options,
-                            main_manager()->originalPly, main_manager()->originalTimeAdjust);
+    main_manager()->tm.init(limits, rootPos.side_to_move(), rootPos.game_ply(), options, main_manager()->originalTimeAdjust);
     tt.new_search();
 
     if (rootMoves.empty())

--- a/src/search.h
+++ b/src/search.h
@@ -209,7 +209,6 @@ class SearchManager: public ISearchManager {
 
     Stockfish::TimeManagement tm;
     double                    originalTimeAdjust;
-    int                       originalPly;
     int                       callsCnt;
     std::atomic_bool          ponder;
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -213,12 +213,13 @@ void ThreadPool::clear() {
     for (auto&& th : threads)
         th->wait_for_search_finished();
 
+    // These two affect the time taken on the first move of a game:
+    main_manager()->bestPreviousAverageScore = VALUE_INFINITE;
+    main_manager()->previousTimeReduction    = 0.85;
+
     main_manager()->callsCnt                 = 0;
     main_manager()->bestPreviousScore        = VALUE_INFINITE;
-    main_manager()->bestPreviousAverageScore = VALUE_INFINITE;
-    main_manager()->originalPly              = -1;
     main_manager()->originalTimeAdjust       = -1;
-    main_manager()->previousTimeReduction    = 1.0;
     main_manager()->tm.clear();
 }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -48,7 +48,6 @@ void TimeManagement::init(Search::LimitsType& limits,
                           Color               us,
                           int                 ply,
                           const OptionsMap&   options,
-                          int&                originalPly,
                           double&             originalTimeAdjust) {
     TimePoint npmsec = TimePoint(options["nodestime"]);
 
@@ -59,9 +58,6 @@ void TimeManagement::init(Search::LimitsType& limits,
 
     if (limits.time[us] == 0)
         return;
-
-    if (originalPly == -1)
-        originalPly = ply;
 
     TimePoint moveOverhead = TimePoint(options["Move Overhead"]);
 
@@ -115,8 +111,6 @@ void TimeManagement::init(Search::LimitsType& limits,
     {
         // Use extra time with larger increments
         double optExtra = scaledInc < 500 ? 1.0 : 1.13;
-        if (ply - originalPly < 2)
-            optExtra *= 0.95;
         optExtra *= originalTimeAdjust;
 
         // Calculate time constants based on current time left.

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -40,7 +40,6 @@ class TimeManagement {
               Color               us,
               int                 ply,
               const OptionsMap&   options,
-              int&                originalPly,
               double&             originalTimeAdjust);
 
     TimePoint optimum() const;


### PR DESCRIPTION
The code added to do this is not needed, the same effect is achieved here by changing the initial value of previousTimeReduction.

Passed STC 10+0.1:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 185600 W: 47863 L: 47808 D: 89929
Ptnml(0-2): 429, 19058, 53787, 19081, 445
https://tests.stockfishchess.org/tests/view/6658e10a6b0e318cefa9017f

Passed LTC 60+0.1:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 136128 W: 34573 L: 34477 D: 67078
Ptnml(0-2): 60, 13151, 41550, 13239, 64
https://tests.stockfishchess.org/tests/view/6658fe7b6b0e318cefa90232

Bench 1484840