### PR TITLE
Simplify away eval in TM

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -65,9 +65,6 @@ using namespace Search;
 
 namespace {
 
-static constexpr double EvalLevel[10] = {0.981, 0.956, 0.895, 0.949, 0.913,
-                                         0.942, 0.933, 0.890, 0.984, 0.941};
-
 // Futility margin
 Value futility_margin(Depth d, bool noTtCutNode, bool improving, bool oppWorsening) {
     Value futilityMult       = 109 - 40 * noTtCutNode;
@@ -463,11 +460,10 @@ void Search::Worker::iterative_deepening() {
             timeReduction    = lastBestMoveDepth + 8 < completedDepth ? 1.495 : 0.687;
             double reduction = (1.48 + mainThread->previousTimeReduction) / (2.17 * timeReduction);
             double bestMoveInstability = 1 + 1.88 * totBestMoveChanges / threads.size();
-            int    el                  = std::clamp((bestValue + 750) / 150, 0, 9);
             double recapture           = limits.capSq == rootMoves[0].pv[0].to_sq() ? 0.955 : 1.005;
 
             double totalTime = mainThread->tm.optimum() * fallingEval * reduction
-                             * bestMoveInstability * EvalLevel[el] * recapture;
+                             * bestMoveInstability * recapture;
 
             // Cap used time in case of a single legal move for a better viewer experience
             if (rootMoves.size() == 1)


### PR DESCRIPTION
Simplify away eval in TM

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 40160 W: 10523 L: 10309 D: 19328
Ptnml(0-2): 129, 4543, 10524, 4753, 131
https://tests.stockfishchess.org/tests/view/6685ab8b99271ae49479dbe9

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 195672 W: 49681 L: 49639 D: 96352
Ptnml(0-2): 112, 20976, 55597, 21060, 91
https://tests.stockfishchess.org/tests/view/6686f27a7092ade1206f7889

bench: 1138753