### PR TITLE
Adding a small term to the futility calculation that depends on eval - beta #2

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -865,7 +865,7 @@ Value Search::Worker::search(
     // Step 8. Futility pruning: child node
     // The depth condition is important for mate finding.
     if (!ss->ttPv && depth < 14
-        && eval
+        && eval + (eval - beta) / 8
                - futility_margin(depth, cutNode && !ss->ttHit, improving, opponentWorsening,
                                  (ss - 1)->statScore, std::abs(correctionValue))
              >= beta


### PR DESCRIPTION
dding a small term to the futility calculation that depends on eval - beta.

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 203136 W: 52797 L: 52239 D: 98100
Ptnml(0-2): 549, 23827, 52255, 24391, 546
https://tests.stockfishchess.org/tests/view/680e84a43629b02d74b15e2e

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 100356 W: 25950 L: 25507 D: 48899
Ptnml(0-2): 35, 10683, 28302, 11120, 38
https://tests.stockfishchess.org/tests/view/680ebcb03629b02d74b16040

bench: 1815939