### PR TITLE
Simplify improving deduction in futility margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -68,7 +68,7 @@ namespace {
 // Futility margin
 Value futility_margin(Depth d, bool noTtCutNode, bool improving, bool oppWorsening) {
     Value futilityMult       = 122 - 37 * noTtCutNode;
-    Value improvingDeduction = 58 * improving * futilityMult / 32;
+    Value improvingDeduction = improving * futilityMult * 2;
     Value worseningDeduction = oppWorsening * futilityMult / 3;
 
     return futilityMult * d - improvingDeduction - worseningDeduction;


### PR DESCRIPTION
Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/668981d4df142e108ffc9bb4
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 312672 W: 80280 L: 80363 D: 152029
Ptnml(0-2): 729, 37198, 80529, 37187, 693

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/668988c6df142e108ffca042
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 126042 W: 31971 L: 31857 D: 62214
Ptnml(0-2): 50, 13988, 34832, 14100, 51

bench 1026642