### PR TITLE
Adjust bonus to move that caused a fail low

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1371,7 +1371,9 @@ moves_loop:  // When in check, search starts here
                      + 32 * (!(ss - 1)->inCheck && bestValue > -(ss - 1)->staticEval + 76));
 
         // Proportional to "how much damage we have to undo"
-        bonus += std::clamp(-(ss - 1)->statScore / 100, -64, 300);
+        bonus += std::clamp(-(ss - 1)->statScore / 100, -94, 300);
+
+        bonus = std::max(bonus, 0);
 
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       stat_bonus(depth) * bonus / 100);


### PR DESCRIPTION
This is an elo gainer and simultaneously a minor logical fix to bonuses that caused a fail low.
It increases maximum of statscore based subtraction - but disallows negative bonuses.
This patch has a conflict with https://github.com/official-stockfish/Stockfish/pull/5491
Despite latter being effectively a simplification and this one actually adds code I think this one is more desirable to be merged because it fixes a logical oversight of having negative bonuses possible there - which makes absolutely no sense. Since simplification in PR is so strong it's probably going to pass on top of current patch anyway.
Passed STC:
https://tests.stockfishchess.org/tests/view/66955e6f4ff211be9d4ec063
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 44640 W: 11805 L: 11472 D: 21363
Ptnml(0-2): 166, 5178, 11335, 5439, 202 
Passed LTC:
https://tests.stockfishchess.org/tests/view/66963fde4ff211be9d4ec190
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 72288 W: 18478 L: 18082 D: 35728
Ptnml(0-2): 50, 7919, 19825, 8285, 65 
bench 1639629