### PR TITLE
No Ply Restriction in the condition that limits the depth extension to a certain point

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1240,7 +1240,7 @@ moves_loop:  // When in check, search starts here
             (ss + 1)->pv[0] = Move::none();
 
             // Extend move from transposition table if we are about to dive into qsearch.
-            if (move == ttData.move && ss->ply <= thisThread->rootDepth * 2)
+            if (move == ttData.move && thisThread->rootDepth > 8)
                 newDepth = std::max(newDepth, 1);
 
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);


### PR DESCRIPTION
Follow up to #5737 
No Ply Restriction in the condition that limits the depth extension to a certain point

Passed again LTC rebased:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 195108 W: 49916 L: 49872 D: 95320
Ptnml(0-2): 170, 21846, 53464, 21918, 156
https://tests.stockfishchess.org/tests/view/6795542a406a4efe9eb7d361

bench: 1912103