### PR TITLE
Allow disabling of SyzygyExtendPv

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -125,6 +125,8 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("SyzygyProbeLimit", Option(7, 0, 7));
 
+    options.add("SyzygyExtendPv", Option(true));
+
     options.add(  //
       "EvalFile", Option(EvalFileDefaultNameBig, [this](const Option& o) {
           load_big_network(o);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1954,6 +1954,10 @@ void syzygy_extend_pv(const OptionsMap&         options,
     auto t_start      = std::chrono::steady_clock::now();
     int  moveOverhead = int(options["Move Overhead"]);
     bool rule50       = bool(options["Syzygy50MoveRule"]);
+    bool extend       = bool(options["SyzygyExtendPv"]);
+
+    if (!extend)
+      return;
 
     // Do not use more than moveOverhead / 2 time, if time management is active
     auto time_abort = [&t_start, &moveOverhead, &limits]() -> bool {


### PR DESCRIPTION
The PV extension can lead to time losses, as in this [tcec game](https://tcec-chess.com/#div=frdfl&game=83&season=27). 

As a quick fix, we allow disabling of the PV extensions.

Users on discord reported that this feature would be useful for running many fixed depth games in parallel, for example.

The following example shows default behaviour (PV extension) in first search, and new behaviour with option set to `false` in second search.

```
setoption name SyzygyPath value /disk1/syzygy/3-4-5-6/WDL:/disk2/syzygy/3-4-5-6/DTZ
position fen 8/8/8/5k2/8/1R6/R7/4K3 w - - 0 1
go depth 1
info string Available processors: 0-23
info string Using 1 thread
info string info string NNUE evaluation using nn-1c0000000000.nnue (133MiB, (22528, 3072, 15, 32, 1))
info string info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
info depth 1 seldepth 3 multipv 1 score cp 20000 nodes 38 nps 1225 hashfull 0 tbhits 33 time 31 pv b3b1 f5e4 b1b5 e4e3 a2a4 e3f3 b5g5 f3e3 g5g3
bestmove b3b1 ponder f5e4
setoption name SyzygyExtendPv value false
go depth 1
info string Available processors: 0-23
info string Using 1 thread
info string info string NNUE evaluation using nn-1c0000000000.nnue (133MiB, (22528, 3072, 15, 32, 1))
info string info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
info depth 1 seldepth 3 multipv 1 score cp 20000 nodes 35 nps 35000 hashfull 0 tbhits 33 time 1 pv b3b1
bestmove b3b1
```

No functional change.