### PR TITLE
Preserve all moves in movepicker

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -321,20 +321,20 @@ void MovePicker::skip_quiet_moves() { skipQuiets = true; }
 
 bool MovePicker::otherPieceTypesMobile(PieceType pt) {
     if (stage != GOOD_QUIET  && stage != BAD_QUIET)
-       return true;
+        return true;
 
     // verify all generated captures and quiets
-    for (ExtMove *c = moves; c < endBadQuiets; ++c)
+    for (ExtMove *m = moves; m < endBadQuiets; ++m)
     {
-       if (c->value == ILLEGALMOVE)
-          continue;
-       if (type_of(pos.moved_piece(*c)) != pt)
-       {
-         if (type_of(pos.moved_piece(*c)) != KING)
-           return true;
-         if (pos.legal(*c))
-           return true;
-       }
+        if (m->value == ILLEGALMOVE)
+            continue;
+        if (type_of(pos.moved_piece(*m)) != pt)
+        {
+            if (type_of(pos.moved_piece(*m)) != KING)
+               return true;
+            if (pos.legal(*m))
+               return true;
+        }
     }
     return false;
 }

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -241,7 +241,7 @@ top:
 
     case GOOD_CAPTURE :
         if (select([&]() {
-                // Score losing capture with 88888 to be tried later
+                // Score losing capture with BADCAPTURE to be tried later
                 return pos.see_ge(*cur, -cur->value / 18) ? true
                                                           : (cur->value = BADCAPTURE, false);
             }))

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -19,8 +19,8 @@
 #include "movepick.h"
 
 #include <cassert>
-#include <cstddef>
 #include <limits>
