### PR TITLE
Adjust lowest depth constants to the natural place

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -196,8 +196,8 @@ enum : int {
     // For TT entries where no searching at all was done (whether regular or qsearch) we use
     // _UNSEARCHED, which should thus compare lower than any QS or regular depth. _ENTRY_OFFSET is used
     // only for the TT entry occupancy check (see tt.cpp), and should thus be lower than _UNSEARCHED.
-    DEPTH_UNSEARCHED   = -6,
-    DEPTH_ENTRY_OFFSET = -7
+    DEPTH_UNSEARCHED   = -2,
+    DEPTH_ENTRY_OFFSET = -3
 };
 
 // clang-format off


### PR DESCRIPTION
Passed STC: https://tests.stockfishchess.org/tests/view/665ce3f8fd45fb0f907c537f
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 282784 W: 73032 L: 73082 D: 136670
Ptnml(0-2): 680, 31845, 76364, 31851, 652

Recently when I overhauled these comments, Disservin asked why these were so much lower: they're a relic from when we had a third QS stage at -5. Now we don't, so fix these to the obvious place.

I was fairly sure it was nonfunctional but ran the nonreg to be double sure.

no functional change