### PR TITLE
Simplify improving term

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -895,7 +895,7 @@ Value Search::Worker::search(
         }
     }
 
-    improving |= ss->staticEval >= beta + 94 * !PvNode;
+    improving |= ss->staticEval >= beta;
 
     // Step 10. Internal iterative reductions
     // At sufficient depth, reduce depth for PV/Cut nodes without a TTMove.


### PR DESCRIPTION
Set improving whenever ss->staticEval >= beta

Passed simplification STC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 38016 W: 10122 L: 9900 D: 17994
Ptnml(0-2): 143, 4388, 9747, 4564, 166 
https://tests.stockfishchess.org/tests/view/688803917b562f5f7b7322eb

Passed simplification LTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 21648 W: 5594 L: 5375 D: 10679
Ptnml(0-2): 12, 2241, 6096, 2466, 9 
https://tests.stockfishchess.org/tests/view/688820397b562f5f7b73235d

bench 3318006