### PR TITLE
Simplify material term in risk 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -102,9 +102,7 @@ int risk_tolerance(const Position& pos, Value v) {
         return 644800 * x / ((x * x + 3 * y * y) * y);
     };
 
-    int m = (67 * pos.count<PAWN>() + 182 * pos.count<KNIGHT>() + 182 * pos.count<BISHOP>()
-             + 337 * pos.count<ROOK>() + 553 * pos.count<QUEEN>())
-          / 64;
+    int m = pos.count<PAWN>() + pos.non_pawn_material() / 300;
 
     // a and b are the crude approximation of the wdl model.
     // The win rate is: 1/(1+exp((a-v)/b))


### PR DESCRIPTION
Simply use non_pawn_material rather than summing tuned terms

Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 136576 W: 35285 L: 35175 D: 66116
Ptnml(0-2): 410, 16179, 34997, 16295, 407 
https://tests.stockfishchess.org/tests/view/67e5dc736682f97da2178da6

Passed rebased simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 85482 W: 21812 L: 21658 D: 42012
Ptnml(0-2): 34, 9260, 24022, 9368, 57 
https://tests.stockfishchess.org/tests/view/67e852cb31d7cf8afdc44966

bench 2006483