### PR TITLE
Simplify internal iterative reductions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -840,11 +840,8 @@ Value Search::Worker::search(
 
     // Step 10. Internal iterative reductions (~9 Elo)
     // For PV nodes without a ttMove, we decrease depth.
-    // Additionally, if the current position is found in the TT
-    // and the stored depth in the TT is greater than or equal to
-    // current search depth, we decrease search depth even further.
     if (PvNode && !ttData.move)
-        depth -= 3 + (ss->ttHit && ttData.depth >= depth);
+        depth -= 3;
 
     // Use qsearch if depth <= 0.
     if (depth <= 0)


### PR DESCRIPTION
This is a revert of cc992e5. 
This patch is based on consistent observations that decreasing depth more in IIR generally has a bad scaling behaviour (good at STC, bad at longer time controls).

Simplification STC: https://tests.stockfishchess.org/tests/view/6689266659cb3228a4759b26
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 96992 W: 24977 L: 24824 D: 47191
Ptnml(0-2): 251, 11497, 24851, 11642, 255 

Simplification LTC: https://tests.stockfishchess.org/tests/view/668930ffe59d990b103f6ab1
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 35808 W: 9185 L: 8980 D: 17643
Ptnml(0-2): 25, 3776, 10101, 3973, 29 

Bench: 1322303