### PR TITLE
Linearize corrHist application (again)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -82,7 +82,7 @@ constexpr int futility_move_count(bool improving, Depth depth) {
 // does not hit the tablebase range.
 Value to_corrected_static_eval(Value v, const Worker& w, const Position& pos) {
     auto cv = w.correctionHistory[pos.side_to_move()][pawn_structure_index<Correction>(pos)];
-    v += cv * std::abs(cv) / 5073;
+    v += 66 * cv / 512;
     return std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
 }
 


### PR DESCRIPTION
Passed STC: https://tests.stockfishchess.org/tests/view/66919cdec6827afcdcee146f
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 130656 W: 33579 L: 33461 D: 63616
Ptnml(0-2): 394, 15548, 33318, 15682, 386

Passed VVLTC: https://tests.stockfishchess.org/tests/view/6691acb2c6827afcdcee1645
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 160314 W: 40925 L: 40854 D: 78535
Ptnml(0-2): 12, 14754, 50551, 14831, 9

Rumors of nonstandard scaling were premature

bench 1687659