### PR TITLE
Simplification of Score Construction for Mates

### DIFF
--- a/src/score.cpp
+++ b/src/score.cpp
@@ -40,8 +40,7 @@ Score::Score(Value v, const Position& pos) {
     }
     else
     {
-        auto distance = VALUE_MATE - std::abs(v);
-        score         = (v > 0) ? Mate{distance} : Mate{-distance};
+        score = Mate{v > 0 ? VALUE_MATE - v : -VALUE_MATE - v};
     }
 }
 


### PR DESCRIPTION
Simplification of Score Construction for Mates

Combining the calculation into a single, more direct ternary expression, eliminating the need for std::abs and the intermediate distance variable.

No functional change
