### PR TITLE
Introduce a new term to the bonus calculation for prior countermoves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1364,12 +1364,13 @@ moves_loop:  // When in check, search starts here
     // Bonus for prior countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
     {
-        int bonus = (114 * (depth > 5) + 116 * (PvNode || cutNode) + 123 * ((ss - 1)->moveCount > 8)
-                     + 64 * (!ss->inCheck && bestValue <= ss->staticEval - 108)
-                     + 153 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 76));
+        int bonus = (138 * (depth > 5) + 58 * (PvNode || cutNode) + 160 * ((ss - 1)->moveCount > 8)
+                     + 84 * (!ss->inCheck && bestValue <= ss->staticEval - 108)
+                     + 153 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 76)
+                     + 32  *  (!(ss - 1)->inCheck && bestValue > -(ss - 1)->staticEval + 76));
 
         // Proportional to "how much damage we have to undo"
-        bonus += std::clamp(-(ss - 1)->statScore / 100, -50, 274);
+        bonus += std::clamp(-(ss - 1)->statScore / 100, -64, 300);
 
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       stat_bonus(depth) * bonus / 100);


### PR DESCRIPTION
Introduce a new term to the bonus calculation for prior countermoves

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 140896 W: 36545 L: 36079 D: 68272
Ptnml(0-2): 383, 16505, 36217, 16949, 394
https://tests.stockfishchess.org/tests/view/6691c73cc6827afcdcee1816

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 126660 W: 32089 L: 31587 D: 62984
Ptnml(0-2): 63, 13774, 35154, 14276, 63
https://tests.stockfishchess.org/tests/view/6691cdc4c6827afcdcee1930

bench: 1411310