### PR TITLE
Remove reduction in think time for recaptures

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -58,7 +58,6 @@ Engine::Engine(std::optional<std::string> path) :
         NN::NetworkBig({EvalFileDefaultNameBig, "None", ""}, NN::EmbeddedNNUEType::BIG),
         NN::NetworkSmall({EvalFileDefaultNameSmall, "None", ""}, NN::EmbeddedNNUEType::SMALL))) {
     pos.set(StartFEN, false, &states->back());
-    capSq = SQ_NONE;
 
     options["Debug Log File"] << Option("", [](const Option& o) {
         start_logger(o);
@@ -125,7 +124,6 @@ std::uint64_t Engine::perft(const std::string& fen, Depth depth, bool isChess960
 void Engine::go(Search::LimitsType& limits) {
     assert(limits.perft == 0);
     verify_networks();
-    limits.capSq = capSq;
 
     threads.start_thinking(options, pos, states, limits);
 }
@@ -168,7 +166,6 @@ void Engine::set_position(const std::string& fen, const std::vector<std::string>
     states = StateListPtr(new std::deque<StateInfo>(1));
     pos.set(fen, options["UCI_Chess960"], &states->back());
 
-    capSq = SQ_NONE;
     for (const auto& move : moves)
     {
         auto m = UCIEngine::to_move(pos, move);
@@ -178,11 +175,6 @@ void Engine::set_position(const std::string& fen, const std::vector<std::string>
 
         states->emplace_back();
         pos.do_move(m, states->back());
-
-        capSq          = SQ_NONE;
-        DirtyPiece& dp = states->back().dirtyPiece;
-        if (dp.dirty_num > 1 && dp.to[1] == SQ_NONE)
-            capSq = m.to_sq();
     }
 }
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -39,8 +39,6 @@
 
 namespace Stockfish {
 
-enum Square : int;
-
 class Engine {
    public:
     using InfoShort = Search::InfoShort;
@@ -116,7 +114,6 @@ class Engine {
 
     Position     pos;
     StateListPtr states;
-    Square       capSq;
 
     OptionsMap                               options;
     ThreadPool                               threads;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -453,10 +453,9 @@ void Search::Worker::iterative_deepening() {
             timeReduction    = lastBestMoveDepth + 8 < completedDepth ? 1.495 : 0.687;
             double reduction = (1.48 + mainThread->previousTimeReduction) / (2.17 * timeReduction);
             double bestMoveInstability = 1 + 1.88 * totBestMoveChanges / threads.size();
-            double recapture           = limits.capSq == rootMoves[0].pv[0].to_sq() ? 0.955 : 1.005;
 
             double totalTime =
-              mainThread->tm.optimum() * fallingEval * reduction * bestMoveInstability * recapture;
+              mainThread->tm.optimum() * fallingEval * reduction * bestMoveInstability;
 
             // Cap used time in case of a single legal move for a better viewer experience
             if (rootMoves.size() == 1)

--- a/src/search.h
+++ b/src/search.h
@@ -126,7 +126,6 @@ struct LimitsType {
     int                      movestogo, depth, mate, perft, infinite;
     uint64_t                 nodes;
     bool                     ponderMode;
-    Square                   capSq;
 };
 
 


### PR DESCRIPTION


Remove reduction in think time for recaptures

Passed simplification STC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 54016 W: 14098 L: 13902 D: 26016
Ptnml(0-2): 165, 5797, 14919, 5931, 196
https://tests.stockfishchess.org/tests/view/6758a90486d5ee47d954201e

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 296940 W: 75631 L: 75689 D: 145620
Ptnml(0-2): 145, 28928, 90384, 28866, 147
https://tests.stockfishchess.org/tests/view/6758df7a86d5ee47d9542091

Bench: 934447
