### PR TITLE
Simplify Probcut Malus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -863,8 +863,6 @@ Value Search::Worker::search(
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
         MovePicker mp(pos, ttData.move, probCutBeta - ss->staticEval, &thisThread->captureHistory);
-        Move       probcutCapturesSearched[32];
-        int        probcutCaptureCount = 0;
         Piece      captured;
 
         while ((move = mp.next_move()) != Move::none())
@@ -902,25 +900,12 @@ Value Search::Worker::search(
                     thisThread->captureHistory[movedPiece][move.to_sq()][type_of(captured)]
                       << stat_bonus(depth - 2);
 
-                    for (int i = 0; i < probcutCaptureCount; i++)
-                    {
-                        movedPiece = pos.moved_piece(probcutCapturesSearched[i]);
-                        captured   = pos.piece_on(probcutCapturesSearched[i].to_sq());
-
-                        thisThread->captureHistory[movedPiece][probcutCapturesSearched[i].to_sq()]
-                                                  [type_of(captured)]
-                          << -stat_malus(depth - 3);
-                    }
-
                     // Save ProbCut data into transposition table
                     ttWriter.write(posKey, value_to_tt(value, ss->ply), ss->ttPv, BOUND_LOWER,
                                    depth - 3, move, unadjustedStaticEval, tt.generation());
                     return std::abs(value) < VALUE_TB_WIN_IN_MAX_PLY ? value - (probCutBeta - beta)
                                                                      : value;
                 }
-
-                if (probcutCaptureCount < 32)
-                    probcutCapturesSearched[probcutCaptureCount++] = move;
             }
 
         Eval::NNUE::hint_common_parent_position(pos, networks[numaAccessToken], refreshTable);


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 74880 W: 19261 L: 19083 D: 36536
Ptnml(0-2): 202, 8861, 19120, 9071, 186 
https://tests.stockfishchess.org/tests/view/668a0966eca84f4d25864cba

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 263916 W: 66690 L: 66718 D: 130508
Ptnml(0-2): 125, 29348, 73040, 29320, 125 
https://tests.stockfishchess.org/tests/view/668a17e3eca84f4d25864e91

bench 1300177