### PR TITLE
Removing the conditional bonus calculation

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1257,7 +1257,7 @@ moves_loop:  // When in check, search starts here
                     value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, newDepth, !cutNode);
 
                 // Post LMR continuation history updates
-                int bonus = (value >= beta) * 1800;
+                int bonus = 1600;
                 update_continuation_histories(ss, movedPiece, move.to_sq(), bonus);
             }
             else if (value > alpha && value < bestValue + 9)


### PR DESCRIPTION
Removing the conditional bonus calculation.
And the new value is just a guessed value, which means that tuning it later on will probably improve the strength even further.

Passed STC:
https://tests.stockfishchess.org/tests/view/67d5ee09517865b4a2dfd2df
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 52128 W: 13516 L: 13312 D: 25300
Ptnml(0-2): 157, 6044, 13451, 6262, 150

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 42384 W: 10855 L: 10657 D: 20872
Ptnml(0-2): 19, 4554, 11852, 4744, 23
https://tests.stockfishchess.org/tests/view/67d5f9d3517865b4a2dfd2ef

bench: 1683574