### PR TITLE
Allow more than 1024 threads on high-end machines

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -32,6 +32,7 @@
 #include "misc.h"
 #include "nnue/network.h"
 #include "nnue/nnue_common.h"
+#include "numa.h"
 #include "perft.h"
 #include "position.h"
 #include "search.h"
@@ -46,6 +47,7 @@ namespace NN = Eval::NNUE;
 
 constexpr auto StartFEN  = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 constexpr int  MaxHashMB = Is64Bit ? 33554432 : 2048;
+int            MaxThreads = std::max(1024, 4 * int(get_hardware_concurrency()));
 
 Engine::Engine(std::optional<std::string> path) :
     binaryDirectory(path ? CommandLine::get_binary_directory(*path) : ""),
@@ -74,7 +76,7 @@ Engine::Engine(std::optional<std::string> path) :
       }));
 
     options.add(  //
-      "Threads", Option(1, 1, 1024, [this](const Option&) {
+      "Threads", Option(1, 1, MaxThreads, [this](const Option&) {
           resize_threads();
           return thread_allocation_information_as_string();
       }));


### PR DESCRIPTION
This PR changes the  maximum value for `Threads` from the constant 1024 to four times the number of available processors.

This follows some discussion on discord. 

No functional change.

