### PR TITLE
Remove razoring changes from https://github.com/official-stockfish/Stockfish/pull/5360

### DIFF
--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -178,16 +178,16 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
 
     for (std::size_t bucket = 0; bucket < LayerStacks; ++bucket)
     {
-        ss << "|  " << bucket << "        ";
-        ss << " |  ";
+        ss << "|  " << bucket << "        "  //
+           << " |  ";
         format_cp_aligned_dot(t.psqt[bucket], ss, pos);
-        ss << "  "
+        ss << "  "  //
            << " |  ";
         format_cp_aligned_dot(t.positional[bucket], ss, pos);
-        ss << "  "
+        ss << "  "  //
            << " |  ";
         format_cp_aligned_dot(t.psqt[bucket] + t.positional[bucket], ss, pos);
-        ss << "  "
+        ss << "  "  //
            << " |";
         if (bucket == t.correctBucket)
             ss << " <-- this bucket is used";

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -554,7 +554,7 @@ Value Search::Worker::search(
     bool     givesCheck, improving, priorCapture, opponentWorsening;
     bool     capture, moveCountPruning, ttCapture;
     Piece    movedPiece;
-    int      moveCount, captureCount, quietCount, futilityMargin;
+    int      moveCount, captureCount, quietCount;
     Bound    singularBound;
 
     // Step 1. Initialize node
@@ -762,12 +762,10 @@ Value Search::Worker::search(
 
     opponentWorsening = ss->staticEval + (ss - 1)->staticEval > 2;
 
-    futilityMargin = futility_margin(depth, cutNode && !ss->ttHit, improving, opponentWorsening);
-
     // Step 7. Razoring (~1 Elo)
     // If eval is really low check with qsearch if it can exceed alpha, if it can't,
     // return a fail low.
-    if (eval < alpha - 465 - futilityMargin * depth * 33 / 32)
+    if (eval < alpha - 512 - 293 * depth * depth)
     {
         value = qsearch<NonPV>(pos, ss, alpha - 1, alpha);
         if (value < alpha)
@@ -776,7 +774,10 @@ Value Search::Worker::search(
 
     // Step 8. Futility pruning: child node (~40 Elo)
     // The depth condition is important for mate finding.
-    if (!ss->ttPv && depth < 13 && eval - futilityMargin - (ss - 1)->statScore / 263 >= beta
+    if (!ss->ttPv && depth < 13
+        && eval - futility_margin(depth, cutNode && !ss->ttHit, improving, opponentWorsening)
+               - (ss - 1)->statScore / 263
+             >= beta
         && eval >= beta && eval < VALUE_TB_WIN_IN_MAX_PLY && (!ttMove || ttCapture))
         return beta > VALUE_TB_LOSS_IN_MAX_PLY ? beta + (eval - beta) / 3 : eval;
 

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -58,8 +58,11 @@ void make_option(OptionsMap* options, const string& n, int v, const SetRange& r)
     LastOption = &((*options)[n]);
 
     // Print formatted parameters, ready to be copy-pasted in Fishtest
-    std::cout << n << "," << v << "," << r(v).first << "," << r(v).second << ","
-              << (r(v).second - r(v).first) / 20.0 << ","
+    std::cout << n << ","                                  //
+              << v << ","                                  //
+              << r(v).first << ","                         //
+              << r(v).second << ","                        //
+              << (r(v).second - r(v).first) / 20.0 << ","  //
               << "0.0020" << std::endl;
 }
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -324,8 +324,9 @@ void UCIEngine::bench(std::istream& args) {
 
     dbg_print();
 
-    std::cerr << "\n==========================="
-              << "\nTotal time (ms) : " << elapsed << "\nNodes searched  : " << nodes
+    std::cerr << "\n==========================="    //
+              << "\nTotal time (ms) : " << elapsed  //
+              << "\nNodes searched  : " << nodes    //
               << "\nNodes/second    : " << 1000 * nodes / elapsed << std::endl;
 
     // reset callback, to not capture a dangling reference to nodesSearched


### PR DESCRIPTION
The mentioned patch introduced the usage of futility_margin into razoring alongside a tune to futility_margin. It seems the elo gained in this patch comes from the tune of futility_margin and not the introduction of futility_margin to razoring, so simplify it away here.

Passed Non-regression STC:https://tests.stockfishchess.org/tests/view/66606581c340c8eed7757bc8
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 169056 W: 43922 L: 43848 D: 81286
Ptnml(0-2): 438, 20288, 43034, 20298, 470

Passed Non-regression LTC:https://tests.stockfishchess.org/tests/view/66607764c340c8eed7757c58
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 157134 W: 39805 L: 39723 D: 77606
Ptnml(0-2): 74, 17444, 43461, 17502, 86
bench 1150518
