### PR TITLE
Update clang-format to version 18

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -25,7 +25,7 @@ jobs:
         id: clang-format
         continue-on-error: true
         with:
-          clang-format-version: "17"
+          clang-format-version: "18"
           exclude-regex: "incbin"
 
       - name: Comment on PR
@@ -33,9 +33,9 @@ jobs:
         uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # @v2.5.0
         with:
           message: |
-            clang-format 17 needs to be run on this PR.
+            clang-format 18 needs to be run on this PR.
             If you do not have clang-format installed, the maintainer will run it when merging.
-            For the exact version please see https://packages.ubuntu.com/mantic/clang-format-17.
+            For the exact version please see https://packages.ubuntu.com/noble/clang-format-18.
 
             _(execution **${{ github.run_id }}** / attempt **${{ github.run_attempt }}**)_
           comment_tag: execution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ discussion._
 
 Changes to Stockfish C++ code should respect our coding style defined by
 [.clang-format](.clang-format). You can format your changes by running
-`make format`. This requires clang-format version 17 to be installed on your system.
+`make format`. This requires clang-format version 18 to be installed on your system.
 
 ## Navigate
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -153,8 +153,8 @@ dotprod = no
 arm_version = 0
 STRIP = strip
 
-ifneq ($(shell which clang-format-17 2> /dev/null),)
-	CLANG-FORMAT = clang-format-17
+ifneq ($(shell which clang-format-18 2> /dev/null),)
+	CLANG-FORMAT = clang-format-18
 else
 	CLANG-FORMAT = clang-format
 endif

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -579,9 +579,10 @@ Value Search::Worker::search(
         // Step 2. Check for aborted search and immediate draw
         if (threads.stop.load(std::memory_order_relaxed) || pos.is_draw(ss->ply)
             || ss->ply >= MAX_PLY)
-            return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate(
-                     networks[numaAccessToken], pos, refreshTable, thisThread->optimism[us])
-                                                        : value_draw(thisThread->nodes);
+            return (ss->ply >= MAX_PLY && !ss->inCheck)
+                   ? evaluate(networks[numaAccessToken], pos, refreshTable,
+                              thisThread->optimism[us])
+                   : value_draw(thisThread->nodes);
 
         // Step 3. Mate distance pruning. Even if we mate at the next move our score
         // would be at best mate_in(ss->ply + 1), but if alpha is already bigger because

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -179,7 +179,7 @@ void ThreadPool::set(const NumaConfig&                           numaConfig,
             const size_t    threadId = threads.size();
             const NumaIndex numaId   = doBindThreads ? boundThreadToNumaNode[threadId] : 0;
             auto            manager  = threadId == 0 ? std::unique_ptr<Search::ISearchManager>(
-                             std::make_unique<Search::SearchManager>(updateContext))
+                                             std::make_unique<Search::SearchManager>(updateContext))
                                                      : std::make_unique<Search::NullSearchManager>();
 
             // When not binding threads we want to force all access to happen

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -118,7 +118,6 @@ void Tune::Entry<Tune::PostUpdate>::read_option() {
 
 namespace Stockfish {
 
-void Tune::read_results() { /* ...insert your values here... */
-}
+void Tune::read_results() { /* ...insert your values here... */ }
 
 }  // namespace Stockfish


### PR DESCRIPTION
clang-format-18 is available in ubuntu noble(24.04), if you are on a version lower than that you can use the update script from llvm. https://apt.llvm.org/

Windows users should be able to download and use clang-format from their release builds https://github.com/llvm/llvm-project/releases or get the latest from msys2
https://packages.msys2.org/package/mingw-w64-x86_64-clang.

macOS users can resort to "brew install clang-format".

No functional change