### PR TITLE
Adjust futility pruning thresholds using history

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -132,6 +132,7 @@ Kenneth Lee (kennethlee33)
 Kian E (KJE-98)
 kinderchocolate
 Kiran Panditrao (Krgp)
+Kirill Zaripov (kokodio)
 Kojirion
 Krisztián Peőcz
 Krystian Kuzniarek (kuzkry)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1101,8 +1101,9 @@ moves_loop:  // When in check, search starts here
 
                 lmrDepth += history / 3388;
 
-                Value futilityValue = ss->staticEval + (bestMove ? 46 : 138) + 117 * lmrDepth
-                                    + 102 * (ss->staticEval > alpha);
+                Value baseFutility = (bestMove ? 46 : 138 + std::abs(history / 300));
+                Value futilityValue =
+                  ss->staticEval + baseFutility + 117 * lmrDepth + 102 * (ss->staticEval > alpha);
 
                 // Futility pruning: parent node
                 // (*Scaler): Generally, more frequent futility pruning


### PR DESCRIPTION
Passed STC:
https://tests.stockfishchess.org/tests/view/6833095a6ec7634154f9b5b3
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 56896 W: 14946 L: 14604 D: 27346
Ptnml(0-2): 117, 6674, 14561, 6942, 154

Passed LTC:
https://tests.stockfishchess.org/tests/view/6833179d6ec7634154f9b5da
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 200742 W: 51660 L: 51012 D: 98070
Ptnml(0-2): 96, 21520, 56473, 22204, 78
bench 2087595