### PR TITLE
More stat bonus for good moves.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -99,7 +99,7 @@ Value to_corrected_static_eval(Value v, const int cv) {
 }
 
 // History and stats update bonus, based on depth
-int stat_bonus(Depth d) { return std::min(154 * d - 102, 1661); }
+int stat_bonus(Depth d) { return std::min(77 * d - 51, 830) * (2 + (d > 5)); }
 
 // History and stats update malus, based on depth
 int stat_malus(Depth d) { return std::min(831 * d - 269, 2666); }


### PR DESCRIPTION
For depth > 5 increase stat bonus by 50%.

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 105984 W: 27652 L: 27227 D: 51105
Ptnml(0-2): 408, 12538, 26689, 12935, 422
https://tests.stockfishchess.org/tests/view/6787faae3b8f206a2696b77b

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 357642 W: 91186 L: 90197 D: 176259
Ptnml(0-2): 317, 39639, 97917, 40634, 314
https://tests.stockfishchess.org/tests/view/678b5a00c00c743bc9ea0a08

Bench: 1899779