### PR TITLE
Remove Killer Heuristic

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -88,15 +88,13 @@ MovePicker::MovePicker(const Position&              p,
                        const ButterflyHistory*      mh,
                        const CapturePieceToHistory* cph,
                        const PieceToHistory**       ch,
-                       const PawnHistory*           ph,
-                       Move                         km) :
+                       const PawnHistory*           ph) :
     pos(p),
     mainHistory(mh),
     captureHistory(cph),
     continuationHistory(ch),
     pawnHistory(ph),
     ttMove(ttm),
-    killer(km),
     depth(d) {
 
     if (pos.checkers())
@@ -165,8 +163,6 @@ void MovePicker::score() {
             m.value += (*continuationHistory[2])[pc][to] / 3;
             m.value += (*continuationHistory[3])[pc][to];
             m.value += (*continuationHistory[5])[pc][to];
-
-            m.value += (m == killer) * 65536;
 
             // bonus for checks
             m.value += bool(pos.check_squares(pt) & to) * 16384;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -159,8 +159,7 @@ class MovePicker {
                const ButterflyHistory*,
                const CapturePieceToHistory*,
                const PieceToHistory**,
-               const PawnHistory*,
-               Move killer = Move::none());
+               const PawnHistory*);
     MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
     Move next_move(bool skipQuiets = false);
 
@@ -177,7 +176,7 @@ class MovePicker {
     const CapturePieceToHistory* captureHistory;
     const PieceToHistory**       continuationHistory;
     const PawnHistory*           pawnHistory;
-    Move                         ttMove, killer;
+    Move                         ttMove;
     ExtMove *                    cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
     int                          stage;
     int                          threshold;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -931,7 +931,7 @@ moves_loop:  // When in check, search starts here
 
 
     MovePicker mp(pos, ttData.move, depth, &thisThread->mainHistory, &thisThread->captureHistory,
-                  contHist, &thisThread->pawnHistory, ss->killer);
+                  contHist, &thisThread->pawnHistory);
 
     value = bestValue;
 


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 80480 W: 20979 L: 20802 D: 38699
Ptnml(0-2): 279, 9610, 20337, 9683, 331 
https://tests.stockfishchess.org/tests/view/669c12c14ff211be9d4ec69b

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 77988 W: 19788 L: 19624 D: 38576
Ptnml(0-2): 66, 8605, 21481, 8783, 59 
https://tests.stockfishchess.org/tests/view/669d628a4ff211be9d4ec7a8

bench 1339848