### PR TITLE
Tweak correction history factors.

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -132,7 +132,7 @@ using PawnHistory = Stats<std::int16_t, 8192, PAWN_HISTORY_SIZE, PIECE_NB, SQUAR
 // see https://www.chessprogramming.org/Static_Evaluation_Correction_History
 enum CorrHistType {
     Pawn,          // By color and pawn structure
-    Minor,         // By color and positions of minor pieces (Knight, Bishop) and King
+    Minor,         // By color and positions of minor pieces (Knight, Bishop)
     NonPawn,       // By Non-pawn material positions and color
     PieceTo,       // By [piece][to] move
     Continuation,  // Combined history of move pairs

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -335,6 +335,7 @@ void Position::set_check_info() const {
 void Position::set_state() const {
 
     st->key = st->materialKey = 0;
+    st->minorPieceKey         = 0;
     st->nonPawnKey[WHITE] = st->nonPawnKey[BLACK] = 0;
     st->pawnKey                                   = Zobrist::noPawns;
     st->nonPawnMaterial[WHITE] = st->nonPawnMaterial[BLACK] = VALUE_ZERO;
@@ -361,11 +362,6 @@ void Position::set_state() const {
 
                 if (type_of(pc) <= BISHOP)
                     st->minorPieceKey ^= Zobrist::psq[pc][s];
-            }
-
-            else
-            {
-                st->minorPieceKey ^= Zobrist::psq[pc][s];
             }
         }
     }
@@ -867,12 +863,7 @@ void Position::do_move(Move                      m,
     {
         st->nonPawnKey[us] ^= Zobrist::psq[pc][from] ^ Zobrist::psq[pc][to];
 
-        if (type_of(pc) == KING)
-        {
-            st->minorPieceKey ^= Zobrist::psq[pc][from] ^ Zobrist::psq[pc][to];
-        }
-
-        else if (type_of(pc) <= BISHOP)
+        if (type_of(pc) <= BISHOP)
             st->minorPieceKey ^= Zobrist::psq[pc][from] ^ Zobrist::psq[pc][to];
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -94,7 +94,7 @@ int correction_value(const Worker& w, const Position& pos, const Stack* ss) {
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                  : 0;
 
-    return (7000 * pcv + 6300 * micv + 7550 * (wnpcv + bnpcv) + 6320 * cntcv);
+    return 7037 * pcv + 6671 * micv + 7631 * (wnpcv + bnpcv) + 6362 * cntcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -1430,20 +1430,21 @@ moves_loop:  // When in check, search starts here
             || (bestValue > ss->staticEval && bestMove)))     // positive correction & no fail low
     {
         const auto    m             = (ss - 1)->currentMove;
-        constexpr int nonPawnWeight = 165;
+        constexpr int nonPawnWeight = 159;
 
         auto bonus = std::clamp(int(bestValue - ss->staticEval) * depth / 8,
                                 -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
         thisThread->pawnCorrectionHistory[us][pawn_structure_index<Correction>(pos)]
-          << bonus * 114 / 128;
-        thisThread->minorPieceCorrectionHistory[us][minor_piece_index(pos)] << bonus * 146 / 128;
+          << bonus * 104 / 128;
+        thisThread->minorPieceCorrectionHistory[us][minor_piece_index(pos)] << bonus * 145 / 128;
         thisThread->nonPawnCorrectionHistory[WHITE][non_pawn_index<WHITE>(pos)][us]
           << bonus * nonPawnWeight / 128;
         thisThread->nonPawnCorrectionHistory[BLACK][non_pawn_index<BLACK>(pos)][us]
           << bonus * nonPawnWeight / 128;
 
         if (m.is_ok())
-            (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()] << bonus;
+            (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
+              << bonus * 146 / 128;
     }
 
     assert(bestValue > -VALUE_INFINITE && bestValue < VALUE_INFINITE);


### PR DESCRIPTION
The values are taken from this tuning https://tests.stockfishchess.org/tests/view/679c4e150774dfd78deaf376 which added also a new material correction history. The full tune doesn't work but ignoring the new history results in this changes.

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 102368 W: 27057 L: 26638 D: 48673
Ptnml(0-2): 394, 12031, 25949, 12382, 428
https://tests.stockfishchess.org/tess/view/679d2ca70774dfd78deaf796

Passed LTC:
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 55044 W: 14215 L: 13855 D: 26974
Ptnml(0-2): 43, 5956, 15172, 6300, 51
https://tests.stockfishchess.org/tests/view/679d30be0774dfd78deafda2

Bench: 2239499