### PR TITLE
Simplify Bonus Formula In Static Evaluation Based History Adjustment

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -750,8 +750,7 @@ Value Search::Worker::search(
     // Use static evaluation difference to improve quiet move ordering (~9 Elo)
     if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture)
     {
-        int bonus = std::clamp(-10 * int((ss - 1)->staticEval + ss->staticEval), -1590, 1371);
-        bonus     = bonus > 0 ? 2 * bonus : bonus / 2;
+        int bonus = std::clamp(-10 * int((ss - 1)->staticEval + ss->staticEval), -1590, 1371) + 800;
         thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()] << bonus;
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
             thisThread->pawnHistory[pawn_structure_index(pos)][pos.piece_on(prevSq)][prevSq]


### PR DESCRIPTION
Inspired by a discord message [1] from @Vizvezdenec, this patch simplifies the bonus adjustment `bonus = bonus > 0 ? 2 * bonus : bonus / 2` to a constant addition, maintaining bonus average at around 0 in regular bench. As @cj5716 pointed in discord [2], the constant bonus can also be considered as factoring tempo when calculating bonus, yielding a better value of the move.

[1] https://discord.com/channels/435943710472011776/882956631514689597/1243877089443188776
[2] https://discord.com/channels/435943710472011776/813919248455827515/1252277437249622077

Passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 29984 W: 7908 L: 7677 D: 14399
Ptnml(0-2): 95, 3502, 7594, 3679, 122 
https://tests.stockfishchess.org/tests/view/666f7210602682471b064fa2

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 170136 W: 43214 L: 43145 D: 83777
Ptnml(0-2): 158, 19185, 46311, 19258, 156 
https://tests.stockfishchess.org/tests/view/666fb32e602682471b064fb5

bench 1355272