### PR TITLE
Tweak futility formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1101,7 +1101,7 @@ moves_loop:  // When in check, search starts here
                 lmrDepth += history / 3593;
 
                 Value futilityValue = ss->staticEval + (bestMove ? 48 : 146) + 116 * lmrDepth
-                                    + 103 * (bestValue < ss->staticEval - 128);
+                                    + 103 * (bestValue < ss->staticEval - 128 && ss->staticEval > alpha - 50);
 
                 // Futility pruning: parent node
                 // (*Scaler): Generally, more frequent futility pruning


### PR DESCRIPTION
Only enable the static eval term if it is at least alpha minus fifty

Passed STC
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 248448 W: 64344 L: 63718 D: 120386
Ptnml(0-2): 750, 29172, 63783, 29740, 779 
https://tests.stockfishchess.org/tests/view/68056f5598cd372e3aea2901

Passed LTC
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 118824 W: 30358 L: 29874 D: 58592
Ptnml(0-2): 59, 12797, 33228, 13257, 71 
https://tests.stockfishchess.org/tests/view/6805675698cd372e3aea20d0

bench 1870596