### PR TITLE
Tweak the logic for setting the improving flag when the static evaluation is significantly higher than alpha #2

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -886,7 +886,7 @@ Value Search::Worker::search(
         }
     }
 
-    improving |= ss->staticEval >= beta + 94;
+    improving |= ss->staticEval >= beta + 94 * !PvNode;
 
     // Step 10. Internal iterative reductions
     // At sufficient depth, reduce depth for PV/Cut nodes without a TTMove.


### PR DESCRIPTION
A simpler alternative for #6179 

Tweak the logic for setting the improving flag when the static evaluation is significantly higher than alpha.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 92320 W: 24057 L: 23664 D: 44599
Ptnml(0-2): 247, 10689, 23893, 11086, 245
https://tests.stockfishchess.org/tests/view/68860aba966ed85face248a1

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 281292 W: 72496 L: 71683 D: 137113
Ptnml(0-2): 135, 30289, 78995, 31082, 145
https://tests.stockfishchess.org/tests/view/6886168c966ed85face24962



bench: 2864631