### PR TITLE
Further Simplify Stalemate Detection

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1049,16 +1049,11 @@ moves_loop:  // When in check, search starts here
                 }
 
                 // SEE based pruning for captures and checks
+                // Avoid pruning sacrifices of our last piece for stalemate
                 int margin = std::max(157 * depth + captHist / 29, 0);
-                if (!pos.see_ge(move, -margin))
-                {
-                    bool mayStalemateTrap =
-                      depth > 2 && alpha < 0 && pos.non_pawn_material(us) == PieceValue[movedPiece];
-
-                    // avoid pruning sacrifices of our last piece for stalemate
-                    if (!mayStalemateTrap)
-                        continue;
-                }
+                if ((alpha >= VALUE_DRAW || pos.non_pawn_material(us) != PieceValue[movedPiece])
+                    && !pos.see_ge(move, -margin))
+                    continue;
             }
             else
             {


### PR DESCRIPTION
Non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 155200 W: 40650 L: 40562 D: 73988
Ptnml(0-2): 533, 17588, 41258, 17700, 521
https://tests.stockfishchess.org/tests/view/68abe11375da51a345a5adec

Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 82824 W: 21442 L: 21287 D: 40095
Ptnml(0-2): 51, 8738, 23675, 8901, 47
https://tests.stockfishchess.org/tests/view/68b205606217b8721dca9c8e

10k Stalemate:
Elo: 1.46 ± 1.2 (95%) LOS: 99.0%
Total: 10000 W: 4640 L: 4598 D: 762
Ptnml(0-2): 0, 140, 4678, 182, 0
https://tests.stockfishchess.org/tests/view/68b2059b6217b8721dca9c90

Bench: 2437320