### PR TITLE
Simplify separate malus formulas

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1021,9 +1021,6 @@ moves_loop:  // When in check, search starts here
         if (ss->ttPv)
             r += 946;
 
-        dbg_mean_of(mainHistory[us][move.from_to()]);
-        dbg_mean_of((*(ss-1)->continuationHistory)[pos.piece_on(move.from_sq())][move.to_sq()], 2);
-
         // Step 14. Pruning at shallow depth.
         // Depth conditions are important for mate finding.
         if (!rootNode && pos.non_pawn_material(us) && !is_loss(bestValue))


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 16352 W: 4336 L: 4090 D: 7926
Ptnml(0-2): 54, 1832, 4157, 2080, 53
https://tests.stockfishchess.org/tests/view/68a808f0b6fb3300203bca08

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 94014 W: 24129 L: 23986 D: 45899
Ptnml(0-2): 47, 9917, 26934, 10064, 45
https://tests.stockfishchess.org/tests/view/68a8f45cb6fb3300203bcb5e

Bench: 2589354