### PR TITLE
Fixed non UCI compliance

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Alexander Kure
 Alexander Pagel (Lolligerhans)
 Alfredo Menezes (lonfom169)
 Ali AlZhrani (Cooffe)
+Andreas Jan van der Meulen (Andyson007)
 Andreas Matthies (Matthies)
 Andrei Vetrov (proukornew)
 Andrew Grant (AndyGrant)

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -93,7 +93,7 @@ Engine::Engine(std::string path) :
     options["UCI_LimitStrength"] << Option(false);
     options["UCI_Elo"] << Option(1320, 1320, 3190);
     options["UCI_ShowWDL"] << Option(false);
-    options["SyzygyPath"] << Option("<empty>", [](const Option& o) {
+    options["SyzygyPath"] << Option("", [](const Option& o) {
         Tablebases::init(o);
         return std::nullopt;
     });

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1344,7 +1344,7 @@ void Tablebases::init(const std::string& paths) {
     MaxCardinality = 0;
     TBFile::Paths  = paths;
 
-    if (paths.empty() || paths == "<empty>")
+    if (paths.empty())
         return;
 
     // MapB1H1H7[] encodes a square below a1-h8 diagonal to 0..27

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -193,7 +193,7 @@ std::ostream& operator<<(std::ostream& os, const OptionsMap& om) {
 
                 if (o.type == "string")
                 {
-                    std::string defaultValue = o.defaultValue == "" ? "<empty>" : o.defaultValue;
+                    std::string defaultValue = o.defaultValue.empty() ? "<empty>" : o.defaultValue;
                     os << " default " << o.defaultValue;
                 }
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -188,8 +188,14 @@ std::ostream& operator<<(std::ostream& os, const OptionsMap& om) {
                 const Option& o = it.second;
                 os << "\noption name " << it.first << " type " << o.type;
 
-                if (o.type == "string" || o.type == "check" || o.type == "combo")
+                if (o.type == "check" || o.type == "combo")
                     os << " default " << o.defaultValue;
+
+                if (o.type == "string")
+                {
+                    std::string defaultValue = o.defaultValue == "" ? "<empty>" : o.defaultValue;
+                    os << " default " << o.defaultValue;
+                }
 
                 if (o.type == "spin")
                     os << " default " << int(stof(o.defaultValue)) << " min " << o.min << " max "

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -166,7 +166,9 @@ Option& Option::operator=(const std::string& v) {
             return *this;
     }
 
-    if (type != "button")
+    if (type == "string")
+        currentValue = v == "<empty>" ? "" : v;
+    else if (type != "button")
         currentValue = v;
 
     if (on_change)

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -194,7 +194,7 @@ std::ostream& operator<<(std::ostream& os, const OptionsMap& om) {
                 if (o.type == "string")
                 {
                     std::string defaultValue = o.defaultValue.empty() ? "<empty>" : o.defaultValue;
-                    os << " default " << o.defaultValue;
+                    os << " default " << defaultValue;
                 }
 
                 if (o.type == "spin")

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -191,13 +191,13 @@ std::ostream& operator<<(std::ostream& os, const OptionsMap& om) {
                 if (o.type == "check" || o.type == "combo")
                     os << " default " << o.defaultValue;
 
-                if (o.type == "string")
+                else if (o.type == "string")
                 {
                     std::string defaultValue = o.defaultValue.empty() ? "<empty>" : o.defaultValue;
                     os << " default " << defaultValue;
                 }
 
-                if (o.type == "spin")
+                else if (o.type == "spin")
                     os << " default " << int(stof(o.defaultValue)) << " min " << o.min << " max "
                        << o.max;
 


### PR DESCRIPTION
UCI options now print `<empty>` instead of an empty string. and defaulted `SyzygyPath` to an empty string instead of `<empty>`

Fixes #5473 