### PR TITLE
Merge maluses

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1817,9 +1817,8 @@ void update_all_stats(const Position& pos,
     Piece                  movedPiece     = pos.moved_piece(bestMove);
     PieceType              capturedPiece;
 
-    int bonus        = std::min(151 * depth - 91, 1730) + 302 * (bestMove == ttMove);
-    int quietMalus   = std::min(798 * depth - 175, 2268) - 33 * quietsSearched.size();
-    int captureMalus = std::min(757 * depth - 134, 2129) - 28 * capturesSearched.size();
+    int bonus = std::min(151 * depth - 91, 1730) + 302 * (bestMove == ttMove);
+    int malus = std::min(798 * depth - 175, 2268) - 33 * quietsSearched.size();
 
     if (!pos.capture_stage(bestMove))
     {
@@ -1827,7 +1826,7 @@ void update_all_stats(const Position& pos,
 
         // Decrease stats for all non-best quiet moves
         for (Move move : quietsSearched)
-            update_quiet_histories(pos, ss, workerThread, move, -quietMalus * 1208 / 1024);
+            update_quiet_histories(pos, ss, workerThread, move, -malus * 1208 / 1024);
     }
     else
     {
@@ -1839,15 +1838,14 @@ void update_all_stats(const Position& pos,
     // Extra penalty for a quiet early move that was not a TT move in
     // previous ply when it gets refuted.
     if (prevSq != SQ_NONE && ((ss - 1)->moveCount == 1 + (ss - 1)->ttHit) && !pos.captured_piece())
-        update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
-                                      -captureMalus * 594 / 1024);
+        update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq, -malus * 594 / 1024);
 
     // Decrease stats for all non-best capture moves
     for (Move move : capturesSearched)
     {
         movedPiece    = pos.moved_piece(move);
         capturedPiece = type_of(pos.piece_on(move.to_sq()));
-        captureHistory[movedPiece][move.to_sq()][capturedPiece] << -captureMalus * 1366 / 1024;
+        captureHistory[movedPiece][move.to_sq()][capturedPiece] << -malus * 1366 / 1024;
     }
 }
 


### PR DESCRIPTION
Merge maluses

Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 68064 W: 17733 L: 17549 D: 32782
Ptnml(0-2): 202, 7892, 17656, 8084, 198 
https://tests.stockfishchess.org/tests/view/68a27e85b6fb3300203bc2a9

Passed simplification LTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 132204 W: 33994 L: 33887 D: 64323
Ptnml(0-2): 61, 14440, 37013, 14507, 81 
https://tests.stockfishchess.org/tests/view/68a2a55eb6fb3300203bc3df

bench 2206050