### PR TITLE
Linearize corrHist application

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -74,7 +74,7 @@ constexpr int futility_move_count(bool improving, Depth depth) {
 // Add correctionHistory value to raw staticEval and guarantee evaluation does not hit the tablebase range
 Value to_corrected_static_eval(Value v, const Worker& w, const Position& pos) {
     auto cv = w.correctionHistory[pos.side_to_move()][pawn_structure_index<Correction>(pos)];
-    v += cv * std::abs(cv) / 4990;
+    v += cv / 10;
     return std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
 }
 


### PR DESCRIPTION
However, this is something I would suspect to have weird scaling issues. Should we check this again at V/VLTC?

Passed STC: https://tests.stockfishchess.org/tests/view/6661fff88dd8f31ed3c5d819
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 17504 W: 4651 L: 4406 D: 8447
Ptnml(0-2): 71, 1975, 4384, 2282, 40

Passed LTC: https://tests.stockfishchess.org/tests/view/666205b48dd8f31ed3c61296
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 24522 W: 6313 L: 6094 D: 12115
Ptnml(0-2): 14, 2643, 6726, 2866, 12

bench 1134681