### PR TITLE
Simplify second probcut to linear function of depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -111,18 +111,6 @@ Value to_corrected_static_eval(const Value v, const int cv) {
     return std::clamp(v + cv / 131072, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
 }
 
-int adaptive_probcut_margin(Depth depth) {
-    // Base margin
-    constexpr int base = 180;
-
-    // Approximate log2(depth) using a fast lookup table
-    static constexpr int logTable[32] = {0, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3,
-                                         4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
-
-    int logDepth = logTable[std::min(depth, 31)];
-    return base + logDepth * 60 + std::min(10, (depth - 16) * 2);
-};
-
 void update_correction_history(const Position& pos,
                                Stack* const    ss,
                                Search::Worker& workerThread,
@@ -993,7 +981,7 @@ Value Search::Worker::search(
 moves_loop:  // When in check, search starts here
 
     // Step 12. A small Probcut idea
-    probCutBeta = beta + adaptive_probcut_margin(depth);
+    probCutBeta = beta + 180 + depth * 20;
     if ((ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4 && ttData.value >= probCutBeta
         && !is_decisive(beta) && is_valid(ttData.value) && !is_decisive(ttData.value))
         return probCutBeta;


### PR DESCRIPTION
Simplify second probcut to linear function of depth

Passed non-regression STC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 57472 W: 14962 L: 14765 D: 27745
Ptnml(0-2): 140, 6715, 14817, 6936, 128 
https://tests.stockfishchess.org/tests/view/680df1063629b02d74b15b69

Passed non-regression LTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 88416 W: 22499 L: 22348 D: 43569
Ptnml(0-2): 31, 9565, 24874, 9698, 40 
https://tests.stockfishchess.org/tests/view/680df3a93629b02d74b15b7d

Bench: 1814651