### PR TITLE
Use same pawn value in both nets when doing material scaling of eval

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,6 +47,7 @@ Bryan Cross (crossbr)
 candirufish
 Carlos Esparza Sánchez (ces42)
 Chess13234
+Chris Bao (sscg13)
 Chris Cain (ceebo)
 Ciekce
 clefrks

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -78,7 +78,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     optimism += optimism * nnueComplexity / 468;
     nnue -= nnue * nnueComplexity / (smallNet ? 20233 : 17879);
 
-    int material = (smallNet ? 553 : 532) * pos.count<PAWN>() + pos.non_pawn_material();
+    int material = 535 * pos.count<PAWN>() + pos.non_pawn_material();
     int v        = (nnue * (77777 + material) + optimism * (7777 + material)) / 77777;
 
     // Damp down the evaluation linearly when shuffling


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 221312 W: 57291 L: 57274 D: 106747
Ptnml(0-2): 760, 26152, 56841, 26117, 786
https://tests.stockfishchess.org/tests/view/676e2a101a2f267f20548453

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 176808 W: 45084 L: 45023 D: 86701
Ptnml(0-2): 112, 19418, 49286, 19473, 115
https://tests.stockfishchess.org/tests/view/676f424d1a2f267f2054857f

bench: 1130944
