### PR TITLE
Simplify away capthist bonus in Probcut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -906,8 +906,6 @@ Value Search::Worker::search(
 
             if (value >= probCutBeta)
             {
-                thisThread->captureHistory[movedPiece][move.to_sq()][type_of(captured)] << 1226;
-
                 // Save ProbCut data into transposition table
                 ttWriter.write(posKey, value_to_tt(value, ss->ply), ss->ttPv, BOUND_LOWER,
                                depth - 3, move, unadjustedStaticEval, tt.generation());

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -864,7 +864,6 @@ Value Search::Worker::search(
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
         MovePicker mp(pos, ttData.move, probCutBeta - ss->staticEval, &thisThread->captureHistory);
-        Piece      captured;
 
         while ((move = mp.next_move()) != Move::none())
         {
@@ -877,10 +876,6 @@ Value Search::Worker::search(
                 continue;
 
             assert(pos.capture_stage(move));
-
-            movedPiece = pos.moved_piece(move);
-            captured   = pos.piece_on(move.to_sq());
-
 
             // Prefetch the TT entry for the resulting position
             prefetch(tt.first_entry(pos.key_after(move)));


### PR DESCRIPTION
The explicit bonus has been obsoleted with the introduction of #5695 

Passed Non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 132832 W: 34519 L: 34403 D: 63910
Ptnml(0-2): 430, 15754, 33931, 15872, 429
https://tests.stockfishchess.org/tests/view/678158c49168c8bf30927834

Passed Non-regression LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 123492 W: 31426 L: 31309 D: 60757
Ptnml(0-2): 79, 13705, 34051, 13842, 69
https://tests.stockfishchess.org/tests/view/6782b07e6ddf09c0b4b6dbb7

bench 1088944