### PR TITLE
Increase reduction based on correct expectation

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1156,7 +1156,7 @@ moves_loop:  // When in check, search starts here
 
         // Increase reduction if next ply has a lot of fail high (~5 Elo)
         if ((ss + 1)->cutoffCnt > 3)
-            r++;
+            r += 1 + !(PvNode || cutNode);
 
         // For first picked move (ttMove) reduce reduction
         // but never allow it to go below 0 (~3 Elo)


### PR DESCRIPTION
If the current node is not a cutNode then it means that the child is one in LMR and the cutoff count is expected, so more reduction when the cutoffs are expected

Passed STC:
https://tests.stockfishchess.org/tests/view/66815e791c5b344a34ca7090
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 64416 W: 16876 L: 16519 D: 31021
Ptnml(0-2): 150, 7670, 16264, 7921, 203

Passed LTC:
https://tests.stockfishchess.org/tests/view/668162f61c5b344a34ca725c
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 78186 W: 19905 L: 19499 D: 38782
Ptnml(0-2): 55, 8561, 21437, 9003, 37

bench: 1138299