### PR TITLE
Simplify away tt history term in lmr

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1273,11 +1273,9 @@ moves_loop:  // When in check, search starts here
             if (!ttData.move)
                 r += 1128;
 
-            r -= ttMoveHistory / 8;
-
             // Note that if expected reduction is high, we reduce search depth here
             value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha,
-                                   newDepth - (r > 3564) - (r > 4969 && newDepth > 2), !cutNode);
+                                   newDepth - (r > 3200) - (r > 4600 && newDepth > 2), !cutNode);
         }
 
         // For PV nodes only, do a full PV search on the first move or after a fail high,


### PR DESCRIPTION
Simplify away tt history term in lmr

Passed simplification STC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 163168 W: 42136 L: 42055 D: 78977
Ptnml(0-2): 410, 19224, 42212, 19351, 387 
https://tests.stockfishchess.org/tests/view/684e16ee703522d4f129c9e9

Passed simplification LTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 303144 W: 77580 L: 77647 D: 147917
Ptnml(0-2): 150, 33110, 85134, 33013, 165 
https://tests.stockfishchess.org/tests/view/6852ff97703522d4f129d5f7


bench 2006800