### PR TITLE
When cloned Stockfish sources using Windows Git client but using MSYS2 or CygWin make, an error was given in .sh files due to DOS CR/LF.

### DIFF
--- a/scripts/.gitattributes
+++ b/scripts/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/tests/.gitattributes
+++ b/tests/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Under Windows with CygWin, you could simply compile StockFish by running bash.exe and then from the prompt `make -j profile-build`, but DOS CR/LF lines in .sh files in the `scripts` directory gave error such as `../scripts/get_native_properties.sh: line 2: $'\r': command not found`, so we have to specify that .sh files have LF only even under Windows. 

This error also happens when using MSYS2 (mingw) but cloned the Stockfish source code earlier using Windows Git client.

P.S. Switching branches after the repository is cloned does not change CR/LF. If the .gitattributes file is in the master branch, the clone will take it into consideration. Otherwise, use `git clone --branch proper-crlf git@github.com:maximmasiutin/Stockfish.git` or `git clone --branch proper-crlf git@github.com:official-stockfish/Stockfish.git` because the branch `proper-crlf` already contains the file.