### PR TITLE
Penalty to TT move history on MultiCut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1149,7 +1149,10 @@ moves_loop:  // When in check, search starts here
             // singular (multiple moves fail high), and we can prune the whole
             // subtree by returning a softbound.
             else if (value >= beta && !is_decisive(value))
+            {
+                ttMoveHistory << std::max(-400 - 100 * depth, -4000);
                 return value;
+            }
 
             // Negative extensions
             // If other moves failed high over (ttValue - margin) without the


### PR DESCRIPTION
If a reduced search fails high with the TT move excluded, we know that there are multiple moves that can produce cutoffs. Applying a  penalty to the TT move history reduces extensions for TT moves so that it may spend a bit more time exploring other moves.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 263680 W: 68965 L: 68313 D: 126402
Ptnml(0-2): 855, 31090, 67336, 31666, 893
https://tests.stockfishchess.org/tests/view/68c1f65a59efc3c96b6110e5

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 61008 W: 15713 L: 15350 D: 29945
Ptnml(0-2): 27, 6428, 17235, 6783, 31
https://tests.stockfishchess.org/tests/view/68c1fc5359efc3c96b611141

Passed non-regression VLTC (60+0.6, Threads=8):
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 50340 W: 13003 L: 12830 D: 24507
Ptnml(0-2): 3, 4570, 15849, 4747, 1
https://tests.stockfishchess.org/tests/view/68c2056559efc3c96b6111c3

Bench: 3190153