### PR TITLE
Remove the cap from maxscale for x moves in y seconds TC

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -125,7 +125,7 @@ void TimeManagement::init(Search::LimitsType& limits,
     else
     {
         optScale = std::min((0.88 + ply / 116.4) / mtg, 0.88 * limits.time[us] / timeLeft);
-        maxScale = std::min(6.3, 1.5 + 0.11 * mtg);
+        maxScale = 1.3 + 0.11 * mtg;
     }
 
     // Limit the maximum possible time for this move


### PR DESCRIPTION
Remove the cap from maxscale for x moves in y seconds TC.

Passed STC 40/10:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 48800 W: 13044 L: 12835 D: 22921
Ptnml(0-2): 229, 5457, 12863, 5578, 273
https://tests.stockfishchess.org/tests/view/67862dae460e2910c51de7c9

Passed LTC 40/40:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 141296 W: 36110 L: 36014 D: 69172
Ptnml(0-2): 222, 14350, 41440, 14382, 254
https://tests.stockfishchess.org/tests/view/678799903b8f206a2696b6f8

Passed STC 80/8:
LLR: 2.99 (-2.94,2.94) <-1.75,0.25>
Total: 155120 W: 41442 L: 41346 D: 72332
Ptnml(0-2): 953, 17232, 41102, 17312, 961
https://tests.stockfishchess.org/tests/view/678aca4dc00c743bc9e9fc47

Passed LTC 80/60:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 93950 W: 24042 L: 23904 D: 46004
Ptnml(0-2): 80, 9020, 28627, 9178, 70
https://tests.stockfishchess.org/tests/view/678af705c00c743bc9e9fe94

bench: 1379150