### PR TITLE
Use matching llvm-profdata

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -567,6 +567,15 @@ ifeq ($(COMP),ndk)
 	LDFLAGS += -static-libstdc++ -pie -lm -latomic
 endif
 
+# llvm-profdata must be version compatible with the specified CXX (be it clang, or the gcc alias)
+# make -j profile-build CXX=clang++-20 COMP=clang
+# Locate the version in the same directory as the compiler used,
+# with fallback to a generic one if it can't be located
+	LLVM_PROFDATA := $(dir $(realpath $(shell which $(CXX))))llvm-profdata
+ifeq ($(wildcard $(LLVM_PROFDATA)),)
+	LLVM_PROFDATA := llvm-profdata
+endif
+
 ifeq ($(comp),icx)
 	profile_make = icx-profile-make
 	profile_use = icx-profile-use
@@ -1081,7 +1090,7 @@ clang-profile-make:
 	all
 
 clang-profile-use:
-	$(XCRUN) llvm-profdata merge -output=stockfish.profdata *.profraw
+	$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
 	EXTRACXXFLAGS='-fprofile-use=stockfish.profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \


### PR DESCRIPTION
when using multiple clang compilers in parallel, it is necessary to use a matching llvm-profdata, as the profile data format may change between versions. To use the proper llvm-profdata binary, the one in the same directory as the compiler is used. This allows for code like:

```bash
echo "Compiling clang"
for comp in clang++-11 clang++-12 clang++-13 clang++-14  clang++-15  clang++-16  clang++-17 clang++-18 clang++-19 clang++-20
do
   make -j profile-build CXX=$comp COMP=clang >& out.compile.$comp
   mv stockfish stockfish.$comp
done
```

after installing the required versions with the automatic installation script (https://apt.llvm.org/)

No functional change