### PR TITLE
Simplify stat eval history adjustment further

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -813,7 +813,7 @@ Value Search::Worker::search(
     }
 
     // Use static evaluation difference to improve quiet move ordering
-    if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture && ttData.depth <= 2)
+    if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture && !ttHit)
     {
         int bonus = std::clamp(-10 * int((ss - 1)->staticEval + ss->staticEval), -1858, 1492) + 661;
         thisThread->mainHistory[~us][((ss - 1)->currentMove).from_to()] << bonus * 1057 / 1024;


### PR DESCRIPTION
Tested upon #6099

Passed Non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 78144 W: 20379 L: 20204 D: 37561
Ptnml(0-2): 183, 9277, 20014, 9378, 220
https://tests.stockfishchess.org/tests/view/68341abf6ec7634154f9cb91

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 87780 W: 22670 L: 22518 D: 42592
Ptnml(0-2): 32, 9580, 24531, 9698, 49
https://tests.stockfishchess.org/tests/view/6836d68b6ec7634154f9d00b