### PR TITLE
[RFC] Remove an instruction from find_nnz()

### DIFF
--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -88,8 +88,9 @@ void find_nnz(const std::int32_t* RESTRICT input,
     constexpr IndexType SimdWidthOut = 32;  // 512 bits / 16 bits
     constexpr IndexType NumChunks    = InputDimensions / SimdWidthOut;
     const __m512i       increment    = _mm512_set1_epi16(SimdWidthOut);
-    __m512i base = _mm512_set_epi16(31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
-                                    15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+    __m512i base = _mm512_set_epi16( // Same permute order as _mm512_packus_epi32()
+        31, 30, 29, 28,  15, 14, 13, 12,  27, 26, 25, 24,  11, 10, 9, 8,
+        23, 22, 21, 20,   7,  6,  5,  4,  19, 18, 17, 16,   3,  2, 1, 0);
 
     IndexType count = 0;
     for (IndexType i = 0; i < NumChunks; ++i)
@@ -98,8 +99,8 @@ void find_nnz(const std::int32_t* RESTRICT input,
         const __m512i inputV1 = _mm512_load_si512(input + i * 2 * SimdWidthIn + SimdWidthIn);
 
         // Get a bitmask and gather non zero indices
-        const __mmask32 nnzMask = _mm512_kunpackw(_mm512_test_epi32_mask(inputV1, inputV1),
-                                                  _mm512_test_epi32_mask(inputV0, inputV0));
+        const __m512i   inputV01 = _mm512_packus_epi32(inputV0, inputV1);
+        const __mmask32 nnzMask  = _mm512_test_epi16_mask(inputV01, inputV01);
 
         // Avoid _mm512_mask_compressstoreu_epi16() as it's 256 uOps on Zen4
         __m512i nnz = _mm512_maskz_compress_epi16(nnzMask, base);


### PR DESCRIPTION
This removes one _mm512_test_epi32_mask() instruction.  I don't measure any speed difference however.  The reason this is an RFC is because the resulting indices will be listed in a non strictly increasing order(which is non functional) but could affect sequential memory prefetching when they are used later.  Can we see if anyone else can measure either a speed up or slow down?  (Only applies to the x86-64-avx512icl ARHC.)

No functional change
bench: 2946135