### PR TITLE
Remove an unnecessary update for the smallNet variable.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -69,7 +69,6 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     {
         std::tie(psqt, positional) = networks.big.evaluate(pos, accumulators, &caches.big);
         nnue                       = (125 * psqt + 131 * positional) / 128;
-        smallNet                   = false;
     }
 
     // Blend optimism and eval with nnue complexity


### PR DESCRIPTION
Remove an unnecessary update for the smallNet variable.
The variable smallNet is not read or used anywhere after this block.

When it was introduced in #5244 it used to be functional, and it had a purpose. But now no more.

Non-functional
bench: 1715901