### PR TITLE
Simplify key after

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -703,10 +703,10 @@ Value Search::Worker::search(
             if (depth >= 8 && ttData.move && pos.pseudo_legal(ttData.move) && pos.legal(ttData.move)
                 && !is_decisive(ttData.value))
             {
-                do_move(pos, ttData.move, st, nullptr);
+                pos.do_move(ttData.move, st);
                 Key nextPosKey                             = pos.key();
                 auto [ttHitNext, ttDataNext, ttWriterNext] = tt.probe(nextPosKey);
-                undo_move(pos, ttData.move);
+                pos.undo_move(ttData.move);
 
                 // Check that the ttValue after the tt move would also trigger a cutoff
                 if (!is_valid(ttDataNext.value))


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 534016 W: 139438 L: 139771 D: 254807
Ptnml(0-2): 2098, 63469, 136136, 63278, 2027
https://tests.stockfishchess.org/tests/view/688ac64d502b34dd5e7110a4

Passed Non-regression LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 43980 W: 11346 L: 11149 D: 21485
Ptnml(0-2): 31, 4689, 12353, 4886, 31
https://tests.stockfishchess.org/tests/view/688ea8a47d68fe4f7f130eb3

Bench: 2943323