### PR TITLE
Revert "Adjust return bonus from tt cutoffs at fail highs"

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -640,12 +640,7 @@ Value Search::Worker::search(
         // Partial workaround for the graph history interaction problem
         // For high rule50 counts don't produce transposition table cutoffs.
         if (pos.rule50_count() < 90)
-        {
-            if (ttValue >= beta && std::abs(ttValue) < VALUE_TB_WIN_IN_MAX_PLY
-                && std::abs(beta) < VALUE_TB_WIN_IN_MAX_PLY)
-                ttValue = (ttValue * tte->depth() + beta) / (tte->depth() + 1);
             return ttValue;
-        }
     }
 
     // Step 5. Tablebases probe


### PR DESCRIPTION
This reverts commit 783dfc2eb235236ff799618436d68d0c1a3f3807.

could lead to a division by zero for:

ttValue = (ttValue * tte->depth() + beta) / (tte->depth() + 1)

as other threads can overwrite the tte with a QS depth of -1.

Bench: 1280020