### PR TITLE
Simplify futility pruning term

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1109,7 +1109,7 @@ moves_loop:  // When in check, search starts here
 
                 Value futilityValue =
                   ss->staticEval + (bestMove ? 46 : 138) + 117 * lmrDepth
-                  + 102 * (bestValue < ss->staticEval - 127 && ss->staticEval > alpha - 50);
+                  + 102 * (ss->staticEval > alpha);
 
                 // Futility pruning: parent node
                 // (*Scaler): Generally, more frequent futility pruning


### PR DESCRIPTION
Simplify futility pruning term

Passed simplification STC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 49920 W: 12933 L: 12727 D: 24260
Ptnml(0-2): 141, 5865, 12752, 6051, 151 
https://tests.stockfishchess.org/tests/view/681d01d33629b02d74b1756e

Passed simplification LTC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 68808 W: 17573 L: 17402 D: 33833
Ptnml(0-2): 23, 7343, 19511, 7494, 33 
https://tests.stockfishchess.org/tests/view/681e33843629b02d74b176b1

bench 2275397