### PR TITLE
Avoid changing bestvalue

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1484,7 +1484,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
               to_corrected_static_eval(unadjustedStaticEval, *thisThread, pos);
 
             // ttValue can be used as a better position evaluation (~13 Elo)
-            if (ttValue != VALUE_NONE
+            if (std::abs(ttValue) < VALUE_TB_WIN_IN_MAX_PLY
                 && (tte->bound() & (ttValue > bestValue ? BOUND_LOWER : BOUND_UPPER)))
                 bestValue = ttValue;
         }


### PR DESCRIPTION
in the case the ttValue contains mate scores, do not return them as bestValue, since they are not proven.

passed STC
https://tests.stockfishchess.org/tests/view/665b1ea5586058766677cfa3
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 58912 W: 15319 L: 15130 D: 28463
Ptnml(0-2): 141, 6562, 15854, 6765, 134

passed LTC:
https://tests.stockfishchess.org/tests/view/665b2712586058766677cfc4
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 141666 W: 35976 L: 35879 D: 69811
Ptnml(0-2): 61, 15513, 39584, 15618, 57

Bench: 1329897