### PR TITLE
Fix output for GUI

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -357,9 +357,10 @@ void Search::Worker::iterative_deepening() {
                     break;
 
                 // When failing high/low give some update before a re-search.
-                // To avoid excessive output, only start at rootDepth > 30.
+                // To avoid excessive output that could hang GUIs like Fritz 19, only start
+                // at nodes > 10M (rather than depth N, which can be reached quickly)
                 if (mainThread && multiPV == 1 && (bestValue <= alpha || bestValue >= beta)
-                    && rootDepth > 30)
+                    && nodes > 10000000)
                     main_manager()->pv(*this, threads, tt, rootDepth);
 
                 // In case of failing low/high increase aspiration window and
@@ -390,7 +391,7 @@ void Search::Worker::iterative_deepening() {
             std::stable_sort(rootMoves.begin() + pvFirst, rootMoves.begin() + pvIdx + 1);
 
             if (mainThread
-                && (threads.stop || pvIdx + 1 == multiPV || rootDepth > 30)
+                && (threads.stop || pvIdx + 1 == multiPV || nodes > 10000000)
                 // A thread that aborted search can have mated-in/TB-loss PV and score
                 // that cannot be trusted, i.e. it can be delayed or refuted if we would have
                 // had time to fully search other root-moves. Thus we suppress this output and
@@ -974,7 +975,7 @@ moves_loop:  // When in check, search starts here
 
         ss->moveCount = ++moveCount;
 
-        if (rootNode && is_mainthread() && rootDepth > 30)
+        if (rootNode && is_mainthread() && nodes > 10000000)
         {
             main_manager()->updates.onIter(
               {depth, UCIEngine::move(move, pos.is_chess960()), moveCount + thisThread->pvIdx});


### PR DESCRIPTION
Fritz 19 can hang with the current way to provide output, i.e. too much output in a short time for a mate / depth 245 found quickly.

No functional change