### PR TITLE
revert #6259

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -115,7 +115,9 @@ MovePicker::MovePicker(const Position& p, Move ttm, int th, const CapturePieceTo
     threshold(th) {
     assert(!pos.checkers());
 
-    stage = PROBCUT_TT + !(ttm && pos.capture_stage(ttm) && pos.pseudo_legal(ttm));
+    // Removing the SEE check passes as simplification, but hurts mate finding
+    stage = PROBCUT_TT
+          + !(ttm && pos.capture_stage(ttm) && pos.pseudo_legal(ttm) && pos.see_ge(ttm, threshold));
 }
 
 // Assigns a numerical value to each move in a list, used for sorting.


### PR DESCRIPTION
The recent commit https://github.com/official-stockfish/Stockfish/commit/af181d9fe11216a296113292f772561cfd9823d3 was merged as a simplification, but unfortunately hurts mate finding efficiency.

```
2025-08-24T19:55:35+02:00	e2fdf6f005bd772b6d376c8ddeb14b12760f73c2	6554	3459	2421				
4076
2025-08-24T19:58:49+02:00	af181d9fe11216a296113292f772561cfd9823d3	6554	3180	2293
```
https://github.com/vondele/matetrack/blob/69f5c5e8627c163a6a8480b869ee09bc44dc44d4/matetrack1000000.csv#L4075-L4076

So this PR proposes to revert it, while adding a comment in the code for future reference.

Bench: 2500080