### PR TITLE
Refactor root history into low ply history.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -82,20 +82,20 @@ MovePicker::MovePicker(const Position&              p,
                        Move                         ttm,
                        Depth                        d,
                        const ButterflyHistory*      mh,
-                       const ButterflyHistory*      rh,
+                       const LowPlyHistory*         lph,
                        const CapturePieceToHistory* cph,
                        const PieceToHistory**       ch,
                        const PawnHistory*           ph,
-                       bool                         rn) :
+                       int                          pl) :
     pos(p),
     mainHistory(mh),
-    rootHistory(rh),
+    lowPlyHistory(lph),
     captureHistory(cph),
     continuationHistory(ch),
     pawnHistory(ph),
     ttMove(ttm),
     depth(d),
-    rootNode(rn) {
+    ply(pl) {
 
     if (pos.checkers())
         stage = EVASION_TT + !(ttm && pos.pseudo_legal(ttm));
@@ -179,8 +179,8 @@ void MovePicker::score() {
                         : pt == ROOK && bool(to & threatenedByMinor) ? 24335
                                                                      : 0);
 
-            if (rootNode)
-                m.value += 4 * (*rootHistory)[pos.side_to_move()][m.from_to()];
+            if (ply < 4)
+                m.value += 8 * (*lowPlyHistory)[pos.side_to_move()][ply][m.from_to()] / (1 + 2 * ply);
         }
 
         else  // Type == EVASIONS

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -180,7 +180,7 @@ void MovePicker::score() {
                                                                      : 0);
 
             if (ply < 4)
-                m.value += 8 * (*lowPlyHistory)[pos.side_to_move()][ply][m.from_to()] / (1 + 2 * ply);
+                m.value += 8 * (*lowPlyHistory)[ply][m.from_to()] / (1 + 2 * ply);
         }
 
         else  // Type == EVASIONS

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -135,6 +135,8 @@ enum StatsType {
 // see https://www.chessprogramming.org/Butterfly_Boards (~11 elo)
 using ButterflyHistory = Stats<int16_t, 7183, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)>;
 
+using LowPlyHistory = Stats<int16_t, 7183, COLOR_NB, 4, int(SQUARE_NB) * int(SQUARE_NB)>;
+
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;
 
@@ -195,11 +197,11 @@ class MovePicker {
                Move,
                Depth,
                const ButterflyHistory*,
-               const ButterflyHistory*,
+               const LowPlyHistory*,
                const CapturePieceToHistory*,
                const PieceToHistory**,
                const PawnHistory*,
-               bool);
+               int);
     MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
     Move next_move(bool skipQuiets = false);
 
@@ -213,7 +215,7 @@ class MovePicker {
 
     const Position&              pos;
     const ButterflyHistory*      mainHistory;
-    const ButterflyHistory*      rootHistory;
+    const LowPlyHistory*         lowPlyHistory;
     const CapturePieceToHistory* captureHistory;
     const PieceToHistory**       continuationHistory;
     const PawnHistory*           pawnHistory;
@@ -222,7 +224,7 @@ class MovePicker {
     int                          stage;
     int                          threshold;
     Depth                        depth;
-    bool                         rootNode;
+    int                          ply;
     ExtMove                      moves[MAX_MOVES];
 };
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -135,7 +135,7 @@ enum StatsType {
 // see https://www.chessprogramming.org/Butterfly_Boards (~11 elo)
 using ButterflyHistory = Stats<int16_t, 7183, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)>;
 
-using LowPlyHistory = Stats<int16_t, 7183, COLOR_NB, 4, int(SQUARE_NB) * int(SQUARE_NB)>;
+using LowPlyHistory = Stats<int16_t, 7183, 4, int(SQUARE_NB) * int(SQUARE_NB)>;
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
 using CapturePieceToHistory = Stats<int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -135,6 +135,8 @@ enum StatsType {
 // see https://www.chessprogramming.org/Butterfly_Boards (~11 elo)
 using ButterflyHistory = Stats<int16_t, 7183, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)>;
 
+// LowPlyHistory is adressed by play and move's from and to squares, used
+// to improve move ordering near the root
 using LowPlyHistory = Stats<int16_t, 7183, 4, int(SQUARE_NB) * int(SQUARE_NB)>;
 
 // CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -109,8 +109,7 @@ void  update_quiet_histories(const Position& pos,
                              Stack*          ss,
                              Search::Worker& workerThread,
                              Move            move,
-                             int             bonus,
-                             bool            rootNode);
+                             int             bonus);
 void  update_all_stats(const Position&      pos,
                        Stack*               ss,
                        Search::Worker&      workerThread,
@@ -118,8 +117,7 @@ void  update_all_stats(const Position&      pos,
                        Square               prevSq,
                        ValueList<Move, 32>& quietsSearched,
                        ValueList<Move, 32>& capturesSearched,
-                       Depth                depth,
-                       bool                 rootNode);
+                       Depth                depth);
 
 }  // namespace
 
