### PR TITLE
Remove unnecessary return statement

### DIFF
--- a/src/memory.h
+++ b/src/memory.h
@@ -52,7 +52,6 @@ void memory_deleter(T* ptr, FREE_FUNC free_func) {
         ptr->~T();
 
     free_func(ptr);
-    return;
 }
 
 // Frees memory which was placed there with placement new.


### PR DESCRIPTION
Remove an unnecessary return statement, as it automatically returns at the end of a void function. 

Non- functional
bench: 1715901