### PR TITLE
Remove the type of moved piece from the evasion capture movepick formula

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -187,7 +187,7 @@ void MovePicker::score() {
         {
             if (pos.capture_stage(m))
                 m.value =
-                  PieceValue[pos.piece_on(m.to_sq())] - type_of(pos.moved_piece(m)) + (1 << 28);
+                  PieceValue[pos.piece_on(m.to_sq())] + (1 << 28);
             else
                 m.value = (*mainHistory)[pos.side_to_move()][m.from_to()]
                         + (*continuationHistory[0])[pos.moved_piece(m)][m.to_sq()]


### PR DESCRIPTION
Remove the type of moved piece from the evasion capture movepick formula.
Since it didn't change the bench, I opened a PR after passing STC, if also an LTC is needed, let me know.

Passed:
LLR: 2.98 (-2.94,2.94) <-1.75,0.25>
Total: 170560 W: 44222 L: 44148 D: 82190
Ptnml(0-2): 569, 18792, 46488, 18858, 573
https://tests.stockfishchess.org/tests/view/678530ee460e2910c51de21d

bench: 1379150