### PR TITLE
Simplify away check term in statscore

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1235,7 +1235,7 @@ moves_loop:  // When in check, search starts here
         else
             ss->statScore = 2 * thisThread->mainHistory[us][move.from_to()]
                           + (*contHist[0])[movedPiece][move.to_sq()]
-                          + (*contHist[1])[movedPiece][move.to_sq()] + 1000 * ss->inCheck - 3206;
+                          + (*contHist[1])[movedPiece][move.to_sq()] - 3206;
 
         // Decrease/increase reduction for moves with a good/bad history
         r -= ss->statScore * 826 / 8192;


### PR DESCRIPTION
Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 61696 W: 16031 L: 15841 D: 29824
Ptnml(0-2): 151, 7160, 16046, 7330, 161 
https://tests.stockfishchess.org/tests/view/68353fcc6ec7634154f9cdd5

Passed simplification LTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 237990 W: 60994 L: 60995 D: 116001
Ptnml(0-2): 95, 25964, 66903, 25913, 120 
https://tests.stockfishchess.org/tests/view/683642256ec7634154f9cf5e

bench 2546083