### PR TITLE
Simplify static evaluation difference to move ordering logic

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -801,7 +801,7 @@ Value Search::Worker::search(
     }
 
     // Use static evaluation difference to improve quiet move ordering
-    if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture && !ttHit)
+    if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture)
     {
         int bonus = std::clamp(-10 * int((ss - 1)->staticEval + ss->staticEval), -1858, 1492) + 661;
         mainHistory[~us][((ss - 1)->currentMove).from_to()] << bonus * 1057 / 1024;


### PR DESCRIPTION
Passed STC simplification bounds
https://tests.stockfishchess.org/tests/view/686fcb091451bd6fb83082bc
LLR: 2.92 (-2.94,2.94) <-1.75,0.25>
Total: 762816 W: 196717 L: 197295 D: 368804
Ptnml(0-2): 2052, 90457, 196853, 90109, 1937

Passed LTC simplification bounds
https://tests.stockfishchess.org/tests/view/68808d316e17e7fa3939b35d
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 44736 W: 11499 L: 11303 D: 21934
Ptnml(0-2): 24, 4766, 12586, 4974, 18

bench: 2808070