### PR TITLE
Remove full depth search reduction when cutNode

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1292,9 +1292,6 @@ moves_loop:  // When in check, search starts here
 
             r -= ttMoveHistory / 8;
 
-            if (cutNode)
-                r += 520;
-
             // Note that if expected reduction is high, we reduce search depth here
             value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha,
                                    newDepth - (r > 3564) - (r > 4969 && newDepth > 2), !cutNode);


### PR DESCRIPTION
(Rebased)

Passed STC-simplification bounds:
https://tests.stockfishchess.org/tests/view/6829dd6d6ec7634154f99fd3
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 67872 W: 17629 L: 17443 D: 32800
Ptnml(0-2): 167, 7988, 17451, 8152, 178

Passed LTC-simplification bounds:
https://tests.stockfishchess.org/tests/view/6829f2176ec7634154f9a01c
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 94818 W: 24328 L: 24184 D: 46306
Ptnml(0-2): 52, 10246, 26667, 10394, 50


bench: 2245168