### PR TITLE
Grade low statscore bonus for countermoves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ src/-lstdc++.res
 # Neural network for the NNUE evaluation
 **/*.nnue
 
+/.vs

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1360,7 +1360,8 @@ moves_loop:  // When in check, search starts here
 
 
         // proportional to "how much damage we have to undo"
-        bonus += std::clamp(-(ss - 1)->statScore / 100, 0, 250);
+        if ((ss - 1)->statScore < -8000)
+          bonus += std::clamp(-(ss - 1)->statScore / 100, 0, 250);
 
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       stat_bonus(depth) * bonus / 100);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1022,6 +1022,9 @@ moves_loop:  // When in check, search starts here
                 Value futilityValue =
                   ss->staticEval + (bestValue < ss->staticEval - 51 ? 138 : 54) + 140 * lmrDepth;
 
+                if (bestValue < ss->staticEval - 150)
+                    futilityValue += 50;
+
                 // Futility pruning: parent node (~13 Elo)
                 if (!ss->inCheck && lmrDepth < 12 && futilityValue <= alpha)
                 {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1358,12 +1358,9 @@ moves_loop:  // When in check, search starts here
                      + 64 * (!ss->inCheck && bestValue <= ss->staticEval - 107)
                      + 147 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 75));
 
-        if ((ss - 1)->statScore < -25000)
-            bonus += 250;
-        else if ((ss - 1)->statScore < -14396)
-            bonus += 180;
-        else if ((ss - 1)->statScore < -8000)
-            bonus += 100;
+
+        // proportional to "how much damage we have to undo"
+        bonus += std::clamp(-(ss - 1)->statScore / 100, 0, 250);
 
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       stat_bonus(depth) * bonus / 100);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1022,9 +1022,6 @@ moves_loop:  // When in check, search starts here
                 Value futilityValue =
                   ss->staticEval + (bestValue < ss->staticEval - 51 ? 138 : 54) + 140 * lmrDepth;
 
-                if (bestValue < ss->staticEval - 150)
-                    futilityValue += 50;
-
                 // Futility pruning: parent node (~13 Elo)
                 if (!ss->inCheck && lmrDepth < 12 && futilityValue <= alpha)
                 {
@@ -1357,10 +1354,17 @@ moves_loop:  // When in check, search starts here
     // Bonus for prior countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
     {
-        int bonus = (113 * (depth > 5) + 118 * (PvNode || cutNode)
-                     + 191 * ((ss - 1)->statScore < -14396) + 119 * ((ss - 1)->moveCount > 8)
+        int bonus = (113 * (depth > 5) + 118 * (PvNode || cutNode) + 119 * ((ss - 1)->moveCount > 8)
                      + 64 * (!ss->inCheck && bestValue <= ss->staticEval - 107)
                      + 147 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 75));
+
+        if ((ss - 1)->statScore < -25000)
+            bonus += 250;
+        else if ((ss - 1)->statScore < -14396)
+            bonus += 180;
+        else if ((ss - 1)->statScore < -8000)
+            bonus += 100;
+
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       stat_bonus(depth) * bonus / 100);
         thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()]


### PR DESCRIPTION
Passed STC:
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 338592 W: 88396 L: 87627 D: 162569
Ptnml(0-2): 1161, 40201, 85788, 41000, 1146 
https://tests.stockfishchess.org/tests/view/6679d40c0c2db3fa2dcecbcc

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 83526 W: 21429 L: 21010 D: 41087
Ptnml(0-2): 54, 9173, 22913, 9546, 77 
https://tests.stockfishchess.org/tests/view/667c5f2980450dba965911fc