### PR TITLE
Simplify accumulator updates

### DIFF
--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -819,7 +819,7 @@ class FeatureTransformer {
             return;
         StateInfo* oldest = try_find_computed_accumulator<Perspective>(pos);
 
-        if ((oldest->*accPtr).computed[Perspective] && oldest != pos.state())
+        if ((oldest->*accPtr).computed[Perspective])
             // Start from the oldest computed accumulator, update all the
             // accumulators up to the current position.
             update_accumulator_incremental<Perspective>(pos, oldest);


### PR DESCRIPTION
A very deep bench (`bench 64 1 22`) reveals that, if `(oldest->*accPtr).computed[Perspective]` is true, then `oldest != pos.state()` is always true.
This can be demonstrated too: we verify right above that the current accumulator is not computed. If `oldest` is computed instead, it can't be the same as current accumulator

Non functional change