### PR TITLE
Remove risk tolerance

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -28,7 +28,6 @@
 #include <cstdlib>
 #include <initializer_list>
 #include <iostream>
-#include <limits>
 #include <list>
 #include <ratio>
 #include <string>
@@ -131,29 +130,6 @@ void update_correction_history(const Position& pos,
     if (m.is_ok())
         (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
           << bonus * 141 / 128;
-}
-
-int risk_tolerance(Value v) {
-    // Returns (some constant of) second derivative of sigmoid.
-    static constexpr auto sigmoid_d2 = [](int x, int y) {
-        return 631760 * x / ((x * x + 3 * y * y) * y);
-    };
-
-    // a and b are the crude approximation of the wdl model.
-    // The win rate is: 1/(1+exp((a-v)/b))
-    // The loss rate is 1/(1+exp((v+a)/b))
-    int a = 340;
-    int b = 122;
-
-    // guard against overflow
-    assert(abs(v) + a <= std::numeric_limits<int>::max() / 644800);
-
-    // The risk utility is therefore d/dv^2 (1/(1+exp(-(v-a)/b)) -1/(1+exp(-(-v-a)/b)))
-    // -115200x/(x^2+3) = -345600(ab) / (a^2+3b^2) (multiplied by some constant) (second degree pade approximant)
-    int winning_risk = sigmoid_d2(v - a, b);
-    int losing_risk  = sigmoid_d2(v + a, b);
-
-    return -(winning_risk + losing_risk) * 32;
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
@@ -1224,9 +1200,6 @@ moves_loop:  // When in check, search starts here
         r += 316;  // Base reduction offset to compensate for other tweaks
         r -= moveCount * 66;
         r -= std::abs(correctionValue) / 28047;
-
-        if (PvNode && std::abs(bestValue) <= 2078)
-            r -= risk_tolerance(bestValue);
 
         // Increase reduction for cut nodes
         if (cutNode)


### PR DESCRIPTION
Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 379328 W: 97567 L: 97724 D: 184037
Ptnml(0-2): 909, 44861, 98314, 44638, 942
https://tests.stockfishchess.org/tests/view/680defc63629b02d74b15b62

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 160752 W: 40762 L: 40685 D: 79305
Ptnml(0-2): 60, 17548, 45091, 17609, 68
https://tests.stockfishchess.org/tests/view/680e8ff43629b02d74b15e65

bench 2033045