### PR TITLE
Clean up NNUE template parameters

### DIFF
--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -49,11 +49,11 @@ constexpr int       L3Small                           = 32;
 constexpr IndexType PSQTBuckets = 8;
 constexpr IndexType LayerStacks = 8;
 
-template<IndexType L1, int L2, int L3>
+template<typename Type>
 struct NetworkArchitecture {
-    static constexpr IndexType TransformedFeatureDimensions = L1;
-    static constexpr int       FC_0_OUTPUTS                 = L2;
-    static constexpr int       FC_1_OUTPUTS                 = L3;
+    static constexpr IndexType TransformedFeatureDimensions = Type::L1;
+    static constexpr int       FC_0_OUTPUTS                 = Type::L2;
+    static constexpr int       FC_1_OUTPUTS                 = Type::L3;
 
     Layers::AffineTransformSparseInput<TransformedFeatureDimensions, FC_0_OUTPUTS + 1> fc_0;
     Layers::SqrClippedReLU<FC_0_OUTPUTS + 1>                                           ac_sqr_0;

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -188,17 +188,18 @@ static constexpr int BestRegisterCount() {
 
 
 // Input feature converter
-template<IndexType                                 TransformedFeatureDimensions,
-         Accumulator<TransformedFeatureDimensions> StateInfo::*accPtr>
+template<typename Type>
 class FeatureTransformer {
-
     // Number of output dimensions for one side
-    static constexpr IndexType HalfDimensions = TransformedFeatureDimensions;
+    static constexpr IndexType HalfDimensions = Type::L1;
+
+    // A pointer-to-member to the Accumulator in StateInfo struct
+    static constexpr auto accPtr = Type::accPtr;
 
    private:
 #ifdef VECTOR
     static constexpr int NumRegs =
-      BestRegisterCount<vec_t, WeightType, TransformedFeatureDimensions, NumRegistersSIMD>();
+      BestRegisterCount<vec_t, WeightType, HalfDimensions, NumRegistersSIMD>();
     static constexpr int NumPsqtRegs =
       BestRegisterCount<psqt_vec_t, PSQTWeightType, PSQTBuckets, NumRegistersSIMD>();
 


### PR DESCRIPTION
Having multiple template parameters might lead to confusion that unallowed combinations are possible to use, such as:

`FeatureTransformer<TransformedFeatureDimensionsSmall, &StateInfo::accumulatorBig>`

By grouping the parameters into a single struct, the code becomes more clear, comprehensible, and easier to maintain.

No functional change