### PR TITLE
Introduce USE_POSIX_ALIGNED_ALLOC compilation flag

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -64,16 +64,16 @@ using AdjustTokenPrivileges_t =
 
 namespace Stockfish {
 
-// Wrapper for systems where the c++17 implementation
-// does not guarantee the availability of aligned_alloc(). Memory allocated with
-// std_aligned_alloc() must be freed with std_aligned_free().
+// Wrapper for systems where the c++17 implementation does not guarantee
+// the availability of aligned_alloc(). Memory allocated with std_aligned_alloc()
+// must be freed with std_aligned_free().
 void* std_aligned_alloc(size_t alignment, size_t size) {
-    // Apple requires 10.15, which is enforced in the makefile
-#if defined(_ISOC11_SOURCE) || defined(__APPLE__)
+#if !defined(USE_POSIX_ALIGNED_ALLOC) && (defined(_ISOC11_SOURCE) || defined(__APPLE__))
     return aligned_alloc(alignment, size);
 #elif defined(POSIXALIGNEDALLOC)
-    void* mem;
-    return posix_memalign(&mem, alignment, size) ? nullptr : mem;
+    void* mem = nullptr;
+    posix_memalign(&mem, alignment, size);
+    return mem;
 #elif defined(_WIN32) && !defined(_M_ARM) && !defined(_M_ARM64)
     return _mm_malloc(size, alignment);
 #elif defined(_WIN32)


### PR DESCRIPTION
With this patch, it is now possible to pass USE_POSIX_ALIGNED_ALLOC to the compiler flags to force the use of the posix_memalign() function as aligned memory allocator.

The behavior is unchanged compared to master if USE_POSIX_ALIGNED_ALLOC if not defined, but if USE_POSIX_ALIGNED_ALLOC is defined we now fall back to posix_memalign() if available. This allows the compilation of Stockfish on Macintosh prior to 10.15 (using clang or gcc compiler).

====

Example of usage :

export CXXFLAGS=-DUSE_POSIX_ALIGNED_ALLOC
make -j profile-build COMP=clang COMPCXX=clang++-mp-11

export CXXFLAGS=-DUSE_POSIX_ALIGNED_ALLOC
make -j profile-build COMP=gcc COMPCXX=g++-mp-14

====

closes https://github.com/official-stockfish/Stockfish/pull/5426

No functional change