### PR TITLE
Add support for UCI wait command

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -136,6 +136,10 @@ void UCIEngine::loop() {
         else if (token == "isready")
             sync_cout << "readyok" << sync_endl;
 
+        // Add custom non-UCI commands, which can be used during a search
+        else if (token == "wait")
+            engine.wait_for_search_finished();
+
         // Add custom non-UCI commands, mainly for debugging purposes.
         // These commands must not be used during a search!
         else if (token == "flip")


### PR DESCRIPTION
UCI wait command comes from Torch, and has been made quite popular, recently picked up by Lc0, as a way of being able to run the engine with some minor sync. from a simple list of commands

No functional change

Bench 2249459


Observe the utility as follows:



```
# We don't finish the search, because the EOF is reached.
$ cat bar.txt
go depth 10
$ ./stockfish < bar.txt
Stockfish dev-20250702-ce73441f by the Stockfish developers (see AUTHORS file)
info string Available processors: 0-31
info string Using 1 thread
info string NNUE evaluation using nn-1c0000000000.nnue (133MiB, (22528, 3072, 15, 32, 1))
info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
bestmove a2a3

# We demand finishing the search via wait, and such happens.
$ cat foo.txt
go depth 10
wait
$ ./stockfish < foo.txt
Stockfish dev-20250702-ce73441f by the Stockfish developers (see AUTHORS file)
info string Available processors: 0-31
info string Using 1 thread
info string NNUE evaluation using nn-1c0000000000.nnue (133MiB, (22528, 3072, 15, 32, 1))
info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
info depth 1 seldepth 2 multipv 1 score cp 17 nodes 20 nps 20000 hashfull 0 tbhits 0 time 1 pv e2e4
info depth 2 seldepth 3 multipv 1 score cp 34 nodes 45 nps 45000 hashfull 0 tbhits 0 time 1 pv e2e4
info depth 3 seldepth 4 multipv 1 score cp 49 nodes 74 nps 74000 hashfull 0 tbhits 0 time 1 pv e2e4
info depth 4 seldepth 7 multipv 1 score cp 20 nodes 1573 nps 1573000 hashfull 1 tbhits 0 time 1 pv c2c4
info depth 5 seldepth 7 multipv 1 score cp 21 nodes 1863 nps 1863000 hashfull 1 tbhits 0 time 1 pv c2c4 e7e6 b1c3 d7d5 c4d5 e6d5
info depth 6 seldepth 7 multipv 1 score cp 34 nodes 2320 nps 2320000 hashfull 1 tbhits 0 time 1 pv e2e4
info depth 7 seldepth 8 multipv 1 score cp 38 nodes 2821 nps 1410500 hashfull 1 tbhits 0 time 2 pv e2e4 d7d5 e4d5 d8d5
info depth 8 seldepth 10 multipv 1 score cp 58 nodes 3369 nps 1684500 hashfull 1 tbhits 0 time 2 pv e2e4
info depth 9 seldepth 17 multipv 1 score cp 32 nodes 11931 nps 1491375 hashfull 4 tbhits 0 time 8 pv e2e4 c7c5 g1f3 b8c6 d2d4 c5d4 f3d4 e7e6 b1c3 g8f6 d4c6
info depth 10 seldepth 18 multipv 1 score cp 29 nodes 18336 nps 1528000 hashfull 4 tbhits 0 time 12 pv e2e4 c7c5 g1f3 b8c6 d2d4 c5d4 f3d4 g8f6 b1c3 e7e6 f1e2 f8b4
bestmove e2e4 ponder c7c5
```