### PR TITLE
do not change cursed wins to draws (take 2)

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1187,11 +1187,12 @@ bool Position::is_draw(int ply) const {
     if (st->rule50 > 99 && (!checkers() || MoveList<LEGAL>(*this).size()))
         return true;
 
-    // Return a draw score if a position repeats once earlier but strictly
-    // after the root, or repeats twice before or at the root.
-    return st->repetition && st->repetition < ply;
+    return is_repetition(ply);
 }
 
+// Return a draw score if a position repeats once earlier but strictly
+// after the root, or repeats twice before or at the root.
+bool Position::is_repetition(int ply) const { return st->repetition && st->repetition < ply; }
 
 // Tests whether there has been at least one repetition
 // of positions since the last capture or pawn move.

--- a/src/position.h
+++ b/src/position.h
@@ -163,6 +163,7 @@ class Position {
     int   game_ply() const;
     bool  is_chess960() const;
     bool  is_draw(int ply) const;
+    bool  is_repetition(int ply) const;
     bool  upcoming_repetition(int ply) const;
     bool  has_repeated() const;
     int   rule50_count() const;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1952,6 +1952,7 @@ void syzygy_extend_pv(const OptionsMap&         options,
 
     auto t_start      = std::chrono::steady_clock::now();
     int  moveOverhead = int(options["Move Overhead"]);
+    bool rule50       = bool(options["Syzygy50MoveRule"]);
 
     // Do not use more than moveOverhead / 2 time, if time management is active
     auto time_abort = [&t_start, &moveOverhead, &limits]() -> bool {
@@ -1989,7 +1990,7 @@ void syzygy_extend_pv(const OptionsMap&         options,
         pos.do_move(pvMove, st);
 
         // Do not allow for repetitions or drawing moves along the PV in TB regime
-        if (config.rootInTB && pos.is_draw(ply))
+        if (config.rootInTB && ((rule50 && pos.is_draw(ply)) || pos.is_repetition(ply)))
         {
             pos.undo_move(pvMove);
             ply--;
@@ -2008,7 +2009,7 @@ void syzygy_extend_pv(const OptionsMap&         options,
     // Step 2, now extend the PV to mate, as if the user explored syzygy-tables.info
     // using top ranked moves (minimal DTZ), which gives optimal mates only for simple
     // endgames e.g. KRvK.
-    while (!pos.is_draw(0))
+    while (!(rule50 && pos.is_draw(0)))
     {
         if (time_abort())
             break;
@@ -2051,7 +2052,7 @@ void syzygy_extend_pv(const OptionsMap&         options,
         pos.do_move(pvMove, st);
     }
 
-    // Finding a draw in this function is an exceptional case, that cannot happen
+    // Finding a draw in this function is an exceptional case, that cannot happen when rule50 is false or
     // during engine game play, since we have a winning score, and play correctly
     // with TB support. However, it can be that a position is draw due to the 50 move
     // rule if it has been been reached on the board with a non-optimal 50 move counter

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1620,7 +1620,7 @@ bool Tablebases::root_probe(Position&          pos,
             WDLScore wdl = -probe_wdl(pos, &result);
             dtz          = dtz_before_zeroing(wdl);
         }
-        else if (pos.is_draw(1))
+        else if ((rule50 && pos.is_draw(1)) || pos.is_repetition(1))
         {
             // In case a root move leads to a draw by repetition or 50-move rule,
             // we set dtz to zero. Note: since we are only 1 ply from the root,


### PR DESCRIPTION
This PR is an improvement upon https://github.com/official-stockfish/Stockfish/pull/5805.

It fixes a bug each in https://github.com/official-stockfish/Stockfish/pull/5414 and https://github.com/official-stockfish/Stockfish/commit/4c4e104cadceae678668f1738b5ca6296b2b4ef8.

The problem in each case is that `is_draw()` has no knowledge of the UCI option `Syzygy50MoveRule`, and so its calls have to be guarded.

An example position where the bug triggers is [`7b/8/6b1/8/5Nk1/4K3/8/8 b - - 0 1`](https://syzygy-tables.info/?fen=7b/8/6b1/8/5Nk1/4K3/8/8_b_-_-_0_1). I.e. master shows an evaluation of `cp 0`, while the patch correctly shows `cp 20000`.

This PR also leads to correct PV extensions for cursed wins. Below the output of the corresponding matetrack check using the new `matecheck.py` script and the FEN collection `cursed.epd` from https://github.com/vondele/matetrack/pull/130.
```
> python matecheck.py --epdFile cursed.epd --engine ../stockfish/src/patch --nodes 1000 --syzygyPath /disk1/syzygy/3-4-5-6/WDL:/disk2/syzygy/3-4-5-6/DTZ --syzygy50MoveRule false
Loaded 30 FENs, with max(|bm|) = 1.

Matetrack started for ../stockfish/src/patch on cursed.epd with --nodes 1000 --syzygyPath /disk1/syzygy/3-4-5-6/WDL:/disk2/syzygy/3-4-5-6/DTZ --syzygy50MoveRule false ...
100%|###########################################| 30/30 [00:03<00:00,  9.56it/s]

Found 510 tablebases. Checking 33 TB win PVs. This may take some time ...

Using ../stockfish/src/patch on cursed.epd with --nodes 1000 --syzygyPath /disk1/syzygy/3-4-5-6/WDL:/disk2/syzygy/3-4-5-6/DTZ --syzygy50MoveRule false
Engine ID:     Stockfish dev-20250121-4e5ae2be
Total FENs:    30
Found mates:   0
Best mates:    0
Found TB wins: 30
```

No functional change.