### PR TITLE
Simplify Quiet Early Move Penalty

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1877,8 +1877,7 @@ void update_all_stats(const Position&      pos,
     // Extra penalty for a quiet early move that was not a TT move in
     // previous ply when it gets refuted.
     if (prevSq != SQ_NONE && ((ss - 1)->moveCount == 1 + (ss - 1)->ttHit) && !pos.captured_piece())
-        update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
-                                      -malus * (512 + depth * 16) / 1024);
+        update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq, -malus * 580 / 1024);
 
     // Decrease stats for all non-best capture moves
     for (Move move : capturesSearched)


### PR DESCRIPTION
Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 185344 W: 47995 L: 47939 D: 89410
Ptnml(0-2): 527, 21898, 47754, 21978, 515
https://tests.stockfishchess.org/tests/view/682a47536ec7634154f9a3bc

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 101706 W: 26050 L: 25912 D: 49744
Ptnml(0-2): 53, 11056, 28499, 11190, 55
https://tests.stockfishchess.org/tests/view/682a61736ec7634154f9a50e

bench 1794980