### PR TITLE
simplify risk_tolerance + avoid overflow

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -96,7 +96,6 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     return 7685 * pcv + 7495 * micv + 9144 * (wnpcv + bnpcv) + 6469 * cntcv;
 }
 
-// abs(v) needs to be less than 2974 to avoid overflows
 int risk_tolerance(const Position& pos, Value v) {
     // Returns (some constant of) second derivative of sigmoid.
     static constexpr auto sigmoid_d2 = [](int x, int y) {
@@ -107,13 +106,14 @@ int risk_tolerance(const Position& pos, Value v) {
                     + 337 * pos.count<ROOK>() + 553 * pos.count<QUEEN>())
                  / 64;
 
-
     // a and b are the crude approximation of the wdl model.
     // The win rate is: 1/(1+exp((a-v)/b))
     // The loss rate is 1/(1+exp((v+a)/b))
     int a = 356;
     int b = ((65 * m - 3172) * m  + 240578) / 2048;
 
+    // guard against overflow
+    assert(abs(v) + a <= std::numeric_limits<int>::max() / 644800);
 
     // The risk utility is therefore d/dv^2 (1/(1+exp(-(v-a)/b)) -1/(1+exp(-(-v-a)/b)))
     // -115200x/(x^2+3) = -345600(ab) / (a^2+3b^2) (multiplied by some constant) (second degree pade approximant)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -28,6 +28,7 @@
 #include <cstdlib>
 #include <initializer_list>
 #include <iostream>
+#include <limits>
 #include <list>
 #include <ratio>
 #include <string>

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -96,31 +96,31 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     return 7685 * pcv + 7495 * micv + 9144 * (wnpcv + bnpcv) + 6469 * cntcv;
 }
 
+// abs(v) needs to be less than 2974 to avoid overflows
 int risk_tolerance(const Position& pos, Value v) {
     // Returns (some constant of) second derivative of sigmoid.
     static constexpr auto sigmoid_d2 = [](int x, int y) {
-        return -355752 * x / (x * x + 3 * y * y);
+        return 644800 * x / ((x * x + 3 * y * y) * y);
     };
 
-    int material = (67 * pos.count<PAWN>() + 182 * pos.count<KNIGHT>() + 182 * pos.count<BISHOP>()
+    int m = (67 * pos.count<PAWN>() + 182 * pos.count<KNIGHT>() + 182 * pos.count<BISHOP>()
                     + 337 * pos.count<ROOK>() + 553 * pos.count<QUEEN>())
                  / 64;
 
-    int m = std::clamp(material, 17, 78);
 
     // a and b are the crude approximation of the wdl model.
     // The win rate is: 1/(1+exp((a-v)/b))
     // The loss rate is 1/(1+exp((v+a)/b))
-    int a = ((-m * 3037 / 256 + 2270) * m / 256 - 637) * m / 256 + 413;
-    int b = ((m * 7936 / 256 - 2255) * m / 256 + 319) * m / 256 + 83;
+    int a = 356;
+    int b = ((65 * m - 3172) * m  + 240578) / 2048;
 
 
     // The risk utility is therefore d/dv^2 (1/(1+exp(-(v-a)/b)) -1/(1+exp(-(-v-a)/b)))
     // -115200x/(x^2+3) = -345600(ab) / (a^2+3b^2) (multiplied by some constant) (second degree pade approximant)
     int winning_risk = sigmoid_d2(v - a, b);
-    int losing_risk  = -sigmoid_d2(-v - a, b);
+    int losing_risk  = sigmoid_d2(v + a, b);
 
-    return (winning_risk + losing_risk) * 58 / b;
+    return -(winning_risk + losing_risk) * 32;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -1192,7 +1192,7 @@ moves_loop:  // When in check, search starts here
 
         r -= std::abs(correctionValue) / 29696;
 
-        if (PvNode && !is_decisive(bestValue))
+        if (PvNode && std::abs(bestValue) <= 2000)
             r -= risk_tolerance(pos, bestValue);
 
         // Increase reduction for cut nodes


### PR DESCRIPTION
passed simplification STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 73984 W: 19058 L: 18879 D: 36047
Ptnml(0-2): 232, 8735, 18866, 8940, 219
https://tests.stockfishchess.org/tests/view/67c269a38200cf1034c9baf9

passed simplification LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 39288 W: 10033 L: 9833 D: 19422
Ptnml(0-2): 14, 4168, 11086, 4356, 20
https://tests.stockfishchess.org/tests/view/67c34f8c8200cf1034c9bda1