### PR TITLE
Simplify quiet move streak

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1006,7 +1006,7 @@ moves_loop:  // When in check, search starts here
         movedPiece = pos.moved_piece(move);
         givesCheck = pos.gives_check(move);
 
-        (ss + 1)->quietMoveStreak = (!capture && !givesCheck) ? (ss->quietMoveStreak + 1) : 0;
+        (ss + 1)->quietMoveStreak = capture ? 0 : (ss->quietMoveStreak + 1);
 
         // Calculate new depth for this move
         newDepth = depth - 1;


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 46272 W: 12076 L: 11866 D: 22330
Ptnml(0-2): 140, 5407, 11860, 5561, 168
https://tests.stockfishchess.org/tests/view/68a9c26575da51a345a5a6a2

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 140442 W: 35984 L: 35886 D: 68572
Ptnml(0-2): 72, 15333, 39305, 15447, 64
https://tests.stockfishchess.org/tests/view/68aa245e75da51a345a5a80d

Bench: 2155586