### PR TITLE
Simplify a separate term in low ply history bonus formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1876,7 +1876,7 @@ void update_quiet_histories(
     workerThread.mainHistory[us][move.from_to()] << bonus;  // Untuned to prevent duplicate effort
 
     if (ss->ply < LOW_PLY_HISTORY_SIZE)
-        workerThread.lowPlyHistory[ss->ply][move.from_to()] << (bonus * 741 / 1024) + 38;
+        workerThread.lowPlyHistory[ss->ply][move.from_to()] << bonus * 761 / 1024;
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 955 / 1024);
 


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 211200 W: 54887 L: 54860 D: 101453
Ptnml(0-2): 719, 24894, 54296, 25023, 668
https://tests.stockfishchess.org/tests/view/68c21e7f59efc3c96b6112c8

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 217842 W: 55587 L: 55568 D: 106687
Ptnml(0-2): 130, 23651, 61313, 23724, 103
https://tests.stockfishchess.org/tests/view/68c230ec59efc3c96b61135a

Bench: 2769562