### PR TITLE
corrplexity for futility pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -787,6 +787,7 @@ Value Search::Worker::search(
     if (!ss->ttPv && depth < 14
         && eval - futility_margin(depth, cutNode && !ss->ttHit, improving, opponentWorsening)
                - (ss - 1)->statScore / 290
+               + (ss->staticEval == eval) * (40 - std::abs(correctionValue) / 131072)
              >= beta
         && eval >= beta && (!ttData.move || ttCapture) && !is_loss(beta) && !is_win(eval))
         return beta + (eval - beta) / 3;


### PR DESCRIPTION
Add corrhist-based term to futility margin

Inspired by a recent patch of Shawn Xu, this tweak increases the margin over beta needed to futility prune based on the correction history, with an offset.

Passed STC
LLR: 2.97 (-2.94,2.94) <0.00,2.00>
Total: 545504 W: 141957 L: 140885 D: 262662
Ptnml(0-2): 1829, 64226, 139551, 65336, 1810
https://tests.stockfishchess.org/tests/view/67634a8386d5ee47d95439db

Passed LTC
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 125994 W: 32199 L: 31695 D: 62100
Ptnml(0-2): 97, 13742, 34798, 14280, 80
https://tests.stockfishchess.org/tests/view/6765cf9986d5ee47d9544217

bench 1251551