### PR TITLE
Speedup_threat_by_lesser

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -129,13 +129,15 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
 
     Color us = pos.side_to_move();
 
-    [[maybe_unused]] Bitboard threatByLesser[QUEEN + 1];
+    [[maybe_unused]] Bitboard threatByLesser[KING + 1];
     if constexpr (Type == QUIETS)
     {
+        threatByLesser[PAWN] = 0;
         threatByLesser[KNIGHT] = threatByLesser[BISHOP] = pos.attacks_by<PAWN>(~us);
         threatByLesser[ROOK] =
           pos.attacks_by<KNIGHT>(~us) | pos.attacks_by<BISHOP>(~us) | threatByLesser[KNIGHT];
         threatByLesser[QUEEN] = pos.attacks_by<ROOK>(~us) | threatByLesser[ROOK];
+        threatByLesser[KING] = pos.attacks_by<QUEEN>(~us) | threatByLesser[QUEEN];
     }
 
     ExtMove* it = cur;
@@ -170,12 +172,10 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
 
             // penalty for moving to a square threatened by a lesser piece
             // or bonus for escaping an attack by a lesser piece.
-            if (KNIGHT <= pt && pt <= QUEEN)
-            {
-                static constexpr int bonus[QUEEN + 1] = {0, 0, 144, 144, 256, 517};
-                int v = threatByLesser[pt] & to ? -95 : 100 * bool(threatByLesser[pt] & from);
-                m.value += bonus[pt] * v;
-            }
+            static constexpr int bonus[KING + 1] = {0, 0, 144, 144, 256, 517, 10000};
+            int v = threatByLesser[pt] & to ? -95 : 100 * bool(threatByLesser[pt] & from);
+            m.value += bonus[pt] * v;
+
 
             if (ply < LOW_PLY_HISTORY_SIZE)
                 m.value += 8 * (*lowPlyHistory)[ply][m.from_to()] / (1 + ply);


### PR DESCRIPTION
Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 131040 W: 34247 L: 33792 D: 63001
Ptnml(0-2): 407, 15281, 33675, 15764, 393
https://tests.stockfishchess.org/tests/live_elo/68a9a75b75da51a345a5a66d
Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 280146 W: 72055 L: 71242 D: 136849
Ptnml(0-2): 153, 30252, 78438, 31089, 141
https://tests.stockfishchess.org/tests/view/68a9f58475da51a345a5a6e0

bench: 2622144

This patch should ideally have been a non-functional speedup, but changing the ranking of illegal moves, for some reasons, change the bench. So, it had to pass LTC. Thankfully, it passed. 