### PR TITLE
large bonus for capture that caused a fail low

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -889,7 +889,8 @@ Value Search::Worker::search(
             // Prefetch the TT entry for the resulting position
             prefetch(tt.first_entry(pos.key_after(move)));
 
-            ss->currentMove = move;
+            ss->currentMove   = move;
+            ss->capturedPiece = captured;
             ss->continuationHistory =
               &this->continuationHistory[ss->inCheck][true][pos.moved_piece(move)][move.to_sq()];
             ss->continuationCorrectionHistory =
@@ -1139,7 +1140,8 @@ moves_loop:  // When in check, search starts here
         prefetch(tt.first_entry(pos.key_after(move)));
 
         // Update the current move (this must be done after singular extension search)
-        ss->currentMove = move;
+        ss->currentMove   = move;
+        ss->capturedPiece = pos.piece_on(move.to_sq());
         ss->continuationHistory =
           &thisThread->continuationHistory[ss->inCheck][capture][movedPiece][move.to_sq()];
         ss->continuationCorrectionHistory =
@@ -1403,6 +1405,14 @@ moves_loop:  // When in check, search starts here
               << stat_bonus(depth) * bonus / 24;
     }
 
+    else if (priorCapture && prevSq != SQ_NONE)
+    {
+        Piece capturedPiece = (ss - 1)->capturedPiece;
+        assert(capturedPiece != NO_PIECE);
+        // bonus for prior countermoves that caused the fail low
+        thisThread->captureHistory[pos.piece_on(prevSq)][prevSq][type_of(capturedPiece)]
+          << stat_bonus(depth) * 2;
+    }
     // Bonus when search fails low and there is a TT move
     else if (ttData.move && !allNode)
         thisThread->mainHistory[us][ttData.move.from_to()] << stat_bonus(depth) * 23 / 100;
@@ -1647,7 +1657,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
         prefetch(tt.first_entry(pos.key_after(move)));
 
         // Update the current move
-        ss->currentMove = move;
+        ss->currentMove   = move;
+        ss->capturedPiece = pos.piece_on(move.to_sq());
         ss->continuationHistory =
           &thisThread
              ->continuationHistory[ss->inCheck][capture][pos.moved_piece(move)][move.to_sq()];

--- a/src/search.h
+++ b/src/search.h
@@ -66,6 +66,7 @@ struct Stack {
     CorrectionHistory<PieceTo>* continuationCorrectionHistory;
     int                         ply;
     Move                        currentMove;
+    Piece                       capturedPiece;
     Move                        excludedMove;
     Value                       staticEval;
     int                         statScore;


### PR DESCRIPTION
Bonus for a prior capture that causes a fail low.

This tweak adds a bonus equal to twice the stat_bonus for the current depth for a prior capture that caused a fail high, similar to the prior countermove bonus we currently have. 

Passed STC
https://tests.stockfishchess.org/tests/view/673bc14b86d5ee47d953f1f2
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 105824 W: 27538 L: 27118 D: 51168
Ptnml(0-2): 358, 12370, 27024, 12814, 346 

Passed LTC
https://tests.stockfishchess.org/tests/view/673ccbff86d5ee47d953f2d9
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 134502 W: 34340 L: 33820 D: 66342
Ptnml(0-2): 102, 14634, 37229, 15214, 72 

Bench: 914094


