### PR TITLE
Simplify search functions according DRY principle

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -297,8 +297,8 @@ class Worker {
    private:
     void iterative_deepening();
 
-    void do_move(Position& pos, const Move move, StateInfo& st);
-    void do_move(Position& pos, const Move move, StateInfo& st, const bool givesCheck);
+    void do_move(Position& pos, const Move move, StateInfo& st, Stack* const ss);
+    void do_move(Position& pos, const Move move, StateInfo& st, const bool givesCheck, Stack* const ss);
     void do_null_move(Position& pos, StateInfo& st);
     void undo_move(Position& pos, const Move move);
     void undo_null_move(Position& pos);


### PR DESCRIPTION
Moves some redundant stack instructions into one single point.

Passed STC non-regression bounds
https://tests.stockfishchess.org/tests/view/6870db4bfa93cf16d3bb286a
LLR: 3.00 (-2.94,2.94) <-1.75,0.25>
Total: 182016 W: 46735 L: 46673 D: 88608
Ptnml(0-2): 368, 19895, 50465, 19867, 413

no functional change