### PR TITLE
Make pruning at ttpv nodes more aggressive.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -981,6 +981,12 @@ moves_loop:  // When in check, search starts here
 
         Depth r = reduction(improving, depth, moveCount, delta);
 
+        // Increase reduction for ttPv nodes (*Scaler)
+        // Smaller or even negative value is better for short time controls
+        // Bigger value is better for long time controls
+        if (ss->ttPv)
+            r += 1024;
+
         // Step 14. Pruning at shallow depth.
         // Depth conditions are important for mate finding.
         if (!rootNode && pos.non_pawn_material(us) && !is_loss(bestValue))
@@ -1141,7 +1147,7 @@ moves_loop:  // When in check, search starts here
 
         // Decrease reduction for PvNodes (*Scaler)
         if (ss->ttPv)
-            r -= 1037 + (ttData.value > alpha) * 965 + (ttData.depth >= depth) * 960;
+            r -= 2061 + (ttData.value > alpha) * 965 + (ttData.depth >= depth) * 960;
 
         if (PvNode)
             r -= 1018;


### PR DESCRIPTION
Continuation of work done by @FauziAkram and @Viren6 
They had a series of patches that decrease pruning for ttPv nodes - and it passed as a gainer at lower time controls while revert passed as a gainer at higher time controls.
So it's a logical continuation of this work that increases pruning for ttPv nodes in hopes of scaling to longer TCs.
Fixed games STC:
https://tests.stockfishchess.org/tests/view/679ee3910774dfd78deb0efd
Elo: -4.98 ± 2.1 (95%) LOS: 0.0%
Total: 28584 W: 7229 L: 7639 D: 13716
Ptnml(0-2): 143, 3579, 7219, 3247, 104
nElo: -9.54 ± 4.0 (95%) PairsRatio: 0.90 
Passed VVLTC with STC bounds:
https://tests.stockfishchess.org/tests/view/679d21f70774dfd78deaf553
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 323282 W: 83729 L: 83105 D: 156448
Ptnml(0-2): 37, 29842, 101269, 30446, 47 
Passed VVLTC with LTC bounds:
https://tests.stockfishchess.org/tests/view/679e7a970774dfd78deb0cd3
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 113712 W: 29485 L: 29051 D: 55176
Ptnml(0-2): 13, 10376, 35640, 10818, 9 
bench 2162181