### PR TITLE
Use slightly different formula for stat score when position is in check.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1216,6 +1216,9 @@ moves_loop:  // When in check, search starts here
               846 * int(PieceValue[pos.captured_piece()]) / 128
               + thisThread->captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())]
               - 4822;
+        else if (ss->inCheck)
+              ss->statScore = thisThread->mainHistory[us][move.from_to()]
+                            + (*contHist[0])[movedPiece][move.to_sq()] - 2771;
         else
             ss->statScore = 2 * thisThread->mainHistory[us][move.from_to()]
                           + (*contHist[0])[movedPiece][move.to_sq()]


### PR DESCRIPTION
Use formula that is closer to movepicker one.
Passed STC:
https://tests.stockfishchess.org/tests/view/67cffb337be98c1ad9b021ee
LLR: 2.99 (-2.94,2.94) <0.00,2.00>
Total: 250432 W: 64978 L: 64343 D: 121111
Ptnml(0-2): 795, 29390, 64159, 30129, 743 
Passed LTC:
https://tests.stockfishchess.org/tests/view/67d3905d517865b4a2dfce8a
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 140004 W: 35742 L: 35215 D: 69047
Ptnml(0-2): 60, 15111, 39151, 15602, 78 
bench 1828707
