### PR TITLE
Remove cutNode as a condition from futility margin formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -839,7 +839,7 @@ Value Search::Worker::search(
     // The depth condition is important for mate finding.
     {
         auto futility_margin = [&](Depth d) {
-            Value futilityMult = 90 - 20 * (cutNode && !ss->ttHit);
+            Value futilityMult = 90 - 20 * !ss->ttHit;
 
             return futilityMult * d                      //
                  - improving * futilityMult * 2          //


### PR DESCRIPTION
Remove cutNode as a condition from futility margin formula

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 53472 W: 13941 L: 13738 D: 25793
Ptnml(0-2): 174, 6273, 13654, 6446, 189
https://tests.stockfishchess.org/tests/view/6899fe91fd8719b088c8d482

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 313350 W: 80226 L: 80303 D: 152821
Ptnml(0-2): 176, 34113, 88171, 34042, 173
https://tests.stockfishchess.org/tests/view/689c90c2fd8719b088c8d6e2


bench: 3052415