### PR TITLE
Simplify Capture Futility Pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1038,9 +1038,8 @@ moves_loop:  // When in check, search starts here
                 int   captHist = captureHistory[movedPiece][move.to_sq()][type_of(capturedPiece)];
 
                 // Futility pruning for captures
-                if (!givesCheck && lmrDepth < 7 && !ss->inCheck)
+                if (!givesCheck && lmrDepth < 7)
                 {
-
                     Value futilityValue = ss->staticEval + 231 + 211 * lmrDepth
                                         + PieceValue[capturedPiece] + 130 * captHist / 1024;
 


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 187904 W: 48639 L: 48583 D: 90682
Ptnml(0-2): 560, 22150, 48502, 22154, 586
https://tests.stockfishchess.org/tests/view/68aad56075da51a345a5a9e3

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 94302 W: 24246 L: 24101 D: 45955
Ptnml(0-2): 44, 10274, 26371, 10417, 45
https://tests.stockfishchess.org/tests/view/68ab541975da51a345a5aacf

Bench: 2342048