### PR TITLE
Simplify `eval >= beta` condition from NMP

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,6 +30,7 @@ Andy Duplain
 Antoine Champion (antoinechampion)
 Aram Tumanian (atumanian)
 Arjun Temurnikar
+Aron Petkovski (fury)
 Artem Solopiy (EntityFX)
 Auguste Pop
 Balazs Szilagyi

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -853,12 +853,10 @@ Value Search::Worker::search(
     }
 
     // Step 9. Null move search with verification search
-    if (cutNode && (ss - 1)->currentMove != Move::null() && eval >= beta
+    if (cutNode && (ss - 1)->currentMove != Move::null()
         && ss->staticEval >= beta - 19 * depth + 389 && !excludedMove && pos.non_pawn_material(us)
         && ss->ply >= thisThread->nmpMinPly && !is_loss(beta))
     {
-        assert(eval - beta >= 0);
-
         // Null move dynamic reduction based on depth
         Depth R = 7 + depth / 3;
 


### PR DESCRIPTION
It seems that now only checking if static eval is above beta by some margin is all that's necessary.

Passed Non-Regression STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 227264 W: 58430 L: 58421 D: 110413
Ptnml(0-2): 532, 26559, 59454, 26542, 545 
https://tests.stockfishchess.org/tests/view/68763a77432ca24f6388c766

Passed Non-Regression LTC
 LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 72048 W: 18622 L: 18455 D: 34971
Ptnml(0-2): 26, 7775, 20272, 7908, 43 
https://tests.stockfishchess.org/tests/view/687c9f2b6e17e7fa3939b0c5

Bench: 2089086