### PR TITLE
Remove eval, beta diff from Null move dynamic reduction formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -857,8 +857,8 @@ Value Search::Worker::search(
     {
         assert(eval - beta >= 0);
 
-        // Null move dynamic reduction based on depth and eval
-        Depth R = std::min(int(eval - beta) / 213, 6) + depth / 3 + 5;
+        // Null move dynamic reduction based on depth
+        Depth R = 7 + depth / 3;
 
         ss->currentMove                   = Move::null();
         ss->continuationHistory           = &thisThread->continuationHistory[0][0][NO_PIECE][0];


### PR DESCRIPTION
Remove eval, beta diff from Null move dynamic reduction formula

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 43456 W: 11178 L: 10966 D: 21312
Ptnml(0-2): 114, 5078, 11114, 5326, 96
https://tests.stockfishchess.org/tests/view/6849ae13e84567164b5c9de9

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 63090 W: 16302 L: 16125 D: 30663
Ptnml(0-2): 37, 6837, 17603, 7048, 20
https://tests.stockfishchess.org/tests/view/684ab516e84567164b5ca02f