### PR TITLE
Remove log depth reduction terms.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1177,27 +1177,27 @@ moves_loop:  // When in check, search starts here
 
         // These reduction adjustments have no proven non-linear scaling
 
-        r += 700 - 6 * msb(depth);  // Base reduction offset to compensate for other tweaks
-        r -= moveCount * (64 - 2 * msb(depth));
+        r += 671;  // Base reduction offset to compensate for other tweaks
+        r -= moveCount * 66;
         r -= std::abs(correctionValue) / 30450;
 
         // Increase reduction for cut nodes
         if (cutNode)
-            r += 3092 + 2 * msb(depth) + (980 + 15 * msb(depth)) * !ttData.move;
+            r += 3094 + 1056 * !ttData.move;
 
         // Increase reduction if ttMove is a capture
         if (ttCapture)
-            r += 1467 - 40 * msb(depth);
+            r += 1415;
 
         // Increase reduction if next ply has a lot of fail high
         if ((ss + 1)->cutoffCnt > 2)
-            r += 1041 + 34 * msb(depth) + allNode * (752 + 226 * msb(depth));
+            r += 1051 + allNode * 814;
 
         r += (ss + 1)->quietMoveStreak * 50;
 
         // For first picked move (ttMove) reduce reduction
         if (move == ttData.move)
-            r -= 2096 + 27 * msb(depth);
+            r -= 2018;
 
         if (capture)
             ss->statScore = 803 * int(PieceValue[pos.captured_piece()]) / 128
@@ -1208,7 +1208,7 @@ moves_loop:  // When in check, search starts here
                           + (*contHist[1])[movedPiece][move.to_sq()];
 
         // Decrease/increase reduction for moves with a good/bad history
-        r -= ss->statScore * (734 - 12 * msb(depth)) / 8192;
+        r -= ss->statScore * 794 / 8192;
 
         // Step 17. Late moves reduction / extension (LMR)
         if (depth >= 2 && moveCount > 1)
@@ -1250,7 +1250,7 @@ moves_loop:  // When in check, search starts here
         {
             // Increase reduction if ttMove is not present
             if (!ttData.move)
-                r += 1178 + 35 * msb(depth);
+                r += 1118;
 
             if (depth < 5)
                 r += 1080;


### PR DESCRIPTION
Motivated by the elo loss of last VVLTC regression test i remove the new log depth reductions (tuned at STC) to regain strength at VVLTC. The constant terms are adjusted based on the old values and the changes from the last added VVLTC tuning.

Passed VVLTC with STC bound:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 53802 W: 14030 L: 13740 D: 26032
Ptnml(0-2): 5, 4924, 16754, 5212, 6
https://tests.stockfishchess.org/tests/view/68a9a9f575da51a345a5a675

Passed VVLTC with LTC bound:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 53658 W: 14022 L: 13699 D: 25937
Ptnml(0-2): 3, 4894, 16712, 5217, 3
https://tests.stockfishchess.org/tests/view/68a8d2b2b6fb3300203bca77

Bench: 2566780