### PR TITLE
Increase the depth margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1068,7 +1068,7 @@ moves_loop:  // When in check, search starts here
             // and lower extension margins scale well.
 
             if (!rootNode && move == ttData.move && !excludedMove
-                && depth >= 4 - (thisThread->completedDepth > 33) + ss->ttPv
+                && depth >= 5 - (thisThread->completedDepth > 33) + ss->ttPv
                 && is_valid(ttData.value) && !is_decisive(ttData.value)
                 && (ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 3)
             {


### PR DESCRIPTION
Increase the depth margin
Tested at VVLTC against the passed patches.

Test 1 against PR5764
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 167260 W: 43053 L: 42521 D: 81686
Ptnml(0-2): 7, 15272, 52542, 15800, 9
https://tests.stockfishchess.org/tests/view/6782ef196ddf09c0b4b6e780

Test 2 against PR5765
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 300012 W: 77364 L: 76771 D: 145877
Ptnml(0-2): 22, 27555, 94256, 28154, 19
https://tests.stockfishchess.org/tests/view/678366446ddf09c0b4b7028c

bench: 939072