### PR TITLE
Simplify Away Move Count Pruning Adjustment Using Singular Search Result

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -559,12 +559,11 @@ Value Search::Worker::search(
     Key   posKey;
     Move  move, excludedMove, bestMove;
     Depth extension, newDepth;
-    Value bestValue, value, eval, maxValue, probCutBeta, singularValue;
+    Value bestValue, value, eval, maxValue, probCutBeta;
     bool  givesCheck, improving, priorCapture, opponentWorsening;
     bool  capture, moveCountPruning, ttCapture;
     Piece movedPiece;
     int   moveCount, captureCount, quietCount;
-    Bound singularBound;
 
     // Step 1. Initialize node
     Worker* thisThread = this;
@@ -948,8 +947,6 @@ moves_loop:  // When in check, search starts here
 
     value            = bestValue;
     moveCountPruning = false;
-    singularValue    = VALUE_INFINITE;
-    singularBound    = BOUND_NONE;
 
     // Step 13. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
@@ -999,9 +996,7 @@ moves_loop:  // When in check, search starts here
         if (!rootNode && pos.non_pawn_material(us) && bestValue > VALUE_TB_LOSS_IN_MAX_PLY)
         {
             // Skip quiet moves if movecount exceeds our FutilityMoveCount threshold (~8 Elo)
-            moveCountPruning =
-              moveCount >= futility_move_count(improving, depth)
-                             - (singularBound == BOUND_UPPER && singularValue < alpha - 51);
+            moveCountPruning = moveCount >= futility_move_count(improving, depth);
 
             // Reduced depth of the next LMR search
             int lmrDepth = newDepth - r;
@@ -1087,9 +1082,8 @@ moves_loop:  // When in check, search starts here
                 Depth singularDepth = newDepth / 2;
 
                 ss->excludedMove = move;
-                value            = singularValue =
+                value =
                   search<NonPV>(pos, ss, singularBeta - 1, singularBeta, singularDepth, cutNode);
-                singularBound    = singularValue >= singularBeta ? BOUND_LOWER : BOUND_UPPER;
                 ss->excludedMove = Move::none();
 
                 if (value < singularBeta)


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 3.01 (-2.94,2.94) <-1.75,0.25>
Total: 62688 W: 16319 L: 16121 D: 30248
Ptnml(0-2): 196, 7317, 16104, 7547, 180 
https://tests.stockfishchess.org/tests/view/66879bf51b527f04dd477ff9

Passed Non-regression LTC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 116502 W: 29504 L: 29379 D: 57619
Ptnml(0-2): 66, 12881, 32226, 13018, 60 
https://tests.stockfishchess.org/tests/view/6688629e0c9d7c1ab33ed030

bench 1188630