### PR TITLE
Simplify sign term in quiet histories

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1870,7 +1870,7 @@ void update_quiet_histories(
         workerThread.lowPlyHistory[ss->ply][move.from_to()] << (bonus * 741 / 1024) + 38;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(),
-                                  bonus * (bonus > 0 ? 995 : 915) / 1024);
+                                  bonus * 955 / 1024);
 
     int pIndex = pawn_history_index(pos);
     workerThread.pawnHistory[pIndex][pos.moved_piece(move)][move.to_sq()]


### PR DESCRIPTION
Simplify sign term in quiet histories

Passed simplification STC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 497824 W: 129130 L: 129418 D: 239276
Ptnml(0-2): 1546, 59040, 128008, 58792, 1526 
https://tests.stockfishchess.org/tests/view/68a2a9c1b6fb3300203bc3ed

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 70830 W: 18185 L: 18016 D: 34629
Ptnml(0-2): 36, 7658, 19861, 7821, 39 
https://tests.stockfishchess.org/tests/view/68af36c96217b8721dca98d9

bench 2378138