### PR TITLE
Simplify away constants in statscore

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1193,7 +1193,7 @@ moves_loop:  // When in check, search starts here
 
         // These reduction adjustments have no proven non-linear scaling
 
-        r += 316;  // Base reduction offset to compensate for other tweaks
+        r += 650;  // Base reduction offset to compensate for other tweaks
         r -= moveCount * 66;
         r -= std::abs(correctionValue) / 28047;
 
@@ -1218,12 +1218,11 @@ moves_loop:  // When in check, search starts here
         if (capture)
             ss->statScore =
               826 * int(PieceValue[pos.captured_piece()]) / 128
-              + thisThread->captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())]
-              - 5030;
+              + thisThread->captureHistory[movedPiece][move.to_sq()][type_of(pos.captured_piece())];
         else
             ss->statScore = 2 * thisThread->mainHistory[us][move.from_to()]
                           + (*contHist[0])[movedPiece][move.to_sq()]
-                          + (*contHist[1])[movedPiece][move.to_sq()] - 3206;
+                          + (*contHist[1])[movedPiece][move.to_sq()];
 
         // Decrease/increase reduction for moves with a good/bad history
         r -= ss->statScore * 826 / 8192;


### PR DESCRIPTION
Remove constants in statscore, adjusting the baseline reduction to counteract.

Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 317280 W: 81589 L: 81678 D: 154013
Ptnml(0-2): 799, 37651, 81847, 37526, 817 
https://tests.stockfishchess.org/tests/view/684e197a703522d4f129c9f0

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 174816 W: 44656 L: 44593 D: 85567
Ptnml(0-2): 83, 19064, 49058, 19113, 90 
https://tests.stockfishchess.org/tests/view/6858aa54a596a06817bb924f

bench 1907497