### PR TITLE
Make ProbCut search shallower in cutNode

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -928,7 +928,7 @@ Value Search::Worker::search(
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
         MovePicker mp(pos, ttData.move, probCutBeta - ss->staticEval, &thisThread->captureHistory);
-        Depth      probCutDepth = std::max(depth - 4, 0);
+        Depth      probCutDepth = std::max(depth - (4 + cutNode), 0);
 
         while ((move = mp.next_move()) != Move::none())
         {


### PR DESCRIPTION
Passed STC:
https://tests.stockfishchess.org/tests/view/6832d2436ec7634154f9b4fc
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 455072 W: 118162 L: 117237 D: 219673
Ptnml(0-2): 1233, 53409, 117362, 54264, 1268

Passed LTC:
https://tests.stockfishchess.org/tests/view/6833323e6ec7634154f9ba17
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 128436 W: 32916 L: 32415 D: 63105
Ptnml(0-2): 50, 13737, 36137, 14250, 44

bench 2196896