### PR TITLE
Execute series of cmdline arguments as if they were stdin, keeping legacy bench support

### DIFF
--- a/src/uci.h
+++ b/src/uci.h
@@ -60,6 +60,8 @@ class UCIEngine {
 
     static void print_info_string(std::string_view str);
 
+    bool process_command(const std::string& is);
+
     void          go(std::istringstream& is);
     void          bench(std::istream& args);
     void          benchmark(std::istream& args);


### PR DESCRIPTION
Bench 2249459 ; No functional change

This time do an idea that was made popular by Koivisto ( BUT I AM NOT CLAIMING THAT IT WAS NEVER THOUGHT OF BEFORE ), where you can formulate simple strings of UCI commands as cmdline arguments, to satisfy simple use cases for the engine. Such a thing is common for small CI testing, local debugging when you want to repeatadly set a few options like Syzygy, etc.

When paired with uciwait, it becomes more powerful.
The following command shows a simple example, without the need to use any more complex setup like printf piping. 
` ./stockfish "go perft 2" "ucinewgame" "go depth 10" "ucinewgame" "quit"`