### PR TITLE
Do more pruning in moves loop.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1053,8 +1053,6 @@ moves_loop:  // When in check, search starts here
 
         Depth r = reduction(improving, depth, moveCount, delta);
 
-        r -= 32 * moveCount;
-
         // Increase reduction for ttPv nodes (*Scaler)
         // Smaller or even negative value is better for short time controls
         // Bigger value is better for long time controls
@@ -1233,7 +1231,7 @@ moves_loop:  // When in check, search starts here
 
         // These reduction adjustments have no proven non-linear scaling
 
-        r += 306 - moveCount * 34;
+        r += 306 - moveCount * 66;
 
         r -= std::abs(correctionValue) / 29696;
 


### PR DESCRIPTION
Effectively reverts one commit from some months ago.
Passed VVLTC SPRT with STC bounds - 
https://tests.stockfishchess.org/tests/view/680d39373629b02d74b156d7
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 405058 W: 104843 L: 104111 D: 196104
Ptnml(0-2): 35, 38029, 125672, 38755, 38 
Passed VVLTC SPRT with LTC bounds - 
https://tests.stockfishchess.org/tests/view/680d1a3b3629b02d74b1563d
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 57032 W: 14917 L: 14588 D: 27527
Ptnml(0-2): 6, 5202, 17768, 5537, 3 
bench 1746048