### PR TITLE
Further Simplify Stalemate Detection

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -66,7 +66,7 @@ class MovePicker {
     const PieceToHistory**       continuationHistory;
     const PawnHistory*           pawnHistory;
     Move                         ttMove;
-    ExtMove *                    cur, *endCur, *endBadCaptures, *endCaptures, *endGenerated = moves;
+    ExtMove *                    cur, *endCur, *endBadCaptures, *endCaptures, *endGenerated;
     int                          stage;
     int                          threshold;
     Depth                        depth;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1053,10 +1053,7 @@ moves_loop:  // When in check, search starts here
                 if (!pos.see_ge(move, -margin))
                 {
                     bool mayStalemateTrap =
-                      depth > 2 && alpha < 0 && pos.non_pawn_material(us) == PieceValue[movedPiece]
-                      && PieceValue[movedPiece] >= RookValue
-                      // it can't be stalemate if we moved a piece adjacent to the king
-                      && !(attacks_bb<KING>(pos.square<KING>(us)) & move.from_sq());
+                      depth > 2 && alpha < 0 && pos.non_pawn_material(us) == PieceValue[movedPiece];
 
                     // avoid pruning sacrifices of our last piece for stalemate
                     if (!mayStalemateTrap)


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.98 (-2.94,2.94) <-1.75,0.25>
Total: 191520 W: 49633 L: 49582 D: 92305
Ptnml(0-2): 557, 20676, 53260, 20693, 574
https://tests.stockfishchess.org/tests/view/68ab570075da51a345a5abe1

Passed Non-regression LTC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 212934 W: 54643 L: 54618 D: 103673
Ptnml(0-2): 117, 22417, 61364, 22462, 107
https://tests.stockfishchess.org/tests/view/68ab84e975da51a345a5ac6b

10k Stalemate:
Elo: 0.35 ± 1.2 (95%) LOS: 71.6%
Total: 10000 W: 4602 L: 4592 D: 806
Ptnml(0-2): 0, 148, 4694, 158, 0
nElo: 1.99 ± 6.8 (95%) PairsRatio: 1.07
https://tests.stockfishchess.org/tests/view/68abeb8175da51a345a5af82

Bench: 2571749