### PR TITLE
Fix clang-format version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ discussion._
 
 Changes to Stockfish C++ code should respect our coding style defined by
 [.clang-format](.clang-format). You can format your changes by running
-`make format`. This requires clang-format version 18 to be installed on your system.
+`make format`. This requires clang-format version 20 to be installed on your system.
 
 ## Navigate
 


### PR DESCRIPTION
Minor left-over from https://github.com/official-stockfish/Stockfish/pull/6085.

No functional change.