### PR TITLE
Simplify depth term in reductions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1235,7 +1235,7 @@ moves_loop:  // When in check, search starts here
                 const bool doDeeperSearch = d < newDepth && value > (bestValue + 43 + 2 * newDepth);
                 const bool doShallowerSearch = value < bestValue + 9;
 
-                newDepth += doDeeperSearch - doShallowerSearch;
+                newDepth += doDeeperSearch - doShallowerSearch + PvNode;
 
                 if (newDepth > d)
                     value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, newDepth, !cutNode);


### PR DESCRIPTION
Simplify depth term in reductions

Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 317344 W: 82352 L: 82442 D: 152550
Ptnml(0-2): 999, 37395, 81907, 37439, 932 
https://tests.stockfishchess.org/tests/live_elo/68976798f8a258623dda6c46

Passed simplification LTC
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 291708 W: 74733 L: 74787 D: 142188
Ptnml(0-2): 159, 31813, 81956, 31775, 151 
https://tests.stockfishchess.org/tests/live_elo/689791a5f8a258623dda6d03

bench 3857610