### PR TITLE
Handle printing of `info string` in a single place. Fix printing of empty info strings.

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -371,6 +371,8 @@ std::ostream& operator<<(std::ostream& os, SyncCout sc) {
     return os;
 }
 
+void sync_cout_start() { std::cout << IO_LOCK; }
+void sync_cout_end() { std::cout << IO_UNLOCK; }
 
 // Trampoline helper to avoid moving Logger to misc.h
 void start_logger(const std::string& fname) { Logger::start(fname); }
@@ -417,6 +419,10 @@ std::optional<std::string> read_file_to_string(const std::string& path) {
 
 void remove_whitespace(std::string& s) {
     s.erase(std::remove_if(s.begin(), s.end(), [](char c) { return std::isspace(c); }), s.end());
+}
+
+bool is_whitespace(const std::string& s) {
+    return std::all_of(s.begin(), s.end(), [](char c) { return std::isspace(c); });
 }
 
 std::string CommandLine::get_binary_directory(std::string argv0) {

--- a/src/misc.h
+++ b/src/misc.h
@@ -101,6 +101,7 @@ inline std::vector<std::string> split(const std::string& s, const std::string& d
 }
 
 void remove_whitespace(std::string& s);
+bool is_whitespace(const std::string& s);
 
 enum SyncCout {
     IO_LOCK,
@@ -110,6 +111,9 @@ std::ostream& operator<<(std::ostream&, SyncCout);
 
 #define sync_cout std::cout << IO_LOCK
 #define sync_endl std::endl << IO_UNLOCK
+
+void sync_cout_start();
+void sync_cout_end();
 
 // True if and only if the binary is compiled on a little-endian machine
 static inline const union {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -48,19 +48,25 @@ struct overload: Ts... {
 template<typename... Ts>
 overload(Ts...) -> overload<Ts...>;
 
+void UCIEngine::print_info_string(const std::string& str) {
+    sync_cout_start();
+    for (auto& line : split(str, "\n"))
+    {
+        if (!is_whitespace(line))
+        {
+            std::cout << "info string " << line << '\n';
+        }
+    }
+    sync_cout_end();
+}
+
 UCIEngine::UCIEngine(int argc, char** argv) :
     engine(argv[0]),
     cli(argc, argv) {
 
     engine.get_options().add_info_listener([](const std::optional<std::string>& str) {
-        if (!str || (*str).empty())
-            return;
-
-        // split all lines
-        auto ss = std::istringstream{*str};
-
-        for (std::string line; std::getline(ss, line, '\n');)
-            sync_cout << "info string " << line << sync_endl;
+        if (str.has_value())
+            print_info_string(*str);
     });
 
     engine.set_on_iter([](const auto& i) { on_iter(i); });
@@ -102,9 +108,8 @@ void UCIEngine::loop() {
             sync_cout << "id name " << engine_info(true) << "\n"
                       << engine.get_options() << sync_endl;
 
-            sync_cout << "info string " << engine.numa_config_information_as_string() << sync_endl;
-            sync_cout << "info string " << engine.thread_binding_information_as_string()
-                      << sync_endl;
+            print_info_string(engine.numa_config_information_as_string());
+            print_info_string(engine.thread_binding_information_as_string());
 
             sync_cout << "uciok" << sync_endl;
         }

--- a/src/uci.h
+++ b/src/uci.h
@@ -58,6 +58,8 @@ class UCIEngine {
     Engine      engine;
     CommandLine cli;
 
+    static void print_info_string(const std::string& str);
+
     void          go(std::istringstream& is);
     void          bench(std::istream& args);
     void          position(std::istringstream& is);


### PR DESCRIPTION
Fixes #5386