### PR TITLE
Simplify stalemate detection

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -315,18 +315,4 @@ top:
 
 void MovePicker::skip_quiet_moves() { skipQuiets = true; }
 
-// this function must be called after all quiet moves and captures have been generated
-bool MovePicker::can_move_king_or_pawn() {
-    // SEE negative captures shouldn't be returned in GOOD_CAPTURE stage
-    assert(stage > GOOD_CAPTURE && stage != EVASION_INIT);
-
-    for (ExtMove* m = moves; m < endCur; ++m)
-    {
-        PieceType movedPieceType = type_of(pos.moved_piece(*m));
-        if ((movedPieceType == PAWN || movedPieceType == KING) && pos.legal(*m))
-            return true;
-    }
-    return false;
-}
-
 }  // namespace Stockfish

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -50,7 +50,6 @@ class MovePicker {
     MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
     Move next_move();
     void skip_quiet_moves();
-    bool can_move_king_or_pawn();
 
    private:
     template<typename Pred>

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1072,8 +1072,7 @@ moves_loop:  // When in check, search starts here
                       depth > 2 && alpha < 0 && pos.non_pawn_material(us) == PieceValue[movedPiece]
                       && PieceValue[movedPiece] >= RookValue
                       // it can't be stalemate if we moved a piece adjacent to the king
-                      && !(attacks_bb<KING>(pos.square<KING>(us)) & move.from_sq())
-                      && !mp.can_move_king_or_pawn();
+                      && !(attacks_bb<KING>(pos.square<KING>(us)) & move.from_sq());
 
                     // avoid pruning sacrifices of our last piece for stalemate
                     if (!mayStalemateTrap)


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 148224 W: 38464 L: 38370 D: 71390
Ptnml(0-2): 370, 16509, 40243, 16637, 353
https://tests.stockfishchess.org/tests/view/6836c4466ec7634154f9cfeb

Passed Non-regression LTC (against #6119):
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 223896 W: 57367 L: 57354 D: 109175
Ptnml(0-2): 85, 23602, 64555, 23627, 79
https://tests.stockfishchess.org/tests/view/683aaa116ec7634154f9d490

Stalemate 10k games:
Elo: 1.91 ± 1.2 (95%) LOS: 99.9%
Total: 10000 W: 4660 L: 4605 D: 735
Ptnml(0-2): 0, 132, 4681, 187, 0
nElo: 10.71 ± 6.8 (95%) PairsRatio: 1.42
https://tests.stockfishchess.org/tests/view/683c05066ec7634154f9d929

Bench: 2448963