### PR TITLE
Simplify bestvalue update formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1695,8 +1695,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
         return mated_in(ss->ply);  // Plies to mate from the root
     }
 
-    if (!is_decisive(bestValue) && bestValue >= beta)
-        bestValue = (3 * bestValue + beta) / 4;
+    if (!is_decisive(bestValue) && bestValue > beta)
+        bestValue = (bestValue + beta) / 2;
 
     // Save gathered info in transposition table. The static evaluation
     // is saved as it was before adjustment by correction history.


### PR DESCRIPTION
Simplify bestvalue update formula

Passed STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 124960 W: 32598 L: 32472 D: 59890
Ptnml(0-2): 480, 14852, 31694, 14970, 484
https://tests.stockfishchess.org/tests/view/67b348bae00eea114cdba37d

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 150306 W: 38220 L: 38132 D: 73954
Ptnml(0-2): 98, 16430, 42005, 16526, 94
https://tests.stockfishchess.org/tests/view/67b5e37918a66624a7a3f751

bench: 2332691