### PR TITLE
Simplify newDepth modification formulas

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1233,11 +1233,11 @@ moves_loop:  // When in check, search starts here
             // Do a full-depth search when reduced LMR search fails high
             // (*Scaler) Usually doing more shallower searches
             // doesn't scale well to longer TCs
-            if (value > alpha && d < newDepth)
+            if (value > alpha)
             {
                 // Adjust full-depth search based on LMR results - if the result was
                 // good enough search deeper, if it was bad enough search shallower.
-                const bool doDeeperSearch    = value > (bestValue + 42 + 2 * newDepth);
+                const bool doDeeperSearch    = d < newDepth && value > (bestValue + 42 + 2 * newDepth);
                 const bool doShallowerSearch = value < bestValue + 9;
 
                 newDepth += doDeeperSearch - doShallowerSearch;
@@ -1248,8 +1248,6 @@ moves_loop:  // When in check, search starts here
                 // Post LMR continuation history updates
                 update_continuation_histories(ss, movedPiece, move.to_sq(), 1508);
             }
-            else if (value > alpha && value < bestValue + 9)
-                newDepth--;
         }
 
         // Step 18. Full-depth search when LMR is skipped


### PR DESCRIPTION
Simplify newDepth modification formulas

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 21856 W: 5709 L: 5471 D: 10676
Ptnml(0-2): 77, 2466, 5589, 2734, 62
https://tests.stockfishchess.org/tests/view/68862ea4966ed85face24a27

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 108828 W: 27893 L: 27763 D: 53172
Ptnml(0-2): 59, 11860, 30435, 12012, 48
https://tests.stockfishchess.org/tests/view/68863046966ed85face24a3b

bench: 2401510