### PR TITLE
Don't use 5th continuation history in move ordering.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -162,7 +162,6 @@ void MovePicker::score() {
             m.value += (*continuationHistory[1])[pc][to];
             m.value += (*continuationHistory[2])[pc][to];
             m.value += (*continuationHistory[3])[pc][to];
-            m.value += (*continuationHistory[4])[pc][to] / 3;
             m.value += (*continuationHistory[5])[pc][to];
 
             // bonus for checks


### PR DESCRIPTION
Simplification: don't use 5th continuation history in move ordering.

Passed simplification STC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 136960 W: 35374 L: 35262 D: 66324
Ptnml(0-2): 420, 16214, 35049, 16428, 369 
https://tests.stockfishchess.org/tests/view/67e6d0ae6682f97da2178ee5

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 233016 W: 59063 L: 59059 D: 114894
Ptnml(0-2): 113, 25430, 65421, 25428, 116 
https://tests.stockfishchess.org/tests/view/67e9f7fb31d7cf8afdc44ad4

bench 1840043