### PR TITLE
Simplify ttcut depth condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -672,7 +672,7 @@ Value Search::Worker::search(
     if (!PvNode && !excludedMove && ttData.depth > depth - (ttData.value <= beta)
         && is_valid(ttData.value)  // Can happen when !ttHit or when access race in probe()
         && (ttData.bound & (ttData.value >= beta ? BOUND_LOWER : BOUND_UPPER))
-        && (cutNode == (ttData.value >= beta) || depth > 9))
+        && (cutNode == (ttData.value >= beta) || depth > 5))
     {
         // If ttMove is quiet, update move sorting heuristics on TT hit
         if (ttData.move && ttData.value >= beta)


### PR DESCRIPTION
Simplify ttcut depth condition in a recent tweak of Nonlinear

Passed simplification STC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 235328 W: 61646 L: 61644 D: 112038
Ptnml(0-2): 1039, 27947, 59676, 27977, 1025 
https://tests.stockfishchess.org/tests/view/67abc7fba04df5eb8dbeb442

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 63744 W: 16306 L: 16128 D: 31310
Ptnml(0-2): 58, 6918, 17748, 7084, 64 
https://tests.stockfishchess.org/tests/view/67abd776a04df5eb8dbeb9c1

Bench 2779055