### PR TITLE
Simplify continuation histories

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -182,7 +182,7 @@ void MovePicker::score() {
             m.value += 2 * (*pawnHistory)[pawn_structure_index(pos)][pc][to];
             m.value += 2 * (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
-            m.value += (*continuationHistory[2])[pc][to] / 4;
+            m.value += (*continuationHistory[2])[pc][to] / 3;
             m.value += (*continuationHistory[3])[pc][to];
             m.value += (*continuationHistory[5])[pc][to];
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1811,7 +1811,7 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
         if (ss->inCheck && i > 2)
             break;
         if (((ss - i)->currentMove).is_ok())
-            (*(ss - i)->continuationHistory)[pc][to] << bonus / (1 + 3 * (i == 3));
+            (*(ss - i)->continuationHistory)[pc][to] << bonus / (1 + (i == 3));
     }
 }
 


### PR DESCRIPTION
Functional simplification.
Simplify continuation histories, therefore increasing the effect of stats updates and movepicker bonuses for continuation history 3 plies deep.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 229184 W: 59087 L: 59080 D: 111017
Ptnml(0-2): 554, 27248, 59002, 27213, 575
https://tests.stockfishchess.org/tests/view/665c7a09fd45fb0f907c223b

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 44532 W: 11419 L: 11223 D: 21890
Ptnml(0-2): 18, 4787, 12457, 4989, 15
https://tests.stockfishchess.org/tests/view/665c8842fd45fb0f907c23ec

bench: 1326444