### PR TITLE
Adding a small term to the futility calculation that depends on eval - beta

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -857,7 +857,7 @@ Value Search::Worker::search(
     // The depth condition is important for mate finding.
     if (!ss->ttPv && depth < 14
         && eval - futility_margin(depth, cutNode && !ss->ttHit, improving, opponentWorsening)
-               - (ss - 1)->statScore / 301 + 37 - std::abs(correctionValue) / 139878
+             - (ss - 1)->statScore / 301 + 37 + ((eval - beta) / 8) - std::abs(correctionValue) / 139878
              >= beta
         && eval >= beta && (!ttData.move || ttCapture) && !is_loss(beta) && !is_win(eval))
         return beta + (eval - beta) / 3;


### PR DESCRIPTION
Adding a small term to the futility calculation that depends on eval - beta.
Refactored to a simpler form.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 74176 W: 19323 L: 18954 D: 35899
Ptnml(0-2): 226, 8576, 19117, 8941, 228
https://tests.stockfishchess.org/tests/view/67e6b0946682f97da2178eaf

Passed LTC:
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 135090 W: 34499 L: 33983 D: 66608
Ptnml(0-2): 79, 14403, 38040, 14969, 54
https://tests.stockfishchess.org/tests/view/67e757cc6682f97da2178f62

bench: 1951187