### PR TITLE
Simplify away cutoff term in prior countermove bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1443,11 +1443,10 @@ moves_loop:  // When in check, search starts here
     // Bonus for prior quiet countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
     {
-        int bonusScale = -302;
+        int bonusScale = -220;
         bonusScale += std::min(-(ss - 1)->statScore / 103, 323);
         bonusScale += std::min(73 * depth, 531);
         bonusScale += 174 * ((ss - 1)->moveCount > 8);
-        bonusScale += 90 * (ss->cutoffCnt <= 3);
         bonusScale += 144 * (!ss->inCheck && bestValue <= ss->staticEval - 104);
         bonusScale += 128 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 82);
 


### PR DESCRIPTION
Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 61120 W: 16010 L: 15819 D: 29291
Ptnml(0-2): 150, 7105, 15869, 7276, 160 
https://tests.stockfishchess.org/tests/view/683560226ec7634154f9ce0f

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 225090 W: 57555 L: 57543 D: 109992
Ptnml(0-2): 104, 24367, 63603, 24355, 116 
https://tests.stockfishchess.org/tests/view/6836420c6ec7634154f9cf5c

bench 2498770