### PR TITLE
Add scaling note to futility pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1061,6 +1061,8 @@ moves_loop:  // When in check, search starts here
                     futilityValue += 108;
 
                 // Futility pruning: parent node
+                // (*Scaler): Generally, more frequent futility pruning
+                // scales well with respect to time and threads
                 if (!ss->inCheck && lmrDepth < 12 && futilityValue <= alpha)
                 {
                     if (bestValue <= futilityValue && !is_decisive(bestValue)


### PR DESCRIPTION
Note that both patches below effectively reduces the frequency of futility pruning.

### Patch 1
Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 51680 W: 13599 L: 13253 D: 24828
Ptnml(0-2): 217, 6056, 12959, 6380, 228 
https://tests.stockfishchess.org/tests/view/67ac218fa04df5eb8dbebf26

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 51798 W: 13338 L: 12986 D: 25474
Ptnml(0-2): 42, 5584, 14310, 5906, 57
https://tests.stockfishchess.org/tests/view/67acf04152879dfd14d7e846

Regression at STC SMP:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 231552 W: 60226 L: 59642 D: 111684
Ptnml(0-2): 565, 25994, 62031, 26664, 522

### Patch 2
Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 22560 W: 6022 L: 5725 D: 10813
Ptnml(0-2): 87, 2524, 5762, 2819, 88
https://tests.stockfishchess.org/tests/view/67ac202aa04df5eb8dbebf22

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 66138 W: 16953 L: 16572 D: 32613
Ptnml(0-2): 62, 7103, 18360, 7480, 64
https://tests.stockfishchess.org/tests/view/67ad47d852879dfd14d7e899

Regression at VVLTC SMP:
LLR: -2.94 (-2.94,2.94) <-1.75,0.25>
Total: 29138 W: 7408 L: 7655 D: 14075
Ptnml(0-2): 0, 2816, 9189, 2559, 5
https://tests.stockfishchess.org/tests/view/67b159ce6c6b9e172ad1598f

no functional change