### PR TITLE
Guard futility margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1061,7 +1061,8 @@ moves_loop:  // When in check, search starts here
                     futilityValue += 108;
 
                 // Futility pruning: parent node
-                if (!ss->inCheck && lmrDepth < 12 && futilityValue <= alpha)
+                if (!ss->inCheck && lmrDepth < 12 && futilityValue <= alpha
+                    && ss->staticEval <= alpha)
                 {
                     if (bestValue <= futilityValue && !is_decisive(bestValue)
                         && !is_win(futilityValue))


### PR DESCRIPTION
Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 22560 W: 6022 L: 5725 D: 10813
Ptnml(0-2): 87, 2524, 5762, 2819, 88
https://tests.stockfishchess.org/tests/view/67ac202aa04df5eb8dbebf22

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 66138 W: 16953 L: 16572 D: 32613
Ptnml(0-2): 62, 7103, 18360, 7480, 64
https://tests.stockfishchess.org/tests/view/67ad47d852879dfd14d7e899

bench 2567812