### PR TITLE
Disable linux gcc riscv64

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,14 +39,15 @@ jobs:
             comp: ndk
             run_armv7_tests: true
             shell: bash
-          - name: Linux GCC riscv64
-            os: ubuntu-22.04
-            compiler: g++
-            comp: gcc
-            run_riscv64_tests: true
-            base_image: "riscv64/alpine:edge"
-            platform: linux/riscv64
-            shell: bash
+          # Currently segfaults in the CI unrelated to a Stockfish change.
+          # - name: Linux GCC riscv64
+          #   os: ubuntu-22.04
+          #   compiler: g++
+          #   comp: gcc
+          #   run_riscv64_tests: true
+          #   base_image: "riscv64/alpine:edge"
+          #   platform: linux/riscv64
+          #   shell: bash
           - name: Linux GCC ppc64
             os: ubuntu-22.04
             compiler: g++


### PR DESCRIPTION
Temporarily disable it, until we figure out the toolchain issues which are causing the crashes.

No functional change