### PR TITLE
Remove -stat_malus(newDepth)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1195,8 +1195,7 @@ moves_loop:  // When in check, search starts here
                     value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, newDepth, !cutNode);
 
                 // Post LMR continuation history updates (~1 Elo)
-                int bonus = value >= beta ? (1 + 2 * (moveCount > depth)) * stat_bonus(newDepth)
-                                          : -stat_malus(newDepth);
+                int bonus = 3 * (value >= beta && moveCount > depth) * stat_bonus(newDepth);
                 update_continuation_histories(ss, movedPiece, move.to_sq(), bonus);
             }
         }


### PR DESCRIPTION
Simplification on top of PR #5621 
Remove -stat_malus(newDepth)

Passed STC (Tested against PR 5621):
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 32544 W: 8448 L: 8221 D: 15875
Ptnml(0-2): 112, 3813, 8192, 4046, 109
https://tests.stockfishchess.org/tests/view/6709178286d5ee47d953c148

Passed LTC (Tested against PR 5621):
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 41046 W: 10391 L: 10189 D: 20466
Ptnml(0-2): 25, 4497, 11284, 4685, 32
https://tests.stockfishchess.org/tests/view/6709579886d5ee47d953c16a

bench: 1137315