### PR TITLE
Introducing a depth-dependent term to the LMR reduction formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -981,7 +981,7 @@ moves_loop:  // When in check, search starts here
 
         // Decrease reduction if position is or has been on the PV (~7 Elo)
         if (ss->ttPv)
-            r -= 1037 + (ttData.value > alpha) * 965 + (ttData.depth >= depth) * 960;
+            r -= 1037 + (ttData.value > alpha) * 965 + (ttData.depth >= depth) * 960 + 16 * depth;
 
         // Step 14. Pruning at shallow depth (~120 Elo).
         // Depth conditions are important for mate finding.
@@ -1408,7 +1408,7 @@ moves_loop:  // When in check, search starts here
 
     else if (priorCapture && prevSq != SQ_NONE)
     {
-        // bonus for prior countermoves that caused the fail low
+        // Bonus for prior countermoves that caused the fail low
         Piece capturedPiece = pos.captured_piece();
         assert(capturedPiece != NO_PIECE);
         thisThread->captureHistory[pos.piece_on(prevSq)][prevSq][type_of(capturedPiece)]


### PR DESCRIPTION
Introducing a depth-dependent term to the LMR reduction formula.

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 118912 W: 30938 L: 30498 D: 57476
Ptnml(0-2): 393, 13962, 30315, 14384, 402
https://tests.stockfishchess.org/tests/view/678cf401d63764e34db49009

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 88338 W: 22660 L: 22230 D: 43448
Ptnml(0-2): 71, 9776, 24042, 10212, 68
https://tests.stockfishchess.org/tests/view/678d3232d63764e34db4915e

bench: 1420562