### PR TITLE
Simplify "MCP more after a bad singular search"

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -550,12 +550,11 @@ Value Search::Worker::search(
     Key      posKey;
     Move     ttMove, move, excludedMove, bestMove;
     Depth    extension, newDepth;
-    Value    bestValue, value, ttValue, eval, maxValue, probCutBeta, singularValue;
+    Value    bestValue, value, ttValue, eval, maxValue, probCutBeta;
     bool     givesCheck, improving, priorCapture, opponentWorsening;
     bool     capture, moveCountPruning, ttCapture;
     Piece    movedPiece;
     int      moveCount, captureCount, quietCount, futilityMargin;
-    Bound    singularBound;
 
     // Step 1. Initialize node
     Worker* thisThread = this;
@@ -924,8 +923,6 @@ moves_loop:  // When in check, search starts here
 
     value            = bestValue;
     moveCountPruning = false;
-    singularValue    = VALUE_INFINITE;
-    singularBound    = BOUND_NONE;
 
     // Step 13. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
@@ -975,9 +972,7 @@ moves_loop:  // When in check, search starts here
         if (!rootNode && pos.non_pawn_material(us) && bestValue > VALUE_TB_LOSS_IN_MAX_PLY)
         {
             // Skip quiet moves if movecount exceeds our FutilityMoveCount threshold (~8 Elo)
-            moveCountPruning =
-              moveCount >= futility_move_count(improving, depth)
-                             - (singularBound == BOUND_UPPER && singularValue < alpha - 50);
+            moveCountPruning = moveCount >= futility_move_count(improving, depth);
 
             // Reduced depth of the next LMR search
             int lmrDepth = newDepth - r;
@@ -1063,9 +1058,8 @@ moves_loop:  // When in check, search starts here
                 Depth singularDepth = newDepth / 2;
 
                 ss->excludedMove = move;
-                value            = singularValue =
+                value            =
                   search<NonPV>(pos, ss, singularBeta - 1, singularBeta, singularDepth, cutNode);
-                singularBound    = singularValue >= singularBeta ? BOUND_LOWER : BOUND_UPPER;
                 ss->excludedMove = Move::none();
 
                 if (value < singularBeta)


### PR DESCRIPTION
Passed Non-Reg STC:
https://tests.stockfishchess.org/tests/view/6660c934c340c8eed7758179
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 166112 W: 43016 L: 42937 D: 80159
Ptnml(0-2): 468, 19639, 42695, 19854, 400

Passed Non-Reg LTC:
https://tests.stockfishchess.org/tests/view/6660d41a6489614cdad13d2a
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 148626 W: 37743 L: 37652 D: 73231
Ptnml(0-2): 62, 16584, 40943, 16649, 75

bench 1040443