### PR TITLE
Simplify search fails low bonus formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1402,7 +1402,7 @@ moves_loop:  // When in check, search starts here
 
     // Bonus when search fails low and there is a TT move
     else if (ttData.move && !allNode)
-        thisThread->mainHistory[us][ttData.move.from_to()] << stat_bonus(depth) * 23 / 100;
+        thisThread->mainHistory[us][ttData.move.from_to()] << stat_bonus(depth) / 4;
 
     if (PvNode)
         bestValue = std::min(bestValue, maxValue);


### PR DESCRIPTION
Simplify search fails low bonus formula, keeping the more simple form, since having double operations doesn't bring any elo gain.

Passed STC:
LLR: 2.98 (-2.94,2.94) <-1.75,0.25>
Total: 162944 W: 42216 L: 42131 D: 78597
Ptnml(0-2): 517, 19335, 41697, 19392, 531
https://tests.stockfishchess.org/tests/view/674718b586d5ee47d953fdc2

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 118080 W: 30093 L: 29971 D: 58016
Ptnml(0-2): 70, 13040, 32712, 13134, 84
https://tests.stockfishchess.org/tests/view/67474a0486d5ee47d953fe0b

bench: 1041901