### PR TITLE
Limit depth after extensions to avoid asserts.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -528,6 +528,9 @@ Value Search::Worker::search(
     if (depth <= 0)
         return qsearch < PvNode ? PV : NonPV > (pos, ss, alpha, beta);
 
+    // Limit the depth if extensions made it too large
+    depth = std::min(depth, MAX_PLY - 1);
+
     // Check if we have an upcoming move that draws by repetition, or
     // if the opponent had an alternative move earlier to this position.
     if (!rootNode && alpha < VALUE_DRAW && pos.has_game_cycle(ss->ply))

--- a/tests/instrumented.sh
+++ b/tests/instrumented.sh
@@ -171,6 +171,11 @@ cat << EOF > game.exp
  expect "bestmove"
 
  send "ucinewgame\n"
+ send "position fen 7K/P1p1p1p1/2P1P1Pk/6pP/3p2P1/1P6/3P4/8 w - - 0 1\n"
+ send "go nodes 500000\n"
+ expect "bestmove"
+
+ send "ucinewgame\n"
  send "position fen 8/5R2/2K1P3/4k3/8/b1PPpp1B/5p2/8 w - -\n"
  send "go depth 18\n"
  expect "score mate 2 * pv c6d7 * f7f5"


### PR DESCRIPTION
currently extensions can cause depth to exceed MAX_PLY.

This triggers the assert near line 542 in search when running a binary compiled with `debug=yes` on a testcase like:
```
position fen 7K/P1p1p1p1/2P1P1Pk/6pP/3p2P1/1P6/3P4/8 w - - 0 1
go nodes 1000000
```

passed STC
https://tests.stockfishchess.org/tests/view/6668a56a602682471b064c8d
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 143936 W: 37338 L: 37238 D: 69360
Ptnml(0-2): 514, 16335, 38149, 16477, 493
    
closes https://github.com/official-stockfish/Stockfish/pull/5383

Bench: 1160467