### PR TITLE
Simplify bonusScale calculation using std::min

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1447,7 +1447,7 @@ moves_loop:  // When in check, search starts here
     else if (!priorCapture && prevSq != SQ_NONE)
     {
         int bonusScale =
-          (std::clamp(80 * depth - 320, 0, 200) + 34 * !allNode + 164 * ((ss - 1)->moveCount > 8)
+          (std::min(78 * depth - 312, 194) + 34 * !allNode + 164 * ((ss - 1)->moveCount > 8)
            + 141 * (!ss->inCheck && bestValue <= ss->staticEval - 100)
            + 121 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 75)
            + 86 * ((ss - 1)->isTTMove) + 86 * (ss->cutoffCnt <= 3)


### PR DESCRIPTION
Simplify bonusScale calculation using std::min
Allowing this specific term to potentially become negative for low depth values is ok, because the overall `bonusScale` is explicitly ensured to be non-negative a few lines later:
bonusScale = std::max(bonusScale, 0);

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 164928 W: 42446 L: 42368 D: 80114
Ptnml(0-2): 497, 19551, 42306, 19597, 513
https://tests.stockfishchess.org/tests/view/67debf0b8888403457d8736c

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 234942 W: 59539 L: 59537 D: 115866
Ptnml(0-2): 113, 25639, 65964, 25643, 112
https://tests.stockfishchess.org/tests/view/67e2e1c48888403457d87768

bench: 1801704