### PR TITLE
Remove compensation factor to adjust extra time according to time control

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -155,8 +155,7 @@ void Search::Worker::start_searching() {
         return;
     }
 
-    main_manager()->tm.init(limits, rootPos.side_to_move(), rootPos.game_ply(), options,
-                            main_manager()->originalTimeAdjust);
+    main_manager()->tm.init(limits, rootPos.side_to_move(), rootPos.game_ply(), options);
     tt.new_search();
 
     if (rootMoves.empty())

--- a/src/search.h
+++ b/src/search.h
@@ -238,7 +238,6 @@ class SearchManager: public ISearchManager {
             Depth                     depth);
 
     Stockfish::TimeManagement tm;
-    double                    originalTimeAdjust;
     int                       callsCnt;
     std::atomic_bool          ponder;
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -218,7 +218,6 @@ void ThreadPool::clear() {
 
     main_manager()->callsCnt           = 0;
     main_manager()->bestPreviousScore  = VALUE_INFINITE;
-    main_manager()->originalTimeAdjust = -1;
     main_manager()->tm.clear();
 }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -47,8 +47,7 @@ void TimeManagement::advance_nodes_time(std::int64_t nodes) {
 void TimeManagement::init(Search::LimitsType& limits,
                           Color               us,
                           int                 ply,
-                          const OptionsMap&   options,
-                          double&             originalTimeAdjust) {
+                          const OptionsMap&   options) {
     TimePoint npmsec = TimePoint(options["nodestime"]);
 
     // If we have no time, we don't need to fully initialize TM.
@@ -105,18 +104,13 @@ void TimeManagement::init(Search::LimitsType& limits,
     // game time for the current move, so also cap to a percentage of available game time.
     if (limits.movestogo == 0)
     {
-        // Extra time according to timeLeft
-        if (originalTimeAdjust < 0)
-            originalTimeAdjust = 0.3285 * std::log10(timeLeft) - 0.4830;
-
         // Calculate time constants based on current time left.
         double logTimeInSec = std::log10(scaledTime / 1000.0);
         double optConstant  = std::min(0.00308 + 0.000319 * logTimeInSec, 0.00506);
         double maxConstant  = std::max(3.39 + 3.01 * logTimeInSec, 2.93);
 
         optScale = std::min(0.0122 + std::pow(ply + 2.95, 0.462) * optConstant,
-                            0.213 * limits.time[us] / timeLeft)
-                 * originalTimeAdjust;
+                            0.213 * limits.time[us] / timeLeft);
 
         maxScale = std::min(6.64, maxConstant + ply / 12.0);
     }

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -39,8 +39,7 @@ class TimeManagement {
     void init(Search::LimitsType& limits,
               Color               us,
               int                 ply,
-              const OptionsMap&   options,
-              double&             originalTimeAdjust);
+              const OptionsMap&   options);
 
     TimePoint optimum() const;
     TimePoint maximum() const;


### PR DESCRIPTION
Remove the compensation factor to adjust extra time according to time control, as it's no longer bringing benefit.
P.s: When introduced it was also tested at 180+1.8, so let me know if an additional test at this TC is needed.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 102752 W: 26712 L: 26566 D: 49474
Ptnml(0-2): 395, 11713, 26950, 11987, 331
https://tests.stockfishchess.org/tests/view/67630eb286d5ee47d9543420

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 67284 W: 17133 L: 16962 D: 33189
Ptnml(0-2): 24, 7133, 19184, 7250, 51
https://tests.stockfishchess.org/tests/view/6763fe0686d5ee47d9543d2b

bench: 934447