### PR TITLE
Increase the limit of max debug slots

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -281,7 +281,7 @@ std::string compiler_info() {
 
 
 // Debug functions used mainly to collect run-time statistics
-constexpr int MaxDebugSlots = 32;
+constexpr int MaxDebugSlots = 128;
 
 namespace {
 


### PR DESCRIPTION
Increase the limit of max debug slots
It can be useful for future studies similar to this:
https://github.com/official-stockfish/Stockfish/compare/master...FauziAkram:Stockfish:dddggg3
https://docs.google.com/spreadsheets/d/1IL4fkSq8uIdVDjyz52TQfDRTZsnWHlObX8BzAGrZCy0/

In this case, I used 112 debug slots without any problem. However, I had to increase the limit manually.

Non-Functional
bench: 3197798