### PR TITLE
Reintroduce reduction term in LMR for cutnodes.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1185,7 +1185,7 @@ moves_loop:  // When in check, search starts here
 
         // Increase reduction for cut nodes
         if (cutNode)
-            r += 3000;
+            r += 3000 + 1024 * !ttData.move;
 
         // Increase reduction if ttMove is a capture
         if (ttCapture)


### PR DESCRIPTION
This term increases reduction for cutnodes without tt move, term was simplified away recently.
Passed STC:
https://tests.stockfishchess.org/tests/view/688882007b562f5f7b73262f
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 187616 W: 49367 L: 48824 D: 89425
Ptnml(0-2): 710, 21898, 48034, 22471, 695 
Passed LTC:
https://tests.stockfishchess.org/tests/view/688c71f4502b34dd5e71139a
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 140280 W: 36280 L: 35750 D: 68250
Ptnml(0-2): 79, 15175, 39121, 15667, 98 
bench 2996732