### PR TITLE
Simplify and cleanup futility pruning for child nodes.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -71,12 +71,14 @@ namespace {
 // tests at these types of time controls.
 
 // Futility margin
-Value futility_margin(Depth d, bool noTtCutNode, bool improving, bool oppWorsening) {
-    Value futilityMult       = 110 - 25 * noTtCutNode;
+Value futility_margin(Depth d, bool noTtCutNode, bool improving, bool oppWorsening, int statScore, int correctionValue) {
+    Value futilityMult       = 98 - 22 * noTtCutNode;
     Value improvingDeduction = improving * futilityMult * 2;
     Value worseningDeduction = oppWorsening * futilityMult / 3;
+    Value statScoreAddition  = statScore / 339;
+    Value correctionAddition = correctionValue / 157363;
 
-    return futilityMult * d - improvingDeduction - worseningDeduction;
+    return futilityMult * d - improvingDeduction - worseningDeduction + statScoreAddition + correctionAddition;
 }
 
 constexpr int futility_move_count(bool improving, Depth depth) {
@@ -856,10 +858,8 @@ Value Search::Worker::search(
     // Step 8. Futility pruning: child node
     // The depth condition is important for mate finding.
     if (!ss->ttPv && depth < 14
-        && eval - futility_margin(depth, cutNode && !ss->ttHit, improving, opponentWorsening)
-               - (ss - 1)->statScore / 301 + 37 + ((eval - beta) / 8)
-               - std::abs(correctionValue) / 139878
-             >= beta
+        && eval - futility_margin(depth, cutNode && !ss->ttHit, improving, opponentWorsening, (ss - 1)->statScore, std::abs(correctionValue))
+                >= beta
         && eval >= beta && (!ttData.move || ttCapture) && !is_loss(beta) && !is_win(eval))
         return beta + (eval - beta) / 3;
 


### PR DESCRIPTION
This patch removes (eval - beta) / 8 addition and adjusts constants accordingly, also moves every calculation into futility_margin function.
Passed STC:
https://tests.stockfishchess.org/tests/view/6806d00f878abf56f9a0d524
LLR: 2.99 (-2.94,2.94) <-1.75,0.25>
Total: 483456 W: 124592 L: 124860 D: 234004
Ptnml(0-2): 1419, 57640, 123927, 57274, 1468 
Passed LTC:
https://tests.stockfishchess.org/tests/view/680cceb33629b02d74b1554c
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 263868 W: 67076 L: 67104 D: 129688
Ptnml(0-2): 155, 28893, 73846, 28905, 135 
bench 1754741