### PR TITLE
Fix PVs when exceeding maxValue

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1369,8 +1369,15 @@ moves_loop:  // When in check, search starts here
               << stat_bonus(depth) * bonus / 25;
     }
 
-    if (PvNode)
-        bestValue = std::min(bestValue, maxValue);
+    // if the child can't find the win (mostly in qsearch), set back this node to the TB loss value probed.
+    if (PvNode && bestValue > maxValue)
+    {
+        assert(maxValue != VALUE_INFINITE);
+        (ss + 1)->pv = pv;
+        ss->pv[0]    = Move::none();
+        bestValue    = maxValue;
+    }
+
 
     // If no good move is found and the previous position was ttPv, then the previous
     // opponent move is probably good and the new position is added to the search tree. (~7 Elo)


### PR DESCRIPTION
In case next ply dives in qsearch and thus no TB probe and no quiets generated the PV will be incorrect so not only adjust bestValue but also truncate the PV

only case left for TB is when at root then the PV could be wrong due to the whole score being masked while printing, this should be dealt with here https://github.com/official-stockfish/Stockfish/pull/5414

 python matecheck.py --engine ./stockfish --epdFile mates2000.epd --syzygyPath C:\builds\tb6 --nodes 10000
Loaded 2000 FENs, with max(abs(bm)) = 27.

```
Matetrack started for ./stockfish on mates2000.epd with --nodes 10000 --syzygyPath C:\builds\tb6 ... 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 16/16 [01:38<00:00,  6.18s/it]

Checking 1390 TB win PVs. This may take some time... Found TB score -20000 with PV status "draw" for FEN "8/8/8/8/1N5B/p7/4r3/k1K5 b - -" with bm #-8. PV: e2e6 h4g5 e6e1 c1d2
Found TB score 20000 with PV status "draw" for FEN "8/8/8/5K2/7k/7p/7N/7N w - -" with bm #9. PV: h2f3 h4h5 h1g3 h5h6
Found TB score 20000 with PV status "draw" for FEN "8/7n/7P/8/6nK/5k2/8/8 b - -" with bm #10. PV: f3f4 h4h3 h7g5 h3g2
Found TB score -20000 with PV status "draw" for FEN "8/8/1N6/8/8/k1K5/1Bp5/1b6 b - -" with bm #-6. PV: a3a2 b6d5 c2c1q b2c1
Found TB score 20000 with PV status "draw" for FEN "7k/8/5rRK/5P2/8/1B6/8/8 w - -" with bm #8. PV: h6g5 f6a6 g6h6 h8g7 h6a6
Found TB score -20000 with PV status "draw" for FEN "rr5k/RR6/7K/8/8/8/8/8 b - -" with bm #-6. PV: h8g8 b7b8 a8b8
Found TB score -20000 with PV status "wrong" for FEN "4N3/8/8/3p1p2/8/8/p7/k1K5 b - -" with bm #-6. PV: f5f4 e8g7 f4f3 g7f5
Found TB score -20000 with PV status "draw" for FEN "1b6/2p5/8/2K5/k7/8/1PB5/8 b - -" with bm #-7. PV: a4a5 b2b4 a5a6 c2d3 a6b7
Found TB score -20000 with PV status "draw" for FEN "Q7/8/8/8/8/8/6rp/4K2k b - -" with bm #-11. PV: h1g1 a8a7 g1h1 a7f7
Found TB score -20000 with PV status "draw" for FEN "8/8/N7/2B5/8/7p/5K1P/7k b - -" with bm #-7. PV: h1h2 a6b4
Found TB score -20000 with PV status "draw" for FEN "1b6/k1p5/2K2N2/8/8/8/8/5B2 b - -" with bm #-8. PV: a7a8 f6d7 b8a7 c6c7
Found TB score -20000 with PV status "draw" for FEN "8/8/8/8/2Q5/1qN5/k7/2K5 b - -" with bm #-7. PV: a2a3 c3b1 b3b1 c1b1
Found TB score -20000 with PV status "draw" for FEN "7k/8/4B1K1/8/4R3/1r6/8/8 b - -" with bm #-6. PV: b3b4 e6g4 b4e4
Found TB score -20000 with PV status "draw" for FEN "8/p7/8/8/P7/3N4/5K1p/7k b - -" with bm #-6. PV: a7a5 d3f4
Found TB score -20000 with PV status "draw" for FEN "8/8/8/8/6NK/7p/7N/7k b - -" with bm #-9. PV: h1g1 h4h3
Found TB score -20000 with PV status "draw" for FEN "8/1p6/8/2P5/8/8/p2K4/Bk6 b - -" with bm #-9. PV: b1a1 d2c1
Found TB score 20000 with PV status "draw" for FEN "7k/8/4K3/5N2/3N4/4p3/8/8 w - -" with bm #9. PV: d4e2 h8h7 f5d4 h7g6
Found TB score 20000 with PV status "draw" for FEN "8/8/6p1/4N3/6N1/8/5K2/7k w - -" with bm #7. PV: e5f3 g6g5 g4e3
Found TB score 20000 with PV status "draw" for FEN "8/8/1N6/8/8/k1K5/2p5/Bb6 w - -" with bm #7. PV: a1b2 a3a2 b2c1 a2a1 c3b3
Found TB score 20000 with PV status "draw" for FEN "7Q/8/8/8/8/8/6rp/4K2k w - -" with bm #12. PV: h8a8 h1g1 a8a7 g1h1 a7f7 g2g1 e1f2 g1g2 f2e3
Found TB score -20000 with PV status "draw" for FEN "8/8/8/8/2B2K2/7N/6r1/5N1k b - -" with bm #-6. PV: g2b2 f4g3 b2g2 g3h4
Found TB score -20000 with PV status "draw" for FEN "7K/8/8/1p6/8/3N4/2N5/kB6 b - -" with bm #-11. PV: a1b1 c2a3 b1a2
Found TB score -20000 with PV status "draw" for FEN "8/8/8/8/4R3/8/p1K1n3/k7 b - -" with bm #-8. PV: e2d4 c2c3 d4f3 e4b4 f3e5 b4b6 e5f3
Found TB score -20000 with PV status "draw" for FEN "8/8/6p1/8/2N3N1/8/5K2/7k b - -" with bm #-6. PV: g6g5 c4d2
Found TB score -20000 with PV status "draw" for FEN "8/4p3/8/8/8/1N3p1p/5K2/7k b - -" with bm #-15. PV: e7e5 b3d2 h1h2 d2e4 h2h1 e4f6 h1h2 f6g4 h2h1 f2f1 e5e4 Found TB score -20000 with PV status "draw" for FEN "8/8/2Q5/8/8/7p/8/q2N1K1k b - -" with bm #-11. PV: h1h2 c6d6 h2h1 d6d5 h1h2 d5d2 h2g3
Found TB score -20000 with PV status "draw" for FEN "1k6/8/3N4/1N6/6pK/8/8/7B b - -" with bm #-7. PV: g4g3 h4g3
Found TB score 20000 with PV status "draw" for FEN "1rr4k/1RR5/8/7K/8/8/8/8 w - -" with bm #7. PV: h5h6 h8g8 c7g7 g8f8 b7f7 f8e8 h6h7 b8b2 f7e7 e8d8

Using ./stockfish on mates2000.epd with --nodes 10000 --syzygyPath C:\builds\tb6
Engine ID:     Stockfish dev-20240629-nogit
Total FENs:    2000
Found mates:   374
Best mates:    316
Found TB wins: 309

Parsing the engine's full UCI output, the following issues were detected:
Bad PVs:       54   (from 28 FENs)
```

No functional change