### PR TITLE
Simplify depth increase condition further

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1107,7 +1107,7 @@ moves_loop:  // When in check, search starts here
                     extension = 1 + (value < singularBeta - doubleMargin)
                               + (value < singularBeta - tripleMargin);
 
-                    depth += (depth < 15);
+                    depth++;
                 }
 
                 // Multi-cut pruning


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 51232 W: 13560 L: 13351 D: 24321
Ptnml(0-2): 183, 6075, 12920, 6226, 212
https://tests.stockfishchess.org/tests/view/679d7b2b0774dfd78deb043f

Passed Non-regression LTC (v. #5827):
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 172398 W: 44108 L: 44042 D: 84248
Ptnml(0-2): 122, 19207, 47489, 19245, 136
https://tests.stockfishchess.org/tests/view/679d7fb10774dfd78deb05d2

Passed Non-regression VLTC (v. #5827):
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 388540 W: 99314 L: 99464 D: 189762
Ptnml(0-2): 89, 40454, 113350, 40272, 105
https://tests.stockfishchess.org/tests/view/679da3be0774dfd78deb0ad4

bench 2688175