### PR TITLE
[Ergodice] remove non-functional std::min()

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1159,7 +1159,7 @@ moves_loop:  // When in check, search starts here
 
         r += 330;
 
-        r -= std::min(std::abs(correctionValue) / 32768, 2048);
+        r -= std::abs(correctionValue) / 32768;
 
         // Increase reduction for cut nodes (~4 Elo)
         if (cutNode)


### PR DESCRIPTION
Remove non-fuctional std::min statement. Spotted by @Ergodice

no functional change