### PR TITLE
Skip futility pruning if beta is below TB loss value

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -784,8 +784,9 @@ Value Search::Worker::search(
         && eval - futility_margin(depth, cutNode && !ss->ttHit, improving, opponentWorsening)
                - (ss - 1)->statScore / 263
              >= beta
-        && eval >= beta && eval < VALUE_TB_WIN_IN_MAX_PLY && (!ttData.move || ttCapture))
-        return beta > VALUE_TB_LOSS_IN_MAX_PLY ? beta + (eval - beta) / 3 : eval;
+        && eval >= beta && (!ttData.move || ttCapture) && beta > VALUE_TB_LOSS_IN_MAX_PLY
+        && eval < VALUE_TB_WIN_IN_MAX_PLY)
+        return beta + (eval - beta) / 3;
 
     // Step 9. Null move search with verification search (~35 Elo)
     if (!PvNode && (ss - 1)->currentMove != Move::null() && (ss - 1)->statScore < 14369


### PR DESCRIPTION
Passed STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 77024 W: 20122 L: 19946 D: 36956
Ptnml(0-2): 278, 8754, 20277, 8920, 283
https://tests.stockfishchess.org/tests/view/66752d59602682471b0652f3

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 93114 W: 23623 L: 23477 D: 46014
Ptnml(0-2): 77, 9839, 26566, 10011, 64
https://tests.stockfishchess.org/tests/view/6676b3e1602682471b065395

bench: 1003441