### PR TITLE
Grade countermove bonus for low statscore

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1354,10 +1354,16 @@ moves_loop:  // When in check, search starts here
     // Bonus for prior countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
     {
-        int bonus = (113 * (depth > 5) + 118 * (PvNode || cutNode)
-                     + 191 * ((ss - 1)->statScore < -14396) + 119 * ((ss - 1)->moveCount > 8)
+        int bonus = (113 * (depth > 5) + 118 * (PvNode || cutNode) + 119 * ((ss - 1)->moveCount > 8)
                      + 64 * (!ss->inCheck && bestValue <= ss->staticEval - 107)
                      + 147 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 75));
+
+
+        // proportional to "how much damage we have to undo"
+        if ((ss - 1)->statScore < -8000)
+            bonus += std::clamp(-(ss - 1)->statScore / 100, 0, 250);
+
+
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       stat_bonus(depth) * bonus / 100);
         thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()]


### PR DESCRIPTION
Passed STC:
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 338592 W: 88396 L: 87627 D: 162569
Ptnml(0-2): 1161, 40201, 85788, 41000, 1146 
https://tests.stockfishchess.org/tests/view/6679d40c0c2db3fa2dcecbcc

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 83526 W: 21429 L: 21010 D: 41087
Ptnml(0-2): 54, 9173, 22913, 9546, 77 
https://tests.stockfishchess.org/tests/view/667c5f2980450dba965911fc

bench 1475789