### PR TITLE
remove eval== staticeval check in fut pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -784,7 +784,7 @@ Value Search::Worker::search(
     if (!ss->ttPv && depth < 14
         && eval - futility_margin(depth, cutNode && !ss->ttHit, improving, opponentWorsening)
                - (ss - 1)->statScore / 310
-               + (ss->staticEval == eval) * (40 - std::abs(correctionValue) / 131072)
+               + 40 - std::abs(correctionValue) / 131072
              >= beta
         && eval >= beta && (!ttData.move || ttCapture) && !is_loss(beta) && !is_win(eval))
         return beta + (eval - beta) / 3;


### PR DESCRIPTION
Simplify corrplexity in futility margin
Don't check that staticEval == eval when applying the corrplexity-based adjustment in futility pruning.

Passed Simplification STC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 121760 W: 31640 L: 31512 D: 58608
Ptnml(0-2): 349, 14400, 31289, 14458, 384
https://tests.stockfishchess.org/tests/view/6780c4109168c8bf30927777

Passed Simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 134772 W: 34245 L: 34140 D: 66387
Ptnml(0-2): 94, 14869, 37350, 14984, 89 
https://tests.stockfishchess.org/tests/view/6782d6ea6ddf09c0b4b6dd36

bench 1487627