### PR TITLE
Prefer discovered and double checks in capture ordering.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -146,7 +146,11 @@ void MovePicker::score() {
     for (auto& m : *this)
         if constexpr (Type == CAPTURES)
             m.value =
-              7 * int(PieceValue[pos.piece_on(m.to_sq())])
+              (2
+                 * (pos.blockers_for_king(~pos.side_to_move()) & m.from_sq()
+                    && !aligned(m.from_sq(), m.to_sq(), pos.square<KING>(~pos.side_to_move())))
+               + 7)
+                * int(PieceValue[pos.piece_on(m.to_sq())])
               + (*captureHistory)[pos.moved_piece(m)][m.to_sq()][type_of(pos.piece_on(m.to_sq()))];
 
         else if constexpr (Type == QUIETS)


### PR DESCRIPTION
Increase weight for captured piece value if also a discovered or double check.

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 142144 W: 36632 L: 36164 D: 69348
Ptnml(0-2): 429, 16470, 36788, 16974, 411
https://tests.stockfishchess.org/tests/view/68052d7498cd372e3ae9faaa

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 668328 W: 170837 L: 169238 D: 328253
Ptnml(0-2): 308, 72010, 187990, 73487, 369
https://tests.stockfishchess.org/tests/view/68053c9398cd372e3aea043b

Bench: 1688284