### PR TITLE
Update default main net to nn-31337bea577c.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-e8bac1c07a5a.nnue"
+#define EvalFileDefaultNameBig "nn-31337bea577c.nnue"
 #define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
 
 namespace NNUE {


### PR DESCRIPTION
Created by updating output weights (256) and biases (8) of the previous main net with values found with spsa around 101k / 120k games at 140+1.4.

264 spsa params: output weights and biases in nn-e8bac1c07a5a.nnue
A: 6000, alpha: 0.602, gamma: 0.101
weights: [-127, 127], c_end = 6
biases: [-8192, 8192], c_end = 64

Among the 264 params, 189 weights and all 8 biases were changed.

Changes in the weights:
- mean: -0.111 +/- 3.57
- range: [-8, 8]

Found with the same method as:
https://github.com/official-stockfish/Stockfish/pull/5459

Due to the original name (nn-ea8c9128c325.nnue) being too similar to the previous main net (nn-e8bac1c07a5a.nnue) and creating confusion, it was renamed by making non-functional changes to the .nnue file the same way as past nets with:
https://github.com/linrock/nnue-namer

To verify that bench is the same and view the modified non-functional bytes:
```bash
echo -e "setoption name EvalFile value nn-ea8c9128c325.nnue\nbench" | ./stockfish
echo -e "setoption name EvalFile value nn-31337bea577c.nnue\nbench" | ./stockfish

cmp -l nn-ea8c9128c325.nnue nn-31337bea577c.nnue

diff <(xxd nn-ea8c9128c325.nnue) <(xxd nn-31337bea577c.nnue)
```

Passed STC:
https://tests.stockfishchess.org/tests/view/669564154ff211be9d4ec080
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 57280 W: 15139 L: 14789 D: 27352
Ptnml(0-2): 209, 6685, 14522, 6995, 229

Passed LTC:
https://tests.stockfishchess.org/tests/view/669694204ff211be9d4ec1b4
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 63030 W: 16093 L: 15720 D: 31217
Ptnml(0-2): 47, 6766, 17516, 7139, 47

bench 1736720