### PR TITLE
Tweak low ply history

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -36,7 +36,7 @@ namespace Stockfish {
 constexpr int PAWN_HISTORY_SIZE        = 512;    // has to be a power of 2
 constexpr int CORRECTION_HISTORY_SIZE  = 32768;  // has to be a power of 2
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
-constexpr int LOW_PLY_HISTORY_SIZE     = 4;
+constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
 static_assert((PAWN_HISTORY_SIZE & (PAWN_HISTORY_SIZE - 1)) == 0,
               "PAWN_HISTORY_SIZE has to be a power of 2");

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -186,8 +186,12 @@ void MovePicker::score() {
             if (pos.capture_stage(m))
                 m.value = PieceValue[pos.piece_on(m.to_sq())] + (1 << 28);
             else
+            {
                 m.value = (*mainHistory)[pos.side_to_move()][m.from_to()]
                         + (*continuationHistory[0])[pos.moved_piece(m)][m.to_sq()];
+                if (ply < LOW_PLY_HISTORY_SIZE)
+                    m.value += 2 * (*lowPlyHistory)[ply][m.from_to()] / (1 + ply);
+            }
         }
 }
 


### PR DESCRIPTION
Increase low ply history maximum ply by 1 and also allow to use it for check evasions scoring.
Pased STC:
https://tests.stockfishchess.org/tests/view/682a2db36ec7634154f9a358
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 66464 W: 17440 L: 17081 D: 31943
Ptnml(0-2): 191, 7717, 17056, 8078, 190 
Passed LTC:
https://tests.stockfishchess.org/tests/view/682a3d406ec7634154f9a39c
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 384030 W: 98476 L: 97452 D: 188102
Ptnml(0-2): 180, 41564, 107522, 42550, 199 
bench 1989929