### PR TITLE
Simpler snipers

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -448,9 +448,8 @@ void Position::update_slider_blockers(Color c) const {
     st->pinners[~c]        = 0;
 
     // Snipers are sliders that attack 's' when a piece and other snipers are removed
-    Bitboard snipers = ((attacks_bb<ROOK>(ksq) & pieces(QUEEN, ROOK))
-                        | (attacks_bb<BISHOP>(ksq) & pieces(QUEEN, BISHOP)))
-                     & pieces(~c);
+    Bitboard snipers = ((attacks_bb<ROOK>(ksq) & pieces(~c, QUEEN, ROOK))
+                        | (attacks_bb<BISHOP>(ksq) & pieces(~c, QUEEN, BISHOP)));
     Bitboard occupancy = pieces() ^ snipers;
 
     while (snipers)


### PR DESCRIPTION
This change modifies the calculation of snipers in the update_slider_blockers() function. By directly filtering the sliding attacks with pieces(~c, QUEEN, ROOK) and pieces(~c, QUEEN, BISHOP), we avoid the redundant & pieces(~c) operation later.

Passed STC non-reg:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 123936 W: 32338 L: 32215 D: 59383
Ptnml(0-2): 395, 14161, 32747, 14256, 409
https://tests.stockfishchess.org/tests/view/666449ef0612cd151f9e77a2


Non functional bench: 1174094