### PR TITLE
Tweak multicut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1086,8 +1086,8 @@ moves_loop:  // When in check, search starts here
                 // and if after excluding the ttMove with a reduced search we fail high over the original beta,
                 // we assume this expected cut-node is not singular (multiple moves fail high),
                 // and we can prune the whole subtree by returning a softbound.
-                else if (singularBeta >= beta)
-                    return singularBeta;
+                else if (value >= beta && std::abs(value) < VALUE_TB_WIN_IN_MAX_PLY)
+                    return value;
 
                 // Negative extensions
                 // If other moves failed high over (ttValue - margin) without the ttMove on a reduced search,


### PR DESCRIPTION
This patch is an original patch by author of Altair (https://github.com/Alex2262/AltairChessEngine) chess engine.
It allows to produce more aggressive multicut compared to master by changing condition it needs to fulfil and also returns bigger value.
Also has applied matetrack fix on top.
Passed STC:
https://tests.stockfishchess.org/tests/view/667223ab602682471b0650e2
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 50048 W: 13200 L: 12860 D: 23988
Ptnml(0-2): 181, 5822, 12679, 6160, 182
Passed LTC:
https://tests.stockfishchess.org/tests/view/6672f777602682471b06515d
LLR: 2.97 (-2.94,2.94) <0.50,2.50>
Total: 706380 W: 179707 L: 177981 D: 348692
Ptnml(0-2): 656, 79250, 191665, 80950, 669
bench 1092924