### PR TITLE
Decrease lmr depth if static eval decreases a lot

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -808,6 +808,10 @@ Value Search::Worker::search(
 
     if (priorReduction >= 3 && !opponentWorsening)
         depth++;
+    if (priorReduction >= 1 && depth >= 2 && !(ss - 1)->inCheck && ss->staticEval + (ss - 1)->staticEval > 200 && pos.non_pawn_material(~us))
+    {
+        depth--;
+    }
 
     // Step 7. Razoring
     // If eval is really low, skip search entirely and return the qsearch value.


### PR DESCRIPTION
Decrease lmr depth if static eval decreases a lot

Passed STC
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 60064 W: 15797 L: 15439 D: 28828
Ptnml(0-2): 236, 7080, 15106, 7310, 300 
https://tests.stockfishchess.org/tests/view/67a2af9cfedef70e42ac3325

Passed LTC
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 76794 W: 19740 L: 19337 D: 37717
Ptnml(0-2): 61, 8327, 21236, 8694, 79 
https://tests.stockfishchess.org/tests/view/67a2c904fedef70e42ac374d

Passed Non-Regression VVLTC scaling check
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 29046 W: 7581 L: 7389 D: 14076
Ptnml(0-2): 2, 2557, 9213, 2749, 2 
https://tests.stockfishchess.org/tests/view/67a54b591c4a3ea87241cb83

Bench: 2712545