### PR TITLE
Simplify Razoring

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -775,12 +775,9 @@ Value Search::Worker::search(
     // Step 7. Razoring (~1 Elo)
     // If eval is really low, check with qsearch if we can exceed alpha. If the
     // search suggests we cannot exceed alpha, return a speculative fail low.
-    if (eval < alpha - 469 - 307 * depth * depth)
-    {
-        value = qsearch<NonPV>(pos, ss, alpha - 1, alpha);
-        if (value < alpha && !is_decisive(value))
-            return value;
-    }
+    // For PvNodes, we must have a guard against mates being returned.
+    if (!PvNode && eval < alpha - 469 - 307 * depth * depth)
+        return qsearch<NonPV>(pos, ss, alpha - 1, alpha);
 
     // Step 8. Futility pruning: child node (~40 Elo)
     // The depth condition is important for mate finding.


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 95584 W: 24906 L: 24750 D: 45928
Ptnml(0-2): 285, 11227, 24632, 11343, 305
https://tests.stockfishchess.org/tests/view/675e0ed286d5ee47d95429ee

Passed Non-regression LTC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 191292 W: 48637 L: 48589 D: 94066
Ptnml(0-2): 97, 21061, 53276, 21121, 91
https://tests.stockfishchess.org/tests/view/675f08c686d5ee47d9542be3

bench 1163093