### PR TITLE
Enable syzygy in the matetrack action

### DIFF
--- a/.github/workflows/matetrack.yml
+++ b/.github/workflows/matetrack.yml
@@ -24,15 +24,31 @@ jobs:
         with:
           repository: vondele/matetrack
           path: matetrack
-          ref: 20287a1a145f30a166b7ef251eddb611e4e44fbf
+          ref: 814160f82e6428ed2f6522dc06c2a6fa539cd413
           persist-credentials: false
 
       - name: matetrack install deps
         working-directory: matetrack
         run: pip install -r requirements.txt
 
+      - name: cache syzygy
+        id: cache-syzygy
+        uses: actions/cache@v4
+        with:
+           path: |
+              matetrack/3-4-5-wdl/
+              matetrack/3-4-5-dtz/
+           key: key-syzygy
+
+      - name: download syzygy 3-4-5 if needed
+        working-directory: matetrack
+        if: steps.cache-syzygy.outputs.cache-hit != 'true'
+        run: |
+          wget --no-verbose -r -nH --cut-dirs=2 --no-parent --reject="index.html*" -e robots=off https://tablebase.lichess.ovh/tables/standard/3-4-5-wdl/
+          wget --no-verbose -r -nH --cut-dirs=2 --no-parent --reject="index.html*" -e robots=off https://tablebase.lichess.ovh/tables/standard/3-4-5-dtz/
+
       - name: Run matetrack
         working-directory: matetrack
         run: |
-          python matecheck.py --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile mates2000.epd --nodes 100000 | tee matecheckout.out
+          python matecheck.py  --syzygyPath 3-4-5-wdl/:3-4-5-dtz/ --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile mates2000.epd --nodes 100000 | tee matecheckout.out
           ! grep "issues were detected" matecheckout.out > /dev/null


### PR DESCRIPTION
now checks correctness of PV lines with TB score.

uses 3-4-5 man table bases, downloaded from lichess, which are cached with the appropriate action.

No functional change