### PR TITLE
Tweak pruning formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1579,7 +1579,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
 
                 // If static exchange evaluation is much worse than what is needed to not
                 // fall below alpha we can prune this move.
-                if (futilityBase > alpha && !pos.see_ge(move, (alpha - futilityBase) * 4))
+                if (futilityBase > alpha && !pos.see_ge(move, (alpha - futilityBase) * 2 - 30))
                 {
                     bestValue = alpha;
                     continue;


### PR DESCRIPTION
Tweak pruning formula, including a constant.
I started from an old yellow patch, if I'm not mistaken by Viz (Unfortunately I lost the link) where he tried something similar.
I worked on it, trying different variations, until I came up with a good configuration to pass.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 213120 W: 55351 L: 54778 D: 102991
Ptnml(0-2): 572, 25209, 54437, 25758, 584
https://tests.stockfishchess.org/tests/view/6660c9a7c340c8eed7758195

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 315324 W: 80176 L: 79284 D: 155864
Ptnml(0-2): 155, 34711, 87030, 35619, 147
https://tests.stockfishchess.org/tests/view/6660d7bb6489614cdad13d66

bench: 1291835