### PR TITLE
use same term for small and large net in eval

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -76,7 +76,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     // Blend optimism and eval with nnue complexity
     int nnueComplexity = std::abs(psqt - positional);
     optimism += optimism * nnueComplexity / 468;
-    nnue -= nnue * nnueComplexity / (smallNet ? 20233 : 17879);
+    nnue -= nnue * nnueComplexity / 18000;
 
     int material = 535 * pos.count<PAWN>() + pos.non_pawn_material();
     int v        = (nnue * (77777 + material) + optimism * (7777 + material)) / 77777;


### PR DESCRIPTION
Use same term for small and large net for nnue complexity adjustment

Passed simplification STC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 386496 W: 100682 L: 100850 D: 184964
Ptnml(0-2): 1686, 46399, 97218, 46287, 1658 
https://tests.stockfishchess.org/tests/view/67a9cc6d851bb0f25324449e

Passed rebased simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 160884 W: 41090 L: 41012 D: 78782
Ptnml(0-2): 133, 17883, 44321, 17983, 122 
https://tests.stockfishchess.org/tests/view/67aef2e91a4c73ae1f930e85

bench 2434649