### PR TITLE
Moving up the if position is or has been on the PV reduction, and add a cutnode component

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -972,6 +972,10 @@ moves_loop:  // When in check, search starts here
 
         Depth r = reduction(improving, depth, moveCount, delta);
 
+        // Decrease reduction if position is or has been on the PV (~7 Elo)
+        if (ss->ttPv)
+            r -= 1024 + (ttData.value > alpha) * 965 + (ttData.depth >= depth) * 960 + cutNode * 768;
+      
         // Step 14. Pruning at shallow depth (~120 Elo).
         // Depth conditions are important for mate finding.
         if (!rootNode && pos.non_pawn_material(us) && !is_loss(bestValue))
@@ -1140,10 +1144,6 @@ moves_loop:  // When in check, search starts here
         // They are optimized to time controls of 180 + 1.8 and longer,
         // so changing them or adding conditions that are similar requires
         // tests at these types of time controls.
-
-        // Decrease reduction if position is or has been on the PV (~7 Elo)
-        if (ss->ttPv)
-            r -= 1037 + (ttData.value > alpha) * 965 + (ttData.depth >= depth) * 960;
 
         // Decrease reduction for PvNodes (~0 Elo on STC, ~2 Elo on LTC)
         if (PvNode)


### PR DESCRIPTION
Moving up the if position is or has been on the PV reduction, and add a cutnode component.
This conflicts with the previous PR, so just choose one to merge.

Passed STC:
LLR: 2.97 (-2.94,2.94) <0.00,2.00>
Total: 16896 W: 4532 L: 4241 D: 8123
Ptnml(0-2): 46, 1905, 4269, 2168, 60
https://tests.stockfishchess.org/tests/view/678ac9b1c00c743bc9e9fc43

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 98388 W: 25154 L: 24705 D: 48529
Ptnml(0-2): 54, 10859, 26954, 11238, 89
https://tests.stockfishchess.org/tests/view/678ad353c00c743bc9e9fcf8

bench: 1498159