### PR TITLE
Simplify PV term in lmr

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -655,7 +655,6 @@ Value Search::Worker::search(
     priorReduction = (ss - 1)->reduction;
     (ss - 1)->reduction = 0;
     ss->statScore       = 0;
-    ss->isPvNode        = PvNode;
     (ss + 2)->cutoffCnt = 0;
 
     // Step 4. Transposition table lookup
@@ -1238,7 +1237,7 @@ moves_loop:  // When in check, search starts here
             // std::clamp has been replaced by a more robust implementation.
             Depth d = std::max(1, std::min(newDepth - r / 1024,
                                            newDepth + !allNode + (PvNode && !bestMove)))
-                    + (ss - 1)->isPvNode;
+                    + PvNode;
 
             ss->reduction = newDepth - d;
             value         = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);

--- a/src/search.h
+++ b/src/search.h
@@ -75,7 +75,6 @@ struct Stack {
     bool                        ttHit;
     int                         cutoffCnt;
     int                         reduction;
-    bool                        isPvNode;
     int                         quietMoveStreak;
 };
 


### PR DESCRIPTION
Simplify PV term in lmr
Tests were done prior to the last merge wave but there is no reason to expect interaction.

Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 204000 W: 52541 L: 52506 D: 98953
Ptnml(0-2): 561, 24133, 52589, 24144, 573 
https://tests.stockfishchess.org/tests/view/684f24ce703522d4f129cab5

Passed simplification LTC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 156150 W: 39890 L: 39807 D: 76453
Ptnml(0-2): 82, 16882, 44043, 17007, 61 
https://tests.stockfishchess.org/tests/view/6855d8bf1d0d9fc6587538f8

bench 2766493