### PR TITLE
Reduce less for positions without tt move.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1245,7 +1245,7 @@ moves_loop:  // When in check, search starts here
         {
             // Increase reduction if ttMove is not present
             if (!ttData.move)
-                r += 2111;
+                r += 1111;
 
             // Note that if expected reduction is high, we reduce search depth here
             value =


### PR DESCRIPTION
Continuation of work on scaling.
In line with previous scaling patches this one massively reduces reduction for moves that don't go thru lmr for position without a tt move.
Passed VVLTC with STC bounds:
https://tests.stockfishchess.org/tests/view/679fd2450774dfd78deb12b2
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 74718 W: 19354 L: 19042 D: 36322
Ptnml(0-2): 5, 6724, 23595, 7024, 11 
Passed VVLTC with LTC bounds:
https://tests.stockfishchess.org/tests/view/67a009930774dfd78deb2346
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 82638 W: 21587 L: 21212 D: 39839
Ptnml(0-2): 15, 7476, 25953, 7869, 6 
bench 3695583