### PR TITLE
Tweak TT Move Reduction by TT Move History

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1298,6 +1298,8 @@ moves_loop:  // When in check, search starts here
             if (!ttData.move)
                 r += 1156;
 
+            r -= ttMoveHistory[pawn_structure_index(pos)][us] / 8;
+
             // Note that if expected reduction is high, we reduce search depth here
             value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha,
                                    newDepth - (r > 3495) - (r > 5510 && newDepth > 2), !cutNode);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1298,7 +1298,7 @@ moves_loop:  // When in check, search starts here
             if (!ttData.move)
                 r += 1156;
 
-            r -= ttMoveHistory[pawn_structure_index(pos)][us] / 8;
+            r -= ttMoveHistory / 8;
 
             // Note that if expected reduction is high, we reduce search depth here
             value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha,


### PR DESCRIPTION
Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 62496 W: 16197 L: 15844 D: 30455
Ptnml(0-2): 200, 7234, 16011, 7619, 184
https://tests.stockfishchess.org/tests/view/67f7fa9b31d7cf8afdc4609c

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 400470 W: 102068 L: 101012 D: 197390
Ptnml(0-2): 201, 43207, 112347, 44295, 185
https://tests.stockfishchess.org/tests/view/67f927b0cd501869c66975e0

bench 1869867