### PR TITLE
Allow some nodes to spawn even deeper lmr searches.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -690,6 +690,7 @@ Value Search::Worker::search(
     (ss + 2)->cutoffCnt = 0;
     Square prevSq = ((ss - 1)->currentMove).is_ok() ? ((ss - 1)->currentMove).to_sq() : SQ_NONE;
     ss->statScore = 0;
+    ss->isPvNode = PvNode;
 
     // Step 4. Transposition table lookup
     excludedMove                   = ss->excludedMove;
@@ -1263,7 +1264,7 @@ moves_loop:  // When in check, search starts here
 
 
             Depth d = std::max(
-              1, std::min(newDepth - r / 1024, newDepth + !allNode + (PvNode && !bestMove)));
+              1, std::min(newDepth - r / 1024, newDepth + !allNode + (PvNode && !bestMove))) + (!cutNode && (ss - 1)->isPvNode && moveCount < 8);
 
             ss->reduction = newDepth - d;
 

--- a/src/search.h
+++ b/src/search.h
@@ -76,6 +76,7 @@ struct Stack {
     int                         cutoffCnt;
     int                         reduction;
     bool                        isTTMove;
+    bool                        isPvNode;
 };
 
 


### PR DESCRIPTION
This includes nodes that were PvNode on a previous ply and only for non cutNodes and movecounts < 8.
Passed STC:
https://tests.stockfishchess.org/tests/view/680cdf2e3629b02d74b15576
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 123552 W: 31979 L: 31539 D: 60034
Ptnml(0-2): 322, 14449, 31803, 14871, 331 
https://tests.stockfishchess.org/tests/view/680cf09a3629b02d74b15599
Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 114306 W: 29310 L: 28837 D: 56159
Ptnml(0-2): 51, 12247, 32090, 12708, 57 
bench 1935441