### PR TITLE
Simplify Razoring

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -773,11 +773,10 @@ Value Search::Worker::search(
     opponentWorsening = ss->staticEval + (ss - 1)->staticEval > 2;
 
     // Step 7. Razoring (~1 Elo)
-    // If eval is really low, check with qsearch if we can exceed alpha. If the
-    // search suggests we cannot exceed alpha, return a speculative fail low.
+    // If eval is really low, skip search entirely and return the qsearch value.
     // For PvNodes, we must have a guard against mates being returned.
     if (!PvNode && eval < alpha - 462 - 297 * depth * depth)
-        return qsearch<NonPV>(pos, ss, alpha - 1, alpha);
+        return qsearch<NonPV>(pos, ss, alpha, beta);
 
     // Step 8. Futility pruning: child node (~40 Elo)
     // The depth condition is important for mate finding.


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 93056 W: 24215 L: 24054 D: 44787
Ptnml(0-2): 364, 11085, 23470, 11244, 365 
https://tests.stockfishchess.org/tests/view/67883a5d3b8f206a2696b804

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 66564 W: 16971 L: 16794 D: 32799
Ptnml(0-2): 56, 7403, 18192, 7570, 61
https://tests.stockfishchess.org/tests/view/6789ffa78082388fa0cbfe95

bench 1449898