### PR TITLE
Refactor Position::pseudo_legal Pawn Move Check

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -597,10 +597,14 @@ bool Position::pseudo_legal(const Move m) const {
         if ((Rank8BB | Rank1BB) & to)
             return false;
 
-        if (!(attacks_bb<PAWN>(from, us) & pieces(~us) & to)  // Not a capture
-            && !((from + pawn_push(us) == to) && empty(to))   // Not a single push
-            && !((from + 2 * pawn_push(us) == to)             // Not a double push
-                 && (relative_rank(us, from) == RANK_2) && empty(to) && empty(to - pawn_push(us))))
+        // Check if it's a valid capture, single push, or double push
+        bool isCapture = bool(attacks_bb<PAWN>(from, us) & pieces(~us) & to);
+        bool isSinglePush = (from + pawn_push(us) == to) && empty(to);
+        bool isDoublePush = (from + 2 * pawn_push(us) == to)
+                            && (relative_rank(us, from) == RANK_2)
+                            && empty(to) && empty(to - pawn_push(us));
+
+        if (!(isCapture || isSinglePush || isDoublePush))
             return false;
     }
     else if (!(attacks_bb(type_of(pc), from, pieces()) & to))


### PR DESCRIPTION
Refactor Position::pseudo_legal Pawn Move Check

The original code used a single, complex if statement with many negated conditions to determine if a pawn move was not valid. The modified code first calculates boolean flags for each valid pawn move type. It then uses a simpler if statement to check if the move matches none of these valid types. While this introduces intermediate boolean variables, it arguably makes the final condition easier to read by separating the logic for each move type.

non functional
bench: 1857323