### PR TITLE
Another scaling revert

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1277,6 +1277,8 @@ moves_loop:  // When in check, search starts here
             ss->reduction = 0;
 
             // Do a full-depth search when reduced LMR search fails high
+            // (*Scaler) Usually doing more shallower searches
+            // doesn't scale well to longer TCs
             if (value > alpha && d < newDepth)
             {
                 // Adjust full-depth search based on LMR results - if the result was
@@ -1293,11 +1295,7 @@ moves_loop:  // When in check, search starts here
                 update_continuation_histories(ss, movedPiece, move.to_sq(), 1508);
             }
             else if (value > alpha && value < bestValue + 9)
-            {
                 newDepth--;
-                if (value < bestValue + 4)
-                    newDepth--;
-            }
         }
 
         // Step 18. Full-depth search when LMR is skipped


### PR DESCRIPTION
Revert recent passer because it seems to not scale for longer time controls.
Adjust comments accordingly.
Passed VVLTC SPRT with STC bounds:
https://tests.stockfishchess.org/tests/view/680ddff73629b02d74b15b3f
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 198316 W: 51317 L: 50846 D: 96153
Ptnml(0-2): 17, 18459, 61737, 18926, 19 
Passed VVLTC SPRT with LTC bounds:
https://tests.stockfishchess.org/tests/view/680d5b7e3629b02d74b15a21
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 123274 W: 31738 L: 31283 D: 60253
Ptnml(0-2): 7, 11444, 38282, 11895, 9 
bench 2106162