### PR TITLE
Syntaxic sugar for Position::see_ge(move, threshold)

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -110,7 +110,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, int th, const CapturePieceTo
     assert(!pos.checkers());
 
     stage = PROBCUT_TT
-          + !(ttm && pos.capture_stage(ttm) && pos.pseudo_legal(ttm) && pos.see_ge(ttm, threshold));
+          + !(ttm && pos.capture_stage(ttm) && pos.pseudo_legal(ttm) && pos.see(ttm) >= threshold);
 }
 
 // Assigns a numerical value to each move in a list, used for sorting.
@@ -238,7 +238,7 @@ top:
     case GOOD_CAPTURE :
         if (select<Next>([&]() {
                 // Move losing capture to endBadCaptures to be tried later
-                return pos.see_ge(*cur, -cur->value / 18) ? true
+                return pos.see(*cur) >= (-cur->value / 18) ? true
                                                           : (*endBadCaptures++ = *cur, false);
             }))
             return *(cur - 1);
@@ -305,7 +305,7 @@ top:
         return select<Best>([]() { return true; });
 
     case PROBCUT :
-        return select<Next>([&]() { return pos.see_ge(*cur, threshold); });
+        return select<Next>([&]() { return pos.see(*cur) >= threshold; });
 
     case QCAPTURE :
         return select<Next>([]() { return true; });

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1022,9 +1022,9 @@ Key Position::key_after(Move m) const {
 }
 
 
-// Tests if the SEE (Static Exchange Evaluation)
-// value of move is greater or equal to the given threshold. We'll use an
-// algorithm similar to alpha-beta pruning with a null window.
+// Tests if the SEE (Static Exchange Evaluation) value of a move is
+// greater or equal to the given threshold. We will use an algorithm
+// similar to alpha-beta pruning with a null window.
 bool Position::see_ge(Move m, int threshold) const {
 
     assert(m.is_ok());

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -986,7 +986,7 @@ moves_loop:  // When in check, search starts here
 
                 // SEE based pruning for captures and checks (~11 Elo)
                 int seeHist = std::clamp(captHist / 32, -182 * depth, 166 * depth);
-                if (!pos.see_ge(move, -168 * depth - seeHist))
+                if (pos.see(move) < -168 * depth - seeHist)
                     continue;
             }
             else
@@ -1019,7 +1019,7 @@ moves_loop:  // When in check, search starts here
                 lmrDepth = std::max(lmrDepth, 0);
 
                 // Prune moves with negative SEE (~4 Elo)
-                if (!pos.see_ge(move, -24 * lmrDepth * lmrDepth))
+                if (pos.see(move) < -24 * lmrDepth * lmrDepth)
                     continue;
             }
         }
@@ -1566,7 +1566,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
 
                 // If static eval is much lower than alpha and move is
                 // not winning material, we can prune this move. (~2 Elo)
-                if (futilityBase <= alpha && !pos.see_ge(move, 1))
+                if (futilityBase <= alpha && pos.see(move) <= 0)
                 {
                     bestValue = std::max(bestValue, futilityBase);
                     continue;
@@ -1574,7 +1574,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
 
                 // If static exchange evaluation is much worse than what
                 // is needed to not fall below alpha, we can prune this move.
-                if (futilityBase > alpha && !pos.see_ge(move, (alpha - futilityBase) * 4))
+                if (futilityBase > alpha && pos.see(move) < (alpha - futilityBase) * 4)
                 {
                     bestValue = alpha;
                     continue;
@@ -1591,7 +1591,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
                 continue;
 
             // Do not search moves with bad enough SEE values (~5 Elo)
-            if (!pos.see_ge(move, -83))
+            if (pos.see(move) < -83)
                 continue;
         }
 


### PR DESCRIPTION
Syntactic sugar around Position::see_ge(), so that we can use the more readable pos.see(move) >= threshold instead of pos.see_ge(move, threshold), and similar readable code for the other comparison operators.

Patch tested locally for speed with both clang and gcc, no speed penalty found.

[Edit]
Non-regression test started here: https://tests.stockfishchess.org/tests/view/66b49f254ff211be9d4edf2a

No functional change.