### PR TITLE
 Introducing a depth component to the penalty.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1917,7 +1917,7 @@ void update_all_stats(const Position&      pos,
     // Extra penalty for a quiet early move that was not a TT move in
     // previous ply when it gets refuted.
     if (prevSq != SQ_NONE && ((ss - 1)->moveCount == 1 + (ss - 1)->ttHit) && !pos.captured_piece())
-        update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq, -malus * 980 / 1024);
+        update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq, -malus * (512 + depth * 16) / 1024);
 
     // Decrease stats for all non-best capture moves
     for (Move move : capturesSearched)


### PR DESCRIPTION
 Introducing a depth component to the penalty.

Passed STC:
LLR: 2.97 (-2.94,2.94) <0.00,2.00>
Total: 31648 W: 8358 L: 8050 D: 15240
Ptnml(0-2): 78, 3596, 8182, 3876, 92
https://tests.stockfishchess.org/tests/view/680fa73d3629b02d74b165a9

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 177720 W: 45524 L: 44920 D: 87276
Ptnml(0-2): 91, 19130, 49813, 19736, 90
https://tests.stockfishchess.org/tests/view/68109e2c3629b02d74b166ee

bench: 2320936