### PR TITLE
Reduce on ttcaptures iff not capture

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1136,8 +1136,8 @@ moves_loop:  // When in check, search starts here
         if (cutNode)
             r += 2 - (ttData.depth >= depth && ss->ttPv);
 
-        // Increase reduction if ttMove is a capture (~3 Elo)
-        if (ttCapture)
+        // Increase reduction if ttMove is a capture but the current move is not a capture (~3 Elo)
+        if (ttCapture && !capture)
             r++;
 
         // Increase reduction if next ply has a lot of fail high (~5 Elo)


### PR DESCRIPTION
Tweak ttcapture reduction

Reduce on ttcaptures only if the current move is a capture

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 94912 W: 24896 L: 24492 D: 45524
Ptnml(0-2): 301, 11197, 24087, 11539, 332 
https://tests.stockfishchess.org/tests/view/66cd2264bf8c9d8780fdab34

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 60738 W: 15465 L: 15096 D: 30177
Ptnml(0-2): 42, 6573, 16775, 6932, 47 
https://tests.stockfishchess.org/tests/view/66cf356d9de3e7f9b33d0fde

bench 1726335