### PR TITLE
Bigger thread dependent initial window.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -322,7 +322,7 @@ void Search::Worker::iterative_deepening() {
             selDepth = 0;
 
             // Reset aspiration window starting size
-            delta     = 5 + std::abs(rootMoves[pvIdx].meanSquaredScore) / 11131;
+            delta     = 5 + threadIdx % 8 + std::abs(rootMoves[pvIdx].meanSquaredScore) / 11131;
             Value avg = rootMoves[pvIdx].averageScore;
             alpha     = std::max(avg - delta, -VALUE_INFINITE);
             beta      = std::min(avg + delta, VALUE_INFINITE);


### PR DESCRIPTION
Increase the initial delta of the aspiration window  by "thread id mod 8".

Passed SMP STC:
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 106176 W: 27470 L: 27069 D: 51637
Ptnml(0-2): 121, 12032, 28386, 12423, 126
https://tests.stockfishchess.org/tests/view/68a178fab6fb3300203bbaec

Passed SMP LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 133076 W: 34272 L: 33772 D: 65032
Ptnml(0-2): 38, 13709, 38537, 14223, 31
https://tests.stockfishchess.org/tests/view/68a1b5d2b6fb3300203bbb71

Bench: 2996176