### PR TITLE
Simplify 50 move rule dampening

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -80,10 +80,10 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     int material = 300 * pos.count<PAWN>() + 350 * pos.count<KNIGHT>() + 400 * pos.count<BISHOP>()
                  + 640 * pos.count<ROOK>() + 1200 * pos.count<QUEEN>();
 
-    v = (nnue * (34300 + material) + optimism * (4400 + material)) / 35967;
+    v = (nnue * (34300 + material) + optimism * (4400 + material)) / 36672;
 
     // Damp down the evaluation linearly when shuffling
-    v = v * (204 - pos.rule50_count()) / 208;
+    v -= v * pos.rule50_count() / 212;
 
     // Guarantee evaluation does not hit the tablebase range
     v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);


### PR DESCRIPTION
Refactor the logic of 50 move rule dampening by removing a constant.

Passed non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 35232 W: 9214 L: 8992 D: 17026
Ptnml(0-2): 114, 4081, 8999, 4313, 109
https://tests.stockfishchess.org/tests/view/665a329013d08af3c1725610

Passed non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 38406 W: 9732 L: 9530 D: 19144
Ptnml(0-2): 14, 4132, 10708, 4336, 13
https://tests.stockfishchess.org/tests/view/665a370913d08af3c1725651

Bench: 1248630