### PR TITLE
Unify Movepick Constructor

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -99,29 +99,12 @@ MovePicker::MovePicker(const Position&              p,
     ttMove(ttm),
     killer{km, 0},
     depth(d) {
-    assert(d > 0);
 
-    stage = (pos.checkers() ? EVASION_TT : MAIN_TT) + !(ttm && pos.pseudo_legal(ttm));
-}
+    if (pos.checkers())
+        stage = EVASION_TT + !(ttm && pos.pseudo_legal(ttm));
 
-// Constructor for quiescence search
-MovePicker::MovePicker(const Position&              p,
-                       Move                         ttm,
-                       Depth                        d,
-                       const ButterflyHistory*      mh,
-                       const CapturePieceToHistory* cph,
-                       const PieceToHistory**       ch,
-                       const PawnHistory*           ph) :
-    pos(p),
-    mainHistory(mh),
-    captureHistory(cph),
-    continuationHistory(ch),
-    pawnHistory(ph),
-    ttMove(ttm),
-    depth(d) {
-    assert(d <= 0);
-
-    stage = (pos.checkers() ? EVASION_TT : QSEARCH_TT) + !(ttm && pos.pseudo_legal(ttm));
+    else
+        stage = (depth > 0 ? MAIN_TT : QSEARCH_TT) + !(ttm && pos.pseudo_legal(ttm));
 }
 
 // Constructor for ProbCut: we generate captures with SEE greater than or equal

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -160,14 +160,7 @@ class MovePicker {
                const CapturePieceToHistory*,
                const PieceToHistory**,
                const PawnHistory*,
-               Move);
-    MovePicker(const Position&,
-               Move,
-               Depth,
-               const ButterflyHistory*,
-               const CapturePieceToHistory*,
-               const PieceToHistory**,
-               const PawnHistory*);
+               Move killer = Move::none());
     MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
     Move next_move(bool skipQuiets = false);
 


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 168704 W: 43524 L: 43455 D: 81725
Ptnml(0-2): 414, 17173, 49076, 17308, 381 
https://tests.stockfishchess.org/tests/view/66904b7b5034141ae599a197

Passed Non-regression LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 120294 W: 30473 L: 30364 D: 59457
Ptnml(0-2): 40, 10974, 38032, 11039, 62 
https://tests.stockfishchess.org/tests/view/66905b235034141ae599a223

bench 1234309