### PR TITLE
Add offsets to history updates

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1890,13 +1890,15 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
     static constexpr std::array<ConthistBonus, 6> conthist_bonuses = {
       {{1, 1092}, {2, 631}, {3, 294}, {4, 517}, {5, 126}, {6, 445}}};
 
+    static constexpr int conthist_offsets[6] {71, 106, -22, -20, 29, -74};
+
     for (const auto [i, weight] : conthist_bonuses)
     {
         // Only update the first 2 continuation histories if we are in check
         if (ss->inCheck && i > 2)
             break;
         if (((ss - i)->currentMove).is_ok())
-            (*(ss - i)->continuationHistory)[pc][to] << bonus * weight / 1024;
+            (*(ss - i)->continuationHistory)[pc][to] << (bonus * weight / 1024) + conthist_offsets[i - 1];
     }
 }
 
@@ -1909,14 +1911,14 @@ void update_quiet_histories(
     workerThread.mainHistory[us][move.from_to()] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.from_to()] << bonus * 792 / 1024;
+        workerThread.lowPlyHistory[ss->ply][move.from_to()] << (bonus * 792 / 1024) + 40;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(),
                                   bonus * (bonus > 0 ? 1082 : 784) / 1024);
 
     int pIndex = pawn_structure_index(pos);
     workerThread.pawnHistory[pIndex][pos.moved_piece(move)][move.to_sq()]
-      << bonus * (bonus > 0 ? 705 : 450) / 1024;
+        << (bonus * (bonus > 0 ? 705 : 450) / 1024) + 70;
 }
 
 }


### PR DESCRIPTION
All parameters were tuned on 60k STC games (https://tests.stockfishchess.org/tests/view/6867ef49fe0f2fe354c0c735). 

Passed STC:
LLR: 2.98 (-2.94,2.94) <0.00,2.00>
Total: 60576 W: 15794 L: 15444 D: 29338
Ptnml(0-2): 141, 7003, 15642, 7369, 133
https://tests.stockfishchess.org/tests/view/686d5af11451bd6fb830772a

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 58722 W: 15159 L: 14799 D: 28764
Ptnml(0-2): 19, 6259, 16455, 6599, 29
https://tests.stockfishchess.org/tests/view/686f9fd51451bd6fb83081c9

bench 2115335