### PR TITLE
Fix upperbound/lowerbound output in multithreaded case

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -299,7 +299,7 @@ void Search::Worker::iterative_deepening() {
             searchAgainCounter++;
 
         // MultiPV loop. We perform a full root search for each PV line
-        for (pvIdx = 0; pvIdx < multiPV && !threads.stop; ++pvIdx)
+        for (pvIdx = 0; pvIdx < multiPV; ++pvIdx)
         {
             if (pvIdx == pvLast)
             {
@@ -390,6 +390,9 @@ void Search::Worker::iterative_deepening() {
                 // below pick a proven score/PV for this thread (from the previous iteration).
                 && !(threads.abortedSearch && rootMoves[0].uciScore <= VALUE_TB_LOSS_IN_MAX_PLY))
                 main_manager()->pv(*this, threads, tt, rootDepth);
+
+            if (threads.stop)
+                break;
         }
 
         if (!threads.stop)


### PR DESCRIPTION
In case a stop is received during multithreaded searches, the PV of the best thread might be printed without the correct upperbound/lowerbound indicators. This was due to the pvIdx variable being incremented after receiving the stop.

passed STC:
https://tests.stockfishchess.org/tests/view/666985da602682471b064d08
 LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 196576 W: 51039 L: 50996 D: 94541
Ptnml(0-2): 760, 22545, 51603, 22652, 728

Bench: 1160467