### PR TITLE
Simplify away conthist 0

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1644,9 +1644,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
 
             // Continuation history based pruning
             if (!capture
-                && (*contHist[0])[pos.moved_piece(move)][move.to_sq()]
-                       + pawnHistory[pawn_history_index(pos)][pos.moved_piece(move)][move.to_sq()]
-                     <= 5475)
+                && pawnHistory[pawn_history_index(pos)][pos.moved_piece(move)][move.to_sq()]
+                     < 7300)
                 continue;
 
             // Do not search moves with bad enough SEE values


### PR DESCRIPTION
Simplify away conthist 0

Passed STC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 25376 W: 6660 L: 6423 D: 12293
Ptnml(0-2): 77, 2947, 6403, 3184, 77
https://tests.stockfishchess.org/tests/view/68c1ccf759efc3c96b610deb

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 208464 W: 53371 L: 53342 D: 101751
Ptnml(0-2): 110, 22776, 58426, 22815, 105
https://tests.stockfishchess.org/tests/view/68c1d04b59efc3c96b610e13

bench: 2621926