### PR TITLE
skip 5th conthist

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1890,7 +1890,7 @@ void update_all_stats(const Position&      pos,
 // at ply -1, -2, -3, -4, and -6 with current move.
 void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
     static constexpr std::array<ConthistBonus, 6> conthist_bonuses = {
-      {{1, 1103}, {2, 659}, {3, 323}, {4, 533}, {5, 121}, {6, 474}}};
+      {{1, 1103}, {2, 659}, {3, 323}, {4, 533}, {6, 474}}};
 
     for (const auto [i, weight] : conthist_bonuses)
     {


### PR DESCRIPTION
Skip 5th continuation history

Passed simplification STC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 70208 W: 18098 L: 17914 D: 34196
Ptnml(0-2): 199, 8300, 17907, 8514, 184
https://tests.stockfishchess.org/tests/view/67ed889b31d7cf8afdc451cb


Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 485004 W: 122703 L: 122956 D: 239345
Ptnml(0-2): 288, 53162, 135805, 53009, 238 
https://tests.stockfishchess.org/tests/view/67ee810231d7cf8afdc452ea

bench 1594667