### PR TITLE
Decrease delta.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -320,7 +320,7 @@ void Search::Worker::iterative_deepening() {
 
             // Reset aspiration window starting size
             Value avg = rootMoves[pvIdx].averageScore;
-            delta     = 9 + avg * avg / 10424;
+            delta     = 5 + avg * avg / 13424;
             alpha     = std::max(avg - delta, -VALUE_INFINITE);
             beta      = std::min(avg + delta, VALUE_INFINITE);
 


### PR DESCRIPTION
Decrease delta in aspiration windows - both initial value and quadratic function of previous best value.
Passed STC:
https://tests.stockfishchess.org/tests/view/6691a52ec6827afcdcee1569
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 55456 W: 14449 L: 14107 D: 26900
Ptnml(0-2): 174, 6416, 14193, 6784, 161 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6691aac1c6827afcdcee1625
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 107940 W: 27530 L: 27065 D: 53345
Ptnml(0-2): 52, 11787, 29840, 12226, 65 
bench 1243934