### PR TITLE
removed second killer move

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -160,7 +160,7 @@ class MovePicker {
                const CapturePieceToHistory*,
                const PieceToHistory**,
                const PawnHistory*,
-               const Move*);
+               Move);
     MovePicker(const Position&,
                Move,
                Depth,
@@ -185,7 +185,7 @@ class MovePicker {
     const PieceToHistory**       continuationHistory;
     const PawnHistory*           pawnHistory;
     Move                         ttMove;
-    ExtMove refutations[2], *cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
+    ExtMove killer, *cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
     int     stage;
     int     threshold;
     Depth   depth;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -122,7 +122,7 @@ Value value_to_tt(Value v, int ply);
 Value value_from_tt(Value v, int ply, int r50c);
 void  update_pv(Move* pv, Move move, const Move* childPv);
 void  update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus);
-void  update_refutations(Stack* ss, Move move);
+void  update_killer(Stack* ss, Move move);
 void  update_quiet_histories(
    const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus);
 void update_quiet_stats(
@@ -605,9 +605,9 @@ Value Search::Worker::search(
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
-    bestMove             = Move::none();
-    (ss + 2)->killers[0] = (ss + 2)->killers[1] = Move::none();
-    (ss + 2)->cutoffCnt                         = 0;
+    bestMove            = Move::none();
+    (ss + 1)->killer    = Move::none();
+    (ss + 2)->cutoffCnt = 0;
     Square prevSq = ((ss - 1)->currentMove).is_ok() ? ((ss - 1)->currentMove).to_sq() : SQ_NONE;
     ss->statScore = 0;
 
@@ -933,7 +933,7 @@ moves_loop:  // When in check, search starts here
 
 
     MovePicker mp(pos, ttData.move, depth, &thisThread->mainHistory, &thisThread->captureHistory,
-                  contHist, &thisThread->pawnHistory, ss->killers);
+                  contHist, &thisThread->pawnHistory, ss->killer);
 
     value            = bestValue;
     moveCountPruning = false;
@@ -1153,7 +1153,7 @@ moves_loop:  // When in check, search starts here
         // Increase reduction for cut nodes (~4 Elo)
         if (cutNode)
             r += 2 - (ttData.depth >= depth && ss->ttPv)
-               + (!ss->ttPv && move != ttData.move && move != ss->killers[0]);
+               + (!ss->ttPv && move != ttData.move && move != ss->killer);
 
         // Increase reduction if ttMove is a capture (~3 Elo)
         if (ttCapture)
@@ -1796,7 +1796,7 @@ void update_all_stats(const Position& pos,
     // main killer move in previous ply when it gets refuted.
     if (prevSq != SQ_NONE
         && ((ss - 1)->moveCount == 1 + (ss - 1)->ttHit
-            || ((ss - 1)->currentMove == (ss - 1)->killers[0]))
+            || ((ss - 1)->currentMove == (ss - 1)->killer))
         && !pos.captured_piece())
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq, -quietMoveMalus);
 
@@ -1827,14 +1827,10 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
 }
 
 // Updates move sorting heuristics
-void update_refutations(Stack* ss, Move move) {
+void update_killer(Stack* ss, Move move) {
 
     // Update killers
-    if (ss->killers[0] != move)
-    {
-        ss->killers[1] = ss->killers[0];
-        ss->killers[0] = move;
-    }
+    ss->killer = move;
 }
 
 void update_quiet_histories(
@@ -1853,7 +1849,7 @@ void update_quiet_histories(
 void update_quiet_stats(
   const Position& pos, Stack* ss, Search::Worker& workerThread, Move move, int bonus) {
 
-    update_refutations(ss, move);
+    update_killer(ss, move);
     update_quiet_histories(pos, ss, workerThread, move, bonus);
 }
 

--- a/src/search.h
+++ b/src/search.h
@@ -65,7 +65,7 @@ struct Stack {
     int             ply;
     Move            currentMove;
     Move            excludedMove;
-    Move            killers[2];
+    Move            killer;
     Value           staticEval;
     int             statScore;
     int             moveCount;


### PR DESCRIPTION
Removed second killer move and refactored movepicker

STC with movepicker rewrite:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 46656 W: 12208 L: 11995 D: 22453
Ptnml(0-2): 203, 5461, 11777, 5694, 193
https://tests.stockfishchess.org/tests/view/668d98a15034141ae5999e68

Dirty removal STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 468896 W: 120999 L: 120054 D: 227843
Ptnml(0-2): 1207, 55209, 120639, 56218, 1175
https://tests.stockfishchess.org/tests/view/668b17d2cf91c430fca58630

Dirty removal LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 550524 W: 139553 L: 139877 D: 271094
Ptnml(0-2): 333, 61646, 151616, 61346, 321
https://tests.stockfishchess.org/tests/view/668b2e04cf91c430fca586b1

bench 1234309