### PR TITLE
Simplify cutnode reduction formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1133,7 +1133,7 @@ moves_loop:  // When in check, search starts here
 
         // Increase reduction for cut nodes (~4 Elo)
         if (cutNode)
-            r += 2 - (ttData.depth >= depth && ss->ttPv) + !ss->ttPv;
+            r += 2 - (ttData.depth >= depth && ss->ttPv);
 
         // Increase reduction if ttMove is a capture (~3 Elo)
         if (ttCapture)


### PR DESCRIPTION
Simplify cutnode reduction formula

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 137994 W: 34705 L: 34603 D: 68686
Ptnml(0-2): 124, 15371, 37903, 15477, 122
https://tests.stockfishchess.org/tests/view/66aeb74b4ff211be9d4eda10

Passed LTC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 131456 W: 34148 L: 34031 D: 63277
Ptnml(0-2): 506, 15571, 33465, 15672, 514
https://tests.stockfishchess.org/tests/view/66ae258b4ff211be9d4ed95d

bench: 1684552