### PR TITLE
Simplify PCM TTMove Bonus

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -75,7 +75,6 @@ struct Stack {
     bool                        ttHit;
     int                         cutoffCnt;
     int                         reduction;
-    bool                        isTTMove;
     bool                        isPvNode;
 };
 


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 114048 W: 29597 L: 29459 D: 54992
Ptnml(0-2): 315, 13619, 29045, 13703, 342
https://tests.stockfishchess.org/tests/view/681e83533629b02d74b17701

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 61014 W: 15582 L: 15405 D: 30027
Ptnml(0-2): 25, 6485, 17307, 6668, 22
https://tests.stockfishchess.org/tests/view/68226b523629b02d74b17b89

bench 2016566