### PR TITLE
Replace simple eval with psqt in re-eval condition

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -59,8 +59,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 
     assert(!pos.checkers());
 
-    int  simpleEval = simple_eval(pos, pos.side_to_move());
-    bool smallNet   = use_smallnet(pos);
+    bool smallNet = use_smallnet(pos);
     int  v;
 
     auto [psqt, positional] = smallNet ? networks.small.evaluate(pos, &caches.small)
@@ -70,7 +69,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     int   nnueComplexity = std::abs(psqt - positional);
 
     // Re-evaluate the position when higher eval accuracy is worth the time spent
-    if (smallNet && (nnue * simpleEval < 0 || std::abs(nnue) < 227))
+    if (smallNet && (nnue * psqt < 0 || std::abs(nnue) < 227))
     {
         std::tie(psqt, positional) = networks.big.evaluate(pos, &caches.big);
         nnue                       = (125 * psqt + 131 * positional) / 128;


### PR DESCRIPTION
As a result, re-eval depends only on smallnet outputs so an extra call to simple eval can be removed.

Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/669743054ff211be9d4ec232
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 214912 W: 55801 L: 55777 D: 103334
Ptnml(0-2): 746, 24597, 56760, 24593, 760

No functional change