### PR TITLE
Do less aggressive pruning for higher movecounts

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -999,6 +999,8 @@ moves_loop:  // When in check, search starts here
 
         Depth r = reduction(improving, depth, moveCount, delta);
 
+        r -= 32 * moveCount;
+
         // Increase reduction for ttPv nodes (*Scaler)
         // Smaller or even negative value is better for short time controls
         // Bigger value is better for long time controls
@@ -1169,7 +1171,7 @@ moves_loop:  // When in check, search starts here
 
         // These reduction adjustments have no proven non-linear scaling
 
-        r += 307 - moveCount * 64;
+        r += 307 - moveCount * 32;
 
         r -= std::abs(correctionValue) / 34112;
 


### PR DESCRIPTION
Move part of heuristic that makes reduction less before pruning stage.
Passed STC:
https://tests.stockfishchess.org/tests/view/679fdf1b0774dfd78deb13b3
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 47136 W: 12484 L: 12146 D: 22506
Ptnml(0-2): 211, 5472, 11866, 5806, 213 
Passed LTC:
https://tests.stockfishchess.org/tests/view/679fe6790774dfd78deb1753
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 100536 W: 25837 L: 25383 D: 49316
Ptnml(0-2): 103, 10990, 27622, 11456, 97 
bench 3478757