### PR TITLE
Simplify away hint for common parent position at probcut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -914,8 +914,6 @@ Value Search::Worker::search(
                 return is_decisive(value) ? value : value - (probCutBeta - beta);
             }
         }
-
-        Eval::NNUE::hint_common_parent_position(pos, networks[numaAccessToken], refreshTable);
     }
 
 moves_loop:  // When in check, search starts here


### PR DESCRIPTION
Since it's introduction at probcut step the nnue network has changed substantially
and now it no longer seems useful.

Passed non-regression test at STC
https://tests.stockfishchess.org/tests/view/675fe27986d5ee47d9542d86
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 118656 W: 30732 L: 30609 D: 57315
Ptnml(0-2): 319, 12767, 33049, 12858, 335

N.B.: It may be useful to reintroduce it here at probcut if we know that a node that was cut away previously now has to be explored. Exploring new ground will deliver no tt-hits so in this case the hint for common parent position might be useful.

no functional change
bench: 999324