### PR TITLE
add cursed win checks to CI matetrack tests

### DIFF
--- a/.github/workflows/matetrack.yml
+++ b/.github/workflows/matetrack.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           repository: vondele/matetrack
           path: matetrack
-          ref: 814160f82e6428ed2f6522dc06c2a6fa539cd413
+          ref: 4f8a80860ed8f3607f05a9195df8b40203bdc360
           persist-credentials: false
 
       - name: matetrack install deps
@@ -50,5 +50,22 @@ jobs:
       - name: Run matetrack
         working-directory: matetrack
         run: |
-          python matecheck.py  --syzygyPath 3-4-5-wdl/:3-4-5-dtz/ --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile mates2000.epd --nodes 100000 | tee matecheckout.out
+          python matecheck.py --syzygyPath 3-4-5-wdl/:3-4-5-dtz/ --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile mates2000.epd --nodes 100000 | tee matecheckout.out
           ! grep "issues were detected" matecheckout.out > /dev/null
+
+      - name: Run matetrack with --syzygy50MoveRule false
+        working-directory: matetrack
+        run: |
+          grep 5men cursed.epd > cursed5.epd
+          python matecheck.py --syzygyPath 3-4-5-wdl/:3-4-5-dtz/ --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile cursed5.epd --nodes 100000 --syzygy50MoveRule false | tee matecheckcursed.out
+          ! grep "issues were detected" matecheckcursed.out > /dev/null
+
+      - name: Verify mate and TB win count for matecheckcursed.out
+        working-directory: matetrack
+        run: |
+          mates=$(grep "Found mates:" matecheckcursed.out | awk '{print $3}')
+          tbwins=$(grep "Found TB wins:" matecheckcursed.out | awk '{print $4}')
+          if [ $(($mates + $tbwins)) -ne 32 ]; then
+            echo "Sum of mates and TB wins is not 32 in matecheckcursed.out" >&2
+            exit 1
+          fi


### PR DESCRIPTION
This PR adds a run for the `matecheck.py` script from the matetrack repo with the option `--syzygy50MoveRule false`.

The new tests guard against a re-introduction of the bugs recently fixed by https://github.com/official-stockfish/Stockfish/pull/5814.

No functional change.