### PR TITLE
Simplify cutoffCnt formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1328,7 +1328,7 @@ moves_loop:  // When in check, search starts here
 
                 if (value >= beta)
                 {
-                    ss->cutoffCnt += !ttData.move + (extension < 2);
+                    ss->cutoffCnt += (extension < 2);
                     assert(value >= beta);  // Fail high
                     break;
                 }


### PR DESCRIPTION
Simplify cutoffCnt formula.

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 235872 W: 61156 L: 61155 D: 113561
Ptnml(0-2): 843, 28269, 59658, 28376, 790
https://tests.stockfishchess.org/tests/view/6794dd3e4f7de645171fb380

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 61494 W: 15644 L: 15462 D: 30388
Ptnml(0-2): 61, 6822, 16788, 7026, 50
https://tests.stockfishchess.org/tests/view/6794f86a406a4efe9eb7d093

bench: 2168937