### PR TITLE
Increase PCM bonus when cutOffCnt is low

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1399,7 +1399,8 @@ moves_loop:  // When in check, search starts here
         int bonusScale = (118 * (depth > 5) + 36 * !allNode + 161 * ((ss - 1)->moveCount > 8)
                           + 133 * (!ss->inCheck && bestValue <= ss->staticEval - 107)
                           + 120 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 84)
-                          + 81 * ((ss - 1)->isTTMove) + std::min(-(ss - 1)->statScore / 108, 320));
+                          + 81 * ((ss - 1)->isTTMove) + 100 * (ss->cutoffCnt <= 3)
+                          + std::min(-(ss - 1)->statScore / 108, 320));
 
         bonusScale = std::max(bonusScale, 0);
 


### PR DESCRIPTION
Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 36832 W: 9763 L: 9438 D: 17631
Ptnml(0-2): 159, 4267, 9254, 4562, 174
https://tests.stockfishchess.org/tests/view/67a29dbafedef70e42ac329a

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 19728 W: 5124 L: 4839 D: 9765
Ptnml(0-2): 18, 2029, 5485, 2314, 18
https://tests.stockfishchess.org/tests/view/67a2a1abfedef70e42ac32b7

bench 3032633