### PR TITLE
Simplify ttpv condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -701,7 +701,7 @@ Value Search::Worker::search(
                  : ttHit    ? ttData.move
                             : Move::none();
     ttData.value = ttHit ? value_from_tt(ttData.value, ss->ply, pos.rule50_count()) : VALUE_NONE;
-    ss->ttPv     = excludedMove ? ss->ttPv : PvNode || (ttHit && ttData.is_pv);
+    ss->ttPv     = PvNode || (ttHit && ttData.is_pv);
     ttCapture    = ttData.move && pos.capture_stage(ttData.move);
 
     // At this point, if excluded, skip straight to step 6, static eval. However,


### PR DESCRIPTION
Don't set ttpv separately when excluded move

Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 60096 W: 15614 L: 15421 D: 29061
Ptnml(0-2): 185, 6965, 15524, 7220, 154 
https://tests.stockfishchess.org/tests/view/67f7361631d7cf8afdc45f9c

Passed rebased simplification VLTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 90162 W: 22982 L: 22840 D: 44340
Ptnml(0-2): 13, 8989, 26936, 9129, 14 
https://tests.stockfishchess.org/tests/view/6802d92ccd501869c6698211

bench 1705254