### PR TITLE
Fix for stalemate issue #5899

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -19,6 +19,7 @@
 #include "movepick.h"
 
 #include <cassert>
+#include <cstddef>
 #include <limits>
 
 #include "bitboard.h"
@@ -316,5 +317,31 @@ top:
 }
 
 void MovePicker::skip_quiet_moves() { skipQuiets = true; }
+
+bool MovePicker::otherPieceTypesMobile(PieceType pt, ValueList<Move, 32>& capturesSearched) {
+    if (stage != GOOD_QUIET  && stage != BAD_QUIET)
+        return true;
+
+    // verify good captures
+    for (std::size_t i=0; i< capturesSearched.size();i++)
+        if (type_of(pos.moved_piece(capturesSearched[i])) != pt)
+        {
+            if (type_of(pos.moved_piece(capturesSearched[i])) != KING)
+                return true;
+            if (pos.legal(capturesSearched[i]))
+                return true;
+        }
+
+    // now verify bad captures and quiets
+    for (ExtMove *c = moves; c < endBadQuiets; ++c)
+        if (type_of(pos.moved_piece(*c)) != pt)
+        {
+           if (type_of(pos.moved_piece(*c)) != KING)
+               return true;
+           if (pos.legal(*c))
+               return true;
+        }
+    return false;
+}
 
 }  // namespace Stockfish

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -19,6 +19,8 @@
 #ifndef MOVEPICK_H_INCLUDED
 #define MOVEPICK_H_INCLUDED
 
+#include <cstddef>
+
 #include "history.h"
 #include "movegen.h"
 #include "types.h"
@@ -26,6 +28,8 @@
 namespace Stockfish {
 
 class Position;
+
+template <typename T, std::size_t MaxSize> class ValueList;
 
 // The MovePicker class is used to pick one pseudo-legal move at a time from the
 // current position. The most important method is next_move(), which emits one
@@ -50,6 +54,7 @@ class MovePicker {
     MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
     Move next_move();
     void skip_quiet_moves();
+    bool otherPieceTypesMobile(PieceType pt, ValueList<Move, 32>& capturesSearched);
 
    private:
     template<typename Pred>

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -34,6 +34,7 @@
 #include <string>
 #include <utility>
 
+#include "bitboard.h"
 #include "evaluate.h"
 #include "history.h"
 #include "misc.h"
@@ -1071,7 +1072,15 @@ moves_loop:  // When in check, search starts here
                 // SEE based pruning for captures and checks
                 int seeHist = std::clamp(captHist / 32, -138 * depth, 135 * depth);
                 if (!pos.see_ge(move, -154 * depth - seeHist))
-                    continue;
+                {
+                    bool skip = true;
+                    if (depth > 2 && !capture && givesCheck && alpha < 0 && pos.non_pawn_material(us) == PieceValue[movedPiece] && PieceValue[movedPiece] >= RookValue
+                        && !(PseudoAttacks[KING][pos.square<KING>(us)] & move.from_sq()))
+                          skip = mp.otherPieceTypesMobile(type_of(movedPiece), capturesSearched); // if the opponent captures last mobile piece it might be stalemate
+
+                     if (skip)
+                       continue;
+                }
             }
             else
             {
@@ -1491,7 +1500,7 @@ moves_loop:  // When in check, search starts here
                        bestValue >= beta    ? BOUND_LOWER
                        : PvNode && bestMove ? BOUND_EXACT
                                             : BOUND_UPPER,
-                       depth, bestMove, unadjustedStaticEval, tt.generation());
+                       moveCount != 0 ? depth : std::min(MAX_PLY - 1, depth + 6), bestMove, unadjustedStaticEval, tt.generation());
 
     // Adjust correction history
     if (!ss->inCheck && !(bestMove && pos.capture(bestMove))
@@ -1743,6 +1752,19 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
 
     if (!is_decisive(bestValue) && bestValue > beta)
         bestValue = (bestValue + beta) / 2;
+
+
+    Color us = pos.side_to_move();
+    if(!ss->inCheck && !moveCount && !pos.non_pawn_material(us) && type_of(pos.captured_piece()) >= ROOK)
+    {
+        if (!((us == WHITE ? shift<NORTH>(pos.pieces(us, PAWN)) : shift<SOUTH>(pos.pieces(us, PAWN))) & ~pos.pieces())) // no pawn pushes available
+        {
+            pos.state()->checkersBB = Rank1BB; // search for legal king-moves only
+            if (!MoveList<LEGAL>(pos).size()) // stalemate
+                bestValue = VALUE_DRAW;
+            pos.state()->checkersBB = 0;
+        }
+    }
 
     // Save gathered info in transposition table. The static evaluation
     // is saved as it was before adjustment by correction history.


### PR DESCRIPTION
This is a proposal to fix the stalemate issue explained in #5899 were SF missed to convert a won position. The position is from game https://www.chess.com/computer-chess-championship#event=ccc23-rapid-finals&game=81 where Leela already at move 34 seems to recognize the tactical motif by sealing the position shut playing h6. SF in turn don’t sees the draw coming even at move 40. This is embarassing for an over 3000 elo rated engine. 
(SF17_1 with 1 thread and low hash pressure requires about 3 minutes the recognize the draw at position 
FEN  2rr4/5pBk/PqP3p1/1N3pPp/1PQ1bP1P/8/3R4/R4K2 b - - 0 40 )

Currently SF’s quiescence search like most alpha-beta based engines doesn’t verify for stalemate because doing it each leaf position is to expensive and costs elo.
However in certain positions this creates a blindspot for SF, not recognizing soon enough that the opponent can reach a stalemate by sacrifycing his last mobile heavy piece(s). This tactical motif & it’s measure are similar to zugzwang & verification search: the measure itself does not gain elo, but prevents SF from loosing/drawing games in an awkward way.

The fix consists of 3 measures:

1. Make qsearch verify for stalemate on transitions to pure KP-material for the side to move with our last Rook/Queen just been captured. In fact this is the scenario where stalemate happens with highest frequency. The stalemate-verification itself is optimized by merely checking for pawn pushes & king mobility (captures were already tried by qssearch)

2. Another culprit for the issue figured out to be SEE based pruning for checks in step 14. Here often the move forcing the stalemate (or forcing the opponent to not retake) get pruned away and it need to much time to reach enough depth. To encounter this we verify following conditions:

-   a) side to move is happy with a draw (alpha < 0)
-   b) we are about to sacrify our last heavy & unique mobile piece in this position.
-   c) this piece doesn’t move away from our kingring giving the king a new square to move.
     When all 3 conditions meet we don’t prune the move, because there is a good chance that capturing the piece means stalemate.

