### PR TITLE
Consider more nodes as ttPv nodes.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1421,7 +1421,7 @@ moves_loop:  // When in check, search starts here
     // If no good move is found and the previous position was ttPv, then the previous
     // opponent move is probably good and the new position is added to the search tree. (~7 Elo)
     if (bestValue <= alpha)
-        ss->ttPv = ss->ttPv || ((ss - 1)->ttPv && depth > 3);
+        ss->ttPv = ss->ttPv || (ss - 1)->ttPv;
 
     // Write gathered information in transposition table. Note that the
     // static evaluation is saved as it was before correction history.


### PR DESCRIPTION
Remove depth condition in propagation rule for ttPv state from a node to
it childs.

Because this change marks more nodes as ttPv, we have a time sensitive
ttPv reduction rule and the STC snd LTC seems to show bad scaling. So i
have also submitted a VLTC non-regression to check the scaling at higher
time control.

The results gives a little indication that we have perhaps good scaling
with more ttPv nodes so that could be further explored.

Passed non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 82528 W: 21627 L: 21453 D: 39448
Ptnml(0-2): 317, 9809, 20891, 9877, 370
https://tests.stockfishchess.org/tests/view/678e608cd63764e34db49ad7

Passed non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 310440 W: 78879 L: 78956 D: 152605
Ptnml(0-2): 255, 34915, 84938, 34876, 236
https://tests.stockfishchess.org/tests/view/678fab89ac8f8f5496155f3c

Passed non-regression VLTC for scaling verification:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 59496 W: 15158 L: 14983 D: 29355
Ptnml(0-2): 15, 6039, 17470, 6204, 20
https://tests.stockfishchess.org/tests/view/6794bd1f4f7de645171fb33b

Bench: 1498882