### PR TITLE
Decrease depth further if some conditions are met

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -830,9 +830,12 @@ Value Search::Worker::search(
     }
 
     // Step 10. Internal iterative reductions (~9 Elo)
-    // For PV nodes without a ttMove, we decrease depth by 3.
+    // For PV nodes without a ttMove, we decrease depth.
+    // Additionally, if the current position is found in the TT 
+    // and the stored depth in the TT is greater than or equal to
+    // current search depth, we decrease search depth even further.
     if (PvNode && !ttData.move)
-        depth -= 3;
+        depth -= 3 + (ss->ttHit && ttData.depth >= depth);
 
     // Use qsearch if depth <= 0.
     if (depth <= 0)


### PR DESCRIPTION
For PV nodes without a ttMove, we decrease depth.
But in this patch, additionally, if the current position is found in the TT, and the stored depth in the TT is greater than or equal to
the current search depth, we decrease the search depth even further.

Passed STC:
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 84384 W: 22154 L: 21761 D: 40469
Ptnml(0-2): 292, 9972, 21315, 10277, 336
https://tests.stockfishchess.org/tests/view/666b0a4d602682471b064db6

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 92106 W: 23471 L: 23032 D: 45603
Ptnml(0-2): 79, 10155, 25154, 10578, 87
https://tests.stockfishchess.org/tests/view/666c423d602682471b064e56

bench: 1413061