### PR TITLE
Bound info belongs directly to score info.

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -630,11 +630,11 @@ void UCIEngine::on_update_full(const Engine::InfoFull& info, bool showWDL) {
        << " multipv " << info.multiPV             //
        << " score " << format_score(info.score);  //
 
-    if (showWDL)
-        ss << " wdl " << info.wdl;
-
     if (!info.bound.empty())
         ss << " " << info.bound;
+
+    if (showWDL)
+        ss << " wdl " << info.wdl;
 
     ss << " nodes " << info.nodes        //
        << " nps " << info.nps            //


### PR DESCRIPTION
It looks a bit strange if upperbound or lowerbound info appear after the WDL stats.

No functional change.