### PR TITLE
Check maximum time every iteration

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -501,8 +501,8 @@ void Search::Worker::iterative_deepening() {
                 && !mainThread->ponder)
                 threads.stop = true;
 
-            // Stop the search if we have exceeded the totalTime
-            if (elapsedTime > totalTime)
+            // Stop the search if we have exceeded the totalTime or maximum
+            if (elapsedTime > std::min(totalTime, double(mainThread->tm.maximum())))
             {
                 // If we are allowed to ponder do not stop the search now but
                 // keep pondering until the GUI sends "ponderhit" or "stop".


### PR DESCRIPTION
This fixes a TCEC timeloss, where slow DTZ TB7 access, in combination with syzygy PV extension, led to a timeloss.

While the extension code correctly aborted after spending moveOverhead/2 time, the mainThread did not search sufficient nodes (512 in > 1s) to trigger the stop in check_time. At the same time, totalTime exceeded tm.maximum() due to the factors multiplying tm.optimum().

This corner case is fixed by checking also against the tm.maximum() at each iteration.

Even though this problem can't be triggered on fishtest, the patch was verified there.

passed STC:
https://tests.stockfishchess.org/tests/view/67b99e1be99f8640b318810d
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 136832 W: 35625 L: 35518 D: 65689
Ptnml(0-2): 499, 14963, 37431, 14978, 545

No functional change