### PR TITLE
Avoid unnecessarily initializing TTData with 0's.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -922,7 +922,7 @@ moves_loop:  // When in check, search starts here
 
     // Step 12. A small Probcut idea (~4 Elo)
     probCutBeta = beta + 417;
-    if ((ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4 && ttData.value >= probCutBeta
+    if (ttHit && (ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4 && ttData.value >= probCutBeta
         && !is_decisive(beta) && is_valid(ttData.value) && !is_decisive(ttData.value))
         return probCutBeta;
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -238,7 +238,14 @@ std::tuple<bool, TTData, TTWriter> TranspositionTable::probe(const Key key) cons
             > tte[i].depth8 - tte[i].relative_age(generation8) * 2)
             replace = &tte[i];
 
+#if !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     return {false, TTData(), TTWriter(replace)};
+#if !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 }
 
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -51,6 +51,10 @@ struct TTData {
     Depth depth;
     Bound bound;
     bool  is_pv;
+
+    TTData() {}; // Prevent the default constructor from initializing to 0
+    TTData(Move m, Value v, Value ev, Depth d, Bound b, bool pv) :
+        move(m), value(v), eval(ev), depth(d), bound(b), is_pv(pv) {};
 };
 
 


### PR DESCRIPTION
The compiler generated default constructor is initializing TTData with 0's when we invoke it here
https://github.com/official-stockfish/Stockfish/blob/c76c1793615b17b97dd504f8c81c1ff2c63c232a/src/tt.cpp#L241

An empty default constructor avoids this as shown here https://godbolt.org/z/a8q8o3EEz
(For some reason gcc initializes to 0 even with an empty constructor which seems like a gcc bug?)

No functional change
bench: 999324