### PR TITLE
Limit search explosions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1148,16 +1148,24 @@ moves_loop:  // When in check, search starts here
 
             if (value < singularBeta)
             {
-                int corrValAdj1  = std::abs(correctionValue) / 248400;
-                int corrValAdj2  = std::abs(correctionValue) / 249757;
-                int doubleMargin = -4 + 244 * PvNode - 206 * !ttCapture - corrValAdj1
-                                 - 997 * ttMoveHistory / 131072
-                                 - (ss->ply * 2 > thisThread->rootDepth * 3) * 47;
-                int tripleMargin = 84 + 269 * PvNode - 253 * !ttCapture + 91 * ss->ttPv
-                                 - corrValAdj2 - (ss->ply * 2 > thisThread->rootDepth * 3) * 54;
+                // measure against search explosions: don't double/triple extend bouncing & triangulation moves
+                if (ss->ply > 6 && (move == (ss-2)->currentMove.reverse() ||
+                   (move.to_sq() == (ss-4)->currentMove.from_sq() && move.from_sq() == (ss-2)->currentMove.to_sq()
+                   && (ss-4)->currentMove.to_sq() == (ss-2)->currentMove.from_sq())))
+                       extension = 1;
+                else
+                {
+                    int corrValAdj1  = std::abs(correctionValue) / 248400;
+                    int corrValAdj2  = std::abs(correctionValue) / 249757;
+                    int doubleMargin = -4 + 244 * PvNode - 206 * !ttCapture - corrValAdj1
+                                     - 997 * ttMoveHistory / 131072
+                                     - (ss->ply * 2 > thisThread->rootDepth * 3) * 47;
+                    int tripleMargin = 84 + 269 * PvNode - 253 * !ttCapture + 91 * ss->ttPv
+                                     - corrValAdj2 - (ss->ply * 2 > thisThread->rootDepth * 3) * 54;
 
-                extension =
-                  1 + (value < singularBeta - doubleMargin) + (value < singularBeta - tripleMargin);
+                    extension =
+                      1 + (value < singularBeta - doubleMargin) + (value < singularBeta - tripleMargin);
+                }
 
                 depth++;
             }

--- a/src/types.h
+++ b/src/types.h
@@ -403,6 +403,8 @@ class Move {
 
     constexpr MoveType type_of() const { return MoveType(data & (3 << 14)); }
 
+    constexpr Move reverse() const { return Move(to_sq(), from_sq()); }
+
     constexpr PieceType promotion_type() const { return PieceType(((data >> 12) & 3) + KNIGHT); }
 
     constexpr bool is_ok() const { return none().data != data && null().data != data; }


### PR DESCRIPTION
This is a measure against issue #5023.
Don't double/triple extend bouncing & triangulation moves.
According to xu-shawn (see issue #5023) the search explosions often happen on drawish side-lines 
where the defending side can maintain a fortress by shuffling a piece between two squares.
Since the opponent also might do some in-between move (zwischenzug) before attacking the fortress, the defender might also need triangulation moves to defend it.

Preliminary STC (paused)
https://tests.stockfishchess.org/tests/view/68245928a527315e07ccca78
LLR: -0.58 (-2.94,2.94) <0.00,2.00>
Total: 33408 W: 8682 L: 8684 D: 16042
Ptnml(0-2): 83, 3970, 8623, 3922, 106

Passed non-regression LTC
https://tests.stockfishchess.org/tests/view/6825be8ea527315e07cccd11
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 133182 W: 34009 L: 33904 D: 65269
Ptnml(0-2): 73, 14488, 37344, 14633, 53

N.B.: So far I did test only few positions:

8/8/8/1B6/6p1/8/3K1Ppp/3N2kr w - - 0 1 
k7/P7/3B4/3K4/8/8/2r5/R7 w - - 13 97

On both positions the patch effectively helps against the stucking problem (tested with 1 thread, 512 MB hash)

bench: 2249166