### PR TITLE
Simplify tm, removing faster 1st move and 1.13 extraTime.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -160,8 +160,7 @@ void Search::Worker::start_searching() {
         return;
     }
 
-    main_manager()->tm.init(limits, rootPos.side_to_move(), rootPos.game_ply(), options,
-                            main_manager()->originalPly, main_manager()->originalTimeAdjust);
+    main_manager()->tm.init(limits, rootPos.side_to_move(), rootPos.game_ply(), options, main_manager()->originalTimeAdjust);
     tt.new_search();
 
     if (rootMoves.empty())

--- a/src/search.h
+++ b/src/search.h
@@ -209,7 +209,6 @@ class SearchManager: public ISearchManager {
 
     Stockfish::TimeManagement tm;
     double                    originalTimeAdjust;
-    int                       originalPly;
     int                       callsCnt;
     std::atomic_bool          ponder;
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -213,12 +213,13 @@ void ThreadPool::clear() {
     for (auto&& th : threads)
         th->wait_for_search_finished();
 
+    // These two affect the time taken on the first move of a game:
+    main_manager()->bestPreviousAverageScore = VALUE_INFINITE;
+    main_manager()->previousTimeReduction    = 0.85;
+
     main_manager()->callsCnt                 = 0;
     main_manager()->bestPreviousScore        = VALUE_INFINITE;
-    main_manager()->bestPreviousAverageScore = VALUE_INFINITE;
-    main_manager()->originalPly              = -1;
     main_manager()->originalTimeAdjust       = -1;
-    main_manager()->previousTimeReduction    = 1.0;
     main_manager()->tm.clear();
 }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -48,7 +48,6 @@ void TimeManagement::init(Search::LimitsType& limits,
                           Color               us,
                           int                 ply,
                           const OptionsMap&   options,
-                          int&                originalPly,
                           double&             originalTimeAdjust) {
     TimePoint npmsec = TimePoint(options["nodestime"]);
 
@@ -59,9 +58,6 @@ void TimeManagement::init(Search::LimitsType& limits,
 
     if (limits.time[us] == 0)
         return;
-
-    if (originalPly == -1)
-        originalPly = ply;
 
     TimePoint moveOverhead = TimePoint(options["Move Overhead"]);
 
@@ -104,20 +100,14 @@ void TimeManagement::init(Search::LimitsType& limits,
     TimePoint timeLeft = std::max(TimePoint(1), limits.time[us] + limits.inc[us] * (mtg - 1)
                                                   - moveOverhead * (2 + mtg));
 
-    // Extra time according to timeLeft
-    if (originalTimeAdjust < 0)
-        originalTimeAdjust = 0.2078 + 0.1623 * std::log10(timeLeft);
-
     // x basetime (+ z increment)
     // If there is a healthy increment, timeLeft can exceed the actual available
     // game time for the current move, so also cap to a percentage of available game time.
     if (limits.movestogo == 0)
     {
-        // Use extra time with larger increments
-        double optExtra = scaledInc < 500 ? 1.0 : 1.13;
-        if (ply - originalPly < 2)
-            optExtra *= 0.95;
-        optExtra *= originalTimeAdjust;
+        // Extra time according to timeLeft
+        if (originalTimeAdjust < 0)
+            originalTimeAdjust = 0.3285 * std::log10(timeLeft) - 0.4830;
 
         // Calculate time constants based on current time left.
         double logTimeInSec = std::log10(scaledTime / 1000.0);
@@ -126,7 +116,7 @@ void TimeManagement::init(Search::LimitsType& limits,
 
         optScale = std::min(0.0122 + std::pow(ply + 2.95, 0.462) * optConstant,
                             0.213 * limits.time[us] / timeLeft)
-                 * optExtra;
+                 * originalTimeAdjust;
 
         maxScale = std::min(6.64, maxConstant + ply / 12.0);
     }

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -40,7 +40,6 @@ class TimeManagement {
               Color               us,
               int                 ply,
               const OptionsMap&   options,
-              int&                originalPly,
               double&             originalTimeAdjust);
 
     TimePoint optimum() const;


### PR DESCRIPTION
Passed STC 10+0.1 :
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 349760 W: 90112 L: 90231 D: 169417
Ptnml(0-2): 784, 37970, 97496, 37841, 789
https://tests.stockfishchess.org/tests/view/665aeee00223e235f05b7d21

Passed LTC 60+0.6 :
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 140082 W: 35463 L: 35370 D: 69249
Ptnml(0-2): 59, 13492, 42851, 13575, 64
https://tests.stockfishchess.org/tests/view/665b15e78da109e362924e5a

Bench 1484840