### PR TITLE
Small cleanup for stats adjustments

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1172,9 +1172,12 @@ moves_loop:  // When in check, search starts here
         if (ttCapture && !capture)
             r += 1 + (depth < 8);
 
+        if (ss->staticEval - unadjustedStaticEval < -50)
+            r++;
+
         // Increase reduction if next ply has a lot of fail high (~5 Elo)
         if ((ss + 1)->cutoffCnt > 3)
-            r += 1 + allNode + (ss->staticEval < alpha - 88);
+            r += 1 + allNode;
 
         // For first picked move (ttMove) reduce reduction (~3 Elo)
         else if (move == ttData.move)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1237,7 +1237,7 @@ moves_loop:  // When in check, search starts here
             (ss + 1)->pv[0] = Move::none();
 
             // Extend move from transposition table if we are about to dive into qsearch.
-            if (move == ttData.move && ss->statScore > -10000 && ss->ply <= thisThread->rootDepth * 2)
+            if (move == ttData.move && ss->statScore > -25000 && ss->ply <= thisThread->rootDepth * 2)
                 newDepth = std::max(newDepth, 1);
 
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1120,10 +1120,7 @@ moves_loop:  // When in check, search starts here
                 // If we are on a cutNode but the ttMove is not assumed to fail high
                 // over current beta (~1 Elo)
                 else if (cutNode)
-                {
                     extension = -2;
-                    depth--;
-                }
             }
 
             // Extension for capturing the previous moved piece (~1 Elo at LTC)
@@ -1240,7 +1237,7 @@ moves_loop:  // When in check, search starts here
             (ss + 1)->pv[0] = Move::none();
 
             // Extend move from transposition table if we are about to dive into qsearch.
-            if (move == ttData.move && ss->ply <= thisThread->rootDepth * 2)
+            if (move == ttData.move && ss->statScore > 0 && ss->ply <= thisThread->rootDepth * 2)
                 newDepth = std::max(newDepth, 1);
 
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1172,8 +1172,8 @@ moves_loop:  // When in check, search starts here
         if (ttCapture && !capture)
             r += 1 + (depth < 8);
 
-        if (ss->staticEval - unadjustedStaticEval < -80)
-            r++;
+        if (ss->staticEval - unadjustedStaticEval > -50)
+            r--;
 
         // Increase reduction if next ply has a lot of fail high (~5 Elo)
         if ((ss + 1)->cutoffCnt > 3)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1172,7 +1172,7 @@ moves_loop:  // When in check, search starts here
         if (ttCapture && !capture)
             r += 1 + (depth < 8);
 
-        if (ss->staticEval - unadjustedStaticEval < -70)
+        if (ss->staticEval - unadjustedStaticEval < -80)
             r++;
 
         // Increase reduction if next ply has a lot of fail high (~5 Elo)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -660,6 +660,12 @@ Value Search::Worker::search(
             return ttData.value;
     }
 
