### PR TITLE
Simplify Probcut Condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -853,7 +853,7 @@ Value Search::Worker::search(
     // If we have a good enough capture (or queen promotion) and a reduced search
     // returns a value much above beta, we can (almost) safely prune the previous move.
     probCutBeta = beta + 187 - 56 * improving;
-    if (!PvNode && depth > 3
+    if (depth > 3
         && !is_decisive(beta)
         // If value from transposition table is lower than probCutBeta, don't attempt
         // probCut there and in further interactions with transposition table cutoff
@@ -911,7 +911,9 @@ Value Search::Worker::search(
                 // Save ProbCut data into transposition table
                 ttWriter.write(posKey, value_to_tt(value, ss->ply), ss->ttPv, BOUND_LOWER,
                                depth - 3, move, unadjustedStaticEval, tt.generation());
-                return is_decisive(value) ? value : value - (probCutBeta - beta);
+
+                if (!is_decisive(value))
+                    return value - (probCutBeta - beta);
             }
         }
 


### PR DESCRIPTION
Rebased and properly guarded #5720 

Passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 179616 W: 45764 L: 45706 D: 88146
Ptnml(0-2): 125, 19665, 50162, 19739, 117
https://tests.stockfishchess.org/tests/view/677590531a2f267f20548b82

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 445728 W: 113467 L: 113682 D: 218579
Ptnml(0-2): 331, 49226, 123900, 49141, 266
https://tests.stockfishchess.org/tests/view/67734f351a2f267f205489d9

bench 1100665