### PR TITLE
Add cstddef header

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -37,6 +37,7 @@
 //               | only in 64-bit mode and requires hardware with pext support.
 
     #include <cassert>
+    #include <cstddef>
     #include <cstdint>
     #include <type_traits>
 


### PR DESCRIPTION
Fix missing header for std::size_t reported on discord.