### PR TITLE
Use copy of TT entry for consistent values at a node.

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -117,14 +117,14 @@ void TranspositionTable::clear(ThreadPool& threads) {
 // to be replaced later. The replace value of an entry is calculated as its depth
 // minus 8 times its relative age. TTEntry t1 is considered more valuable than
 // TTEntry t2 if its replace value is greater than that of t2.
-TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
+TTData TranspositionTable::probe(const Key key, bool& found) const {
 
     TTEntry* const tte   = first_entry(key);
     const uint16_t key16 = uint16_t(key);  // Use the low 16 bits as key inside the cluster
 
     for (int i = 0; i < ClusterSize; ++i)
         if (tte[i].key16 == key16)
-            return found = bool(tte[i].depth8), &tte[i];
+            return found = bool(tte[i].depth8), TTData(&tte[i]);
 
     // Find an entry to be replaced according to the replacement strategy
     TTEntry* replace = tte;
@@ -133,7 +133,7 @@ TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
             > tte[i].depth8 - tte[i].relative_age(generation8) * 2)
             replace = &tte[i];
 
-    return found = false, replace;
+    return found = false, TTData(replace);
 }
 
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -65,6 +65,20 @@ struct TTEntry {
     int16_t  eval16;
 };
 
+struct TTData: public TTEntry {
+
+    explicit TTData(TTEntry* tte) :
+        TTEntry(*tte),
+        entry(tte) {}
+    void
+    save(Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev, uint8_t generation8) const {
+        entry->save(k, v, pv, b, d, m, ev, generation8);
+    }
+
+   private:
+    TTEntry* entry;
+};
+
 class ThreadPool;
 
 // A TranspositionTable is an array of Cluster, of size clusterCount. Each
@@ -101,10 +115,10 @@ class TranspositionTable {
         generation8 += GENERATION_DELTA;
     }
 
-    TTEntry* probe(const Key key, bool& found) const;
-    int      hashfull() const;
-    void     resize(size_t mbSize, ThreadPool& threads);
-    void     clear(ThreadPool& threads);
+    TTData probe(const Key key, bool& found) const;
+    int    hashfull() const;
+    void   resize(size_t mbSize, ThreadPool& threads);
+    void   clear(ThreadPool& threads);
 
     TTEntry* first_entry(const Key key) const {
         return &table[mul_hi64(key, clusterCount)].entry[0];


### PR DESCRIPTION
To avoid that a retrieved TT entry changes at a node during the search use a copy of it instead.

For this a new struct TTData is introduced as storage which is simply an extended TTEntry. This data structure contains an additional pointer to the original TT entry for saving.

Passed STC (non-regression):
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 69248 W: 18020 L: 17845 D: 33383
Ptnml(0-2): 176, 7385, 19332, 7550, 181
https://tests.stockfishchess.org/tests/view/665c2c87ab5608f07fdcca6e

Passed LTC (non-regression):a
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 219006 W: 55631 L: 55613 D: 107762
Ptnml(0-2): 88, 21934, 65447, 21940, 94
https://tests.stockfishchess.org/tests/view/665c43b304452685e60249bf

Passed SMP STC (non-regression):
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 51136 W: 13344 L: 13149 D: 24643
Ptnml(0-2): 45, 5794, 13705, 5969, 55
https://tests.stockfishchess.org/tests/view/665c507704452685e6024ebc

Passed SMP LTC (non-regression):
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 157240 W: 40229 L: 40151 D: 76860
Ptnml(0-2): 23, 16171, 46155, 16247, 24
https://tests.stockfishchess.org/tests/view/665c7021fd45fb0f907c214a

Bench: 1369817