### PR TITLE
Remove an unnecessary bound check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1424,7 +1424,7 @@ moves_loop:  // When in check, search starts here
     assert(moveCount || !ss->inCheck || excludedMove || !MoveList<LEGAL>(pos).size());
 
     // Adjust best value for fail high cases
-    if (bestValue >= beta && !is_decisive(bestValue) && !is_decisive(beta) && !is_decisive(alpha))
+    if (bestValue >= beta && !is_decisive(bestValue) && !is_decisive(alpha))
         bestValue = (bestValue * depth + beta) / (depth + 1);
 
     if (!moveCount)


### PR DESCRIPTION
When failing high, it is always true that `alpha < beta` and `beta <= bestValue`. Therefore if alpha and bestValue is not in decisive range, it is guaranteed that beta is not.

no functional change