### PR TITLE
Remove quiet move streak

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1022,8 +1022,6 @@ moves_loop:  // When in check, search starts here
         movedPiece = pos.moved_piece(move);
         givesCheck = pos.gives_check(move);
 
-        (ss + 1)->quietMoveStreak = capture ? 0 : (ss->quietMoveStreak + 1);
-
         // Calculate new depth for this move
         newDepth = depth - 1;
 
@@ -1182,7 +1180,7 @@ moves_loop:  // When in check, search starts here
 
         // These reduction adjustments have no proven non-linear scaling
 
-        r += 543;  // Base reduction offset to compensate for other tweaks
+        r += 843;  // Base reduction offset to compensate for other tweaks
         r -= moveCount * 66;
         r -= std::abs(correctionValue) / 30450;
 
@@ -1197,8 +1195,6 @@ moves_loop:  // When in check, search starts here
         // Increase reduction if next ply has a lot of fail high
         if ((ss + 1)->cutoffCnt > 2)
             r += 1051 + allNode * 814;
-
-        r += (ss + 1)->quietMoveStreak * 50;
 
         // For first picked move (ttMove) reduce reduction
         if (move == ttData.move)

--- a/src/search.h
+++ b/src/search.h
@@ -75,7 +75,6 @@ struct Stack {
     bool                        ttHit;
     int                         cutoffCnt;
     int                         reduction;
-    int                         quietMoveStreak;
 };
 
 


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 67712 W: 17744 L: 17555 D: 32413
Ptnml(0-2): 204, 8030, 17274, 8069, 279
https://tests.stockfishchess.org/tests/view/68b784628f94a4e5a7fe7706

Passed Non-regression LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 196050 W: 50270 L: 50228 D: 95552
Ptnml(0-2): 122, 21465, 54813, 21499, 126
https://tests.stockfishchess.org/tests/view/68ba119d8f94a4e5a7fe7941

Bench: 2525349