### PR TITLE
Update default smallnet to nn-37f18f62d772.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -34,7 +34,7 @@ namespace Eval {
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
 #define EvalFileDefaultNameBig "nn-ddcfb9224cdb.nnue"
-#define EvalFileDefaultNameSmall "nn-baff1ede1f90.nnue"
+#define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
 
 namespace NNUE {
 struct Networks;


### PR DESCRIPTION
Created by training L1-128 from scratch with:
- skipping based on simple eval in the trainer, for compatibility with regular binpacks without requiring pre-filtering all binpacks
- minimum simple eval of 950, lower than 1000 previously
- usage of some hse-v1 binpacks with minimum simple eval 1000
- addition of hse-v6 binpacks with minimum simple eval 500
- permuting the FT with 10k positions from fishpack32.binpack
- torch.compile to speed up smallnet training

Training is significantly slower when using non-pre-filtered binpacks due to the increased skipping required.

This net was reached at epoch 339.

```yaml
experiment-name: 128--S1-hse-1k-T80-v6-unfilt-less-sf--se-gt950-no-wld-skip

training-dataset:
  /data/:
    - dfrc99-16tb7p.v2.min.binpack

  /data/hse-v1/:
    - leela96-filt-v2.min.high-simple-eval-1k.min-v2.binpack

    - test60-novdec2021-12tb7p-filter-v6-dd.min-mar2023.unmin.high-simple-eval-1k.min-v2.binpack

    - test77-nov2021-2tb7p.no-db.min.high-simple-eval-1k.min-v2.binpack
    - test77-dec2021-16tb7p.no-db.min.high-simple-eval-1k.min-v2.binpack
    - test77-jan2022-2tb7p.high-simple-eval-1k.min-v2.binpack

    - test78-jantomay2022-16tb7p-filter-v6-dd.min-mar2023.unmin.high-simple-eval-1k.min-v2.binpack
    - test78-juntosep2022-16tb7p-filter-v6-dd.min-mar2023.unmin.high-simple-eval-1k.min-v2.binpack

    - test79-apr2022-16tb7p.min.high-simple-eval-1k.min-v2.binpack
    - test79-may2022-16tb7p-filter-v6-dd.min-mar2023.unmin.high-simple-eval-1k.min-v2.binpack

    - test80-apr2022-16tb7p.min.high-simple-eval-1k.min-v2.binpack
    - test80-may2022-16tb7p.high-simple-eval-1k.min-v2.binpack
    - test80-jun2022-16tb7p-filter-v6-dd.min-mar2023.unmin.high-simple-eval-1k.min-v2.binpack
    - test80-jul2022-16tb7p.v6-dd.min.high-simple-eval-1k.min-v2.binpack
    - test80-sep2022-16tb7p-filter-v6-dd.min-mar2023.unmin.high-simple-eval-1k.min-v2.binpack
    - test80-nov2022-16tb7p-v6-dd.min.high-simple-eval-1k.min-v2.binpack

  /data/S11-mar2024/:
    - test80-2022-08-aug-16tb7p.v6-dd.min.binpack
    - test80-2022-10-oct-16tb7p.v6-dd.binpack
    - test80-2022-12-dec-16tb7p.min.binpack

    - test80-2023-01-jan-16tb7p.v6-sk20.min.binpack
    - test80-2023-02-feb-16tb7p.v6-sk20.min.binpack
    - test80-2023-03-mar-2tb7p.v6-sk16.min.binpack
    - test80-2023-04-apr-2tb7p.v6-sk16.min.binpack
    - test80-2023-05-may-2tb7p.v6.min.binpack
    - test80-2023-06-jun-2tb7p.binpack.min-v2.binpack
    - test80-2023-07-jul-2tb7p.binpack.min-v2.binpack
    - test80-2023-08-aug-2tb7p.v6.min.binpack
    - test80-2023-09-sep-2tb7p.binpack.hse-v6.binpack
    - test80-2023-10-oct-2tb7p.binpack.hse-v6.binpack
    - test80-2023-11-nov-2tb7p.binpack.hse-v6.binpack
    - test80-2023-12-dec-2tb7p.binpack.hse-v6.binpack

    - test80-2024-01-jan-2tb7p.binpack.hse-v6.binpack
    - test80-2024-02-feb-2tb7p.binpack.hse-v6.binpack
    - test80-2024-03-mar-2tb7p.binpack

wld-fen-skipping: False

nnue-pytorch-branch: linrock/nnue-pytorch/128-skipSimpleEval-lt950-torch-compile
engine-test-branch: linrock/Stockfish/L1-128-nolazy
engine-base-branch: linrock/Stockfish/L1-128
start-from-engine-test-net: False

num-epochs: 500
start-lambda: 1.0
end-lambda: 1.0
```

Training data can be found at:
https://robotmoon.com/nnue-training-data/

Passed STC:
https://tests.stockfishchess.org/tests/view/66549c16a86388d5e27daff5
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 196608 W: 51254 L: 50697 D: 94657
Ptnml(0-2): 722, 23244, 49796, 23839, 703

Passed LTC:
https://tests.stockfishchess.org/tests/view/6658d1aa6b0e318cefa90122
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 122538 W: 31332 L: 30835 D: 60371
Ptnml(0-2): 69, 13407, 33811, 13922, 60

bench 1423429