### PR TITLE
Simplify low-ply history weight

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -182,7 +182,7 @@ void MovePicker::score() {
             }
 
             if (ply < LOW_PLY_HISTORY_SIZE)
-                m.value += 8 * (*lowPlyHistory)[ply][m.from_to()] / (1 + 2 * ply);
+                m.value += 8 * (*lowPlyHistory)[ply][m.from_to()] / (1 + ply);
         }
 
         else  // Type == EVASIONS


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 116064 W: 30095 L: 29959 D: 56010
Ptnml(0-2): 333, 13753, 29731, 13875, 340
https://tests.stockfishchess.org/tests/view/681229f53629b02d74b168d3

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 172824 W: 44096 L: 44031 D: 84697
Ptnml(0-2): 91, 18868, 48410, 18971, 72
https://tests.stockfishchess.org/tests/view/681474243629b02d74b16b44

Bench 2002219