### PR TITLE
Change "!cutNode" condition to directly "false"

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -809,7 +809,7 @@ Value Search::Worker::search(
 
         pos.do_null_move(st, tt);
 
-        Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, !cutNode);
+        Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);
 
         pos.undo_null_move();
 


### PR DESCRIPTION
Change "!cutNode" condition to directly "false".
Can we consider this a simplification? it should do one less condition check, similar to when we remove a condition from a formula.

Passed STC non-reg bounds:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 78112 W: 20174 L: 20001 D: 37937
Ptnml(0-2): 222, 9118, 20194, 9309, 213
https://tests.stockfishchess.org/tests/view/6691d519c6827afcdcee19f3

Passed LTC non-reg bounds:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 62112 W: 15716 L: 15536 D: 30860
Ptnml(0-2): 35, 6850, 17098, 7046, 27
https://tests.stockfishchess.org/tests/view/6691d769c6827afcdcee1a28

bench: 1244746