### PR TITLE
Use integer type for UCI spin values

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -110,7 +110,7 @@ Option::Option(OnChange f) :
     max(0),
     on_change(std::move(f)) {}
 
-Option::Option(double v, int minv, int maxv, OnChange f) :
+Option::Option(int v, int minv, int maxv, OnChange f) :
     type("spin"),
     min(minv),
     max(maxv),
@@ -154,7 +154,7 @@ Option& Option::operator=(const std::string& v) {
 
     if ((type != "button" && type != "string" && v.empty())
         || (type == "check" && v != "true" && v != "false")
-        || (type == "spin" && (std::stof(v) < min || std::stof(v) > max)))
+        || (type == "spin" && (std::stoi(v) < min || std::stoi(v) > max)))
         return *this;
 
     if (type == "combo")
@@ -202,7 +202,7 @@ std::ostream& operator<<(std::ostream& os, const OptionsMap& om) {
                 }
 
                 else if (o.type == "spin")
-                    os << " default " << int(stof(o.defaultValue)) << " min " << o.min << " max "
+                    os << " default " << stoi(o.defaultValue) << " min " << o.min << " max "
                        << o.max;
 
                 break;

--- a/src/ucioption.h
+++ b/src/ucioption.h
@@ -43,7 +43,7 @@ class Option {
     Option(OnChange = nullptr);
     Option(bool v, OnChange = nullptr);
     Option(const char* v, OnChange = nullptr);
-    Option(double v, int minv, int maxv, OnChange = nullptr);
+    Option(int v, int minv, int maxv, OnChange = nullptr);
     Option(const char* v, const char* cur, OnChange = nullptr);
 
     Option& operator=(const std::string&);


### PR DESCRIPTION
In particular, parse spin values as integers to avoid rounding errors.

Fixes https://github.com/official-stockfish/Stockfish/issues/6263

No functional change