### PR TITLE
History_second_order

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -84,7 +84,9 @@ class StatsEntry {
     void operator<<(int bonus) {
         // Make sure that bonus is in range [-D, D]
         int clampedBonus = std::clamp(bonus, -D, D);
-        entry += clampedBonus - entry * std::abs(clampedBonus) / D;
+        int squaredBonus = clampedBonus * clampedBonus;
+        int bonus_sign = (1-2*(bonus<=0));
+        entry += clampedBonus - (entry * std::abs(clampedBonus)  + bonus_sign*squaredBonus/2)/ D + squaredBonus*entry/(2*D*D);
 
         assert(std::abs(entry) <= D);
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -83,7 +83,7 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                  : 0;
 
-    return 8867 * pcv + 8136 * micv + 10757 * (wnpcv + bnpcv) + 7232 * cntcv;
+    return 9162 * pcv + 7734 * micv + 10923 * (wnpcv + bnpcv) + 7560 * cntcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -99,10 +99,10 @@ void update_correction_history(const Position& pos,
     const Move  m  = (ss - 1)->currentMove;
     const Color us = pos.side_to_move();
 
-    static constexpr int nonPawnWeight = 165;
+    static constexpr int nonPawnWeight = 155;
 
     workerThread.pawnCorrectionHistory[pawn_correction_history_index(pos)][us] << bonus;
-    workerThread.minorPieceCorrectionHistory[minor_piece_index(pos)][us] << bonus * 153 / 128;
+    workerThread.minorPieceCorrectionHistory[minor_piece_index(pos)][us] << bonus * 144 / 128;
     workerThread.nonPawnCorrectionHistory[non_pawn_index<WHITE>(pos)][WHITE][us]
       << bonus * nonPawnWeight / 128;
     workerThread.nonPawnCorrectionHistory[non_pawn_index<BLACK>(pos)][BLACK][us]
@@ -110,7 +110,7 @@ void update_correction_history(const Position& pos,
 
     if (m.is_ok())
         (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-          << bonus * 153 / 128;
+          << bonus * 144 / 128;
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
@@ -1403,31 +1403,31 @@ moves_loop:  // When in check, search starts here
         update_all_stats(pos, ss, *this, bestMove, prevSq, quietsSearched, capturesSearched, depth,
                          ttData.move);
         if (!PvNode)
-            ttMoveHistory << (bestMove == ttData.move ? 811 : -848);
+            ttMoveHistory << (bestMove == ttData.move ? 737 : -886);
     }
 
     // Bonus for prior quiet countermove that caused the fail low
     else if (!priorCapture && prevSq != SQ_NONE)
     {
-        int bonusScale = -215;
-        bonusScale += std::min(-(ss - 1)->statScore / 103, 337);
-        bonusScale += std::min(64 * depth, 552);
-        bonusScale += 177 * ((ss - 1)->moveCount > 8);
-        bonusScale += 141 * (!ss->inCheck && bestValue <= ss->staticEval - 94);
-        bonusScale += 141 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 76);
+        int bonusScale = -270;
+        bonusScale += std::min(-(ss - 1)->statScore / 104, 342);
+        bonusScale += std::min(61 * depth, 536);
+        bonusScale += 197 * ((ss - 1)->moveCount > 8);
+        bonusScale += 153 * (!ss->inCheck && bestValue <= ss->staticEval - 99);
+        bonusScale += 131 * (!(ss - 1)->inCheck && bestValue <= -(ss - 1)->staticEval - 76);
 
         bonusScale = std::max(bonusScale, 0);
 
-        const int scaledBonus = std::min(155 * depth - 88, 1416) * bonusScale;
+        const int scaledBonus = std::min(139 * depth - 95, 1439) * bonusScale;
 
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
-                                      scaledBonus * 397 / 32768);
+                                      scaledBonus * 395 / 32768);
 
-        mainHistory[~us][((ss - 1)->currentMove).from_to()] << scaledBonus * 224 / 32768;
+        mainHistory[~us][((ss - 1)->currentMove).from_to()] << scaledBonus * 229 / 32768;
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
             pawnHistory[pawn_history_index(pos)][pos.piece_on(prevSq)][prevSq]
-              << scaledBonus * 1127 / 32768;
+              << scaledBonus * 1053 / 32768;
     }
 
     // Bonus for prior capture countermove that caused the fail low
@@ -1818,10 +1818,10 @@ void update_all_stats(const Position& pos,
     Piece                  movedPiece     = pos.moved_piece(bestMove);
     PieceType              capturedPiece;
 
-    int quietBonus   = std::min(170 * depth - 87, 1598) + 332 * (bestMove == ttMove);
-    int quietMalus   = std::min(743 * depth - 180, 2287) - 33 * quietsSearched.size();
-    int captureBonus = std::min(124 * depth - 62, 1245) + 336 * (bestMove == ttMove);
-    int captureMalus = std::min(708 * depth - 148, 2287) - 29 * capturesSearched.size();
+    int quietBonus   = std::min(163 * depth - 99, 1610) + 340 * (bestMove == ttMove);
+    int quietMalus   = std::min(702 * depth - 179, 2332) - 37 * quietsSearched.size();
+    int captureBonus = std::min(117 * depth - 58, 1316) + 330 * (bestMove == ttMove);
+    int captureMalus = std::min(690 * depth - 137, 2352) - 38 * capturesSearched.size();
 
     if (!pos.capture_stage(bestMove))
     {
@@ -1858,7 +1858,7 @@ void update_all_stats(const Position& pos,
 // at ply -1, -2, -3, -4, and -6 with current move.
 void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
     static constexpr std::array<ConthistBonus, 6> conthist_bonuses = {
-      {{1, 1108}, {2, 652}, {3, 273}, {4, 572}, {5, 126}, {6, 449}}};
+      {{1, 1068}, {2, 668}, {3, 316}, {4, 551}, {5, 210}, {6, 384}}};
 
     for (const auto [i, weight] : conthist_bonuses)
     {
@@ -1879,14 +1879,14 @@ void update_quiet_histories(
     workerThread.mainHistory[us][move.from_to()] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.from_to()] << (bonus * 771 / 1024) + 40;
+        workerThread.lowPlyHistory[ss->ply][move.from_to()] << (bonus * 853 / 1024) + 40;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(),
-                                  bonus * (bonus > 0 ? 979 : 842) / 1024);
+                                  bonus * 910 / 1024);
 
     int pIndex = pawn_history_index(pos);
     workerThread.pawnHistory[pIndex][pos.moved_piece(move)][move.to_sq()]
-      << (bonus * (bonus > 0 ? 704 : 439) / 1024) + 70;
+      << (bonus * (bonus > 0 ? 701 : 364) / 1024) + 70;
 }
 
 }


