### PR TITLE
Avoid wrongful TT/history updates when unwinding the search during a thread stop

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -895,6 +895,11 @@ Value Search::Worker::search(
 
             pos.undo_move(move);
 
+            // If a stop occurred, the return value of the search cannot be trusted, and we
+            // must return immediately without updating any histories nor the transposition table.
+            if (threads.stop.load(std::memory_order_relaxed))
+                return VALUE_ZERO;
+
             if (value >= probCutBeta)
             {
                 thisThread->captureHistory[movedPiece][move.to_sq()][type_of(captured)]


### PR DESCRIPTION
Bench 1511354

Probcut does not have the same logic that exists in the primary move loop during pvsearch, which guards against acting on invalid scores from child nodes. With this PR, it does. The solution, and the comment, are copy-pasted from the other location.

STC non-reg: https://tests.stockfishchess.org/tests/view/66fd0c2e86d5ee47d953b9af
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 67136 W: 17581 L: 17398 D: 32157
Ptnml(0-2): 215, 7478, 18033, 7593, 249

LTC non-reg: https://tests.stockfishchess.org/tests/view/66feec5686d5ee47d953bb4f
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 350766 W: 88748 L: 88862 D: 173156
Ptnml(0-2): 211, 36626, 101794, 36570, 182

