### PR TITLE
Introduce TT Move History Double Extensions

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -166,6 +166,8 @@ struct CorrHistTypedef<NonPawn> {
 template<CorrHistType T>
 using CorrectionHistory = typename Detail::CorrHistTypedef<T>::type;
 
+using TTMoveHistory = Stats<std::int16_t, 8192, PAWN_HISTORY_SIZE, COLOR_NB>;
+
 }  // namespace Stockfish
 
 #endif  // #ifndef HISTORY_H_INCLUDED

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -583,6 +583,8 @@ void Search::Worker::clear() {
     minorPieceCorrectionHistory.fill(0);
     nonPawnCorrectionHistory.fill(0);
 
+    ttMoveHistory.fill(0);
+
     for (auto& to : continuationCorrectionHistory)
         for (auto& h : to)
             h.fill(5);
@@ -1146,7 +1148,8 @@ moves_loop:  // When in check, search starts here
                 {
                     int corrValAdj1  = std::abs(correctionValue) / 248873;
                     int corrValAdj2  = std::abs(correctionValue) / 255331;
-                    int doubleMargin = 262 * PvNode - 188 * !ttCapture - corrValAdj1;
+                    int doubleMargin = 262 * PvNode - 188 * !ttCapture - corrValAdj1
+                                     - ttMoveHistory[pawn_structure_index(pos)][us] / 128;
                     int tripleMargin =
                       88 + 265 * PvNode - 256 * !ttCapture + 93 * ss->ttPv - corrValAdj2;
 
@@ -1438,8 +1441,15 @@ moves_loop:  // When in check, search starts here
     // If there is a move that produces search value greater than alpha,
     // we update the stats of searched moves.
     else if (bestMove)
+    {
         update_all_stats(pos, ss, *this, bestMove, prevSq, quietsSearched, capturesSearched, depth,
                          bestMove == ttData.move, moveCount);
+        if (!PvNode)
+        {
+            int bonus = (ttData.move == move) ? 800 : -600 * moveCount;
+            ttMoveHistory[pawn_structure_index(pos)][us] << bonus;
+        }
+    }
 
     // Bonus for prior quiet countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)

--- a/src/search.h
+++ b/src/search.h
@@ -292,6 +292,8 @@ class Worker {
     CorrectionHistory<NonPawn>      nonPawnCorrectionHistory;
     CorrectionHistory<Continuation> continuationCorrectionHistory;
 
+    TTMoveHistory ttMoveHistory;
+
    private:
     void iterative_deepening();
 


### PR DESCRIPTION
Passed VVLTC w/ STC bounds:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 74918 W: 19436 L: 19120 D: 36362
Ptnml(0-2): 6, 6890, 23354, 7200, 9
https://tests.stockfishchess.org/tests/view/67e4a1088888403457d878bb

Passed VVLTC w/ LTC bounds:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 111706 W: 29050 L: 28619 D: 54037
Ptnml(0-2): 13, 10218, 34959, 10651, 12
https://tests.stockfishchess.org/tests/view/67d6877c517865b4a2dfd36b

STC Elo Estimate:
Elo: 1.26 ± 2.0 (95%) LOS: 88.8%
Total: 30000 W: 7855 L: 7746 D: 14399
Ptnml(0-2): 104, 3531, 7630, 3622, 113
nElo: 2.44 ± 3.9 (95%) PairsRatio: 1.03
https://tests.stockfishchess.org/tests/view/67eacb8c31d7cf8afdc44b99

bench 1866379