### PR TITLE
simplify bonusScale formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1399,10 +1399,10 @@ moves_loop:  // When in check, search starts here
     // Bonus for prior countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
     {
-        int bonusScale = (118 * (depth > 5) + 37 * !allNode + 169 * ((ss - 1)->moveCount > 8)
-                          + 128 * (!ss->inCheck && bestValue <= ss->staticEval - 102)
-                          + 115 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 82)
-                          + 80 * ((ss - 1)->isTTMove) + std::min(-(ss - 1)->statScore / 106, 318));
+        int bonusScale = (125 * (depth > 5) + 176 * ((ss - 1)->moveCount > 8)
+                          + 135 * (!ss->inCheck && bestValue <= ss->staticEval - 102)
+                          + 122 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 82)
+                          + 87 * ((ss - 1)->isTTMove) + std::min(-(ss - 1)->statScore / 106, 318));
 
         bonusScale = std::max(bonusScale, 0);
 


### PR DESCRIPTION
Passed STC:
https://tests.stockfishchess.org/tests/view/679ea7bc0774dfd78deb0d68
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 47680 W: 12575 L: 12364 D: 22741
Ptnml(0-2): 179, 5589, 12139, 5708, 225

Passed LTC:
https://tests.stockfishchess.org/tests/view/679eb7760774dfd78deb0dbb
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 314220 W: 80110 L: 80189 D: 153921
Ptnml(0-2): 265, 35121, 86420, 35036, 268

Bench: 3344367