### PR TITLE
Simplify Probcut Clamp Further

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -932,8 +932,7 @@ Value Search::Worker::search(
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
         MovePicker mp(pos, ttData.move, probCutBeta - ss->staticEval, &captureHistory);
-        Depth      dynamicReduction = std::max((ss->staticEval - beta) / 306, -1);
-        Depth      probCutDepth     = std::max(depth - 5 - dynamicReduction, 0);
+        Depth      probCutDepth = std::clamp(depth - 5 - (ss->staticEval - beta) / 306, 0, depth);
 
         while ((move = mp.next_move()) != Move::none())
         {


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 157984 W: 41116 L: 41030 D: 75838
Ptnml(0-2): 568, 18570, 40601, 18714, 539
https://tests.stockfishchess.org/tests/view/68b750518f94a4e5a7fe76cd

Passed Non-regression LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 335232 W: 85443 L: 85543 D: 164246
Ptnml(0-2): 177, 36616, 94137, 36502, 184
https://tests.stockfishchess.org/tests/view/68bc767259efc3c96b61076b

Bench: 2598281