### PR TITLE
Fix trivial errors in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -996,10 +996,6 @@ net:
 format:
 	$(CLANG-FORMAT) -i $(SRCS) $(HEADERS) -style=file
 
-# default target
-default:
-	help
-
 ### ==========================================================================
 ### Section 5. Private Targets
 ### ==========================================================================
@@ -1125,6 +1121,6 @@ icx-profile-use:
 .depend: $(SRCS)
 	-@$(CXX) $(DEPENDFLAGS) -MM $(SRCS) > $@ 2> /dev/null
 
-ifeq (, $(filter $(MAKECMDGOALS), help strip install clean net objclean profileclean config-sanity))
+ifeq (, $(filter $(MAKECMDGOALS), help strip install clean net objclean profileclean format config-sanity))
 -include .depend
 endif


### PR DESCRIPTION
1. Remove "default" rule as "default" has no special meaning as a rule name. Make runs the very first rule whose name doesn't begin with a dot (which is "help" currently).

2. Make "format" rule not update dependencies.

No functional change