### PR TITLE
Small tt verify simplification

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -701,18 +701,12 @@ Value Search::Worker::search(
                 do_move(pos, ttData.move, st);
                 Key nextPosKey                             = pos.key();
                 auto [ttHitNext, ttDataNext, ttWriterNext] = tt.probe(nextPosKey);
-                ttDataNext.value =
-                  ttHitNext ? value_from_tt(ttDataNext.value, ss->ply + 1, pos.rule50_count())
-                            : VALUE_NONE;
                 undo_move(pos, ttData.move);
-
+               
+                // Check that the ttValue after the tt move would also trigger a cutoff
                 if (!is_valid(ttDataNext.value))
                     return ttData.value;
-
-                if (ttData.value >= beta && -ttDataNext.value >= beta)
-                    return ttData.value;
-
-                if (ttData.value <= alpha && -ttDataNext.value <= alpha)
+                if ((ttData.value >= beta) == (-ttDataNext.value >= beta))
                     return ttData.value;
             }
             else
@@ -916,9 +910,7 @@ Value Search::Worker::search(
     if (depth >= 3
         && !is_decisive(beta)
         // If value from transposition table is lower than probCutBeta, don't attempt
-        // probCut there and in further interactions with transposition table cutoff
-        // depth is set to depth - 3 because probCut search has depth set to depth - 4
-        // but we also do a move before it. So effective depth is equal to depth - 3.
+        // probCut there
         && !(is_valid(ttData.value) && ttData.value < probCutBeta))
     {
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);


### PR DESCRIPTION
Small tt verify simplification
Also fix probcut comment

Passed non-regression STC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 69728 W: 18080 L: 17909 D: 33739
Ptnml(0-2): 161, 7157, 20044, 7354, 148 
https://tests.stockfishchess.org/tests/view/68324b116ec7634154f9b478

bench 2302782