### PR TITLE
Remove nmpMinPly

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -775,7 +775,7 @@ Value Search::Worker::search(
     // Step 9. Null move search with verification search (~35 Elo)
     if (cutNode && (ss - 1)->currentMove != Move::null() && eval >= beta
         && ss->staticEval >= beta - 21 * depth + 390 && !excludedMove && pos.non_pawn_material(us)
-        && ss->ply >= thisThread->nmpMinPly && beta > VALUE_TB_LOSS_IN_MAX_PLY)
+        && beta > VALUE_TB_LOSS_IN_MAX_PLY)
     {
         assert(eval - beta >= 0);
 
@@ -794,18 +794,16 @@ Value Search::Worker::search(
         // Do not return unproven mate or TB scores
         if (nullValue >= beta && nullValue < VALUE_TB_WIN_IN_MAX_PLY)
         {
-            if (thisThread->nmpMinPly || depth < 16)
+            if (thisThread->verification || depth < 16)
                 return nullValue;
 
-            assert(!thisThread->nmpMinPly);  // Recursive verification is not allowed
+            assert(!thisThread->verification);  // Recursive verification is not allowed
 
-            // Do verification search at high depths, with null move pruning disabled
-            // until ply exceeds nmpMinPly.
-            thisThread->nmpMinPly = ss->ply + 3 * (depth - R) / 4;
+            thisThread->verification = true;
 
             Value v = search<NonPV>(pos, ss, beta - 1, beta, depth - R, false);
 
-            thisThread->nmpMinPly = 0;
+            thisThread->verification = false;
 
             if (v >= beta)
                 return nullValue;

--- a/src/search.h
+++ b/src/search.h
@@ -310,7 +310,8 @@ class Worker {
 
     size_t                pvIdx, pvLast;
     std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;
-    int                   selDepth, nmpMinPly;
+    int                   selDepth;
+    bool                  verification;
 
     Value optimism[COLOR_NB];
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -282,8 +282,8 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
     {
         th->run_custom_job([&]() {
             th->worker->limits = limits;
-            th->worker->nodes = th->worker->tbHits = th->worker->nmpMinPly =
-              th->worker->bestMoveChanges          = 0;
+            th->worker->nodes = th->worker->tbHits = th->worker->bestMoveChanges = 0;
+            th->worker->verification = false;
             th->worker->rootDepth = th->worker->completedDepth = 0;
             th->worker->rootMoves                              = rootMoves;
             th->worker->rootPos.set(pos.fen(), pos.is_chess960(), &th->worker->rootState);


### PR DESCRIPTION
Passed STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 108256 W: 28116 L: 27975 D: 52165
Ptnml(0-2): 394, 12286, 28608, 12465, 375
https://tests.stockfishchess.org/tests/view/66d5ffa99de3e7f9b33d14bd

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 184530 W: 46414 L: 46360 D: 91756
Ptnml(0-2): 152, 20203, 51499, 20261, 150
https://tests.stockfishchess.org/tests/view/66d6f6219de3e7f9b33d1562

bench: 1281840