### PR TITLE
Remove `delta`/`adjusted`/`complexity` from nnue code

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -24,8 +24,9 @@
 #include <cstdlib>
 #include <iomanip>
 #include <iostream>
-#include <sstream>
 #include <memory>
+#include <sstream>
+#include <tuple>
 
 #include "nnue/network.h"
 #include "nnue/nnue_misc.h"
@@ -61,16 +62,21 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 
     int  simpleEval = simple_eval(pos, pos.side_to_move());
     bool smallNet   = use_smallnet(pos);
-    int  nnueComplexity;
     int  v;
 
-    Value nnue = smallNet ? networks.small.evaluate(pos, &caches.small, true, &nnueComplexity)
-                          : networks.big.evaluate(pos, &caches.big, true, &nnueComplexity);
+    auto [psqt, positional] = smallNet ? networks.small.evaluate(pos, &caches.small)
+                                       : networks.big.evaluate(pos, &caches.big);
+
+    constexpr int delta = 3;
+    Value nnue = ((128 - delta) * psqt + (128 + delta) * positional) / 128;
+    int nnueComplexity = std::abs(psqt - positional);
 
     // Re-evaluate the position when higher eval accuracy is worth the time spent
     if (smallNet && (nnue * simpleEval < 0 || std::abs(nnue) < 250))
     {
-        nnue     = networks.big.evaluate(pos, &caches.big, true, &nnueComplexity);
+        std::tie(psqt, positional) = networks.big.evaluate(pos, &caches.big);
+        nnue = ((128 - delta) * psqt + (128 + delta) * positional) / 128;
+        nnueComplexity = std::abs(psqt - positional);
         smallNet = false;
     }
 
@@ -109,7 +115,8 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
 
     ss << std::showpoint << std::showpos << std::fixed << std::setprecision(2) << std::setw(15);
 
-    Value v = networks.big.evaluate(pos, &caches->big, false);
+    auto [psqt, positional] = networks.big.evaluate(pos, &caches->big);
+    Value v = psqt + positional;
     v       = pos.side_to_move() == WHITE ? v : -v;
     ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)\n";
 

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -18,7 +18,6 @@
 
 #include "network.h"
 
-#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -228,15 +227,12 @@ bool Network<Arch, Transformer>::save(const std::optional<std::string>& filename
 
 
 template<typename Arch, typename Transformer>
-Value Network<Arch, Transformer>::evaluate(const Position&                         pos,
-                                           AccumulatorCaches::Cache<FTDimensions>* cache,
-                                           bool                                    adjusted,
-                                           int* complexity) const {
+NetworkOutput Network<Arch, Transformer>::evaluate(const Position&                         pos,
+                                                   AccumulatorCaches::Cache<FTDimensions>* cache) const {
     // We manually align the arrays on the stack because with gcc < 9.3
     // overaligning stack variables with alignas() doesn't work correctly.
 
     constexpr uint64_t alignment = CacheLineSize;
-    constexpr int      delta     = 24;
 
 #if defined(ALIGNAS_ON_STACK_VARIABLES_BROKEN)
     TransformedFeatureType
@@ -254,16 +250,7 @@ Value Network<Arch, Transformer>::evaluate(const Position&                      
     const int  bucket     = (pos.count<ALL_PIECES>() - 1) / 4;
     const auto psqt       = featureTransformer->transform(pos, cache, transformedFeatures, bucket);
     const auto positional = network[bucket]->propagate(transformedFeatures);
-
-    if (complexity)
-        *complexity = std::abs(psqt - positional) / OutputScale;
-
-    // Give more value to positional evaluation when adjusted flag is set
-    if (adjusted)
-        return static_cast<Value>(((1024 - delta) * psqt + (1024 + delta) * positional)
-                                  / (1024 * OutputScale));
-    else
-        return static_cast<Value>((psqt + positional) / OutputScale);
+    return {static_cast<Value>(psqt / OutputScale), static_cast<Value>(positional / OutputScale)};
 }
 
 

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 
 #include "../misc.h"
@@ -40,6 +41,7 @@ enum class EmbeddedNNUEType {
     SMALL,
 };
 
+using NetworkOutput = std::tuple<Value, Value>;
 
 template<typename Arch, typename Transformer>
 class Network {
@@ -59,10 +61,8 @@ class Network {
     void load(const std::string& rootDirectory, std::string evalfilePath);
     bool save(const std::optional<std::string>& filename) const;
 
-    Value evaluate(const Position&                         pos,
-                   AccumulatorCaches::Cache<FTDimensions>* cache,
-                   bool                                    adjusted   = false,
-                   int*                                    complexity = nullptr) const;
+    NetworkOutput evaluate(const Position&                         pos,
+                           AccumulatorCaches::Cache<FTDimensions>* cache) const;
 
 
     void hint_common_access(const Position&                         pos,

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <sstream>
 #include <string_view>
+#include <tuple>
 
 #include "../evaluate.h"
 #include "../position.h"
@@ -131,7 +132,8 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
 
     // We estimate the value of each piece by doing a differential evaluation from
     // the current base eval, simulating the removal of the piece from its square.
-    Value base = networks.big.evaluate(pos, &caches.big);
+    auto [psqt, positional] = networks.big.evaluate(pos, &caches.big);
+    Value base = psqt + positional;
     base       = pos.side_to_move() == WHITE ? base : -base;
 
     for (File f = FILE_A; f <= FILE_H; ++f)
@@ -148,7 +150,8 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
                 pos.remove_piece(sq);
                 st->accumulatorBig.computed[WHITE] = st->accumulatorBig.computed[BLACK] = false;
 
-                Value eval = networks.big.evaluate(pos, &caches.big);
+                std::tie(psqt, positional) = networks.big.evaluate(pos, &caches.big);
+                Value eval = psqt + positional;
                 eval       = pos.side_to_move() == WHITE ? eval : -eval;
                 v          = base - eval;
 


### PR DESCRIPTION
...rather they're the consumer's concern whether to tweak the result or not

Passed STC: https://tests.stockfishchess.org/tests/view/665cea9ffd45fb0f907c53bd
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 69696 W: 18101 L: 17918 D: 33677
Ptnml(0-2): 195, 8171, 17929, 8362, 191

Passed LTC: https://tests.stockfishchess.org/tests/view/665cf761fd45fb0f907c5406
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 63720 W: 16344 L: 16165 D: 31211
Ptnml(0-2): 32, 6990, 17625, 7193, 20

non functional except for rounding issues of OutputScale changing bench

bench 1182556