### PR TITLE
Simplify worsening deduction in futility margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -62,7 +62,7 @@ static constexpr double EvalLevel[10] = {0.981, 0.956, 0.895, 0.949, 0.913,
 Value futility_margin(Depth d, bool noTtCutNode, bool improving, bool oppWorsening) {
     Value futilityMult       = 109 - 40 * noTtCutNode;
     Value improvingDeduction = 59 * improving * futilityMult / 32;
-    Value worseningDeduction = 328 * oppWorsening * futilityMult / 1024;
+    Value worseningDeduction = oppWorsening * futilityMult / 3;
 
     return futilityMult * d - improvingDeduction - worseningDeduction;
 }


### PR DESCRIPTION
Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/66817d46442423e547141226
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 345408 W: 89146 L: 89266 D: 166996
Ptnml(0-2): 954, 41317, 88286, 41189, 958

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/66818dbe1e90a146232d1f62
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 173214 W: 43821 L: 43755 D: 85638
Ptnml(0-2): 108, 19407, 47492, 19511, 89

bench 1318404