### PR TITLE
Add quiet move streak tracking to search stack

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -148,6 +148,7 @@ Lucas Braesch (lucasart)
 Lyudmil Antonov (lantonov)
 Maciej Żenczykowski (zenczykowski)
 Malcolm Campbell (xoto10)
+Mark Marosi (Mapika)
 Mark Tenzer (31m059)
 marotear
 Mathias Parnaudeau (mparnaudeau)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1007,6 +1007,8 @@ moves_loop:  // When in check, search starts here
         movedPiece = pos.moved_piece(move);
         givesCheck = pos.gives_check(move);
 
+        (ss + 1)->quietMoveStreak = (!capture && !givesCheck) ? (ss->quietMoveStreak + 1) : 0;
+
         // Calculate new depth for this move
         newDepth = depth - 1;
 
@@ -1201,6 +1203,10 @@ moves_loop:  // When in check, search starts here
         // Increase reduction if next ply has a lot of fail high
         if ((ss + 1)->cutoffCnt > 2)
             r += 1036 + allNode * 848;
+
+        if (!capture && !givesCheck && ss->quietMoveStreak >= 2) {
+            r += (ss->quietMoveStreak - 1) * 50;  // Penalty for quiet move streak
+        }
 
         // For first picked move (ttMove) reduce reduction
         else if (ss->isTTMove)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1204,9 +1204,8 @@ moves_loop:  // When in check, search starts here
         if ((ss + 1)->cutoffCnt > 2)
             r += 1036 + allNode * 848;
 
-        if (!capture && !givesCheck && ss->quietMoveStreak >= 2) {
-            r += (ss->quietMoveStreak - 1) * 50;  // Penalty for quiet move streak
-        }
+        if (!capture && !givesCheck && ss->quietMoveStreak >= 2) 
+            r += (ss->quietMoveStreak - 1) * 50;
 
         // For first picked move (ttMove) reduce reduction
         else if (ss->isTTMove)

--- a/src/search.h
+++ b/src/search.h
@@ -77,6 +77,7 @@ struct Stack {
     int                         reduction;
     bool                        isTTMove;
     bool                        isPvNode;
+    int quietMoveStreak=0;
 };
 
 

--- a/src/search.h
+++ b/src/search.h
@@ -77,7 +77,7 @@ struct Stack {
     int                         reduction;
     bool                        isTTMove;
     bool                        isPvNode;
-    int quietMoveStreak=0;
+    int                         quietMoveStreak;
 };
 
 


### PR DESCRIPTION
Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 109344 W: 28473 L: 28053 D: 52818
Ptnml(0-2): 320, 12756, 28085, 13206, 305 
[https://tests.stockfishchess.org/tests/view/6828c43e6ec7634154f99a10](https://tests.stockfishchess.org/tests/view/6828c43e6ec7634154f99a10
)
Passed LTC:
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 76308 W: 19721 L: 19323 D: 37264
Ptnml(0-2): 39, 8145, 21386, 8547, 37 
[https://tests.stockfishchess.org/tests/view/6828f65a6ec7634154f99b72](https://tests.stockfishchess.org/tests/view/6828f65a6ec7634154f99b72)


Bench: 2127419