### PR TITLE
Introduction evaluation grain of 16 (and randomize)

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -85,6 +85,9 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     int material = 554 * pos.count<PAWN>() + pos.non_pawn_material();
     v            = (nnue * (73921 + material) + optimism * (8112 + material)) / 73260;
 
+    // Evaluation grain (to get more alpha-beta cuts) with randomization (for robustness) 
+    v = (v / 16) * 16 - 1 + (pos.key() & 0x2);
+
     // Damp down the evaluation linearly when shuffling
     v -= v * pos.rule50_count() / 212;
 


### PR DESCRIPTION
This patch uses an evaluation grain of 16 in order to get more cutoffs in the alpha-beta algorithm. For a discussion of the efficiency of alpha-beta related to changes in the number of discrete values of terminal nodes, see for instance section 9.1.2 of Judea Pearl's classical book "Heuristics" :

https://mat.uab.cat/~alseda/MasterOpt/Judea_Pearl-Heuristics_Intelligent_Search_Strategies_for_Computer_Problem_Solving.pdf

Moreover, we add a small (-1, +1) random component after the quantification to help the search exploration a little bit. This is similar in spirit to the (-1, +1) random component already present in the function draw_value() to make Stockfish more robust in draw evaluations.

passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 220960 W: 57249 L: 56668 D: 107043
Ptnml(0-2): 499, 26017, 56882, 26568, 514
https://tests.stockfishchess.org/tests/view/668907fb7edfb6f233f999f8

passed LTC :
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 48966 W: 12574 L: 12233 D: 24159
Ptnml(0-2): 14, 5233, 13654, 5562, 20
https://tests.stockfishchess.org/tests/view/6689105659cb3228a47598bf

closes https://github.com/official-stockfish/Stockfish/pull/5449

bench: 1336007