### PR TITLE
Simplify Zobrist keys for captures

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1012,7 +1012,7 @@ void Position::do_castling(Color us, Square from, Square& to, Square& rfrom, Squ
 
 // Used to do a "null move": it flips
 // the side to move without executing any move on the board.
-void Position::do_null_move(StateInfo& newSt, TranspositionTable& tt) {
+void Position::do_null_move(StateInfo& newSt, const TranspositionTable& tt) {
 
     assert(!checkers());
     assert(&newSt != st);
@@ -1071,10 +1071,7 @@ Key Position::key_after(Move m) const {
     Piece  captured = piece_on(to);
     Key    k        = st->key ^ Zobrist::side;
 
-    if (captured)
-        k ^= Zobrist::psq[captured][to];
-
-    k ^= Zobrist::psq[pc][to] ^ Zobrist::psq[pc][from];
+    k ^= Zobrist::psq[captured][to] ^ Zobrist::psq[pc][to] ^ Zobrist::psq[pc][from];
 
     return (captured || type_of(pc) == PAWN) ? k : adjust_key50<true>(k);
 }

--- a/src/position.h
+++ b/src/position.h
@@ -143,7 +143,7 @@ class Position {
     void do_move(Move m, StateInfo& newSt);
     void do_move(Move m, StateInfo& newSt, bool givesCheck);
     void undo_move(Move m);
-    void do_null_move(StateInfo& newSt, TranspositionTable& tt);
+    void do_null_move(StateInfo& newSt, const TranspositionTable& tt);
     void undo_null_move();
 
     // Static Exchange Evaluation


### PR DESCRIPTION
The Zobrist keys for NO_PIECE are 0 so no need to special case captures.
Also the TranspositionTable reference passed to do_null_move() can be const.

https://tests.stockfishchess.org/tests/view/6764a79a86d5ee47d9544005
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 114240 W: 29654 L: 29523 D: 55063
Ptnml(0-2): 329, 12360, 31620, 12473, 338 

No functional change
bench: 934447