### PR TITLE
Simplify statScore divisor into a constant

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1159,7 +1159,7 @@ moves_loop:  // When in check, search starts here
                       + (*contHist[1])[movedPiece][move.to_sq()] - 5169;
 
         // Decrease/increase reduction for moves with a good/bad history (~8 Elo)
-        r -= ss->statScore / (12219 - std::min(depth, 13) * 120);
+        r -= ss->statScore / 11049;
 
         // Step 17. Late moves reduction / extension (LMR, ~117 Elo)
         if (depth >= 2 && moveCount > 1 + rootNode)


### PR DESCRIPTION
Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/665b392ff4a1fd0c208ea864
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 114752 W: 29628 L: 29495 D: 55629
Ptnml(0-2): 293, 13694, 29269, 13827, 293

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/665b588c11645bd3d3fac467
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 65322 W: 16549 L: 16373 D: 32400
Ptnml(0-2): 30, 7146, 18133, 7322, 30

bench 1400991