### PR TITLE
Add improving to a condition of NMP

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -129,6 +129,7 @@ Kian E (KJE-98)
 kinderchocolate
 Kiran Panditrao (Krgp)
 Kojirion
+Krisztián Peőcz
 Krystian Kuzniarek (kuzkry)
 Leonardo Ljubičić (ICCF World Champion)
 Leonid Pechenik (lp--)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -801,7 +801,7 @@ Value Search::Worker::search(
 
     // Step 9. Null move search with verification search (~35 Elo)
     if (cutNode && (ss - 1)->currentMove != Move::null() && eval >= beta
-        && ss->staticEval >= beta - 20 * depth + 440 - 30 * improving && !excludedMove && pos.non_pawn_material(us)
+        && ss->staticEval >= beta - 20 * depth + 470 - 60 * improving && !excludedMove && pos.non_pawn_material(us)
         && ss->ply >= thisThread->nmpMinPly && !is_loss(beta))
     {
         assert(eval - beta >= 0);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -803,7 +803,7 @@ Value Search::Worker::search(
 
     // Step 9. Null move search with verification search (~35 Elo)
     if (cutNode && (ss - 1)->currentMove != Move::null() && eval >= beta
-        && ss->staticEval >= beta - 20 * depth + 440 && !excludedMove && pos.non_pawn_material(us)
+        && ss->staticEval >= beta - 20 * depth + 440 - 30 * improving && !excludedMove && pos.non_pawn_material(us)
         && ss->ply >= thisThread->nmpMinPly && !is_loss(beta))
     {
         assert(eval - beta >= 0);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -799,8 +799,6 @@ Value Search::Worker::search(
         && eval >= beta && (!ttData.move || ttCapture) && !is_loss(beta) && !is_win(eval))
         return beta + (eval - beta) / 3;
 
-    improving |= ss->staticEval >= beta + 97;
-
     // Step 9. Null move search with verification search (~35 Elo)
     if (cutNode && (ss - 1)->currentMove != Move::null() && eval >= beta
         && ss->staticEval >= beta - 20 * depth + 440 - 30 * improving && !excludedMove && pos.non_pawn_material(us)
@@ -841,6 +839,8 @@ Value Search::Worker::search(
                 return nullValue;
         }
     }
+
+    improving |= ss->staticEval >= beta + 97;
 
     // Step 10. Internal iterative reductions (~9 Elo)
     // For PV nodes without a ttMove as well as for deep enough cutNodes, we decrease depth.


### PR DESCRIPTION
This patch makes one of the conditions for null-move pruning depend on whether we're improving. Keep in mind that it relies on the "classical" definiton, rather than the refined one.

Passed STC: https://tests.stockfishchess.org/tests/view/678d5267d63764e34db49720
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 38976 W: 10296 L: 9974 D: 18706
Ptnml(0-2): 135, 4504, 9902, 4798, 149

Passed LTC: https://tests.stockfishchess.org/tests/view/678d5891d63764e34db49731
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 275772 W: 70655 L: 69836 D: 135281
Ptnml(0-2): 217, 30615, 75394, 31452, 208

Bench: 1442128