### PR TITLE
Tweak late move extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1163,7 +1163,7 @@ moves_loop:  // When in check, search starts here
             // beyond the first move depth.
             // To prevent problems when the max value is less than the min value,
             // std::clamp has been replaced by a more robust implementation.
-            Depth d = std::max(1, std::min(newDepth - r, newDepth + 1));
+            Depth d = std::max(1, std::min(newDepth - r, newDepth + (PvNode || cutNode)));
 
             value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);
 


### PR DESCRIPTION
Allow late move extensions only for PV and cut nodes.

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 44512 W: 11688 L: 11355 D: 21469
Ptnml(0-2): 167, 5180, 11229, 5513, 167
https://tests.stockfishchess.org/tests/view/66c0509d4ff211be9d4ef10e

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 152970 W: 39026 L: 38466 D: 75478
Ptnml(0-2): 102, 16792, 42164, 17298, 129
https://tests.stockfishchess.org/tests/view/66c0994d21503a509c13b2b6

bench: 1420582