### PR TITLE
Simplify Away Killer Stage

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -184,12 +184,12 @@ class MovePicker {
     const CapturePieceToHistory* captureHistory;
     const PieceToHistory**       continuationHistory;
     const PawnHistory*           pawnHistory;
-    Move                         ttMove;
-    ExtMove killer, *cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
-    int     stage;
-    int     threshold;
-    Depth   depth;
-    ExtMove moves[MAX_MOVES];
+    Move                         ttMove, killer;
+    ExtMove *                    cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
+    int                          stage;
+    int                          threshold;
+    Depth                        depth;
+    ExtMove                      moves[MAX_MOVES];
 };
 
 }  // namespace Stockfish


### PR DESCRIPTION
Simplify away killer stage to a constant bonus given to the killer move during quiet move scoring.

Passed Non-regression STC (Against then-pending PR #5472):
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 106176 W: 27685 L: 27539 D: 50952
Ptnml(0-2): 410, 12765, 26637, 12821, 455 
https://tests.stockfishchess.org/tests/view/668dd0835034141ae5999e8f

Passed Non-regression LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 92472 W: 23426 L: 23276 D: 45770
Ptnml(0-2): 55, 10376, 25215, 10544, 46 
https://tests.stockfishchess.org/tests/view/669019e45034141ae5999fd2

bench 1459677