### PR TITLE
Remove m512_hadd128x16_interleave()

### DIFF
--- a/src/nnue/layers/simd.h
+++ b/src/nnue/layers/simd.h
@@ -43,39 +43,6 @@ namespace Stockfish::Simd {
     return _mm512_reduce_add_epi32(sum) + bias;
 }
 
-/*
-      Parameters:
-        sum0 = [zmm0.i128[0], zmm0.i128[1], zmm0.i128[2], zmm0.i128[3]]
-        sum1 = [zmm1.i128[0], zmm1.i128[1], zmm1.i128[2], zmm1.i128[3]]
-        sum2 = [zmm2.i128[0], zmm2.i128[1], zmm2.i128[2], zmm2.i128[3]]
-        sum3 = [zmm3.i128[0], zmm3.i128[1], zmm3.i128[2], zmm3.i128[3]]
-
-      Returns:
-        ret = [
-          reduce_add_epi32(zmm0.i128[0]), reduce_add_epi32(zmm1.i128[0]), reduce_add_epi32(zmm2.i128[0]), reduce_add_epi32(zmm3.i128[0]),
-          reduce_add_epi32(zmm0.i128[1]), reduce_add_epi32(zmm1.i128[1]), reduce_add_epi32(zmm2.i128[1]), reduce_add_epi32(zmm3.i128[1]),
-          reduce_add_epi32(zmm0.i128[2]), reduce_add_epi32(zmm1.i128[2]), reduce_add_epi32(zmm2.i128[2]), reduce_add_epi32(zmm3.i128[2]),
-          reduce_add_epi32(zmm0.i128[3]), reduce_add_epi32(zmm1.i128[3]), reduce_add_epi32(zmm2.i128[3]), reduce_add_epi32(zmm3.i128[3])
-        ]
-    */
-[[maybe_unused]] static __m512i
-m512_hadd128x16_interleave(__m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3) {
-
-    __m512i sum01a = _mm512_unpacklo_epi32(sum0, sum1);
-    __m512i sum01b = _mm512_unpackhi_epi32(sum0, sum1);
-
-    __m512i sum23a = _mm512_unpacklo_epi32(sum2, sum3);
-    __m512i sum23b = _mm512_unpackhi_epi32(sum2, sum3);
-
-    __m512i sum01 = _mm512_add_epi32(sum01a, sum01b);
-    __m512i sum23 = _mm512_add_epi32(sum23a, sum23b);
-
-    __m512i sum0123a = _mm512_unpacklo_epi64(sum01, sum23);
-    __m512i sum0123b = _mm512_unpackhi_epi64(sum01, sum23);
-
-    return _mm512_add_epi32(sum0123a, sum0123b);
-}
-
 [[maybe_unused]] static void m512_add_dpbusd_epi32(__m512i& acc, __m512i a, __m512i b) {
 
     #if defined(USE_VNNI)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1660,7 +1660,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
     return bestValue;
 }
 
-Depth Search::Worker::reduction(bool i, Depth d, int mn, int delta) {
+Depth Search::Worker::reduction(bool i, Depth d, int mn, int delta) const {
     int reductionScale = reductions[d] * reductions[mn];
     return (reductionScale + 1222 - delta * 733 / rootDelta) / 1024 + (!i && reductionScale > 1231);
 }

--- a/src/search.h
+++ b/src/search.h
@@ -265,7 +265,7 @@ class Worker {
     template<NodeType nodeType>
     Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth = 0);
 
-    Depth reduction(bool i, Depth d, int mn, int delta);
+    Depth reduction(bool i, Depth d, int mn, int delta) const;
 
     // Get a pointer to the search manager, only allowed to be called by the
     // main thread.


### PR DESCRIPTION
Remove m512_hadd128x16_interleave() which is no longer used anywhere.
Also Search::Worker::reduction() should be const and probably not worth a separate PR so including it here.

No functional change
bench: 1378596