### PR TITLE
Simplify see margin term in pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1049,7 +1049,7 @@ moves_loop:  // When in check, search starts here
                 }
 
                 // SEE based pruning for captures and checks
-                int margin = std::clamp(158 * depth + captHist / 31, 0, 283 * depth);
+                int margin = std::max(158 * depth + captHist / 31, 0);
                 if (!pos.see_ge(move, -margin))
                 {
                     bool mayStalemateTrap =


### PR DESCRIPTION
Simplify see margin term in pruning

Passed simplification STC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 64576 W: 16972 L: 16780 D: 30824
Ptnml(0-2): 226, 7575, 16504, 7747, 236 
https://tests.stockfishchess.org/tests/view/6899698f0049e8ccef9d64d3

Passed simplification LTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 126420 W: 32387 L: 32274 D: 61759
Ptnml(0-2): 60, 13821, 35349, 13906, 74 
https://tests.stockfishchess.org/tests/view/689a30d9fd8719b088c8d4bb

bench 3088980