### PR TITLE
Correct Size of Refutation Moves in Movepick

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -185,7 +185,7 @@ class MovePicker {
     const PieceToHistory**       continuationHistory;
     const PawnHistory*           pawnHistory;
     Move                         ttMove;
-    ExtMove refutations[3], *cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
+    ExtMove refutations[2], *cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
     int     stage;
     int     threshold;
     Depth   depth;


### PR DESCRIPTION
Thanks @MinetaS for the catch

no functional change