### PR TITLE
Simplify Away Countermove Heuristic

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -91,7 +91,6 @@ MovePicker::MovePicker(const Position&              p,
                        const CapturePieceToHistory* cph,
                        const PieceToHistory**       ch,
                        const PawnHistory*           ph,
-                       Move                         cm,
                        const Move*                  killers) :
     pos(p),
     mainHistory(mh),
@@ -99,7 +98,7 @@ MovePicker::MovePicker(const Position&              p,
     continuationHistory(ch),
     pawnHistory(ph),
     ttMove(ttm),
-    refutations{{killers[0], 0}, {killers[1], 0}, {cm, 0}},
+    refutations{{killers[0], 0}, {killers[1], 0}},
     depth(d) {
     assert(d > 0);
 
@@ -272,10 +271,6 @@ top:
         // Prepare the pointers to loop over the refutations array
         cur      = std::begin(refutations);
         endMoves = std::end(refutations);
-
-        // If the countermove is the same as a killer, skip it
-        if (refutations[0] == refutations[2] || refutations[1] == refutations[2])
-            --endMoves;
 
         ++stage;
         [[fallthrough]];

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -118,10 +118,6 @@ enum StatsType {
 // see www.chessprogramming.org/Butterfly_Boards (~11 elo)
 using ButterflyHistory = Stats<int16_t, 7183, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)>;
 
-// CounterMoveHistory stores counter moves indexed by [piece][to] of the previous
-// move, see www.chessprogramming.org/Countermove_Heuristic
-using CounterMoveHistory = Stats<Move, NOT_USED, PIECE_NB, SQUARE_NB>;
-
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;
 
@@ -164,7 +160,6 @@ class MovePicker {
                const CapturePieceToHistory*,
                const PieceToHistory**,
                const PawnHistory*,
-               Move,
                const Move*);
     MovePicker(const Position&,
                Move,

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -125,7 +125,7 @@ Value value_to_tt(Value v, int ply);
 Value value_from_tt(Value v, int ply, int r50c);
 void  update_pv(Move* pv, Move move, const Move* childPv);
 void  update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus);
-void  update_refutations(const Position& pos, Stack* ss, Search::Worker& workerThread, Move move);
+void  update_refutations(Stack* ss, Move move);
 void  update_quiet_histories(
    const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus);
 void update_quiet_stats(
@@ -510,7 +510,6 @@ void Search::Worker::iterative_deepening() {
 }
 
 void Search::Worker::clear() {
-    counterMoves.fill(Move::none());
     mainHistory.fill(0);
     captureHistory.fill(-700);
     pawnHistory.fill(-1193);
@@ -950,11 +949,9 @@ moves_loop:  // When in check, search starts here
                                         nullptr,
                                         (ss - 6)->continuationHistory};
 
-    Move countermove =
-      prevSq != SQ_NONE ? thisThread->counterMoves[pos.piece_on(prevSq)][prevSq] : Move::none();
 
     MovePicker mp(pos, ttData.move, depth, &thisThread->mainHistory, &thisThread->captureHistory,
-                  contHist, &thisThread->pawnHistory, countermove, ss->killers);
+                  contHist, &thisThread->pawnHistory, ss->killers);
 
     value            = bestValue;
     moveCountPruning = false;
@@ -1860,20 +1857,13 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
 }
 
 // Updates move sorting heuristics
-void update_refutations(const Position& pos, Stack* ss, Search::Worker& workerThread, Move move) {
+void update_refutations(Stack* ss, Move move) {
 
     // Update killers
     if (ss->killers[0] != move)
     {
         ss->killers[1] = ss->killers[0];
         ss->killers[0] = move;
-    }
-
-    // Update countermove history
-    if (((ss - 1)->currentMove).is_ok())
-    {
-        Square prevSq                                           = ((ss - 1)->currentMove).to_sq();
-        workerThread.counterMoves[pos.piece_on(prevSq)][prevSq] = move;
     }
 }
 
@@ -1893,7 +1883,7 @@ void update_quiet_histories(
 void update_quiet_stats(
   const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus) {
 
-    update_refutations(pos, ss, workerThread, move);
+    update_refutations(ss, move);
     update_quiet_histories(pos, ss, workerThread, move, bonus);
 }
 

--- a/src/search.h
+++ b/src/search.h
@@ -247,7 +247,6 @@ class Worker {
     bool is_mainthread() const { return threadIdx == 0; }
 
     // Public because they need to be updatable by the stats
-    CounterMoveHistory    counterMoves;
     ButterflyHistory      mainHistory;
     CapturePieceToHistory captureHistory;
     ContinuationHistory   continuationHistory[2][2];


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 977824 W: 252072 L: 252888 D: 472864
Ptnml(0-2): 2518, 117120, 250560, 116088, 2626 
https://tests.stockfishchess.org/tests/view/6683452d95b0d1e881e81541

Passed Non-regression LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 81048 W: 20630 L: 20470 D: 39948
Ptnml(0-2): 36, 8915, 22464, 9071, 38
https://tests.stockfishchess.org/tests/view/66886b7b0c9d7c1ab33ed281

bench 1300997