### PR TITLE
Don't increase rule50 when doing null moves

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1023,11 +1023,6 @@ void Position::do_null_move(StateInfo& newSt, const TranspositionTable& tt) {
     st->next       = &newSt;
     st             = &newSt;
 
-    st->dirtyPiece.dirty_num               = 0;
-    st->dirtyPiece.piece[0]                = NO_PIECE;  // Avoid checks in UpdateAccumulator()
-    st->accumulatorBig.computed[WHITE]     = st->accumulatorBig.computed[BLACK] =
-      st->accumulatorSmall.computed[WHITE] = st->accumulatorSmall.computed[BLACK] = false;
-
     if (st->epSquare != SQ_NONE)
     {
         st->key ^= Zobrist::enpassant[file_of(st->epSquare)];
@@ -1035,8 +1030,12 @@ void Position::do_null_move(StateInfo& newSt, const TranspositionTable& tt) {
     }
 
     st->key ^= Zobrist::side;
-    ++st->rule50;
     prefetch(tt.first_entry(key()));
+
+    st->dirtyPiece.dirty_num               = 0;
+    st->dirtyPiece.piece[0]                = NO_PIECE;  // Avoid checks in UpdateAccumulator()
+    st->accumulatorBig.computed[WHITE]     = st->accumulatorBig.computed[BLACK] =
+      st->accumulatorSmall.computed[WHITE] = st->accumulatorSmall.computed[BLACK] = false;
 
     st->pliesFromNull = 0;
 


### PR DESCRIPTION
passed STC: https://tests.stockfishchess.org/tests/view/678c0860f4dc0a8b4ae8cf58
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 67328 W: 17608 L: 17418 D: 32302
Ptnml(0-2): 256, 7905, 17156, 8087, 260

passed LTC: https://tests.stockfishchess.org/tests/view/678c1a56f4dc0a8b4ae8cfb1
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 340896 W: 86577 L: 86685 D: 167634
Ptnml(0-2): 291, 38325, 93332, 38201, 299

bench: 1910281