### PR TITLE
Adding LowestElo and HighestElo constants

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -91,7 +91,7 @@ Engine::Engine(std::string path) :
     options["nodestime"] << Option(0, 0, 10000);
     options["UCI_Chess960"] << Option(false);
     options["UCI_LimitStrength"] << Option(false);
-    options["UCI_Elo"] << Option(Skill::LowestElo, Skill::LowestElo, Skill::HighestElo);
+    options["UCI_Elo"] << Option(Search::Skill::LowestElo, Search::Skill::LowestElo, Search::Skill::HighestElo);
     options["UCI_ShowWDL"] << Option(false);
     options["SyzygyPath"] << Option("", [](const Option& o) {
         Tablebases::init(o);

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -91,7 +91,7 @@ Engine::Engine(std::string path) :
     options["nodestime"] << Option(0, 0, 10000);
     options["UCI_Chess960"] << Option(false);
     options["UCI_LimitStrength"] << Option(false);
-    options["UCI_Elo"] << Option(1320, 1320, 3190);
+    options["UCI_Elo"] << Option(Skill::LowestElo, Skill::LowestElo, Skill::HighestElo);
     options["UCI_ShowWDL"] << Option(false);
     options["SyzygyPath"] << Option("", [](const Option& o) {
         Tablebases::init(o);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -102,10 +102,12 @@ Value value_draw(size_t nodes) { return VALUE_DRAW - 1 + Value(nodes & 0x2); }
 // Skill 0 .. 19 now covers CCRL Blitz Elo from 1320 to 3190, approximately
 // Reference: https://github.com/vondele/Stockfish/commit/a08b8d4e9711c2
 struct Skill {
+    static constexpr int LowestElo = 1320;
+    static constexpr int HighestElo = 3190;
     Skill(int skill_level, int uci_elo) {
         if (uci_elo)
         {
-            double e = double(uci_elo - 1320) / (3190 - 1320);
+            double e = double(uci_elo - LowestElo) / (HighestElo - LowestElo);
             level = std::clamp((((37.2473 * e - 40.8525) * e + 22.2943) * e - 0.311438), 0.0, 19.0);
         }
         else


### PR DESCRIPTION
Adding LowestElo and HighestElo constants.

These values represent the lowest Elo rating in the skill level calculation, and the highest one, but it's not clear from the code where these values come from other than the comment.

This should improve code readability and maintainability. It makes the purpose of the values clear and allows for easy modification if the Elo range for skill level calculation changes in the future.


Non-Functional
bench: 1477054