### PR TITLE
Remove depth condition from ttCapture reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1203,7 +1203,7 @@ moves_loop:  // When in check, search starts here
 
         // Increase reduction if ttMove is a capture
         if (ttCapture)
-            r += 1210 + (depth < 8) * 963;
+            r += 1350;
 
         // Increase reduction if next ply has a lot of fail high
         if ((ss + 1)->cutoffCnt > 2)


### PR DESCRIPTION
Remove depth condition from ttCapture reduction

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 25920 W: 6822 L: 6593 D: 12505
Ptnml(0-2): 54, 2932, 6783, 3113, 78
https://tests.stockfishchess.org/tests/view/6853f9c2038630d25f468672

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 177318 W: 45339 L: 45278 D: 86701
Ptnml(0-2): 85, 19333, 49765, 19388, 88
https://tests.stockfishchess.org/tests/view/6854468a038630d25f4686c0

bench: 2138806

