### PR TITLE
Simplify In-Check Statscore

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1211,13 +1211,10 @@ moves_loop:  // When in check, search starts here
               826 * int(PieceValue[pos.captured_piece()]) / 128
               + thisThread->captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())]
               - 5030;
-        else if (ss->inCheck)
-            ss->statScore = thisThread->mainHistory[us][move.from_to()]
-                          + (*contHist[0])[movedPiece][move.to_sq()] - 2766;
         else
             ss->statScore = 2 * thisThread->mainHistory[us][move.from_to()]
                           + (*contHist[0])[movedPiece][move.to_sq()]
-                          + (*contHist[1])[movedPiece][move.to_sq()] - 3206;
+                          + (*contHist[1])[movedPiece][move.to_sq()] + 1000 * ss->inCheck - 3206;
 
         // Decrease/increase reduction for moves with a good/bad history
         r -= ss->statScore * 826 / 8192;


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.98 (-2.94,2.94) <-1.75,0.25>
Total: 129760 W: 33701 L: 33580 D: 62479
Ptnml(0-2): 359, 15248, 33575, 15309, 389
https://tests.stockfishchess.org/tests/view/681a88193629b02d74b17123

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 519612 W: 132224 L: 132512 D: 254876
Ptnml(0-2): 246, 56823, 145960, 56527, 250
https://tests.stockfishchess.org/tests/view/681f9ed43629b02d74b177c3

bench 2364807