### PR TITLE
Immediately return instead of setting bestValue

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1551,7 +1551,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
             // ttValue can be used as a better position evaluation
             if (is_valid(ttData.value) && !is_decisive(ttData.value)
                 && (ttData.bound & (ttData.value > bestValue ? BOUND_LOWER : BOUND_UPPER)))
-                bestValue = ttData.value;
+                return ttData.value;
         }
         else
         {


### PR DESCRIPTION
Immediately return instead of setting bestValue, introducing a more aggressive use of the transposition table for early cutoffs.

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 12800 W: 3549 L: 3261 D: 5990
Ptnml(0-2): 48, 1398, 3241, 1644, 69
https://tests.stockfishchess.org/tests/view/679fa9f30774dfd78deb119b

Passed LTC:
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 59106 W: 15483 L: 15112 D: 28511
Ptnml(0-2): 58, 6451, 16169, 6812, 63
https://tests.stockfishchess.org/tests/view/679fabd70774dfd78deb11a5

bench: 2484034