### PR TITLE
Simplify futility_move_count

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -75,7 +75,7 @@ Value futility_margin(Depth d, bool noTtCutNode, bool improving, bool oppWorseni
 }
 
 constexpr int futility_move_count(bool improving, Depth depth) {
-    return improving ? (3 + depth * depth) : (3 + depth * depth) / 2;
+    return (3 + depth * depth) / (2 - improving);
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation


### PR DESCRIPTION
This patch reverts changes from #4032 which was introduced as a speedup. Modern compilers no longer use DIV/IDIV instructions, potentially making the explicit branch perform worse. Since evaluations spend significantly more time now, the impact of the speedup in search diminishes with old compilers as well.

GCC 14.1.0 profile-build, x86-64-vnni512
```
.text:000000014010FEA9                 mov     ecx, [rsp+3FB8h+var_3F5C]
...
.text:000000014010FEBD                 mov     r10d, ecx
.text:000000014010FEC0                 imul    r10d, ecx
.text:000000014010FEC4                 mov     ecx, dword ptr [rsp+3FB8h+var_3F44+4]
.text:000000014010FEC8                 add     r10d, 3
.text:000000014010FECC                 mov     r11d, r10d
.text:000000014010FECF                 sar     r11d, 1
.text:000000014010FED2                 cmp     [rsp+3FB8h+var_3EE7], 0
.text:000000014010FEDA                 cmovnz  r11d, r10d
```

LLVM 18.1.18 profile-build, x86-64-vnni512
```
.text:0000000140001EDC                 mov     [rsp+40h+arg_E0], r13
.text:0000000140001EE4                 movsxd  rcx, r13d
.text:0000000140001EE7                 mov     rax, rcx
.text:0000000140001EEA                 mov     [rsp+40h+arg_B8], rcx
.text:0000000140001EF2                 imul    eax, eax
.text:0000000140001EF5                 add     eax, 3
.text:0000000140001EF8                 mov     ecx, [rsp+40h+arg_8C]
.text:0000000140001EFF                 shrx    eax, eax, ecx
.text:0000000140001F04                 mov     [rsp+40h+arg_190], rax
```

Passed non-regression STC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 109504 W: 28420 L: 28280 D: 52804
Ptnml(0-2): 355, 12326, 29273, 12420, 378
https://tests.stockfishchess.org/tests/view/6690dc095034141ae599c5fe

No functional changes