### PR TITLE
Simplify static exchange evaluation pruning formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1580,7 +1580,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
 
                 // If static exchange evaluation is much worse than what is needed to not
                 // fall below alpha we can prune this move.
-                if (futilityBase > alpha && !pos.see_ge(move, (alpha - futilityBase) * 2 - 30))
+                if (futilityBase > alpha && !pos.see_ge(move, (alpha - futilityBase) * 4))
                 {
                     bestValue = alpha;
                     continue;


### PR DESCRIPTION
Passed STC: https://tests.stockfishchess.org/tests/view/666bda31602682471b064e1f
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 141696 W: 36932 L: 36826 D: 67938
Ptnml(0-2): 510, 16880, 35989, 16932, 537

Passed LTC: https://tests.stockfishchess.org/tests/view/666e6b67602682471b064f4b
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 159504 W: 40552 L: 40471 D: 78481
Ptnml(0-2): 130, 18160, 43103, 18217, 142

bench: 1415784