### PR TITLE
Non-functional Fixes & Updates

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -67,8 +67,7 @@ std::optional<std::string> read_file_to_string(const std::string& path);
 void dbg_hit_on(bool cond, int slot = 0);
 void dbg_mean_of(int64_t value, int slot = 0);
 void dbg_stdev_of(int64_t value, int slot = 0);
-void dbg_extremes_of(int64_t value, int slot);
-
+void dbg_extremes_of(int64_t value, int slot = 0);
 void dbg_correl_of(int64_t value1, int64_t value2, int slot = 0);
 void dbg_print();
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1075,8 +1075,8 @@ moves_loop:  // When in check, search starts here
         // We take care to not overdo to avoid search getting stuck.
         if (ss->ply < thisThread->rootDepth * 2)
         {
-            // Singular extension search (~94 Elo). If all moves but one fail low on a
-            // search of (alpha-s, beta-s), and just one fails high on (alpha, beta),
+            // Singular extension search (~76 Elo, ~170 nElo). If all moves but one fail
+            // low on a search of (alpha-s, beta-s), and just one fails high on (alpha, beta),
             // then that move is singular and should be extended. To verify this we do
             // a reduced search on the position excluding the ttMove and if the result
             // is lower than ttValue minus a margin, then we will extend the ttMove.


### PR DESCRIPTION
Fixes a missing default slot for `dbg_extremes of`, removes a extra newline, and updates SE elo estimate from
https://tests.stockfishchess.org/tests/view/664ebd1e928b1fb18de4e4b7 while we are at it.

no functional change

bench 1138753