### PR TITLE
Simplify LMR Extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1219,7 +1219,7 @@ moves_loop:  // When in check, search starts here
             // To prevent problems when the max value is less than the min value,
             // std::clamp has been replaced by a more robust implementation.
             Depth d =
-              std::max(1, std::min(newDepth - r / 1024, newDepth + (PvNode ? 2 : 1))) + PvNode;
+              std::max(1, std::min(newDepth - r / 1024, newDepth + 1)) + PvNode;
 
             ss->reduction = newDepth - d;
             value         = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1219,7 +1219,7 @@ moves_loop:  // When in check, search starts here
             // To prevent problems when the max value is less than the min value,
             // std::clamp has been replaced by a more robust implementation.
             Depth d =
-              std::max(1, std::min(newDepth - r / 1024, newDepth + 1)) + PvNode;
+              std::max(1, std::min(newDepth - r / 1024, newDepth + 2)) + PvNode;
 
             ss->reduction = newDepth - d;
             value         = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 236896 W: 61683 L: 61683 D: 113530
Ptnml(0-2): 730, 28057, 60901, 28003, 757
https://tests.stockfishchess.org/tests/view/68a9c20475da51a345a5a6a0

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 73644 W: 18936 L: 18770 D: 35938
Ptnml(0-2): 33, 7951, 20685, 8123, 30
https://tests.stockfishchess.org/tests/view/68aa95c575da51a345a5a88a