### PR TITLE
Tweak the logic for setting the improving flag when the static evaluation is significantly higher than alpha.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -886,7 +886,7 @@ Value Search::Worker::search(
         }
     }
 
-    improving |= ss->staticEval >= beta + 94;
+    improving |= ss->staticEval >= beta + 30 + 64 * !PvNode;
 
     // Step 10. Internal iterative reductions
     // At sufficient depth, reduce depth for PV/Cut nodes without a TTMove.


### PR DESCRIPTION
Tweak the logic for setting the improving flag when the static evaluation is significantly higher than alpha.

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 57472 W: 15059 L: 14714 D: 27699
Ptnml(0-2): 139, 6706, 14703, 7047, 141
https://tests.stockfishchess.org/tests/view/68860ac0966ed85face248a3

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 181476 W: 46579 L: 45969 D: 88928
Ptnml(0-2): 82, 19443, 51085, 20039, 89
https://tests.stockfishchess.org/tests/view/68861013966ed85face248f3


bench: 2777318