### PR TITLE
Increment cutoffCnt less often after fail high

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1348,7 +1348,8 @@ moves_loop:  // When in check, search starts here
 
                 if (value >= beta)
                 {
-                    ss->cutoffCnt += (extension < 2);
+                    // (* Scaler) Especially if they make cutoffCnt increment more often.
+                    ss->cutoffCnt += (extension < 2) || PvNode;
                     assert(value >= beta);  // Fail high
                     break;
                 }


### PR DESCRIPTION
Tested vs #5851. 

Only increment when extension is less than 2 or it's a PvNode.

Failed STC:
LLR: -2.97 (-2.94,2.94) <0.00,2.00>
Total: 360064 W: 94546 L: 94271 D: 171247
Ptnml(0-2): 1835, 42826, 90314, 43343, 1714
https://tests.stockfishchess.org/tests/view/679f79cc0774dfd78deb1112

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 443076 W: 113942 L: 113081 D: 216053
Ptnml(0-2): 480, 49076, 121579, 49909, 494
https://tests.stockfishchess.org/tests/view/679fa21b0774dfd78deb1178

Passed VLTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 187184 W: 48098 L: 47495 D: 91591
Ptnml(0-2): 59, 19036, 54792, 19653, 52
https://tests.stockfishchess.org/tests/view/679fb6000774dfd78deb11e8

bench 3396761