### PR TITLE
Reducing probcut depth more when staticEval is very good

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -915,7 +915,8 @@ Value Search::Worker::search(
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
         MovePicker mp(pos, ttData.move, probCutBeta - ss->staticEval, &captureHistory);
-        Depth      probCutDepth = std::max(depth - 5, 0);
+        Depth      dynamicReduction = (ss->staticEval - beta) / 300;
+        Depth      probCutDepth     = std::max(depth - 5 - dynamicReduction, 0);
 
         while ((move = mp.next_move()) != Move::none())
         {


### PR DESCRIPTION
… and less if staticEval is not so good compared to beta.

Bench: 2950653

STC: https://tests.stockfishchess.org/tests/view/68926bf6690844f940fa1350
LLR: 2.98 (-2.94,2.94) <0.00,2.00>
Total: 174400 W: 45698 L: 45174 D: 83528
Ptnml(0-2): 622, 20356, 44672, 20976, 574

LTC: https://tests.stockfishchess.org/tests/view/689651b4f8a258623dda6531
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 56010 W: 14547 L: 14191 D: 27272
Ptnml(0-2): 31, 5929, 15738, 6267, 40

This patch was generated using `qwen3-235b-a22b-thinking-2507`:

Prompt: https://rentry.co/bm6vriai
Thinking: https://rentry.co/34km4zf8
Final respone: https://rentry.co/rauotrvr