### PR TITLE
Remove upper bound in see margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1049,7 +1049,7 @@ moves_loop:  // When in check, search starts here
                 }
 
                 // SEE based pruning for captures and checks
-                int margin = std::clamp(157 * depth + captHist / 29, 0, 279 * depth);
+                int margin = std::max(157 * depth + captHist / 29, 0);
                 if (!pos.see_ge(move, -margin))
                 {
                     bool mayStalemateTrap =


### PR DESCRIPTION
Remove upper bound in see margin

Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 99840 W: 25965 L: 25815 D: 48060
Ptnml(0-2): 326, 11708, 25688, 11886, 312 
https://tests.stockfishchess.org/tests/view/68a24504b6fb3300203bbdae

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 248388 W: 63544 L: 63556 D: 121288
Ptnml(0-2): 125, 27132, 69709, 27086, 142 
https://tests.stockfishchess.org/tests/view/68a24f3bb6fb3300203bbdee

bench 2565252