### PR TITLE
Allow Pv nodes at certain conditions to spawn zero window searches deeper than default.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1198,7 +1198,7 @@ moves_loop:  // When in check, search starts here
             // beyond the first move depth.
             // To prevent problems when the max value is less than the min value,
             // std::clamp has been replaced by a more robust implementation.
-            Depth d = std::max(1, std::min(newDepth - r / 1024, newDepth + !allNode));
+            Depth d = std::max(1, std::min(newDepth - r / 1024, newDepth + !allNode + (PvNode && !bestMove)));
 
             value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);
 


### PR DESCRIPTION
In current case it's allowed if there is no best move.
Passed STC:
https://tests.stockfishchess.org/tests/view/67640fd586d5ee47d9543d5a
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 392480 W: 102038 L: 101192 D: 189250
Ptnml(0-2): 1303, 46287, 100253, 47055, 1342 
Passed LTC:
https://tests.stockfishchess.org/tests/view/67671a4686d5ee47d9544476
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 128616 W: 32941 L: 32433 D: 63242
Ptnml(0-2): 84, 13997, 35634, 14513, 80 
bench 1095871