### PR TITLE
Adjustment of the aspiration window after fail high/low.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -344,7 +344,8 @@ void Search::Worker::iterative_deepening() {
                 // effective increment for every four searchAgain steps (see issue #2717).
                 Depth adjustedDepth =
                   std::max(1, rootDepth - failedHighCnt - 3 * (searchAgainCounter + 1) / 4);
-                rootDelta = beta - alpha;
+                rootDelta                      = beta - alpha;
+                size_t previousBestMoveChanges = bestMoveChanges;
                 bestValue = search<Root>(rootPos, ss, alpha, beta, adjustedDepth, false);
 
                 // Bring the best move to the front. It is critical that sorting
@@ -372,7 +373,9 @@ void Search::Worker::iterative_deepening() {
                 // otherwise exit the loop.
                 if (bestValue <= alpha)
                 {
-                    beta  = alpha;
+                    beta =
+                      (alpha * 123 + beta * 9 + std::min(bestValue + delta, VALUE_INFINITE) * 12)
+                      / 144;
                     alpha = std::max(bestValue - delta, -VALUE_INFINITE);
 
                     failedHighCnt = 0;
@@ -381,6 +384,15 @@ void Search::Worker::iterative_deepening() {
                 }
                 else if (bestValue >= beta)
                 {
+                    if (bestMoveChanges > previousBestMoveChanges)
+                        alpha =
+                          (alpha * 116 + beta + std::max(bestValue - delta, -VALUE_INFINITE) * 7)
+                          / 124;
+                    else
+                        alpha = (alpha * 119 + beta * 6
+                                 + std::max(bestValue - delta, -VALUE_INFINITE) * 16)
+                              / 141;
+
                     beta = std::min(bestValue + delta, VALUE_INFINITE);
                     ++failedHighCnt;
                 }


### PR DESCRIPTION
For the new bound in the opposite direction of the fail, use a weighted average of alpha, beta and best value +- delta. In the case of a fail high, different average weights are used depending on whether or not there was a best move change during the last search.

The weights are determined from the following two consecutive LTC tunings.

First tuning: https://tests.stockfishchess.org/tests/view/68ab727975da51a345a5ac2e
Second tuning: https://tests.stockfishchess.org/tests/view/68aba3fe75da51a345a5ad52

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 39504 W: 10243 L: 9947 D: 19314
Ptnml(0-2): 25, 4182, 11041, 4480, 24
https://tests.stockfishchess.org/tests/view/68acbb6d6217b8721dca95f8

Passed VLTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 91196 W: 23574 L: 23167 D: 44455
Ptnml(0-2): 13, 8943, 27276, 9356, 10
https://tests.stockfishchess.org/tests/view/68af64786217b8721dca993d

Bench: 2776937