### PR TITLE
Enable Exception Handling in Stockfish

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -403,7 +403,7 @@ ifeq ($(MAKELEVEL),0)
        export ENV_LDFLAGS := $(LDFLAGS)
 endif
 
-CXXFLAGS = $(ENV_CXXFLAGS) -Wall -Wcast-qual -fno-exceptions -std=c++17 $(EXTRACXXFLAGS)
+CXXFLAGS = $(ENV_CXXFLAGS) -Wall -Wcast-qual -fexceptions -std=c++17 $(EXTRACXXFLAGS)
 DEPENDFLAGS = $(ENV_DEPENDFLAGS) -std=c++17
 LDFLAGS = $(ENV_LDFLAGS) $(EXTRALDFLAGS)
 


### PR DESCRIPTION
A try and catch is basically a way to handle the error by outputting a message or passing to another method.
```cpp
try {
  // Block of code to try
  throw exception; // Throw an exception when a problem arise
}
catch () {
  // Block of code to handle errors
} 
```
Currently, SF does not support the **try...catch** statement. I use '-fexceptions' to enable it.

No Functional Change