### PR TITLE
Moving up the if position is or has been on the PV reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -972,6 +972,10 @@ moves_loop:  // When in check, search starts here
 
         Depth r = reduction(improving, depth, moveCount, delta);
 
+        // Decrease reduction if position is or has been on the PV (~7 Elo)
+        if (ss->ttPv)
+            r -= 1037 + (ttData.value > alpha) * 965 + (ttData.depth >= depth) * 960;
+      
         // Step 14. Pruning at shallow depth (~120 Elo).
         // Depth conditions are important for mate finding.
         if (!rootNode && pos.non_pawn_material(us) && !is_loss(bestValue))
@@ -1140,10 +1144,6 @@ moves_loop:  // When in check, search starts here
         // They are optimized to time controls of 180 + 1.8 and longer,
         // so changing them or adding conditions that are similar requires
         // tests at these types of time controls.
-
-        // Decrease reduction if position is or has been on the PV (~7 Elo)
-        if (ss->ttPv)
-            r -= 1037 + (ttData.value > alpha) * 965 + (ttData.depth >= depth) * 960;
 
         // Decrease reduction for PvNodes (~0 Elo on STC, ~2 Elo on LTC)
         if (PvNode)


### PR DESCRIPTION
Moving up the if position is or has been on the PV reduction.
This conflicts with the next PR, so just choose one to merge.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 29664 W: 7880 L: 7570 D: 14214
Ptnml(0-2): 93, 3487, 7390, 3741, 121
https://tests.stockfishchess.org/tests/view/678ac957c00c743bc9e9fc3f

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 81354 W: 20903 L: 20487 D: 39964
Ptnml(0-2): 66, 9003, 22123, 9419, 66
https://tests.stockfishchess.org/tests/view/678ad359c00c743bc9e9fcfa

bench: 1286290