### PR TITLE
Make IIR less aggressive.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -836,18 +836,16 @@ Value Search::Worker::search(
     }
 
     // Step 10. Internal iterative reductions (~9 Elo)
-    // For PV nodes without a ttMove, we decrease depth.
-    if (PvNode && !ttData.move)
-        depth -= 3;
+    // For PV nodes without a ttMove as well as for deep enough cutNodes, we decrease depth.
+    // This heuristic is known to scale non-linearly, current version was tested at VVLTC.
+    // Further improvements need to be tested at similar time control if they make IIR
+    // more aggressive.
+    if ((PvNode || (cutNode && depth >= 7)) && !ttData.move)
+        depth -= 2;
 
     // Use qsearch if depth <= 0
     if (depth <= 0)
         return qsearch<PV>(pos, ss, alpha, beta);
-
-    // For cutNodes, if depth is high enough, decrease depth by 2 if there is no ttMove,
-    // or by 1 if there is a ttMove with an upper bound.
-    if (cutNode && depth >= 7 && (!ttData.move || ttData.bound == BOUND_UPPER))
-        depth -= 1 + !ttData.move;
 
     // Step 11. ProbCut (~10 Elo)
     // If we have a good enough capture (or queen promotion) and a reduced search


### PR DESCRIPTION
This patch is an elo gaining simplification which gains elo at longer time controls.
Patch disallows IIR for cutNodes with existing tt moves as well as makes IIR for pv nodes less aggressive, basiclally confirming suspected scaling patterns for this heuristic.
Result of 50k games STC run:
https://tests.stockfishchess.org/tests/view/678304676ddf09c0b4b6f9f9
Elo: -2.93 ± 1.6 (95%) LOS: 0.0%
Total: 50000 W: 12718 L: 13140 D: 24142
Ptnml(0-2): 189, 6087, 12835, 5735, 154
nElo: -5.71 ± 3.0 (95%) PairsRatio: 0.94 
Passed VVLTC SPRT with STC bounds:
https://tests.stockfishchess.org/tests/view/6782eb1a6ddf09c0b4b6e6b0
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 150292 W: 38868 L: 38458 D: 72966
Ptnml(0-2): 19, 13890, 46907, 14322, 8 
Passed VVLTC SPRT with LTC bounds:
https://tests.stockfishchess.org/tests/view/6782d8d96ddf09c0b4b6df18
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 153388 W: 39791 L: 39285 D: 74312
Ptnml(0-2): 13, 13924, 48311, 14436, 10 
bench 1324656