### PR TITLE
Less stat malus for bad moves.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -102,7 +102,7 @@ Value to_corrected_static_eval(Value v, const int cv) {
 int stat_bonus(Depth d) { return std::min(154 * d - 102, 1661); }
 
 // History and stats update malus, based on depth
-int stat_malus(Depth d) { return std::min(831 * d - 269, 2666); }
+int stat_malus(Depth d) { return std::min(415 * d - 135, 1333) * (1 + (d > 5)); }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
 Value value_draw(size_t nodes) { return VALUE_DRAW - 1 + Value(nodes & 0x2); }


### PR DESCRIPTION
For depth <= 5 decrease stat malus by 50%.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 22496 W: 6035 L: 5735 D: 10726
Ptnml(0-2): 85, 2585, 5606, 2889, 83
https://tests.stockfishchess.org/tests/view/678b977dc00c743bc9ea0f5b

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 226638 W: 57886 L: 57168 D: 111584
Ptnml(0-2): 210, 25166, 61834, 25914, 195
https://tests.stockfishchess.org/tests/view/678ba31bf4dc0a8b4ae8cd62

Bench: 1540283