### PR TITLE
Simplify Post-LMR Conthist Bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1216,8 +1216,8 @@ moves_loop:  // When in check, search starts here
                     value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, newDepth, !cutNode);
 
                 // Post LMR continuation history updates (~1 Elo)
-                int bonus = (value >= beta) * stat_bonus(newDepth);
-                update_continuation_histories(ss, movedPiece, move.to_sq(), bonus * 1427 / 1024);
+                int bonus = (value >= beta) * 2048;
+                update_continuation_histories(ss, movedPiece, move.to_sq(), bonus);
             }
         }
 


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 49184 W: 12735 L: 12528 D: 23921
Ptnml(0-2): 134, 5746, 12647, 5909, 156
https://tests.stockfishchess.org/tests/view/6765cd2e86d5ee47d954420e

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 177270 W: 45227 L: 45166 D: 86877
Ptnml(0-2): 132, 19498, 49302, 19583, 120
https://tests.stockfishchess.org/tests/view/676721fd86d5ee47d9544489

bench 1115990