### PR TITLE
Rewrite of 'Adjust correction history' condition 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1425,9 +1425,9 @@ moves_loop:  // When in check, search starts here
                        depth, bestMove, unadjustedStaticEval, tt.generation());
 
     // Adjust correction history
-    if (!ss->inCheck && (!bestMove || !pos.capture(bestMove))
-        && !(bestValue >= beta && bestValue <= ss->staticEval)
-        && !(!bestMove && bestValue >= ss->staticEval))
+    if (!ss->inCheck && !(bestMove && pos.capture(bestMove))
+        && ((bestValue < ss->staticEval && bestValue < beta )   // negative correction & no fail high
+         || (bestValue > ss->staticEval && bestMove)))          // positive correction & no fail low
     {
         const auto m = (ss - 1)->currentMove;
 


### PR DESCRIPTION
Current condition is IMO convoluted and hard to understand because of several negations.
Also added 2 comments to make the concept behind the condition better understandable.

No functional change

bench: 840721