### PR TITLE
Simplify beta formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -369,7 +369,7 @@ void Search::Worker::iterative_deepening() {
                 // otherwise exit the loop.
                 if (bestValue <= alpha)
                 {
-                    beta  = (3 * alpha + beta) / 4;
+                    beta  = alpha;
                     alpha = std::max(bestValue - delta, -VALUE_INFINITE);
 
                     failedHighCnt = 0;


### PR DESCRIPTION
Simplify beta formula

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 152384 W: 39907 L: 39814 D: 72663
Ptnml(0-2): 557, 17958, 39053, 18083, 541
https://tests.stockfishchess.org/tests/view/6890b66692fcad741b804a10

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 98688 W: 25411 L: 25270 D: 48007
Ptnml(0-2): 45, 10692, 27743, 10805, 59
https://tests.stockfishchess.org/tests/view/6896019c618946ab878347b0

bench: 3207375