### PR TITLE
Use std::is_arithmetic_v

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -71,7 +71,7 @@ inline int non_pawn_index(const Position& pos) {
 template<typename T, int D>
 class StatsEntry {
 
-    static_assert(std::is_arithmetic<T>::value, "Not an arithmetic type");
+    static_assert(std::is_arithmetic_v<T>, "Not an arithmetic type");
     static_assert(D <= std::numeric_limits<T>::max(), "D overflows T");
 
     T entry;

--- a/src/misc.h
+++ b/src/misc.h
@@ -212,7 +212,6 @@ class MultiArray {
 
     template<typename U>
     void fill(const U& v) {
-        static_assert(std::is_assignable_v<T, U>, "Cannot assign fill value to entry type");
         for (auto& ele : data_)
         {
             if constexpr (sizeof...(Sizes) == 0)

--- a/src/misc.h
+++ b/src/misc.h
@@ -212,6 +212,7 @@ class MultiArray {
 
     template<typename U>
     void fill(const U& v) {
+        static_assert(std::is_assignable_v<T&, U>, "Cannot assign fill value to entry type");
         for (auto& ele : data_)
         {
             if constexpr (sizeof...(Sizes) == 0)


### PR DESCRIPTION
Use std::is_arithmetic_v as it is the more modern and concise way to check for arithmetic types.
While at it, r̶e̶m̶o̶v̶i̶n̶g̶ a̶ n̶o̶t̶ n̶e̶e̶d̶e̶d̶ s̶t̶a̶t̶i̶c̶ modified a static assert based on Shawn's suggestion (Thnx).

Non-Functional
bench: 3197798