### PR TITLE
Keep mate PVs intact.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -768,7 +768,7 @@ Value Search::Worker::search(
     if (eval < alpha - 512 - 293 * depth * depth)
     {
         value = qsearch<NonPV>(pos, ss, alpha - 1, alpha);
-        if (value < alpha)
+        if (value < alpha && std::abs(value) < VALUE_TB_WIN_IN_MAX_PLY)
             return value;
     }
 


### PR DESCRIPTION
do not return a cutoff value in razoring if that value is in the mate/tb range.

passed STC:
https://tests.stockfishchess.org/tests/view/666381880ff7cb4868d1fe58
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 130848 W: 34046 L: 33931 D: 62871
Ptnml(0-2): 429, 14968, 34524, 15065, 438

passed LTC:
https://tests.stockfishchess.org/tests/view/66643f120612cd151f9e7788
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 39702 W: 10157 L: 9959 D: 19586
Ptnml(0-2): 20, 4108, 11402, 4296, 25

Bench: 1174094