### PR TITLE
Remove redundant template from adjust_key50

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ Antoine Champion (antoinechampion)
 Aram Tumanian (atumanian)
 Arjun Temurnikar
 Aron Petkovski (fury)
+Arseniy Surkov (codedeliveryservice)
 Artem Solopiy (EntityFX)
 Auguste Pop
 Balazs Szilagyi

--- a/src/position.h
+++ b/src/position.h
@@ -184,7 +184,6 @@ class Position {
                      Square&           rfrom,
                      Square&           rto,
                      DirtyPiece* const dp = nullptr);
-    template<bool AfterMove>
     Key adjust_key50(Key k) const;
 
     // Data members
@@ -288,11 +287,10 @@ inline Bitboard Position::pinners(Color c) const { return st->pinners[c]; }
 
 inline Bitboard Position::check_squares(PieceType pt) const { return st->checkSquares[pt]; }
 
-inline Key Position::key() const { return adjust_key50<false>(st->key); }
+inline Key Position::key() const { return adjust_key50(st->key); }
 
-template<bool AfterMove>
 inline Key Position::adjust_key50(Key k) const {
-    return st->rule50 < 14 - AfterMove ? k : k ^ make_key((st->rule50 - (14 - AfterMove)) / 8);
+    return st->rule50 < 14 ? k : k ^ make_key((st->rule50 - 14) / 8);
 }
 
 inline Key Position::pawn_key() const { return st->pawnKey; }


### PR DESCRIPTION
Remove the AfterMove template from the adjust_key50 function, which is only ever called with false.

No functional change