### PR TITLE
Remove !ttData.move condition from cutNode reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1199,7 +1199,7 @@ moves_loop:  // When in check, search starts here
 
         // Increase reduction for cut nodes
         if (cutNode)
-            r += 2864 + 966 * !ttData.move;
+            r += 3000;
 
         // Increase reduction if ttMove is a capture
         if (ttCapture)


### PR DESCRIPTION
Remove !ttData.move condition from cutNode reduction.

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 118080 W: 30427 L: 30298 D: 57355
Ptnml(0-2): 290, 13880, 30561, 14029, 280
https://tests.stockfishchess.org/tests/view/6853f9bc038630d25f468670

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 232272 W: 59187 L: 59182 D: 113903
Ptnml(0-2): 111, 25430, 65014, 25505, 76
https://tests.stockfishchess.org/tests/view/68585c40a596a06817bb922e

bench: 1789880