### PR TITLE
Reduce depth by 5 in probcut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -924,7 +924,7 @@ Value Search::Worker::search(
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
         MovePicker mp(pos, ttData.move, probCutBeta - ss->staticEval, &thisThread->captureHistory);
-        Depth      probCutDepth = std::max(depth - (4 + cutNode), 0);
+        Depth      probCutDepth = std::max(depth - 5, 0);
 
         while ((move = mp.next_move()) != Move::none())
         {


### PR DESCRIPTION
Reduce depth by 5 in probcut
Both tests were done against kokodio's patch

Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 63328 W: 16402 L: 16213 D: 30713
Ptnml(0-2): 174, 7378, 16340, 7629, 143
https://tests.stockfishchess.org/tests/view/6833530e6ec7634154f9be7f

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 69936 W: 17795 L: 17625 D: 34516
Ptnml(0-2): 29, 7631, 19474, 7809, 25
https://tests.stockfishchess.org/tests/view/68335e386ec7634154f9c266

bench 2122564
