### PR TITLE
Simplify in-check condition for Probcut-in-check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -928,10 +928,9 @@ Value Search::Worker::search(
 
 moves_loop:  // When in check, search starts here
 
-    // Step 12. A small Probcut idea, when we are in check (~4 Elo)
+    // Step 12. A small Probcut idea (~4 Elo)
     probCutBeta = beta + 390;
-    if (ss->inCheck && (ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4
-        && ttData.value >= probCutBeta && std::abs(ttData.value) < VALUE_TB_WIN_IN_MAX_PLY
+    if ((ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4 && ttData.value >= probCutBeta
         && std::abs(beta) < VALUE_TB_WIN_IN_MAX_PLY)
         return probCutBeta;
 


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 512000 W: 132193 L: 132497 D: 247310
Ptnml(0-2): 1600, 61170, 130704, 60986, 1540
https://tests.stockfishchess.org/tests/view/66838911c4f539faa03268a2

Passed Non-regression LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 380268 W: 95894 L: 96042 D: 188332
Ptnml(0-2): 193, 42861, 104180, 42701, 199
https://tests.stockfishchess.org/tests/view/6688d0550c9d7c1ab33ed5a8

bench 1491775