### PR TITLE
Micro-optimization for SEE: remove a superfluous condition 

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1147,8 +1147,8 @@ bool Position::see_ge(Move m, int threshold) const {
 
         else if ((bb = stmAttackers & pieces(QUEEN)))
         {
-            if ((swap = QueenValue - swap) < res)
-                break;
+            swap = QueenValue - swap;
+            assert (swap >= res); //  implies that the previous recapture was done by a higher rated piece than a Queen (King is excluded)
             occupied ^= least_significant_square_bb(bb);
 
             attackers |= (attacks_bb<BISHOP>(to, occupied) & pieces(BISHOP, QUEEN))


### PR DESCRIPTION
The removed condition can never be true, it's superfluous.
It never triggers even with a bench 16 1 20 run.
To met the condition it would imply that the previous recapture was done by a higher rated piece than a Queen.
This is only the case when the King recaptures and that's already handled in line 1161: (return (attackers & ~pieces(stm)) ? res ^ 1).
To maintain the code robust and understandable I added an assert and a comment.
Thanks to mstembera in helping me for this PR.

no functional change
bench: 1767398