### PR TITLE
Clean up search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -658,8 +658,7 @@ Value Search::Worker::search(
     Value bestValue, value, eval, maxValue, probCutBeta;
     bool  givesCheck, improving, priorCapture, opponentWorsening;
     bool  capture, ttCapture;
-    int   priorReduction = (ss - 1)->reduction;
-    (ss - 1)->reduction  = 0;
+    int   priorReduction;
     Piece movedPiece;
 
     ValueList<Move, 32> capturesSearched;
@@ -704,11 +703,13 @@ Value Search::Worker::search(
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
-    bestMove            = Move::none();
+    Square prevSq  = ((ss - 1)->currentMove).is_ok() ? ((ss - 1)->currentMove).to_sq() : SQ_NONE;
+    bestMove       = Move::none();
+    priorReduction = (ss - 1)->reduction;
+    (ss - 1)->reduction = 0;
+    ss->statScore       = 0;
+    ss->isPvNode        = PvNode;
     (ss + 2)->cutoffCnt = 0;
-    Square prevSq = ((ss - 1)->currentMove).is_ok() ? ((ss - 1)->currentMove).to_sq() : SQ_NONE;
-    ss->statScore = 0;
-    ss->isPvNode  = PvNode;
 
     // Step 4. Transposition table lookup
     excludedMove                   = ss->excludedMove;
@@ -927,8 +928,8 @@ Value Search::Worker::search(
 
     // Step 10. Internal iterative reductions
     // For PV nodes without a ttMove as well as for deep enough cutNodes, we decrease depth.
-    // (* Scaler) Especially if they make IIR more aggressive.
-    if (((PvNode || cutNode) && depth >= 7 - 3 * PvNode) && !ttData.move)
+    // (*Scaler) Especially if they make IIR less aggressive.
+    if (depth >= 7 - 3 * PvNode && !allNode && !ttData.move)
         depth--;
 
     // Step 11. ProbCut
@@ -1153,7 +1154,7 @@ moves_loop:  // When in check, search starts here
             // and if the result is lower than ttValue minus a margin, then we will
             // extend the ttMove. Recursive singular search is avoided.
 
-            // (* Scaler) Generally, higher singularBeta (i.e closer to ttValue)
+            // (*Scaler) Generally, higher singularBeta (i.e closer to ttValue)
             // and lower extension margins scale well.
 
             if (!rootNode && move == ttData.move && !excludedMove
@@ -1233,8 +1234,8 @@ moves_loop:  // When in check, search starts here
 
         // These reduction adjustments have no proven non-linear scaling
 
-        r += 306 - moveCount * 34;
-
+        r += 306;  // Base reduction offset to compensate for other tweaks
+        r -= moveCount * 34;
         r -= std::abs(correctionValue) / 29696;
 
         if (PvNode && std::abs(bestValue) <= 2000)
@@ -1280,17 +1281,13 @@ moves_loop:  // When in check, search starts here
             // beyond the first move depth.
             // To prevent problems when the max value is less than the min value,
             // std::clamp has been replaced by a more robust implementation.
-
-
             Depth d = std::max(1, std::min(newDepth - r / 1024,
                                            newDepth + !allNode + (PvNode && !bestMove)))
                     + (!cutNode && (ss - 1)->isPvNode && moveCount < 8);
 
             ss->reduction = newDepth - d;
-
             value         = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);
             ss->reduction = 0;
-
 
             // Do a full-depth search when reduced LMR search fails high
             if (value > alpha && d < newDepth)
@@ -1487,12 +1484,14 @@ moves_loop:  // When in check, search starts here
     // Bonus for prior quiet countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
     {
-        int bonusScale =
-          (std::min(78 * depth - 312, 194) + 34 * !allNode + 164 * ((ss - 1)->moveCount > 8)
-           + 141 * (!ss->inCheck && bestValue <= ss->staticEval - 100)
-           + 121 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 75)
-           + 86 * ((ss - 1)->isTTMove) + 86 * (ss->cutoffCnt <= 3)
-           + std::min(-(ss - 1)->statScore / 112, 303));
+        int bonusScale = std::min(-(ss - 1)->statScore / 112, 303);
+        bonusScale += std::min(78 * depth - 312, 194);
+        bonusScale += 34 * !allNode;
+        bonusScale += 164 * ((ss - 1)->moveCount > 8);
+        bonusScale += 86 * (ss - 1)->isTTMove;
+        bonusScale += 86 * (ss->cutoffCnt <= 3);
+        bonusScale += 141 * (!ss->inCheck && bestValue <= ss->staticEval - 100);
+        bonusScale += 121 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 75);
 
         bonusScale = std::max(bonusScale, 0);
 
@@ -1903,14 +1902,14 @@ void update_all_stats(const Position&      pos,
                       ValueList<Move, 32>& quietsSearched,
                       ValueList<Move, 32>& capturesSearched,
                       Depth                depth,
-                      Move                 TTMove,
+                      Move                 ttMove,
                       int                  moveCount) {
 
     CapturePieceToHistory& captureHistory = workerThread.captureHistory;
     Piece                  moved_piece    = pos.moved_piece(bestMove);
     PieceType              captured;
 
-    int bonus = std::min(141 * depth - 89, 1613) + 311 * (bestMove == TTMove);
+    int bonus = std::min(141 * depth - 89, 1613) + 311 * (bestMove == ttMove);
     int malus = std::min(695 * depth - 215, 2808) - 31 * (moveCount - 1);
 
     if (!pos.capture_stage(bestMove))


### PR DESCRIPTION
* Correct IIR scaling comments
* Replace `(PvNode || cutNode)` with `!allNode`
* Consistent formatting for scaler tags
* Add comments to some recently-introduced LMR terms
* Add comments on PCM bonus tweaks

Passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 389472 W: 102457 L: 102622 D: 184393
Ptnml(0-2): 1676, 41887, 107798, 41676, 1699
https://tests.stockfishchess.org/tests/view/67a0ea670774dfd78deb23cd

bench 3088494