### PR TITLE
Simplify Fail-low Bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1411,10 +1411,6 @@ moves_loop:  // When in check, search starts here
           << stat_bonus(depth) * 2;
     }
 
-    // Bonus when search fails low and there is a TT move
-    else if (ttData.move && !allNode)
-        thisThread->mainHistory[us][ttData.move.from_to()] << stat_bonus(depth) * 287 / 1024;
-
     if (PvNode)
         bestValue = std::min(bestValue, maxValue);
 


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.92 (-2.94,2.94) <-1.75,0.25>
Total: 66592 W: 17426 L: 17239 D: 31927
Ptnml(0-2): 208, 7812, 17109, 7919, 248
https://tests.stockfishchess.org/tests/view/6774e1711a2f267f20548b22

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 179616 W: 45764 L: 45706 D: 88146
Ptnml(0-2): 125, 19665, 50162, 19739, 117
https://tests.stockfishchess.org/tests/view/677590531a2f267f20548b82

bench 1254485