### PR TITLE
Re-adding ttHit  condition, but this time in the inner block

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -813,7 +813,7 @@ Value Search::Worker::search(
     {
         int bonus = std::clamp(-10 * int((ss - 1)->staticEval + ss->staticEval), -1979, 1561) + 630;
         mainHistory[~us][((ss - 1)->currentMove).from_to()] << bonus * 935 / 1024;
-        if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
+        if (!ttHit && type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
             pawnHistory[pawn_structure_index(pos)][pos.piece_on(prevSq)][prevSq]
               << bonus * 1428 / 1024;
     }


### PR DESCRIPTION
Re-adding ttHit  condition, but this time in the inner block

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 150240 W: 39305 L: 38819 D: 72116
Ptnml(0-2): 536, 17541, 38494, 17999, 550
https://tests.stockfishchess.org/tests/view/6887ce577b562f5f7b731a85

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 159120 W: 41025 L: 40461 D: 77634
Ptnml(0-2): 96, 16974, 44866, 17518, 106
https://tests.stockfishchess.org/tests/view/6887f0ba7b562f5f7b731c5d

bench: 3498926