### PR TITLE
Removing redundant equal sign

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1661,7 +1661,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta,
         return mated_in(ss->ply);  // Plies to mate from the root
     }
 
-    if (std::abs(bestValue) < VALUE_TB_WIN_IN_MAX_PLY && bestValue >= beta)
+    if (std::abs(bestValue) < VALUE_TB_WIN_IN_MAX_PLY && bestValue > beta)
         bestValue = (3 * bestValue + beta) / 4;
 
     // Save gathered info in transposition table


### PR DESCRIPTION
Non functional change

The current formula averages bestValue and beta when bestValue is greater than OR EQUAL to beta. However, this averaging is logically redundant when bestValue and beta are equal. In such cases, the averaging does not provide any meaningful benefit and can be considered unnecessary.

Hit rate of bestValue == beta in this part of the code is 10% , so it should spare us some extra operations when the two values are equal (around 10% of the time).

So even though the speedup is not big enough to pass any test, it's still a very safe change to make which makes sense from a logical point of view to don't average two values when they are equal.

bench: 1227870