### PR TITLE
Simplify corrections in extension margins

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1143,13 +1143,12 @@ moves_loop:  // When in check, search starts here
 
             if (value < singularBeta)
             {
-                int corrValAdj1  = std::abs(correctionValue) / 248400;
-                int corrValAdj2  = std::abs(correctionValue) / 249757;
-                int doubleMargin = -4 + 244 * PvNode - 206 * !ttCapture - corrValAdj1
+                int corrValAdj  = std::abs(correctionValue) / 248400;
+                int doubleMargin = -4 + 244 * PvNode - 206 * !ttCapture - corrValAdj
                                  - 997 * ttMoveHistory / 131072
                                  - (ss->ply > thisThread->rootDepth) * 47;
                 int tripleMargin = 84 + 269 * PvNode - 253 * !ttCapture + 91 * ss->ttPv
-                                 - corrValAdj2 - (ss->ply * 2 > thisThread->rootDepth * 3) * 54;
+                                 - corrValAdj - (ss->ply * 2 > thisThread->rootDepth * 3) * 54;
 
                 extension =
                   1 + (value < singularBeta - doubleMargin) + (value < singularBeta - tripleMargin);


### PR DESCRIPTION
Simplify corrections in extension margins

Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 96192 W: 25002 L: 24852 D: 46338
Ptnml(0-2): 242, 10868, 25716, 11038, 232 
https://tests.stockfishchess.org/tests/view/683b44cb6ec7634154f9d6ac

Passed simplification LTC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 83334 W: 21473 L: 21317 D: 40544
Ptnml(0-2): 37, 8877, 23674, 9051, 28 
https://tests.stockfishchess.org/tests/view/683b79786ec7634154f9d75a

bench 2290044