### PR TITLE
Introduce Secondary TT Aging

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -110,6 +110,8 @@ void TTEntry::save(
         value16   = int16_t(v);
         eval16    = int16_t(ev);
     }
+    else if (depth8 + DEPTH_ENTRY_OFFSET >= 5 && Bound(genBound8 & 0x3) != BOUND_EXACT)
+        depth8--;
 }
 
 


### PR DESCRIPTION
When a high-depth TT entry fail to produce a cutoff, decrease the stored depth by 1. This is intended to help cases such as https://github.com/official-stockfish/Stockfish/issues/5023#issuecomment-2814209391, where entries with extremely high depths prevent TT cutoffs, contributing to search explosions.

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 128800 W: 33502 L: 33053 D: 62245
Ptnml(0-2): 331, 15084, 33149, 15477, 359
https://tests.stockfishchess.org/tests/view/683958e56ec7634154f9d2a9

Passed LTC:
LLR: 2.97 (-2.94,2.94) <0.50,2.50>
Total: 63288 W: 16376 L: 16005 D: 30907
Ptnml(0-2): 26, 6712, 17798, 7081, 27
https://tests.stockfishchess.org/tests/view/683aa4026ec7634154f9d469

Bench: 2122557