### PR TITLE
Simplification: move node increment inside do_move function.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -557,6 +557,7 @@ void Search::Worker::do_move(Position& pos, const Move move, StateInfo& st) {
 
 void Search::Worker::do_move(Position& pos, const Move move, StateInfo& st, const bool givesCheck) {
     DirtyPiece dp = pos.do_move(move, st, givesCheck, &tt);
+    nodes.fetch_add(1, std::memory_order_relaxed);
     accumulatorStack.push(dp);
 }
 
@@ -940,7 +941,6 @@ Value Search::Worker::search(
             movedPiece = pos.moved_piece(move);
 
             do_move(pos, move, st);
-            thisThread->nodes.fetch_add(1, std::memory_order_relaxed);
 
             ss->currentMove = move;
             ss->isTTMove    = (move == ttData.move);
@@ -1181,7 +1181,6 @@ moves_loop:  // When in check, search starts here
 
         // Step 16. Make the move
         do_move(pos, move, st, givesCheck);
-        thisThread->nodes.fetch_add(1, std::memory_order_relaxed);
 
         // Add extension to new depth
         newDepth += extension;
@@ -1698,7 +1697,6 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
         Piece movedPiece = pos.moved_piece(move);
 
         do_move(pos, move, st, givesCheck);
-        thisThread->nodes.fetch_add(1, std::memory_order_relaxed);
 
         // Update the current move
         ss->currentMove = move;


### PR DESCRIPTION
Move node increment inside do_move function so that we can centralize the increment into a single point.

no functional change
bench: 1887897