### PR TITLE
Simplify nmp verification. (Discussion needed.)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -854,10 +854,9 @@ Value Search::Worker::search(
     }
 
     // Step 9. Null move search with verification search
-    if (cutNode && ss->staticEval >= beta - 18 * depth + 390 && !excludedMove
-        && pos.non_pawn_material(us) && ss->ply >= nmpMinPly && !is_loss(beta))
+    if (((cutNode && ss->staticEval >= beta - 18 * depth + 390 && !excludedMove
+        && pos.non_pawn_material(us) && !is_loss(beta))|| ((ss-1)->currentMove == Move::null())) &&((ss-2)->currentMove != Move::null()))
     {
-        assert((ss - 1)->currentMove != Move::null());
 
         // Null move dynamic reduction based on depth
         Depth R = 6 + depth / 3;
@@ -874,23 +873,7 @@ Value Search::Worker::search(
 
         // Do not return unproven mate or TB scores
         if (nullValue >= beta && !is_win(nullValue))
-        {
-            if (nmpMinPly || depth < 16)
-                return nullValue;
-
-            assert(!nmpMinPly);  // Recursive verification is not allowed
-
-            // Do verification search at high depths, with null move pruning disabled
-            // until ply exceeds nmpMinPly.
-            nmpMinPly = ss->ply + 3 * (depth - R) / 4;
-
-            Value v = search<NonPV>(pos, ss, beta - 1, beta, depth - R, false);
-
-            nmpMinPly = 0;
-
-            if (v >= beta)
-                return nullValue;
-        }
+            return nullValue;
     }
 
     improving |= ss->staticEval >= beta;

--- a/src/search.h
+++ b/src/search.h
@@ -329,7 +329,7 @@ class Worker {
 
     size_t                pvIdx, pvLast;
     std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;
-    int                   selDepth, nmpMinPly;
+    int                   selDepth;
 
     Value optimism[COLOR_NB];
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -282,7 +282,7 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
     {
         th->run_custom_job([&]() {
             th->worker->limits = limits;
-            th->worker->nodes = th->worker->tbHits = th->worker->nmpMinPly =
+            th->worker->nodes = th->worker->tbHits =
               th->worker->bestMoveChanges          = 0;
             th->worker->rootDepth = th->worker->completedDepth = 0;
             th->worker->rootMoves                              = rootMoves;


### PR DESCRIPTION
Passed non-regression STC:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 434272 W: 112616 L: 112832 D: 208824
Ptnml(0-2): 1337, 51551, 111643, 51201, 1404
https://tests.stockfishchess.org/tests/view/68a44b59b6fb3300203bc66a
Passed non-regression LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 136986 W: 35274 L: 35172 D: 66540
Ptnml(0-2): 59, 14906, 38461, 15008, 59
https://tests.stockfishchess.org/tests/view/68a8ea1bb6fb3300203bcb31

bench: 2367551

This involves nmp verification search. A test on zugzwang is needed. I found that it does okay on several zugzwang positions, but I'm not sure if it regresses in others. Discussion needed.