### PR TITLE
Simplify away a useless TTEntry::read() when we don't hit.

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -238,7 +238,7 @@ std::tuple<bool, TTData, TTWriter> TranspositionTable::probe(const Key key) cons
             > tte[i].depth8 - tte[i].relative_age(generation8) * 2)
             replace = &tte[i];
 
-    return {false, replace->read(), TTWriter(replace)};
+    return {false, TTData(), TTWriter(replace)};
 }
 
 


### PR DESCRIPTION
No functional change
bench: 1038234