### PR TITLE
Remove an unnecessary refresh during accumulator stack reset

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -101,8 +101,6 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
     Eval::NNUE::AccumulatorStack accumulators;
     auto                         caches = std::make_unique<Eval::NNUE::AccumulatorCaches>(networks);
 
-    accumulators.reset(pos, networks, *caches);
-
     std::stringstream ss;
     ss << std::showpoint << std::noshowpos << std::fixed << std::setprecision(2);
     ss << '\n' << NNUE::trace(pos, networks, *caches) << '\n';

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -41,8 +41,6 @@ using BiasType       = std::int16_t;
 using PSQTWeightType = std::int32_t;
 using IndexType      = std::uint32_t;
 
-struct Networks;
-
 template<IndexType Size>
 struct alignas(CacheLineSize) Accumulator;
 
@@ -149,13 +147,12 @@ struct AccumulatorState {
 class AccumulatorStack {
    public:
     AccumulatorStack() :
-        m_accumulators(MAX_PLY + 1),
-        m_current_idx{} {}
+        accumulators(MAX_PLY + 1),
+        size{1} {}
 
     [[nodiscard]] const AccumulatorState& latest() const noexcept;
 
-    void
-    reset(const Position& rootPos, const Networks& networks, AccumulatorCaches& caches) noexcept;
+    void reset() noexcept;
     void push(const DirtyPiece& dirtyPiece) noexcept;
     void pop() noexcept;
 
@@ -185,8 +182,8 @@ class AccumulatorStack {
                                      const FeatureTransformer<Dimensions>& featureTransformer,
                                      const std::size_t                     end) noexcept;
 
-    std::vector<AccumulatorState> m_accumulators;
-    std::size_t                   m_current_idx;
+    std::vector<AccumulatorState> accumulators;
+    std::size_t                   size;
 };
 
 }  // namespace Stockfish::Eval::NNUE

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -121,7 +121,6 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
     };
 
     AccumulatorStack accumulators;
-    accumulators.reset(pos, networks, caches);
 
     // We estimate the value of each piece by doing a differential evaluation from
     // the current base eval, simulating the removal of the piece from its square.
@@ -140,7 +139,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
             {
                 pos.remove_piece(sq);
 
-                accumulators.reset(pos, networks, caches);
+                accumulators.reset();
                 std::tie(psqt, positional) = networks.big.evaluate(pos, accumulators, &caches.big);
                 Value eval                 = psqt + positional;
                 eval                       = pos.side_to_move() == WHITE ? eval : -eval;
@@ -157,7 +156,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
         ss << board[row] << '\n';
     ss << '\n';
 
-    accumulators.reset(pos, networks, caches);
+    accumulators.reset();
     auto t = networks.big.trace_evaluate(pos, accumulators, &caches.big);
 
     ss << " NNUE network contributions "

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -195,7 +195,7 @@ void Search::Worker::ensure_network_replicated() {
 
 void Search::Worker::start_searching() {
 
-    accumulatorStack.reset(rootPos, networks[numaAccessToken], refreshTable);
+    accumulatorStack.reset();
 
     // Non-main threads go directly to iterative_deepening()
     if (!is_mainthread())


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 219360 W: 56600 L: 56583 D: 106177
Ptnml(0-2): 582, 23419, 61620, 23518, 541
https://tests.stockfishchess.org/tests/view/67fad20dcd501869c669780f

no functional change