### PR TITLE
Re-adding the 5th continuation history

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1917,7 +1917,7 @@ void update_all_stats(const Position&      pos,
 // at ply -1, -2, -3, -4, and -6 with current move.
 void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
     static constexpr std::array<ConthistBonus, 6> conthist_bonuses = {
-      {{1, 1103}, {2, 659}, {3, 323}, {4, 533}, {6, 474}}};
+      {{1, 1103}, {2, 659}, {3, 323}, {4, 533}, {5, 121}, {6, 474}}};
 
     for (const auto [i, weight] : conthist_bonuses)
     {


### PR DESCRIPTION
Re-adding the 5th continuation history
This is why I was against #5992 before verifying that it's safe to remove it either against #5978 , or to merge both simplifications and test against master, because the two simplifications are strongly correlated.

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 98016 W: 25415 L: 25008 D: 47593
Ptnml(0-2): 291, 11509, 25005, 11908, 295
https://tests.stockfishchess.org/tests/view/6802774fcd501869c6698168

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 588588 W: 150073 L: 148633 D: 289882
Ptnml(0-2): 281, 63615, 165078, 65023, 297
https://tests.stockfishchess.org/tests/view/6804cbdacd501869c66987dc


bench: 1792850