### PR TITLE
Separate eval params for smallnet and main net

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -79,11 +79,11 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     }
 
     // Blend optimism and eval with nnue complexity
-    optimism += optimism * nnueComplexity / 457;
-    nnue -= nnue * nnueComplexity / 19157;
+    optimism += optimism * nnueComplexity / (smallNet ? 433 : 453);
+    nnue -= nnue * nnueComplexity / (smallNet ? 18815 : 17864);
 
-    int material = 554 * pos.count<PAWN>() + pos.non_pawn_material();
-    v            = (nnue * (73921 + material) + optimism * (8112 + material)) / 73260;
+    int material = (smallNet ? 553 : 532) * pos.count<PAWN>() + pos.non_pawn_material();
+    v = (nnue * (73921 + material) + optimism * (8112 + material)) / (smallNet ? 68104 : 74715);
 
     // Evaluation grain (to get more alpha-beta cuts) with randomization (for robustness)
     v = (v / 16) * 16 - 1 + (pos.key() & 0x2);


### PR DESCRIPTION
Values found with spsa around 80% of 120k games at 60+0.6: https://tests.stockfishchess.org/tests/view/669205dac6827afcdcee3ea4

Passed STC:
https://tests.stockfishchess.org/tests/view/6692928b4ff211be9d4e98a9
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 313696 W: 81107 L: 80382 D: 152207
Ptnml(0-2): 934, 36942, 80363, 37683, 926

Passed LTC:
https://tests.stockfishchess.org/tests/view/6692aab54ff211be9d4e9915
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 228420 W: 57903 L: 57190 D: 113327
Ptnml(0-2): 131, 25003, 63243, 25688, 145

bench 1251217