### PR TITLE
replace depth increase condition with !opponentWorsening

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -247,10 +247,14 @@ void Search::Worker::iterative_deepening() {
           &this->continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel
         (ss - i)->continuationCorrectionHistory = &this->continuationCorrectionHistory[NO_PIECE][0];
         (ss - i)->staticEval                    = VALUE_NONE;
+        (ss - i)->reduction                     = 0;
     }
 
     for (int i = 0; i <= MAX_PLY + 2; ++i)
+    {
         (ss + i)->ply = i;
+        (ss + i)->reduction = 0;
+    }
 
     ss->pv = pv;
 
@@ -567,6 +571,8 @@ Value Search::Worker::search(
     Value bestValue, value, eval, maxValue, probCutBeta;
     bool  givesCheck, improving, priorCapture, opponentWorsening;
     bool  capture, ttCapture;
+    int   priorReduction = ss->reduction;
+    ss->reduction        = 0;
     Piece movedPiece;
 
     ValueList<Move, 32> capturesSearched;
@@ -771,6 +777,9 @@ Value Search::Worker::search(
     improving = ss->staticEval > (ss - 2)->staticEval;
 
     opponentWorsening = ss->staticEval + (ss - 1)->staticEval > 2;
+
+    if (priorReduction >= 3 && !opponentWorsening) depth++;
+
 
     // Step 7. Razoring (~1 Elo)
     // If eval is really low, check with qsearch if we can exceed alpha. If the
@@ -1192,10 +1201,16 @@ moves_loop:  // When in check, search starts here
             // beyond the first move depth.
             // To prevent problems when the max value is less than the min value,
             // std::clamp has been replaced by a more robust implementation.
+
+            
             Depth d = std::max(
               1, std::min(newDepth - r / 1024, newDepth + !allNode + (PvNode && !bestMove)));
 
+            (ss + 1)->reduction = newDepth - d;
+
             value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);
+            (ss + 1)->reduction = 0;
+
 
             // Do a full-depth search when reduced LMR search fails high
             if (value > alpha && d < newDepth)

--- a/src/search.h
+++ b/src/search.h
@@ -74,6 +74,7 @@ struct Stack {
     bool                        ttPv;
     bool                        ttHit;
     int                         cutoffCnt;
+    int                         reduction;
 };
 
 


### PR DESCRIPTION

Replace depth increase condition with !opponentWorsening

Passed simplification STC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 220544 W: 57417 L: 57399 D: 105728
Ptnml(0-2): 816, 26554, 55540, 26520, 842 
https://tests.stockfishchess.org/tests/view/678970e38082388fa0cbfe02

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 132600 W: 33868 L: 33760 D: 64972
Ptnml(0-2): 126, 14770, 36390, 14898, 116 
https://tests.stockfishchess.org/tests/view/678accabc00c743bc9e9fc7f

bench 1517399