### PR TITLE
change the bonusScale depth component

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1424,7 +1424,8 @@ moves_loop:  // When in check, search starts here
     // Bonus for prior countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
     {
-        int bonusScale = (112 * (depth > 5) + 34 * !allNode + 164 * ((ss - 1)->moveCount > 8)
+        int bonusScale = (std::clamp(160*(depth - 4)/2, 0, 200)
+                          + 34 * !allNode + 164 * ((ss - 1)->moveCount > 8)
                           + 141 * (!ss->inCheck && bestValue <= ss->staticEval - 100)
                           + 121 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 75)
                           + 86 * ((ss - 1)->isTTMove) + 86 * (ss->cutoffCnt <= 3)


### PR DESCRIPTION
Passed STC:
https://tests.stockfishchess.org/tests/view/67d35f66517865b4a2dfc801
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 110816 W: 28875 L: 28449 D: 53492
Ptnml(0-2): 329, 13064, 28231, 13420, 364

Passed LTC:
https://tests.stockfishchess.org/tests/view/67d4bdf0517865b4a2dfd131
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 121824 W: 31047 L: 30559 D: 60218
Ptnml(0-2): 52, 13056, 34214, 13532, 58

Bench: 2046580