### PR TITLE
Simplify Post-LMR Continuation History Updates

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1181,9 +1181,7 @@ moves_loop:  // When in check, search starts here
                     value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, newDepth, !cutNode);
 
                 // Post LMR continuation history updates (~1 Elo)
-                int bonus = value <= alpha ? -stat_malus(newDepth)
-                          : value >= beta  ? stat_bonus(newDepth)
-                                           : 0;
+                int bonus = value >= beta ? stat_bonus(newDepth) : -stat_malus(newDepth);
 
                 update_continuation_histories(ss, movedPiece, move.to_sq(), bonus);
             }


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 55520 W: 14625 L: 14420 D: 26475
Ptnml(0-2): 247, 6522, 14007, 6747, 237
https://tests.stockfishchess.org/tests/view/66ad40874ff211be9d4ed8f7

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 216168 W: 54561 L: 54540 D: 107067
Ptnml(0-2): 196, 24212, 59244, 24239, 193
https://tests.stockfishchess.org/tests/view/66aeac954ff211be9d4eda03

bench 1418263