### PR TITLE
Use threats in quiet move generation and simplify castling check in pos.legal()

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -254,7 +254,7 @@ Move* generate_all(const Position& pos, Move* moveList, Bitboard threats) {
 
     if ((Type == QUIETS || Type == NON_EVASIONS) && pos.can_castle(Us & ANY_CASTLING))
         for (CastlingRights cr : {Us & KING_SIDE, Us & QUEEN_SIDE})
-            if (!pos.castling_impeded(cr) && pos.can_castle(cr))
+            if (!pos.castling_impeded(cr, threats) && pos.can_castle(cr))
                 *moveList++ = Move::make<CASTLING>(ksq, pos.castling_rook_square(cr));
 
     return moveList;

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -226,7 +226,7 @@ Move* generate_moves(const Position& pos, Move* moveList, Bitboard target) {
 
 
 template<Color Us, GenType Type>
-Move* generate_all(const Position& pos, Move* moveList) {
+Move* generate_all(const Position& pos, Move* moveList, Bitboard threats) {
 
     static_assert(Type != LEGAL, "Unsupported type in generate_all()");
 
@@ -248,7 +248,7 @@ Move* generate_all(const Position& pos, Move* moveList) {
         moveList = generate_moves<Us, QUEEN>(pos, moveList, target);
     }
 
-    Bitboard b = attacks_bb<KING>(ksq) & (Type == EVASIONS ? ~pos.pieces(Us) : target);
+    Bitboard b = attacks_bb<KING>(ksq) & (Type == EVASIONS ? ~pos.pieces(Us) : target) & ~threats;
 
     moveList = splat_moves(moveList, ksq, b);
 
@@ -270,27 +270,27 @@ Move* generate_all(const Position& pos, Move* moveList) {
 //
 // Returns a pointer to the end of the move list.
 template<GenType Type>
-Move* generate(const Position& pos, Move* moveList) {
+Move* generate(const Position& pos, Move* moveList, Bitboard threats) {
 
     static_assert(Type != LEGAL, "Unsupported type in generate()");
     assert((Type == EVASIONS) == bool(pos.checkers()));
 
     Color us = pos.side_to_move();
 
-    return us == WHITE ? generate_all<WHITE, Type>(pos, moveList)
-                       : generate_all<BLACK, Type>(pos, moveList);
+    return us == WHITE ? generate_all<WHITE, Type>(pos, moveList, threats)
+                       : generate_all<BLACK, Type>(pos, moveList, threats);
 }
 
 // Explicit template instantiations
-template Move* generate<CAPTURES>(const Position&, Move*);
-template Move* generate<QUIETS>(const Position&, Move*);
-template Move* generate<EVASIONS>(const Position&, Move*);
-template Move* generate<NON_EVASIONS>(const Position&, Move*);
+template Move* generate<CAPTURES>(const Position&, Move*, Bitboard);
+template Move* generate<QUIETS>(const Position&, Move*, Bitboard);
+template Move* generate<EVASIONS>(const Position&, Move*, Bitboard);
+template Move* generate<NON_EVASIONS>(const Position&, Move*, Bitboard);
 
 // generate<LEGAL> generates all the legal moves in the given position
 
 template<>
-Move* generate<LEGAL>(const Position& pos, Move* moveList) {
+Move* generate<LEGAL>(const Position& pos, Move* moveList, [[maybe_unused]] Bitboard threats) {
 
     Color    us     = pos.side_to_move();
     Bitboard pinned = pos.blockers_for_king(us) & pos.pieces(us);
@@ -298,7 +298,7 @@ Move* generate<LEGAL>(const Position& pos, Move* moveList) {
     Move*    cur    = moveList;
 
     moveList =
-      pos.checkers() ? generate<EVASIONS>(pos, moveList) : generate<NON_EVASIONS>(pos, moveList);
+      pos.checkers() ? generate<EVASIONS>(pos, moveList, 0) : generate<NON_EVASIONS>(pos, moveList, 0);
     while (cur != moveList)
         if (((pinned & cur->from_sq()) || cur->from_sq() == ksq || cur->type_of() == EN_PASSANT)
             && !pos.legal(*cur))

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -253,9 +253,18 @@ Move* generate_all(const Position& pos, Move* moveList, Bitboard threats) {
     moveList = splat_moves(moveList, ksq, b);
 
     if ((Type == QUIETS || Type == NON_EVASIONS) && pos.can_castle(Us & ANY_CASTLING))
+    {
+        if (Type == NON_EVASIONS)
+        {
+            Color us = pos.side_to_move();
+            threats = pos.attacks_by<PAWN>(~us) | pos.attacks_by<PAWN>(~us)
+                        | pos.attacks_by<PAWN>(~us) | pos.attacks_by<QUEEN>(~us)
+                        | pos.attacks_by<KING>(~us);
+        }
         for (CastlingRights cr : {Us & KING_SIDE, Us & QUEEN_SIDE})
             if (!pos.castling_impeded(cr, threats) && pos.can_castle(cr))
                 *moveList++ = Move::make<CASTLING>(ksq, pos.castling_rook_square(cr));
+    }
 
     return moveList;
 }

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -255,12 +255,9 @@ Move* generate_all(const Position& pos, Move* moveList, Bitboard threats) {
     if ((Type == QUIETS || Type == NON_EVASIONS) && pos.can_castle(Us & ANY_CASTLING))
     {
         if (Type == NON_EVASIONS)
-        {
-            Color us = pos.side_to_move();
-            threats = pos.attacks_by<PAWN>(~us) | pos.attacks_by<PAWN>(~us)
-                        | pos.attacks_by<PAWN>(~us) | pos.attacks_by<QUEEN>(~us)
-                        | pos.attacks_by<KING>(~us);
-        }
+            threats = pos.attacks_by<PAWN>(~Us) | pos.attacks_by<PAWN>(~Us)
+                        | pos.attacks_by<PAWN>(~Us) | pos.attacks_by<QUEEN>(~Us)
+                        | pos.attacks_by<KING>(~Us);
         for (CastlingRights cr : {Us & KING_SIDE, Us & QUEEN_SIDE})
             if (!pos.castling_impeded(cr, threats) && pos.can_castle(cr))
                 *moveList++ = Move::make<CASTLING>(ksq, pos.castling_rook_square(cr));

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -255,9 +255,9 @@ Move* generate_all(const Position& pos, Move* moveList, Bitboard threats) {
     if ((Type == QUIETS || Type == NON_EVASIONS) && pos.can_castle(Us & ANY_CASTLING))
     {
         if (Type == NON_EVASIONS)
-            threats = pos.attacks_by<PAWN>(~Us) | pos.attacks_by<PAWN>(~Us)
-                        | pos.attacks_by<PAWN>(~Us) | pos.attacks_by<QUEEN>(~Us)
-                        | pos.attacks_by<KING>(~Us);
+            threats = pos.attacks_by<PAWN>(~Us) | pos.attacks_by<KNIGHT>(~Us)
+                        | pos.attacks_by<BISHOP>(~Us) | pos.attacks_by<ROOK>(~Us)
+                        | pos.attacks_by<QUEEN>(~Us) | pos.attacks_by<KING>(~Us);
         for (CastlingRights cr : {Us & KING_SIDE, Us & QUEEN_SIDE})
             if (!pos.castling_impeded(cr, threats) && pos.can_castle(cr))
                 *moveList++ = Move::make<CASTLING>(ksq, pos.castling_rook_square(cr));

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -49,7 +49,7 @@ struct ExtMove: public Move {
 inline bool operator<(const ExtMove& f, const ExtMove& s) { return f.value < s.value; }
 
 template<GenType>
-Move* generate(const Position& pos, Move* moveList);
+Move* generate(const Position& pos, Move* moveList, Bitboard threats);
 
 // The MoveList struct wraps the generate() function and returns a convenient
 // list of moves. Using MoveList is sometimes preferable to directly calling
@@ -57,8 +57,8 @@ Move* generate(const Position& pos, Move* moveList);
 template<GenType T>
 struct MoveList {
 
-    explicit MoveList(const Position& pos) :
-        last(generate<T>(pos, moveList)) {}
+    explicit MoveList(const Position& pos, Bitboard threats = 0ULL) :
+        last(generate<T>(pos, moveList, threats)) {}
     const Move* begin() const { return moveList; }
     const Move* end() const { return last; }
     size_t      size() const { return last - moveList; }

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -162,7 +162,7 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
 
             // penalty for moving to a square threatened by a lesser piece
             // or bonus for escaping an attack by a lesser piece.
-            static constexpr int bonus[KING + 1] = {0, 0, 144, 144, 256, 517, 10000};
+            static constexpr int bonus[KING + 1] = {0, 0, 144, 144, 256, 517, 0};
             int v = threatByLesser[pt] & to ? -95 : 100 * bool(threatByLesser[pt] & from);
             m.value += bonus[pt] * v;
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -130,17 +130,6 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
 
     Color us = pos.side_to_move();
 
-    [[maybe_unused]] Bitboard threatByLesser[KING + 1];
-    if constexpr (Type == QUIETS)
-    {
-        threatByLesser[PAWN]   = 0;
-        threatByLesser[KNIGHT] = threatByLesser[BISHOP] = pos.attacks_by<PAWN>(~us);
-        threatByLesser[ROOK] =
-          pos.attacks_by<KNIGHT>(~us) | pos.attacks_by<BISHOP>(~us) | threatByLesser[KNIGHT];
-        threatByLesser[QUEEN] = pos.attacks_by<ROOK>(~us) | threatByLesser[ROOK];
-        threatByLesser[KING]  = pos.attacks_by<QUEEN>(~us) | pos.attacks_by<KING>(~us) | threatByLesser[QUEEN];
-    }
-
     ExtMove* it = cur;
     for (auto move : ml)
     {
@@ -254,7 +243,15 @@ top:
     case QUIET_INIT :
         if (!skipQuiets)
         {
-            MoveList<QUIETS> ml(pos);
+            Color us = pos.side_to_move();
+            threatByLesser[PAWN]   = 0;
+            threatByLesser[KNIGHT] = threatByLesser[BISHOP] = pos.attacks_by<PAWN>(~us);
+            threatByLesser[ROOK] =
+              pos.attacks_by<KNIGHT>(~us) | pos.attacks_by<BISHOP>(~us) | threatByLesser[KNIGHT];
+            threatByLesser[QUEEN] = pos.attacks_by<ROOK>(~us) | threatByLesser[ROOK];
+            threatByLesser[KING]  = pos.attacks_by<QUEEN>(~us) | pos.attacks_by<KING>(~us) | threatByLesser[QUEEN];
+
+            MoveList<QUIETS> ml(pos, threatByLesser[KING]);
 
             endCur = endGenerated = score<QUIETS>(ml);
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -138,7 +138,7 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
         threatByLesser[ROOK] =
           pos.attacks_by<KNIGHT>(~us) | pos.attacks_by<BISHOP>(~us) | threatByLesser[KNIGHT];
         threatByLesser[QUEEN] = pos.attacks_by<ROOK>(~us) | threatByLesser[ROOK];
-        threatByLesser[KING]  = pos.attacks_by<QUEEN>(~us) | threatByLesser[QUEEN];
+        threatByLesser[KING]  = pos.attacks_by<QUEEN>(~us) | pos.attacks_by<KING>(~us) | threatByLesser[QUEEN];
     }
 
     ExtMove* it = cur;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -73,6 +73,7 @@ class MovePicker {
     int                          ply;
     bool                         skipQuiets = false;
     ExtMove                      moves[MAX_MOVES];
+    Bitboard threatByLesser[KING + 1];
 };
 
 }  // namespace Stockfish

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -534,18 +534,15 @@ bool Position::legal(Move m) const {
             && !(attacks_bb<BISHOP>(ksq, occupied) & pieces(~us, QUEEN, BISHOP));
     }
 
+    // In case of Chess960, verify if the Rook blocks some checks.
+    // For instance an enemy queen in SQ_A1 when castling rook is in SQ_B1.
+    if (m.type_of() == CASTLING)
+        return !chess960 || !(blockers_for_king(us) & m.to_sq());
 
     // If the moving piece is a king, check whether the destination square is
     // attacked by the opponent.
     if (type_of(piece_on(from)) == KING)
-    {
-        // In case of Chess960, verify if the Rook blocks some checks.
-        // For instance an enemy queen in SQ_A1 when castling rook is in SQ_B1.
-        if (m.type_of() == CASTLING)
-            return !chess960 || !(blockers_for_king(us) & m.to_sq());
-
         return !(attackers_to_exist(to, pieces() ^ from, ~us));
-    }
 
     // A non-king move is legal if and only if it is not pinned or it
     // is moving along the ray towards or away from the king.

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -535,7 +535,7 @@ bool Position::legal(Move m) const {
 
     // Castling moves generation does not check if the castling path is clear of
     // enemy attacks, it is delayed at a later time: now!
-    if (m.type_of() == CASTLING)
+    if (chess960 && m.type_of() == CASTLING)
     {
         // After castling, the rook and king final positions are the same in
         // Chess960 as they would be in standard chess.
@@ -548,7 +548,7 @@ bool Position::legal(Move m) const {
 
         // In case of Chess960, verify if the Rook blocks some checks.
         // For instance an enemy queen in SQ_A1 when castling rook is in SQ_B1.
-        return !chess960 || !(blockers_for_king(us) & m.to_sq());
+        return !(blockers_for_king(us) & m.to_sq());
     }
 
     // If the moving piece is a king, check whether the destination square is

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -309,6 +309,7 @@ void Position::set_castling_right(Color c, Square rfrom) {
     Square kto = relative_square(c, cr & KING_SIDE ? SQ_G1 : SQ_C1);
     Square rto = relative_square(c, cr & KING_SIDE ? SQ_F1 : SQ_D1);
 
+    castlingKingPath[cr] = between_bb(kfrom, kto);
     castlingPath[cr] = (between_bb(rfrom, rto) | between_bb(kfrom, kto)) & ~(kfrom | rfrom);
 }
 
@@ -533,30 +534,32 @@ bool Position::legal(Move m) const {
             && !(attacks_bb<BISHOP>(ksq, occupied) & pieces(~us, QUEEN, BISHOP));
     }
 
-    // Castling moves generation does not check if the castling path is clear of
-    // enemy attacks, it is delayed at a later time: now!
-    if (m.type_of() == CASTLING)
-    {
-        if (!chess960)
-            return true;
-        // After castling, the rook and king final positions are the same in
-        // Chess960 as they would be in standard chess.
-        to             = relative_square(us, to > from ? SQ_G1 : SQ_C1);
-        Direction step = to > from ? WEST : EAST;
-
-        for (Square s = to; s != from; s += step)
-            if (attackers_to_exist(s, pieces(), ~us))
-                return false;
-
-        // In case of Chess960, verify if the Rook blocks some checks.
-        // For instance an enemy queen in SQ_A1 when castling rook is in SQ_B1.
-        return !chess960 || !(blockers_for_king(us) & m.to_sq());
-    }
 
     // If the moving piece is a king, check whether the destination square is
     // attacked by the opponent.
     if (type_of(piece_on(from)) == KING)
+    {
+        // Castling moves generation does not check if the castling path is clear of
+        // enemy attacks, it is delayed at a later time: now!
+        if (m.type_of() == CASTLING)
+        {
+            if (!chess960)
+                return true;
+            // After castling, the rook and king final positions are the same in
+            // Chess960 as they would be in standard chess.
+            to             = relative_square(us, to > from ? SQ_G1 : SQ_C1);
+            Direction step = to > from ? WEST : EAST;
+
+            for (Square s = to; s != from; s += step)
+                if (attackers_to_exist(s, pieces(), ~us))
+                    return false;
+
+            // In case of Chess960, verify if the Rook blocks some checks.
+            // For instance an enemy queen in SQ_A1 when castling rook is in SQ_B1.
+            return !chess960 || !(blockers_for_king(us) & m.to_sq());
+        }
         return !(attackers_to_exist(to, pieces() ^ from, ~us));
+    }
 
     // A non-king move is legal if and only if it is not pinned or it
     // is moving along the ray towards or away from the king.

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -539,25 +539,11 @@ bool Position::legal(Move m) const {
     // attacked by the opponent.
     if (type_of(piece_on(from)) == KING)
     {
-        // Castling moves generation does not check if the castling path is clear of
-        // enemy attacks, it is delayed at a later time: now!
+        // In case of Chess960, verify if the Rook blocks some checks.
+        // For instance an enemy queen in SQ_A1 when castling rook is in SQ_B1.
         if (m.type_of() == CASTLING)
-        {
-            if (!chess960)
-                return true;
-            // After castling, the rook and king final positions are the same in
-            // Chess960 as they would be in standard chess.
-            to             = relative_square(us, to > from ? SQ_G1 : SQ_C1);
-            Direction step = to > from ? WEST : EAST;
-
-            for (Square s = to; s != from; s += step)
-                if (attackers_to_exist(s, pieces(), ~us))
-                    return false;
-
-            // In case of Chess960, verify if the Rook blocks some checks.
-            // For instance an enemy queen in SQ_A1 when castling rook is in SQ_B1.
             return !chess960 || !(blockers_for_king(us) & m.to_sq());
-        }
+
         return !(attackers_to_exist(to, pieces() ^ from, ~us));
     }
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -535,8 +535,10 @@ bool Position::legal(Move m) const {
 
     // Castling moves generation does not check if the castling path is clear of
     // enemy attacks, it is delayed at a later time: now!
-    if (chess960 && m.type_of() == CASTLING)
+    if (m.type_of() == CASTLING)
     {
+        if (!chess960)
+            return true;
         // After castling, the rook and king final positions are the same in
         // Chess960 as they would be in standard chess.
         to             = relative_square(us, to > from ? SQ_G1 : SQ_C1);
@@ -548,7 +550,7 @@ bool Position::legal(Move m) const {
 
         // In case of Chess960, verify if the Rook blocks some checks.
         // For instance an enemy queen in SQ_A1 when castling rook is in SQ_B1.
-        return !(blockers_for_king(us) & m.to_sq());
+        return !chess960 || !(blockers_for_king(us) & m.to_sq());
     }
 
     // If the moving piece is a king, check whether the destination square is

--- a/src/position.h
+++ b/src/position.h
@@ -193,6 +193,7 @@ class Position {
     int        castlingRightsMask[SQUARE_NB];
     Square     castlingRookSquare[CASTLING_RIGHT_NB];
     Bitboard   castlingPath[CASTLING_RIGHT_NB];
+    Bitboard   castlingKingPath[CASTLING_RIGHT_NB];
     StateInfo* st;
     int        gamePly;
     Color      sideToMove;
@@ -248,7 +249,7 @@ inline bool Position::can_castle(CastlingRights cr) const { return st->castlingR
 
 inline bool Position::castling_impeded(CastlingRights cr, Bitboard threats) const {
     assert(cr == WHITE_OO || cr == WHITE_OOO || cr == BLACK_OO || cr == BLACK_OOO);
-    return (pieces() | threats) & castlingPath[cr];
+    return pieces() & castlingPath[cr] || threats & castlingKingPath[cr];
 }
 
 inline Square Position::castling_rook_square(CastlingRights cr) const {

--- a/src/position.h
+++ b/src/position.h
@@ -104,7 +104,7 @@ class Position {
 
     // Castling
     bool           can_castle(CastlingRights cr) const;
-    bool           castling_impeded(CastlingRights cr, Bitboard threats = 0) const;
+    bool           castling_impeded(CastlingRights cr, Bitboard threats) const;
     Square         castling_rook_square(CastlingRights cr) const;
 
     // Checking
@@ -265,8 +265,6 @@ inline Bitboard Position::attacks_by(Color c) const {
     if constexpr (Pt == PAWN)
         return c == WHITE ? pawn_attacks_bb<WHITE>(pieces(WHITE, PAWN))
                           : pawn_attacks_bb<BLACK>(pieces(BLACK, PAWN));
-    else if constexpr (Pt == KING)
-        return attacks_bb<KING>(square<KING>(c));
     else
     {
         Bitboard threats   = 0;

--- a/src/position.h
+++ b/src/position.h
@@ -264,6 +264,8 @@ inline Bitboard Position::attacks_by(Color c) const {
     if constexpr (Pt == PAWN)
         return c == WHITE ? pawn_attacks_bb<WHITE>(pieces(WHITE, PAWN))
                           : pawn_attacks_bb<BLACK>(pieces(BLACK, PAWN));
+    else if constexpr (Pt == KING)
+        return attacks_bb<KING>(square<KING>(c));
     else
     {
         Bitboard threats   = 0;

--- a/src/position.h
+++ b/src/position.h
@@ -103,9 +103,9 @@ class Position {
     Square square(Color c) const;
 
     // Castling
-    bool   can_castle(CastlingRights cr) const;
-    bool   castling_impeded(CastlingRights cr) const;
-    Square castling_rook_square(CastlingRights cr) const;
+    bool           can_castle(CastlingRights cr) const;
+    bool           castling_impeded(CastlingRights cr, Bitboard threats = 0) const;
+    Square         castling_rook_square(CastlingRights cr) const;
 
     // Checking
     Bitboard checkers() const;
@@ -246,9 +246,9 @@ inline Square Position::ep_square() const { return st->epSquare; }
 
 inline bool Position::can_castle(CastlingRights cr) const { return st->castlingRights & cr; }
 
-inline bool Position::castling_impeded(CastlingRights cr) const {
+inline bool Position::castling_impeded(CastlingRights cr, Bitboard threats) const {
     assert(cr == WHITE_OO || cr == WHITE_OOO || cr == BLACK_OO || cr == BLACK_OOO);
-    return pieces() & castlingPath[cr];
+    return (pieces() | threats) & castlingPath[cr];
 }
 
 inline Square Position::castling_rook_square(CastlingRights cr) const {


### PR DESCRIPTION
Recent changes to movepicker mean that we're computing (almost all) threatened squares for quiet move ranking. This patch uses the bitboard of all threatened square in movegen to avoid generating any illegal king move in the quiet stage. This allows removing the code in `pos.legal(Move)`  that checks whether the king moves through a threatened square when castling.
I was hoping this would lead to a speedup since we no longer need to rank and sort the illegal king moves, but that doesn't seem to be the case.

Tests were done agains an older version of master, but rebasing is straightforward.

passed STC: https://tests.stockfishchess.org/tests/view/68ade27c6217b8721dca9765
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 198720 W: 51786 L: 51741 D: 95193
Ptnml(0-2): 712, 23321, 51261, 23342, 724

passed LTC: https://tests.stockfishchess.org/tests/view/68b1c4c26217b8721dca9c56
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 277068 W: 70944 L: 70984 D: 135140
Ptnml(0-2): 154, 30225, 77815, 30187, 153