### PR TITLE
Remove duplicated info string printing

### DIFF
--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -268,9 +268,8 @@ void Network<Arch, Transformer>::verify(std::string                             
     if (f)
     {
         size_t size = sizeof(*featureTransformer) + sizeof(Arch) * LayerStacks;
-        f("info string NNUE evaluation using " + evalfilePath + " ("
-          + std::to_string(size / (1024 * 1024)) + "MiB, ("
-          + std::to_string(featureTransformer->InputDimensions) + ", "
+        f("NNUE evaluation using " + evalfilePath + " (" + std::to_string(size / (1024 * 1024))
+          + "MiB, (" + std::to_string(featureTransformer->InputDimensions) + ", "
           + std::to_string(network[0].TransformedFeatureDimensions) + ", "
           + std::to_string(network[0].FC_0_OUTPUTS) + ", " + std::to_string(network[0].FC_1_OUTPUTS)
           + ", 1))");


### PR DESCRIPTION
```
info string info string NNUE evaluation using nn-1c0000000000.nnue (133MiB, (22528, 3072, 15, 32, 1))
info string info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
```