### PR TITLE
Simplification: Futility pruning for captures (test45)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1048,7 +1048,6 @@ moves_loop:  // When in check, search starts here
                     int imbalanceAdjustment = std::clamp(materialImbalance / 80, -50, 50);
 
                     Value futilityValue = ss->staticEval + 232 + 224 * lmrDepth
-                                        + PieceValue[capturedPiece] + 131 * captHist / 1024;
                                         + PieceValue[capturedPiece] + 131 * captHist / 1024
                                         + imbalanceAdjustment;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1043,13 +1043,8 @@ moves_loop:  // When in check, search starts here
                 if (!givesCheck && lmrDepth < 7 && !ss->inCheck)
                 {
 
-                    // Consider material imbalance when evaluating capture futility
-                    Value materialImbalance = pos.non_pawn_material(us) - pos.non_pawn_material(~us);
-                    int imbalanceAdjustment = std::clamp(materialImbalance / 80, -50, 50);
-
                     Value futilityValue = ss->staticEval + 232 + 224 * lmrDepth
-                                        + PieceValue[capturedPiece] + 131 * captHist / 1024
-                                        + imbalanceAdjustment;
+                                        + PieceValue[capturedPiece] + 131 * captHist / 1024;
 
                     if (futilityValue <= alpha)
                         continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1042,9 +1042,16 @@ moves_loop:  // When in check, search starts here
                 // Futility pruning for captures
                 if (!givesCheck && lmrDepth < 7 && !ss->inCheck)
                 {
-                    Value futilityValue = ss->staticEval + 225 + 220 * lmrDepth
-                                        + 275 * (move.to_sq() == prevSq) + PieceValue[capturedPiece]
-                                        + 131 * captHist / 1024;
+
+                    // Consider material imbalance when evaluating capture futility
+                    Value materialImbalance = pos.non_pawn_material(us) - pos.non_pawn_material(~us);
+                    int imbalanceAdjustment = std::clamp(materialImbalance / 80, -50, 50);
+
+                    Value futilityValue = ss->staticEval + 232 + 224 * lmrDepth
+                                        + PieceValue[capturedPiece] + 131 * captHist / 1024;
+                                        + PieceValue[capturedPiece] + 131 * captHist / 1024
+                                        + imbalanceAdjustment;
+
                     if (futilityValue <= alpha)
                         continue;
                 }


### PR DESCRIPTION
LTC: https://tests.stockfishchess.org/tests/view/688e85a17d68fe4f7f130e24

LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 113682 W: 29199 L: 29074 D: 55409
Ptnml(0-2): 68, 12359, 31859, 12490, 65