### PR TITLE
Update some params for pruning at shallow depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -993,7 +993,7 @@ moves_loop:  // When in check, search starts here
                 // Futility pruning for captures (~2 Elo)
                 if (!givesCheck && lmrDepth < 7 && !ss->inCheck)
                 {
-                    Value futilityValue = ss->staticEval + 287 + 248 * lmrDepth
+                    Value futilityValue = ss->staticEval + 294 + 246 * lmrDepth
                                         + PieceValue[capturedPiece] + captHist / 7;
                     if (futilityValue <= alpha)
                         continue;
@@ -1001,7 +1001,7 @@ moves_loop:  // When in check, search starts here
 
                 // SEE based pruning for captures and checks (~11 Elo)
                 int seeHist = std::clamp(captHist / 32, -180 * depth, 163 * depth);
-                if (!pos.see_ge(move, -160 * depth - seeHist))
+                if (!pos.see_ge(move, -163 * depth - seeHist))
                     continue;
             }
             else
@@ -1012,15 +1012,15 @@ moves_loop:  // When in check, search starts here
                   + thisThread->pawnHistory[pawn_structure_index(pos)][movedPiece][move.to_sq()];
 
                 // Continuation history based pruning (~2 Elo)
-                if (lmrDepth < 6 && history < -4151 * depth)
+                if (lmrDepth < 6 && history < -3899 * depth)
                     continue;
 
                 history += 2 * thisThread->mainHistory[us][move.from_to()];
 
-                lmrDepth += history / 3678;
+                lmrDepth += history / 4040;
 
                 Value futilityValue =
-                  ss->staticEval + (bestValue < ss->staticEval - 51 ? 138 : 54) + 140 * lmrDepth;
+                  ss->staticEval + (bestValue < ss->staticEval - 51 ? 135 : 56) + 140 * lmrDepth;
 
                 // Futility pruning: parent node (~13 Elo)
                 if (!ss->inCheck && lmrDepth < 12 && futilityValue <= alpha)


### PR DESCRIPTION
Values found around 82k / 120k spsa games at 60+0.6: https://tests.stockfishchess.org/tests/view/6681aca4481148df247298bd

Passed STC:
https://tests.stockfishchess.org/tests/view/6681c795c1657e386d2948fa
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 145216 W: 37595 L: 37122 D: 70499
Ptnml(0-2): 375, 17122, 37185, 17507, 419

Passed LTC:
https://tests.stockfishchess.org/tests/view/6681d4eec1657e386d2949e0
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 154062 W: 39117 L: 38557 D: 76388
Ptnml(0-2): 67, 16874, 42608, 17396, 86

bench 1180451