### PR TITLE
Removed ROOK threatenedByPawn

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -176,8 +176,8 @@ void MovePicker::score() {
 
             // malus for putting piece en prise
             m.value -= (pt == QUEEN  ? bool(to & threatenedByRook) * 49000
-                        : pt == ROOK ? bool(to & threatenedByMinor) * 24335
-                                     : bool(to & threatenedByPawn) * 14900);
+                      : pt == ROOK && bool(to & threatenedByMinor) ? 24335
+                                     : 0);
 
             if (rootNode)
                 m.value += 4 * (*rootHistory)[pos.side_to_move()][m.from_to()];


### PR DESCRIPTION
Removed ROOK threatenedByPawn
Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 56608 W: 14788 L: 14588 D: 27232
Ptnml(0-2): 162, 6763, 14313, 6845, 221
https://tests.stockfishchess.org/tests/view/66e83f9c86d5ee47d953ab1d

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 175758 W: 44501 L: 44438 D: 86819
Ptnml(0-2): 125, 19489, 48601, 19526, 138
https://tests.stockfishchess.org/tests/view/66e882d486d5ee47d953ab8a

bench: 1241271