### PR TITLE
Replacing pext(b, m.mask) with m.index(b)

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -183,10 +183,7 @@ void init_magics(PieceType pt, Bitboard table[], Magic magics[][2]) {
             occupancy[size] = b;
 #endif
             reference[size] = sliding_attack(pt, s, b);
-
-            if (HasPext)
-                m.attacks[pext(b, m.mask)] = reference[size];
-
+            m.attacks[m.index(b)] = reference[size];
             size++;
             b = (b - m.mask) & m.mask;
         } while (b);


### PR DESCRIPTION
Replacing pext(b, m.mask) with m.index(b).

Passed non-reg:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 60096 W: 15512 L: 15329 D: 29255
Ptnml(0-2): 150, 6104, 17373, 6255, 166
https://tests.stockfishchess.org/tests/view/67bcd1aef6b602bd7222ea3d

Non-Functional
bench: 2146010