### PR TITLE
Make IIR for PvNodes less aggressive

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -848,12 +848,8 @@ Value Search::Worker::search(
     // Step 10. Internal iterative reductions
     // For PV nodes without a ttMove as well as for deep enough cutNodes, we decrease depth.
     // (* Scaler) Especially if they make IIR more aggressive.
-    if ((PvNode || (cutNode && depth >= 7)) && !ttData.move)
+    if (((PvNode || cutNode) && depth >= 7 - 4 * PvNode) && !ttData.move)
         depth -= 2;
-
-    // Use qsearch if depth <= 0
-    if (depth <= 0)
-        return qsearch<PV>(pos, ss, alpha, beta);
 
     // Step 11. ProbCut
     // If we have a good enough capture (or queen promotion) and a reduced search


### PR DESCRIPTION
In line with previous experiments on improving scaling of IIR.
Now it disables IIR for pv nodes with depth <= 2, so disallowing for it to perform a qsearch dive.
Fixed games STC:
https://tests.stockfishchess.org/tests/view/679ae6a951037ccaf3e30fb3
Elo: -10.36 ± 2.5 (95%) LOS: 0.0%
Total: 20020 W: 4902 L: 5499 D: 9619
Ptnml(0-2): 128, 2653, 4976, 2194, 59
Passed VVLTC with STC bounds:
https://tests.stockfishchess.org/tests/view/67954f2e406a4efe9eb7d266
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 196758 W: 50725 L: 50258 D: 95775
Ptnml(0-2): 21, 18153, 61564, 18620, 21 
Passed VVLTC with LTC bounds:
https://tests.stockfishchess.org/tests/view/6795a26bf6281b7d7b18698b
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 323092 W: 83679 L: 82857 D: 156556
Ptnml(0-2): 48, 29475, 101659, 30335, 29 
bench 3624739