### PR TITLE
reduce full depth search twice

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1249,7 +1249,8 @@ moves_loop:  // When in check, search starts here
 
             // Note that if expected reduction is high, we reduce search depth here
             value =
-              -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, newDepth - (r > 3444), !cutNode);
+              -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha,
+                            newDepth - (r > 3444) - (r > 5588 && newDepth > 2), !cutNode);
         }
 
         // For PV nodes only, do a full PV search on the first move or after a fail high,


### PR DESCRIPTION
Passed STC:
https://tests.stockfishchess.org/tests/view/679f429e0774dfd78deb10a5
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 71584 W: 18905 L: 18529 D: 34150
Ptnml(0-2): 302, 8372, 18081, 8722, 315

Passed LTC:
https://tests.stockfishchess.org/tests/view/679f72a00774dfd78deb1102
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 353952 W: 91007 L: 90024 D: 172921
Ptnml(0-2): 375, 39163, 96921, 40138, 379

Bench: 3037667