### PR TITLE
Simplify Away Razoring History Adjustments

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -760,10 +760,12 @@ Value Search::Worker::search(
 
     opponentWorsening = ss->staticEval + (ss - 1)->staticEval > 2;
 
-    // Step 7. Razoring (~1 Elo)
+    // Step 7. Razoring (~4 Elo)
     // If eval is really low check with qsearch if it can exceed alpha, if it can't,
-    // return a fail low.
-    if (eval < alpha - 501 - 305 * depth * depth)
+    // return a fail low. (Main history ~3 Elo out of 4)
+    if (eval < alpha - 501 - 305 * depth * depth
+                           - (priorCapture ? 0
+                              : thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()] / 32))
     {
         value = qsearch<NonPV>(pos, ss, alpha - 1, alpha);
         if (value < alpha)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -578,9 +578,10 @@ Value Search::Worker::search(
         // Step 2. Check for aborted search and immediate draw
         if (threads.stop.load(std::memory_order_relaxed) || pos.is_draw(ss->ply)
             || ss->ply >= MAX_PLY)
-            return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate(
-                     networks[numaAccessToken], pos, refreshTable, thisThread->optimism[us])
-                                                        : value_draw(thisThread->nodes);
+            return (ss->ply >= MAX_PLY && !ss->inCheck)
+                   ? evaluate(networks[numaAccessToken], pos, refreshTable,
+                              thisThread->optimism[us])
+                   : value_draw(thisThread->nodes);
 
         // Step 3. Mate distance pruning. Even if we mate at the next move our score
         // would be at best mate_in(ss->ply + 1), but if alpha is already bigger because
@@ -762,10 +763,8 @@ Value Search::Worker::search(
 
     // Step 7. Razoring (~4 Elo)
     // If eval is really low check with qsearch if it can exceed alpha, if it can't,
-    // return a fail low. (Main history ~3 Elo out of 4)
-    if (eval < alpha - 501 - 305 * depth * depth
-                           - (priorCapture ? 0
-                              : thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()] / 32))
+    // return a fail low. (priorCapture ~3 Elo out of 4)
+    if (eval < alpha - 457 - 305 * depth * depth - priorCapture * 44)
     {
         value = qsearch<NonPV>(pos, ss, alpha - 1, alpha);
         if (value < alpha)


### PR DESCRIPTION
Per @dubslow on [Discord](https://discord.com/channels/435943710472011776/882956631514689597/1246358091646238821), it doesn't make sense to reduce the amount of razoring when the opponent's move has a good history. This patch simplifies the `thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()] / 32` formula to its overall average.

Tested against #5329

Passed Non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 300864 W: 77581 L: 77653 D: 145630
Ptnml(0-2): 826, 35784, 77284, 35712, 826 
https://tests.stockfishchess.org/tests/view/665accd50223e235f05b7ca3

Passed Non-regression LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 63018 W: 16012 L: 15832 D: 31174
Ptnml(0-2): 41, 6921, 17405, 7101, 41 
https://tests.stockfishchess.org/tests/view/665ae3500223e235f05b7d07