+    probCutBeta = beta + 379;
+    if ((ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4 && ttData.value >= probCutBeta
+        && std::abs(beta) < VALUE_TB_WIN_IN_MAX_PLY
+        && std::abs(ttData.value) < VALUE_TB_WIN_IN_MAX_PLY)
+        return probCutBeta;
+
     // Step 5. Tablebases probe
     if (!rootNode && !excludedMove && tbConfig.cardinality)
     {
@@ -926,11 +932,6 @@ Value Search::Worker::search(
 moves_loop:  // When in check, search starts here
 
     // Step 12. A small Probcut idea (~4 Elo)
-    probCutBeta = beta + 379;
-    if ((ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4 && ttData.value >= probCutBeta
-        && std::abs(beta) < VALUE_TB_WIN_IN_MAX_PLY
-        && std::abs(ttData.value) < VALUE_TB_WIN_IN_MAX_PLY)
-        return probCutBeta;
 
     const PieceToHistory* contHist[] = {(ss - 1)->continuationHistory,
                                         (ss - 2)->continuationHistory,
@@ -1171,9 +1172,6 @@ moves_loop:  // When in check, search starts here
         // Increase reduction if ttMove is a capture but the current move is not a capture (~3 Elo)
         if (ttCapture && !capture)
             r += 1 + (depth < 8);
-
-        if (ss->staticEval - unadjustedStaticEval > 90)
-            r--;
 
         // Increase reduction if next ply has a lot of fail high (~5 Elo)
         if ((ss + 1)->cutoffCnt > 3)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1115,7 +1115,10 @@ moves_loop:  // When in check, search starts here
 
                 // If the ttMove is assumed to fail high over current beta (~7 Elo)
                 else if (ttData.value >= beta)
+                {
                     extension = -3;
+                    depth--;
+                }
 
                 // If we are on a cutNode but the ttMove is not assumed to fail high
                 // over current beta (~1 Elo)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1237,7 +1237,7 @@ moves_loop:  // When in check, search starts here
             (ss + 1)->pv[0] = Move::none();
 
             // Extend move from transposition table if we are about to dive into qsearch.
-            if (move == ttData.move && ss->statScore > -25000 && ss->ply <= thisThread->rootDepth * 2)
+            if (move == ttData.move && ss->statScore > -15000 && ss->ply <= thisThread->rootDepth * 2)
                 newDepth = std::max(newDepth, 1);
 
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1172,7 +1172,7 @@ moves_loop:  // When in check, search starts here
         if (ttCapture && !capture)
             r += 1 + (depth < 8);
 
-        if (ss->staticEval - unadjustedStaticEval < -60)
+        if (ss->staticEval - unadjustedStaticEval < -70)
             r++;
 
         // Increase reduction if next ply has a lot of fail high (~5 Elo)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -660,7 +660,7 @@ Value Search::Worker::search(
             return ttData.value;
     }
 
-    probCutBeta = beta + 379;
+    probCutBeta = beta + 359;
     if ((ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4 && ttData.value >= probCutBeta
         && std::abs(beta) < VALUE_TB_WIN_IN_MAX_PLY
         && std::abs(ttData.value) < VALUE_TB_WIN_IN_MAX_PLY)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1115,15 +1115,15 @@ moves_loop:  // When in check, search starts here
 
                 // If the ttMove is assumed to fail high over current beta (~7 Elo)
                 else if (ttData.value >= beta)
-                {
                     extension = -3;
-                    depth--;
-                }
 
                 // If we are on a cutNode but the ttMove is not assumed to fail high
                 // over current beta (~1 Elo)
                 else if (cutNode)
+                {
                     extension = -2;
+                    depth--;
+                }
             }
 
             // Extension for capturing the previous moved piece (~1 Elo at LTC)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1237,7 +1237,7 @@ moves_loop:  // When in check, search starts here
             (ss + 1)->pv[0] = Move::none();
 
             // Extend move from transposition table if we are about to dive into qsearch.
-            if (move == ttData.move && ss->statScore > 0 && ss->ply <= thisThread->rootDepth * 2)
+            if (move == ttData.move && ss->statScore > -10000 && ss->ply <= thisThread->rootDepth * 2)
                 newDepth = std::max(newDepth, 1);
 
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1172,7 +1172,7 @@ moves_loop:  // When in check, search starts here
         if (ttCapture && !capture)
             r += 1 + (depth < 8);
 
-        if (ss->staticEval - unadjustedStaticEval > 80)
+        if (ss->staticEval - unadjustedStaticEval > 90)
             r--;
 
         // Increase reduction if next ply has a lot of fail high (~5 Elo)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -929,7 +929,7 @@ Value Search::Worker::search(
                 {
                     movedPiece = pos.moved_piece(negMove);
                     captured    = pos.piece_on(negMove.to_sq());
-                    captureHistory[movedPiece][negMove.to_sq()][type_of(captured)] << -stat_malus(depth - 2);
+                    captureHistory[movedPiece][negMove.to_sq()][type_of(captured)] << -stat_malus(depth - 3);
                 }
                 
                 return std::abs(value) < VALUE_TB_WIN_IN_MAX_PLY ? value - (probCutBeta - beta)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1172,7 +1172,7 @@ moves_loop:  // When in check, search starts here
         if (ttCapture && !capture)
             r += 1 + (depth < 8);
 
-        if (ss->staticEval - unadjustedStaticEval < -50)
+        if (ss->staticEval - unadjustedStaticEval < -60)
             r++;
 
         // Increase reduction if next ply has a lot of fail high (~5 Elo)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1172,7 +1172,7 @@ moves_loop:  // When in check, search starts here
         if (ttCapture && !capture)
             r += 1 + (depth < 8);
 
-        if (ss->staticEval - unadjustedStaticEval > -50)
+        if (ss->staticEval - unadjustedStaticEval > 80)
             r--;
 
         // Increase reduction if next ply has a lot of fail high (~5 Elo)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1174,7 +1174,7 @@ moves_loop:  // When in check, search starts here
 
         // Increase reduction if next ply has a lot of fail high (~5 Elo)
         if ((ss + 1)->cutoffCnt > 3)
-            r += 1 + allNode;
+            r += 1 + allNode + (ss->staticEval < alpha - 88);
 
         // For first picked move (ttMove) reduce reduction (~3 Elo)
         else if (move == ttData.move)
@@ -1237,7 +1237,7 @@ moves_loop:  // When in check, search starts here
             (ss + 1)->pv[0] = Move::none();
 
             // Extend move from transposition table if we are about to dive into qsearch.
-            if (move == ttData.move && ss->statScore > -15000 && ss->ply <= thisThread->rootDepth * 2)
+            if (move == ttData.move && ss->ply <= thisThread->rootDepth * 2)
                 newDepth = std::max(newDepth, 1);
 
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -919,7 +919,7 @@ Value Search::Worker::search(
             if (value >= probCutBeta)
             {
                 thisThread->captureHistory[movedPiece][move.to_sq()][type_of(captured)]
-                  << stat_bonus(depth - 2);
+                  << stat_bonus(depth - 3);
 
                 // Save ProbCut data into transposition table
                 ttWriter.write(posKey, value_to_tt(value, ss->ply), ss->ttPv, BOUND_LOWER,

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -660,7 +660,7 @@ Value Search::Worker::search(
             return ttData.value;
     }
 
-    probCutBeta = beta + 359;
+    probCutBeta = beta + 399;
     if ((ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4 && ttData.value >= probCutBeta
         && std::abs(beta) < VALUE_TB_WIN_IN_MAX_PLY
         && std::abs(ttData.value) < VALUE_TB_WIN_IN_MAX_PLY)


### PR DESCRIPTION
After some simplifications bonuses and maluses are the same for quiet and non-quiet moves so it makes no sense to use quietMoveBonus/Malus, instead use just bonus/malus.
No functional change.