### PR TITLE
Simplify Away Killer Condition in Cutnode LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1131,8 +1131,7 @@ moves_loop:  // When in check, search starts here
 
         // Increase reduction for cut nodes (~4 Elo)
         if (cutNode)
-            r += 2 - (ttData.depth >= depth && ss->ttPv)
-               + (!ss->ttPv && move != ttData.move && move != ss->killer);
+            r += 2 - (ttData.depth >= depth && ss->ttPv) + (!ss->ttPv && move != ttData.move);
 
         // Increase reduction if ttMove is a capture (~3 Elo)
         if (ttCapture)


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 42944 W: 11240 L: 11024 D: 20680
Ptnml(0-2): 159, 5056, 10825, 5274, 158
https://tests.stockfishchess.org/tests/view/669c13384ff211be9d4ec69f

Passed Non-regression LTC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 163548 W: 41366 L: 41289 D: 80893
Ptnml(0-2): 109, 18246, 45007, 18283, 129
https://tests.stockfishchess.org/tests/view/669cb1254ff211be9d4ec73a

bench 1178570