### PR TITLE
Reduce more when stat eval decreases by a lot

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -808,6 +808,8 @@ Value Search::Worker::search(
 
     if (priorReduction >= 3 && !opponentWorsening)
         depth++;
+    if (priorReduction >= 1 && !(ss - 1)->inCheck && ss->staticEval + (ss - 1)->staticEval > 200)
+        depth--;
 
     // Step 7. Razoring
     // If eval is really low, skip search entirely and return the qsearch value.


### PR DESCRIPTION
Retroactive LMR depth decrease when the last move decreases eval by a lot

Passed STC
LLR: 2.98 (-2.94,2.94) <0.00,2.00>
Total: 43008 W: 11529 L: 11190 D: 20289
Ptnml(0-2): 195, 5019, 10760, 5312, 218 
https://tests.stockfishchess.org/tests/view/67a16f79612069de394afb56

Passed LTC
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 44694 W: 11627 L: 11289 D: 21778
Ptnml(0-2): 36, 4814, 12315, 5140, 42
https://tests.stockfishchess.org/tests/view/67a19726612069de394afb91

Bench: 2939265