### PR TITLE
Remove a cutNode condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1270,7 +1270,7 @@ moves_loop:  // When in check, search starts here
             // std::clamp has been replaced by a more robust implementation.
             Depth d = std::max(1, std::min(newDepth - r / 1024,
                                            newDepth + !allNode + (PvNode && !bestMove)))
-                    + (!cutNode && (ss - 1)->isPvNode && moveCount < 8);
+                    + ((ss - 1)->isPvNode && moveCount < 8);
 
             ss->reduction = newDepth - d;
             value         = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);


### PR DESCRIPTION
Allow some nodes to spawn even deeper lmr searches, also for cutNodes

Passed STC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 59072 W: 15387 L: 15190 D: 28495
Ptnml(0-2): 145, 6956, 15166, 7095, 174
https://tests.stockfishchess.org/tests/view/6810b4c13629b02d74b16714

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 93294 W: 23737 L: 23591 D: 45966
Ptnml(0-2): 47, 10116, 26169, 10274, 41
https://tests.stockfishchess.org/tests/view/681170613629b02d74b167f3

bench: 1809112