### PR TITLE
Simplify handling of good/bad quiets

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -68,7 +68,7 @@ class MovePicker {
     const PieceToHistory**       continuationHistory;
     const PawnHistory*           pawnHistory;
     Move                         ttMove;
-    ExtMove *                    cur, *endMoves, *endBadCaptures, *beginBadQuiets, *endBadQuiets;
+    ExtMove *                    cur, *endMoves, *endBadCaptures, *endBadQuiets;
     int                          stage;
     int                          threshold;
     Depth                        depth;


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/6827a68c6ec7634154f9992b
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 75936 W: 19722 L: 19547 D: 36667
Ptnml(0-2): 186, 8937, 19589, 9028, 228 

LTC https://tests.stockfishchess.org/tests/view/6828f8096ec7634154f99b82
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 104112 W: 26773 L: 26638 D: 50701
Ptnml(0-2): 51, 11363, 29098, 11488, 56 

Simplify the handling of good/bad quiets and make it more similar to the way we handle good/bad captures. The good quiet limit was adjusted from -7998 to -14000 to keep the ratio of good/bad quiets about the same as master.
This also fixes a "bug" that previously returned some bad quiets during the GOOD_QUIET stage when some qood quiets weren't sorted at low depths.  Some discussion regarding this w/ @pb00068 is here https://github.com/official-stockfish/Stockfish/pull/4975#issuecomment-2842066744

bench: 1826738