### PR TITLE
Check evaluation after ttMove before doing a tt cut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -680,6 +680,8 @@ Value Search::Worker::search(
         && (ttData.bound & (ttData.value >= beta ? BOUND_LOWER : BOUND_UPPER))
         && (cutNode == (ttData.value >= beta) || depth > 5))
     {
+
+
         // If ttMove is quiet, update move sorting heuristics on TT hit
         if (ttData.move && ttData.value >= beta)
         {
@@ -696,7 +698,30 @@ Value Search::Worker::search(
         // Partial workaround for the graph history interaction problem
         // For high rule50 counts don't produce transposition table cutoffs.
         if (pos.rule50_count() < 90)
-            return ttData.value;
+        {
+            if (depth >= 8 && ttData.move && pos.pseudo_legal(ttData.move) && pos.legal(ttData.move)
+                && !is_decisive(ttData.value))
+            {
+                do_move(pos, ttData.move, st);
+                Key nextPosKey                             = pos.key();
+                auto [ttHitNext, ttDataNext, ttWriterNext] = tt.probe(nextPosKey);
+                ttDataNext.value =
+                  ttHitNext ? value_from_tt(ttDataNext.value, ss->ply + 1, pos.rule50_count())
+                            : VALUE_NONE;
+                undo_move(pos, ttData.move);
+
+                if (!is_valid(ttDataNext.value))
+                    return ttData.value;
+                if (ttData.value >= beta && -ttDataNext.value >= beta)
+                    return ttData.value;
+                if (ttData.value <= alpha && -ttDataNext.value <= alpha)
+                    return ttData.value;
+            }
+            else
+            {
+                return ttData.value;
+            }
+        }
     }
 
     // Step 5. Tablebases probe


### PR DESCRIPTION
Check evaluation after ttMove prior to tt cut

Passed STC
LLR: 2.97 (-2.94,2.94) <0.00,2.00>
Total: 239136 W: 62222 L: 61608 D: 115306
Ptnml(0-2): 675, 28046, 61525, 28634, 688 
https://tests.stockfishchess.org/tests/view/681053293629b02d74b1668f

Passed LTC
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 448770 W: 115237 L: 114088 D: 219445
Ptnml(0-2): 177, 48128, 126619, 49291, 170 
https://tests.stockfishchess.org/tests/view/681902de3629b02d74b16f6d

bench 2220365