### PR TITLE
Simplify tt depth in stat eval history adjustment

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -813,8 +813,7 @@ Value Search::Worker::search(
     }
 
     // Use static evaluation difference to improve quiet move ordering
-    if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture
-        && (ttData.depth - 2) <= depth)
+    if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture && ttData.depth <= 2)
     {
         int bonus = std::clamp(-10 * int((ss - 1)->staticEval + ss->staticEval), -1858, 1492) + 661;
         thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()] << bonus * 1057 / 1024;


### PR DESCRIPTION
Simplify tt depth in stat eval history adjustment

Passed simplification STC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 102208 W: 26498 L: 26349 D: 49361
Ptnml(0-2): 284, 12095, 26166, 12306, 253 
https://tests.stockfishchess.org/tests/view/683354c76ec7634154f9be88

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 133422 W: 34050 L: 33945 D: 65427
Ptnml(0-2): 56, 14473, 37559, 14556, 67 
https://tests.stockfishchess.org/tests/view/683363626ec7634154f9c298

bench 2652411