### PR TITLE
Do more reductions for cut nodes without a tt move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1171,7 +1171,7 @@ moves_loop:  // When in check, search starts here
 
         // Increase reduction for cut nodes
         if (cutNode)
-            r += 2608 - (ttData.depth >= depth && ss->ttPv) * 1159;
+            r += 2608 - (ttData.depth >= depth && ss->ttPv) * 1159 + 1024 * !ttData.move;
 
         // Increase reduction if ttMove is a capture but the current move is not a capture
         if (ttCapture && !capture)


### PR DESCRIPTION
Logic is somewhat similar to IIR but in LMR.
Usually things like reducing more in IIR scale badly but this patch does this in LMR where reducing more for cutNodes is in general good, so I believe there is no non-linear scaling.
Passed STC:
https://tests.stockfishchess.org/tests/view/67abc9aaa04df5eb8dbeb452
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 42304 W: 11223 L: 10892 D: 20189
Ptnml(0-2): 184, 4904, 10669, 5187, 208 
Passed LTC:
https://tests.stockfishchess.org/tests/view/67abcd7ba04df5eb8dbeb96c
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 32334 W: 8386 L: 8074 D: 15874
Ptnml(0-2): 26, 3446, 8916, 3748, 31 
bench 2050042