### PR TITLE
Remove reduction at lower depths in the full-depth search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1252,9 +1252,6 @@ moves_loop:  // When in check, search starts here
             if (!ttData.move)
                 r += 1178 + 35 * msb(depth);
 
-            if (depth < 5)
-                r += 1080;
-
             // Note that if expected reduction is high, we reduce search depth here
             value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha,
                                    newDepth - (r > 3212) - (r > 4784 && newDepth > 2), !cutNode);


### PR DESCRIPTION
Passed simplification STC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 217184 W: 56218 L: 56195 D: 104771
Ptnml(0-2): 627, 25673, 55985, 25664, 643
https://tests.stockfishchess.org/tests/view/68a21e0eb6fb3300203bbcf3

Passed simplification LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 30474 W: 7923 L: 7713 D: 14838
Ptnml(0-2): 20, 3205, 8569, 3431, 12
https://tests.stockfishchess.org/tests/view/68a2adacb6fb3300203bc3f9


bench 2302226