### PR TITLE
Always Decrease Reduction on TTMove

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1229,7 +1229,7 @@ moves_loop:  // When in check, search starts here
             r += (ss->quietMoveStreak - 1) * 50;
 
         // For first picked move (ttMove) reduce reduction
-        else if (move == ttData.move)
+        if (move == ttData.move)
             r -= 2006;
 
         if (capture)


### PR DESCRIPTION
Passed VVLTC w/ LTC Bounds:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 57792 W: 15005 L: 14676 D: 28111
Ptnml(0-2): 2, 5241, 18082, 5568, 3
https://tests.stockfishchess.org/tests/view/682a0e3c6ec7634154f9a07e

Passed VVLTC w/ STC Bounds:
 LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 372298 W: 96342 L: 95655 D: 180301
Ptnml(0-2): 37, 34598, 116181, 35307, 26
https://tests.stockfishchess.org/tests/view/682a45b16ec7634154f9a3b3

STC Elo Estimate:
https://tests.stockfishchess.org/tests/view/68335d276ec7634154f9c25c

bench 1926868