### PR TITLE
Copy values from TT on probe. Encapsulate probe and save.

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -33,7 +33,25 @@
 #define stringify2(x) #x
 #define stringify(x) stringify2(x)
 
+#if defined(__clang__)
+
+    #define FORCE_INLINE [[gnu::always_inline]] [[gnu::gnu_inline]] inline
+
+#elif defined(__GNUC__)
+
+    #define FORCE_INLINE [[gnu::always_inline]] inline
+
+#elif defined(_MSC_VER)
+
+    #pragma warning(error: 4714)
+    #define FORCE_INLINE __forceinline
+
+#endif
+
 namespace Stockfish {
+
+// Size of cache line (in bytes)
+constexpr std::size_t CacheLineSize = 64;
 
 std::string engine_info(bool to_uci = false);
 std::string compiler_info();

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -55,9 +55,6 @@ constexpr std::uint32_t Version = 0x7AF32F20u;
 constexpr int OutputScale     = 16;
 constexpr int WeightScaleBits = 6;
 
-// Size of cache line (in bytes)
-constexpr std::size_t CacheLineSize = 64;
-
 constexpr const char        Leb128MagicString[]   = "COMPRESSED_LEB128";
 constexpr const std::size_t Leb128MagicStringSize = sizeof(Leb128MagicString) - 1;
 

--- a/src/perft.h
+++ b/src/perft.h
@@ -34,7 +34,7 @@ template<bool Root>
 uint64_t perft(Position& pos, Depth depth) {
 
     StateInfo st;
-    ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
+    ASSERT_ALIGNED(&st, CacheLineSize);
 
     uint64_t   cnt, nodes = 0;
     const bool leaf = (depth == 2);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -83,7 +83,7 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
     if (int(Tablebases::MaxCardinality) >= popcount(pos.pieces()) && !pos.can_castle(ANY_CASTLING))
     {
         StateInfo st;
-        ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
+        ASSERT_ALIGNED(&st, CacheLineSize);
 
         Position p;
         p.set(pos.fen(), pos.is_chess960(), &st);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -54,6 +54,64 @@ using Eval::evaluate;
 using namespace Search;
 
 namespace {
+Value value_to_tt(Value v, int ply);
+Value value_from_tt(Value v, int ply, int r50c);
+}
+
+class alignas(CacheLineSize) ProbedTTEntry final {
+   private:
+    TranspositionTable* tt;
+    TTEntry*            tte;
+    Key                 key;
+    int                 ply;
+
+   public:
+    Value value;
+    Value eval;
+    Move  move;
+    Bound bound;
+    Depth depth;
+    bool  hit;
+    bool  capture;
+    bool  pv;
+
+    FORCE_INLINE
+    ProbedTTEntry(TranspositionTable& tt_, const Position& pos, int ply_, Move moveOverride) :
+        tt(&tt_),
+        key(pos.key()),
+        ply(ply_) {
+        tte = tt_.probe(key, hit);
+
+        if (hit)
+        {
+            value = value_from_tt(tte->value(), ply_, pos.rule50_count());
+            move  = moveOverride != Move::none() ? moveOverride : tte->move();
+            depth = tte->depth();
+            bound = tte->bound();
+            eval  = tte->eval();
+            pv    = tte->is_pv();
+        }
+        else
+        {
+            value = VALUE_NONE;
+            move  = moveOverride;
+            depth = DEPTH_UNSEARCHED;
+            bound = BOUND_NONE;
+            eval  = VALUE_NONE;
+            pv    = false;
+        }
+
+        capture = move && pos.capture_stage(move);
+    }
+
+    FORCE_INLINE void change_for_next_probe(
+      Value newValue, bool newIsPv, Bound newBound, Depth newDepth, Move newMove, Value newEval) {
+        tte->save(key, value_to_tt(newValue, ply), newIsPv, newBound, newDepth, newMove, newEval,
+                  tt->generation());
+    }
+};
+
+namespace {
 
 static constexpr double EvalLevel[10] = {0.981, 0.956, 0.895, 0.949, 0.913,
                                          0.942, 0.933, 0.890, 0.984, 0.941};
@@ -111,13 +169,11 @@ struct Skill {
     Move   best = Move::none();
 };
 
-Value value_to_tt(Value v, int ply);
-Value value_from_tt(Value v, int ply, int r50c);
-void  update_pv(Move* pv, Move move, const Move* childPv);
-void  update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus);
-void  update_refutations(const Position& pos, Stack* ss, Search::Worker& workerThread, Move move);
-void  update_quiet_histories(
-   const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus);
+void update_pv(Move* pv, Move move, const Move* childPv);
+void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus);
+void update_refutations(const Position& pos, Stack* ss, Search::Worker& workerThread, Move move);
+void update_quiet_histories(
+  const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus);
 void update_quiet_stats(
   const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus);
 void update_all_stats(const Position& pos,
@@ -544,18 +600,16 @@ Value Search::Worker::search(
 
     Move      pv[MAX_PLY + 1], capturesSearched[32], quietsSearched[32];
     StateInfo st;
-    ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
+    ASSERT_ALIGNED(&st, CacheLineSize);
 
-    TTEntry* tte;
-    Key      posKey;
-    Move     ttMove, move, excludedMove, bestMove;
-    Depth    extension, newDepth;
-    Value    bestValue, value, ttValue, eval, maxValue, probCutBeta, singularValue;
-    bool     givesCheck, improving, priorCapture, opponentWorsening;
-    bool     capture, moveCountPruning, ttCapture;
-    Piece    movedPiece;
-    int      moveCount, captureCount, quietCount, futilityMargin;
-    Bound    singularBound;
+    Move  move, excludedMove, bestMove;
+    Depth extension, newDepth;
+    Value bestValue, value, eval, maxValue, probCutBeta, singularValue;
+    bool  givesCheck, improving, priorCapture, opponentWorsening;
+    bool  capture, moveCountPruning;
+    Piece movedPiece;
+    int   moveCount, captureCount, quietCount, futilityMargin;
+    Bound singularBound;
 
     // Step 1. Initialize node
     Worker* thisThread = this;
@@ -606,30 +660,26 @@ Value Search::Worker::search(
 
     // Step 4. Transposition table lookup.
     excludedMove = ss->excludedMove;
-    posKey       = pos.key();
-    tte          = tt.probe(posKey, ss->ttHit);
-    ttValue   = ss->ttHit ? value_from_tt(tte->value(), ss->ply, pos.rule50_count()) : VALUE_NONE;
-    ttMove    = rootNode  ? thisThread->rootMoves[thisThread->pvIdx].pv[0]
-              : ss->ttHit ? tte->move()
-                          : Move::none();
-    ttCapture = ttMove && pos.capture_stage(ttMove);
+    ProbedTTEntry tte(tt, pos, ss->ply,
+                      rootNode ? thisThread->rootMoves[thisThread->pvIdx].pv[0] : Move::none());
+    ss->ttHit = tte.hit;
 
     // At this point, if excluded, skip straight to step 6, static eval. However,
     // to save indentation, we list the condition in all code between here and there.
     if (!excludedMove)
-        ss->ttPv = PvNode || (ss->ttHit && tte->is_pv());
+        ss->ttPv = PvNode || tte.pv;
 
     // At non-PV nodes we check for an early TT cutoff
-    if (!PvNode && !excludedMove && tte->depth() > depth - (ttValue <= beta)
-        && ttValue != VALUE_NONE  // Possible in case of TT access race or if !ttHit
-        && (tte->bound() & (ttValue >= beta ? BOUND_LOWER : BOUND_UPPER)))
+    if (!PvNode && !excludedMove && tte.depth > depth - (tte.value <= beta)
+        && tte.value != VALUE_NONE  // Possible in case of TT access race or if !ttHit
+        && (tte.bound & (tte.value >= beta ? BOUND_LOWER : BOUND_UPPER)))
     {
         // If ttMove is quiet, update move sorting heuristics on TT hit (~2 Elo)
-        if (ttMove && ttValue >= beta)
+        if (tte.move && tte.value >= beta)
         {
             // Bonus for a quiet ttMove that fails high (~2 Elo)
-            if (!ttCapture)
-                update_quiet_stats(pos, ss, *this, ttMove, stat_bonus(depth));
+            if (!tte.capture)
+                update_quiet_stats(pos, ss, *this, tte.move, stat_bonus(depth));
 
             // Extra penalty for early quiet moves of
             // the previous ply (~1 Elo on STC, ~2 Elo on LTC)
@@ -641,7 +691,7 @@ Value Search::Worker::search(
         // Partial workaround for the graph history interaction problem
         // For high rule50 counts don't produce transposition table cutoffs.
         if (pos.rule50_count() < 90)
-            return ttValue;
+            return tte.value;
     }
 
     // Step 5. Tablebases probe
@@ -679,9 +729,8 @@ Value Search::Worker::search(
 
                 if (b == BOUND_EXACT || (b == BOUND_LOWER ? value >= beta : value <= alpha))
                 {
-                    tte->save(posKey, value_to_tt(value, ss->ply), ss->ttPv, b,
-                              std::min(MAX_PLY - 1, depth + 6), Move::none(), VALUE_NONE,
-                              tt.generation());
+                    tte.change_for_next_probe(value, ss->ttPv, b, std::min(MAX_PLY - 1, depth + 6),
+                                              Move::none(), VALUE_NONE);
 
                     return value;
                 }
@@ -716,7 +765,7 @@ Value Search::Worker::search(
     else if (ss->ttHit)
     {
         // Never assume anything about values stored in TT
-        unadjustedStaticEval = tte->eval();
+        unadjustedStaticEval = tte.eval;
         if (unadjustedStaticEval == VALUE_NONE)
             unadjustedStaticEval =
               evaluate(networks[numaAccessToken], pos, refreshTable, thisThread->optimism[us]);
@@ -726,8 +775,8 @@ Value Search::Worker::search(
         ss->staticEval = eval = to_corrected_static_eval(unadjustedStaticEval, *thisThread, pos);
 
         // ttValue can be used as a better position evaluation (~7 Elo)
-        if (ttValue != VALUE_NONE && (tte->bound() & (ttValue > eval ? BOUND_LOWER : BOUND_UPPER)))
-            eval = ttValue;
+        if (tte.value != VALUE_NONE && (tte.bound & (tte.value > eval ? BOUND_LOWER : BOUND_UPPER)))
+            eval = tte.value;
     }
     else
     {
@@ -736,8 +785,8 @@ Value Search::Worker::search(
         ss->staticEval = eval = to_corrected_static_eval(unadjustedStaticEval, *thisThread, pos);
 
         // Static evaluation is saved as it was before adjustment by correction history
-        tte->save(posKey, VALUE_NONE, ss->ttPv, BOUND_NONE, DEPTH_UNSEARCHED, Move::none(),
-                  unadjustedStaticEval, tt.generation());
+        tte.change_for_next_probe(VALUE_NONE, ss->ttPv, BOUND_NONE, DEPTH_UNSEARCHED, Move::none(),
+                                  unadjustedStaticEval);
     }
 
     // Use static evaluation difference to improve quiet move ordering (~9 Elo)
@@ -777,7 +826,7 @@ Value Search::Worker::search(
     // Step 8. Futility pruning: child node (~40 Elo)
     // The depth condition is important for mate finding.
     if (!ss->ttPv && depth < 13 && eval - futilityMargin - (ss - 1)->statScore / 263 >= beta
-        && eval >= beta && eval < VALUE_TB_WIN_IN_MAX_PLY && (!ttMove || ttCapture))
+        && eval >= beta && eval < VALUE_TB_WIN_IN_MAX_PLY && (!tte.move || tte.capture))
         return beta > VALUE_TB_LOSS_IN_MAX_PLY ? beta + (eval - beta) / 3 : eval;
 
     // Step 9. Null move search with verification search (~35 Elo)
@@ -832,7 +881,7 @@ Value Search::Worker::search(
 
     // Step 10. Internal iterative reductions (~9 Elo)
     // For PV nodes without a ttMove, we decrease depth by 3.
-    if (PvNode && !ttMove)
+    if (PvNode && !tte.move)
         depth -= 3;
 
     // Use qsearch if depth <= 0.
@@ -841,8 +890,8 @@ Value Search::Worker::search(
 
     // For cutNodes, if depth is high enough, decrease depth by 2 if there is no ttMove, or
     // by 1 if there is a ttMove with an upper bound.
-    if (cutNode && depth >= 8 && (!ttMove || tte->bound() == BOUND_UPPER))
-        depth -= 1 + !ttMove;
+    if (cutNode && depth >= 8 && (!tte.move || tte.bound == BOUND_UPPER))
+        depth -= 1 + !tte.move;
 
     // Step 11. ProbCut (~10 Elo)
     // If we have a good enough capture (or queen promotion) and a reduced search returns a value
@@ -855,11 +904,11 @@ Value Search::Worker::search(
       // there and in further interactions with transposition table cutoff depth is set to depth - 3
       // because probCut search has depth set to depth - 4 but we also do a move before it
       // So effective depth is equal to depth - 3
-      && !(tte->depth() >= depth - 3 && ttValue != VALUE_NONE && ttValue < probCutBeta))
+      && !(tte.depth >= depth - 3 && tte.value != VALUE_NONE && tte.value < probCutBeta))
     {
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
-        MovePicker mp(pos, ttMove, probCutBeta - ss->staticEval, &thisThread->captureHistory);
+        MovePicker mp(pos, tte.move, probCutBeta - ss->staticEval, &thisThread->captureHistory);
 
         while ((move = mp.next_move()) != Move::none())
             if (move != excludedMove && pos.legal(move))
@@ -890,8 +939,8 @@ Value Search::Worker::search(
                 if (value >= probCutBeta)
                 {
                     // Save ProbCut data into transposition table
-                    tte->save(posKey, value_to_tt(value, ss->ply), ss->ttPv, BOUND_LOWER, depth - 3,
-                              move, unadjustedStaticEval, tt.generation());
+                    tte.change_for_next_probe(value, ss->ttPv, BOUND_LOWER, depth - 3, move,
+                                              unadjustedStaticEval);
                     return std::abs(value) < VALUE_TB_WIN_IN_MAX_PLY ? value - (probCutBeta - beta)
                                                                      : value;
                 }
@@ -904,9 +953,9 @@ moves_loop:  // When in check, search starts here
 
     // Step 12. A small Probcut idea, when we are in check (~4 Elo)
     probCutBeta = beta + 388;
-    if (ss->inCheck && !PvNode && ttCapture && (tte->bound() & BOUND_LOWER)
-        && tte->depth() >= depth - 4 && ttValue >= probCutBeta
-        && std::abs(ttValue) < VALUE_TB_WIN_IN_MAX_PLY && std::abs(beta) < VALUE_TB_WIN_IN_MAX_PLY)
+    if (ss->inCheck && !PvNode && tte.capture && (tte.bound & BOUND_LOWER) && tte.depth >= depth - 4
+        && tte.value >= probCutBeta && std::abs(tte.value) < VALUE_TB_WIN_IN_MAX_PLY
+        && std::abs(beta) < VALUE_TB_WIN_IN_MAX_PLY)
         return probCutBeta;
 
     const PieceToHistory* contHist[] = {(ss - 1)->continuationHistory,
@@ -919,7 +968,7 @@ moves_loop:  // When in check, search starts here
     Move countermove =
       prevSq != SQ_NONE ? thisThread->counterMoves[pos.piece_on(prevSq)][prevSq] : Move::none();
 
-    MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory, &thisThread->captureHistory,
+    MovePicker mp(pos, tte.move, depth, &thisThread->mainHistory, &thisThread->captureHistory,
                   contHist, &thisThread->pawnHistory, countermove, ss->killers);
 
     value            = bestValue;
@@ -1054,12 +1103,12 @@ moves_loop:  // When in check, search starts here
             // Generally, higher singularBeta (i.e closer to ttValue) and lower extension
             // margins scale well.
 
-            if (!rootNode && move == ttMove && !excludedMove
+            if (!rootNode && move == tte.move && !excludedMove
                 && depth >= 4 - (thisThread->completedDepth > 35) + ss->ttPv
-                && std::abs(ttValue) < VALUE_TB_WIN_IN_MAX_PLY && (tte->bound() & BOUND_LOWER)
-                && tte->depth() >= depth - 3)
+                && std::abs(tte.value) < VALUE_TB_WIN_IN_MAX_PLY && (tte.bound & BOUND_LOWER)
+                && tte.depth >= depth - 3)
             {
-                Value singularBeta  = ttValue - (52 + 80 * (ss->ttPv && !PvNode)) * depth / 64;
+                Value singularBeta  = tte.value - (52 + 80 * (ss->ttPv && !PvNode)) * depth / 64;
                 Depth singularDepth = newDepth / 2;
 
                 ss->excludedMove = move;
@@ -1070,8 +1119,8 @@ moves_loop:  // When in check, search starts here
 
                 if (value < singularBeta)
                 {
-                    int doubleMargin = 290 * PvNode - 200 * !ttCapture;
-                    int tripleMargin = 107 + 247 * PvNode - 278 * !ttCapture + 99 * ss->ttPv;
+                    int doubleMargin = 290 * PvNode - 200 * !tte.capture;
+                    int tripleMargin = 107 + 247 * PvNode - 278 * !tte.capture + 99 * ss->ttPv;
 
                     extension = 1 + (value < singularBeta - doubleMargin)
                               + (value < singularBeta - tripleMargin);
@@ -1094,7 +1143,7 @@ moves_loop:  // When in check, search starts here
                 // so we reduce the ttMove in favor of other moves based on some conditions:
 
                 // If the ttMove is assumed to fail high over current beta (~7 Elo)
-                else if (ttValue >= beta)
+                else if (tte.value >= beta)
                     extension = -3;
 
                 // If we are on a cutNode but the ttMove is not assumed to fail high over current beta (~1 Elo)
@@ -1134,7 +1183,7 @@ moves_loop:  // When in check, search starts here
 
         // Decrease reduction if position is or has been on the PV (~7 Elo)
         if (ss->ttPv)
-            r -= 1 + (ttValue > alpha) + (tte->depth() >= depth);
+            r -= 1 + (tte.value > alpha) + (tte.depth >= depth);
 
         // Decrease reduction for PvNodes (~0 Elo on STC, ~2 Elo on LTC)
         if (PvNode)
@@ -1144,11 +1193,11 @@ moves_loop:  // When in check, search starts here
 
         // Increase reduction for cut nodes (~4 Elo)
         if (cutNode)
-            r += 2 - (tte->depth() >= depth && ss->ttPv)
-               + (!ss->ttPv && move != ttMove && move != ss->killers[0]);
+            r += 2 - (tte.depth >= depth && ss->ttPv)
+               + (!ss->ttPv && move != tte.move && move != ss->killers[0]);
 
         // Increase reduction if ttMove is a capture (~3 Elo)
-        if (ttCapture)
+        if (tte.capture)
             r++;
 
         // Increase reduction if next ply has a lot of fail high (~5 Elo)
@@ -1157,7 +1206,7 @@ moves_loop:  // When in check, search starts here
 
         // For first picked move (ttMove) reduce reduction
         // but never allow it to go below 0 (~3 Elo)
-        else if (move == ttMove)
+        else if (move == tte.move)
             r = std::max(0, r - 2);
 
         ss->statScore = 2 * thisThread->mainHistory[us][move.from_to()]
@@ -1205,7 +1254,7 @@ moves_loop:  // When in check, search starts here
         else if (!PvNode || moveCount > 1)
         {
             // Increase reduction if ttMove is not present (~6 Elo)
-            if (!ttMove)
+            if (!tte.move)
                 r += 2;
 
             // Note that if expected reduction is high, we reduce search depth by 1 here (~9 Elo)
@@ -1295,7 +1344,7 @@ moves_loop:  // When in check, search starts here
 
                 if (value >= beta)
                 {
-                    ss->cutoffCnt += 1 + !ttMove - (extension >= 2);
+                    ss->cutoffCnt += 1 + !tte.move - (extension >= 2);
                     assert(value >= beta);  // Fail high
                     break;
                 }
@@ -1371,11 +1420,11 @@ moves_loop:  // When in check, search starts here
     // Write gathered information in transposition table
     // Static evaluation is saved as it was before correction history
     if (!excludedMove && !(rootNode && thisThread->pvIdx))
-        tte->save(posKey, value_to_tt(bestValue, ss->ply), ss->ttPv,
-                  bestValue >= beta    ? BOUND_LOWER
-                  : PvNode && bestMove ? BOUND_EXACT
-                                       : BOUND_UPPER,
-                  depth, bestMove, unadjustedStaticEval, tt.generation());
+        tte.change_for_next_probe(bestValue, ss->ttPv,
+                                  bestValue >= beta    ? BOUND_LOWER
+                                  : PvNode && bestMove ? BOUND_EXACT
+                                                       : BOUND_UPPER,
+                                  depth, bestMove, unadjustedStaticEval);
 
     // Adjust correction history
     if (!ss->inCheck && (!bestMove || !pos.capture(bestMove))
@@ -1420,16 +1469,13 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
 
     Move      pv[MAX_PLY + 1];
     StateInfo st;
-    ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
+    ASSERT_ALIGNED(&st, CacheLineSize);
 
-    TTEntry* tte;
-    Key      posKey;
-    Move     ttMove, move, bestMove;
-    Depth    ttDepth;
-    Value    bestValue, value, ttValue, futilityBase;
-    bool     pvHit, givesCheck, capture;
-    int      moveCount;
-    Color    us = pos.side_to_move();
+    Move  move, bestMove;
+    Value bestValue, value, futilityBase;
+    bool  givesCheck, capture;
+    int   moveCount;
+    Color us = pos.side_to_move();
 
     // Step 1. Initialize node
     if (PvNode)
@@ -1458,20 +1504,17 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
     // Note that unlike regular search, which stores literal depth, in QS we only store the
     // current movegen stage. If in check, we search all evasions and thus store
     // DEPTH_QS_CHECKS. (Evasions may be quiet, and _CHECKS includes quiets.)
-    ttDepth = ss->inCheck || depth >= DEPTH_QS_CHECKS ? DEPTH_QS_CHECKS : DEPTH_QS_NORMAL;
+    Depth qsDepth = ss->inCheck || depth >= DEPTH_QS_CHECKS ? DEPTH_QS_CHECKS : DEPTH_QS_NORMAL;
 
     // Step 3. Transposition table lookup
-    posKey  = pos.key();
-    tte     = tt.probe(posKey, ss->ttHit);
-    ttValue = ss->ttHit ? value_from_tt(tte->value(), ss->ply, pos.rule50_count()) : VALUE_NONE;
-    ttMove  = ss->ttHit ? tte->move() : Move::none();
-    pvHit   = ss->ttHit && tte->is_pv();
+    ProbedTTEntry tte(tt, pos, ss->ply, Move::none());
+    ss->ttHit = tte.hit;
 
     // At non-PV nodes we check for an early TT cutoff
-    if (!PvNode && tte->depth() >= ttDepth
-        && ttValue != VALUE_NONE  // Only in case of TT access race or if !ttHit
-        && (tte->bound() & (ttValue >= beta ? BOUND_LOWER : BOUND_UPPER)))
-        return ttValue;
+    if (!PvNode && tte.depth >= qsDepth
+        && tte.value != VALUE_NONE  // Only in case of TT access race or if !ttHit
+        && (tte.bound & (tte.value >= beta ? BOUND_LOWER : BOUND_UPPER)))
+        return tte.value;
 
     // Step 4. Static evaluation of the position
     Value unadjustedStaticEval = VALUE_NONE;
@@ -1482,7 +1525,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
         if (ss->ttHit)
         {
             // Never assume anything about values stored in TT
-            unadjustedStaticEval = tte->eval();
+            unadjustedStaticEval = tte.eval;
             if (unadjustedStaticEval == VALUE_NONE)
                 unadjustedStaticEval =
                   evaluate(networks[numaAccessToken], pos, refreshTable, thisThread->optimism[us]);
@@ -1490,9 +1533,9 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
               to_corrected_static_eval(unadjustedStaticEval, *thisThread, pos);
 
             // ttValue can be used as a better position evaluation (~13 Elo)
-            if (std::abs(ttValue) < VALUE_TB_WIN_IN_MAX_PLY
-                && (tte->bound() & (ttValue > bestValue ? BOUND_LOWER : BOUND_UPPER)))
-                bestValue = ttValue;
+            if (std::abs(tte.value) < VALUE_TB_WIN_IN_MAX_PLY
+                && (tte.bound & (tte.value > bestValue ? BOUND_LOWER : BOUND_UPPER)))
+                bestValue = tte.value;
         }
         else
         {
@@ -1511,8 +1554,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
             if (std::abs(bestValue) < VALUE_TB_WIN_IN_MAX_PLY && !PvNode)
                 bestValue = (3 * bestValue + beta) / 4;
             if (!ss->ttHit)
-                tte->save(posKey, value_to_tt(bestValue, ss->ply), false, BOUND_LOWER,
-                          DEPTH_UNSEARCHED, Move::none(), unadjustedStaticEval, tt.generation());
+                tte.change_for_next_probe(bestValue, false, BOUND_LOWER, DEPTH_UNSEARCHED,
+                                          Move::none(), unadjustedStaticEval);
 
             return bestValue;
         }
@@ -1532,7 +1575,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
     // (Presently, having the checks stage is worth only 1 Elo, and may be removable in the near future,
     // which would result in only a single stage of QS movegen.)
     Square     prevSq = ((ss - 1)->currentMove).is_ok() ? ((ss - 1)->currentMove).to_sq() : SQ_NONE;
-    MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory, &thisThread->captureHistory,
+    MovePicker mp(pos, tte.move, depth, &thisThread->mainHistory, &thisThread->captureHistory,
                   contHist, &thisThread->pawnHistory);
 
     // Step 5. Loop through all pseudo-legal moves until no moves remain or a beta cutoff occurs.
@@ -1651,9 +1694,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
 
     // Save gathered info in transposition table
     // Static evaluation is saved as it was before adjustment by correction history
-    tte->save(posKey, value_to_tt(bestValue, ss->ply), pvHit,
-              bestValue >= beta ? BOUND_LOWER : BOUND_UPPER, ttDepth, bestMove,
-              unadjustedStaticEval, tt.generation());
+    tte.change_for_next_probe(bestValue, tte.pv, bestValue >= beta ? BOUND_LOWER : BOUND_UPPER,
+                              qsDepth, bestMove, unadjustedStaticEval);
 
     assert(bestValue > -VALUE_INFINITE && bestValue < VALUE_INFINITE);
 
@@ -1686,7 +1728,8 @@ namespace {
 // The function is called before storing a value in the transposition table.
 Value value_to_tt(Value v, int ply) {
 
-    assert(v != VALUE_NONE);
+    if (v == VALUE_NONE)
+        return v;
     return v >= VALUE_TB_WIN_IN_MAX_PLY ? v + ply : v <= VALUE_TB_LOSS_IN_MAX_PLY ? v - ply : v;
 }
 
@@ -1992,7 +2035,7 @@ void SearchManager::pv(const Search::Worker&     worker,
 bool RootMove::extract_ponder_from_tt(const TranspositionTable& tt, Position& pos) {
 
     StateInfo st;
-    ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
+    ASSERT_ALIGNED(&st, CacheLineSize);
 
     bool ttHit;
 


### PR DESCRIPTION
Actually passed this time, after some optimizations. https://tests.stockfishchess.org/tests/view/66604642c340c8eed77569bf

```
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 170416 W: 43888 L: 43819 D: 82709
Ptnml(0-2): 144, 19220, 46400, 19311, 133 
```

Alternative to #5345 and #5348. Waiting for opinions.

bench comparison between master, v1 of this patch (failed simplification), v1 of this patch with forceinline, and this patch
![image](https://github.com/official-stockfish/Stockfish/assets/8037982/f27d630c-0d22-4f7c-a881-6913270cf705)
