### PR TITLE
Simplify common hint for parent position

### DIFF
--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -449,8 +449,8 @@ class FeatureTransformer {
 
     void hint_common_access(const Position&                           pos,
                             AccumulatorCaches::Cache<HalfDimensions>* cache) const {
-        hint_common_access_for_perspective<WHITE>(pos, cache);
-        hint_common_access_for_perspective<BLACK>(pos, cache);
+        update_accumulator<WHITE>(pos, cache);
+        update_accumulator<BLACK>(pos, cache);
     }
 
    private:
@@ -821,31 +821,12 @@ class FeatureTransformer {
             entry.byTypeBB[pt] = pos.pieces(pt);
     }
 
-    template<Color Perspective>
-    void hint_common_access_for_perspective(const Position&                           pos,
-                                            AccumulatorCaches::Cache<HalfDimensions>* cache) const {
-
-        // Works like update_accumulator, but performs less work.
-        // Updates ONLY the accumulator for pos.
-
-        // Look for a usable accumulator of an earlier position. We keep track
-        // of the estimated gain in terms of features to be added/subtracted.
-        // Fast early exit.
-        if ((pos.state()->*accPtr).computed[Perspective])
-            return;
-
-        StateInfo* oldest = try_find_computed_accumulator<Perspective>(pos);
-
-        if ((oldest->*accPtr).computed[Perspective] && oldest != pos.state())
-            update_accumulator_incremental<Perspective>(pos, oldest);
-        else
-            update_accumulator_refresh_cache<Perspective>(pos, cache);
-    }
 
     template<Color Perspective>
     void update_accumulator(const Position&                           pos,
                             AccumulatorCaches::Cache<HalfDimensions>* cache) const {
-
+        if ((pos.state()->*accPtr).computed[Perspective])
+            return;
         StateInfo* oldest = try_find_computed_accumulator<Perspective>(pos);
 
         if ((oldest->*accPtr).computed[Perspective] && oldest != pos.state())


### PR DESCRIPTION
Removes function hint_common_access_for_perspective together with it's comments which weren't accurate anymore since merge of  #5576

https://tests.stockfishchess.org/tests/view/6784c9cd460e2910c51dde39
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 295104 W: 76702 L: 76765 D: 141637
Ptnml(0-2): 1031, 32135, 81249, 32140, 997

no functional change
bench: 1379150