### PR TITLE
When finding bestMove, consider more moves near leaves.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1282,11 +1282,13 @@ moves_loop:  // When in check, search starts here
                 rm.score = -VALUE_INFINITE;
         }
 
-        if (value > bestValue)
+        int inc = (value == bestValue && (int(nodes) & 15) == 0 && ss->ply + 2 >= thisThread->rootDepth);
+
+        if (value + inc > bestValue)
         {
             bestValue = value;
 
-            if (value > alpha)
+            if (value + inc > alpha)
             {
                 bestMove = move;
 


### PR DESCRIPTION
Try to avoid missing good moves for opponent or engine. When updating bestMove, use value == bestValue sometimes as well as the normal value > bestValue. Only do this in the deepest part of the tree, so that the search logic near the root is unchanged.

Passed SMP LTC 6+0.06 th7 :
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 66696 W: 17417 L: 17077 D: 32202
Ptnml(0-2): 42, 7374, 18181, 7704, 47
https://tests.stockfishchess.org/tests/view/665fa1d0fd11ae7170b48662

Passed SMP LTC 24+0.24 th7 :
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 118122 W: 30265 L: 29801 D: 58056
Ptnml(0-2): 22, 11844, 34864, 12310, 21
https://tests.stockfishchess.org/tests/view/665fc7f6fd11ae7170b48a2d

Bench 1238040