### PR TITLE
return in qs when reaching alpha

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1674,10 +1674,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
                 if (PvNode)  // Update pv even in fail-high case
                     update_pv(ss->pv, move, (ss + 1)->pv);
 
-                if (value < beta)  // Update alpha here!
-                    alpha = value;
-                else
-                    break;  // Fail high
+                break;
             }
         }
     }


### PR DESCRIPTION
Simplify score improvement in qsearch

Before if we passed alpha but didn't achieve a beta cutoff we updated alpha and kept alpha. This patch makes it so that a value greater than alpha is returned immediately.

Passed STC:
https://tests.stockfishchess.org/tests/view/67383c6a86d5ee47d953ee9a
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 44992 W: 11764 L: 11551 D: 21677
Ptnml(0-2): 146, 5238, 11505, 5471, 136 

Passed LTC:
https://tests.stockfishchess.org/tests/view/6738c2ea86d5ee47d953eef8
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 210474 W: 53710 L: 53683 D: 103081
Ptnml(0-2): 123, 23186, 58607, 23183, 138 

Bench: 798787