### PR TITLE
Avoid duplicated initializations after startup

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -44,7 +44,8 @@ namespace Stockfish {
 
 namespace NN = Eval::NNUE;
 
-constexpr auto StartFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+constexpr auto StartFEN  = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+constexpr int  MaxHashMB = Is64Bit ? 33554432 : 2048;
 
 Engine::Engine(std::string path) :
     binaryDirectory(CommandLine::get_binary_directory(path)),
@@ -58,6 +59,58 @@ Engine::Engine(std::string path) :
         NN::NetworkSmall({EvalFileDefaultNameSmall, "None", ""}, NN::EmbeddedNNUEType::SMALL))) {
     pos.set(StartFEN, false, &states->back());
     capSq = SQ_NONE;
+
+    options["Debug Log File"] << Option("", [](const Option& o) {
+        start_logger(o);
+        return std::nullopt;
+    });
+
+    options["NumaPolicy"] << Option("auto", [this](const Option& o) {
+        set_numa_config_from_option(o);
+        return numa_config_information_as_string() + "\n" + thread_binding_information_as_string();
+    });
+
+    options["Threads"] << Option(1, 1, 1024, [this](const Option&) {
+        resize_threads();
+        return thread_binding_information_as_string();
+    });
+
+    options["Hash"] << Option(16, 1, MaxHashMB, [this](const Option& o) {
+        set_tt_size(o);
+        return std::nullopt;
+    });
+
+    options["Clear Hash"] << Option([this](const Option&) {
+        search_clear();
+        return std::nullopt;
+    });
+    options["Ponder"] << Option(false);
+    options["MultiPV"] << Option(1, 1, MAX_MOVES);
+    options["Skill Level"] << Option(20, 0, 20);
+    options["Move Overhead"] << Option(10, 0, 5000);
+    options["nodestime"] << Option(0, 0, 10000);
+    options["UCI_Chess960"] << Option(false);
+    options["UCI_LimitStrength"] << Option(false);
+    options["UCI_Elo"] << Option(1320, 1320, 3190);
+    options["UCI_ShowWDL"] << Option(false);
+    options["SyzygyPath"] << Option("<empty>", [](const Option& o) {
+        Tablebases::init(o);
+        return std::nullopt;
+    });
+    options["SyzygyProbeDepth"] << Option(1, 1, 100);
+    options["Syzygy50MoveRule"] << Option(true);
+    options["SyzygyProbeLimit"] << Option(7, 0, 7);
+    options["EvalFile"] << Option(EvalFileDefaultNameBig, [this](const Option& o) {
+        load_big_network(o);
+        return std::nullopt;
+    });
+    options["EvalFileSmall"] << Option(EvalFileDefaultNameSmall, [this](const Option& o) {
+        load_small_network(o);
+        return std::nullopt;
+    });
+
+    load_networks();
+    resize_threads();
 }
 
 std::uint64_t Engine::perft(const std::string& fen, Depth depth, bool isChess960) {
@@ -212,7 +265,8 @@ void Engine::trace_eval() const {
     sync_cout << "\n" << Eval::trace(p, *networks) << sync_endl;
 }
 
-OptionsMap& Engine::get_options() { return options; }
+const OptionsMap& Engine::get_options() const { return options; }
+OptionsMap&       Engine::get_options() { return options; }
 
 std::string Engine::fen() const { return pos.fen(); }
 
@@ -239,6 +293,32 @@ std::vector<std::pair<size_t, size_t>> Engine::get_bound_thread_count_by_numa_no
 
 std::string Engine::get_numa_config_as_string() const {
     return numaContext.get_numa_config().to_string();
+}
+
+std::string Engine::numa_config_information_as_string() const {
+    auto cfgStr = get_numa_config_as_string();
+    return "Available Processors: " + cfgStr;
+}
+
+std::string Engine::thread_binding_information_as_string() const {
+    auto boundThreadsByNode = get_bound_thread_count_by_numa_node();
+    if (boundThreadsByNode.empty())
+        return "";
+
+    std::stringstream ss;
+    ss << "NUMA Node Thread Binding: ";
+
+    bool isFirst = true;
+
+    for (auto&& [current, total] : boundThreadsByNode)
+    {
+        if (!isFirst)
+            ss << ":";
+        ss << current << "/" << total;
+        isFirst = false;
+    }
+
+    return ss.str();
 }
 
 }

--- a/src/engine.h
+++ b/src/engine.h
@@ -29,13 +29,13 @@
 #include <vector>
 
 #include "nnue/network.h"
+#include "numa.h"
 #include "position.h"
 #include "search.h"
 #include "syzygy/tbprobe.h"  // for Stockfish::Depth
 #include "thread.h"
 #include "tt.h"
 #include "ucioption.h"
