### PR TITLE
Simplify intrinsic call

### DIFF
--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -126,7 +126,7 @@ void find_nnz(const std::int32_t* RESTRICT input,
         // Get a bitmask and gather non zero indices
         const __mmask16 nnzMask = _mm512_test_epi32_mask(inputV, inputV);
         const __m512i   nnzV    = _mm512_maskz_compress_epi32(nnzMask, base);
-        _mm512_mask_cvtepi32_storeu_epi16(out + count, 0xFFFF, nnzV);
+        _mm512_cvtepi32_storeu_epi16(out + count, nnzV);
         count += popcount(nnzMask);
         base = _mm512_add_epi32(base, increment);
     }


### PR DESCRIPTION
Simplify intrinsic call
A mask of 0xFFFF corresponds to 1111111111111111 in binary, which means all 16 lanes are active.
The implementation of find_nnz uses a masked store instruction _mm512_mask_cvtepi32_storeu_epi16 with a mask of 0xFFFF, which means all lanes are active. This is equivalent to the non-masked version of the instruction, _mm512_cvtepi32_storeu_epi16. Using the non-masked version is simpler and shorter as it removes a redundant argument.

No functional change