### PR TITLE
update the WDL model

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -339,8 +339,8 @@ WinRateParams win_rate_params(const Position& pos) {
     double m = std::clamp(material, 17, 78) / 58.0;
 
     // Return a = p_a(material) and b = p_b(material), see github.com/official-stockfish/WDL_model
-    constexpr double as[] = {-41.25712052, 121.47473115, -124.46958843, 411.84490997};
-    constexpr double bs[] = {84.92998051, -143.66658718, 80.09988253, 49.80869370};
+    constexpr double as[] = {-37.45051876, 121.19101539, -132.78783573, 420.70576692};
+    constexpr double bs[] = {90.26261072, -137.26549898, 71.10130540, 51.35259597};
 
     double a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
     double b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];


### PR DESCRIPTION
This PR updates the internal WDL model, using data from 2.6M games played by the revisions since 9fb58328e363d84e3cf720b018e639b139ba95c2. Note that the normalizing constant increases only moderately from 368 to 372.

```
> ./updateWDL.sh --firstrev 9fb58328e363d84e3cf720b018e639b139ba95c2
Running: ./updateWDL.sh --firstrev 9fb58328e363d84e3cf720b018e639b139ba95c2 --lasttrev HEAD --materialMin 17 --EloDiffMax 5
started at:  Tue 3 Sep 07:58:46 CEST 2024
Look recursively in directory pgns for games with max nElo difference 5 using books matching "UHO_Lichess_4852_v..epd" for SF revisions between 9fb58328e363d84e3cf720b018e639b139ba95c2 (from 2024-08-20 21:37:25 +0200) and HEAD (from 2024-08-28 09:35:21 +0200).
Based on 136760463 positions from 2555313 games, NormalizeToPawnValue should change from 368 to 372.
ended at:  Tue 3 Sep 08:00:25 CEST 2024
```

```
> cat scoreWDL.log
Converting evals with NormalizeData = {'momType': 'material', 'momMin': 17, 'momMax': 78, 'momTarget': 58, 'as': [-41.25712052, 121.47473115, -124.46958843, 411.84490997]}.
Reading eval stats from updateWDL.json.
Retained (W,D,L) = (33076119, 69977375, 33706969) positions.
Saved distribution plot to updateWDLdistro.png.
Fit WDL model based on material.
Initial objective function:  0.3715652967144619
Final objective function:    0.3715617461834834
Optimization terminated successfully.
const int NormalizeToPawnValue = 372;
Corresponding spread = 75;
Corresponding normalized spread = 0.203011710365265;
Draw rate at 0.0 eval at material 58 = 0.9855910765358731;
Parameters in internal value units: 
p_a = ((-37.451 * x / 58 + 121.191) * x / 58 + -132.788) * x / 58 + 420.706
p_b = ((90.263 * x / 58 + -137.265) * x / 58 + 71.101) * x / 58 + 51.353
    constexpr double as[] = {-37.45051876, 121.19101539, -132.78783573, 420.70576692};
    constexpr double bs[] = {90.26261072, -137.26549898, 71.10130540, 51.35259597};
Preparing plots.
Saved graphics to updateWDL.png.
Total elapsed time = 35.50s.
```