### PR TITLE
Simplify Double Margin Formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1152,7 +1152,7 @@ moves_loop:  // When in check, search starts here
                 int corrValAdj2  = std::abs(correctionValue) / 249757;
                 int doubleMargin = -4 + 244 * PvNode - 206 * !ttCapture - corrValAdj1
                                  - 997 * ttMoveHistory / 131072
-                                 - (ss->ply * 2 > thisThread->rootDepth * 3) * 47;
+                                 - (ss->ply > thisThread->rootDepth) * 47;
                 int tripleMargin = 84 + 269 * PvNode - 253 * !ttCapture + 91 * ss->ttPv
                                  - corrValAdj2 - (ss->ply * 2 > thisThread->rootDepth * 3) * 54;
 


### PR DESCRIPTION
Simplify Double Margin Formula

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 267296 W: 69214 L: 69248 D: 128834
Ptnml(0-2): 760, 31511, 69141, 31475, 761
https://tests.stockfishchess.org/tests/view/682f5d9a6ec7634154f9b01e

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 67872 W: 17460 L: 17289 D: 33123
Ptnml(0-2): 25, 7238, 19243, 7401, 29
https://tests.stockfishchess.org/tests/view/6833074b6ec7634154f9b5ae

Passed VLTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 118000 W: 30337 L: 30222 D: 57441
Ptnml(0-2): 15, 11783, 35289, 11898, 15
https://tests.stockfishchess.org/tests/view/683336c56ec7634154f9ba46

bench: 2233830