### PR TITLE
clean up code

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -19,8 +19,6 @@
 #ifndef MOVEPICK_H_INCLUDED
 #define MOVEPICK_H_INCLUDED
 
-#include <cstddef>
-
 #include "history.h"
 #include "movegen.h"
 #include "types.h"
@@ -28,9 +26,6 @@
 namespace Stockfish {
 
 class Position;
-
-template<typename T, std::size_t MaxSize>
-class ValueList;
 
 // The MovePicker class is used to pick one pseudo-legal move at a time from the
 // current position. The most important method is next_move(), which emits one
@@ -55,7 +50,7 @@ class MovePicker {
     MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
     Move next_move();
     void skip_quiet_moves();
-    bool otherPieceTypesMobile(PieceType pt, ValueList<Move, 32>& capturesSearched);
+    bool can_move_king_or_pawn();
 
    private:
     template<typename Pred>

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -918,7 +918,7 @@ Value Search::Worker::search(
     // Step 10. Internal iterative reductions
     // For PV nodes without a ttMove as well as for deep enough cutNodes, we decrease depth.
     // (*Scaler) Especially if they make IIR less aggressive.
-    if ((!allNode && depth >= (PvNode ? 5 : 7)) && !ttData.move)
+    if (!allNode && depth >= (PvNode ? 5 : 7) && !ttData.move)
         depth--;
 
     // Step 11. ProbCut
@@ -1079,16 +1079,17 @@ moves_loop:  // When in check, search starts here
                 int seeHist = std::clamp(captHist / 31, -137 * depth, 125 * depth);
                 if (!pos.see_ge(move, -158 * depth - seeHist))
                 {
-                    bool skip = true;
-                    if (depth > 2 && !capture && givesCheck && alpha < 0
+                    bool mayStalemateTrap = depth > 2 && givesCheck && alpha < 0
+                        && !ss->inCheck // stalemate traps while in check are unlikely
+                        && !capture // we consider that captures will likely destroy the stalemate configuration
                         && pos.non_pawn_material(us) == PieceValue[movedPiece]
                         && PieceValue[movedPiece] >= RookValue
-                        && !(PseudoAttacks[KING][pos.square<KING>(us)] & move.from_sq()))
-                        skip = mp.otherPieceTypesMobile(
-                          type_of(movedPiece),
-                          capturesSearched);  // if the opponent captures last mobile piece it might be stalemate
+                        // it can't be stalemate if we moved a piece adjacent to the king
+                        && !(attacks_bb<KING>(pos.square<KING>(us)) & move.from_sq())
+                        && !mp.can_move_king_or_pawn(); 
 
-                    if (skip)
+                    // avoid pruning sacrifices of our last piece for stalemate
+                    if (!mayStalemateTrap)
                         continue;
                 }
             }
@@ -1893,8 +1894,8 @@ void update_all_stats(const Position&      pos,
                       int                  moveCount) {
 
     CapturePieceToHistory& captureHistory = workerThread.captureHistory;
-    Piece                  moved_piece    = pos.moved_piece(bestMove);
-    PieceType              captured;
+    Piece                  movedPiece     = pos.moved_piece(bestMove);
+    PieceType              capturedPiece;
 
     int bonus = std::min(143 * depth - 89, 1496) + 302 * (bestMove == ttMove);
     int malus = std::min(737 * depth - 179, 3141) - 30 * moveCount;
@@ -1910,8 +1911,8 @@ void update_all_stats(const Position&      pos,
     else
     {
         // Increase stats for the best move in case it was a capture move
-        captured = type_of(pos.piece_on(bestMove.to_sq()));
-        captureHistory[moved_piece][bestMove.to_sq()][captured] << bonus * 1213 / 1024;
+        capturedPiece = type_of(pos.piece_on(bestMove.to_sq()));
+        captureHistory[movedPiece][bestMove.to_sq()][capturedPiece] << bonus * 1213 / 1024;
     }
 
     // Extra penalty for a quiet early move that was not a TT move in
@@ -1922,9 +1923,9 @@ void update_all_stats(const Position&      pos,
     // Decrease stats for all non-best capture moves
     for (Move move : capturesSearched)
     {
-        moved_piece = pos.moved_piece(move);
-        captured    = type_of(pos.piece_on(move.to_sq()));
-        captureHistory[moved_piece][move.to_sq()][captured] << -malus * 1388 / 1024;
+        movedPiece    = pos.moved_piece(move);
+        capturedPiece = type_of(pos.piece_on(move.to_sq()));
+        captureHistory[movedPiece][move.to_sq()][capturedPiece] << -malus * 1388 / 1024;
     }
 }
 


### PR DESCRIPTION
No functional change.

in search.cpp:
- an unnecessary pair of parenthesis in the IIR condition has been removed.
- added comments / improved the stalemate trap detection code

in movepick.cpp:
- use the variables `from`, `to`, `piece`, `pieceType` and `capturedPiece`  instead of calling the same functions multiple times in `MovePicker::score()`.
- rewrite and rename `MovePicker::otherPieceTypesMobile()`.

Bench: 1857323