### PR TITLE
Speedup binary upload step in CI

### DIFF
--- a/.github/workflows/upload_binaries.yml
+++ b/.github/workflows/upload_binaries.yml
@@ -12,20 +12,17 @@ on:
 jobs:
   Artifacts:
     name: ${{ matrix.config.name }} ${{ matrix.binaries }}
-    runs-on: ${{ matrix.config.os }}
+    runs-on: ubuntu-latest
     env:
-      COMPCXX: ${{ matrix.config.compiler }}
-      COMP: ${{ matrix.config.comp }}
       EXT: ${{ matrix.config.ext }}
       NAME: ${{ matrix.config.simple_name }}
       BINARY: ${{ matrix.binaries }}
-      SDE: ${{ matrix.config.sde }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(inputs.matrix) }}
     defaults:
       run:
-        shell: ${{ matrix.config.shell }}
+        shell: bash
     steps:
       - uses: actions/checkout@v4
         with:
@@ -36,13 +33,6 @@ jobs:
         with:
           name: ${{ matrix.config.simple_name }} ${{ matrix.binaries }}
           path: ${{ matrix.config.simple_name }} ${{ matrix.binaries }}
-
-      - name: Setup msys and install required packages
-        if: runner.os == 'Windows'
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: ${{ matrix.config.msys_sys }}
-          install: mingw-w64-${{ matrix.config.msys_env }} make git zip
 
       - name: Create Package
         run: |
@@ -69,13 +59,13 @@ jobs:
           cp CONTRIBUTING.md ../stockfish/
 
       - name: Create tar
-        if: runner.os != 'Windows'
+        if: ${{ !startsWith(matrix.config.os, 'windows') }}
         run: |
           chmod +x ./stockfish/stockfish-$NAME-$BINARY$EXT
           tar -cvf stockfish-$NAME-$BINARY.tar stockfish
 
       - name: Create zip
-        if: runner.os == 'Windows'
+        if: ${{ startsWith(matrix.config.os, 'windows') }}
         run: |
           zip -r stockfish-$NAME-$BINARY.zip stockfish
 


### PR DESCRIPTION
Previously the upload step used the os of the artifact to create the upload and used an extra msys2 step. This is in fact not needed and we can do all required changes on ubuntu instead.

This reduces the avg time of windows runners from previously 1-2min down to ~20 seconds.
Test run here https://github.com/Disservin/Stockfish/actions/runs/17527479725 with the corresponding prerelease https://github.com/Disservin/Stockfish/releases/tag/stockfish-dev-20250907-31fcde7a.