### PR TITLE
Simplify away reductions adjustment for multithreaded search.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -521,7 +521,7 @@ void Search::Worker::clear() {
                     h->fill(-645);
 
     for (size_t i = 1; i < reductions.size(); ++i)
-        reductions[i] = int((19.43 + std::log(size_t(options["Threads"])) / 2) * std::log(i));
+        reductions[i] = int(19.43 * std::log(i));
 
     refreshTable.clear(networks[numaAccessToken]);
 }


### PR DESCRIPTION
Seem to no longer bring measurable benefit.
Passed STC SMP simplification:
https://tests.stockfishchess.org/tests/view/6753561a86d5ee47d954151f
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 38000 W: 9864 L: 9656 D: 18480
Ptnml(0-2): 53, 4177, 10320, 4409, 41 
Passed LTC SMP simplification:
https://tests.stockfishchess.org/tests/view/6753d75f86d5ee47d9541669
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 258674 W: 66314 L: 66335 D: 126025
Ptnml(0-2): 77, 26957, 75303, 26910, 90 
Passed 16 threads LTC simplification:
https://tests.stockfishchess.org/tests/view/675a066286d5ee47d9542296
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 221804 W: 56950 L: 56936 D: 107918
Ptnml(0-2): 34, 21491, 67839, 21503, 35 
bench 934447