### PR TITLE
Further simplify stat bonuses.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -86,7 +86,7 @@ Value to_corrected_static_eval(Value v, const Worker& w, const Position& pos) {
 }
 
 // History and stats update bonus, based on depth
-int stat_bonus(Depth d) { return std::clamp(190 * d - 298, 20, 1596); }
+int stat_bonus(Depth d) { return std::min(190 * d - 108, 1596); }
 
 // History and stats update malus, based on depth
 int stat_malus(Depth d) { return (d < 4 ? 736 * d - 268 : 2044); }
@@ -1793,7 +1793,7 @@ void update_all_stats(const Position& pos,
     Piece                  moved_piece    = pos.moved_piece(bestMove);
     PieceType              captured;
 
-    int quietMoveBonus = stat_bonus(depth + 1);
+    int quietMoveBonus = stat_bonus(depth);
     int quietMoveMalus = stat_malus(depth);
 
     if (!pos.capture_stage(bestMove))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -131,8 +131,6 @@ void update_all_stats(const Position& pos,
                       Stack*          ss,
                       Search::Worker& workerThread,
                       Move            bestMove,
-                      Value           bestValue,
-                      Value           beta,
                       Square          prevSq,
                       Move*           quietsSearched,
                       int             quietCount,
@@ -1369,7 +1367,7 @@ moves_loop:  // When in check, search starts here
 
     // If there is a move that produces search value greater than alpha we update the stats of searched moves
     else if (bestMove)
-        update_all_stats(pos, ss, *this, bestMove, bestValue, beta, prevSq, quietsSearched,
+        update_all_stats(pos, ss, *this, bestMove, prevSq, quietsSearched,
                          quietCount, capturesSearched, captureCount, depth);
 
     // Bonus for prior countermove that caused the fail low
@@ -1780,8 +1778,6 @@ void update_all_stats(const Position& pos,
                       Stack*          ss,
                       Search::Worker& workerThread,
                       Move            bestMove,
-                      Value           bestValue,
-                      Value           beta,
                       Square          prevSq,
                       Move*           quietsSearched,
                       int             quietCount,
@@ -1798,10 +1794,7 @@ void update_all_stats(const Position& pos,
 
     if (!pos.capture_stage(bestMove))
     {
-        int bestMoveBonus = bestValue > beta + 172 ? quietMoveBonus      // larger bonus
-                                                   : stat_bonus(depth);  // smaller bonus
-
-        update_quiet_stats(pos, ss, workerThread, bestMove, bestMoveBonus);
+        update_quiet_stats(pos, ss, workerThread, bestMove, quietMoveBonus);
 
         // Decrease stats for all non-best quiet moves
         for (int i = 0; i < quietCount; ++i)


### PR DESCRIPTION
Based on recent simplification by @linrock 
Since it completely removed any special bonuses based on values difference and made it flat stat_bonus(depth + 1) I got an idea that we might as well remove all (depth + 1) bonuses and make them usual depth bonuses.
Also removes weird negative bonus for depth 1 as a side effect.
Passed STC:
https://tests.stockfishchess.org/tests/view/6689d817eca84f4d25863746
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 18080 W: 4789 L: 4552 D: 8739
Ptnml(0-2): 46, 1987, 4727, 2244, 36 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6689daa4eca84f4d258639d7
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 109062 W: 27548 L: 27417 D: 54097
Ptnml(0-2): 58, 11983, 30293, 12164, 33 
Passed direct LTC vs linrock patch:
https://tests.stockfishchess.org/tests/view/668a46f8eca84f4d25866fe9
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 100002 W: 25351 L: 25209 D: 49442
Ptnml(0-2): 54, 11119, 27529, 11229, 70 
bench 1325111