### PR TITLE
Simplify ttPv reduction formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1168,8 +1168,7 @@ moves_loop:  // When in check, search starts here
 
         // Decrease reduction if position is or has been on the PV (~7 Elo)
         if (ss->ttPv)
-            r -= 1 + (ttData.value > alpha) + (ttData.depth >= depth)
-               - (PvNode && ttData.value < alpha && ttData.depth >= depth);
+            r -= 1 + (ttData.value > alpha) + (ttData.depth >= depth);
 
         // Decrease reduction for PvNodes (~0 Elo on STC, ~2 Elo on LTC)
         if (PvNode)


### PR DESCRIPTION
This is a revert of 2046c92.
This patch is based on the fact that the ttPv reduction has proven non-linear scaling (as documented in the code, along with testing guidelines); however, the original patch had (erroneously) not been tested at VLTC or longer.

Simplification STC: https://tests.stockfishchess.org/tests/view/6689266e59cb3228a4759b28
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 100320 W: 25913 L: 25763 D: 48644
Ptnml(0-2): 270, 11842, 25750, 12064, 234 

Simplification LTC: https://tests.stockfishchess.org/tests/view/66893103e59d990b103f6ab3
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 57078 W: 14466 L: 14282 D: 28330
Ptnml(0-2): 34, 6214, 15851, 6414, 26

Bench: 1138280