### PR TITLE
Tweak Bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1968,12 +1968,14 @@ void update_quiet_histories(
     workerThread.mainHistory[us][move.from_to()] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.from_to()] << bonus * 829 / 1024;
+        workerThread.lowPlyHistory[ss->ply][move.from_to()] << bonus * 800 / 1024;
 
-    update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 1004 / 1024);
+    update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(),
+                                  bonus * (bonus > 0 ? 1094 : 790) / 1024);
 
     int pIndex = pawn_structure_index(pos);
-    workerThread.pawnHistory[pIndex][pos.moved_piece(move)][move.to_sq()] << bonus * 587 / 1024;
+    workerThread.pawnHistory[pIndex][pos.moved_piece(move)][move.to_sq()]
+      << bonus * (bonus > 0 ? 725 : 460) / 1024;
 }
 
 }


### PR DESCRIPTION
Inspired by @Ergodice , who came up first with the idea.
It is currently being tuned at VLTC to adjust the values toward higher time controls.

Passed STC:
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 18400 W: 4867 L: 4576 D: 8957
Ptnml(0-2): 52, 2052, 4714, 2317, 65
https://tests.stockfishchess.org/tests/view/68062a3c98cd372e3aea5959

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 454338 W: 116461 L: 115294 D: 222583
Ptnml(0-2): 198, 49139, 127346, 50270, 216
https://tests.stockfishchess.org/tests/view/6806347c98cd372e3aea5967

Passed VLTC non-reg:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 385970 W: 98401 L: 98546 D: 189023
Ptnml(0-2): 51, 38958, 115105, 38827, 44
https://tests.stockfishchess.org/tests/view/680cfe873629b02d74b155cf

bench: 2051566