### PR TITLE
Use optional for the engine path

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -47,8 +47,8 @@ namespace NN = Eval::NNUE;
 constexpr auto StartFEN  = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 constexpr int  MaxHashMB = Is64Bit ? 33554432 : 2048;
 
-Engine::Engine(std::string path) :
-    binaryDirectory(CommandLine::get_binary_directory(path)),
+Engine::Engine(std::optional<std::string> path) :
+    binaryDirectory(path ? CommandLine::get_binary_directory(*path) : ""),
     numaContext(NumaConfig::from_system()),
     states(new std::deque<StateInfo>(1)),
     threads(),

--- a/src/engine.h
+++ b/src/engine.h
@@ -47,7 +47,7 @@ class Engine {
     using InfoFull  = Search::InfoFull;
     using InfoIter  = Search::InfoIteration;
 
-    Engine(std::string path = "");
+    Engine(std::optional<std::string> path = std::nullopt);
 
     // Cannot be movable due to components holding backreferences to fields
     Engine(const Engine&)            = delete;


### PR DESCRIPTION
- A small quality of file change is to change the type of engine path from a string to an optional string, skips the binary directory lookup, which is commonly disabled by people who create wasm builds or include stockfish as a library.