### PR TITLE
Update sde action to 2.4, switch to 9.33.0

### DIFF
--- a/.github/ci/matrix.json
+++ b/.github/ci/matrix.json
@@ -8,7 +8,7 @@
       "comp": "gcc",
       "shell": "bash",
       "archive_ext": "tar",
-      "sde": "/home/runner/work/Stockfish/Stockfish/.output/sde-temp-files/sde-external-9.27.0-2023-09-13-lin/sde -future --"
+      "sde": "/home/runner/work/Stockfish/Stockfish/.output/sde-temp-files/sde-external-9.33.0-2024-01-07-lin/sde -future --"
     },
     {
       "name": "MacOS 13 Apple Clang",
@@ -38,7 +38,7 @@
       "msys_env": "x86_64-gcc",
       "shell": "msys2 {0}",
       "ext": ".exe",
-      "sde": "/d/a/Stockfish/Stockfish/.output/sde-temp-files/sde-external-9.27.0-2023-09-13-win/sde.exe -future --",
+      "sde": "/d/a/Stockfish/Stockfish/.output/sde-temp-files/sde-external-9.33.0-2024-01-07-win/sde.exe -future --",
       "archive_ext": "zip"
     },
     {

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -43,10 +43,10 @@ jobs:
 
       - name: Download SDE package
         if: runner.os == 'Linux' || runner.os == 'Windows'
-        uses: petarpetrovt/setup-sde@91a1a03434384e064706634125a15f7446d2aafb # @v2.3
+        uses: petarpetrovt/setup-sde@f0fa5971dc275704531e94264dd23250c442aa41 # @v2.4
         with:
           environmentVariableName: SDE_DIR
-          sdeVersion: 9.27.0
+          sdeVersion: 9.33.0
 
       - name: Download the used network from the fishtest framework
         run: make net


### PR DESCRIPTION
older version no longer downloadable.

No functional change