### PR TITLE
CI: limit artifact uploads

### DIFF
--- a/.github/workflows/arm_compilation.yml
+++ b/.github/workflows/arm_compilation.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download required linux packages
         if: runner.os == 'Linux'
@@ -91,4 +92,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.config.simple_name }} ${{ matrix.binaries }}
-          path: .
+          path: |
+            .
+            !.git
+            !.output

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Run clang-format style check
         uses: jidicula/clang-format-action@f62da5e3d3a2d88ff364771d9d938773a618ab5e # @v4.11.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -25,6 +25,8 @@ jobs:
         shell: ${{ matrix.config.shell }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install fixed GCC on Linux
         if: runner.os == 'Linux'
@@ -86,4 +88,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.config.simple_name }} ${{ matrix.binaries }}
-          path: .
+          path: |
+             .
+             !.git
+             !.output

--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: Stockfish
+          persist-credentials: false
 
       - name: build debug enabled version of SF
         working-directory: Stockfish/src
@@ -24,6 +25,7 @@ jobs:
           repository: Disservin/fast-chess
           path: fast-chess
           ref: d54af1910d5479c669dc731f1f54f9108a251951
+          persist-credentials: false
 
       - name: fast-chess build
         working-directory: fast-chess

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: Stockfish
+          persist-credentials: false
 
       - name: Checkout include-what-you-use
         uses: actions/checkout@v4
@@ -21,6 +22,7 @@ jobs:
           repository: include-what-you-use/include-what-you-use
           ref: f25caa280dc3277c4086ec345ad279a2463fea0f
           path: include-what-you-use
+          persist-credentials: false
 
       - name: Download required linux packages
         run: |

--- a/.github/workflows/matetrack.yml
+++ b/.github/workflows/matetrack.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: Stockfish
+          persist-credentials: false
 
       - name: build SF
         working-directory: Stockfish/src
@@ -24,6 +25,7 @@ jobs:
           repository: vondele/matetrack
           path: matetrack
           ref: 20287a1a145f30a166b7ef251eddb611e4e44fbf
+          persist-credentials: false
 
       - name: matetrack install deps
         working-directory: matetrack

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -40,6 +40,8 @@ jobs:
         shell: ${{ matrix.config.shell }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Download required linux packages
         run: |

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # returns null if no pre-release exists
       - name: Get Commit SHA of Latest Pre-release
@@ -66,6 +68,8 @@ jobs:
       arm_matrix: ${{ steps.set-arm-matrix.outputs.arm_matrix }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - id: set-matrix
         run: |
           TASKS=$(echo $(cat .github/ci/matrix.json) )

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,6 +106,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download required linux packages
         if: runner.os == 'Linux'

--- a/.github/workflows/upload_binaries.yml
+++ b/.github/workflows/upload_binaries.yml
@@ -25,6 +25,8 @@ jobs:
         shell: ${{ matrix.config.shell }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Download artifact from compilation
         uses: actions/download-artifact@v4


### PR DESCRIPTION
do not upload some unneeded intermediate directories, disable running authenticated git commands with the checkout action.

Thanks to Yaron A for the report.

No functional change