### PR TITLE
Adjust usage of previous statscore in bonus assignments.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1379,6 +1379,8 @@ moves_loop:  // When in check, search starts here
                      + 64 * (!ss->inCheck && bestValue <= ss->staticEval - 108)
                      + 153 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 76));
 
+        bonus += std::clamp(-(ss - 1)->statScore / 100, -50, 274);
+
         // Proportional to "how much damage we have to undo"
         if ((ss - 1)->statScore < -7865)
             bonus += std::clamp(-(ss - 1)->statScore / 103, 0, 258);


### PR DESCRIPTION
This patch adjusts usage of previous statscore for bonus assginments - allowing it for any statscores and clamping it to wider range.
Passed STC:
https://tests.stockfishchess.org/tests/view/66892e76e59d990b103f6a91
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 431520 W: 111767 L: 110872 D: 208881
Ptnml(0-2): 1180, 51165, 110133, 52144, 1138 
Passed LTC:
https://tests.stockfishchess.org/tests/view/66897176e59d990b103f9605
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 143184 W: 36463 L: 35929 D: 70792
Ptnml(0-2): 55, 15540, 39863, 16084, 50 
bench 1234390