### PR TITLE
Introduce Correction History Quad Extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1082,11 +1082,16 @@ moves_loop:  // When in check, search starts here
 
                 if (value < singularBeta)
                 {
-                    int doubleMargin = 249 * PvNode - 194 * !ttCapture;
-                    int tripleMargin = 94 + 287 * PvNode - 249 * !ttCapture + 99 * ss->ttPv;
+                    int corrValAdj   = std::abs(correctionValue) / 262144;
+                    int doubleMargin = 249 * PvNode - 194 * !ttCapture - corrValAdj;
+                    int tripleMargin =
+                      94 + 287 * PvNode - 249 * !ttCapture + 99 * ss->ttPv - corrValAdj;
+                    int quadMargin =
+                      394 + 287 * PvNode - 249 * !ttCapture + 99 * ss->ttPv - corrValAdj;
 
                     extension = 1 + (value < singularBeta - doubleMargin)
-                              + (value < singularBeta - tripleMargin);
+                              + (value < singularBeta - tripleMargin)
+                              + (value < singularBeta - quadMargin);
 
                     depth += ((!PvNode) && (depth < 14));
                 }


### PR DESCRIPTION
Also modifies the double and triple extension margins with the correction history adjustment.

STC Elo Estimate:
Elo: -4.40 ± 1.4 (95%) LOS: 0.0%
Total: 60000 W: 15230 L: 15990 D: 28780
Ptnml(0-2): 264, 7495, 15168, 6883, 190
nElo: -8.48 ± 2.8 (95%) PairsRatio: 0.91
https://tests.stockfishchess.org/tests/view/6783a3786ddf09c0b4b703a1

Passed 1st VVLTC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 35736 W: 9354 L: 9088 D: 17294
Ptnml(0-2): 4, 3191, 11212, 3457, 4
https://tests.stockfishchess.org/tests/view/6783a3336ddf09c0b4b7039b

Passed 2nd VVLTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 36394 W: 9515 L: 9225 D: 17654
Ptnml(0-2): 1, 3271, 11364, 3559, 2
https://tests.stockfishchess.org/tests/view/678395e26ddf09c0b4b70345

bench 1574831