### PR TITLE
Improve Skill Level Calculation Consistency

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -35,6 +35,7 @@
 #include "perft.h"
 #include "position.h"
 #include "search.h"
+#include "skill.h"
 #include "syzygy/tbprobe.h"
 #include "types.h"
 #include "uci.h"
@@ -91,7 +92,7 @@ Engine::Engine(std::string path) :
     options["nodestime"] << Option(0, 0, 10000);
     options["UCI_Chess960"] << Option(false);
     options["UCI_LimitStrength"] << Option(false);
-    options["UCI_Elo"] << Option(1320, 1320, 3190);
+    options["UCI_Elo"] << Option(Search::Skill::LowestElo, Search::Skill::LowestElo, Search::Skill::HighestElo);
     options["UCI_ShowWDL"] << Option(false);
     options["SyzygyPath"] << Option("", [](const Option& o) {
         Tablebases::init(o);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -94,31 +94,6 @@ int stat_malus(Depth d) { return std::min(736 * d - 268, 2044); }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
 Value value_draw(size_t nodes) { return VALUE_DRAW - 1 + Value(nodes & 0x2); }
-
-// Skill structure is used to implement strength limit. If we have a UCI_Elo,
-// we convert it to an appropriate skill level, anchored to the Stash engine.
-// This method is based on a fit of the Elo results for games played between
-// Stockfish at various skill levels and various versions of the Stash engine.
-// Skill 0 .. 19 now covers CCRL Blitz Elo from 1320 to 3190, approximately
-// Reference: https://github.com/vondele/Stockfish/commit/a08b8d4e9711c2
-struct Skill {
-    Skill(int skill_level, int uci_elo) {
-        if (uci_elo)
-        {
-            double e = double(uci_elo - 1320) / (3190 - 1320);
-            level = std::clamp((((37.2473 * e - 40.8525) * e + 22.2943) * e - 0.311438), 0.0, 19.0);
-        }
-        else
-            level = double(skill_level);
-    }
-    bool enabled() const { return level < 20.0; }
-    bool time_to_pick(Depth depth) const { return depth == 1 + int(level); }
-    Move pick_best(const RootMoves&, size_t multiPV);
-
-    double level;
-    Move   best = Move::none();
-};
-
 Value value_to_tt(Value v, int ply);
 Value value_from_tt(Value v, int ply, int r50c);
 void  update_pv(Move* pv, Move move, const Move* childPv);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -42,6 +42,7 @@
 #include "nnue/nnue_common.h"
 #include "nnue/nnue_misc.h"
 #include "position.h"
+#include "skill.h"
 #include "syzygy/tbprobe.h"
 #include "thread.h"
 #include "timeman.h"

--- a/src/skill.h
+++ b/src/skill.h
@@ -1,0 +1,54 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2024 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SKILL_H_INCLUDED
+#define SKILL_H_INCLUDED
+
+#include "types.h"
+#include "search.h"
+
+namespace Stockfish {
+namespace Search {
+
+struct Skill {
+    // Add static constants for the lowest and highest Elo ratings
+    static constexpr int LowestElo  = 1320;
+    static constexpr int HighestElo = 3190;
+
+    Skill(int skill_level, int uci_elo) {
+        if (uci_elo)
+        {
+            // Use the constants instead of hardcoded values
+            double e = double(uci_elo - LowestElo) / (HighestElo - LowestElo);
+            level = std::clamp((((37.2473 * e - 40.8525) * e + 22.2943) * e - 0.311438), 0.0, 19.0);
+        }
+        else
+            level = double(skill_level);
+    }
+    bool enabled() const { return level < 20.0; }
+    bool time_to_pick(Depth depth) const { return depth == 1 + int(level); }
+    Move pick_best(const RootMoves&, size_t multiPV);
+
+    double level;
+    Move   best = Move::none();
+};
+
+} // namespace Search
+} // namespace Stockfish
+
+#endif // #ifndef SKILL_H_INCLUDED

--- a/src/skill.h
+++ b/src/skill.h
@@ -25,15 +25,19 @@
 namespace Stockfish {
 namespace Search {
 
+// Skill structure is used to implement strength limit. If we have a UCI_Elo,
+// we convert it to an appropriate skill level, anchored to the Stash engine.
+// This method is based on a fit of the Elo results for games played between
+// Stockfish at various skill levels and various versions of the Stash engine.
+// Skill 0 .. 19 now covers CCRL Blitz Elo from 1320 to 3190, approximately
+// Reference: https://github.com/vondele/Stockfish/commit/a08b8d4e9711c2
 struct Skill {
-    // Add static constants for the lowest and highest Elo ratings
     static constexpr int LowestElo  = 1320;
     static constexpr int HighestElo = 3190;
 
     Skill(int skill_level, int uci_elo) {
         if (uci_elo)
         {
-            // Use the constants instead of hardcoded values
             double e = double(uci_elo - LowestElo) / (HighestElo - LowestElo);
             level = std::clamp((((37.2473 * e - 40.8525) * e + 22.2943) * e - 0.311438), 0.0, 19.0);
         }


### PR DESCRIPTION
Adding LowestElo and HighestElo constants.

These values represent the lowest Elo rating in the skill level calculation, and the highest one, but it's not clear from the code where these values come from other than the comment.

This should improve code readability and maintainability. It makes the purpose of the values clear and allows for easy modification if the Elo range for skill level calculation changes in the future.

Moved the Skill struct definition from search.cpp to the new skill.h header file to define the Search::Skill struct, making it accessible from other files.

Non-Functional
bench: 1477054