### PR TITLE
Adjust statscore for captures

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1177,7 +1177,10 @@ moves_loop:  // When in check, search starts here
         else if (move == ttData.move)
             r -= 2;
 
-        ss->statScore = 2 * thisThread->mainHistory[us][move.from_to()]
+        if (capture)
+            ss->statScore = thisThread->captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())] - 13000;
+        else
+            ss->statScore = 2 * thisThread->mainHistory[us][move.from_to()]
                       + (*contHist[0])[movedPiece][move.to_sq()]
                       + (*contHist[1])[movedPiece][move.to_sq()] - 4410;
 


### PR DESCRIPTION
Instead of using quiet histories use capture history with a different offset.
Passed STC:
https://tests.stockfishchess.org/tests/view/6731d5cc86d5ee47d953e719
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 428896 W: 111160 L: 110269 D: 207467
Ptnml(0-2): 1220, 50296, 110534, 51169, 1229 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6733d9fd86d5ee47d953e962
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 105882 W: 26918 L: 26458 D: 52506
Ptnml(0-2): 66, 11430, 29482, 11904, 59 
bench 1186657