### PR TITLE
Simplify away a term in see pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1055,8 +1055,8 @@ moves_loop:  // When in check, search starts here
                 }
 
                 // SEE based pruning for captures and checks
-                int seeHist = std::clamp(captHist / 31, -137 * depth, 125 * depth);
-                if (!pos.see_ge(move, -158 * depth - seeHist))
+                int margin = std::clamp(158 * depth + captHist / 31, 0, 283 * depth);
+                if (!pos.see_ge(move, -margin))
                 {
                     bool mayStalemateTrap =
                       depth > 2 && alpha < 0 && pos.non_pawn_material(us) == PieceValue[movedPiece]


### PR DESCRIPTION
Simplify away a term in see pruning (no functional change)

This change only sets the margin to 0 when depth <= 2 and margin <= 42 which never has a difference, thus non-functional

Passed non-regression STC
LLR: 3.51 (-2.94,2.94) <-1.75,0.25>
Total: 306976 W: 78935 L: 78961 D: 149080
Ptnml(0-2): 630, 34097, 84067, 34057, 637 
https://tests.stockfishchess.org/tests/view/68708015fa93cf16d3bb2782

bench 2249459