### PR TITLE
update the WDL model

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -513,8 +513,8 @@ WinRateParams win_rate_params(const Position& pos) {
     double m = std::clamp(material, 17, 78) / 58.0;
 
     // Return a = p_a(material) and b = p_b(material), see github.com/official-stockfish/WDL_model
-    constexpr double as[] = {-37.45051876, 121.19101539, -132.78783573, 420.70576692};
-    constexpr double bs[] = {90.26261072, -137.26549898, 71.10130540, 51.35259597};
+    constexpr double as[] = {-13.50030198, 40.92780883, -36.82753545, 386.83004070};
+    constexpr double bs[] = {96.53354896, -165.79058388, 90.89679019, 49.29561889};
 
     double a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
     double b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];


### PR DESCRIPTION
This PR updates the internal WDL model, using data from 2.6M games played by the revisions since f3bfce353168b03e4fedce515de1898c691f81ec. Note that the normalizing constant increases only moderately from 372 to 377.

```
> ./updateWDL.sh --firstrev f3bfce353168b03e4fedce515de1898c691f81ec
Running: ./updateWDL.sh --firstrev f3bfce353168b03e4fedce515de1898c691f81ec --lasttrev HEAD --materialMin 17 --EloDiffMax 5
started at:  Sat 22 Mar 11:02:14 CET 2025
Look recursively in directory pgns for games with max nElo difference 5 using books matching "UHO_Lichess_4852_v..epd" for SF revisions between f3bfce353168b03e4fedce515de1898c691f81ec (from 2025-02-28 09:50:59 +0100) and HEAD (from 2025-03-21 11:22:59 +0100).
Based on 138253430 positions from 2579360 games, NormalizeToPawnValue should change from 372 to 377.
ended at:  Sat 22 Mar 11:04:00 CET 2025
```

```
> cat scoreWDL.log
Converting evals with NormalizeData = {'momType': 'material', 'momMin': 17, 'momMax': 78, 'momTarget': 58, 'as': [-37.45051876, 121.19101539, -132.78783573, 420.70576692]}.
Reading eval stats from updateWDL.json.
Retained (W,D,L) = (33794348, 69943262, 34515820) positions.
Saved distribution plot to updateWDLdistro.png.
Fit WDL model based on material.
Initial objective function:  0.3648260131692729
Final objective function:    0.36482338611818094
Optimization terminated successfully.
const int NormalizeToPawnValue = 377;
Corresponding spread = 71;
Corresponding normalized spread = 0.1879431202530567;
Draw rate at 0.0 eval at material 58 = 0.9902694872976331;
Parameters in internal value units: 
p_a = ((-13.500 * x / 58 + 40.928) * x / 58 + -36.828) * x / 58 + 386.830
p_b = ((96.534 * x / 58 + -165.791) * x / 58 + 90.897) * x / 58 + 49.296
    constexpr double as[] = {-13.50030198, 40.92780883, -36.82753545, 386.83004070};
    constexpr double bs[] = {96.53354896, -165.79058388, 90.89679019, 49.29561889};
Preparing plots.
Saved graphics to updateWDL.png.
Total elapsed time = 46.92s.
```

Only affects displayed `cp` and `wdl` values, no other functional change.