### PR TITLE
Remove pawn_attacks_bb()

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -32,7 +32,6 @@ uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 Bitboard LineBB[SQUARE_NB][SQUARE_NB];
 Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
 Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
-Bitboard PawnAttacks[COLOR_NB][SQUARE_NB];
 
 alignas(64) Magic Magics[SQUARE_NB][2];
 
@@ -86,8 +85,8 @@ void Bitboards::init() {
 
     for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
     {
-        PawnAttacks[WHITE][s1] = pawn_attacks_bb<WHITE>(square_bb(s1));
-        PawnAttacks[BLACK][s1] = pawn_attacks_bb<BLACK>(square_bb(s1));
+        PseudoAttacks[WHITE][s1] = pawn_attacks_bb<WHITE>(square_bb(s1));
+        PseudoAttacks[BLACK][s1] = pawn_attacks_bb<BLACK>(square_bb(s1));
 
         for (int step : {-9, -8, -7, -1, 1, 7, 8, 9})
             PseudoAttacks[KING][s1] |= safe_destination(s1, step);

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -62,7 +62,6 @@ extern uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 extern Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
 extern Bitboard LineBB[SQUARE_NB][SQUARE_NB];
 extern Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
-extern Bitboard PawnAttacks[COLOR_NB][SQUARE_NB];
 
 
 // Magic holds all magic bitboards relevant data for a single square
@@ -155,11 +154,6 @@ constexpr Bitboard pawn_attacks_bb(Bitboard b) {
                       : shift<SOUTH_WEST>(b) | shift<SOUTH_EAST>(b);
 }
 
-inline Bitboard pawn_attacks_bb(Color c, Square s) {
-
-    assert(is_ok(s));
-    return PawnAttacks[c][s];
-}
 
 // Returns a bitboard representing an entire line (from board edge
 // to board edge) that intersects the two given squares. If the given squares
@@ -216,10 +210,10 @@ inline int edge_distance(File f) { return std::min(f, File(FILE_H - f)); }
 // Returns the pseudo attacks of the given piece type
 // assuming an empty board.
 template<PieceType Pt>
-inline Bitboard attacks_bb(Square s) {
+inline Bitboard attacks_bb(Square s, Color c = COLOR_NB) {
 
-    assert((Pt != PAWN) && (is_ok(s)));
-    return PseudoAttacks[Pt][s];
+    assert((Pt != PAWN || c < COLOR_NB) && (is_ok(s)));
+    return Pt == PAWN ? PseudoAttacks[c][s] : PseudoAttacks[Pt][s];
 }
 
 

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -134,7 +134,7 @@ ExtMove* generate_pawn_moves(const Position& pos, ExtMove* moveList, Bitboard ta
             if (Type == EVASIONS && (target & (pos.ep_square() + Up)))
                 return moveList;
 
-            b1 = pawnsNotOn7 & pawn_attacks_bb(Them, pos.ep_square());
+            b1 = pawnsNotOn7 & attacks_bb<PAWN>(pos.ep_square(), Them);
 
             assert(b1);
 


### PR DESCRIPTION
https://tests.stockfishchess.org/tests/view/67e9496231d7cf8afdc44a2e
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 134688 W: 34660 L: 34553 D: 65475
Ptnml(0-2): 298, 14619, 37462, 14608, 357 

Generalize attacks_bb() to handle pawns and remove pawn_attacks_bb()
No functional change
bench: 2030154