### PR TITLE
Use thread count depending search parameters.

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -279,6 +279,8 @@ class Worker {
 
     void ensure_network_replicated();
 
+    int P(int v1, int v8) const;
+
     // Public because they need to be updatable by the stats
     ButterflyHistory mainHistory;
     LowPlyHistory    lowPlyHistory;


### PR DESCRIPTION
For search parameters use an interpolating formula of the form A + B * msb(number of threads). The coefficients A and B are calculated so that the given parameter value for one thread and eight threads are returned. Because of integer arithmetic and rounding the value for one thread can be off by one.

The parameters for one thread were taken from following LTC tuning after 88K games: https://tests.stockfishchess.org/tests/view/68b4c53578ed7a752a9e8fe2. The parameters for eight thread are the same as current master because this were tuned already for 8 threads (VVLTC). So for this time control this patch is non-functional.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 10304 W: 2798 L: 2525 D: 4981
Ptnml(0-2): 13, 1108, 2669, 1317, 45
https://tests.stockfishchess.org/tests/view/68bf28c159efc3c96b610a6f

Passed LTC:
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 25998 W: 6792 L: 6495 D: 12711
Ptnml(0-2): 9, 2735, 7219, 3022, 14
https://tests.stockfishchess.org/tests/view/68bf710259efc3c96b610a96

Bench: 2368858