### PR TITLE
Introduce one more continuation history.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -162,6 +162,7 @@ void MovePicker::score() {
             m.value += (*continuationHistory[1])[pc][to];
             m.value += (*continuationHistory[2])[pc][to];
             m.value += (*continuationHistory[3])[pc][to];
+            m.value += (*continuationHistory[4])[pc][to] / 3;
             m.value += (*continuationHistory[5])[pc][to];
 
             // bonus for checks

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -918,7 +918,7 @@ moves_loop:  // When in check, search starts here
                                         (ss - 2)->continuationHistory,
                                         (ss - 3)->continuationHistory,
                                         (ss - 4)->continuationHistory,
-                                        nullptr,
+                                        (ss - 5)->continuationHistory,
                                         (ss - 6)->continuationHistory};
 
 
@@ -1831,8 +1831,8 @@ void update_all_stats(const Position&      pos,
 // Updates histories of the move pairs formed by moves
 // at ply -1, -2, -3, -4, and -6 with current move.
 void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
-    static constexpr std::array<ConthistBonus, 5> conthist_bonuses = {
-      {{1, 1025}, {2, 621}, {3, 325}, {4, 512}, {6, 534}}};
+    static constexpr std::array<ConthistBonus, 6> conthist_bonuses = {
+      {{1, 1025}, {2, 621}, {3, 325}, {4, 512}, {5, 122}, {6, 534}}};
 
     for (const auto [i, weight] : conthist_bonuses)
     {


### PR DESCRIPTION
This one is counter counter counter history - with really low update value and divided by 3 in movepicker unlike the other ones.
Passed STC:
https://tests.stockfishchess.org/tests/view/67861495460e2910c51de720
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 44352 W: 11699 L: 11370 D: 21283
Ptnml(0-2): 156, 5098, 11361, 5383, 178 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6786e89e3b8f206a2696b646
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 432660 W: 110355 L: 109207 D: 213098
Ptnml(0-2): 381, 48214, 118039, 49268, 428 
bench 1653848