### PR TITLE
Simplify `bestMove` Promotion Formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -567,10 +567,9 @@ Value Search::Worker::search(
         // Step 2. Check for aborted search and immediate draw
         if (threads.stop.load(std::memory_order_relaxed) || pos.is_draw(ss->ply)
             || ss->ply >= MAX_PLY)
-            return (ss->ply >= MAX_PLY && !ss->inCheck)
-                   ? evaluate(networks[numaAccessToken], pos, refreshTable,
-                              thisThread->optimism[us])
-                   : value_draw(thisThread->nodes);
+            return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate(
+                     networks[numaAccessToken], pos, refreshTable, thisThread->optimism[us])
+                                                        : value_draw(thisThread->nodes);
 
         // Step 3. Mate distance pruning. Even if we mate at the next move our score
         // would be at best mate_in(ss->ply + 1), but if alpha is already bigger because
@@ -1276,9 +1275,9 @@ moves_loop:  // When in check, search starts here
 
         // In case we have an alternative move equal in eval to the current bestmove,
         // promote it to bestmove by pretending it just exceeds alpha (but not beta).
-        int inc = (value == bestValue && (int(nodes) & 15) == 0
-                   && ss->ply + 2 + ss->ply / 32 >= thisThread->rootDepth
-                   && std::abs(value) + 1 < VALUE_TB_WIN_IN_MAX_PLY);
+        int inc =
+          (value == bestValue && (int(nodes) & 15) == 0 && ss->ply + 2 >= thisThread->rootDepth
+           && std::abs(value) + 1 < VALUE_TB_WIN_IN_MAX_PLY);
 
         if (value + inc > bestValue)
         {


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 216768 W: 56240 L: 56217 D: 104311
Ptnml(0-2): 794, 24900, 56956, 24957, 777
https://tests.stockfishchess.org/tests/view/66bc11324ff211be9d4ee78b

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 44970 W: 11391 L: 11199 D: 22380
Ptnml(0-2): 44, 4596, 13002, 4810, 33
https://tests.stockfishchess.org/tests/view/66bdbb1b4ff211be9d4eec5a

bench 1277466