### PR TITLE
Simplify TT overwrite logic

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -98,7 +98,7 @@ void TTEntry::save(
         move16 = m;
 
     // Overwrite less valuable entries (cheapest checks first)
-    if (b == BOUND_EXACT || uint16_t(k) != key16 || d - DEPTH_ENTRY_OFFSET + 2 * pv > depth8 - 4
+    if (b == BOUND_EXACT || uint16_t(k) != key16 || d - DEPTH_ENTRY_OFFSET + 2 * pv >= depth8
         || relative_age(generation8))
     {
         assert(d > DEPTH_ENTRY_OFFSET);


### PR DESCRIPTION
Seems that since 'Introduce Secondary TT Aging #6113' the -4 offset is not needed anymore.
Anyhow LTC singlethread test failed, Discussion.

Passed singlethread STC
https://tests.stockfishchess.org/tests/view/683ea76f6ec7634154f9dbaa
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 79872 W: 20566 L: 20395 D: 38911
Ptnml(0-2): 194, 9390, 20600, 9555, 197

Passed multithread STC (8th 5 + 0.05)
https://tests.stockfishchess.org/tests/view/683ff5359bb85e4a27256a07
LLR: 3.40 (-2.94,2.94) <-1.75,0.25>
Total: 52224 W: 13576 L: 13341 D: 25307
Ptnml(0-2): 72, 5894, 13937, 6145, 64

Passed multithread LTC (8th 20 + 0.2)
https://tests.stockfishchess.org/tests/view/68411e78b3a7bbdcda9a442c
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 83510 W: 21414 L: 21263 D: 40833
Ptnml(0-2): 17, 8578, 24422, 8713, 25

Failed singlethread LTC
https://tests.stockfishchess.org/tests/view/6840172c9bb85e4a27256a4e

LLR: -2.95 (-2.94,2.94) <-1.75,0.25>
Total: 117948 W: 29964 L: 30325 D: 57659
Ptnml(0-2): 61, 13023, 33167, 12662, 61

bench: 2378006