### PR TITLE
Set best value to futility value after pruned quiet move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1035,7 +1035,7 @@ moves_loop:  // When in check, search starts here
                 {
                     if (bestValue <= futilityValue && std::abs(bestValue) < VALUE_TB_WIN_IN_MAX_PLY
                         && futilityValue < VALUE_TB_WIN_IN_MAX_PLY)
-                        bestValue = (bestValue + futilityValue * 3) / 4;
+                        bestValue = futilityValue;
                     continue;
                 }
 


### PR DESCRIPTION
Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/6691592f5034141ae599c68d
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 278496 W: 71818 L: 71865 D: 134813
Ptnml(0-2): 865, 33311, 70978, 33194, 900

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/66918fca5034141ae599e761
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 202986 W: 51048 L: 51013 D: 100925
Ptnml(0-2): 107, 22552, 56133, 22601, 100

bench 1386580