### PR TITLE
Simplify Cutnode Reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1127,7 +1127,7 @@ moves_loop:  // When in check, search starts here
 
         // Increase reduction for cut nodes (~4 Elo)
         if (cutNode)
-            r += 2 - (ttData.depth >= depth && ss->ttPv) + (!ss->ttPv && move != ttData.move);
+            r += 2 - (ttData.depth >= depth && ss->ttPv) + !ss->ttPv;
 
         // Increase reduction if ttMove is a capture (~3 Elo)
         if (ttCapture)


### PR DESCRIPTION
Passed Non-regression STC:
LR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 143968 W: 37439 L: 37333 D: 69196
Ptnml(0-2): 521, 17228, 36456, 17182, 597
https://tests.stockfishchess.org/tests/view/66a73f9f4ff211be9d4ed27f

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 198954 W: 50384 L: 50345 D: 98225
Ptnml(0-2): 201, 22360, 54347, 22337, 232
https://tests.stockfishchess.org/tests/view/66a906e94ff211be9d4ed423

bench 1277466