-#include "numa.h"
 
 namespace Stockfish {
 
@@ -92,13 +92,18 @@ class Engine {
 
     // utility functions
 
-    void                                   trace_eval() const;
-    OptionsMap&                            get_options();
+    void trace_eval() const;
+
+    const OptionsMap& get_options() const;
+    OptionsMap&       get_options();
+
     std::string                            fen() const;
     void                                   flip();
     std::string                            visualize() const;
     std::vector<std::pair<size_t, size_t>> get_bound_thread_count_by_numa_node() const;
     std::string                            get_numa_config_as_string() const;
+    std::string                            numa_config_information_as_string() const;
+    std::string                            thread_binding_information_as_string() const;
 
    private:
     const std::string binaryDirectory;

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -178,16 +178,16 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
 
     for (std::size_t bucket = 0; bucket < LayerStacks; ++bucket)
     {
-        ss << "|  " << bucket << "        ";
-        ss << " |  ";
+        ss << "|  " << bucket << "        "  //
+           << " |  ";
         format_cp_aligned_dot(t.psqt[bucket], ss, pos);
-        ss << "  "
+        ss << "  "  //
            << " |  ";
         format_cp_aligned_dot(t.positional[bucket], ss, pos);
-        ss << "  "
+        ss << "  "  //
            << " |  ";
         format_cp_aligned_dot(t.psqt[bucket] + t.positional[bucket], ss, pos);
-        ss << "  "
+        ss << "  "  //
            << " |";
         if (bucket == t.correctBucket)
             ss << " <-- this bucket is used";

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <iostream>
 #include <map>
+#include <optional>
 #include <sstream>
 #include <string>
 
@@ -33,19 +34,19 @@ namespace Stockfish {
 bool          Tune::update_on_last;
 const Option* LastOption = nullptr;
 OptionsMap*   Tune::options;
-
-
 namespace {
 std::map<std::string, int> TuneResults;
 
-void on_tune(const Option& o) {
+std::optional<std::string> on_tune(const Option& o) {
 
     if (!Tune::update_on_last || LastOption == &o)
         Tune::read_options();
+
+    return std::nullopt;
+}
 }
 
-
-void make_option(OptionsMap* options, const string& n, int v, const SetRange& r) {
+void Tune::make_option(OptionsMap* opts, const string& n, int v, const SetRange& r) {
 
     // Do not generate option when there is nothing to tune (ie. min = max)
     if (r(v).first == r(v).second)
@@ -54,8 +55,8 @@ void make_option(OptionsMap* options, const string& n, int v, const SetRange& r)
     if (TuneResults.count(n))
         v = TuneResults[n];
 
-    (*options)[n] << Option(v, r(v).first, r(v).second, on_tune);
-    LastOption = &((*options)[n]);
+    (*opts)[n] << Option(v, r(v).first, r(v).second, on_tune);
+    LastOption = &((*opts)[n]);
 
     // Print formatted parameters, ready to be copy-pasted in Fishtest
     std::cout << n << ","                                  //
@@ -64,7 +65,6 @@ void make_option(OptionsMap* options, const string& n, int v, const SetRange& r)
               << r(v).second << ","                        //
               << (r(v).second - r(v).first) / 20.0 << ","  //
               << "0.0020" << std::endl;
-}
 }
 
 string Tune::next(string& names, bool pop) {

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -58,8 +58,11 @@ void make_option(OptionsMap* options, const string& n, int v, const SetRange& r)
     LastOption = &((*options)[n]);
 
     // Print formatted parameters, ready to be copy-pasted in Fishtest
-    std::cout << n << "," << v << "," << r(v).first << "," << r(v).second << ","
-              << (r(v).second - r(v).first) / 20.0 << ","
+    std::cout << n << ","                                  //
+              << v << ","                                  //
+              << r(v).first << ","                         //
+              << r(v).second << ","                        //
+              << (r(v).second - r(v).first) / 20.0 << ","  //
               << "0.0020" << std::endl;
 }
 }

--- a/src/tune.h
+++ b/src/tune.h
@@ -145,6 +145,8 @@ class Tune {
         return add(value, (next(names), std::move(names)), args...);
     }
 
+    static void make_option(OptionsMap* options, const std::string& n, int v, const SetRange& r);
+
     std::vector<std::unique_ptr<EntryBase>> list;
 
    public:

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -324,8 +324,9 @@ void UCIEngine::bench(std::istream& args) {
 
     dbg_print();
 
-    std::cerr << "\n==========================="
-              << "\nTotal time (ms) : " << elapsed << "\nNodes searched  : " << nodes
+    std::cerr << "\n==========================="    //
+              << "\nTotal time (ms) : " << elapsed  //
+              << "\nNodes searched  : " << nodes    //
               << "\nNodes/second    : " << 1000 * nodes / elapsed << std::endl;
 
     // reset callback, to not capture a dangling reference to nodesSearched

--- a/src/uci.h
+++ b/src/uci.h
@@ -19,10 +19,10 @@
 #ifndef UCI_H_INCLUDED
 #define UCI_H_INCLUDED
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <string_view>
-#include <cstdint>
 
 #include "engine.h"
 #include "misc.h"
@@ -41,9 +41,6 @@ class UCIEngine {
     UCIEngine(int argc, char** argv);
 
     void loop();
-
-    void print_numa_config_information() const;
-    void print_thread_binding_information() const;
 
     static int         to_cp(Value v, const Position& pos);
     static std::string format_score(const Score& s);


### PR DESCRIPTION
It is unnecessary to call engine.search_clear() after engine startup, resize_threads() already does all the necessary work.

No functional change