### PR TITLE
Optimize and Simplify Accumulator Updates

### DIFF
--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -466,8 +466,7 @@ class FeatureTransformer {
         return st;
     }
 
-    // It computes the accumulator of the next position, or updates the
-    // current position's accumulator if CurrentOnly is true.
+    // Computes the accumulator of the next position.
     template<Color Perspective>
     void update_accumulator_incremental(const Position& pos, StateInfo* computed) const {
         assert((computed->*accPtr).computed[Perspective]);


### PR DESCRIPTION
AMD Ryzen 5 7600X
```
sf_base =  1902646 +/-   2114 (95%)
sf_test =  1920873 +/-   2515 (95%)
diff    =    18227 +/-   3067 (95%)
speedup = 0.95800% +/- 0.161% (95%)
```

Passed Non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 23072 W: 6041 L: 5813 D: 11218
Ptnml(0-2): 61, 2435, 6319, 2657, 64
https://tests.stockfishchess.org/tests/view/6780a0ca9168c8bf30927757

bench 999324