### PR TITLE
Fix native arch builds on loongarch64, Add support for LSX and LASX

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -237,6 +237,7 @@ Unai Corzo (unaiic)
 Uri Blass (uriblass)
 Vince Negri (cuddlestmonkey)
 Viren
+Wencey Wang
 windfishballad
 xefoci7612
 Xiang Wang (KatyushaScarlet)

--- a/scripts/get_native_properties.sh
+++ b/scripts/get_native_properties.sh
@@ -26,6 +26,17 @@ check_znver_1_2() {
   [ "$vendor_id" = "AuthenticAMD" ] && [ "$cpu_family" = "23" ] && znver_1_2=true
 }
 
+# Set the file CPU loongarch64 architecture
+set_arch_loongarch64() {
+  if check_flags 'lasx'; then
+    true_arch='loongarch64-lasx'
+  elif check_flags 'lsx'; then
+    true_arch='lonngarch64-lsx'
+  else
+    true_arch='loongarch64'
+  fi
+}
+
 # Set the file CPU x86_64 architecture
 set_arch_x86_64() {
   if check_flags 'avx512vnni' 'avx512dq' 'avx512f' 'avx512bw' 'avx512vl'; then
@@ -89,6 +100,10 @@ case $uname_s in
         if check_flags 'neon'; then
           true_arch="$true_arch-neon"
         fi
+        ;;
+      'loongarch64'*)
+        file_os='linux'
+        set_arch_loongarch64
         ;;
       *) # Unsupported machine type, exit with error
         printf 'Unsupported machine type: %s\n' "$uname_m"

--- a/src/Makefile
+++ b/src/Makefile
@@ -1021,6 +1021,8 @@ config-sanity: net
 	@test "$(vnni256)" = "yes" || test "$(vnni256)" = "no"
 	@test "$(vnni512)" = "yes" || test "$(vnni512)" = "no"
 	@test "$(neon)" = "yes" || test "$(neon)" = "no"
+	@test "$(lsx)" = "yes" || test "$(lsx)" = "no"
+	@test "$(lasx)" = "yes" || test "$(lasx)" = "no"
 	@test "$(comp)" = "gcc" || test "$(comp)" = "icx" || test "$(comp)" = "mingw" || test "$(comp)" = "clang" \
 	|| test "$(comp)" = "armv7a-linux-androideabi16-clang"  || test "$(comp)" = "aarch64-linux-android21-clang"
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -100,6 +100,8 @@ VPATH = syzygy:nnue:nnue/features
 # vnni512 = yes/no    --- -mavx512vnni       --- Use Intel Vector Neural Network Instructions 512
 # neon = yes/no       --- -DUSE_NEON         --- Use ARM SIMD architecture
 # dotprod = yes/no    --- -DUSE_NEON_DOTPROD --- Use ARM advanced SIMD Int8 dot product instructions
+# lsx = yes/no        --- -mlsx              --- Use Loongson SIMD eXtension
+# lasx = yes/no       --- -mlasx             --- use Loongson Advanced SIMD eXtension
 #
 # Note that Makefile is space sensitive, so when adding new architectures
 # or modifying existing flags, you have to make sure there are no extra spaces
@@ -125,7 +127,8 @@ ifeq ($(ARCH), $(filter $(ARCH), \
                  x86-64-vnni512 x86-64-vnni256 x86-64-avx512 x86-64-avxvnni x86-64-bmi2 \
                  x86-64-avx2 x86-64-sse41-popcnt x86-64-modern x86-64-ssse3 x86-64-sse3-popcnt \
                  x86-64 x86-32-sse41-popcnt x86-32-sse2 x86-32 ppc-64 ppc-32 e2k \
-                 armv7 armv7-neon armv8 armv8-dotprod apple-silicon general-64 general-32 riscv64 loongarch64))
+                 armv7 armv7-neon armv8 armv8-dotprod apple-silicon general-64 general-32 riscv64 \
+                 loongarch64 loongarch64-lsx loongarch64-lasx))
    SUPPORTED_ARCH=true
 else
    SUPPORTED_ARCH=false
@@ -151,6 +154,8 @@ vnni512 = no
 neon = no
 dotprod = no
 arm_version = 0
+lsx = no
+lasx = no
 STRIP = strip
 
 ifneq ($(shell which clang-format-18 2> /dev/null),)
@@ -370,8 +375,19 @@ ifeq ($(ARCH),riscv64)
 	arch = riscv64
 endif
 
-ifeq ($(ARCH),loongarch64)
+ifeq ($(findstring loongarch64,$(ARCH)),loongarch64)
 	arch = loongarch64
+	prefetch = yes
+
+ifeq ($(findstring -lasx,$(ARCH)),-lasx)
+	lsx = yes
+	lasx = yes
+endif
+
+ifeq ($(findstring -lsx,$(ARCH)),-lsx)
+	lsx = yes
+endif
+
 endif
 endif
 
@@ -408,7 +424,7 @@ ifeq ($(COMP),gcc)
 		ifeq ($(ARCH),riscv64)
 			CXXFLAGS += -latomic
 		endif
-	else ifeq ($(ARCH),loongarch64)
+	else ifeq ($(arch),loongarch64)
 		CXXFLAGS += -latomic
 	else
 		CXXFLAGS += -m$(bits)
@@ -480,7 +496,7 @@ ifeq ($(COMP),clang)
 		ifeq ($(ARCH),riscv64)
 			CXXFLAGS += -latomic
 		endif
-	else ifeq ($(ARCH),loongarch64)
+	else ifeq ($(arch),loongarch64)
 		CXXFLAGS += -latomic
 	else
 		CXXFLAGS += -m$(bits)
@@ -719,6 +735,18 @@ ifeq ($(dotprod),yes)
 	CXXFLAGS += -march=armv8.2-a+dotprod -DUSE_NEON_DOTPROD
 endif
 
+ifeq ($(lasx),yes)
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
+		CXXFLAGS += -mlasx
+	endif
+endif
+
+ifeq ($(lsx),yes)
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
+		CXXFLAGS += -mlsx
+	endif
+endif
+
 ### 3.7 pext
 ifeq ($(pext),yes)
 	CXXFLAGS += -DUSE_PEXT
@@ -835,6 +863,8 @@ help:
 	@echo "general-32              > unspecified 32-bit"
 	@echo "riscv64                 > RISC-V 64-bit"
 	@echo "loongarch64             > LoongArch 64-bit"
+	@echo "loongarch64-lsx         > LoongArch 64-bit with SIMD eXtension"
+	@echo "loongarch64-lasx        > LoongArch 64-bit with Advanced SIMD eXtension"
 	@echo ""
 	@echo "Supported compilers:"
 	@echo ""
@@ -960,6 +990,8 @@ config-sanity: net
 	@echo "neon: '$(neon)'"
 	@echo "dotprod: '$(dotprod)'"
 	@echo "arm_version: '$(arm_version)'"
+	@echo "lsx: '$(lsx)'"
+	@echo "lasx: '$(lasx)'"
 	@echo "target_windows: '$(target_windows)'"
 	@echo ""
 	@echo "Flags:"


### PR DESCRIPTION
This allows `make -j profile-build` work on loongarch64 and SIMD instruction enabled automatically.

Benchmark on `Loongson-3A6000-HV Not Specified CPU @ 2.5GHz`

```
Total time (ms) : 3959
Nodes searched  : 1011161
Nodes/second    : 255408
```