### PR TITLE
refactor smallnet threshold

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -45,11 +45,6 @@ int Eval::simple_eval(const Position& pos, Color c) {
          + (pos.non_pawn_material(c) - pos.non_pawn_material(~c));
 }
 
-bool Eval::use_smallnet(const Position& pos) {
-    int simpleEval = simple_eval(pos, pos.side_to_move());
-    return std::abs(simpleEval) > 962;
-}
-
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
 // of the position from the point of view of the side to move.
 Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
@@ -60,7 +55,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     assert(!pos.checkers());
 
     int  simpleEval = simple_eval(pos, pos.side_to_move());
-    bool smallNet   = use_smallnet(pos);
+    bool smallNet   = std::abs(simpleEval) > SmallNetThreshold;
     int  v;
 
     auto [psqt, positional] = smallNet ? networks.small.evaluate(pos, &caches.small)

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -29,7 +29,7 @@ class Position;
 
 namespace Eval {
 
-constexpr inline int SmallNetThreshold = 926;
+constexpr inline int SmallNetThreshold = 962;
 
 // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
 // for the build process (profile-build and fishtest) to work. Do not change the

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -29,6 +29,8 @@ class Position;
 
 namespace Eval {
 
+constexpr inline int SmallNetThreshold = 926;
+
 // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -46,7 +46,6 @@ struct AccumulatorCaches;
 std::string trace(Position& pos, const Eval::NNUE::Networks& networks);
 
 int   simple_eval(const Position& pos, Color c);
-bool  use_smallnet(const Position& pos);
 Value evaluate(const NNUE::Networks&          networks,
                const Position&                pos,
                Eval::NNUE::AccumulatorCaches& caches,

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -46,7 +46,7 @@ constexpr std::string_view PieceToChar(" PNBRQK  pnbrqk");
 void hint_common_parent_position(const Position&    pos,
                                  const Networks&    networks,
                                  AccumulatorCaches& caches) {
-    if (Eval::use_smallnet(pos))
+    if (std::abs(simple_eval(pos, pos.side_to_move())) > Eval::SmallNetThreshold)
         networks.small.hint_common_access(pos, &caches.small);
     else
         networks.big.hint_common_access(pos, &caches.big);


### PR DESCRIPTION
move smallnet threshold back to evaluate.h since it is now a constant. also prevents simple eval from being calculated twice. effectively reverts https://github.com/official-stockfish/Stockfish/commit/d92d1f31809afc8aa83cc14fcbd54b95258d09ad

non-functional change

Bench: 1160467