### PR TITLE
Add depth condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -818,7 +818,7 @@ Value Search::Worker::search(
 
     opponentWorsening = ss->staticEval > -(ss - 1)->staticEval;
 
-    if (priorReduction >= 3 && !opponentWorsening)
+    if (priorReduction >= (depth < 10? 1: 3) && !opponentWorsening)
         depth++;
     if (priorReduction >= 1 && depth >= 2 && ss->staticEval + (ss - 1)->staticEval > 175)
         depth--;


### PR DESCRIPTION
Add depth condition

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 103360 W: 26941 L: 26530 D: 49889
Ptnml(0-2): 291, 11964, 26770, 12353, 302
https://tests.stockfishchess.org/tests/view/68863547966ed85face24a6f

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 115128 W: 29734 L: 29258 D: 56136
Ptnml(0-2): 48, 12406, 32182, 12878, 50
https://tests.stockfishchess.org/tests/view/68864f867b562f5f7b7312f2

bench: 3082493