### PR TITLE
VVLTC search tune

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -90,7 +90,7 @@ Value to_corrected_static_eval(Value v, const Worker& w, const Position& pos) {
 int stat_bonus(Depth d) { return std::min(188 * d - 109, 1687); }
 
 // History and stats update malus, based on depth
-int stat_malus(Depth d) { return (d < 4 ? 791 * d - 268 : 2096); }
+int stat_malus(Depth d) { return std::min(791 * d - 268, 2096); }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
 Value value_draw(size_t nodes) { return VALUE_DRAW - 1 + Value(nodes & 0x2); }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -68,7 +68,7 @@ namespace {
 // Futility margin
 Value futility_margin(Depth d, bool noTtCutNode, bool improving, bool oppWorsening) {
     Value futilityMult       = 125 - 39 * noTtCutNode;
-    Value improvingDeduction = 67 * improving * futilityMult / 2;
+    Value improvingDeduction = 67 * improving * futilityMult / 32;
     Value worseningDeduction = oppWorsening * futilityMult / 3;
 
     return futilityMult * d - improvingDeduction - worseningDeduction;


### PR DESCRIPTION
Passed VVLTC 1st sprt: https://tests.stockfishchess.org/tests/view/6695189d4ff211be9d4ec00b
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 38912 W: 9947 L: 9673 D: 19292
Ptnml(0-2): 3, 3599, 11980, 3869, 5 

Passed VVLTC 2nd sprt: https://tests.stockfishchess.org/tests/view/669a2fd74ff211be9d4ec508
 LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 51446 W: 13259 L: 12939 D: 25248
Ptnml(0-2): 1, 4709, 15992, 5011, 10 

Bench: 1227160