### PR TITLE
Using a simple formula instead of array

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1840,16 +1840,15 @@ void update_all_stats(const Position&      pos,
 // Updates histories of the move pairs formed by moves
 // at ply -1, -2, -3, -4, and -6 with current move.
 void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
-    static constexpr std::array<ConthistBonus, 5> conthist_bonuses = {
-      {{1, 1024}, {2, 571}, {3, 339}, {4, 500}, {6, 592}}};
+    bonus = bonus * 50 / 64;
 
-    for (const auto [i, weight] : conthist_bonuses)
+    for (int i : {1, 2, 3, 4, 6})
     {
         // Only update the first 2 continuation histories if we are in check
         if (ss->inCheck && i > 2)
             break;
         if (((ss - i)->currentMove).is_ok())
-            (*(ss - i)->continuationHistory)[pc][to] << bonus * weight / 1024;
+            (*(ss - i)->continuationHistory)[pc][to] << bonus / (1 + (i == 3));
     }
 }
 


### PR DESCRIPTION
Using a simple formula instead of an array.

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 93024 W: 23976 L: 23817 D: 45231
Ptnml(0-2): 290, 11024, 23732, 11169, 297
https://tests.stockfishchess.org/tests/view/676983ea86d5ee47d95449cb

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 166488 W: 42120 L: 42048 D: 82320
Ptnml(0-2): 108, 18314, 46345, 18352, 125
https://tests.stockfishchess.org/tests/view/676a9c2aded468c243a38505

bench: 1045718