### PR TITLE
VVLTC search tune

### DIFF
--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -124,8 +124,7 @@ using psqt_vec_t = int32x4_t;
     #define vec_add_16(a, b) vaddq_s16(a, b)
     #define vec_sub_16(a, b) vsubq_s16(a, b)
     #define vec_mulhi_16(a, b) vqdmulhq_s16(a, b)
-    #define vec_zero() \
-        vec_t { 0 }
+    #define vec_zero() vec_t{0}
     #define vec_set_16(a) vdupq_n_s16(a)
     #define vec_max_16(a, b) vmaxq_s16(a, b)
     #define vec_min_16(a, b) vminq_s16(a, b)
@@ -135,8 +134,7 @@ using psqt_vec_t = int32x4_t;
     #define vec_store_psqt(a, b) *(a) = (b)
     #define vec_add_psqt_32(a, b) vaddq_s32(a, b)
     #define vec_sub_psqt_32(a, b) vsubq_s32(a, b)
-    #define vec_zero_psqt() \
-        psqt_vec_t { 0 }
+    #define vec_zero_psqt() psqt_vec_t{0}
     #define NumRegistersSIMD 16
     #define MaxChunkSize 16
 
@@ -189,7 +187,7 @@ static constexpr int BestRegisterCount() {
 
 // Input feature converter
 template<IndexType                                 TransformedFeatureDimensions,
-         Accumulator<TransformedFeatureDimensions> StateInfo::*accPtr>
+         Accumulator<TransformedFeatureDimensions> StateInfo::* accPtr>
 class FeatureTransformer {
 
     // Number of output dimensions for one side

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1072,8 +1072,7 @@ moves_loop:  // When in check, search starts here
                 && is_valid(ttData.value) && !is_decisive(ttData.value)
                 && (ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 3)
             {
-                Value singularBeta =
-                  ttData.value - (54 + 76 * (ss->ttPv && !PvNode)) * depth / 64;
+                Value singularBeta  = ttData.value - (54 + 76 * (ss->ttPv && !PvNode)) * depth / 64;
                 Depth singularDepth = newDepth / 2;
 
                 ss->excludedMove = move;
@@ -1210,8 +1209,8 @@ moves_loop:  // When in check, search starts here
             {
                 // Adjust full-depth search based on LMR results - if the result was
                 // good enough search deeper, if it was bad enough search shallower.
-                const bool doDeeperSearch = value > (bestValue + 41 + 2 * newDepth);  // (~1 Elo)
-                const bool doShallowerSearch = value < bestValue + 10;                // (~2 Elo)
+                const bool doDeeperSearch    = value > (bestValue + 41 + 2 * newDepth);  // (~1 Elo)
+                const bool doShallowerSearch = value < bestValue + 10;                   // (~2 Elo)
 
                 newDepth += doDeeperSearch - doShallowerSearch;
 
@@ -1382,10 +1381,9 @@ moves_loop:  // When in check, search starts here
     // Bonus for prior countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
     {
-        int bonusScale =
-          (118 * (depth > 5) + 40 * !allNode + 175 * ((ss - 1)->moveCount > 8)
-           + 123 * (!ss->inCheck && bestValue <= ss->staticEval - 106)
-           + 120 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 84));
+        int bonusScale = (118 * (depth > 5) + 40 * !allNode + 175 * ((ss - 1)->moveCount > 8)
+                          + 123 * (!ss->inCheck && bestValue <= ss->staticEval - 106)
+                          + 120 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 84));
 
         // Proportional to "how much damage we have to undo"
         bonusScale += std::min(-(ss - 1)->statScore / 110, 318);
@@ -1397,8 +1395,7 @@ moves_loop:  // When in check, search starts here
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
                                       scaledBonus * 431 / 1024);
 
-        thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()]
-          << scaledBonus * 214 / 1024;
+        thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()] << scaledBonus * 214 / 1024;
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
             thisThread->pawnHistory[pawn_structure_index(pos)][pos.piece_on(prevSq)][prevSq]
@@ -1440,7 +1437,7 @@ moves_loop:  // When in check, search starts here
         && ((bestValue < ss->staticEval && bestValue < beta)  // negative correction & no fail high
             || (bestValue > ss->staticEval && bestMove)))     // positive correction & no fail low
     {
-        const auto       m             = (ss - 1)->currentMove;
+        const auto           m             = (ss - 1)->currentMove;
         static constexpr int nonPawnWeight = 161;
 
         auto bonus = std::clamp(int(bestValue - ss->staticEval) * depth / 8,

--- a/src/thread.h
+++ b/src/thread.h
@@ -164,7 +164,7 @@ class ThreadPool {
     std::vector<std::unique_ptr<Thread>> threads;
     std::vector<NumaIndex>               boundThreadToNumaNode;
 
-    uint64_t accumulate(std::atomic<uint64_t> Search::Worker::*member) const {
+    uint64_t accumulate(std::atomic<uint64_t> Search::Worker::* member) const {
 
         uint64_t sum = 0;
         for (auto&& th : threads)


### PR DESCRIPTION
Values were tuned with 39.5k VVLTC games.

Passed VVLTC 1st sprt: https://tests.stockfishchess.org/tests/view/677e9c8ce8ec2954aff584e2
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 24078 W: 6415 L: 6152 D: 11511
Ptnml(0-2): 0, 2059, 7659, 2320, 1 

Passed VVLTC 2nd sprt: https://tests.stockfishchess.org/tests/view/6780647e9168c8bf309276eb
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 46004 W: 11944 L: 11638 D: 22422
Ptnml(0-2): 2, 4100, 14495, 4400, 5 

Bench: 871752