### PR TITLE
Tweak minor piece correction history.

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -132,7 +132,7 @@ using PawnHistory = Stats<std::int16_t, 8192, PAWN_HISTORY_SIZE, PIECE_NB, SQUAR
 // see https://www.chessprogramming.org/Static_Evaluation_Correction_History
 enum CorrHistType {
     Pawn,          // By color and pawn structure
-    Minor,         // By color and positions of minor pieces (Knight, Bishop) and King
+    Minor,         // By color and positions of minor pieces (Knight, Bishop)
     NonPawn,       // By Non-pawn material positions and color
     PieceTo,       // By [piece][to] move
     Continuation,  // Combined history of move pairs

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -335,6 +335,7 @@ void Position::set_check_info() const {
 void Position::set_state() const {
 
     st->key = st->materialKey = 0;
+    st->minorPieceKey         = 0;
     st->nonPawnKey[WHITE] = st->nonPawnKey[BLACK] = 0;
     st->pawnKey                                   = Zobrist::noPawns;
     st->nonPawnMaterial[WHITE] = st->nonPawnMaterial[BLACK] = VALUE_ZERO;
@@ -361,11 +362,6 @@ void Position::set_state() const {
 
                 if (type_of(pc) <= BISHOP)
                     st->minorPieceKey ^= Zobrist::psq[pc][s];
-            }
-
-            else
-            {
-                st->minorPieceKey ^= Zobrist::psq[pc][s];
             }
         }
     }
@@ -867,12 +863,7 @@ void Position::do_move(Move                      m,
     {
         st->nonPawnKey[us] ^= Zobrist::psq[pc][from] ^ Zobrist::psq[pc][to];
 
-        if (type_of(pc) == KING)
-        {
-            st->minorPieceKey ^= Zobrist::psq[pc][from] ^ Zobrist::psq[pc][to];
-        }
-
-        else if (type_of(pc) <= BISHOP)
+        if (type_of(pc) <= BISHOP)
             st->minorPieceKey ^= Zobrist::psq[pc][from] ^ Zobrist::psq[pc][to];
     }
 


### PR DESCRIPTION
Remove from the used minor piece index the positions of both kings.

Passed non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 78848 W: 20710 L: 20532 D: 37606
Ptnml(0-2): 303, 9403, 19880, 9489, 349
https://tests.stockfishchess.org/tests/view/679bf12851037ccaf3e3129e

Passed non-regression LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 111420 W: 28389 L: 28259 D: 54772
Ptnml(0-2): 91, 12381, 30625, 12533, 80
https://tests.stockfishchess.org/tests/view/679c31450774dfd78deaf34e

Bench: 2131107