### PR TITLE
Simplify Return Value Adjustment Condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1407,7 +1407,7 @@ moves_loop:  // When in check, search starts here
 
     assert(moveCount || !ss->inCheck || excludedMove || !MoveList<LEGAL>(pos).size());
 
-    // Adjust best value for fail high cases at non-pv nodes
+    // Adjust best value for fail high cases
     if (bestValue >= beta && !is_decisive(bestValue) && !is_decisive(beta) && !is_decisive(alpha))
         bestValue = (bestValue * depth + beta) / (depth + 1);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1408,8 +1408,7 @@ moves_loop:  // When in check, search starts here
     assert(moveCount || !ss->inCheck || excludedMove || !MoveList<LEGAL>(pos).size());
 
     // Adjust best value for fail high cases at non-pv nodes
-    if (!PvNode && bestValue >= beta && !is_decisive(bestValue) && !is_decisive(beta)
-        && !is_decisive(alpha))
+    if (bestValue >= beta && !is_decisive(bestValue) && !is_decisive(beta) && !is_decisive(alpha))
         bestValue = (bestValue * depth + beta) / (depth + 1);
 
     if (!moveCount)


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 82112 W: 21281 L: 21110 D: 39721
Ptnml(0-2): 258, 9630, 21112, 9795, 261
https://tests.stockfishchess.org/tests/view/67c42528b7226b5d8a2dd3a0

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 182652 W: 46295 L: 46240 D: 90117
Ptnml(0-2): 103, 20025, 51003, 20104, 91
https://tests.stockfishchess.org/tests/view/67c4d56b685e87e15e7c43d8

bench 1889431