### PR TITLE
Simplify LMR extension limit formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1223,7 +1223,7 @@ moves_loop:  // When in check, search starts here
             // To prevent problems when the max value is less than the min value,
             // std::clamp has been replaced by a more robust implementation.
             Depth d = std::max(1, std::min(newDepth - r / 1024,
-                                           newDepth + !allNode + (PvNode && !bestMove)))
+                                           newDepth + 1 + PvNode))
                     + PvNode;
 
             ss->reduction = newDepth - d;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1222,9 +1222,7 @@ moves_loop:  // When in check, search starts here
             // beyond the first move depth.
             // To prevent problems when the max value is less than the min value,
             // std::clamp has been replaced by a more robust implementation.
-            Depth d = std::max(1, std::min(newDepth - r / 1024,
-                                           newDepth + 1 + PvNode))
-                    + PvNode;
+            Depth d = std::max(1, std::min(newDepth - r / 1024, newDepth + 1 + PvNode)) + PvNode;
 
             ss->reduction = newDepth - d;
             value         = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);


### PR DESCRIPTION
This patch simplifies the maximum depth formula that reductions in LMR can allow.

Passed STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 35616 W: 9358 L: 9139 D: 17119
Ptnml(0-2): 101, 4051, 9278, 4284, 94
https://tests.stockfishchess.org/tests/view/688608cf966ed85face24882

Passed LTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 22284 W: 5833 L: 5613 D: 10838
Ptnml(0-2): 8, 2367, 6173, 2585, 9 
https://tests.stockfishchess.org/tests/view/68860d7f966ed85face248d5