### PR TITLE
Remove addition of 1ms from reported timestamps

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -2123,7 +2123,7 @@ void SearchManager::pv(Search::Worker&           worker,
         if (!isExact)
             info.bound = bound;
 
-        TimePoint time = tm.elapsed_time() + 1;
+        TimePoint time = std::max(TimePoint(1), tm.elapsed_time());
         info.timeMs    = time;
         info.nodes     = nodes;
         info.nps       = nodes * 1000 / time;


### PR DESCRIPTION
The +1 was a quick fix to avoid the division by zero, though I believe a more correct approach would be to use 1ms as the minimum reported timestamp to avoid a division by zero by Stockfish (and potentially other programs parsing the output).
Later timestamps no longer include an additional 1ms.