### PR TITLE
simp futility

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1030,7 +1030,7 @@ moves_loop:  // When in check, search starts here
                 lmrDepth += history / 3459;
 
                 Value futilityValue =
-                  ss->staticEval + (bestValue < ss->staticEval - 47 ? 137 : 47) + 142 * lmrDepth;
+                  ss->staticEval + (bestMove ? 47 : 137) + 142 * lmrDepth;
 
                 // Futility pruning: parent node (~13 Elo)
                 if (!ss->inCheck && lmrDepth < 12 && futilityValue <= alpha)


### PR DESCRIPTION
Simplify futility margin in lmr for quiets.

Replace the "low bestValue condition" with whether there is a best move.

Passed Simplification STC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 102560 W: 26517 L: 26367 D: 49676
Ptnml(0-2): 328, 12223, 26036, 12357, 336 
https://tests.stockfishchess.org/tests/view/679310e4ca18a2c66da02af8

Passed Simplification LTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 66942 W: 17130 L: 16953 D: 32859
Ptnml(0-2): 52, 7459, 18290, 7600, 70 
https://tests.stockfishchess.org/tests/view/679459a3e96bfb672ad18ddf

bench 1569382