### PR TITLE
Simplify Away Quadruple Extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1079,12 +1079,9 @@ moves_loop:  // When in check, search starts here
                     int doubleMargin = 249 * PvNode - 194 * !ttCapture - corrValAdj;
                     int tripleMargin =
                       94 + 287 * PvNode - 249 * !ttCapture + 99 * ss->ttPv - corrValAdj;
-                    int quadMargin =
-                      394 + 287 * PvNode - 249 * !ttCapture + 99 * ss->ttPv - corrValAdj;
 
                     extension = 1 + (value < singularBeta - doubleMargin)
-                              + (value < singularBeta - tripleMargin)
-                              + (value < singularBeta - quadMargin);
+                              + (value < singularBeta - tripleMargin);
 
                     depth += ((!PvNode) && (depth < 15));
                 }


### PR DESCRIPTION
Passed Non-regression LTC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 95856 W: 24551 L: 24404 D: 46901
Ptnml(0-2): 85, 10621, 26364, 10778, 80
https://tests.stockfishchess.org/tests/view/679a9aedae346be6da0eebd6

Passed Non-regression VLTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 157536 W: 40000 L: 39921 D: 77615
Ptnml(0-2): 43, 16416, 45775, 16487, 47
https://tests.stockfishchess.org/tests/view/679aed8f51037ccaf3e30fbf

Passed Non-regression VVLTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 51598 W: 13345 L: 13172 D: 25081
Ptnml(0-2): 0, 4735, 16162, 4896, 6
https://tests.stockfishchess.org/tests/view/679d368b0774dfd78deb0163

bench 1429075