### PR TITLE
Simplify probcut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -983,7 +983,7 @@ Value Search::Worker::search(
 moves_loop:  // When in check, search starts here
 
     // Step 12. A small Probcut idea
-    probCutBeta = beta + 180 + depth * 20;
+    probCutBeta = beta + 400;
     if ((ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4 && ttData.value >= probCutBeta
         && !is_decisive(beta) && is_valid(ttData.value) && !is_decisive(ttData.value))
         return probCutBeta;


### PR DESCRIPTION
Simplify probcut

Passed STC:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 80800 W: 20947 L: 20774 D: 39079
Ptnml(0-2): 217, 9446, 20906, 9609, 222
https://tests.stockfishchess.org/tests/view/680e83163629b02d74b15e2a

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 359004 W: 91362 L: 91486 D: 176156
Ptnml(0-2): 177, 39133, 101007, 39007, 178
https://tests.stockfishchess.org/tests/view/680e95db3629b02d74b15e7a

bench: 2068590