### PR TITLE
Simplify Pre-Qsearch Extension Condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1210,7 +1210,7 @@ moves_loop:  // When in check, search starts here
             (ss + 1)->pv[0] = Move::none();
 
             // Extend move from transposition table if we are about to dive into qsearch.
-            if (move == ttData.move && ss->ply <= thisThread->rootDepth * 2)
+            if (move == ttData.move)
                 newDepth = std::max(newDepth, 1);
 
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);


### PR DESCRIPTION
Passed Non-regression STC:
 LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 47424 W: 12362 L: 12151 D: 22911
Ptnml(0-2): 180, 5489, 12178, 5670, 195
https://tests.stockfishchess.org/tests/view/669ffce14ff211be9d4ecb0d

Passed Non-regression LTC:
LLR: 3.04 (-2.94,2.94) <-1.75,0.25>
Total: 117372 W: 29675 L: 29545 D: 58152
Ptnml(0-2): 84, 12733, 32941, 12825, 103
https://tests.stockfishchess.org/tests/view/66a0eaa34ff211be9d4ecbcd

bench 1660869