### PR TITLE
Only do IIR in minimally reduced nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -892,7 +892,7 @@ Value Search::Worker::search(
     // At sufficient depth, reduce depth for PV/Cut nodes without a TTMove.
     // (*Scaler) Especially if they make IIR less aggressive.
     if (!allNode && depth >= 6 && !ttData.move && priorReduction <= 3)
-        depth -= 1;
+        depth--;
 
     // Step 11. ProbCut
     // If we have a good enough capture (or queen promotion) and a reduced search


### PR DESCRIPTION
Passed STC
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 164256 W: 42799 L: 42299 D: 79158
Ptnml(0-2): 451, 19305, 42087, 19863, 422 
https://tests.stockfishchess.org/tests/view/68868e9b7b562f5f7b731615

Passed LTC
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 279396 W: 71871 L: 71062 D: 136463
Ptnml(0-2): 126, 30117, 78404, 30924, 127 
https://tests.stockfishchess.org/tests/view/6886a4977b562f5f7b731663