### PR TITLE
Remove redundant assignments

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -298,14 +298,10 @@ void Search::Worker::iterative_deepening() {
           &this->continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel
         (ss - i)->continuationCorrectionHistory = &this->continuationCorrectionHistory[NO_PIECE][0];
         (ss - i)->staticEval                    = VALUE_NONE;
-        (ss - i)->reduction                     = 0;
     }
 
     for (int i = 0; i <= MAX_PLY + 2; ++i)
-    {
         (ss + i)->ply       = i;
-        (ss + i)->reduction = 0;
-    }
 
     ss->pv = pv;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -292,7 +292,7 @@ void Search::Worker::iterative_deepening() {
     Stack  stack[MAX_PLY + 10] = {};
     Stack* ss                  = stack + 7;
 
-    for (int i = 7; i > 0; --i)
+    for (int i = 1; i <= 7; ++i)
     {
         (ss - i)->continuationHistory =
           &this->continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -292,7 +292,7 @@ void Search::Worker::iterative_deepening() {
     Stack  stack[MAX_PLY + 10] = {};
     Stack* ss                  = stack + 7;
 
-    for (int i = 1; i <= 7; ++i)
+    for (int i = 7; i > 0; --i)
     {
         (ss - i)->continuationHistory =
           &this->continuationHistory[0][0][NO_PIECE][0];  // Use as a sentinel


### PR DESCRIPTION
Remove redundant assignments.
The aggregate initialization = {}; already value-initializes the Stack array. For members like reduction, this means they are initialized to 0.

Edit: While at it, I also adjusted the loop for clarity (1 to 7 instead of 7 down to 1) to keep it consistent with the other loops.

Non-Functional
bench: 2030154