### PR TITLE
retroactive reduction decrease if eval improves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -247,10 +247,14 @@ void Search::Worker::iterative_deepening() {
           &this->continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel
         (ss - i)->continuationCorrectionHistory = &this->continuationCorrectionHistory[NO_PIECE][0];
         (ss - i)->staticEval                    = VALUE_NONE;
+        (ss - i)->reduction                     = 0;
     }
 
     for (int i = 0; i <= MAX_PLY + 2; ++i)
+    {
         (ss + i)->ply = i;
+        (ss + i)->reduction = 0;
+    }
 
     ss->pv = pv;
 
@@ -567,6 +571,8 @@ Value Search::Worker::search(
     Value bestValue, value, eval, maxValue, probCutBeta;
     bool  givesCheck, improving, priorCapture, opponentWorsening;
     bool  capture, ttCapture;
+    int   priorReduction = ss->reduction;
+    ss->reduction        = 0;
     Piece movedPiece;
 
     ValueList<Move, 32> capturesSearched;
@@ -771,6 +777,11 @@ Value Search::Worker::search(
     improving = ss->staticEval > (ss - 2)->staticEval;
 
     opponentWorsening = ss->staticEval + (ss - 1)->staticEval > 2;
+
+    if (priorReduction >= 3 && ss->staticEval + (ss - 1)->staticEval < 0)
+    {
+        depth++;
+    }
 
     // Step 7. Razoring (~1 Elo)
     // If eval is really low, check with qsearch if we can exceed alpha. If the
@@ -1192,10 +1203,16 @@ moves_loop:  // When in check, search starts here
             // beyond the first move depth.
             // To prevent problems when the max value is less than the min value,
             // std::clamp has been replaced by a more robust implementation.
+
+            
             Depth d = std::max(
               1, std::min(newDepth - r / 1024, newDepth + !allNode + (PvNode && !bestMove)));
 
+            (ss + 1)->reduction = newDepth - d;
+
             value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);
+            (ss + 1)->reduction = 0;
+
 
             // Do a full-depth search when reduced LMR search fails high
             if (value > alpha && d < newDepth)

--- a/src/search.h
+++ b/src/search.h
@@ -74,6 +74,7 @@ struct Stack {
     bool                        ttPv;
     bool                        ttHit;
     int                         cutoffCnt;
+    int                         reduction;
 };
 
 


### PR DESCRIPTION
Retroactive reduction decrease if eval improves

If the previous reduction was large but the static eval improves then increase the search depth. This patch looks at the next node when calculating the reduction, something I don't think has been done before and which can probably used for further elo gaining patches.

Passed STC
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 55936 W: 14813 L: 14462 D: 26661
Ptnml(0-2): 220, 6565, 14094, 6822, 267 
https://tests.stockfishchess.org/tests/view/67845b70460e2910c51ddcff

Passed LTC
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 189468 W: 48411 L: 47773 D: 93284
Ptnml(0-2): 180, 20801, 52131, 21445, 177 
https://tests.stockfishchess.org/tests/view/6784e2cb460e2910c51ddf86

bench 1518363