### PR TITLE
Avoid using _mm512_storeu_epi16() due to gcc 9 & 10

### DIFF
--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -104,7 +104,7 @@ void find_nnz(const std::int32_t* RESTRICT input,
 
         // Avoid _mm512_mask_compressstoreu_epi16() as it's 256 uOps on Zen4
         __m512i nnz = _mm512_maskz_compress_epi16(nnzMask, base);
-        _mm512_storeu_epi16(out + count, nnz);
+        _mm512_storeu_si512(out + count, nnz);
 
         count += popcount(nnzMask);
         base = _mm512_add_epi16(base, increment);


### PR DESCRIPTION
No functional change
bench: 3629755

The is an alt version of https://github.com/official-stockfish/Stockfish/pull/6230