### PR TITLE
Simplify smallnet threshold

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -46,7 +46,7 @@ int Eval::simple_eval(const Position& pos, Color c) {
 
 bool Eval::use_smallnet(const Position& pos) {
     int simpleEval = simple_eval(pos, pos.side_to_move());
-    return std::abs(simpleEval) > 992 + 10 * pos.count<PAWN>();
+    return std::abs(simpleEval) > 992 + 11 * pos.count<PAWN>();
 }
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -46,7 +46,7 @@ int Eval::simple_eval(const Position& pos, Color c) {
 
 bool Eval::use_smallnet(const Position& pos) {
     int simpleEval = simple_eval(pos, pos.side_to_move());
-    return std::abs(simpleEval) > 992 + 10 * pos.count<PAWN>();
+    return std::abs(simpleEval) > 970 + 7 * pos.count<PAWN>();
 }
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -46,8 +46,7 @@ int Eval::simple_eval(const Position& pos, Color c) {
 
 bool Eval::use_smallnet(const Position& pos) {
     int simpleEval = simple_eval(pos, pos.side_to_move());
-    int pawnCount  = pos.count<PAWN>();
-    return std::abs(simpleEval) > 992 + 6 * pawnCount * pawnCount / 16;
+    return std::abs(simpleEval) > 992 + 10 * pos.count<PAWN>();
 }
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -46,7 +46,7 @@ int Eval::simple_eval(const Position& pos, Color c) {
 
 bool Eval::use_smallnet(const Position& pos) {
     int simpleEval = simple_eval(pos, pos.side_to_move());
-    return std::abs(simpleEval) > 970 + 7 * pos.count<PAWN>();
+    return std::abs(simpleEval) > 992 + 10 * pos.count<PAWN>();
 }
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -46,7 +46,7 @@ int Eval::simple_eval(const Position& pos, Color c) {
 
 bool Eval::use_smallnet(const Position& pos) {
     int simpleEval = simple_eval(pos, pos.side_to_move());
-    return std::abs(simpleEval) > 992 + 11 * pos.count<PAWN>();
+    return std::abs(simpleEval) > 992 + 10 * pos.count<PAWN>();
 }
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation


### PR DESCRIPTION
turns the quadratic threshold to a linear one

STC non-reg:
https://tests.stockfishchess.org/tests/view/665ba0b744e8416a9cdc188d
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 330432 W: 85351 L: 85454 D: 159627
Ptnml(0-2): 888, 39643, 84283, 39488, 914

LTC non-reg:
https://tests.stockfishchess.org/tests/view/665cd60ffd45fb0f907c4306
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 139146 W: 35194 L: 35093 D: 68859
Ptnml(0-2): 58, 15523, 38313, 15618, 61

Bench: 1379500