### PR TITLE
Rebased clean up code

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -148,6 +148,7 @@ Lucas Braesch (lucasart)
 Lyudmil Antonov (lantonov)
 Maciej Żenczykowski (zenczykowski)
 Malcolm Campbell (xoto10)
+Mark Marosi (Mapika)
 Mark Tenzer (31m059)
 marotear
 Mathias Parnaudeau (mparnaudeau)

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -249,7 +249,7 @@ top:
         if (!skipQuiets)
         {
             cur = endBadQuiets = endBadCaptures;
-            endMoves = generate<QUIETS>(pos, cur);
+            endMoves           = generate<QUIETS>(pos, cur);
 
             score<QUIETS>();
             partial_insertion_sort(cur, endMoves, -3560 * depth);
@@ -260,8 +260,7 @@ top:
 
     case GOOD_QUIET :
         if (!skipQuiets && select([&]() {
-                return cur->value > -14000 ? true
-                                           : (*endBadQuiets++ = *cur, false);
+                return cur->value > -14000 ? true : (*endBadQuiets++ = *cur, false);
             }))
             return *(cur - 1);
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -126,11 +126,11 @@ void MovePicker::score() {
 
     static_assert(Type == CAPTURES || Type == QUIETS || Type == EVASIONS, "Wrong type");
 
+    Color us = pos.side_to_move();
+
     [[maybe_unused]] Bitboard threatenedPieces, threatByLesser[QUEEN + 1];
     if constexpr (Type == QUIETS)
     {
-        Color us = pos.side_to_move();
-
         threatByLesser[KNIGHT] = threatByLesser[BISHOP] = pos.attacks_by<PAWN>(~us);
         threatByLesser[ROOK] =
           pos.attacks_by<KNIGHT>(~us) | pos.attacks_by<BISHOP>(~us) | threatByLesser[KNIGHT];
@@ -143,21 +143,22 @@ void MovePicker::score() {
     }
 
     for (auto& m : *this)
+    {
+        const Square    from          = m.from_sq();
+        const Square    to            = m.to_sq();
+        const Piece     pc            = pos.moved_piece(m);
+        const PieceType pt            = type_of(pc);
+        const Piece     capturedPiece = pos.piece_on(to);
+
         if constexpr (Type == CAPTURES)
-            m.value =
-              7 * int(PieceValue[pos.piece_on(m.to_sq())])
-              + 1024 * bool(pos.check_squares(type_of(pos.moved_piece(m))) & m.to_sq())
-              + (*captureHistory)[pos.moved_piece(m)][m.to_sq()][type_of(pos.piece_on(m.to_sq()))];
+            m.value = (*captureHistory)[pc][to][type_of(capturedPiece)]
+              + 7 * int(PieceValue[capturedPiece])
+              + 1024 * bool(pos.check_squares(pt) & to);
 
         else if constexpr (Type == QUIETS)
         {
-            Piece     pc   = pos.moved_piece(m);
-            PieceType pt   = type_of(pc);
-            Square    from = m.from_sq();
-            Square    to   = m.to_sq();
-
             // histories
-            m.value = 2 * (*mainHistory)[pos.side_to_move()][m.from_to()];
+            m.value =  2 * (*mainHistory)[us][m.from_to()];
             m.value += 2 * (*pawnHistory)[pawn_structure_index(pos)][pc][to];
             m.value += (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
@@ -184,11 +185,12 @@ void MovePicker::score() {
         else  // Type == EVASIONS
         {
             if (pos.capture_stage(m))
-                m.value = PieceValue[pos.piece_on(m.to_sq())] + (1 << 28);
+                m.value = PieceValue[capturedPiece] + (1 << 28);
             else
-                m.value = (*mainHistory)[pos.side_to_move()][m.from_to()]
-                        + (*continuationHistory[0])[pos.moved_piece(m)][m.to_sq()];
+                m.value = (*mainHistory)[us][m.from_to()]
+                        + (*continuationHistory[0])[pc][to];
         }
+    }
 }
 
 // Returns the next move satisfying a predicate function.
@@ -217,7 +219,6 @@ top:
     case QSEARCH_TT :
     case PROBCUT_TT :
         ++stage;
-        cur = moves + 1;
         return ttMove;
 
     case CAPTURE_INIT :
@@ -233,12 +234,10 @@ top:
 
     case GOOD_CAPTURE :
         if (select([&]() {
-                if (!pos.see_ge(*cur, -cur->value / 18))
-                {
-                    std::swap(*endBadCaptures++, *cur);
-                    return false;
-                }
-                return true;
+                if (pos.see_ge(*cur, -cur->value / 18))
+                    return true;
+                std::swap(*endBadCaptures++, *cur);
+                return false;
             }))
             return *(cur - 1);
 
@@ -311,23 +310,17 @@ top:
 
 void MovePicker::skip_quiet_moves() { skipQuiets = true; }
 
-bool MovePicker::other_piece_types_mobile(PieceType pt) {
+// this function must be called after all quiet moves and captures have been generated
+bool MovePicker::can_move_king_or_pawn() {
     assert(stage == GOOD_QUIET || stage == BAD_QUIET || stage == EVASION);
 
-    // verify all generated captures and quiets
     for (ExtMove* m = moves; m < endMoves; ++m)
     {
-        if (*m && type_of(pos.moved_piece(*m)) != pt)
-        {
-            if (type_of(pos.moved_piece(*m)) != KING)
-                return true;
-            if (pos.legal(*m))
-                return true;
-        }
+        PieceType movedPieceType = type_of(pos.moved_piece(*m));
+        if ((movedPieceType == PAWN || movedPieceType == KING) && pos.legal(*m))
+            return true;
     }
     return false;
 }
-
-void MovePicker::mark_current_illegal() { *(cur - 1) = Move::none(); }
 
 }  // namespace Stockfish

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -68,7 +68,7 @@ class MovePicker {
     const PieceToHistory**       continuationHistory;
     const PawnHistory*           pawnHistory;
     Move                         ttMove;
-    ExtMove *                    cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
+    ExtMove *                    cur, *endMoves, *endBadCaptures, *endBadQuiets;
     int                          stage;
     int                          threshold;
     Depth                        depth;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -50,8 +50,7 @@ class MovePicker {
     MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
     Move next_move();
     void skip_quiet_moves();
-    bool other_piece_types_mobile(PieceType pt);
-    void mark_current_illegal();
+    bool can_move_king_or_pawn();
 
    private:
     template<typename Pred>

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -597,10 +597,14 @@ bool Position::pseudo_legal(const Move m) const {
         if ((Rank8BB | Rank1BB) & to)
             return false;
 
-        if (!(attacks_bb<PAWN>(from, us) & pieces(~us) & to)  // Not a capture
-            && !((from + pawn_push(us) == to) && empty(to))   // Not a single push
-            && !((from + 2 * pawn_push(us) == to)             // Not a double push
-                 && (relative_rank(us, from) == RANK_2) && empty(to) && empty(to - pawn_push(us))))
+        // Check if it's a valid capture, single push, or double push
+        const bool isCapture    = bool(attacks_bb<PAWN>(from, us) & pieces(~us) & to);
+        const bool isSinglePush = (from + pawn_push(us) == to) && empty(to);
+        const bool isDoublePush = (from + 2 * pawn_push(us) == to)
+                               && (relative_rank(us, from) == RANK_2) && empty(to)
+                               && empty(to - pawn_push(us));
+
+        if (!(isCapture || isSinglePush || isDoublePush))
             return false;
     }
     else if (!(attacks_bb(type_of(pc), from, pieces()) & to))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1237,13 +1237,10 @@ moves_loop:  // When in check, search starts here
               826 * int(PieceValue[pos.captured_piece()]) / 128
               + thisThread->captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())]
               - 5030;
-        else if (ss->inCheck)
-            ss->statScore = thisThread->mainHistory[us][move.from_to()]
-                          + (*contHist[0])[movedPiece][move.to_sq()] - 2766;
         else
             ss->statScore = 2 * thisThread->mainHistory[us][move.from_to()]
                           + (*contHist[0])[movedPiece][move.to_sq()]
-                          + (*contHist[1])[movedPiece][move.to_sq()] - 3206;
+                          + (*contHist[1])[movedPiece][move.to_sq()] + 1000 * ss->inCheck - 3206;
 
         // Decrease/increase reduction for moves with a good/bad history
         r -= ss->statScore * 826 / 8192;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1900,8 +1900,7 @@ void update_all_stats(const Position&      pos,
     // Extra penalty for a quiet early move that was not a TT move in
     // previous ply when it gets refuted.
     if (prevSq != SQ_NONE && ((ss - 1)->moveCount == 1 + (ss - 1)->ttHit) && !pos.captured_piece())
-        update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
-                                      -malus * (512 + depth * 16) / 1024);
+        update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq, -malus * 580 / 1024);
 
     // Decrease stats for all non-best capture moves
     for (Move move : capturesSearched)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1004,6 +1004,8 @@ moves_loop:  // When in check, search starts here
         movedPiece = pos.moved_piece(move);
         givesCheck = pos.gives_check(move);
 
+        (ss + 1)->quietMoveStreak = (!capture && !givesCheck) ? (ss->quietMoveStreak + 1) : 0;
+
         // Calculate new depth for this move
         newDepth = depth - 1;
 
@@ -1197,6 +1199,9 @@ moves_loop:  // When in check, search starts here
         // Increase reduction if next ply has a lot of fail high
         if ((ss + 1)->cutoffCnt > 2)
             r += 1036 + allNode * 848;
+
+        if (!capture && !givesCheck && ss->quietMoveStreak >= 2)
+            r += (ss->quietMoveStreak - 1) * 50;
 
         // For first picked move (ttMove) reduce reduction
         else if (move == ttData.move)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1233,7 +1233,7 @@ moves_loop:  // When in check, search starts here
             // std::clamp has been replaced by a more robust implementation.
             Depth d = std::max(1, std::min(newDepth - r / 1024,
                                            newDepth + !allNode + (PvNode && !bestMove)))
-                    + ((ss - 1)->isPvNode && moveCount < 8);
+                                         + ((ss - 1)->isPvNode);
 
             ss->reduction = newDepth - d;
             value         = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -825,19 +825,17 @@ Value Search::Worker::search(
     // The depth condition is important for mate finding.
     {
         auto futility_margin = [&](Depth d) {
-            Value futilityMult       = 105 - 23 * (cutNode && !ss->ttHit);
-            Value improvingDeduction = improving * futilityMult * 2;
-            Value worseningDeduction = opponentWorsening * futilityMult / 3;
+            Value futilityMult = 93 - 20 * (cutNode && !ss->ttHit);
 
-            return futilityMult * d           //
-                 - improvingDeduction         //
-                 - worseningDeduction         //
-                 + (ss - 1)->statScore / 335  //
-                 + std::abs(correctionValue) / 149902;
+            return futilityMult * d                      //
+                 - improving * futilityMult * 2          //
+                 - opponentWorsening * futilityMult / 3  //
+                 + (ss - 1)->statScore / 376             //
+                 + std::abs(correctionValue) / 168639;
         };
 
-        if (!ss->ttPv && depth < 14 && eval + (eval - beta) / 8 - futility_margin(depth) >= beta
-            && eval >= beta && (!ttData.move || ttCapture) && !is_loss(beta) && !is_win(eval))
+        if (!ss->ttPv && depth < 14 && eval - futility_margin(depth) >= beta && eval >= beta
+            && (!ttData.move || ttCapture) && !is_loss(beta) && !is_win(eval))
             return beta + (eval - beta) / 3;
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -910,7 +910,7 @@ Value Search::Worker::search(
     // Step 10. Internal iterative reductions
     // For PV nodes without a ttMove as well as for deep enough cutNodes, we decrease depth.
     // (*Scaler) Especially if they make IIR less aggressive.
-    if ((!allNode && depth >= (PvNode ? 5 : 7)) && !ttData.move)
+    if (!allNode && depth >= (PvNode ? 5 : 7) && !ttData.move)
         depth--;
 
     // Step 11. ProbCut
@@ -1002,10 +1002,8 @@ moves_loop:  // When in check, search starts here
 
         // Check for legality
         if (!pos.legal(move))
-        {
-            mp.mark_current_illegal();
             continue;
-        }
+
         // At root obey the "searchmoves" option and skip moves not listed in Root
         // Move List. In MultiPV mode we also skip PV moves that have been already
         // searched and those of lower "TB rank" if we are in a TB root position.
@@ -1074,15 +1072,16 @@ moves_loop:  // When in check, search starts here
                 int seeHist = std::clamp(captHist / 31, -137 * depth, 125 * depth);
                 if (!pos.see_ge(move, -158 * depth - seeHist))
                 {
-                    bool skip = true;
-                    if (depth > 2 && !capture && givesCheck && alpha < 0
+                    bool mayStalemateTrap = depth > 2 && givesCheck && alpha < 0
+                        && !capture // we consider that captures will likely destroy the stalemate configuration
                         && pos.non_pawn_material(us) == PieceValue[movedPiece]
                         && PieceValue[movedPiece] >= RookValue
-                        && !(PseudoAttacks[KING][pos.square<KING>(us)] & move.from_sq()))
-                        // if the opponent captures last mobile piece it might be stalemate
-                        skip = mp.other_piece_types_mobile(type_of(movedPiece));
+                        // it can't be stalemate if we moved a piece adjacent to the king
+                        && !(attacks_bb<KING>(pos.square<KING>(us)) & move.from_sq())
+                        && !mp.can_move_king_or_pawn();
 
-                    if (skip)
+                    // avoid pruning sacrifices of our last piece for stalemate
+                    if (!mayStalemateTrap)
                         continue;
                 }
             }
@@ -1876,8 +1875,8 @@ void update_all_stats(const Position&      pos,
                       int                  moveCount) {
 
     CapturePieceToHistory& captureHistory = workerThread.captureHistory;
-    Piece                  moved_piece    = pos.moved_piece(bestMove);
-    PieceType              captured;
+    Piece                  movedPiece     = pos.moved_piece(bestMove);
+    PieceType              capturedPiece;
 
     int bonus = std::min(143 * depth - 89, 1496) + 302 * (bestMove == ttMove);
     int malus = std::min(737 * depth - 179, 3141) - 30 * moveCount;
@@ -1893,8 +1892,8 @@ void update_all_stats(const Position&      pos,
     else
     {
         // Increase stats for the best move in case it was a capture move
-        captured = type_of(pos.piece_on(bestMove.to_sq()));
-        captureHistory[moved_piece][bestMove.to_sq()][captured] << bonus * 1213 / 1024;
+        capturedPiece = type_of(pos.piece_on(bestMove.to_sq()));
+        captureHistory[movedPiece][bestMove.to_sq()][capturedPiece] << bonus * 1213 / 1024;
     }
 
     // Extra penalty for a quiet early move that was not a TT move in
@@ -1905,9 +1904,9 @@ void update_all_stats(const Position&      pos,
     // Decrease stats for all non-best capture moves
     for (Move move : capturesSearched)
     {
-        moved_piece = pos.moved_piece(move);
-        captured    = type_of(pos.piece_on(move.to_sq()));
-        captureHistory[moved_piece][move.to_sq()][captured] << -malus * 1388 / 1024;
+        movedPiece    = pos.moved_piece(move);
+        capturedPiece = type_of(pos.piece_on(move.to_sq()));
+        captureHistory[movedPiece][move.to_sq()][capturedPiece] << -malus * 1388 / 1024;
     }
 }
 

--- a/src/search.h
+++ b/src/search.h
@@ -76,6 +76,7 @@ struct Stack {
     int                         cutoffCnt;
     int                         reduction;
     bool                        isPvNode;
+    int                         quietMoveStreak;
 };
 
 

--- a/src/search.h
+++ b/src/search.h
@@ -75,7 +75,6 @@ struct Stack {
     bool                        ttHit;
     int                         cutoffCnt;
     int                         reduction;
-    bool                        isTTMove;
     bool                        isPvNode;
 };
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -28,6 +28,8 @@
 
 namespace Stockfish {
 
+enum Color : int8_t;
+
 TimePoint TimeManagement::optimum() const { return optimumTime; }
 TimePoint TimeManagement::maximum() const { return maximumTime; }
 

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -22,11 +22,11 @@
 #include <cstdint>
 
 #include "misc.h"
-#include "types.h"
 
 namespace Stockfish {
 
 class OptionsMap;
+enum Color : int8_t;
 
 namespace Search {
 struct LimitsType;

--- a/src/types.h
+++ b/src/types.h
@@ -110,13 +110,13 @@ using Bitboard = uint64_t;
 constexpr int MAX_MOVES = 256;
 constexpr int MAX_PLY   = 246;
 
-enum Color {
+enum Color : int8_t {
     WHITE,
     BLACK,
     COLOR_NB = 2
 };
 
-enum CastlingRights {
+enum CastlingRights : int8_t {
     NO_CASTLING,
     WHITE_OO,
     WHITE_OOO = WHITE_OO << 1,
@@ -132,7 +132,7 @@ enum CastlingRights {
     CASTLING_RIGHT_NB = 16
 };
 
-enum Bound {
+enum Bound : int8_t {
     BOUND_NONE,
     BOUND_UPPER,
     BOUND_LOWER,
@@ -183,13 +183,13 @@ constexpr Value QueenValue  = 2538;
 
 
 // clang-format off
-enum PieceType {
+enum PieceType : std::int8_t {
     NO_PIECE_TYPE, PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING,
     ALL_PIECES = 0,
     PIECE_TYPE_NB = 8
 };
 
-enum Piece {
+enum Piece : std::int8_t {
     NO_PIECE,
     W_PAWN = PAWN,     W_KNIGHT, W_BISHOP, W_ROOK, W_QUEEN, W_KING,
     B_PAWN = PAWN + 8, B_KNIGHT, B_BISHOP, B_ROOK, B_QUEEN, B_KING,
@@ -203,26 +203,24 @@ constexpr Value PieceValue[PIECE_NB] = {
 
 using Depth = int;
 
-enum : int {
-    // The following DEPTH_ constants are used for transposition table entries
-    // and quiescence search move generation stages. In regular search, the
-    // depth stored in the transposition table is literal: the search depth
-    // (effort) used to make the corresponding transposition table value. In
-    // quiescence search, however, the transposition table entries only store
-    // the current quiescence move generation stage (which should thus compare
-    // lower than any regular search depth).
-    DEPTH_QS = 0,
-    // For transposition table entries where no searching at all was done
-    // (whether regular or qsearch) we use DEPTH_UNSEARCHED, which should thus
-    // compare lower than any quiescence or regular depth. DEPTH_ENTRY_OFFSET
-    // is used only for the transposition table entry occupancy check (see tt.cpp),
-    // and should thus be lower than DEPTH_UNSEARCHED.
-    DEPTH_UNSEARCHED   = -2,
-    DEPTH_ENTRY_OFFSET = -3
-};
+// The following DEPTH_ constants are used for transposition table entries
+// and quiescence search move generation stages. In regular search, the
+// depth stored in the transposition table is literal: the search depth
+// (effort) used to make the corresponding transposition table value. In
+// quiescence search, however, the transposition table entries only store
+// the current quiescence move generation stage (which should thus compare
+// lower than any regular search depth).
+constexpr Depth DEPTH_QS = 0;
+// For transposition table entries where no searching at all was done
+// (whether regular or qsearch) we use DEPTH_UNSEARCHED, which should thus
+// compare lower than any quiescence or regular depth. DEPTH_ENTRY_OFFSET
+// is used only for the transposition table entry occupancy check (see tt.cpp),
+// and should thus be lower than DEPTH_UNSEARCHED.
+constexpr Depth DEPTH_UNSEARCHED   = -2;
+constexpr Depth DEPTH_ENTRY_OFFSET = -3;
 
 // clang-format off
-enum Square : int {
+enum Square : int8_t {
     SQ_A1, SQ_B1, SQ_C1, SQ_D1, SQ_E1, SQ_F1, SQ_G1, SQ_H1,
     SQ_A2, SQ_B2, SQ_C2, SQ_D2, SQ_E2, SQ_F2, SQ_G2, SQ_H2,
     SQ_A3, SQ_B3, SQ_C3, SQ_D3, SQ_E3, SQ_F3, SQ_G3, SQ_H3,
@@ -238,7 +236,7 @@ enum Square : int {
 };
 // clang-format on
 
-enum Direction : int {
+enum Direction : int8_t {
     NORTH = 8,
     EAST  = 1,
     SOUTH = -NORTH,
@@ -250,7 +248,7 @@ enum Direction : int {
     NORTH_WEST = NORTH + WEST
 };
 
-enum File : int {
+enum File : int8_t {
     FILE_A,
     FILE_B,
     FILE_C,
@@ -262,7 +260,7 @@ enum File : int {
     FILE_NB
 };
 
-enum Rank : int {
+enum Rank : int8_t {
     RANK_1,
     RANK_2,
     RANK_3,

--- a/src/uci.h
+++ b/src/uci.h
@@ -33,7 +33,7 @@ namespace Stockfish {
 class Position;
 class Move;
 class Score;
-enum Square : int;
+enum Square : int8_t;
 using Value = int;
 
 class UCIEngine {


### PR DESCRIPTION
**Non functional changes:**
in search.cpp:
- an unnecessary pair of parenthesis in the IIR condition has been removed.
- refactored the stalemate trap detection code

in movepick.cpp:
- use the variables `from`, `to`, `piece`, `pieceType` and `capturedPiece`  instead of calling the same functions multiple times in `MovePicker::score()`.
- rename `MovePicker::other_piece_types_mobile()`.

**Functional changes:**
- make sure the processed move is always legal in `MovePicker::other_piece_types_mobile()`.

passed non regression STC:
https://tests.stockfishchess.org/tests/view/6829da686ec7634154f99faf
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 95680 W: 24962 L: 24820 D: 45898
Ptnml(0-2): 221, 9622, 28025, 9738, 234

Passed non regression LTC:
https://tests.stockfishchess.org/tests/view/682a102c6ec7634154f9a086
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 117666 W: 30065 L: 29957 D: 57644
Ptnml(0-2): 45, 10173, 38291, 10277, 47

Bench: 2251724