### PR TITLE
Swedish/Norweigian  word changed to english word, Copying.txt

### DIFF
--- a/Copying.txt
+++ b/Copying.txt
@@ -32,7 +32,7 @@ certain responsibilities if you distribute copies of the software, or if
 you modify it: responsibilities to respect the freedom of others.
 
   For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must pass on to the recipients the same
+free or for a fee, you must pass on to the recipients the same
 freedoms that you received.  You must make sure that they, too, receive
 or can get the source code.  And you must show them these terms so they
 know their rights.


### PR DESCRIPTION
I changed "gratis" on line 35 which means free in Swedish or Norwegian to "free" the English word.

(not sure if you should change licenses so otherwise just ignore it, just noticed it when reading and thought it looked off).

Also, I read the contributing guidelines so I hope I didn't miss anything there, said to put my name in authors but it seems extremely silly to change one word in the license, so I did not do that, hopefully, that is fine as well. Just came here to learn about building my own chess engine, great work on stockfish!