### PR DESCRIPTION
Passed STC:
LLR: 2.97 (-2.94,2.94) <0.00,2.00>
Total: 72864 W: 19060 L: 18690 D: 35114
Ptnml(0-2): 208, 8420, 18832, 8738, 234
https://tests.stockfishchess.org/tests/view/6897e839f8a258623dda6e73

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 52890 W: 13807 L: 13456 D: 25627
Ptnml(0-2): 29, 5643, 14752, 5990, 31
https://tests.stockfishchess.org/tests/live_elo/6897c5eaf8a258623dda6dfb

However, this patch involves quite a large tune.
The untuned version passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 38176 W: 10103 L: 9785 D: 18288
Ptnml(0-2): 121, 4371, 9803, 4655, 138
https://tests.stockfishchess.org/tests/view/6896da31f8a258623dda69d8
The untuned version failed LTC:
LLR: -2.94 (-2.94,2.94) <0.50,2.50>
Total: 97284 W: 24948 L: 24991 D: 47345
Ptnml(0-2): 54, 10576, 27418, 10547, 47
https://tests.stockfishchess.org/tests/live_elo/6896dfc7f8a258623dda69e1

Currently, removing the second-order history while maintaining the tuned value seems to be about neutral at LTC. The VLTC could either pass or fail. This suggests a very complex relationship. 

bench: 3068005

What do you think? If it were me, I would merge the patch and wait for the VVLTC tune before attempting to simplify away this second-order history. 