### PR TITLE
Increase prior countermove bonus if TT move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -889,6 +889,7 @@ Value Search::Worker::search(
             thisThread->nodes.fetch_add(1, std::memory_order_relaxed);
 
             ss->currentMove = move;
+            ss->isTTMove = (move == ttData.move);
             ss->continuationHistory =
               &this->continuationHistory[ss->inCheck][true][movedPiece][move.to_sq()];
             ss->continuationCorrectionHistory =
@@ -1138,6 +1139,7 @@ moves_loop:  // When in check, search starts here
 
         // Update the current move (this must be done after singular extension search)
         ss->currentMove = move;
+        ss->isTTMove = (move == ttData.move);
         ss->continuationHistory =
           &thisThread->continuationHistory[ss->inCheck][capture][movedPiece][move.to_sq()];
         ss->continuationCorrectionHistory =
@@ -1387,7 +1389,8 @@ moves_loop:  // When in check, search starts here
     {
         int bonusScale = (118 * (depth > 5) + 37 * !allNode + 169 * ((ss - 1)->moveCount > 8)
                           + 128 * (!ss->inCheck && bestValue <= ss->staticEval - 102)
-                          + 115 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 82));
+                          + 115 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 82)
+                          + 80 * ((ss - 1)->isTTMove));
 
         // Proportional to "how much damage we have to undo"
         bonusScale += std::min(-(ss - 1)->statScore / 106, 318);

--- a/src/search.h
+++ b/src/search.h
@@ -75,6 +75,7 @@ struct Stack {
     bool                        ttHit;
     int                         cutoffCnt;
     int                         reduction;
+    bool                        isTTMove;
 };
 
 


### PR DESCRIPTION
Passed STC:
https://tests.stockfishchess.org/tests/view/678c4c8bf4dc0a8b4ae8db5c
LLR: 2.97 (-2.94,2.94) <0.00,2.00>
Total: 273408 W: 71089 L: 70415 D: 131904
Ptnml(0-2): 937, 32466, 69229, 33130, 942

Passed LTC:
https://tests.stockfishchess.org/tests/view/678ccabdf4dc0a8b4ae8dd7a
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 148614 W: 38138 L: 37584 D: 72892
Ptnml(0-2): 97, 16450, 40689, 16944, 127

Bench: 1589439