### PR TITLE
Simplify improving condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -713,7 +713,7 @@ Value Search::Worker::search(
     if (ss->inCheck)
     {
         // Skip early pruning when in check
-        ss->staticEval = eval = VALUE_NONE;
+        ss->staticEval = eval = (ss-2)->staticEval;
         improving             = false;
         goto moves_loop;
     }
@@ -764,12 +764,9 @@ Value Search::Worker::search(
 
     // Set up the improving flag, which is true if current static evaluation is
     // bigger than the previous static evaluation at our turn (if we were in
-    // check at our previous move we look at static evaluation at move prior to it
-    // and if we were in check at move prior to it flag is set to true) and is
+    // check at our previous move we go back until we weren't in check) and is
     // false otherwise. The improving flag is used in various pruning heuristics.
-    improving = (ss - 2)->staticEval != VALUE_NONE
-                ? ss->staticEval > (ss - 2)->staticEval
-                : (ss - 4)->staticEval != VALUE_NONE && ss->staticEval > (ss - 4)->staticEval;
+    improving = ss->staticEval > (ss - 2)->staticEval;
 
     opponentWorsening = ss->staticEval + (ss - 1)->staticEval > 2;
 


### PR DESCRIPTION
if we were in check at our previous move we go back until we weren't in check and take the staticEval of that position as reference.

https://tests.stockfishchess.org/tests/view/668ba7b65034141ae5996665
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 74784 W: 19454 L: 19274 D: 36056
Ptnml(0-2): 260, 8874, 18952, 9038, 268
sprt @ 10+0.1 th 1

https://tests.stockfishchess.org/tests/view/668cb2db5034141ae599678b
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 241488 W: 61166 L: 61171 D: 119151
Ptnml(0-2): 190, 27154, 66062, 27147, 191
sprt @ 60+0.6 th 1

P.S.: Having always a valid staticEval in the stack (except plies under rootpos) we possibly could simplify other conditions as well.

bench: 1368313