### PR TITLE
Remove quiet move streak

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1006,8 +1006,6 @@ moves_loop:  // When in check, search starts here
         movedPiece = pos.moved_piece(move);
         givesCheck = pos.gives_check(move);
 
-        (ss + 1)->quietMoveStreak = (!capture && !givesCheck) ? (ss->quietMoveStreak + 1) : 0;
-
         // Calculate new depth for this move
         newDepth = depth - 1;
 
@@ -1178,7 +1176,7 @@ moves_loop:  // When in check, search starts here
 
         // These reduction adjustments have no proven non-linear scaling
 
-        r += 650;  // Base reduction offset to compensate for other tweaks
+        r += 1000;  // Base reduction offset to compensate for other tweaks
         r -= moveCount * 69;
         r -= std::abs(correctionValue) / 27160;
 
@@ -1193,8 +1191,6 @@ moves_loop:  // When in check, search starts here
         // Increase reduction if next ply has a lot of fail high
         if ((ss + 1)->cutoffCnt > 2)
             r += 935 + allNode * 763;
-
-        r += (ss + 1)->quietMoveStreak * 51;
 
         // For first picked move (ttMove) reduce reduction
         if (move == ttData.move)

--- a/src/search.h
+++ b/src/search.h
@@ -75,7 +75,6 @@ struct Stack {
     bool                        ttHit;
     int                         cutoffCnt;
     int                         reduction;
-    int                         quietMoveStreak;
 };
 
 


### PR DESCRIPTION
Remove quiet move streak and adjust baseline reduction to counteract

Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 39392 W: 10359 L: 10138 D: 18895
Ptnml(0-2): 147, 4635, 9915, 4848, 151 
https://tests.stockfishchess.org/tests/view/6887fe5a7b562f5f7b7322ce

Passed simplification LTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 154332 W: 39847 L: 39762 D: 74723
Ptnml(0-2): 129, 16854, 43103, 16963, 117 
https://tests.stockfishchess.org/tests/view/688820207b562f5f7b73235b

bench 2741847