### PR TITLE
Remove correction history in null move search

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -72,6 +72,7 @@ Ehsan Rashid (erashid)
 Elvin Liu (solarlight2)
 erbsenzaehler
 Ernesto Gatti
+evqsx
 Fabian Beuke (madnight)
 Fabian Fichter (ianfab)
 Fanael Linithien (Fanael)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -804,16 +804,7 @@ Value Search::Worker::search(
         if (nullValue >= beta && nullValue < VALUE_TB_WIN_IN_MAX_PLY)
         {
             if (thisThread->nmpMinPly || depth < 16)
-            {
-                if (nullValue >= ss->staticEval)
-                {
-                    auto bonus = std::min(int(nullValue - ss->staticEval) * depth / 32,
-                                          CORRECTION_HISTORY_LIMIT / 16);
-                    thisThread->correctionHistory[us][pawn_structure_index<Correction>(pos)]
-                      << bonus;
-                }
                 return nullValue;
-            }
 
             assert(!thisThread->nmpMinPly);  // Recursive verification is not allowed
 


### PR DESCRIPTION
Remove the correction history bonus in null move search

Passed STC: https://tests.stockfishchess.org/tests/view/666168e191e372763104c664
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 94848 W: 24708 L: 24550 D: 45590
Ptnml(0-2): 289, 11355, 24033, 11403, 344 

Passed LTC: https://tests.stockfishchess.org/tests/view/6661e73591e372763104c751
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 70452 W: 17849 L: 17679 D: 34924
Ptnml(0-2): 27, 7707, 19596, 7861, 35 

bench: 1273306