### PR TITLE
Remove allNode term in prior countermove bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1451,10 +1451,9 @@ moves_loop:  // When in check, search starts here
     // Bonus for prior quiet countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
     {
-        int bonusScale = -324;
+        int bonusScale = -302;
         bonusScale += std::min(-(ss - 1)->statScore / 103, 323);
         bonusScale += std::min(73 * depth, 531);
-        bonusScale += 33 * !allNode;
         bonusScale += 174 * ((ss - 1)->moveCount > 8);
         bonusScale += 90 * (ss->cutoffCnt <= 3);
         bonusScale += 144 * (!ss->inCheck && bestValue <= ss->staticEval - 104);


### PR DESCRIPTION
Remove allNode term in prior countermove bonus

Passed simplification STC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 53632 W: 14008 L: 13805 D: 25819
Ptnml(0-2): 136, 6253, 13869, 6388, 170 
https://tests.stockfishchess.org/tests/view/6828f2b26ec7634154f99b5e

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 82482 W: 21202 L: 21045 D: 40235
Ptnml(0-2): 37, 8986, 23052, 9115, 51 
https://tests.stockfishchess.org/tests/view/6829010a6ec7634154f99db3

bench 2302782