### PR TITLE
Simplify stand pat adjustement

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -171,6 +171,7 @@ Niklas Fiekas (niklasf)
 Nikolay Kostov (NikolayIT)
 Norman Schmidt (FireFather)
 notruck
+Nour Berakdar (Nonlinear)
 Ofek Shochat (OfekShochat, ghostway)
 Ondrej Mosnáček (WOnder93)
 Ondřej Mišina (AndrovT)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1504,7 +1504,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
         // Stand pat. Return immediately if static value is at least beta
         if (bestValue >= beta)
         {
-            if (std::abs(bestValue) < VALUE_TB_WIN_IN_MAX_PLY && !PvNode)
+            if (std::abs(bestValue) < VALUE_TB_WIN_IN_MAX_PLY)
                 bestValue = (3 * bestValue + beta) / 4;
             if (!ss->ttHit)
                 ttWriter.write(posKey, value_to_tt(bestValue, ss->ply), false, BOUND_LOWER,


### PR DESCRIPTION
Remove `&& !PvNode` condition for stand pat adjustement in quiescence search.

Passed non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 108544 W: 28228 L: 28085 D: 52231
Ptnml(0-2): 389, 12902, 27554, 13031, 396
https://tests.stockfishchess.org/tests/view/66bb402e4ff211be9d4ee688

Passed non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 193014 W: 48796 L: 48751 D: 95467
Ptnml(0-2): 188, 21481, 53116, 21542, 180
https://tests.stockfishchess.org/tests/view/66bc78774ff211be9d4ee88f

Bench 1184301
