### PR TITLE
Introduce pre-qsearch ttmove extensions at pv nodes.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1230,6 +1230,10 @@ moves_loop:  // When in check, search starts here
             (ss + 1)->pv    = pv;
             (ss + 1)->pv[0] = Move::none();
 
+            // Extend move from transposition table if we are about to dive into qsearch.
+            if (move == ttData.move && ss->ply <= thisThread->rootDepth * 2)
+                newDepth = std::max(newDepth, 1);
+
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);
         }
 


### PR DESCRIPTION
Idea is that we are about to dive into qsearch (so next search depth is <= 0) but we have move in transposition table we should extend it and evaluate with more precise search - because branch seems important.
Passed STC:
https://tests.stockfishchess.org/tests/view/6699d2564ff211be9d4ec488
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 83104 W: 21789 L: 21401 D: 39914
Ptnml(0-2): 293, 9748, 21128, 10044, 339 
Passed LTC:
https://tests.stockfishchess.org/tests/view/669b3f1a4ff211be9d4ec602
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 136098 W: 34636 L: 34111 D: 67351
Ptnml(0-2): 105, 14882, 37550, 15407, 105 
bench 1560667