### PR TITLE
Making the second part of the formula smoother

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1713,7 +1713,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
 
 Depth Search::Worker::reduction(bool i, Depth d, int mn, int delta) const {
     int reductionScale = reductions[d] * reductions[mn];
-    return (reductionScale + 1304 - delta * 814 / rootDelta) + (!i && reductionScale > 1423) * 1135;
+    return (reductionScale + 1304 - delta * 814 / rootDelta) + !i * reductionScale / 3;
 }
 
 // elapsed() returns the time elapsed since the search started. If the


### PR DESCRIPTION
Making the second part of the formula smoother, changing it to a linear function, increasing steadily as reductionScale increases.
And at the same time, it should be a little bit simpler, therefore the simplification bounds.

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 83040 W: 21493 L: 21322 D: 40225
Ptnml(0-2): 252, 9848, 21209, 9899, 312
https://tests.stockfishchess.org/tests/view/6762145486d5ee47d9543242

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 230124 W: 58485 L: 58478 D: 113161
Ptnml(0-2): 175, 25620, 63484, 25589, 194
https://tests.stockfishchess.org/tests/view/6762d4ef86d5ee47d9543367

![rs](https://github.com/user-attachments/assets/5de26eec-e4f5-456b-b064-a21a0877944f)


bench: 953445