### PR TITLE
Introduce Fail Low History Bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1363,6 +1363,10 @@ moves_loop:  // When in check, search starts here
               << stat_bonus(depth) * bonus / 25;
     }
 
+    // Bonus when search fails low and there is a TT move
+    else if (moveCount > 1 && ttData.move && (cutNode || PvNode))
+        thisThread->mainHistory[us][ttData.move.from_to()] << stat_bonus(depth) / 4;
+
     if (PvNode)
         bestValue = std::min(bestValue, maxValue);
 


### PR DESCRIPTION
When a node fails low, give TT move a small bonus 1/4 of normal value.

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 92384 W: 24094 L: 23691 D: 44599
Ptnml(0-2): 323, 10852, 23465, 11203, 349
https://tests.stockfishchess.org/tests/view/66be80794ff211be9d4eed68

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 114660 W: 29260 L: 28778 D: 56622
Ptnml(0-2): 97, 12506, 31653, 12966, 108
https://tests.stockfishchess.org/tests/view/66bf63ee4ff211be9d4eeef0

bench 1488056