### PR TITLE
Add log depth as term to reduction factors.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1178,27 +1178,27 @@ moves_loop:  // When in check, search starts here
 
         // These reduction adjustments have no proven non-linear scaling
 
-        r += 650;  // Base reduction offset to compensate for other tweaks
-        r -= moveCount * 69;
+        r += 679 - 6 * msb(depth);  // Base reduction offset to compensate for other tweaks
+        r -= moveCount * (67 - 2 * msb(depth));
         r -= std::abs(correctionValue) / 27160;
 
         // Increase reduction for cut nodes
         if (cutNode)
-            r += 3000 + 1024 * !ttData.move;
+            r += 2998 + 2 * msb(depth) + (948 + 14 * msb(depth)) * !ttData.move;
 
         // Increase reduction if ttMove is a capture
         if (ttCapture)
-            r += 1350;
+            r += 1402 - 39 * msb(depth);
 
         // Increase reduction if next ply has a lot of fail high
         if ((ss + 1)->cutoffCnt > 2)
-            r += 935 + allNode * 763;
+            r += 925 + 33 * msb(depth) + allNode * (701 + 224 * msb(depth));
 
         r += (ss + 1)->quietMoveStreak * 51;
 
         // For first picked move (ttMove) reduce reduction
         if (move == ttData.move)
-            r -= 2043;
+            r -= 2121 + 28 * msb(depth);
 
         if (capture)
             ss->statScore = 782 * int(PieceValue[pos.captured_piece()]) / 128
@@ -1209,7 +1209,7 @@ moves_loop:  // When in check, search starts here
                           + (*contHist[1])[movedPiece][move.to_sq()];
 
         // Decrease/increase reduction for moves with a good/bad history
-        r -= ss->statScore * 789 / 8192;
+        r -= ss->statScore * (729 - 12 * msb(depth)) / 8192;
 
         // Step 17. Late moves reduction / extension (LMR)
         if (depth >= 2 && moveCount > 1)
@@ -1250,7 +1250,7 @@ moves_loop:  // When in check, search starts here
         {
             // Increase reduction if ttMove is not present
             if (!ttData.move)
-                r += 1139;
+                r += 1199 + 35 * msb(depth);
 
             const int threshold1 = depth <= 4 ? 2000 : 3200;
             const int threshold2 = depth <= 4 ? 3500 : 4600;


### PR DESCRIPTION
Replace most reduction factors with a linear term of the form X + Y * msb(depth) (using msb(depth) as simple and fast approximation for log(depth)) and tune the weights with following SPSA test: https://tests.stockfishchess.org/tests/view/689903860049e8ccef9d6415.

Here the tuned values of X[8] and Y[8] were ignored because a simple test with this parameters alone failed badly (https://tests.stockfishchess.org/tests/view/68992b350049e8ccef9d6482).

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 32448 W: 8651 L: 8342 D: 15455
Ptnml(0-2): 81, 3695, 8408, 3914, 126
https://tests.stockfishchess.org/tests/view/6899489b0049e8ccef9d64ad

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 73854 W: 19042 L: 18649 D: 36163
Ptnml(0-2): 37, 7908, 20659, 8271, 52
https://tests.stockfishchess.org/tests/view/689abbe7fd8719b088c8d514

Bench: 3151102