### PR TITLE
Decrease all stats malus according to move count

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -126,7 +126,8 @@ void update_all_stats(const Position&      pos,
                       ValueList<Move, 32>& quietsSearched,
                       ValueList<Move, 32>& capturesSearched,
                       Depth                depth,
-                      bool                 isTTMove);
+                      bool                 isTTMove,
+                      int                  moveCount);
 
 }  // namespace
 
@@ -1374,7 +1375,7 @@ moves_loop:  // When in check, search starts here
     // we update the stats of searched moves.
     else if (bestMove)
         update_all_stats(pos, ss, *this, bestMove, prevSq, quietsSearched, capturesSearched, depth,
-                         bestMove == ttData.move);
+                         bestMove == ttData.move, moveCount);
 
     // Bonus for prior countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
@@ -1795,14 +1796,15 @@ void update_all_stats(const Position&      pos,
                       ValueList<Move, 32>& quietsSearched,
                       ValueList<Move, 32>& capturesSearched,
                       Depth                depth,
-                      bool                 isTTMove) {
+                      bool                 isTTMove,
+                      int                  moveCount) {
 
     CapturePieceToHistory& captureHistory = workerThread.captureHistory;
     Piece                  moved_piece    = pos.moved_piece(bestMove);
     PieceType              captured;
 
     int bonus = stat_bonus(depth) + 300 * isTTMove;
-    int malus = stat_malus(depth);
+    int malus = stat_malus(depth) - 34*(moveCount - 1);
 
     if (!pos.capture_stage(bestMove))
     {


### PR DESCRIPTION
Passed STC:
https://tests.stockfishchess.org/tests/view/6794c4634f7de645171fb341
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 28096 W: 7412 L: 7106 D: 13578
Ptnml(0-2): 97, 3194, 7148, 3524, 85

Passed LTC:
https://tests.stockfishchess.org/tests/view/6794ea13406a4efe9eb7d06b
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 58086 W: 15049 L: 14684 D: 28353
Ptnml(0-2): 27, 6344, 15957, 6667, 48

Bench: 2049755