### PR TITLE
Separate bonus/malus parameters for quiet and capture moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1813,38 +1813,38 @@ void update_all_stats(const Position& pos,
     Piece                  movedPiece     = pos.moved_piece(bestMove);
     PieceType              capturedPiece;
 
-    int quietBonus   = std::min(163 * depth - 85, 1584) + 328 * (bestMove == ttMove);
-    int quietMalus   = std::min(760 * depth - 180, 2410) - 32 * quietsSearched.size();
-    int captureBonus = std::min(123 * depth - 61, 1233) + 333 * (bestMove == ttMove);
-    int captureMalus = std::min(696 * depth - 151, 2283) - 28 * capturesSearched.size();
+    int quietBonus   = std::min(170 * depth - 87, 1598) + 332 * (bestMove == ttMove);
+    int quietMalus   = std::min(743 * depth - 180, 2287) - 33 * quietsSearched.size();
+    int captureBonus = std::min(124 * depth - 62, 1245) + 336 * (bestMove == ttMove);
+    int captureMalus = std::min(708 * depth - 148, 2287) - 29 * capturesSearched.size();
 
     if (!pos.capture_stage(bestMove))
     {
-        update_quiet_histories(pos, ss, workerThread, bestMove, quietBonus * 981 / 1024);
+        update_quiet_histories(pos, ss, workerThread, bestMove, quietBonus * 978 / 1024);
 
         // Decrease stats for all non-best quiet moves
         for (Move move : quietsSearched)
-            update_quiet_histories(pos, ss, workerThread, move, -quietMalus * 1146 / 1024);
+            update_quiet_histories(pos, ss, workerThread, move, -quietMalus * 1115 / 1024);
     }
     else
     {
         // Increase stats for the best move in case it was a capture move
         capturedPiece = type_of(pos.piece_on(bestMove.to_sq()));
-        captureHistory[movedPiece][bestMove.to_sq()][capturedPiece] << captureBonus * 1280 / 1024;
+        captureHistory[movedPiece][bestMove.to_sq()][capturedPiece] << captureBonus * 1288 / 1024;
     }
 
     // Extra penalty for a quiet early move that was not a TT move in
     // previous ply when it gets refuted.
     if (prevSq != SQ_NONE && ((ss - 1)->moveCount == 1 + (ss - 1)->ttHit) && !pos.captured_piece())
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
-                                      -captureMalus * 609 / 1024);
+                                      -captureMalus * 622 / 1024);
 
     // Decrease stats for all non-best capture moves
     for (Move move : capturesSearched)
     {
         movedPiece    = pos.moved_piece(move);
         capturedPiece = type_of(pos.piece_on(move.to_sq()));
-        captureHistory[movedPiece][move.to_sq()][capturedPiece] << -captureMalus * 1397 / 1024;
+        captureHistory[movedPiece][move.to_sq()][capturedPiece] << -captureMalus * 1431 / 1024;
     }
 }
 


### PR DESCRIPTION
Parameters were tuned on 60k STC games.
(Commit message and branch name incorrectly say 30k; it was actually 60k.)

Passed STC
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 16928 W: 4570 L: 4277 D: 8081
Ptnml(0-2): 57, 1905, 4270, 2152, 80
https://tests.stockfishchess.org/tests/view/688b4486502b34dd5e711122

Passed LTC
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 43602 W: 11373 L: 11041 D: 21188
Ptnml(0-2): 23, 4657, 12116, 4975, 30
https://tests.stockfishchess.org/tests/view/688c0eb5502b34dd5e71124b