### PR TITLE
Add NumaPolicy "hardware" option that bypasses current processor affinity.

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -133,6 +133,11 @@ void Engine::set_numa_config_from_option(const std::string& o) {
     {
         numaContext.set_numa_config(NumaConfig::from_system());
     }
+    else if (o == "hardware")
+    {
+        // Don't respect affinity set in the system.
+        numaContext.set_numa_config(NumaConfig::from_system(false));
+    }
     else if (o == "none")
     {
         numaContext.set_numa_config(NumaConfig{});


### PR DESCRIPTION
Also reinforce correctness of affinity handling on Windows in case of multiple available APIs and existing affinities.

Basically this patch allows overriding affinity set by taskset/(start /affinity) to use all available processors. Custom affinity masks will also be able to override current affinity in more cases. This option works both on Windows and Linux.

The following changes [un]related to the new `hardware` setting have been made:

- On Windows the identification of current affinity was improved, both APIs are considered at the same time and combined. If the affinity is indeterminate (in some cases the old API provides insufficient information) it is assumed that there is no affinity.
- On Windows old API will be used even if new API is available if it is detected that affinity for this process has been set by old API functions. I.e. `GetProcessGroupAffinity` shows affinity on a single processor group. This also means that old API will also be used on configurations with a single processor group.
- On Windows the old and new affinity APIs will be kept in sync if the old API needs to be used. I.e. the new API is always used when available, but may not be the only API used.

--------------------------

Tested on a single processor group Windows 11 and 2 node linux so far. More testing is welcome. The expected behaviour is
```
taskset --cpu-list 1 ./stockfish
setoption name numapolicy value hardware
```
to show all processors as available, and the following continuation
```
setoption name threads value <whateverthemaxforthishardwareis>
go
```
result in expected speed and cpu utilization

Note that if numapolicy value hardware is used (or any custom affinity) the subsequent numapolicy value system calls may see the new affinity. It is generally assumed that numapolicy value system behaves as expected only if ran as the first command. numapolicy value shouldn't really be ran multiple times in the same stockfish instance, though as the behaviour may be unexpected it is always defined.