### PR TITLE
add multithreaded matetrack runs to CI

### DIFF
--- a/.github/workflows/matetrack.yml
+++ b/.github/workflows/matetrack.yml
@@ -47,25 +47,44 @@ jobs:
           wget --no-verbose -r -nH --cut-dirs=2 --no-parent --reject="index.html*" -e robots=off https://tablebase.lichess.ovh/tables/standard/3-4-5-wdl/
           wget --no-verbose -r -nH --cut-dirs=2 --no-parent --reject="index.html*" -e robots=off https://tablebase.lichess.ovh/tables/standard/3-4-5-dtz/
 
-      - name: Run matetrack
+      - name: Run matetrack th1
         working-directory: matetrack
         run: |
-          python matecheck.py --syzygyPath 3-4-5-wdl/:3-4-5-dtz/ --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile mates2000.epd --nodes 100000 | tee matecheckout.out
-          ! grep "issues were detected" matecheckout.out > /dev/null
+          python matecheck.py --syzygyPath 3-4-5-wdl/:3-4-5-dtz/ --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile mates2000.epd --nodes 100000 | tee matecheckout1.out
+          ! grep "issues were detected" matecheckout1.out > /dev/null
 
-      - name: Run matetrack with --syzygy50MoveRule false
+      - name: Run matetrack th4
+        working-directory: matetrack
+        run: |
+          python matecheck.py --syzygyPath 3-4-5-wdl/:3-4-5-dtz/ --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile mates2000.epd --nodes 100000 --threads 4 | tee matecheckout4.out
+          ! grep "issues were detected" matecheckout4.out > /dev/null
+
+      - name: Run matetrack th1 with --syzygy50MoveRule false
         working-directory: matetrack
         run: |
           grep 5men cursed.epd > cursed5.epd
-          python matecheck.py --syzygyPath 3-4-5-wdl/:3-4-5-dtz/ --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile cursed5.epd --nodes 100000 --syzygy50MoveRule false | tee matecheckcursed.out
-          ! grep "issues were detected" matecheckcursed.out > /dev/null
+          python matecheck.py --syzygyPath 3-4-5-wdl/:3-4-5-dtz/ --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile cursed5.epd --nodes 100000 --syzygy50MoveRule false | tee matecheckcursed1.out
+          ! grep "issues were detected" matecheckcursed1.out > /dev/null
 
-      - name: Verify mate and TB win count for matecheckcursed.out
+      - name: Run matetrack th4 with --syzygy50MoveRule false
         working-directory: matetrack
         run: |
-          mates=$(grep "Found mates:" matecheckcursed.out | awk '{print $3}')
-          tbwins=$(grep "Found TB wins:" matecheckcursed.out | awk '{print $4}')
+          grep 5men cursed.epd > cursed5.epd
+          python matecheck.py --syzygyPath 3-4-5-wdl/:3-4-5-dtz/ --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile cursed5.epd --nodes 100000 --threads 4 --syzygy50MoveRule false | tee matecheckcursed4.out
+          ! grep "issues were detected" matecheckcursed4.out > /dev/null
+
+      - name: Verify mate and TB win count for matecheckcursed[14].out
+        working-directory: matetrack
+        run: |
+          mates=$(grep "Found mates:" matecheckcursed1.out | awk '{print $3}')
+          tbwins=$(grep "Found TB wins:" matecheckcursed1.out | awk '{print $4}')
           if [ $(($mates + $tbwins)) -ne 32 ]; then
-            echo "Sum of mates and TB wins is not 32 in matecheckcursed.out" >&2
+            echo "Sum of mates and TB wins is not 32 in matecheckcursed1.out" >&2
+            exit 1
+          fi
+          mates=$(grep "Found mates:" matecheckcursed4.out | awk '{print $3}')
+          tbwins=$(grep "Found TB wins:" matecheckcursed4.out | awk '{print $4}')
+          if [ $(($mates + $tbwins)) -ne 32 ]; then
+            echo "Sum of mates and TB wins is not 32 in matecheckcursed4.out" >&2
             exit 1
           fi


### PR DESCRIPTION
Add runs with `--threads 4` to our matetrack CI. These won't be deterministic, of course. But they may catch early some multithreading bugs in our mate reporting.

Motivated by #6293 and #6296.

No functional change.