### PR TITLE
Simplify Evasion Move Scoring

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -194,8 +194,7 @@ void MovePicker::score() {
                 m.value = PieceValue[pos.piece_on(m.to_sq())] + (1 << 28);
             else
                 m.value = (*mainHistory)[pos.side_to_move()][m.from_to()]
-                        + (*continuationHistory[0])[pos.moved_piece(m)][m.to_sq()]
-                        + (*pawnHistory)[pawn_structure_index(pos)][pos.moved_piece(m)][m.to_sq()];
+                        + (*continuationHistory[0])[pos.moved_piece(m)][m.to_sq()];
         }
 }
 


### PR DESCRIPTION
Simplify Evasion Move Scoring

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 160256 W: 41432 L: 41348 D: 77476
Ptnml(0-2): 485, 19034, 41028, 19074, 507
https://tests.stockfishchess.org/tests/view/680d242c3629b02d74b15662

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 103086 W: 26388 L: 26252 D: 50446
Ptnml(0-2): 41, 11174, 28982, 11300, 46
https://tests.stockfishchess.org/tests/view/680d47f83629b02d74b1571e

bench: 1626674