### PR TITLE
Do second step of shallower search in certain conditions.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1288,7 +1288,11 @@ moves_loop:  // When in check, search starts here
                 update_continuation_histories(ss, movedPiece, move.to_sq(), 1600);
             }
             else if (value > alpha && value < bestValue + 9)
+            {
                 newDepth--;
+                if (value < bestValue + 3)
+                    newDepth--;
+            }
         }
 
         // Step 18. Full-depth search when LMR is skipped


### PR DESCRIPTION
Specifically if lmr depth is not lower than new depth and value is really bad.
Passed STC:
https://tests.stockfishchess.org/tests/view/6805444898cd372e3aea0494
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 77664 W: 20136 L: 19762 D: 37766
Ptnml(0-2): 214, 9006, 20039, 9338, 235 
Passed LTC:
https://tests.stockfishchess.org/tests/view/680549b298cd372e3aea05ac
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 115458 W: 29447 L: 28971 D: 57040
Ptnml(0-2): 62, 12357, 32421, 12821, 68 
bench 1697708