### PR TITLE
Fix warnings in nnue_accumulator

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -129,6 +129,7 @@ template<typename T, std::size_t MaxSize>
 class ValueList {
 
    public:
+    ValueList() : values_{}, size_(0) {}
     std::size_t size() const { return size_; }
     void        push_back(const T& value) { values_[size_++] = value; }
     const T*    begin() const { return values_; }
@@ -137,7 +138,7 @@ class ValueList {
 
    private:
     T           values_[MaxSize];
-    std::size_t size_ = 0;
+    std::size_t size_;
 };
 
 


### PR DESCRIPTION
This commit resolves -Wmaybe-uninitialized warnings in nnue_accumulator.cpp (related to ValueList instances) and subsequent -Wreorder warnings in the ValueList constructor itself.

![image](https://github.com/user-attachments/assets/4a9f604a-18ea-4237-a622-a4daacd1408c)

Changes:
Modified the ValueList default constructor to explicitly zero-initialize its internal values_ array (e.g., values_{}). This ensures the array elements are never in an indeterminate state from the compiler's perspective, fixing the -Wmaybe-uninitialized warning.

No Functional Change
bench: 2012032