### PR TITLE
Remove two unnecessary divisions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -699,13 +699,12 @@ Value Search::Worker::search(
             // Bonus for a quiet ttMove that fails high
             if (!ttCapture)
                 update_quiet_histories(pos, ss, *this, ttData.move,
-                                       std::min(117600 * depth - 71344, 1244992) / 1024);
+                                       std::min(115 * depth - 70, 1216));
 
             // Extra penalty for early quiet moves of the previous ply
             if (prevSq != SQ_NONE && (ss - 1)->moveCount <= 3 && !priorCapture)
                 update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
-                                              -std::min(779788 * (depth + 1) - 271806, 2958308)
-                                                / 1024);
+                                              -std::min(762 * (depth + 1) - 266, 2889));
         }
 
         // Partial workaround for the graph history interaction problem


### PR DESCRIPTION
Remove two unnecessary divisions

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 280768 W: 72187 L: 72236 D: 136345
Ptnml(0-2): 815, 33131, 72550, 33064, 824
https://tests.stockfishchess.org/tests/view/67bcf7afe670525923b8a101

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 108684 W: 27666 L: 27536 D: 53482
Ptnml(0-2): 40, 11768, 30606, 11878, 50
https://tests.stockfishchess.org/tests/view/67be472ed8d5c2c657c52cb8

bench: 2224870