### PR TITLE
removed second killer move

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -160,7 +160,7 @@ class MovePicker {
                const CapturePieceToHistory*,
                const PieceToHistory**,
                const PawnHistory*,
-               const Move*);
+               Move);
     MovePicker(const Position&,
                Move,
                Depth,
@@ -185,7 +185,7 @@ class MovePicker {
     const PieceToHistory**       continuationHistory;
     const PawnHistory*           pawnHistory;
     Move                         ttMove;
-    ExtMove refutations[2], *cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
+    ExtMove refutation, *cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
     int     stage;
     int     threshold;
     Depth   depth;

--- a/src/search.h
+++ b/src/search.h
@@ -65,7 +65,7 @@ struct Stack {
     int             ply;
     Move            currentMove;
     Move            excludedMove;
-    Move            killers[2];
+    Move            killer;
     Value           staticEval;
     int             statScore;
     int             moveCount;


### PR DESCRIPTION
We have a singular killer move, and we clear ply + 1 killers instead of ply + 2.

Passed STC:
https://tests.stockfishchess.org/tests/view/668b17d2cf91c430fca58630
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 468896 W: 120999 L: 120054 D: 227843
Ptnml(0-2): 1207, 55209, 120639, 56218, 1175

Passed Non-Reg LTC:
https://tests.stockfishchess.org/tests/view/668b2e04cf91c430fca586b1
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 550524 W: 139553 L: 139877 D: 271094
Ptnml(0-2): 333, 61646, 151616, 61346, 321

bench 1097251