### PR TITLE
Shrink Enum Sizes

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -28,6 +28,8 @@
 
 namespace Stockfish {
 
+enum Color : int8_t;
+
 TimePoint TimeManagement::optimum() const { return optimumTime; }
 TimePoint TimeManagement::maximum() const { return maximumTime; }
 

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -22,11 +22,11 @@
 #include <cstdint>
 
 #include "misc.h"
-#include "types.h"
 
 namespace Stockfish {
 
 class OptionsMap;
+enum Color : int8_t;
 
 namespace Search {
 struct LimitsType;

--- a/src/types.h
+++ b/src/types.h
@@ -110,13 +110,13 @@ using Bitboard = uint64_t;
 constexpr int MAX_MOVES = 256;
 constexpr int MAX_PLY   = 246;
 
-enum Color {
+enum Color : int8_t {
     WHITE,
     BLACK,
     COLOR_NB = 2
 };
 
-enum CastlingRights {
+enum CastlingRights : int8_t {
     NO_CASTLING,
     WHITE_OO,
     WHITE_OOO = WHITE_OO << 1,
@@ -132,7 +132,7 @@ enum CastlingRights {
     CASTLING_RIGHT_NB = 16
 };
 
-enum Bound {
+enum Bound : int8_t {
     BOUND_NONE,
     BOUND_UPPER,
     BOUND_LOWER,
@@ -183,13 +183,13 @@ constexpr Value QueenValue  = 2538;
 
 
 // clang-format off
-enum PieceType {
+enum PieceType : std::int8_t {
     NO_PIECE_TYPE, PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING,
     ALL_PIECES = 0,
     PIECE_TYPE_NB = 8
 };
 
-enum Piece {
+enum Piece : std::int8_t {
     NO_PIECE,
     W_PAWN = PAWN,     W_KNIGHT, W_BISHOP, W_ROOK, W_QUEEN, W_KING,
     B_PAWN = PAWN + 8, B_KNIGHT, B_BISHOP, B_ROOK, B_QUEEN, B_KING,
@@ -203,26 +203,24 @@ constexpr Value PieceValue[PIECE_NB] = {
 
 using Depth = int;
 
-enum : int {
-    // The following DEPTH_ constants are used for transposition table entries
-    // and quiescence search move generation stages. In regular search, the
-    // depth stored in the transposition table is literal: the search depth
-    // (effort) used to make the corresponding transposition table value. In
-    // quiescence search, however, the transposition table entries only store
-    // the current quiescence move generation stage (which should thus compare
-    // lower than any regular search depth).
-    DEPTH_QS = 0,
-    // For transposition table entries where no searching at all was done
-    // (whether regular or qsearch) we use DEPTH_UNSEARCHED, which should thus
-    // compare lower than any quiescence or regular depth. DEPTH_ENTRY_OFFSET
-    // is used only for the transposition table entry occupancy check (see tt.cpp),
-    // and should thus be lower than DEPTH_UNSEARCHED.
-    DEPTH_UNSEARCHED   = -2,
-    DEPTH_ENTRY_OFFSET = -3
-};
+// The following DEPTH_ constants are used for transposition table entries
+// and quiescence search move generation stages. In regular search, the
+// depth stored in the transposition table is literal: the search depth
+// (effort) used to make the corresponding transposition table value. In
+// quiescence search, however, the transposition table entries only store
+// the current quiescence move generation stage (which should thus compare
+// lower than any regular search depth).
+constexpr Depth DEPTH_QS = 0;
+// For transposition table entries where no searching at all was done
+// (whether regular or qsearch) we use DEPTH_UNSEARCHED, which should thus
+// compare lower than any quiescence or regular depth. DEPTH_ENTRY_OFFSET
+// is used only for the transposition table entry occupancy check (see tt.cpp),
+// and should thus be lower than DEPTH_UNSEARCHED.
+constexpr Depth DEPTH_UNSEARCHED   = -2;
+constexpr Depth DEPTH_ENTRY_OFFSET = -3;
 
 // clang-format off
-enum Square : int {
+enum Square : int8_t {
     SQ_A1, SQ_B1, SQ_C1, SQ_D1, SQ_E1, SQ_F1, SQ_G1, SQ_H1,
     SQ_A2, SQ_B2, SQ_C2, SQ_D2, SQ_E2, SQ_F2, SQ_G2, SQ_H2,
     SQ_A3, SQ_B3, SQ_C3, SQ_D3, SQ_E3, SQ_F3, SQ_G3, SQ_H3,
@@ -238,7 +236,7 @@ enum Square : int {
 };
 // clang-format on
 
-enum Direction : int {
+enum Direction : int8_t {
     NORTH = 8,
     EAST  = 1,
     SOUTH = -NORTH,
@@ -250,7 +248,7 @@ enum Direction : int {
     NORTH_WEST = NORTH + WEST
 };
 
-enum File : int {
+enum File : int8_t {
     FILE_A,
     FILE_B,
     FILE_C,
@@ -262,7 +260,7 @@ enum File : int {
     FILE_NB
 };
 
-enum Rank : int {
+enum Rank : int8_t {
     RANK_1,
     RANK_2,
     RANK_3,

--- a/src/uci.h
+++ b/src/uci.h
@@ -33,7 +33,7 @@ namespace Stockfish {
 class Position;
 class Move;
 class Score;
-enum Square : int;
+enum Square : int8_t;
 using Value = int;
 
 class UCIEngine {


### PR DESCRIPTION
Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 110848 W: 28974 L: 28564 D: 53310
Ptnml(0-2): 302, 12118, 30132, 12612, 260
https://tests.stockfishchess.org/tests/view/68242770a527315e07ccca38

no functional change