### PR TITLE
Remove quiet history pruning depth limit

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1020,7 +1020,7 @@ moves_loop:  // When in check, search starts here
                   + thisThread->pawnHistory[pawn_structure_index(pos)][movedPiece][move.to_sq()];
 
                 // Continuation history based pruning (~2 Elo)
-                if (lmrDepth < 6 && history < -4165 * depth)
+                if (history < -4165 * depth)
                     continue;
 
                 history += 2 * thisThread->mainHistory[us][move.from_to()];


### PR DESCRIPTION
This patch removes lmrDepth limit for quiet moves history based pruning.
Previously removal of this type of depth limits was considered bad because it was performing bad for matetrack - but with this pruning heuristic this shouldn't be that bad because it's "naturally" depth limited by history threshold and should be completely disabled at depth >= 15 or so.
Also this heuristic in previous years was known to scale non-linearly - bigger lmrDepth thresholds were better at longer time controls and removing it completely probably should scale pretty well.
Passed STC:
https://tests.stockfishchess.org/tests/view/6692b89b4ff211be9d4eab21
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 114464 W: 29675 L: 29545 D: 55244
Ptnml(0-2): 372, 12516, 31329, 12640, 375 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6692c4554ff211be9d4eab3d
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 67746 W: 17182 L: 17014 D: 33550
Ptnml(0-2): 28, 6993, 19652, 7183, 17 
bench 1279324