### PR TITLE
Move info strings once more

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -297,16 +297,20 @@ std::string Engine::get_numa_config_as_string() const {
 
 std::string Engine::numa_config_information_as_string() const {
     auto cfgStr = get_numa_config_as_string();
-    return "Available Processors: " + cfgStr;
+    return "Available processors: " + cfgStr;
 }
 
 std::string Engine::thread_binding_information_as_string() const {
-    auto boundThreadsByNode = get_bound_thread_count_by_numa_node();
-    if (boundThreadsByNode.empty())
-        return "";
-
+    auto              boundThreadsByNode = get_bound_thread_count_by_numa_node();
     std::stringstream ss;
-    ss << "NUMA Node Thread Binding: ";
+
+    size_t threadsSize = threads.size();
+    ss << "Using " << threadsSize << (threadsSize > 1 ? " threads" : " thread");
+
+    if (boundThreadsByNode.empty())
+        return ss.str();
+
+    ss << " with NUMA node thread binding: ";
 
     bool isFirst = true;
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -109,16 +109,17 @@ void UCIEngine::loop() {
                       << engine.get_options() << sync_endl;
 
             sync_cout << "uciok" << sync_endl;
-
-            // keep info strings after uciok for old GUIs
-            print_info_string(engine.numa_config_information_as_string());
-            print_info_string(engine.thread_binding_information_as_string());
         }
 
         else if (token == "setoption")
             setoption(is);
         else if (token == "go")
+        {
+            // send info strings after the go command is sent for old GUIs and python-chess
+            print_info_string(engine.numa_config_information_as_string());
+            print_info_string(engine.thread_binding_information_as_string());
             go(is);
+        }
         else if (token == "position")
             position(is);
         else if (token == "ucinewgame")


### PR DESCRIPTION
Follow up from #5404 ... current location leads to troubles with Aquarium GUI

Fixes #5430

Now prints the information on threads and available processors at the beginning of search, where info about the networks is already printed (and is known to work)

Also provided some more information on the number of used threads and adjusted capitalization of words.

No functional change.