### PR TITLE
Adjust return bonus from tt cutoffs at fail highs.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -639,7 +639,12 @@ Value Search::Worker::search(
         // Partial workaround for the graph history interaction problem
         // For high rule50 counts don't produce transposition table cutoffs.
         if (pos.rule50_count() < 90)
+        {
+            if (ttValue >= beta && std::abs(ttValue) < VALUE_TB_WIN_IN_MAX_PLY
+                && std::abs(beta) < VALUE_TB_WIN_IN_MAX_PLY)
+                ttValue = (ttValue * tte->depth() + beta) / (tte->depth() + 1);
             return ttValue;
+        }
     }
 
     // Step 5. Tablebases probe


### PR DESCRIPTION
This is reintroduction of the recently simplified logic - if positive tt cutoff occurs return not a tt value but smth between it and beta.
Difference is that instead of static linear combination there we use basically the same formula as we do in the main search - with the only difference being using tt depth instead of depth, which makes a lot of sense.
Passed STC:
https://tests.stockfishchess.org/tests/view/665b3a34f4a1fd0c208ea870
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 54944 W: 14239 L: 13896 D: 26809
Ptnml(0-2): 151, 6407, 14008, 6760, 146 
Passed LTC:
https://tests.stockfishchess.org/tests/view/665b520011645bd3d3fac341
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 90540 W: 23070 L: 22640 D: 44830
Ptnml(0-2): 39, 9903, 24965, 10315, 48 
bench 1131616