### PR TITLE
Implement smoother time reduction in time management

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -466,7 +466,9 @@ void Search::Worker::iterative_deepening() {
             fallingEval = std::clamp(fallingEval, 0.5786, 1.6752);
 
             // If the bestMove is stable over several iterations, reduce time accordingly
-            timeReduction = lastBestMoveDepth + 8 < completedDepth ? 1.4857 : 0.7046;
+            double k = 0.527;
+            double center = lastBestMoveDepth + 11;
+            timeReduction = 0.8 + 0.84 / (1.077 + std::exp(-k * (completedDepth - center)));
             double reduction =
               (1.4540 + mainThread->previousTimeReduction) / (2.1593 * timeReduction);
             double bestMoveInstability = 0.9929 + 1.8519 * totBestMoveChanges / threads.size();


### PR DESCRIPTION
Implement smoother time reduction in time management by replacing a conditional assignment with a continuous sigmoid-based function. The updated logic employs a sigmoid-like function for a more gradual adjustment.

P.s: It would be nice if someone could generate a graph showing the new behaviour compared to the old one.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 64448 W: 16838 L: 16492 D: 31118
Ptnml(0-2): 145, 7214, 17207, 7466, 192
https://tests.stockfishchess.org/tests/view/6829dc046ec7634154f99fba

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 407340 W: 104458 L: 103408 D: 199474
Ptnml(0-2): 196, 42281, 117664, 43335, 194
https://tests.stockfishchess.org/tests/view/6829fe1b6ec7634154f9a036

No functional change