3. Store terminal nodes (mates & stalemates) in TT with higher depth than searched depth.
This prevents SF from:
- reanalyzing the node  (=trying to generate legal moves) in vain at each iterative deepening step.
- overwriting an already correct draw-evaluation from a previous shallow normal search by a qsearch which doesn’t recognize stalemate and might store a verry erratic evaluation.
 This is due to the 4 constant in the TT-overwrite condition: d - DEPTH_ENTRY_OFFSET + 2 * pv > depth8 – 4
which allows qs to override entries made by normal searches with depth <=4.
This 3hrd measure however is not essential for fixing the issue, but tests (one of vdv & one  of mine) seem to suggest that this measure brings some small benefit.

Another other position where SF benefits from this fix is for instance
Position FEN 8/8/8/1B6/6p1/8/3K1Ppp/3N2kr w - - 0 1 bm f4 +M9 

P.S.: Also this issue higly depends on the used net, how good the net is at evaluate such mobility restricted positions. SF16 was pretty good in solving 2rr4/5pBk/PqP3p1/1N3pPp/1PQ1bP1P/8/3R4/R4K2 b - - 0 40 bm Rxc6 (< 1 second) while SF16_1 with introduction of the dual net needs about 1,5 minutes and SF17.1 requires 3 minutes to find the drawing move Rxc6.

P.S.2: Using more threads produces indeterminism & using high hash pressure makes SF reevaluate explored positions more often which makes it more likely to solve the position. To have stable meaningful results I tested therfore with one single thread and low hash pressure.

Preliminary LTC test at 30k games
https://tests.stockfishchess.org/tests/view/67ece7a931d7cf8afdc44e18 Elo: 0.04 ± 2.0 (95%) LOS: 51.7%
Total: 24416 W: 6226 L: 6223 D: 11967
Ptnml(0-2): 12, 2497, 7185, 2504, 10
nElo: 0.09 ± 4.4 (95%) PairsRatio: 1.00

Passed LTC no-regression sprt
https://tests.stockfishchess.org/tests/view/67ee8e4631d7cf8afdc452fb
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 401556 W: 101612 L: 101776 D: 198168
Ptnml(0-2): 152, 42241, 116170, 42049, 166

bench: 2066177