### PR TITLE
Simplify quiet move streak logic

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1207,8 +1207,7 @@ moves_loop:  // When in check, search starts here
         if ((ss + 1)->cutoffCnt > 2)
             r += 1036 + allNode * 848;
 
-        if (!capture && !givesCheck && ss->quietMoveStreak >= 2)
-            r += (ss->quietMoveStreak - 1) * 50;
+        r += (ss + 1)->quietMoveStreak * 50;
 
         // For first picked move (ttMove) reduce reduction
         if (move == ttData.move)


### PR DESCRIPTION
Simplify quiet move streak logic

Passed non-regression STC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 148960 W: 38409 L: 38312 D: 72239
Ptnml(0-2): 372, 17664, 38318, 17747, 379 
https://tests.stockfishchess.org/tests/view/684c5773703522d4f129c5f7

Passed non-regression LTC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 180720 W: 46188 L: 46130 D: 88402
Ptnml(0-2): 84, 19608, 50929, 19644, 95 
https://tests.stockfishchess.org/tests/view/68505fa5703522d4f129cbab

bench 1905627