### PR TITLE
Fix Merge Regression in Movecount based Reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1165,7 +1165,7 @@ moves_loop:  // When in check, search starts here
 
         // These reduction adjustments have no proven non-linear scaling
 
-        r += 316 - moveCount * 63;
+        r += 316 - moveCount * 32;
 
         r -= std::abs(correctionValue) / 31568;
 


### PR DESCRIPTION
Fixes a wrongly combined merge conflict from the previous merge wave.

Passed STC:
https://tests.stockfishchess.org/tests/view/67a288aaeb183d11c65945f1
LLR: 2.99 (-2.94,2.94) <0.00,2.00>
Total: 51424 W: 13588 L: 13237 D: 24599
Ptnml(0-2): 223, 6039, 12860, 6344, 246 

Passed LTC:
https://tests.stockfishchess.org/tests/view/67a28c0aeb183d11c6594609
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 54144 W: 13900 L: 13543 D: 26701
Ptnml(0-2): 42, 5881, 14870, 6236, 43 

closes https://github.com/official-stockfish/Stockfish/pull/5863

Bench: 2345723