### PR TITLE
Simplify TT cutoff conthist updates

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -724,8 +724,7 @@ Value Search::Worker::search(
 
             // Extra penalty for early quiet moves of the previous ply
             if (prevSq != SQ_NONE && (ss - 1)->moveCount <= 3 && !priorCapture)
-                update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
-                                              -std::min(809 * (depth + 1) - 249, 3052));
+                update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq, -2200);
         }
 
         // Partial workaround for the graph history interaction problem


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 86304 W: 22251 L: 22084 D: 41969
Ptnml(0-2): 250, 10214, 22123, 10249, 316
https://tests.stockfishchess.org/tests/view/67db60cd8c7f315cc372aae7

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 199158 W: 50655 L: 50617 D: 97886
Ptnml(0-2): 103, 21579, 56182, 21607, 108
https://tests.stockfishchess.org/tests/view/67dcdc5b8c7f315cc372ac12

bench 2069191