### PR TITLE
simp probcut disable condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -865,7 +865,7 @@ Value Search::Worker::search(
         // probCut there and in further interactions with transposition table cutoff
         // depth is set to depth - 3 because probCut search has depth set to depth - 4
         // but we also do a move before it. So effective depth is equal to depth - 3.
-        && !(ttData.depth >= depth - 3 && is_valid(ttData.value) && ttData.value < probCutBeta))
+        && !(is_valid(ttData.value) && ttData.value < probCutBeta))
     {
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 


### PR DESCRIPTION
Disable probcut check when we the ttValue is not at least probCutBeta, regardless of tt depth.

Passed simplification STC
LLR: 2.92 (-2.94,2.94) <-1.75,0.25>
Total: 60896 W: 16030 L: 15835 D: 29031
Ptnml(0-2): 220, 7164, 15507, 7315, 242 
https://tests.stockfishchess.org/tests/view/679c0a3251037ccaf3e3141e

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 76644 W: 19557 L: 19392 D: 37695
Ptnml(0-2): 50, 8486, 21104, 8613, 69 
https://tests.stockfishchess.org/tests/view/679c380b0774dfd78deaf35c

bench 1816197