### PR TITLE
Tweak LMR at Root

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1192,7 +1192,7 @@ moves_loop:  // When in check, search starts here
         r -= ss->statScore / 10898;
 
         // Step 17. Late moves reduction / extension (LMR, ~117 Elo)
-        if (depth >= 2 && moveCount > 1 + rootNode)
+        if (depth >= 2 && moveCount > 1 + (rootNode && depth < 10))
         {
             // In general we want to cap the LMR depth search at newDepth, but when
             // reduction is negative, we allow this move a limited search extension


### PR DESCRIPTION
Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 328192 W: 84751 L: 84014 D: 159427
Ptnml(0-2): 758, 38802, 84253, 39511, 772 
https://tests.stockfishchess.org/tests/view/6689203959cb3228a4759a49

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 56748 W: 14494 L: 14136 D: 28118
Ptnml(0-2): 19, 6089, 15803, 6441, 22
https://tests.stockfishchess.org/tests/view/66892d76e59d990b103f6626

bench 1074820