### PR TITLE
Less history pruning at PV nodes.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1067,7 +1067,7 @@ moves_loop:  // When in check, search starts here
                             + pawnHistory[pawn_structure_index(pos)][movedPiece][move.to_sq()];
 
                 // Continuation history based pruning
-                if (history < -4229 * depth)
+                if (history < -4229 * depth - 1024 * PvNode)
                     continue;
 
                 history += 68 * mainHistory[us][move.from_to()] / 32;


### PR DESCRIPTION
Passed STC:
LLR: 2.98 (-2.94,2.94) <0.00,2.00>
Total: 195424 W: 50945 L: 50397 D: 94082
Ptnml(0-2): 493, 22828, 50581, 23258, 552
https://tests.stockfishchess.org/tests/view/68864baf7b562f5f7b7312e4

Passed LTC (tested against passed VVLTC tuning):
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 16512 W: 4464 L: 4187 D: 7861
Ptnml(0-2): 6, 1700, 4575, 1961, 14
https://tests.stockfishchess.org/tests/view/688679697b562f5f7b7315d9

Bench: 2656573