### PR TITLE
Small simplification in lmr

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1147,7 +1147,7 @@ moves_loop:  // When in check, search starts here
         // For first picked move (ttMove) reduce reduction, but never allow
         // reduction to go below 0 (~3 Elo)
         else if (move == ttData.move)
-            r = std::max(0, r - 2);
+            r -= 2;
 
         ss->statScore = 2 * thisThread->mainHistory[us][move.from_to()]
                       + (*contHist[0])[movedPiece][move.to_sq()]

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1144,8 +1144,7 @@ moves_loop:  // When in check, search starts here
         if ((ss + 1)->cutoffCnt > 3)
             r += 1 + allNode;
 
-        // For first picked move (ttMove) reduce reduction, but never allow
-        // reduction to go below 0 (~3 Elo)
+        // For first picked move (ttMove) reduce reduction (~3 Elo)
         else if (move == ttData.move)
             r -= 2;
 


### PR DESCRIPTION
Remove condition that clamps reductions for tt move.
Passed STC:
https://tests.stockfishchess.org/tests/view/66d5f1239de3e7f9b33d14b0
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 91136 W: 23805 L: 23646 D: 43685
Ptnml(0-2): 334, 10328, 24066, 10525, 315 
Passed LTC:
https://tests.stockfishchess.org/tests/view/66d7c5889de3e7f9b33d1721
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 139242 W: 35130 L: 35030 D: 69082
Ptnml(0-2): 78, 15200, 38986, 15258, 99 
bench 1544100