### PR TITLE
Simplify Captures scoring

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -145,11 +145,8 @@ void MovePicker::score() {
     for (auto& m : *this)
         if constexpr (Type == CAPTURES)
             m.value =
-              (2
-                 * (pos.blockers_for_king(~pos.side_to_move()) & m.from_sq()
-                    && !aligned(m.from_sq(), m.to_sq(), pos.square<KING>(~pos.side_to_move())))
-               + 7)
-                * int(PieceValue[pos.piece_on(m.to_sq())])
+                7 * int(PieceValue[pos.piece_on(m.to_sq())])
+              + 1024 * bool(pos.check_squares(type_of(pos.moved_piece(m))) & m.to_sq())
               + (*captureHistory)[pos.moved_piece(m)][m.to_sq()][type_of(pos.piece_on(m.to_sq()))];
 
         else if constexpr (Type == QUIETS)


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/680ee3b43629b02d74b160f3
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 200896 W: 52089 L: 52048 D: 96759
Ptnml(0-2): 592, 23821, 51589, 23846, 600 

LTC https://tests.stockfishchess.org/tests/view/68106adf3629b02d74b166b1
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 128856 W: 33026 L: 32917 D: 62913
Ptnml(0-2): 54, 13916, 36384, 14015, 59 

Replaces discovered checks by direct checks which are simpler and more common.  It's also what's used for scoring quiets.
bench: 1895643