### PR TITLE
Remove completedDepth condition for SE

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -133,6 +133,7 @@ Justin Blanchard (UncombedCoconut)
 Kelly Wilson
 Ken Takusagawa
 Kenneth Lee (kennethlee33)
+kevlu8
 Kian E (KJE-98)
 kinderchocolate
 Kiran Panditrao (Krgp)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1113,7 +1113,7 @@ moves_loop:  // When in check, search starts here
         // and lower extension margins scale well.
 
         if (!rootNode && move == ttData.move && !excludedMove
-            && depth >= 6 - (completedDepth > 26) + ss->ttPv && is_valid(ttData.value)
+            && depth >= 6 + ss->ttPv && is_valid(ttData.value)
             && !is_decisive(ttData.value) && (ttData.bound & BOUND_LOWER)
             && ttData.depth >= depth - 3)
         {


### PR DESCRIPTION
Just removing the term

Passed STC:
LLR: 3.27 (-2.94,2.94) <-1.75,0.25>
Total: 179840 W: 47211 L: 47126 D: 85503
Ptnml(0-2): 567, 17929, 52879, 17942, 603 
https://tests.stockfishchess.org/tests/view/688bdd88502b34dd5e7111ea

Passed LTC:
LLR: 3.26 (-2.94,2.94) <-1.75,0.25>
Total: 150708 W: 38738 L: 38637 D: 73333
Ptnml(0-2): 79, 12922, 49262, 13001, 90 
https://tests.stockfishchess.org/tests/view/688ce857f17748b4d23c8026

Passed VLTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 288312 W: 74104 L: 74152 D: 140056
Ptnml(0-2): 44, 26732, 90657, 26674, 49 
https://tests.stockfishchess.org/tests/view/688ec4f57d68fe4f7f130ee3

Bench: 3629755