### PR TITLE
limit dynamic reduction.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -917,7 +917,7 @@ Value Search::Worker::search(
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
         MovePicker mp(pos, ttData.move, probCutBeta - ss->staticEval, &captureHistory);
-        Depth      dynamicReduction = (ss->staticEval - beta) / 306;
+        Depth      dynamicReduction = std::max((ss->staticEval - beta) / 306, -1);
         Depth      probCutDepth     = std::max(depth - 5 - dynamicReduction, 0);
 
         while ((move = mp.next_move()) != Move::none())


### PR DESCRIPTION
fixes https://github.com/official-stockfish/Stockfish/issues/6280

prevents probcut from extending depth as analyzed here: https://github.com/official-stockfish/Stockfish/pull/6254#issuecomment-3239144280

passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 86688 W: 22591 L: 22426 D: 41671
Ptnml(0-2): 305, 10125, 22311, 10306, 297
https://tests.stockfishchess.org/tests/view/68b418ab467ff96994ae4cd5

passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 82914 W: 21287 L: 21130 D: 40497
Ptnml(0-2): 39, 8959, 23305, 9114, 40
https://tests.stockfishchess.org/tests/view/68b47ffa78ed7a752a9e8f36

Bench: 2787731