### PR TITLE
Add move count based reduction.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1155,7 +1155,7 @@ moves_loop:  // When in check, search starts here
 
         // These reduction adjustments have no proven non-linear scaling
 
-        r += 307;
+        r += 307 - moveCount * 64;
 
         r -= std::abs(correctionValue) / 34112;
 


### PR DESCRIPTION
Do less reduction which is linear increasing with move count (factor = 64).

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 191488 W: 49982 L: 49432 D: 92074
Ptnml(0-2): 731, 22523, 48614, 23217, 659
https://tests.stockfishchess.org/tests/view/678d0b29d63764e34db4904b

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 90582 W: 23150 L: 22717 D: 44715
Ptnml(0-2): 73, 9936, 24822, 10405, 55
https://tests.stockfishchess.org/tests/view/678d347cd63764e34db4916f

Bench: 1803474