### PR TITLE
Simplify move ordering bonuses for putting piece en prise and escaping capture

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -173,11 +173,11 @@ void MovePicker::score() {
 
             // penalty for moving to a square threatened by a lesser piece
             // or bonus for escaping an attack by a lesser piece.
-            constexpr int bonus[4] = {14000, 14000, 24970, 50350};
-            if ( KNIGHT <= pt && pt <= QUEEN )
+            constexpr int bonus[4] = {144, 144, 256, 517};
+            if (KNIGHT <= pt && pt <= QUEEN)
                 m.value += bonus[pt - 2] * (threat_by_lesser[pt - 2] & to
-                                            ? -1
-                                            : bool(threat_by_lesser[pt - 2] & from));
+                                            ? -95
+                                            : 100 * bool(threat_by_lesser[pt - 2] & from));
 
             if (ply < LOW_PLY_HISTORY_SIZE)
                 m.value += 8 * (*lowPlyHistory)[ply][m.from_to()] / (1 + 2 * ply);


### PR DESCRIPTION
passed STC: https://tests.stockfishchess.org/tests/view/68074379878abf56f9a0d5b1
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 96512 W: 24841 L: 24687 D: 46984
Ptnml(0-2): 294, 11336, 24835, 11504, 287

passed LTC: https://tests.stockfishchess.org/tests/view/6808954a878abf56f9a0d76d
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 221328 W: 56271 L: 56255 D: 108802
Ptnml(0-2): 131, 24149, 62071, 24199, 114 

Now there is also a penalty for exposing knights and bishops to capture by a pawn.