### PR TITLE
Make Pv search shallower in some cases

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1237,6 +1237,8 @@ moves_loop:  // When in check, search starts here
                 int bonus = (value >= beta) * 2010;
                 update_continuation_histories(ss, movedPiece, move.to_sq(), bonus);
             }
+            else if (value > alpha && value < bestValue + 9)
+                newDepth--;
         }
 
         // Step 18. Full-depth search when LMR is skipped


### PR DESCRIPTION
Conditions are the same as they are for doShallowerSearch, just that they also apply for cases where LMR wasn't reducing anything - if result is bad enough reduce search depth of PV search by 1.
Passed STC:
https://tests.stockfishchess.org/tests/view/67b9d2aca49c651c2caac818
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 29216 W: 7731 L: 7424 D: 14061
Ptnml(0-2): 87, 3345, 7473, 3580, 123 
Passed LTC:
https://tests.stockfishchess.org/tests/view/67ba538c01f3463ae1d35e69
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 33168 W: 8529 L: 8219 D: 16420
Ptnml(0-2): 12, 3505, 9262, 3771, 34 
bench 1833437