### PR TITLE
Remove manual stack alignment workaround for GCC < 9.3

### DIFF
--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -212,21 +212,11 @@ NetworkOutput
 Network<Arch, Transformer>::evaluate(const Position&                         pos,
                                      AccumulatorStack&                       accumulatorStack,
                                      AccumulatorCaches::Cache<FTDimensions>* cache) const {
-    // We manually align the arrays on the stack because with gcc < 9.3
-    // overaligning stack variables with alignas() doesn't work correctly.
 
     constexpr uint64_t alignment = CacheLineSize;
 
-#if defined(ALIGNAS_ON_STACK_VARIABLES_BROKEN)
-    TransformedFeatureType
-      transformedFeaturesUnaligned[FeatureTransformer<FTDimensions>::BufferSize
-                                   + alignment / sizeof(TransformedFeatureType)];
-
-    auto* transformedFeatures = align_ptr_up<alignment>(&transformedFeaturesUnaligned[0]);
-#else
     alignas(alignment)
       TransformedFeatureType transformedFeatures[FeatureTransformer<FTDimensions>::BufferSize];
-#endif
 
     ASSERT_ALIGNED(transformedFeatures, alignment);
 
@@ -284,20 +274,11 @@ NnueEvalTrace
 Network<Arch, Transformer>::trace_evaluate(const Position&                         pos,
                                            AccumulatorStack&                       accumulatorStack,
                                            AccumulatorCaches::Cache<FTDimensions>* cache) const {
-    // We manually align the arrays on the stack because with gcc < 9.3
-    // overaligning stack variables with alignas() doesn't work correctly.
-    constexpr uint64_t alignment = CacheLineSize;
 
-#if defined(ALIGNAS_ON_STACK_VARIABLES_BROKEN)
-    TransformedFeatureType
-      transformedFeaturesUnaligned[FeatureTransformer<FTDimensions>::BufferSize
-                                   + alignment / sizeof(TransformedFeatureType)];
+constexpr uint64_t alignment = CacheLineSize;
 
-    auto* transformedFeatures = align_ptr_up<alignment>(&transformedFeaturesUnaligned[0]);
-#else
     alignas(alignment)
       TransformedFeatureType transformedFeatures[FeatureTransformer<FTDimensions>::BufferSize];
-#endif
 
     ASSERT_ALIGNED(transformedFeatures, alignment);
 

--- a/src/types.h
+++ b/src/types.h
@@ -57,11 +57,6 @@
 // _WIN32                  Building on Windows (any)
 // _WIN64                  Building on Windows 64 bit
 
-    #if defined(__GNUC__) && (__GNUC__ < 9 || (__GNUC__ == 9 && __GNUC_MINOR__ <= 2)) \
-      && defined(_WIN32) && !defined(__clang__)
-        #define ALIGNAS_ON_STACK_VARIABLES_BROKEN
-    #endif
-
     #define ASSERT_ALIGNED(ptr, alignment) assert(reinterpret_cast<uintptr_t>(ptr) % alignment == 0)
 
     #if defined(_WIN64) && defined(_MSC_VER)  // No Makefile used

--- a/src/types.h
+++ b/src/types.h
@@ -57,6 +57,10 @@
 // _WIN32                  Building on Windows (any)
 // _WIN64                  Building on Windows 64 bit
 
+    #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 9 || (__GNUC__ == 9 && __GNUC_MINOR__ < 3))
+        #error "Stockfish requires GCC 9.3 or later for correct compilation"
+    #endif
+
     #define ASSERT_ALIGNED(ptr, alignment) assert(reinterpret_cast<uintptr_t>(ptr) % alignment == 0)
 
     #if defined(_WIN64) && defined(_MSC_VER)  // No Makefile used


### PR DESCRIPTION
Removes the manual stack alignment workaround previously needed for GCC < 9.3, which is no longer necessary after: https://github.com/official-stockfish/fishtest/pull/2282

P.s:
I kept the ASSERT_ALIGNED check following the declaration. This is an optional debug-build check to verify the compiler correctly applied alignas(). It can be removed, but I think it provides a low-cost sanity check. Let me know if you want me to remove those as well.