### PR TITLE
Syzygy fix w/ Clang 20

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -710,7 +710,7 @@ int map_score(TBTable<DTZ>* entry, File f, int value, WDLScore wdl) {
 
 // A temporary fix for the compiler bug with AVX-512. (#4450)
 #ifdef USE_AVX512
-    #if defined(__clang__) && defined(__clang_major__) && __clang_major__ >= 15
+    #if defined(__clang__) && defined(__clang_major__) && __clang_major__ >= 15 && __clang_major__ <= 19
         #define CLANG_AVX512_BUG_FIX __attribute__((optnone))
     #endif
 #endif


### PR DESCRIPTION
This is fixed in Clang 20. See https://github.com/official-stockfish/Stockfish/issues/4450 for reference.
bench: 2030154