### PR TITLE
Simplify Stalemate Condition Further

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -67,7 +67,7 @@ constexpr int SEARCHEDLIST_CAPACITY = 32;
 using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 
 // (*Scalers):
-// The values with Scaler asterisks have proven non-linear scaling.
+// Search features marked by "(*Scaler)" have proven non-linear scaling.
 // They are optimized to time controls of 180 + 1.8 and longer,
 // so changing them or adding conditions that are similar requires
 // tests at these types of time controls.
@@ -819,16 +819,20 @@ Value Search::Worker::search(
               << bonus * 1428 / 1024;
     }
 
-    // Set up the improving flag, which is true if current static evaluation is
-    // bigger than the previous static evaluation at our turn (if we were in
-    // check at our previous move we go back until we weren't in check) and is
-    // false otherwise. The improving flag is used in various pruning heuristics.
-    improving = ss->staticEval > (ss - 2)->staticEval;
 
+    // Set up the improving and opponentWorsening flags.
+    // These flags are true respectively if the static evaluation is better for us
+    // than it was at our last turn (two plies ago) and the opponent's
+    // last turn (one ply ago).
+    improving         = ss->staticEval > (ss - 2)->staticEval;
     opponentWorsening = ss->staticEval > -(ss - 1)->staticEval;
 
+    // Retroactive LMR adjustments
+    // The ply after beginning an LMR search, we adjust the reduced depth based on
+    // how the opponent's move affected the static evaluation.
     if (priorReduction >= (depth < 10 ? 1 : 3) && !opponentWorsening)
         depth++;
+
     if (priorReduction >= 2 && depth >= 2 && ss->staticEval + (ss - 1)->staticEval > 177)
         depth--;
 
@@ -857,6 +861,7 @@ Value Search::Worker::search(
     }
 
     // Step 9. Null move search with verification search
+    // The non-pawn condition is important for finding Zugzwangs.
     if (cutNode && ss->staticEval >= beta - 19 * depth + 403 && !excludedMove
         && pos.non_pawn_material(us) && ss->ply >= nmpMinPly && !is_loss(beta))
     {
@@ -899,8 +904,8 @@ Value Search::Worker::search(
     improving |= ss->staticEval >= beta;
 
     // Step 10. Internal iterative reductions
-    // At sufficient depth, reduce depth for PV/Cut nodes without a TTMove.
-    // (*Scaler) Especially if they make IIR less aggressive.
+    // For deep enough nodes without ttMoves, we reduce search depth.
+    // (*Scaler) Making the reduction less aggressive scales well
     if (!allNode && depth >= 6 && !ttData.move && priorReduction <= 3)
         depth--;
 
@@ -1053,12 +1058,8 @@ moves_loop:  // When in check, search starts here
                 int margin = std::clamp(158 * depth + captHist / 31, 0, 283 * depth);
                 if (!pos.see_ge(move, -margin))
                 {
-                    bool mayStalemateTrap =
-                      depth > 2 && alpha < 0 && pos.non_pawn_material(us) == PieceValue[movedPiece]
-                      && PieceValue[movedPiece] >= RookValue
-                      // it can't be stalemate if we moved a piece adjacent to the king
-                      && !(attacks_bb<KING>(pos.square<KING>(us)) & move.from_sq())
-                      && !mp.can_move_king_or_pawn();
+                    bool mayStalemateTrap = pos.non_pawn_material(us) == PieceValue[movedPiece]
+                                         && PieceValue[movedPiece] >= RookValue;
 
                     // avoid pruning sacrifices of our last piece for stalemate
                     if (!mayStalemateTrap)
@@ -1109,10 +1110,9 @@ moves_loop:  // When in check, search starts here
         // verify this we do a reduced search on the position excluding the ttMove
         // and if the result is lower than ttValue minus a margin, then we will
         // extend the ttMove. Recursive singular search is avoided.
-
-        // (*Scaler) Generally, higher singularBeta (i.e closer to ttValue)
-        // and lower extension margins scale well.
-
+        //
+        // (*Scaler) Generally, frequent extensions scale well.
+        // This includes high singularBeta values (i.e closer to ttValue) and low extension margins.
         if (!rootNode && move == ttData.move && !excludedMove
             && depth >= 6 - (completedDepth > 26) + ss->ttPv && is_valid(ttData.value)
             && !is_decisive(ttData.value) && (ttData.bound & BOUND_LOWER)
@@ -1353,7 +1353,7 @@ moves_loop:  // When in check, search starts here
 
                 if (value >= beta)
                 {
-                    // (* Scaler) Especially if they make cutoffCnt increment more often.
+                    // (*Scaler) Less frequent cutoff increments scale well
                     ss->cutoffCnt += (extension < 2) || PvNode;
                     assert(value >= beta);  // Fail high
                     break;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1055,16 +1055,12 @@ moves_loop:  // When in check, search starts here
                 }
 
                 // SEE based pruning for captures and checks
+                // We take care to avoid pruning sacrifices
+                // of our last piece for stalemate
                 int margin = std::clamp(158 * depth + captHist / 31, 0, 283 * depth);
-                if (!pos.see_ge(move, -margin))
-                {
-                    bool mayStalemateTrap = pos.non_pawn_material(us) == PieceValue[movedPiece]
-                                         && PieceValue[movedPiece] >= RookValue;
-
-                    // avoid pruning sacrifices of our last piece for stalemate
-                    if (!mayStalemateTrap)
-                        continue;
-                }
+                if (pos.non_pawn_material(us) != PieceValue[movedPiece]
+                    && !pos.see_ge(move, -margin))
+                    continue;
             }
             else
             {


### PR DESCRIPTION
Based on PR #6118

Passed Non-regression STC (vs #6118):
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 110592 W: 28424 L: 28289 D: 53879
Ptnml(0-2): 252, 12473, 29731, 12568, 272
https://tests.stockfishchess.org/tests/view/683c0b326ec7634154f9d932

Passed Non-regression LTC (vs #6118):
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 289158 W: 73963 L: 74016 D: 141179
Ptnml(0-2): 127, 30873, 82639, 30806, 134
https://tests.stockfishchess.org/tests/view/683d53176ec7634154f9da6a

Stalemate 10k:
Elo: 0.03 ± 1.0 (95%) LOS: 52.6%
Total: 10000 W: 4646 L: 4645 D: 709
Ptnml(0-2): 0, 113, 4773, 114, 0
nElo: 0.23 ± 6.8 (95%) PairsRatio: 1.01
https://tests.stockfishchess.org/tests/view/684a70bae84567164b5c9fd6

Bench: 2585661