### PR TITLE
Revert "Moving up the if position is or has been on the PV reduction"

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1142,8 +1142,8 @@ moves_loop:  // When in check, search starts here
 
         // These reduction adjustments have proven non-linear scaling.
         // They are optimized to time controls of 180 + 1.8 and longer,
-        // so changing them or adding conditions that are similar requires
-        // tests at these types of time controls.
+        // so moving them or changing them or adding conditions that are 
+        // similar requires tests at these types of time controls.
 
         // Decrease reduction if position is or has been on the PV (~7 Elo)
         if (ss->ttPv)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -979,10 +979,6 @@ moves_loop:  // When in check, search starts here
 
         Depth r = reduction(improving, depth, moveCount, delta);
 
-        // Decrease reduction if position is or has been on the PV (~7 Elo)
-        if (ss->ttPv)
-            r -= 1037 + (ttData.value > alpha) * 965 + (ttData.depth >= depth) * 960;
-
         // Step 14. Pruning at shallow depth (~120 Elo).
         // Depth conditions are important for mate finding.
         if (!rootNode && pos.non_pawn_material(us) && !is_loss(bestValue))
@@ -1148,6 +1144,10 @@ moves_loop:  // When in check, search starts here
         // They are optimized to time controls of 180 + 1.8 and longer,
         // so changing them or adding conditions that are similar requires
         // tests at these types of time controls.
+
+        // Decrease reduction if position is or has been on the PV (~7 Elo)
+        if (ss->ttPv)
+            r -= 1037 + (ttData.value > alpha) * 965 + (ttData.depth >= depth) * 960;
 
         // Decrease reduction for PvNodes (~0 Elo on STC, ~2 Elo on LTC)
         if (PvNode)


### PR DESCRIPTION
Passed VVLTC 1:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 68362 W: 17830 L: 17523 D: 33009
Ptnml(0-2): 9, 6253, 21347, 6566, 6
https://tests.stockfishchess.org/tests/view/6790271cfc8c306ba6cea2c1

Passed VVLTC 2:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 113256 W: 29158 L: 28721 D: 55377
Ptnml(0-2): 13, 10521, 35122, 10960, 12
https://tests.stockfishchess.org/tests/view/678d3e47d63764e34db491a3

bench 1517478