### PR TITLE
Simplify histories movepick formula

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -178,7 +178,7 @@ void MovePicker::score() {
             Square    to   = m.to_sq();
 
             // histories
-            m.value = 2 * (*mainHistory)[pos.side_to_move()][m.from_to()];
+            m.value = (*mainHistory)[pos.side_to_move()][m.from_to()];
             m.value += 2 * (*pawnHistory)[pawn_structure_index(pos)][pc][to];
             m.value += 2 * (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];


### PR DESCRIPTION
Simplify histories movepick formula

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 81440 W: 21100 L: 20929 D: 39411
Ptnml(0-2): 248, 9659, 20718, 9864, 231
https://tests.stockfishchess.org/tests/view/6659a8b7ea624d64ea5f3208

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 85758 W: 21763 L: 21607 D: 42388
Ptnml(0-2): 34, 9606, 23463, 9722, 54
https://tests.stockfishchess.org/tests/view/6659d7bff426908fcc6b692c

bench: 1273573