### PR TITLE
Bonus Simplification

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -189,7 +189,7 @@ void Search::Worker::start_searching() {
     {}  // Busy wait for a stop or a ponder reset
 
     // Stop the threads if not already stopped (also raise the stop if
-    // "ponderhit" just reset threads.ponder).
+    // "ponderhit" just reset threads.ponder)
     threads.stop = true;
 
     // Wait until all threads have finished

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1362,20 +1362,19 @@ moves_loop:  // When in check, search starts here
     // Bonus for prior countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
     {
-        int bonus = (138 * (depth > 5) + 58 * (PvNode || cutNode) + 160 * ((ss - 1)->moveCount > 8)
-                     + 84 * (!ss->inCheck && bestValue <= ss->staticEval - 108)
-                     + 153 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 76)
-                     + 32 * (!(ss - 1)->inCheck && bestValue > -(ss - 1)->staticEval + 76));
+        int bonus = (122 * (depth > 5) + 39 * (PvNode || cutNode) + 165 * ((ss - 1)->moveCount > 8)
+                     + 107 * (!ss->inCheck && bestValue <= ss->staticEval - 98)
+                     + 134 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 91));
 
         // Proportional to "how much damage we have to undo"
-        bonus += std::clamp(-(ss - 1)->statScore / 100, -94, 300);
+        bonus += std::clamp(-(ss - 1)->statScore / 100, -94, 304);
 
         bonus = std::max(bonus, 0);
 
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
-                                      stat_bonus(depth) * bonus / 100);
+                                      stat_bonus(depth) * bonus / 116);
         thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()]
-          << stat_bonus(depth) * bonus / 200;
+          << stat_bonus(depth) * bonus / 180;
 
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)


### PR DESCRIPTION
This tune removes completely a recently added term.
Passed both STC and LTC, and then was rebased due to Viz bugfix patch conflicting.

Now it passed again LTC.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 61376 W: 16046 L: 15693 D: 29637
Ptnml(0-2): 207, 7132, 15665, 7469, 215
https://tests.stockfishchess.org/tests/view/669512b94ff211be9d4ebffb

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 100662 W: 25474 L: 25020 D: 50168
Ptnml(0-2): 64, 11092, 27581, 11514, 80
https://tests.stockfishchess.org/tests/view/66955f194ff211be9d4ec06a

Passed LTC#2:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 28056 W: 7128 L: 6909 D: 14019
Ptnml(0-2): 18, 3084, 7620, 3273, 33
https://tests.stockfishchess.org/tests/view/669a541a4ff211be9d4ec52b


bench: 1459221