### PR TITLE
removed second killer move

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -91,14 +91,14 @@ MovePicker::MovePicker(const Position&              p,
                        const CapturePieceToHistory* cph,
                        const PieceToHistory**       ch,
                        const PawnHistory*           ph,
-                       const Move*                  killers) :
+                       Move                         killer) :
     pos(p),
     mainHistory(mh),
     captureHistory(cph),
     continuationHistory(ch),
     pawnHistory(ph),
     ttMove(ttm),
-    refutations{{killers[0], 0}, {killers[1], 0}},
+    killer{killer, 0},
     depth(d) {
     assert(d > 0);
 
@@ -267,11 +267,6 @@ top:
                                                           : (*endBadCaptures++ = *cur, false);
             }))
             return *(cur - 1);
-
-        // Prepare the pointers to loop over the refutations array
-        cur      = std::begin(refutations);
-        endMoves = std::end(refutations);
-
         ++stage;
         [[fallthrough]];
 
@@ -279,7 +274,7 @@ top:
         if (select<Next>([&]() {
                 return *cur != Move::none() && !pos.capture_stage(*cur) && pos.pseudo_legal(*cur);
             }))
-            return *(cur - 1);
+            return killer;
         ++stage;
         [[fallthrough]];
 
@@ -297,8 +292,7 @@ top:
         [[fallthrough]];
 
     case GOOD_QUIET :
-        if (!skipQuiets
-            && select<Next>([&]() { return *cur != refutations[0] && *cur != refutations[1]; }))
+        if (!skipQuiets && select<Next>([&]() { return *cur != killer; }))
         {
             if ((cur - 1)->value > -7998 || (cur - 1)->value <= quiet_threshold(depth))
                 return *(cur - 1);
@@ -327,7 +321,7 @@ top:
 
     case BAD_QUIET :
         if (!skipQuiets)
-            return select<Next>([&]() { return *cur != refutations[0] && *cur != refutations[1]; });
+            return select<Next>([&]() { return *cur != killer; });
 
         return Move::none();
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -160,7 +160,7 @@ class MovePicker {
                const CapturePieceToHistory*,
                const PieceToHistory**,
                const PawnHistory*,
-               const Move*);
+               Move);
     MovePicker(const Position&,
                Move,
                Depth,
@@ -185,7 +185,7 @@ class MovePicker {
     const PieceToHistory**       continuationHistory;
     const PawnHistory*           pawnHistory;
     Move                         ttMove;
-    ExtMove refutations[2], *cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
+    ExtMove killer, *cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
     int     stage;
     int     threshold;
     Depth   depth;

--- a/src/search.h
+++ b/src/search.h
@@ -65,7 +65,7 @@ struct Stack {
     int             ply;
     Move            currentMove;
     Move            excludedMove;
-    Move            killers[2];
+    Move            killer;
     Value           staticEval;
     int             statScore;
     int             moveCount;


### PR DESCRIPTION
We have a singular killer move, and we clear ply + 1 killers instead of ply + 2.

Passed STC:
https://tests.stockfishchess.org/tests/view/668b17d2cf91c430fca58630
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 468896 W: 120999 L: 120054 D: 227843
Ptnml(0-2): 1207, 55209, 120639, 56218, 1175

Passed Non-Reg LTC:
https://tests.stockfishchess.org/tests/view/668b2e04cf91c430fca586b1
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 550524 W: 139553 L: 139877 D: 271094
Ptnml(0-2): 333, 61646, 151616, 61346, 321

bench 1097251