### PR TITLE
Speedup write_moves using _mm512_mask_compressstoreu_epi16

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -37,8 +37,7 @@ namespace {
 #if defined(USE_AVX512ICL)
 
 inline Move* write_moves(Move* moveList, uint32_t mask, __m512i vector) {
-    _mm512_storeu_si512(reinterpret_cast<__m512i*>(moveList),
-                        _mm512_maskz_compress_epi16(mask, vector));
+    _mm512_mask_compressstoreu_epi16(moveList, mask, vector);
     return moveList + popcount(mask);
 }
 


### PR DESCRIPTION
We can use the `_mm512_mask_compressstoreu_epi16` instruction which does a compress + store in one instruction rather than two. It's part of the same `AVX512_VBMI2` instruction set.

Baseline:
```
$ ./stockfish_master.exe speedtest
Stockfish dev-20250816-169737a9 by the Stockfish developers (see AUTHORS file)
info string Using 32 threads
Warmup position 3/3
Position 258/258
===========================
Version                    : Stockfish dev-20250816-169737a9
Compiled by                : g++ (GNUC) 15.1.0 on MinGW64
Compilation architecture   : x86-64-avx512icl
Compilation settings       : 64bit AVX512ICL VNNI AVX512 BMI2 AVX2 SSE41 SSSE3 SSE2 POPCNT
Compiler __VERSION__ macro : 15.1.0
Large pages                : no
User invocation            : speedtest
Filled invocation          : speedtest 32 4096 150
Available processors       : 0-31
Thread count               : 32
Thread binding             : none
TT size [MiB]              : 4096
Hash max, avg [per mille]  :
    single search          : 48, 23
    single game            : 647, 456
Total nodes searched       : 5322766982
Total search time [s]      : 153.515
Nodes/second               : 34672618
```

With my change:
```
$ ./stockfish.exe speedtest
Stockfish dev-20250816-169737a9 by the Stockfish developers (see AUTHORS file)
info string Using 32 threads
Warmup position 3/3
Position 258/258
===========================
Version                    : Stockfish dev-20250816-169737a9
Compiled by                : g++ (GNUC) 15.1.0 on MinGW64
Compilation architecture   : x86-64-avx512icl
Compilation settings       : 64bit AVX512ICL VNNI AVX512 BMI2 AVX2 SSE41 SSSE3 SSE2 POPCNT
Compiler __VERSION__ macro : 15.1.0
Large pages                : no
User invocation            : speedtest
Filled invocation          : speedtest 32 4096 150
Available processors       : 0-31
Thread count               : 32
Thread binding             : none
TT size [MiB]              : 4096
Hash max, avg [per mille]  :
    single search          : 47, 22
    single game            : 655, 448
Total nodes searched       : 5403131641
Total search time [s]      : 153.519
Nodes/second               : 35195198
```

Speedup: 1.51%