### PR TITLE
Simplify depth condition in prior reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -824,7 +824,7 @@ Value Search::Worker::search(
     improving         = ss->staticEval > (ss - 2)->staticEval;
     opponentWorsening = ss->staticEval > -(ss - 1)->staticEval;
 
-    if (priorReduction >= (depth < 10 ? 2 : 3) && !opponentWorsening)
+    if (priorReduction >= 3 && !opponentWorsening)
         depth++;
     if (priorReduction >= 2 && depth >= 2 && ss->staticEval + (ss - 1)->staticEval > 173)
         depth--;


### PR DESCRIPTION
 Simplify depth condition in prior reduction 

Passed simplification STC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 172864 W: 45085 L: 45015 D: 82764
Ptnml(0-2): 516, 20456, 44405, 20552, 503 
https://tests.stockfishchess.org/tests/view/68a24791b6fb3300203bbdb6

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 84738 W: 21733 L: 21578 D: 41427
Ptnml(0-2): 49, 9169, 23780, 9320, 51 
https://tests.stockfishchess.org/tests/view/68a2665ab6fb3300203bc269

bench 2055071