### PR TITLE
bench 1600362

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Artem Solopiy (EntityFX)
 Auguste Pop
 Balazs Szilagyi
 Balint Pfliegel
+Baptiste Rech
 Ben Chaney (Chaneybenjamini)
 Ben Koshy (BKSpurgeon)
 Bill Henry (VoyagerOne)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -128,6 +128,23 @@ Value to_corrected_static_eval(const Value v, const int cv) {
     return std::clamp(v + cv / 131072, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
 }
 
+auto adaptiveProbCutMargin = [](int depth) -> int {
+    // Base margin — can tune this as needed
+    constexpr int base = 180;
+
+    // Approximate log2(depth) using a fast lookup table
+    static constexpr int logTable[32] = {
+        0, 0, 1, 1, 2, 2, 2, 2,
+        3, 3, 3, 3, 3, 3, 3, 3,
+        4, 4, 4, 4, 4, 4, 4, 4,
+        4, 4, 4, 4, 4, 4, 4, 4
+    };
+
+    int logDepth = logTable[std::min(depth, 31)];
+    return base + logDepth * 60 + std::min(10, (depth - 16) * 2);
+};
+
+
 void update_correction_history(const Position& pos,
                                Stack* const    ss,
                                Search::Worker& workerThread,
@@ -974,7 +991,7 @@ Value Search::Worker::search(
 moves_loop:  // When in check, search starts here
 
     // Step 12. A small Probcut idea
-    probCutBeta = beta + 415;
+    probCutBeta = beta + adaptiveProbCutMargin(depth);
     if ((ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4 && ttData.value >= probCutBeta
         && !is_decisive(beta) && is_valid(ttData.value) && !is_decisive(ttData.value))
         return probCutBeta;


### PR DESCRIPTION
Replace probcut beta using a depth adaptive formula. 

STC: https://tests.stockfishchess.org/tests/live_elo/680604d798cd372e3aea58fe
LTC: https://tests.stockfishchess.org/tests/view/6805eae498cd372e3aea588a

bench 1600362