@@ -273,7 +271,7 @@ void Search::Worker::iterative_deepening() {
 
     int searchAgainCounter = 0;
 
-    rootHistory.fill(0);
+    lowPlyHistory.fill(0);
 
     // Iterative deepening loop until requested to stop or the target depth is reached
     while (++rootDepth < MAX_PLY && !threads.stop
@@ -499,7 +497,7 @@ void Search::Worker::iterative_deepening() {
 // Reset histories, usually before a new game
 void Search::Worker::clear() {
     mainHistory.fill(0);
-    rootHistory.fill(0);
+    lowPlyHistory.fill(0);
     captureHistory.fill(-753);
     pawnHistory.fill(-1152);
     pawnCorrectionHistory.fill(0);
@@ -638,7 +636,7 @@ Value Search::Worker::search(
         {
             // Bonus for a quiet ttMove that fails high (~2 Elo)
             if (!ttCapture)
-                update_quiet_histories(pos, ss, *this, ttData.move, stat_bonus(depth), rootNode);
+                update_quiet_histories(pos, ss, *this, ttData.move, stat_bonus(depth));
 
             // Extra penalty for early quiet moves of
             // the previous ply (~1 Elo on STC, ~2 Elo on LTC)
@@ -928,8 +926,8 @@ moves_loop:  // When in check, search starts here
                                         (ss - 6)->continuationHistory};
 
 
-    MovePicker mp(pos, ttData.move, depth, &thisThread->mainHistory, &thisThread->rootHistory,
-                  &thisThread->captureHistory, contHist, &thisThread->pawnHistory, rootNode);
+    MovePicker mp(pos, ttData.move, depth, &thisThread->mainHistory, &thisThread->lowPlyHistory,
+                  &thisThread->captureHistory, contHist, &thisThread->pawnHistory, ss->ply);
 
     value = bestValue;
 
@@ -1355,8 +1353,7 @@ moves_loop:  // When in check, search starts here
     // If there is a move that produces search value greater than alpha,
     // we update the stats of searched moves.
     else if (bestMove)
-        update_all_stats(pos, ss, *this, bestMove, prevSq, quietsSearched, capturesSearched, depth,
-                         rootNode);
+        update_all_stats(pos, ss, *this, bestMove, prevSq, quietsSearched, capturesSearched, depth);
 
     // Bonus for prior countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
@@ -1557,9 +1554,9 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
     // Initialize a MovePicker object for the current position, and prepare to search
     // the moves. We presently use two stages of move generator in quiescence search:
     // captures, or evasions only when in check.
-    MovePicker mp(pos, ttData.move, DEPTH_QS, &thisThread->mainHistory, &thisThread->rootHistory,
+    MovePicker mp(pos, ttData.move, DEPTH_QS, &thisThread->mainHistory, &thisThread->lowPlyHistory,
                   &thisThread->captureHistory, contHist, &thisThread->pawnHistory,
-                  nodeType == Root);
+                  ss->ply);
 
     // Step 5. Loop through all pseudo-legal moves until no moves remain or a beta
     // cutoff occurs.
@@ -1768,8 +1765,7 @@ void update_all_stats(const Position&      pos,
                       Square               prevSq,
                       ValueList<Move, 32>& quietsSearched,
                       ValueList<Move, 32>& capturesSearched,
-                      Depth                depth,
-                      bool                 rootNode) {
+                      Depth                depth) {
 
     CapturePieceToHistory& captureHistory = workerThread.captureHistory;
     Piece                  moved_piece    = pos.moved_piece(bestMove);
@@ -1780,11 +1776,11 @@ void update_all_stats(const Position&      pos,
 
     if (!pos.capture_stage(bestMove))
     {
-        update_quiet_histories(pos, ss, workerThread, bestMove, quietMoveBonus, rootNode);
+        update_quiet_histories(pos, ss, workerThread, bestMove, quietMoveBonus);
 
         // Decrease stats for all non-best quiet moves
         for (Move move : quietsSearched)
-            update_quiet_histories(pos, ss, workerThread, move, -quietMoveMalus, rootNode);
+            update_quiet_histories(pos, ss, workerThread, move, -quietMoveMalus);
     }
     else
     {
@@ -1830,13 +1826,12 @@ void update_quiet_histories(const Position& pos,
                             Stack*          ss,
                             Search::Worker& workerThread,
                             Move            move,
-                            int             bonus,
-                            bool            rootNode) {
+                            int             bonus) {
 
     Color us = pos.side_to_move();
     workerThread.mainHistory[us][move.from_to()] << bonus;
-    if (rootNode)
-        workerThread.rootHistory[us][move.from_to()] << bonus;
+    if (ss->ply < 4)
+        workerThread.lowPlyHistory[us][ss->ply][move.from_to()] << bonus;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1831,7 +1831,7 @@ void update_quiet_histories(const Position& pos,
     Color us = pos.side_to_move();
     workerThread.mainHistory[us][move.from_to()] << bonus;
     if (ss->ply < 4)
-        workerThread.lowPlyHistory[us][ss->ply][move.from_to()] << bonus;
+        workerThread.lowPlyHistory[ss->ply][move.from_to()] << bonus;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus);
 

--- a/src/search.h
+++ b/src/search.h
@@ -278,7 +278,7 @@ class Worker {
 
     // Public because they need to be updatable by the stats
     ButterflyHistory mainHistory;
-    ButterflyHistory rootHistory;
+    LowPlyHistory    lowPlyHistory;
 
     CapturePieceToHistory captureHistory;
     ContinuationHistory   continuationHistory[2][2];


### PR DESCRIPTION
This patch changes root history to low ply history - butterfly history for plies < 4.
Doubles weight of this history for root, latter plies have lesser effect.
Passed STC:
https://tests.stockfishchess.org/tests/view/66f77d2386d5ee47d953b65d
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 180992 W: 47362 L: 46830 D: 86800
Ptnml(0-2): 554, 21499, 45928, 21891, 624 
Passed LTC:
https://tests.stockfishchess.org/tests/view/66fb557986d5ee47d953b8e5
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 42462 W: 11013 L: 10682 D: 20767
Ptnml(0-2): 33, 4518, 11795, 4855, 30 
bench 1498677