### PR TITLE
Remove a moveCount condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1232,7 +1232,7 @@ moves_loop:  // When in check, search starts here
             // std::clamp has been replaced by a more robust implementation.
             Depth d = std::max(1, std::min(newDepth - r / 1024,
                                            newDepth + !allNode + (PvNode && !bestMove)))
-                    + ((ss - 1)->isPvNode && moveCount < 8);
+                                         + ((ss - 1)->isPvNode);
 
             ss->reduction = newDepth - d;
             value         = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);


### PR DESCRIPTION
Remove a moveCount condition.

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 70816 W: 18315 L: 18134 D: 34367
Ptnml(0-2): 210, 8213, 18360, 8436, 189
https://tests.stockfishchess.org/tests/view/68248197a527315e07cccb2d

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 121770 W: 31248 L: 31130 D: 59392
Ptnml(0-2): 61, 13338, 33995, 13404, 87
https://tests.stockfishchess.org/tests/view/68272ff46ec7634154f998ad

bench: 2265387