### PR TITLE
tweak the cutnode depth condition for TT cutoffs

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -672,7 +672,7 @@ Value Search::Worker::search(
     if (!PvNode && !excludedMove && ttData.depth > depth - (ttData.value <= beta)
         && is_valid(ttData.value)  // Can happen when !ttHit or when access race in probe()
         && (ttData.bound & (ttData.value >= beta ? BOUND_LOWER : BOUND_UPPER))
-        && (cutNode == (ttData.value >= beta) || depth > 9))
+        && (cutNode == (ttData.value >= beta) || (depth > 9 || (rootDepth > 10 && depth > 5))))
     {
         // If ttMove is quiet, update move sorting heuristics on TT hit
         if (ttData.move && ttData.value >= beta)
@@ -819,7 +819,7 @@ Value Search::Worker::search(
     // The depth condition is important for mate finding.
     if (!ss->ttPv && depth < 14
         && eval - futility_margin(depth, cutNode && !ss->ttHit, improving, opponentWorsening)
-               - (ss - 1)->statScore / 326 + 37 - std::abs(correctionValue) / 132821
+                - (ss - 1)->statScore / 326 + 37 - std::abs(correctionValue) / 132821
              >= beta
         && eval >= beta && (!ttData.move || ttCapture) && !is_loss(beta) && !is_win(eval))
         return beta + (eval - beta) / 3;


### PR DESCRIPTION
Passed STC:
https://tests.stockfishchess.org/tests/view/67ab396ab5c93ee812d851f3
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 83648 W: 21964 L: 21571 D: 40113
Ptnml(0-2): 339, 9779, 21217, 10128, 361

Passed LTC:
https://tests.stockfishchess.org/tests/view/67ab9647133d55b1d3bc171e
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 68160 W: 17551 L: 17166 D: 33443
Ptnml(0-2): 62, 7353, 18870, 7728, 67

Bench: 2468962