### PR TITLE
rebased on master

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1490,7 +1490,6 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
     Value bestValue, value, futilityBase;
     bool  pvHit, givesCheck, capture;
     int   moveCount;
-    Color us = pos.side_to_move();
 
     // Step 1. Initialize node
     if (PvNode)
@@ -1603,7 +1602,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
         moveCount++;
 
         // Step 6. Pruning
-        if (!is_loss(bestValue) && pos.non_pawn_material(us))
+        if (!is_loss(bestValue))
         {
             // Futility pruning and moveCount pruning
             if (!givesCheck && move.to_sq() != prevSq && !is_loss(futilityBase)


### PR DESCRIPTION
Remove non-pawn material check in qsearch pruning

Passed simplification STC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 47712 W: 12621 L: 12409 D: 22682
Ptnml(0-2): 224, 5349, 12480, 5597, 206 
https://tests.stockfishchess.org/tests/view/67a1b4fb612069de394afc37

Passed rebased simplification LTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 188274 W: 47727 L: 47677 D: 92870
Ptnml(0-2): 171, 20429, 52867, 20519, 151 
https://tests.stockfishchess.org/tests/view/67a2a761fedef70e42ac3300

bench 2654242