### PR TITLE
Reintroduce #6259

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -115,9 +115,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, int th, const CapturePieceTo
     threshold(th) {
     assert(!pos.checkers());
 
-    // Removing the SEE check passes as simplification, but hurts mate finding
-    stage = PROBCUT_TT
-          + !(ttm && pos.capture_stage(ttm) && pos.pseudo_legal(ttm) && pos.see_ge(ttm, threshold));
+    stage = PROBCUT_TT + !(ttm && pos.capture_stage(ttm) && pos.pseudo_legal(ttm));
 }
 
 // Assigns a numerical value to each move in a list, used for sorting.


### PR DESCRIPTION
Reintroduces https://github.com/official-stockfish/Stockfish/commit/af181d9fe11216a296113292f772561cfd9823d3, which no longer regresses on matetrack after #6286

```
Using ./stockfish on matetrack.epd with --nodes 1000000
Engine ID:     Stockfish dev-20250902-adfddd2c
Total FENs:    6554
Found mates:   3490
Best mates:    2429
```

Passed Non-regression LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 37608 W: 9726 L: 9523 D: 18359
Ptnml(0-2): 16, 4001, 10578, 4182, 27
https://tests.stockfishchess.org/tests/view/68b886778f94a4e5a7fe77d9
 
Bench: 2493363