### PR TITLE
Give positional output more weight in nnue eval

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -66,14 +66,14 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     auto [psqt, positional] = smallNet ? networks.small.evaluate(pos, &caches.small)
                                        : networks.big.evaluate(pos, &caches.big);
 
-    Value nnue           = psqt + positional;
+    Value nnue           = (125 * psqt + 131 * positional) / 128;
     int   nnueComplexity = std::abs(psqt - positional);
 
     // Re-evaluate the position when higher eval accuracy is worth the time spent
     if (smallNet && (nnue * simpleEval < 0 || std::abs(nnue) < 227))
     {
         std::tie(psqt, positional) = networks.big.evaluate(pos, &caches.big);
-        nnue                       = psqt + positional;
+        nnue                       = (125 * psqt + 131 * positional) / 128;
         nnueComplexity             = std::abs(psqt - positional);
         smallNet                   = false;
     }


### PR DESCRIPTION
This effectively reverts the removal of delta in:
https://github.com/official-stockfish/Stockfish/pull/5373

Passed STC:
https://tests.stockfishchess.org/tests/view/6664d41922234461cef58e6b
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 56448 W: 14849 L: 14500 D: 27099
Ptnml(0-2): 227, 6481, 14457, 6834, 225

Passed LTC:
https://tests.stockfishchess.org/tests/view/666587a1996b40829f4ee007
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 91686 W: 23402 L: 22963 D: 45321
Ptnml(0-2): 78, 10205, 24840, 10640, 80

bench 1179937