### PR TITLE
Guard has_cycle check with mate score check.

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1158,6 +1158,8 @@ bool Position::has_repeated() const {
 
 // Tests if the position has a move which draws by repetition,
 // or an earlier position has a move that directly reaches the current position.
+// This function is currently inexact/buggy: it can return draw,
+// when there is no legal move drawing (see below).
 bool Position::has_game_cycle(int ply) const {
 
     int j;
@@ -1186,13 +1188,16 @@ bool Position::has_game_cycle(int ply) const {
                 if (ply > i)
                     return true;
 
-                // For nodes before or at the root, check that the move is a
-                // repetition rather than a move to the current position.
+                // BUG: This test needs to be before the previous return,
+                // for the function to be accurate. However, fixing this bug
+                // consistently costs Elo.
                 // In the cuckoo table, both moves Rc1c5 and Rc5c1 are stored in
                 // the same location, so we have to select which square to check.
                 if (color_of(piece_on(empty(s1) ? s2 : s1)) != side_to_move())
                     continue;
 
+                // For nodes before or at the root, check that the move is a
+                // repetition rather than a move to the current position.
                 // For repetitions before or at the root, require one more
                 if (stp->repetition)
                     return true;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -536,7 +536,9 @@ Value Search::Worker::search(
 
     // Check if we have an upcoming move that draws by repetition, or
     // if the opponent had an alternative move earlier to this position.
-    if (!rootNode && alpha < VALUE_DRAW && pos.has_game_cycle(ss->ply))
+    // The VALUE_TB_LOSS_IN_MAX_PLY check is necessary as long as has_game_cycle is approximate.
+    if (!rootNode && alpha < VALUE_DRAW && alpha > VALUE_TB_LOSS_IN_MAX_PLY
+        && pos.has_game_cycle(ss->ply))
     {
         alpha = value_draw(this->nodes);
         if (alpha >= beta)
@@ -1420,7 +1422,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
 
     // Check if we have an upcoming move that draws by repetition, or if
     // the opponent had an alternative move earlier to this position. (~1 Elo)
-    if (alpha < VALUE_DRAW && pos.has_game_cycle(ss->ply))
+    // The VALUE_TB_LOSS_IN_MAX_PLY check is necessary as long as has_game_cycle is approximate.
+    if (alpha < VALUE_DRAW && alpha > VALUE_TB_LOSS_IN_MAX_PLY && pos.has_game_cycle(ss->ply))
     {
         alpha = value_draw(this->nodes);
         if (alpha >= beta)


### PR DESCRIPTION
This fixes the last observed instance of short PVs when the score is a mate in +-N, or when the score indicates a table base win/loss.  With this fix, the PV will end in a mate position if the score corresponds to a mate score, or the PV will enter the table base in case of a TB score.

Unfortunately, this check is needed because the current implementation of `has_game_cyle()` can incorrectly return true due to a bug.  Fixing the bug yields the correct result of has_game_cylce() and proper PVs, yet loses Elo. This fix is thus an appropriate workaround, until has_game_cycle is fixed while preserving Elo.

correctness of a fixed has_game_cycle has been tested with: https://github.com/vondele/Stockfish/commits/verifyCycle/

correctness of PV output has been tested playing 10000s of games with https://github.com/vondele/Stockfish/commits/verifyMatePV/

Failed attempts of fixing the bug while preserving Elo were: https://tests.stockfishchess.org/tests/view/6670900a602682471b065018 https://tests.stockfishchess.org/tests/view/66709f45602682471b065023 https://tests.stockfishchess.org/tests/view/66709bc0602682471b06501f https://tests.stockfishchess.org/tests/view/6674fe0c602682471b0652b9 https://tests.stockfishchess.org/tests/view/6675ebf0602682471b065347 https://tests.stockfishchess.org/tests/view/66709f45602682471b065023 https://tests.stockfishchess.org/tests/view/6672a4bd602682471b06510b

This patch passes non-regression testing:
passed STC:
https://tests.stockfishchess.org/tests/view/66704649602682471b064ff9
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 73568 W: 19281 L: 19101 D: 35186
Ptnml(0-2): 246, 8425, 19324, 8481, 308

passed LTC:
https://tests.stockfishchess.org/tests/view/6676ccaf602682471b0653a2
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 55224 W: 14161 L: 13977 D: 27086
Ptnml(0-2): 39, 5726, 15912, 5882, 53

Bench: 1038234