### PR TITLE
Simplify TT Move History

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -166,7 +166,7 @@ struct CorrHistTypedef<NonPawn> {
 template<CorrHistType T>
 using CorrectionHistory = typename Detail::CorrHistTypedef<T>::type;
 
-using TTMoveHistory = Stats<std::int16_t, 8192, PAWN_HISTORY_SIZE, COLOR_NB>;
+using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
 
 }  // namespace Stockfish
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -580,7 +580,7 @@ void Search::Worker::clear() {
     minorPieceCorrectionHistory.fill(0);
     nonPawnCorrectionHistory.fill(0);
 
-    ttMoveHistory.fill(0);
+    ttMoveHistory = 0;
 
     for (auto& to : continuationCorrectionHistory)
         for (auto& h : to)
@@ -1139,10 +1139,10 @@ moves_loop:  // When in check, search starts here
 
                 if (value < singularBeta)
                 {
-                    int corrValAdj1  = std::abs(correctionValue) / 248873;
-                    int corrValAdj2  = std::abs(correctionValue) / 255331;
-                    int doubleMargin = 262 * PvNode - 188 * !ttCapture - corrValAdj1
-                                     - ttMoveHistory[pawn_structure_index(pos)][us] / 128;
+                    int corrValAdj1 = std::abs(correctionValue) / 248873;
+                    int corrValAdj2 = std::abs(correctionValue) / 255331;
+                    int doubleMargin =
+                      262 * PvNode - 188 * !ttCapture - corrValAdj1 - ttMoveHistory / 128;
                     int tripleMargin =
                       88 + 265 * PvNode - 256 * !ttCapture + 93 * ss->ttPv - corrValAdj2;
 
@@ -1439,7 +1439,7 @@ moves_loop:  // When in check, search starts here
         if (!PvNode)
         {
             int bonus = (ttData.move == move) ? 800 : -870;
-            ttMoveHistory[pawn_structure_index(pos)][us] << bonus;
+            ttMoveHistory << bonus;
         }
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1438,7 +1438,7 @@ moves_loop:  // When in check, search starts here
                          bestMove == ttData.move, moveCount);
         if (!PvNode)
         {
-            int bonus = (ttData.move == move) ? 800 : -600 * moveCount;
+            int bonus = (ttData.move == move) ? 800 : -870;
             ttMoveHistory[pawn_structure_index(pos)][us] << bonus;
         }
     }


### PR DESCRIPTION
Part 1 passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 195552 W: 50394 L: 50349 D: 94809
Ptnml(0-2): 581, 23222, 50122, 23273, 578
https://tests.stockfishchess.org/tests/view/67eb6ea831d7cf8afdc44c30

Part 2 passed Non-regression STC:
LLR: 2.92 (-2.94,2.94) <-1.75,0.25>
Total: 181664 W: 46786 L: 46727 D: 88151
Ptnml(0-2): 517, 21403, 46974, 21380, 558
https://tests.stockfishchess.org/tests/view/67eb6f3331d7cf8afdc44c33

Passed Non-regression LTC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 155454 W: 39496 L: 39412 D: 76546
Ptnml(0-2): 77, 16950, 43580, 17052, 68
https://tests.stockfishchess.org/tests/view/67eee76531d7cf8afdc45358

Passed Non-regression VLTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 118266 W: 30263 L: 30148 D: 57855
Ptnml(0-2): 11, 11844, 35309, 11957, 12
https://tests.stockfishchess.org/tests/view/67f2414a31d7cf8afdc45760