### PR TITLE
Simplify razoring

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -826,7 +826,7 @@ Value Search::Worker::search(
     // Step 7. Razoring
     // If eval is really low, skip search entirely and return the qsearch value.
     // For PvNodes, we must have a guard against mates being returned.
-    if (!PvNode && eval < alpha - 486 - 325 * depth * depth)
+    if (!PvNode && eval < alpha - 800 && depth == 1)
         return qsearch<NonPV>(pos, ss, alpha, beta);
 
     // Step 8. Futility pruning: child node


### PR DESCRIPTION
Before we had a quadratic term, now we have a constant term but only apply at depth 1

Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 125888 W: 32451 L: 32331 D: 61106
Ptnml(0-2): 283, 14887, 32516, 14943, 315 
https://tests.stockfishchess.org/tests/view/68708936fa93cf16d3bb279d

Passed simplification LTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 165486 W: 42541 L: 42468 D: 80477
Ptnml(0-2): 71, 18015, 46510, 18064, 83 
https://tests.stockfishchess.org/tests/view/6875c98a432ca24f6388c6e7

new matetrack
Using stockfish_razoringsimp.exe on matetrack.epd with --nodes 1000000
Engine ID:     Stockfish dev-20250727-nogit
Total FENs:    6554
Found mates:   3485
Best mates:    2450

old matetrack
Using stockfish_razoringsimp.exe on matetrack.epd with --nodes 1000000
Engine ID:     master
Total FENs:    6554
Found mates:   3541
Best mates:    2507

bench 2657751