### PR TITLE
build/ci: update to NDK r27c API level 29

### DIFF
--- a/.github/ci/arm_matrix.json
+++ b/.github/ci/arm_matrix.json
@@ -4,7 +4,7 @@
       "name": "Android NDK aarch64",
       "os": "ubuntu-22.04",
       "simple_name": "android",
-      "compiler": "aarch64-linux-android21-clang++",
+      "compiler": "aarch64-linux-android29-clang++",
       "emu": "qemu-aarch64",
       "comp": "ndk",
       "shell": "bash",
@@ -14,7 +14,7 @@
       "name": "Android NDK arm",
       "os": "ubuntu-22.04",
       "simple_name": "android",
-      "compiler": "armv7a-linux-androideabi21-clang++",
+      "compiler": "armv7a-linux-androideabi29-clang++",
       "emu": "qemu-arm",
       "comp": "ndk",
       "shell": "bash",
@@ -26,25 +26,25 @@
     {
       "binaries": "armv8-dotprod",
       "config": {
-        "compiler": "armv7a-linux-androideabi21-clang++"
+        "compiler": "armv7a-linux-androideabi29-clang++"
       }
     },
     {
       "binaries": "armv8",
       "config": {
-        "compiler": "armv7a-linux-androideabi21-clang++"
+        "compiler": "armv7a-linux-androideabi29-clang++"
       }
     },
     {
       "binaries": "armv7",
       "config": {
-        "compiler": "aarch64-linux-android21-clang++"
+        "compiler": "aarch64-linux-android29-clang++"
       }
     },
     {
       "binaries": "armv7-neon",
       "config": {
-        "compiler": "aarch64-linux-android21-clang++"
+        "compiler": "aarch64-linux-android29-clang++"
       }
     }
   ]

--- a/.github/workflows/arm_compilation.yml
+++ b/.github/workflows/arm_compilation.yml
@@ -38,7 +38,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           if [ $COMP == ndk ]; then
-            NDKV="21.4.7075529"
+            NDKV="27.2.12479018"
             ANDROID_ROOT=/usr/local/lib/android
             ANDROID_SDK_ROOT=$ANDROID_ROOT/sdk
             SDKMANAGER=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,13 +29,13 @@ jobs:
             shell: bash
           - name: Android NDK aarch64
             os: ubuntu-22.04
-            compiler: aarch64-linux-android21-clang++
+            compiler: aarch64-linux-android29-clang++
             comp: ndk
             run_armv8_tests: true
             shell: bash
           - name: Android NDK arm
             os: ubuntu-22.04
-            compiler: armv7a-linux-androideabi21-clang++
+            compiler: armv7a-linux-androideabi29-clang++
             comp: ndk
             run_armv7_tests: true
             shell: bash
@@ -126,7 +126,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           if [ $COMP == ndk ]; then
-            NDKV="21.4.7075529"
+            NDKV="27.2.12479018"
             ANDROID_ROOT=/usr/local/lib/android
             ANDROID_SDK_ROOT=$ANDROID_ROOT/sdk
             SDKMANAGER=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager

--- a/src/Makefile
+++ b/src/Makefile
@@ -533,14 +533,12 @@ ifeq ($(KERNEL),Darwin)
 	XCRUN = xcrun
 endif
 
-# To cross-compile for Android, NDK version r21 or later is recommended.
-# In earlier NDK versions, you'll need to pass -fno-addrsig if using GNU binutils.
-# Currently we don't know how to make PGO builds with the NDK yet.
+# To cross-compile for Android, use NDK version r27c or later.
 ifeq ($(COMP),ndk)
-	CXXFLAGS += -stdlib=libc++ -fPIE
+	CXXFLAGS += -stdlib=libc++
 	comp=clang
 	ifeq ($(arch),armv7)
-		CXX=armv7a-linux-androideabi16-clang++
+		CXX=armv7a-linux-androideabi29-clang++
 		CXXFLAGS += -mthumb -march=armv7-a -mfloat-abi=softfp -mfpu=neon
 		ifneq ($(shell which arm-linux-androideabi-strip 2>/dev/null),)
 			STRIP=arm-linux-androideabi-strip
@@ -549,7 +547,7 @@ ifeq ($(COMP),ndk)
 		endif
 	endif
 	ifeq ($(arch),armv8)
-		CXX=aarch64-linux-android21-clang++
+		CXX=aarch64-linux-android29-clang++
 		ifneq ($(shell which aarch64-linux-android-strip 2>/dev/null),)
 			STRIP=aarch64-linux-android-strip
 		else
@@ -557,14 +555,14 @@ ifeq ($(COMP),ndk)
 		endif
 	endif
 	ifeq ($(arch),x86_64)
-		CXX=x86_64-linux-android21-clang++
+		CXX=x86_64-linux-android29-clang++
 		ifneq ($(shell which x86_64-linux-android-strip 2>/dev/null),)
 			STRIP=x86_64-linux-android-strip
 		else
 			STRIP=llvm-strip
 		endif
 	endif
-	LDFLAGS += -static-libstdc++ -pie -lm -latomic
+	LDFLAGS += -static-libstdc++
 endif
 
 ### Allow overwriting CXX from command line


### PR DESCRIPTION
build: update to NDK r27c API level 29

Update to the latest LTS version NDK r27c (27.2.12479018),
the previous NDK are unsupported by Google, see:
https://developer.android.com/ndk/downloads

A build with NDK r27c and API level < 29 returns this error:
"executable's TLS segment is underaligned: alignment is 8 (skew 0), needs to be at least 64 for ARM64 Bionic"

Update the API level to 29 to use the native ELF LTS and avoid the error:
https://android.googlesource.com/platform/bionic/+/HEAD/docs/elf-tls.md
https://android.googlesource.com/platform/bionic/+/HEAD/android-changes-for-ndk-developers.md#elf-tls-available-for-api-level-29

A dynamic link build of Stockfish uses these libraries:

ldd stockfish-android-armv8-dynamic-api35
        libm.so => /system/lib64/libm.so
        libdl.so => /system/lib64/libdl.so
        libc.so => /system/lib64/libc.so
        ld-android.so => /system/lib64/ld-android.so

ld-android.so : the dynamic linker used by Android (on Linux is named ld-linux.so),
                responsible for loading and linking shared libraries into an executable at runtime.
libdl.so      : interface/library layer that provides function for dynamic loading,
                relies on the underlying functionality provided by the dynamic linker
libm.so       : math library for Android
libc.so       : standard C library for Android

References:
Doc for native (C/C++) API
https://developer.android.com/ndk/guides/stable_apis

C libraries (libc, libm, libdl):
https://developer.android.com/ndk/guides/stable_apis#c_library

Bionic changes with API levels:
https://android.googlesource.com/platform/bionic/+/HEAD/docs/status.md

NDK r27c build system:
https://android.googlesource.com/platform/ndk/+/ndk-r27-release/docs/BuildSystemMaintainers.md

No functional change


ci: update to NDK r27c API level 29
Update to NDK r27c (27.2.12479018), the default version in GitHub runner,
to switch to a recent clang 18.

A PGO build requires static linking, because the NDK doesn't ship
the Android loaders (linker/linker64), see:
https://groups.google.com/g/android-ndk/c/3Ep6zD3xxSY

The API level should not be an issue when distributing a static build,
use the API 29, the oldest one not affected by the LTS alignement issue.

No functional change
