### PR TITLE
Simplify extra continuation history updates

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1870,8 +1870,6 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
     static constexpr std::array<ConthistBonus, 6> conthist_bonuses = {
       {{1, 1092}, {2, 631}, {3, 294}, {4, 517}, {5, 126}, {6, 445}}};
 
-    static constexpr int conthist_offsets[6]{71, 106, -22, -20, 29, -74};
-
     for (const auto [i, weight] : conthist_bonuses)
     {
         // Only update the first 2 continuation histories if we are in check
@@ -1879,7 +1877,7 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
             break;
         if (((ss - i)->currentMove).is_ok())
             (*(ss - i)->continuationHistory)[pc][to]
-              << (bonus * weight / 1024) + conthist_offsets[i - 1];
+              << (bonus * weight / 1024) + 80 * (i < 2);
     }
 }
 


### PR DESCRIPTION
Passed simplification STC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 254464 W: 65774 L: 65793 D: 122897
Ptnml(0-2): 699, 30087, 65638, 30150, 658 
https://tests.stockfishchess.org/tests/view/68863283966ed85face24a59

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 144750 W: 37111 L: 37018 D: 70621
Ptnml(0-2): 79, 15676, 40764, 15785, 71 
https://tests.stockfishchess.org/tests/view/6886655f7b562f5f7b731359

bench 2549296