### PR TITLE
update CI fastchess version

### DIFF
--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -19,22 +19,22 @@ jobs:
         working-directory: Stockfish/src
         run: make -j build debug=yes
 
-      - name: Checkout fast-chess repo
+      - name: Checkout fastchess repo
         uses: actions/checkout@v4
         with:
-          repository: Disservin/fast-chess
-          path: fast-chess
-          ref: d54af1910d5479c669dc731f1f54f9108a251951
+          repository: Disservin/fastchess
+          path: fastchess
+          ref: 894616028492ae6114835195f14a899f6fa237d3
           persist-credentials: false
 
-      - name: fast-chess build
-        working-directory: fast-chess
+      - name: fastchess build
+        working-directory: fastchess
         run: make -j
 
       - name: Run games
-        working-directory: fast-chess
+        working-directory: fastchess
         run: |
-          ./fast-chess  -rounds 4 -games 2 -repeat -concurrency 4 -openings file=app/tests/data/openings.epd format=epd order=random -srand $RANDOM\
+          ./fastchess -rounds 4 -games 2 -repeat -concurrency 4 -openings file=app/tests/data/openings.epd format=epd order=random -srand $RANDOM\
                -engine name=sf1 cmd=/home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish\
                -engine name=sf2 cmd=/home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish\
                -ratinginterval 1 -report penta=true -each proto=uci tc=4+0.04 -log file=fast.log | tee fast.out


### PR DESCRIPTION
This PR updates the fastchess version used as part of the CI to the one used on fishtest, see https://github.com/official-stockfish/fishtest/pull/2180.

Also change the name/repo from fast-chess to fastchess.

No functional change.