### PR TITLE
Fix GetProcessGroupAffinity call.

### DIFF
--- a/src/numa.h
+++ b/src/numa.h
@@ -774,7 +774,7 @@ class NumaConfig {
 
             // We are expecting a single group.
             USHORT GroupCount = 1;
-            USHORT GroupArray[1];
+            alignas(4) USHORT GroupArray[1];
             status = GetProcessGroupAffinity_f(GetCurrentProcess(), &GroupCount, GroupArray);
             if (status == 0 || GroupCount != 1)
                 return std::nullopt;


### PR DESCRIPTION
 Experienced cases where it fails with ERROR_NOACCESS otherwise. Right now I can replicate it with 100% rate. master fails, doesn't recognize affinity when running with `taskset --cpu-list 1 ./stockfish.exe`, this patch works.

I can't explain this.