### PR TITLE
Fix initialization of TTData

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -238,7 +238,9 @@ std::tuple<bool, TTData, TTWriter> TranspositionTable::probe(const Key key) cons
             > tte[i].depth8 - tte[i].relative_age(generation8) * 2)
             replace = &tte[i];
 
-    return {false, TTData(), TTWriter(replace)};
+    return {false,
+            TTData{Move::none(), VALUE_NONE, VALUE_NONE, DEPTH_ENTRY_OFFSET, BOUND_NONE, false},
+            TTWriter(replace)};
 }
 
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -51,6 +51,10 @@ struct TTData {
     Depth depth;
     Bound bound;
     bool  is_pv;
+
+    TTData() = delete;
+    TTData(Move m, Value v, Value ev, Depth d, Bound b, bool pv) :
+        move(m), value(v), eval(ev), depth(d), bound(b), is_pv(pv) {};
 };
 
 


### PR DESCRIPTION
https://tests.stockfishchess.org/tests/view/6757757686d5ee47d9541de9
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 151200 W: 39396 L: 39306 D: 72498
Ptnml(0-2): 445, 16404, 41781, 16556, 414 

Discussed in more detail here https://github.com/official-stockfish/Stockfish/pull/5766

No functional change
bench: 1379150