### PR TITLE
Avoid calculating nnue complexity twice

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -66,19 +66,18 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     auto [psqt, positional] = smallNet ? networks.small.evaluate(pos, &caches.small)
                                        : networks.big.evaluate(pos, &caches.big);
 
-    Value nnue           = (125 * psqt + 131 * positional) / 128;
-    int   nnueComplexity = std::abs(psqt - positional);
+    Value nnue = (125 * psqt + 131 * positional) / 128;
 
     // Re-evaluate the position when higher eval accuracy is worth the time spent
     if (smallNet && (nnue * simpleEval < 0 || std::abs(nnue) < 227))
     {
         std::tie(psqt, positional) = networks.big.evaluate(pos, &caches.big);
         nnue                       = (125 * psqt + 131 * positional) / 128;
-        nnueComplexity             = std::abs(psqt - positional);
         smallNet                   = false;
     }
 
     // Blend optimism and eval with nnue complexity
+    int nnueComplexity = std::abs(psqt - positional);
     optimism += optimism * nnueComplexity / (smallNet ? 433 : 453);
     nnue -= nnue * nnueComplexity / (smallNet ? 18815 : 17864);
 


### PR DESCRIPTION
Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/6697459d4ff211be9d4ec236
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 146848 W: 38289 L: 38189 D: 70370
Ptnml(0-2): 503, 16665, 39046, 16649, 561

No functional change