### PR TITLE
Avoid high rule50 count zeroing cutoffs

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -679,7 +679,12 @@ Value Search::Worker::search(
     if (!PvNode && !excludedMove && ttData.depth > depth - (ttData.value <= beta)
         && is_valid(ttData.value)  // Can happen when !ttHit or when access race in probe()
         && (ttData.bound & (ttData.value >= beta ? BOUND_LOWER : BOUND_UPPER))
-        && (cutNode == (ttData.value >= beta) || depth > 5))
+        && (cutNode == (ttData.value >= beta) || depth > 5)
+        // avoid a TT cutoff if the rule50 count is high and the TT move is zeroing
+        && (depth > 8
+            || ttData.move == Move::none() 
+            || pos.rule50_count() < 80 
+            || (!ttCapture && type_of(pos.moved_piece(ttData.move)) != PAWN))) 
     {
         // If ttMove is quiet, update move sorting heuristics on TT hit
         if (ttData.move && ttData.value >= beta)


### PR DESCRIPTION
If the depth is low enough, don't TT cut if the rule50 count is high and the TT move is zeroing.

Passed STC:
https://tests.stockfishchess.org/tests/view/68a8fdd8b6fb3300203bcb92
LLR: 3.05 (-2.94,2.94) <0.00,2.00>
Total: 110304 W: 28805 L: 28402 D: 53097
Ptnml(0-2): 275, 11174, 31875, 11529, 299

Passed LTC:
https://tests.stockfishchess.org/tests/view/68aa200f75da51a345a5a809
LLR: 3.00 (-2.94,2.94) <0.50,2.50>
Total: 187956 W: 48489 L: 47928 D: 91539
Ptnml(0-2): 59, 16118, 61075, 16655, 71

bench: 2641840