### PR TITLE
No Ply Restriction in the condition that limits the depth extension to a certain point

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1241,7 +1241,7 @@ moves_loop:  // When in check, search starts here
             (ss + 1)->pv[0] = Move::none();
 
             // Extend move from transposition table if we are about to dive into qsearch.
-            if (move == ttData.move && ss->ply <= thisThread->rootDepth * 2)
+            if (move == ttData.move && thisThread->rootDepth > 8)
                 newDepth = std::max(newDepth, 1);
 
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1402,7 +1402,7 @@ moves_loop:  // When in check, search starts here
 
     else if (priorCapture && prevSq != SQ_NONE)
     {
-        // bonus for prior countermoves that caused the fail low
+        // Bonus for prior countermoves that caused the fail low
         Piece capturedPiece = pos.captured_piece();
         assert(capturedPiece != NO_PIECE);
         thisThread->captureHistory[pos.piece_on(prevSq)][prevSq][type_of(capturedPiece)]


### PR DESCRIPTION
I was inspired by shawn's tests, which tried to remove the condition completely.
Interestingly, the patch passed STC but quickly failed LTC.

Reference:
shawn complete removal STC (Passed):
https://tests.stockfishchess.org/tests/view/67350b3a86d5ee47d953ea8f
shawn complete removal LTC (Failed):
https://tests.stockfishchess.org/tests/view/6736825586d5ee47d953ec97

Now, in this implementation, the depth extension is no longer tied to the current ply within the search tree, it now limits it based on the root depth itself. The extension will only be applied if the initial root search depth is greater than 8.

Passed STC:
https://tests.stockfishchess.org/tests/view/6767f4bb86d5ee47d9544582

Passed LTC:
https://tests.stockfishchess.org/tests/view/67695f9986d5ee47d954499c

bench: 926381