### PR TITLE
Less reduction for later threads.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1178,6 +1178,7 @@ moves_loop:  // When in check, search starts here
         // These reduction adjustments have no proven non-linear scaling
 
         r += 700 - 6 * msb(depth);  // Base reduction offset to compensate for other tweaks
+        r -= (threadIdx % 8) * 64;
         r -= moveCount * (64 - 2 * msb(depth));
         r -= std::abs(correctionValue) / 30450;
 


### PR DESCRIPTION
Give "(thread id mod 8) * 64" less reductions (up to nearly a half ply).

Passed SMP STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 413176 W: 106496 L: 105666 D: 201014
Ptnml(0-2): 504, 46732, 111266, 47602, 484
https://tests.stockfishchess.org/tests/view/68a24aeeb6fb3300203bbdc4

Passed SMP LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 60420 W: 15622 L: 15268 D: 29530
Ptnml(0-2): 11, 6106, 17632, 6440, 21
https://tests.stockfishchess.org/tests/view/68a2c2ffb6fb3300203bc516

No functional change