### PR TITLE
Improve NonPawnCorrectionHistory indexing

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -138,7 +138,7 @@ enum CorrHistType {
     Pawn,          // By color and pawn structure
     Major,         // By color and positions of major pieces (Queen, Rook) and King
     Minor,         // By color and positions of minor pieces (Knight, Bishop) and King
-    NonPawn,       // By color and non-pawn material positions
+    NonPawn,       // By Non-pawn material positions and color
     PieceTo,       // By [piece][to] move
     Continuation,  // Combined history of move pairs
 };
@@ -148,6 +148,11 @@ namespace Detail {
 template<CorrHistType _>
 struct CorrHistTypedef {
     using type = Stats<std::int16_t, CORRECTION_HISTORY_LIMIT, COLOR_NB, CORRECTION_HISTORY_SIZE>;
+};
+
+template<>
+struct CorrHistTypedef<NonPawn> {
+    using type = Stats<std::int16_t, CORRECTION_HISTORY_LIMIT, CORRECTION_HISTORY_SIZE, COLOR_NB>;
 };
 
 template<>

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -83,8 +83,8 @@ int correction_value(const Worker& w, const Position& pos, const Stack* ss) {
     const auto  pcv   = w.pawnCorrectionHistory[us][pawn_structure_index<Correction>(pos)];
     const auto  macv  = w.majorPieceCorrectionHistory[us][major_piece_index(pos)];
     const auto  micv  = w.minorPieceCorrectionHistory[us][minor_piece_index(pos)];
-    const auto  wnpcv = w.nonPawnCorrectionHistory[WHITE][us][non_pawn_index<WHITE>(pos)];
-    const auto  bnpcv = w.nonPawnCorrectionHistory[BLACK][us][non_pawn_index<BLACK>(pos)];
+    const auto  wnpcv = w.nonPawnCorrectionHistory[WHITE][non_pawn_index<WHITE>(pos)][us];
+    const auto  bnpcv = w.nonPawnCorrectionHistory[BLACK][non_pawn_index<BLACK>(pos)][us];
     const auto  cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                  : 0;
@@ -1446,9 +1446,9 @@ moves_loop:  // When in check, search starts here
           << bonus * 114 / 128;
         thisThread->majorPieceCorrectionHistory[us][major_piece_index(pos)] << bonus * 163 / 128;
         thisThread->minorPieceCorrectionHistory[us][minor_piece_index(pos)] << bonus * 146 / 128;
-        thisThread->nonPawnCorrectionHistory[WHITE][us][non_pawn_index<WHITE>(pos)]
+        thisThread->nonPawnCorrectionHistory[WHITE][non_pawn_index<WHITE>(pos)][us]
           << bonus * nonPawnWeight / 128;
-        thisThread->nonPawnCorrectionHistory[BLACK][us][non_pawn_index<BLACK>(pos)]
+        thisThread->nonPawnCorrectionHistory[BLACK][non_pawn_index<BLACK>(pos)][us]
           << bonus * nonPawnWeight / 128;
 
         if (m.is_ok())


### PR DESCRIPTION
Bench 1632964

LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 75936 W: 19905 L: 19554 D: 36477
Ptnml(0-2): 190, 7863, 21554, 8128, 233 
https://tests.stockfishchess.org/tests/view/67904d0cfc8c306ba6cea332

Improves indexing scheme, by noting that both sides are likely to access the same non_pawn_index nearby.
Seemingly passes an SPRT, which is shocking. But its objectively good practice.

Thanks to @xu-shawn for coding it up, after I mentioned it. 