### PR TITLE
Increase history bonus of TT moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -119,7 +119,8 @@ void update_all_stats(const Position&      pos,
                       Square               prevSq,
                       ValueList<Move, 32>& quietsSearched,
                       ValueList<Move, 32>& capturesSearched,
-                      Depth                depth);
+                      Depth                depth,
+                      bool                 isTTMove);
 
 }  // namespace
 
@@ -1369,7 +1370,8 @@ moves_loop:  // When in check, search starts here
     // If there is a move that produces search value greater than alpha,
     // we update the stats of searched moves.
     else if (bestMove)
-        update_all_stats(pos, ss, *this, bestMove, prevSq, quietsSearched, capturesSearched, depth);
+        update_all_stats(pos, ss, *this, bestMove, prevSq, quietsSearched,
+                         capturesSearched, depth, bestMove == ttData.move);
 
     // Bonus for prior countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
@@ -1789,13 +1791,14 @@ void update_all_stats(const Position&      pos,
                       Square               prevSq,
                       ValueList<Move, 32>& quietsSearched,
                       ValueList<Move, 32>& capturesSearched,
-                      Depth                depth) {
+                      Depth                depth,
+                      bool                 isTTMove) {
 
     CapturePieceToHistory& captureHistory = workerThread.captureHistory;
     Piece                  moved_piece    = pos.moved_piece(bestMove);
     PieceType              captured;
 
-    int bonus = stat_bonus(depth);
+    int bonus = stat_bonus(depth) + 300*isTTMove;
     int malus = stat_malus(depth);
 
     if (!pos.capture_stage(bestMove))


### PR DESCRIPTION
Passed STC:
https://tests.stockfishchess.org/tests/view/678807653b8f206a2696b78b
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 42208 W: 11113 L: 10783 D: 20312
Ptnml(0-2): 148, 4919, 10651, 5227, 159

Passed LTC:
https://tests.stockfishchess.org/tests/view/6788a8463b8f206a2696b956
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 122886 W: 31454 L: 30952 D: 60480
Ptnml(0-2): 105, 13567, 33619, 14025, 127

Bench: 1487120