### PR TITLE
Try nullmoves only on cutnodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -794,7 +794,7 @@ Value Search::Worker::search(
         return beta + (eval - beta) / 3;
 
     // Step 9. Null move search with verification search (~35 Elo)
-    if (!PvNode && (ss - 1)->currentMove != Move::null() && (ss - 1)->statScore < 14389
+    if (cutNode && (ss - 1)->currentMove != Move::null() && (ss - 1)->statScore < 14389
         && eval >= beta && ss->staticEval >= beta - 21 * depth + 390 && !excludedMove
         && pos.non_pawn_material(us) && ss->ply >= thisThread->nmpMinPly
         && beta > VALUE_TB_LOSS_IN_MAX_PLY)
@@ -809,7 +809,7 @@ Value Search::Worker::search(
 
         pos.do_null_move(st, tt);
 
-        Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, !cutNode);
+        Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);
 
         pos.undo_null_move();
 


### PR DESCRIPTION
This is a more correct form of PR #5482
since master only tries nullmoves on cutNodes already with 99.0224% of the cases running bench, We can try null moves at 100% of cutNodes and achieve such simplification as non-functional to any definition, by making passing false already equivalent to passing !cutNode

Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/66941c044ff211be9d4ebf5f
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 153216 W: 39856 L: 39764 D: 73596
Ptnml(0-2): 590, 18174, 38979, 18284, 581

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/6694e5cd4ff211be9d4ebfdf
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 67842 W: 17178 L: 17004 D: 33660
Ptnml(0-2): 52, 7437, 18759, 7631, 42

bench: 1706617