### PR TITLE
Simplify cutoffCnt further

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1348,7 +1348,7 @@ moves_loop:  // When in check, search starts here
 
                 if (value >= beta)
                 {
-                    ss->cutoffCnt += (extension < 2);
+                    ss->cutoffCnt++;
                     assert(value >= beta);  // Fail high
                     break;
                 }


### PR DESCRIPTION
Based off [Simplify cutoffCnt](https://github.com/official-stockfish/Stockfish/commit/69be04d38e10003853e78e4aa2b32aa252a82850) commit

Original [commit](https://github.com/kennethlee33/Stockfish/commit/a77a895c3b7460f86b11a3ddfe3528f5be1276b9) adding extension condition seems to not be improving strength anymore

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 54176 W: 14331 L: 14125 D: 25720
Ptnml(0-2): 261, 6340, 13676, 6554, 257
https://tests.stockfishchess.org/tests/view/679edb7c0774dfd78deb0eed

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 267198 W: 68148 L: 68179 D: 130871
Ptnml(0-2): 232, 30051, 73055, 30038, 223
https://tests.stockfishchess.org/tests/view/679ef2c70774dfd78deb0f43

Bench: 3161942