### PR TITLE
Use main history to better judge what to razor

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -760,10 +760,12 @@ Value Search::Worker::search(
 
     opponentWorsening = ss->staticEval + (ss - 1)->staticEval > 2;
 
-    // Step 7. Razoring (~1 Elo)
+    // Step 7. Razoring (~4 Elo)
     // If eval is really low check with qsearch if it can exceed alpha, if it can't,
-    // return a fail low.
-    if (eval < alpha - 501 - 305 * depth * depth)
+    // return a fail low. (Main history ~3 Elo out of 4)
+    if (eval < alpha - 501 - 305 * depth * depth
+                           - (priorCapture ? 0
+                              : thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()] / 32))
     {
         value = qsearch<NonPV>(pos, ss, alpha - 1, alpha);
         if (value < alpha)


### PR DESCRIPTION
Passed STC: https://tests.stockfishchess.org/tests/view/665a9e1d062b2c3cf814fef6
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 100928 W: 26238 L: 25832 D: 48858
Ptnml(0-2): 231, 11838, 25957, 12170, 268

Passed LTC: https://tests.stockfishchess.org/tests/view/665aac0e062b2c3cf814ff5d
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 28446 W: 7355 L: 7051 D: 14040
Ptnml(0-2): 10, 3051, 7797, 3355, 10

bench 1316945