### PR TITLE
Eval: remove `delta`

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -47,7 +47,7 @@ int Eval::simple_eval(const Position& pos, Color c) {
 
 bool Eval::use_smallnet(const Position& pos) {
     int simpleEval = simple_eval(pos, pos.side_to_move());
-    return std::abs(simpleEval) > 992;
+    return std::abs(simpleEval) > 962;
 }
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
@@ -66,25 +66,24 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     auto [psqt, positional] = smallNet ? networks.small.evaluate(pos, &caches.small)
                                        : networks.big.evaluate(pos, &caches.big);
 
-    constexpr int delta          = 3;
-    Value         nnue           = ((128 - delta) * psqt + (128 + delta) * positional) / 128;
+    Value         nnue           = psqt + positional;
     int           nnueComplexity = std::abs(psqt - positional);
 
     // Re-evaluate the position when higher eval accuracy is worth the time spent
-    if (smallNet && (nnue * simpleEval < 0 || std::abs(nnue) < 250))
+    if (smallNet && (nnue * simpleEval < 0 || std::abs(nnue) < 227))
     {
         std::tie(psqt, positional) = networks.big.evaluate(pos, &caches.big);
-        nnue                       = ((128 - delta) * psqt + (128 + delta) * positional) / 128;
+        nnue                       = psqt + positional;
         nnueComplexity             = std::abs(psqt - positional);
         smallNet                   = false;
     }
 
     // Blend optimism and eval with nnue complexity
-    optimism += optimism * nnueComplexity / 470;
-    nnue -= nnue * nnueComplexity / 20000;
+    optimism += optimism * nnueComplexity / 457;
+    nnue -= nnue * nnueComplexity / 19157;
 
-    int material = 600 * pos.count<PAWN>() + pos.non_pawn_material();
-    v            = (nnue * (68600 + material) + optimism * (8800 + material)) / 73344;
+    int material = 554 * pos.count<PAWN>() + pos.non_pawn_material();
+    v            = (nnue * (73921 + material) + optimism * (8112 + material)) / 73260;
 
     // Damp down the evaluation linearly when shuffling
     v -= v * pos.rule50_count() / 212;


### PR DESCRIPTION
Passed STC: https://tests.stockfishchess.org/tests/view/6660e49c6489614cdad14e29
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 188768 W: 48907 L: 48854 D: 91007
Ptnml(0-2): 584, 22571, 48005, 22656, 568

Passed LTC: https://tests.stockfishchess.org/tests/view/6660ff9791e372763104b38c
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 310680 W: 78651 L: 78727 D: 153302
Ptnml(0-2): 180, 34818, 85433, 34716, 193

bench 1193879