### PR TITLE
Simplify Probcut Conditions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -538,7 +538,7 @@ Value Search::Worker::search(
 
     // Dive into quiescence search when the depth reaches zero
     if (depth <= 0)
-        return qsearch < PvNode ? PV : NonPV > (pos, ss, alpha, beta);
+        return qsearch<PvNode ? PV : NonPV>(pos, ss, alpha, beta);
 
     // Limit the depth if extensions made it too large
     depth = std::min(depth, MAX_PLY - 1);
@@ -856,7 +856,7 @@ Value Search::Worker::search(
     // If we have a good enough capture (or queen promotion) and a reduced search
     // returns a value much above beta, we can (almost) safely prune the previous move.
     probCutBeta = beta + 187 - 56 * improving;
-    if (!PvNode && depth > 3
+    if (depth > 3
         && !is_decisive(beta)
         // If value from transposition table is lower than probCutBeta, don't attempt
         // probCut there and in further interactions with transposition table cutoff


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 248608 W: 64453 L: 64467 D: 119688
Ptnml(0-2): 784, 29486, 63796, 29436, 802
https://tests.stockfishchess.org/tests/view/6759244386d5ee47d95420ea

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 248988 W: 63217 L: 63230 D: 122541
Ptnml(0-2): 142, 27325, 69584, 27290, 153
https://tests.stockfishchess.org/tests/view/675a7ad886d5ee47d9542341

bench 1032143