### PR TITLE
Use std::is_arithmetic_v

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -71,7 +71,7 @@ inline int non_pawn_index(const Position& pos) {
 template<typename T, int D>
 class StatsEntry {
 
-    static_assert(std::is_arithmetic<T>::value, "Not an arithmetic type");
+    static_assert(std::is_arithmetic_v<T>, "Not an arithmetic type");
     static_assert(D <= std::numeric_limits<T>::max(), "D overflows T");
 
     T entry;

--- a/src/misc.h
+++ b/src/misc.h
@@ -155,6 +155,10 @@ struct MultiArrayHelper<T, Size> {
     using ChildType = T;
 };
 
+template<typename To, typename From>
+constexpr bool is_strictly_assignable_v =
+  std::is_assignable_v<To&, From> && (std::is_same_v<To, From> || !std::is_convertible_v<From, To>);
+
 }
 
 // MultiArray is a generic N-dimensional array.
@@ -212,7 +216,8 @@ class MultiArray {
 
     template<typename U>
     void fill(const U& v) {
-        static_assert(std::is_assignable_v<T, U>, "Cannot assign fill value to entry type");
+        static_assert(Detail::is_strictly_assignable_v<T, U>,
+                      "Cannot assign fill value to entry type");
         for (auto& ele : data_)
         {
             if constexpr (sizeof...(Sizes) == 0)


### PR DESCRIPTION
Use std::is_arithmetic_v as it is the more modern and concise way to check for arithmetic types.
While at it, fixing a static assert in misc.h, thanks to Shawn and Disservin for helping.

bench: 2581469
Non-Functional