### PR TITLE
Simplifying the extension formula by removing the move == ttMove condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1103,7 +1103,7 @@ moves_loop:  // When in check, search starts here
             }
 
             // Extension for capturing the previous moved piece (~0 Elo on STC, ~1 Elo on LTC)
-            else if (PvNode && move == ttMove && move.to_sq() == prevSq
+            else if (PvNode && move.to_sq() == prevSq
                      && thisThread->captureHistory[movedPiece][move.to_sq()]
                                                   [type_of(pos.piece_on(move.to_sq()))]
                           > 3988)


### PR DESCRIPTION
Simplifying the extension formula by removing the move == ttMove condition 

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 47328 W: 12324 L: 12117 D: 22887
Ptnml(0-2): 134, 5532, 12097, 5795, 106
https://tests.stockfishchess.org/tests/view/665ca5e6fd45fb0f907c41be

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 72126 W: 18378 L: 18209 D: 35539
Ptnml(0-2): 36, 7841, 20130, 8030, 26
https://tests.stockfishchess.org/tests/view/665cb276fd45fb0f907c41f9

bench: 1406000