### PR TITLE
Simplify dual bonuses

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1818,14 +1818,13 @@ void update_all_stats(const Position& pos,
     Piece                  movedPiece     = pos.moved_piece(bestMove);
     PieceType              capturedPiece;
 
-    int quietBonus   = std::min(170 * depth - 87, 1598) + 332 * (bestMove == ttMove);
+    int bonus   = std::min(170 * depth - 87, 1598) + 332 * (bestMove == ttMove);
     int quietMalus   = std::min(743 * depth - 180, 2287) - 33 * quietsSearched.size();
-    int captureBonus = std::min(124 * depth - 62, 1245) + 336 * (bestMove == ttMove);
     int captureMalus = std::min(708 * depth - 148, 2287) - 29 * capturesSearched.size();
 
     if (!pos.capture_stage(bestMove))
     {
-        update_quiet_histories(pos, ss, workerThread, bestMove, quietBonus * 978 / 1024);
+        update_quiet_histories(pos, ss, workerThread, bestMove, bonus * 978 / 1024);
 
         // Decrease stats for all non-best quiet moves
         for (Move move : quietsSearched)
@@ -1835,7 +1834,7 @@ void update_all_stats(const Position& pos,
     {
         // Increase stats for the best move in case it was a capture move
         capturedPiece = type_of(pos.piece_on(bestMove.to_sq()));
-        captureHistory[movedPiece][bestMove.to_sq()][capturedPiece] << captureBonus * 1288 / 1024;
+        captureHistory[movedPiece][bestMove.to_sq()][capturedPiece] << bonus;
     }
 
     // Extra penalty for a quiet early move that was not a TT move in


### PR DESCRIPTION
Merge dual capture/quiet bonuses into one

Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 223200 W: 57868 L: 57854 D: 107478
Ptnml(0-2): 689, 26441, 57296, 26515, 659 
https://tests.stockfishchess.org/tests/view/6898d28e0049e8ccef9d6384

Passed simplification LTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 147270 W: 37750 L: 37659 D: 71861
Ptnml(0-2): 84, 15869, 41633, 15970, 79 
https://tests.stockfishchess.org/tests/view/68990fe30049e8ccef9d643c

bench 3124381