### PR TITLE
Simplify history term in futility pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1083,7 +1083,7 @@ moves_loop:  // When in check, search starts here
 
                 lmrDepth += history / 3388;
 
-                Value baseFutility = (bestMove ? 46 : 138 + std::abs(history / 300));
+                Value baseFutility = (bestMove ? 46 : 230);
                 Value futilityValue =
                   ss->staticEval + baseFutility + 117 * lmrDepth + 102 * (ss->staticEval > alpha);
 


### PR DESCRIPTION
Simplify history term in futility pruning

Passed simplification STC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 298816 W: 76814 L: 76881 D: 145121
Ptnml(0-2): 726, 35477, 77057, 35434, 714 
https://tests.stockfishchess.org/tests/view/683f440f6ec7634154f9dc7f

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 237774 W: 60801 L: 60802 D: 116171
Ptnml(0-2): 91, 26088, 66532, 26083, 93 
https://tests.stockfishchess.org/tests/view/68441189ffbc71bd236778de

bench 2249833