### PR TITLE
Revert removal of a TB range guard

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -919,7 +919,8 @@ moves_loop:  // When in check, search starts here
     // Step 12. A small Probcut idea (~4 Elo)
     probCutBeta = beta + 390;
     if ((ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4 && ttData.value >= probCutBeta
-        && std::abs(beta) < VALUE_TB_WIN_IN_MAX_PLY)
+        && std::abs(beta) < VALUE_TB_WIN_IN_MAX_PLY
+        && std::abs(ttData.value) < VALUE_TB_WIN_IN_MAX_PLY)
         return probCutBeta;
 
     const PieceToHistory* contHist[] = {(ss - 1)->continuationHistory,


### PR DESCRIPTION
even if beta is below TB range, once we return probcutBeta with beta + 390 we can return wrong TB value, and guard against ttData.value being `VALUE_NONE`

Analysis using TB6 in the text file for master, with a normal TB position:
```
    // Step 12. A small Probcut idea (~4 Elo)
    probCutBeta = beta + 390;
    if ((ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4 && ttData.value >= probCutBeta
        && std::abs(beta) < VALUE_TB_WIN_IN_MAX_PLY)
    {
        dbg_hit_on(probCutBeta >= VALUE_TB_WIN_IN_MAX_PLY);
        return probCutBeta;
    }
```
[text.txt](https://github.com/user-attachments/files/16315612/text.txt)

bench: 1186985