### PR TITLE
Simplify away depth condition in IIR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -906,7 +906,7 @@ Value Search::Worker::search(
     // Step 10. Internal iterative reductions
     // For PV nodes without a ttMove as well as for deep enough cutNodes, we decrease depth.
     // (*Scaler) Especially if they make IIR less aggressive.
-    if (!allNode && depth >= (PvNode ? 5 : 7) && !ttData.move)
+    if (!allNode && depth >= 6 && !ttData.move)
         depth--;
 
     // Step 11. ProbCut


### PR DESCRIPTION
Passed simplification STC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 359520 W: 92714 L: 92849 D: 173957
Ptnml(0-2): 977, 42640, 92614, 42599, 930 
https://tests.stockfishchess.org/tests/view/6833705d6ec7634154f9c302

Passed simplification LTC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 201756 W: 51544 L: 51507 D: 98705
Ptnml(0-2): 89, 21965, 56728, 22012, 84 
https://tests.stockfishchess.org/tests/view/68338e386ec7634154f9c790

Passed simplification VLTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 48558 W: 12675 L: 12492 D: 23391
Ptnml(0-2): 9, 4779, 14516, 4970, 5 
https://tests.stockfishchess.org/tests/view/6838e0b26ec7634154f9d25b

bench 2291767