### PR TITLE
Consistent weights for histories

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -156,11 +156,11 @@ void MovePicker::score() {
             Square    to   = m.to_sq();
 
             // histories
-            m.value = (*mainHistory)[pos.side_to_move()][m.from_to()];
+            m.value =  2 * (*mainHistory)[pos.side_to_move()][m.from_to()];
             m.value += 2 * (*pawnHistory)[pawn_structure_index(pos)][pc][to];
-            m.value += 2 * (*continuationHistory[0])[pc][to];
+            m.value += (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
-            m.value += (*continuationHistory[2])[pc][to] / 3;
+            m.value += (*continuationHistory[2])[pc][to];
             m.value += (*continuationHistory[3])[pc][to];
             m.value += (*continuationHistory[5])[pc][to];
 


### PR DESCRIPTION
This simplification sets all the continuation history weights in quiet move ordering to 1. It also doubles the weight of the main butterfly history, inspired by a recent tune.

Passed non-regression STC: 
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 33920 W: 8956 L: 8730 D: 16234
Ptnml(0-2): 115, 3920, 8693, 4088, 144 
https://tests.stockfishchess.org/tests/view/671b2e5f86d5ee47d953ce90

Passed non-regression LTC: 
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 61338 W: 15590 L: 15411 D: 30337
Ptnml(0-2): 29, 6658, 17133, 6803, 46 
https://tests.stockfishchess.org/tests/view/671bdbf586d5ee47d953cef8
