### PR TITLE
Fix compilation on Apple

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -68,12 +68,12 @@ namespace Stockfish {
 // does not guarantee the availability of aligned_alloc(). Memory allocated with
 // std_aligned_alloc() must be freed with std_aligned_free().
 void* std_aligned_alloc(size_t alignment, size_t size) {
-    // Apple requires 10.15, which is enforced in the makefile
-#if defined(_ISOC11_SOURCE) || defined(__APPLE__)
+#if defined(_ISOC11_SOURCE)
     return aligned_alloc(alignment, size);
 #elif defined(POSIXALIGNEDALLOC)
-    void* mem;
-    return posix_memalign(&mem, alignment, size) ? nullptr : mem;
+    void* mem = nullptr;
+    posix_memalign(&mem, alignment, size);
+    return mem;
 #elif defined(_WIN32) && !defined(_M_ARM) && !defined(_M_ARM64)
     return _mm_malloc(size, alignment);
 #elif defined(_WIN32)


### PR DESCRIPTION
Always use the posix function posix_memalign() as aligned memory allocator on Apple computers. This should allow to compile Stockfish out of the box on all versions of Mac OS X.

Patch tested on the following systems (apart from the CI) :
  • Mac OS 10.9.6 (arch x86-64-sse41-popcnt) with gcc-10
  • Mac OS 10.13.6 (arch x86-64-bmi2) with gcc-10, gcc-14 and clang-11
  • Mac OS 14.1.1 (arch apple-silicon) with clang-15

closes https://github.com/official-stockfish/Stockfish/pull/5462

No functional change