### PR TITLE
Refactor prior countermove bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1382,23 +1382,21 @@ moves_loop:  // When in check, search starts here
         int bonusScale = (118 * (depth > 5) + 37 * !allNode + 169 * ((ss - 1)->moveCount > 8)
                           + 128 * (!ss->inCheck && bestValue <= ss->staticEval - 102)
                           + 115 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 82)
-                          + 80 * ((ss - 1)->isTTMove));
-
-        // Proportional to "how much damage we have to undo"
-        bonusScale += std::min(-(ss - 1)->statScore / 106, 318);
+                          + 80 * ((ss - 1)->isTTMove) + std::min(-(ss - 1)->statScore / 106, 318));
 
         bonusScale = std::max(bonusScale, 0);
 
-        const int scaledBonus = stat_bonus(depth) * bonusScale / 32;
+        const int scaledBonus = stat_bonus(depth) * bonusScale;
 
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
-                                      scaledBonus * 436 / 1024);
+                                      scaledBonus * 436 / 32768);
 
-        thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()] << scaledBonus * 207 / 1024;
+        thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()]
+          << scaledBonus * 207 / 32768;
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
             thisThread->pawnHistory[pawn_structure_index(pos)][pos.piece_on(prevSq)][prevSq]
-              << scaledBonus * 1195 / 1024;
+              << scaledBonus * 1195 / 32768;
     }
 
     else if (priorCapture && prevSq != SQ_NONE)


### PR DESCRIPTION
Refactor prior countermove bonus

Passed simplification STC
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 155424 W: 40252 L: 40159 D: 75013
Ptnml(0-2): 511, 18655, 39328, 18666, 552 
https://tests.stockfishchess.org/tests/view/6794084fe96bfb672ad18d90

Passed rebased simplification LTC
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 103944 W: 26567 L: 26427 D: 50950
Ptnml(0-2): 69, 11640, 28418, 11772, 73 
https://tests.stockfishchess.org/tests/view/67955c9a406a4efe9eb7d7e4

bench 1935787