### PR TITLE
Fix: Use version-aware $(LLVM_PROFDATA) for icx PGO builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1137,7 +1137,7 @@ icx-profile-make:
 	all
 
 icx-profile-use:
-	$(XCRUN) llvm-profdata merge -output=stockfish.profdata *.profraw
+	$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
 	EXTRACXXFLAGS='-fprofile-instr-use=stockfish.profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \


### PR DESCRIPTION
Fix: Use version-aware $(LLVM_PROFDATA) for icx PGO builds

This PR fixes a potential issue in profile-guided optimization (PGO) builds when using the Intel icx compiler by ensuring the correct, version-matched llvm-profdata tool is used.

Context:
#5958  introduced the $(LLVM_PROFDATA) variable to solve a critical issue where using multiple Clang versions in parallel could cause PGO failures due to llvm-profdata version mismatches. The variable correctly locates the llvm-profdata binary that corresponds to the specified CXX compiler (e.g., using llvm-profdata-20 for clang++-20).

Problem:
The Intel icx compiler is also LLVM-based and relies on the same llvm-profdata tool. However, the icx-profile-use target in the Makefile was not updated in the previous change and still uses a hardcoded llvm-profdata command.
This can lead to PGO build failures when a user has multiple LLVM/ICX toolchains installed and the default llvm-profdata in the system path does not match the version of icx being used for the build.

Solution:
This change updates the icx-profile-use target to use the $(LLVM_PROFDATA) variable instead of the hardcoded llvm-profdata. This extends the existing robust logic for version-matching to the icx toolchain, improving build reliability and consistency.

Change Summary:
In Makefile, updated the icx-profile-use target to invoke $(LLVM_PROFDATA) instead of the hardcoded llvm-profdata.


No functional change