### PR TITLE
Simplify NMP eval in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1601,9 +1601,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
         }
         else
         {
-            // In case of null move search, use previous static eval with opposite sign
-            unadjustedStaticEval =
-              (ss - 1)->currentMove != Move::null() ? evaluate(pos) : -(ss - 1)->staticEval;
+            unadjustedStaticEval = evaluate(pos);
             ss->staticEval = bestValue =
               to_corrected_static_eval(unadjustedStaticEval, correctionValue);
         }


### PR DESCRIPTION
Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/6834e9436ec7634154f9cd6e
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 24864 W: 6626 L: 6394 D: 11844
Ptnml(0-2): 62, 2806, 6477, 3012, 75

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/683598fd6ec7634154f9ce82
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 200148 W: 51461 L: 51424 D: 97263
Ptnml(0-2): 92, 21672, 56503, 21721, 86

Bench: 2498281