### PR TITLE
Update movepick.cpp

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -166,7 +166,7 @@ void MovePicker::score() {
             m.value += (*continuationHistory[5])[pc][to];
 
             // bonus for checks
-            m.value += bool(pos.check_squares(pt) & to) * 16384;
+            m.value += pos.gives_check(m) * 16384;
 
             // bonus for escaping from capture
             m.value += threatenedPieces & from ? (pt == QUEEN && !(to & threatenedByRook)   ? 51700


### PR DESCRIPTION
Passed non-regression STC
https://tests.stockfishchess.org/tests/view/67c386deb7226b5d8a2dd2ea
LLR 2.94 [-2.94,2.94] (accepted)
Elo -0.17 [-0.99,0.59] (95%)
LOS 33.4%
Games 241408 [w:25.7%, l:25.7%, d:48.6%]
Pentanomial [725, 28515, 62168, 28632, 664]


Passed non-regression LTC
https://tests.stockfishchess.org/tests/view/67c3fab6b7226b5d8a2dd373
LLR | 2.94 [-2.94,2.94] (accepted)
Elo 0.63 [-0.61,1.84] (95%)
LOS 84.1%
Games 73818 [w:25.4%, l:25.2%, d:49.4%]
Pentanomial [38, 8007, 20650, 8179, 35]

