### PR TITLE
Simplify stalemate detection and fix an assert

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -316,14 +316,14 @@ top:
 
 void MovePicker::skip_quiet_moves() { skipQuiets = true; }
 
-// this function must be called after all quiet moves and captures have been generated
 bool MovePicker::can_move_king_or_pawn() const {
+    // don't call this method while processing tt-move
+    assert (stage != CAPTURE_INIT && stage != QUIET_INIT && stage != PROBCUT_INIT && stage != EVASION_INIT);
 
-    assert((GOOD_QUIET <= stage && stage <= BAD_QUIET) || stage == EVASION);
-
-    // Until good capture state no quiet moves are generated for comparison so simply assume king or pawns can move.
-    // Do the same for other states that don't have a valid available move list.
-    if ((GOOD_QUIET > stage || stage > BAD_QUIET) && stage != EVASION)
+    // For a reliable result we need all moves generated (quiets too)
+    // In the rare case of a 'good capture' candidate for SEE based pruning (= capture with really good history score)
+    // we can safely assume that we still can move king or pawn after the capture
+    if (stage == GOOD_CAPTURE)
         return true;
 
     for (const ExtMove* m = moves; m < endGenerated; ++m)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1053,10 +1053,8 @@ moves_loop:  // When in check, search starts here
                 if (!pos.see_ge(move, -margin))
                 {
                     bool mayStalemateTrap =
-                      depth > 2 && alpha < 0 && pos.non_pawn_material(us) == PieceValue[movedPiece]
+                      alpha < 0 && pos.non_pawn_material(us) == PieceValue[movedPiece]
                       && PieceValue[movedPiece] >= RookValue
-                      // it can't be stalemate if we moved a piece adjacent to the king
-                      && !(attacks_bb<KING>(pos.square<KING>(us)) & move.from_sq())
                       && !mp.can_move_king_or_pawn();
 
                     // avoid pruning sacrifices of our last piece for stalemate


### PR DESCRIPTION
Solves issue #6232 (actually https://github.com/official-stockfish/Stockfish/pull/6235 already did)

Passed nonreg STC
https://tests.stockfishchess.org/tests/view/68a426efb6fb3300203bc644
LLR: 2.99 (-2.94,2.94) <-1.75,0.25>
Total: 130976 W: 34021 L: 33903 D: 63052
Ptnml(0-2): 398, 14655, 35266, 14769, 400

Passed nonreg LTC
https://tests.stockfishchess.org/tests/view/68a805efb6fb3300203bca02
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 115398 W: 29617 L: 29499 D: 56282
Ptnml(0-2): 47, 11538, 34425, 11628, 61

bench: 2149508