### PR TITLE
Tweak the reduction formula if position is or has been on the PV

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1128,7 +1128,8 @@ moves_loop:  // When in check, search starts here
 
         // Decrease reduction if position is or has been on the PV (~7 Elo)
         if (ss->ttPv)
-            r -= 1 + (ttData.value > alpha) + (ttData.depth >= depth);
+            r -= 1 + (ttData.value > alpha) + (ttData.depth >= depth)
+                - (PvNode && ttData.value < alpha && ttData.depth >= depth);
 
         // Decrease reduction for PvNodes (~0 Elo on STC, ~2 Elo on LTC)
         if (PvNode)


### PR DESCRIPTION
Tweak the reduction formula if position is or has been on the PV
Taking inspiration from an old Viren test.

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 78528 W: 20607 L: 20225 D: 37696
Ptnml(0-2): 262, 9297, 19785, 9637, 283
https://tests.stockfishchess.org/tests/view/666339c70ff7cb4868d1fe24

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 138630 W: 35666 L: 35132 D: 67832
Ptnml(0-2): 118, 15345, 37835, 15919, 98
https://tests.stockfishchess.org/tests/view/66645dec0612cd151f9e77b0

bench: 1134281