### PR TITLE
Simplify Futility Margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -825,19 +825,17 @@ Value Search::Worker::search(
     // The depth condition is important for mate finding.
     {
         auto futility_margin = [&](Depth d) {
-            Value futilityMult       = 105 - 23 * (cutNode && !ss->ttHit);
-            Value improvingDeduction = improving * futilityMult * 2;
-            Value worseningDeduction = opponentWorsening * futilityMult / 3;
+            Value futilityMult = 93 - 20 * (cutNode && !ss->ttHit);
 
-            return futilityMult * d           //
-                 - improvingDeduction         //
-                 - worseningDeduction         //
-                 + (ss - 1)->statScore / 335  //
-                 + std::abs(correctionValue) / 149902;
+            return futilityMult * d                      //
+                 - improving * futilityMult * 2          //
+                 - opponentWorsening * futilityMult / 3  //
+                 + (ss - 1)->statScore / 376             //
+                 + std::abs(correctionValue) / 168639;
         };
 
-        if (!ss->ttPv && depth < 14 && eval + (eval - beta) / 8 - futility_margin(depth) >= beta
-            && eval >= beta && (!ttData.move || ttCapture) && !is_loss(beta) && !is_win(eval))
+        if (!ss->ttPv && depth < 14 && eval - futility_margin(depth) >= beta && eval >= beta
+            && (!ttData.move || ttCapture) && !is_loss(beta) && !is_win(eval))
             return beta + (eval - beta) / 3;
     }
 


### PR DESCRIPTION
Passed STC Non-regression:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 159008 W: 41500 L: 41414 D: 76094
Ptnml(0-2): 501, 18821, 40759, 18937, 486
https://tests.stockfishchess.org/tests/view/680ff9e23629b02d74b1663a

Passed LTC Non-regression:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 163572 W: 41617 L: 41543 D: 80412
Ptnml(0-2): 90, 17755, 46024, 17825, 92
https://tests.stockfishchess.org/tests/view/6814dd973629b02d74b16bac

bench 2205797