### PR TITLE
Improve the conditions under which a bonus is applied to quiet moves based on history heuristics

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -844,7 +844,7 @@ Value Search::Worker::search(
     }
 
     // Use static evaluation difference to improve quiet move ordering
-    if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture)
+    if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture && (ttData.depth - 2) <= depth)
     {
         int bonus = std::clamp(-10 * int((ss - 1)->staticEval + ss->staticEval), -1950, 1416) + 655;
         thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()] << bonus * 1124 / 1024;


### PR DESCRIPTION
Improve the conditions under which a bonus is applied to quiet moves based on history heuristics.
Inspired by an old test of Peregrine.

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 453024 W: 117244 L: 116316 D: 219464
Ptnml(0-2): 1336, 53355, 116258, 54171, 1392
https://tests.stockfishchess.org/tests/view/680ccacc3629b02d74b15532

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 140550 W: 35990 L: 35462 D: 69098
Ptnml(0-2): 65, 15152, 39319, 15668, 71
https://tests.stockfishchess.org/tests/view/680d2ed73629b02d74b15691

bench: 1729229