### PR TITLE
Simplify `doShallowerSearch`

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1173,7 +1173,7 @@ moves_loop:  // When in check, search starts here
                 // Adjust full-depth search based on LMR results - if the result was
                 // good enough search deeper, if it was bad enough search shallower.
                 const bool doDeeperSearch    = value > (bestValue + 35 + 2 * newDepth);  // (~1 Elo)
-                const bool doShallowerSearch = value < bestValue + newDepth;             // (~2 Elo)
+                const bool doShallowerSearch = value < bestValue + 8;             // (~2 Elo)
 
                 newDepth += doDeeperSearch - doShallowerSearch;
 


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 242336 W: 62657 L: 62663 D: 117016
Ptnml(0-2): 941, 28949, 61418, 28895, 965
https://tests.stockfishchess.org/tests/view/66bc13c34ff211be9d4ee794

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 128100 W: 32503 L: 32390 D: 63207
Ptnml(0-2): 106, 14319, 35113, 14380, 132
https://tests.stockfishchess.org/tests/view/66bdbb304ff211be9d4eec5d

bench 1334799