### PR TITLE
Using DWORD for _BitScanForward

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -303,16 +303,8 @@ inline Square lsb(Bitboard b) {
     #else  // MSVC, WIN32
     unsigned long idx;
 
-    if (b & 0xffffffff)
-    {
-        _BitScanForward(&idx, int32_t(b));
-        return Square(idx);
-    }
-    else
-    {
-        _BitScanForward(&idx, int32_t(b >> 32));
-        return Square(idx + 32);
-    }
+    _BitScanForward(&idx, DWORD(b));
+    return Square(idx + (b >> 32 ? 32 : 0));
     #endif
 #else  // Compiler is neither GCC nor MSVC compatible
     #error "Compiler not supported."


### PR DESCRIPTION
Using DWORD for _BitScanForward.

Passed non-reg:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 66432 W: 17324 L: 17144 D: 31964
Ptnml(0-2): 191, 6896, 18868, 7064, 197
https://tests.stockfishchess.org/tests/view/67bcd02e28436466447786e3


Non-Functional
bench: 2146010