+#include <utility>
 
 #include "bitboard.h"
 #include "misc.h"

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -326,9 +326,7 @@ bool MovePicker::other_piece_types_mobile(PieceType pt) {
     // verify all generated captures and quiets
     for (ExtMove *m = moves; m < endMoves; ++m)
     {
-        if (!m->raw()) // marked illegal
-            continue;
-        if (type_of(pos.moved_piece(*m)) != pt)
+        if (*m && type_of(pos.moved_piece(*m)) != pt)
         {
             if (type_of(pos.moved_piece(*m)) != KING)
                return true;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -319,9 +319,6 @@ top:
 
 void MovePicker::skip_quiet_moves() { skipQuiets = true; }
 
-void MovePicker::markCurrent_Illegal() {
-   (cur-1)->value = ILLEGALMOVE;
-}
 bool MovePicker::otherPieceTypesMobile(PieceType pt) {
     if (stage != GOOD_QUIET  && stage != BAD_QUIET)
        return true;
@@ -342,5 +339,8 @@ bool MovePicker::otherPieceTypesMobile(PieceType pt) {
     return false;
 }
 
+void MovePicker::markCurrent_Illegal() {
+   (cur-1)->value = ILLEGALMOVE;
+}
 
 }  // namespace Stockfish

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -19,7 +19,6 @@
 #include "movepick.h"
 
 #include <cassert>
-#include <cstddef>
 #include <limits>
 
 #include "bitboard.h"

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -19,7 +19,6 @@
 #ifndef MOVEPICK_H_INCLUDED
 #define MOVEPICK_H_INCLUDED
 
-
 #include "history.h"
 #include "movegen.h"
 #include "types.h"
@@ -51,8 +50,8 @@ class MovePicker {
     MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
     Move next_move();
     void skip_quiet_moves();
-    bool otherPieceTypesMobile(PieceType pt);
-    void markCurrent_Illegal();
+    bool other_piece_types_mobile(PieceType pt);
+    void mark_current_illegal();
 
    private:
     template<typename Pred>
@@ -69,7 +68,7 @@ class MovePicker {
     const PieceToHistory**       continuationHistory;
     const PawnHistory*           pawnHistory;
     Move                         ttMove;
-    ExtMove *                    cur, *endMoves, *endCaptures, *beginBadQuiets, *endBadQuiets;
+    ExtMove *                    cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
     int                          stage;
     int                          threshold;
     Depth                        depth;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -19,7 +19,6 @@
 #ifndef MOVEPICK_H_INCLUDED
 #define MOVEPICK_H_INCLUDED
 
-#include <cstddef>
 
 #include "history.h"
 #include "movegen.h"
@@ -28,9 +27,6 @@
 namespace Stockfish {
 
 class Position;
-
-template<typename T, std::size_t MaxSize>
-class ValueList;
 
 // The MovePicker class is used to pick one pseudo-legal move at a time from the
 // current position. The most important method is next_move(), which emits one
@@ -55,7 +51,8 @@ class MovePicker {
     MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
     Move next_move();
     void skip_quiet_moves();
-    bool otherPieceTypesMobile(PieceType pt, ValueList<Move, 32>& capturesSearched);
+    bool otherPieceTypesMobile(PieceType pt);
+    void markCurrent_Illegal();
 
    private:
     template<typename Pred>
@@ -72,7 +69,7 @@ class MovePicker {
     const PieceToHistory**       continuationHistory;
     const PawnHistory*           pawnHistory;
     Move                         ttMove;
-    ExtMove *                    cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
+    ExtMove *                    cur, *endMoves, *endCaptures, *beginBadQuiets, *endBadQuiets;
     int                          stage;
     int                          threshold;
     Depth                        depth;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1012,7 +1012,7 @@ moves_loop:  // When in check, search starts here
         // Check for legality
         if (!pos.legal(move))
         {
-           mp.markCurrent_Illegal();
+           mp.mark_current_illegal();
            continue;
         }
         // At root obey the "searchmoves" option and skip moves not listed in Root
@@ -1086,7 +1086,7 @@ moves_loop:  // When in check, search starts here
                         && pos.non_pawn_material(us) == PieceValue[movedPiece]
                         && PieceValue[movedPiece] >= RookValue
                         && !(PseudoAttacks[KING][pos.square<KING>(us)] & move.from_sq()))
-                        skip = mp.otherPieceTypesMobile(type_of(movedPiece));  // if the opponent captures last mobile piece it might be stalemate
+                        skip = mp.other_piece_types_mobile(type_of(movedPiece));  // if the opponent captures last mobile piece it might be stalemate
 
                     if (skip)
                         continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1086,7 +1086,8 @@ moves_loop:  // When in check, search starts here
                         && pos.non_pawn_material(us) == PieceValue[movedPiece]
                         && PieceValue[movedPiece] >= RookValue
                         && !(PseudoAttacks[KING][pos.square<KING>(us)] & move.from_sq()))
-                        skip = mp.other_piece_types_mobile(type_of(movedPiece));  // if the opponent captures last mobile piece it might be stalemate
+                        // if the opponent captures last mobile piece it might be stalemate
+                        skip = mp.other_piece_types_mobile(type_of(movedPiece));
 
                     if (skip)
                         continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1011,8 +1011,10 @@ moves_loop:  // When in check, search starts here
 
         // Check for legality
         if (!pos.legal(move))
-            continue;
-
+        {
+           mp.markCurrent_Illegal();
+           continue;
+        }
         // At root obey the "searchmoves" option and skip moves not listed in Root
         // Move List. In MultiPV mode we also skip PV moves that have been already
         // searched and those of lower "TB rank" if we are in a TB root position.
@@ -1084,9 +1086,7 @@ moves_loop:  // When in check, search starts here
                         && pos.non_pawn_material(us) == PieceValue[movedPiece]
                         && PieceValue[movedPiece] >= RookValue
                         && !(PseudoAttacks[KING][pos.square<KING>(us)] & move.from_sq()))
-                        skip = mp.otherPieceTypesMobile(
-                          type_of(movedPiece),
-                          capturesSearched);  // if the opponent captures last mobile piece it might be stalemate
+                        skip = mp.otherPieceTypesMobile(type_of(movedPiece));  // if the opponent captures last mobile piece it might be stalemate
 
                     if (skip)
                         continue;


### PR DESCRIPTION
Simplifies method otherPieceTypesMobile quite a bit and makes it more precise.
More precise because capturesSearched list not always contains all processed captures:
although extremely rare, it can happen that a 'good' capture get pruned at step 14 and doesn't make it to capturesSearched. (functional change at higher depths)

passed STC-simplification bounds
https://tests.stockfishchess.org/tests/view/68025974cd501869c6698153
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 273664 W: 15658 L: 15681 D: 242325
Ptnml(0-2): 166, 10368, 115802, 10315, 181 

passed LTC-simplification bounds
https://tests.stockfishchess.org/tests/view/6804b86acd501869c6698673
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 96780 W: 24547 L: 24419 D: 47814
Ptnml(0-2): 30, 8466, 31286, 8562, 46 

Applied changes requested by disservin & retested to be on the safe side

STC:
https://tests.stockfishchess.org/tests/view/6806110698cd372e3aea5919
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 107392 W: 27739 L: 27606 D: 52047
Ptnml(0-2): 266, 10867, 31306, 10982, 275

LTC:
https://tests.stockfishchess.org/tests/view/6806346198cd372e3aea5965
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 233484 W: 59106 L: 59103 D: 115275
Ptnml(0-2): 116, 22787, 70939, 22778, 122

TODO: 
maybe we should move legality check into movepicker, so Movepicker::mark_current_illegal could be simplified away again.

bench: 1857323