### PR TITLE
Removing contHist[1] from pruning formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1662,10 +1662,9 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
             // Continuation history based pruning
             if (!capture
                 && (*contHist[0])[pos.moved_piece(move)][move.to_sq()]
-                       + (*contHist[1])[pos.moved_piece(move)][move.to_sq()]
-                       + thisThread->pawnHistory[pawn_structure_index(pos)][pos.moved_piece(move)]
+                   + thisThread->pawnHistory[pawn_structure_index(pos)][pos.moved_piece(move)]
                                                 [move.to_sq()]
-                     <= 5923)
+                     <= 6290)
                 continue;
 
             // Do not search moves with bad enough SEE values


### PR DESCRIPTION
Removing contHist[1] from pruning formula

Passed STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 51552 W: 13297 L: 13091 D: 25164
Ptnml(0-2): 166, 6009, 13215, 6225, 161
https://tests.stockfishchess.org/tests/view/67c4de79685e87e15e7c43f5

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 244554 W: 62135 L: 62142 D: 120277
Ptnml(0-2): 137, 26612, 68794, 26589, 145
https://tests.stockfishchess.org/tests/view/67c50982685e87e15e7c443d

bench: 2009330