### PR TITLE
Simplify ttCapture LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1233,7 +1233,7 @@ moves_loop:  // When in check, search starts here
             r += 2864 + 966 * !ttData.move;
 
         // Increase reduction if ttMove is a capture but the current move is not a capture
-        if (ttCapture && !capture)
+        if (ttCapture)
             r += 1210 + (depth < 8) * 963;
 
         // Increase reduction if next ply has a lot of fail high


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 51104 W: 13389 L: 13184 D: 24531
Ptnml(0-2): 182, 5940, 13068, 6215, 147
https://tests.stockfishchess.org/tests/view/680ef2503629b02d74b16498

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 73350 W: 18804 L: 18638 D: 35908
Ptnml(0-2): 30, 7906, 20639, 8068, 32
https://tests.stockfishchess.org/tests/view/6810510e3629b02d74b1668a

bench 1779175