### PR TITLE
Clean up corrhist

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -133,14 +133,14 @@ using PawnHistory = Stats<std::int16_t, 8192, PAWN_HISTORY_SIZE, PIECE_NB, SQUAR
 enum CorrHistType {
     Pawn,          // By color and pawn structure
     Minor,         // By color and positions of minor pieces (Knight, Bishop) and King
-    NonPawn,       // By Non-pawn material positions and color
+    NonPawn,       // By non-pawn material positions and color
     PieceTo,       // By [piece][to] move
     Continuation,  // Combined history of move pairs
 };
 
 namespace Detail {
 
-template<CorrHistType _>
+template<CorrHistType>
 struct CorrHistTypedef {
     using type = Stats<std::int16_t, CORRECTION_HISTORY_LIMIT, COLOR_NB, CORRECTION_HISTORY_SIZE>;
 };

--- a/src/history.h
+++ b/src/history.h
@@ -142,11 +142,6 @@ namespace Detail {
 
 template<CorrHistType>
 struct CorrHistTypedef {
-    using type = Stats<std::int16_t, CORRECTION_HISTORY_LIMIT, COLOR_NB, CORRECTION_HISTORY_SIZE>;
-};
-
-template<>
-struct CorrHistTypedef<NonPawn> {
     using type = Stats<std::int16_t, CORRECTION_HISTORY_LIMIT, CORRECTION_HISTORY_SIZE, COLOR_NB>;
 };
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -83,11 +83,11 @@ constexpr int futility_move_count(bool improving, Depth depth) {
     return (3 + depth * depth) / (2 - improving);
 }
 
-int correction_value(const Worker& w, const Position& pos, const Stack* ss) {
+int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us    = pos.side_to_move();
     const auto  m     = (ss - 1)->currentMove;
-    const auto  pcv   = w.pawnCorrectionHistory[us][pawn_structure_index<Correction>(pos)];
-    const auto  micv  = w.minorPieceCorrectionHistory[us][minor_piece_index(pos)];
+    const auto  pcv   = w.pawnCorrectionHistory[pawn_structure_index<Correction>(pos)][us];
+    const auto  micv  = w.minorPieceCorrectionHistory[minor_piece_index(pos)][us];
     const auto  wnpcv = w.nonPawnCorrectionHistory[WHITE][non_pawn_index<WHITE>(pos)][us];
     const auto  bnpcv = w.nonPawnCorrectionHistory[BLACK][non_pawn_index<BLACK>(pos)][us];
     const auto  cntcv =
@@ -99,22 +99,22 @@ int correction_value(const Worker& w, const Position& pos, const Stack* ss) {
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
 // does not hit the tablebase range.
-Value to_corrected_static_eval(Value v, const int cv) {
+Value to_corrected_static_eval(const Value v, const int cv) {
     return std::clamp(v + cv / 131072, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
 }
 
 void update_correction_history(const Position& pos,
-                               Stack*          ss,
+                               Stack* const    ss,
                                Search::Worker& workerThread,
-                               int             bonus) {
+                               const int       bonus) {
     const Move  m  = (ss - 1)->currentMove;
     const Color us = pos.side_to_move();
 
     static constexpr int nonPawnWeight = 165;
 
-    workerThread.pawnCorrectionHistory[us][pawn_structure_index<Correction>(pos)]
+    workerThread.pawnCorrectionHistory[pawn_structure_index<Correction>(pos)][us]
       << bonus * 114 / 128;
-    workerThread.minorPieceCorrectionHistory[us][minor_piece_index(pos)] << bonus * 146 / 128;
+    workerThread.minorPieceCorrectionHistory[minor_piece_index(pos)][us] << bonus * 146 / 128;
     workerThread.nonPawnCorrectionHistory[WHITE][non_pawn_index<WHITE>(pos)][us]
       << bonus * nonPawnWeight / 128;
     workerThread.nonPawnCorrectionHistory[BLACK][non_pawn_index<BLACK>(pos)][us]


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 89056 W: 23225 L: 23067 D: 42764
Ptnml(0-2): 292, 9688, 24470, 9726, 352 
https://tests.stockfishchess.org/tests/view/679816b2ae346be6da0ee8e7