### PR TITLE
Simplify NMP Conditions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -846,8 +846,8 @@ Value Search::Worker::search(
 
     // Step 9. Null move search with verification search
     if (cutNode && (ss - 1)->currentMove != Move::null() && eval >= beta
-        && ss->staticEval >= beta - 21 * depth + 455 - 60 * improving && !excludedMove
-        && pos.non_pawn_material(us) && ss->ply >= thisThread->nmpMinPly && !is_loss(beta))
+        && ss->staticEval >= beta - 21 * depth + 395 && !excludedMove && pos.non_pawn_material(us)
+        && ss->ply >= thisThread->nmpMinPly && !is_loss(beta))
     {
         assert(eval - beta >= 0);
 


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 142400 W: 36883 L: 36779 D: 68738
Ptnml(0-2): 467, 16804, 36571, 16874, 484
https://tests.stockfishchess.org/tests/view/67bd1898e4a8d7152b974ef1

Passed Non-regression LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 251868 W: 63905 L: 63920 D: 124043
Ptnml(0-2): 133, 27480, 70708, 27495, 118
https://tests.stockfishchess.org/tests/view/67bd1898e4a8d7152b974ef1

bench 2188400