### PR TITLE
Prevent accidential misuse of TUNE()

### DIFF
--- a/src/tune.h
+++ b/src/tune.h
@@ -170,11 +170,20 @@ class Tune {
     static OptionsMap* options;
 };
 
+template<typename... Args>
+constexpr void tune_check_args(Args&&...) {
+    static_assert((!std::is_fundamental_v<Args> && ...), "TUNE macro arguments wrong");
+}
+
 // Some macro magic :-) we define a dummy int variable that the compiler initializes calling Tune::add()
 #define STRINGIFY(x) #x
 #define UNIQUE2(x, y) x##y
 #define UNIQUE(x, y) UNIQUE2(x, y)  // Two indirection levels to expand __LINE__
-#define TUNE(...) int UNIQUE(p, __LINE__) = Tune::add(STRINGIFY((__VA_ARGS__)), __VA_ARGS__)
+#define TUNE(...) \
+    int UNIQUE(p, __LINE__) = []() -> int { \
+        tune_check_args(__VA_ARGS__); \
+        return Tune::add(STRINGIFY((__VA_ARGS__)), __VA_ARGS__); \
+    }();
 
 #define UPDATE_ON_LAST() bool UNIQUE(p, __LINE__) = Tune::update_on_last = true
 


### PR DESCRIPTION
Writing a TUNE expression like 

```cpp
int smallNetThreshold = 962;
TUNE(smallNetThreshold, 850, 1050);
```

is wrong and can lead to a weird binary. It should thus fail to even compile.
A cheap way to prevent this is to disallow any fundamental type in the parameter list.
If this prevents any legal TUNE invocation please lmk.