### PR TITLE
Simplify stalemate detection

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -316,23 +316,4 @@ top:
 
 void MovePicker::skip_quiet_moves() { skipQuiets = true; }
 
-// this function must be called after all quiet moves and captures have been generated
-bool MovePicker::can_move_king_or_pawn() const {
-
-    assert((GOOD_QUIET <= stage && stage <= BAD_QUIET) || stage == EVASION);
-
-    // Until good capture state no quiet moves are generated for comparison so simply assume king or pawns can move.
-    // Do the same for other states that don't have a valid available move list.
-    if ((GOOD_QUIET > stage || stage > BAD_QUIET) && stage != EVASION)
-        return true;
-
-    for (const ExtMove* m = moves; m < endGenerated; ++m)
-    {
-        PieceType movedPieceType = type_of(pos.moved_piece(*m));
-        if ((movedPieceType == PAWN || movedPieceType == KING) && pos.legal(*m))
-            return true;
-    }
-    return false;
-}
-
 }  // namespace Stockfish

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -50,7 +50,6 @@ class MovePicker {
     MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
     Move next_move();
     void skip_quiet_moves();
-    bool can_move_king_or_pawn() const;
 
    private:
     template<typename Pred>

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1056,8 +1056,7 @@ moves_loop:  // When in check, search starts here
                       depth > 2 && alpha < 0 && pos.non_pawn_material(us) == PieceValue[movedPiece]
                       && PieceValue[movedPiece] >= RookValue
                       // it can't be stalemate if we moved a piece adjacent to the king
-                      && !(attacks_bb<KING>(pos.square<KING>(us)) & move.from_sq())
-                      && !mp.can_move_king_or_pawn();
+                      && !(attacks_bb<KING>(pos.square<KING>(us)) & move.from_sq());
 
                     // avoid pruning sacrifices of our last piece for stalemate
                     if (!mayStalemateTrap)


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 107392 W: 27959 L: 27818 D: 51615
Ptnml(0-2): 317, 12094, 28735, 12231, 319
https://tests.stockfishchess.org/tests/view/68a65d8ab6fb3300203bc825

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 94014 W: 24129 L: 23986 D: 45899
Ptnml(0-2): 47, 9917, 26934, 10064, 45
https://tests.stockfishchess.org/tests/view/68a8f45cb6fb3300203bcb5e

Passed Stalemate 10k:
Elo: 2.22 ± 1.3 (95%) LOS: 100.0%
Total: 10000 W: 4626 L: 4562 D: 812
Ptnml(0-2): 1, 137, 4659, 203, 0
nElo: 12.00 ± 6.8 (95%) PairsRatio: 1.47
https://tests.stockfishchess.org/tests/view/68a65d8ab6fb3300203bc825

Supersedes #6114
Closes #6232

Bench: 2607587