### PR TITLE
Increase futility value when capturing last moved piece

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1038,7 +1038,8 @@ moves_loop:  // When in check, search starts here
                 // Futility pruning for captures
                 if (!givesCheck && lmrDepth < 7 && !ss->inCheck)
                 {
-                    Value futilityValue = ss->staticEval + 232 + 224 * lmrDepth
+                    Value futilityValue = ss->staticEval + 225 + 220 * lmrDepth
+                                        + 275 * (move.to_sq() == prevSq)
                                         + PieceValue[capturedPiece] + 131 * captHist / 1024;
                     if (futilityValue <= alpha)
                         continue;


### PR DESCRIPTION
Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 204320 W: 53059 L: 52500 D: 98761
Ptnml(0-2): 551, 23874, 52778, 24379, 578
https://tests.stockfishchess.org/tests/view/688618ae966ed85face24976

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 138582 W: 35748 L: 35225 D: 67609
Ptnml(0-2): 62, 14874, 38900, 15389, 66
https://tests.stockfishchess.org/tests/view/68862717966ed85face249f2

Bench: 2923433