### PR TITLE
futilityValue formula tweak

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1053,7 +1053,10 @@ moves_loop:  // When in check, search starts here
 
                 lmrDepth += history / 3576;
 
-                Value futilityValue = ss->staticEval + (bestMove ? 49 : 135) + 150 * lmrDepth;
+                Value futilityValue = ss->staticEval + (bestMove ? 49 : 143) + 116 * lmrDepth;
+
+                if (bestValue < ss->staticEval - 150 && lmrDepth < 7)
+                   futilityValue += 108;
 
                 // Futility pruning: parent node
                 if (!ss->inCheck && lmrDepth < 12 && futilityValue <= alpha)


### PR DESCRIPTION
futilityValue formula tweak

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 29600 W: 7979 L: 7662 D: 13959
Ptnml(0-2): 138, 3446, 7324, 3745, 147
https://tests.stockfishchess.org/tests/view/67ac7dff52879dfd14d7e7da

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 49662 W: 12850 L: 12502 D: 24310
Ptnml(0-2): 41, 5354, 13689, 5710, 37
https://tests.stockfishchess.org/tests/view/67acc1b252879dfd14d7e81d

bench: 2558575