### PR TITLE
Remove cap from a bonusScale formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1409,7 +1409,7 @@ moves_loop:  // When in check, search starts here
     else if (!priorCapture && prevSq != SQ_NONE)
     {
         int bonusScale = -228;
-        bonusScale += std::min(-(ss - 1)->statScore / 104, 322);
+        bonusScale -= (ss - 1)->statScore / 104;
         bonusScale += std::min(63 * depth, 508);
         bonusScale += 184 * ((ss - 1)->moveCount > 8);
         bonusScale += 143 * (!ss->inCheck && bestValue <= ss->staticEval - 92);


### PR DESCRIPTION
Remove cap from a bonusScale formula

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 127264 W: 33159 L: 33042 D: 61063
Ptnml(0-2): 336, 14509, 33866, 14544, 377
https://tests.stockfishchess.org/tests/view/68a63fccb6fb3300203bc818

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 469512 W: 120094 L: 120331 D: 229087
Ptnml(0-2): 238, 51317, 131885, 51076, 240
https://tests.stockfishchess.org/tests/view/68a8d867b6fb3300203bcab5

bench: 2193028