### PR TITLE
Quadratic smallnet threshold with re-evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -46,7 +46,8 @@ int Eval::simple_eval(const Position& pos, Color c) {
 
 bool Eval::use_smallnet(const Position& pos) {
     int simpleEval = simple_eval(pos, pos.side_to_move());
-    return std::abs(simpleEval) > 992 + 6 * pos.count<PAWN>();
+    int pawnCount  = pos.count<PAWN>();
+    return std::abs(simpleEval) > 992 + 6 * pawnCount * pawnCount / 16;
 }
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
@@ -67,7 +68,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
                           : networks.big.evaluate(pos, &caches.big, true, &nnueComplexity);
 
     // Re-evaluate the position when higher eval accuracy is worth the time spent
-    if (smallNet && nnue * simpleEval < 0)
+    if (smallNet && (nnue * simpleEval < 0 || std::abs(nnue) < 250))
     {
         nnue     = networks.big.evaluate(pos, &caches.big, true, &nnueComplexity);
         smallNet = false;


### PR DESCRIPTION
The threshold now decreases more quickly as pawn count decreases, using the smallnet more compared to before.

Combo of two eval patches:
https://tests.stockfishchess.org/tests/view/66576c5f6b0e318cefa8d26e https://tests.stockfishchess.org/tests/view/664ced40830eb9f886616a77

Passed STC:
https://tests.stockfishchess.org/tests/view/66588c136b0e318cefa8ff21
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 112608 W: 29336 L: 28908 D: 54364
Ptnml(0-2): 344, 13223, 28718, 13699, 320

Passed LTC:
https://tests.stockfishchess.org/tests/view/6658c8786b0e318cefa900f5
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 108288 W: 27493 L: 27026 D: 53769
Ptnml(0-2): 54, 11821, 29930, 12282, 57

bench 1274723