### PR TITLE
Probcut in check no matter if pv or capt

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -905,7 +905,7 @@ moves_loop:  // When in check, search starts here
 
     // Step 12. A small Probcut idea, when we are in check (~4 Elo)
     probCutBeta = beta + 388;
-    if (ss->inCheck && !PvNode && ttCapture && (ttData.bound & BOUND_LOWER)
+    if (ss->inCheck && (ttData.bound & BOUND_LOWER)
         && ttData.depth >= depth - 4 && ttData.value >= probCutBeta
         && std::abs(ttData.value) < VALUE_TB_WIN_IN_MAX_PLY
         && std::abs(beta) < VALUE_TB_WIN_IN_MAX_PLY)


### PR DESCRIPTION
Passed STC: https://tests.stockfishchess.org/tests/view/6681e9c8c1657e386d294cef
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 217824 W: 56149 L: 56129 D: 105546
Ptnml(0-2): 587, 25926, 55848, 25982, 569

Passed LTC: https://tests.stockfishchess.org/tests/view/6681fcb8c1657e386d294db1
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 357552 W: 90546 L: 90671 D: 176335
Ptnml(0-2): 207, 40064, 98362, 39933, 210

Each half of this also passed STC+LTC separately

bench 1356743