### PR TITLE
Simplify use of low-ply history in evasions

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -188,7 +188,7 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
             {
                 m.value = (*mainHistory)[us][m.from_to()] + (*continuationHistory[0])[pc][to];
                 if (ply < LOW_PLY_HISTORY_SIZE)
-                    m.value += 2 * (*lowPlyHistory)[ply][m.from_to()] / (1 + ply);
+                    m.value += 2 * (*lowPlyHistory)[ply][m.from_to()];
             }
         }
     }


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 65024 W: 16991 L: 16804 D: 31229
Ptnml(0-2): 182, 7423, 17119, 7602, 186
https://tests.stockfishchess.org/tests/view/68c23f5459efc3c96b6113df

Passed Non-regression LTC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 207312 W: 53126 L: 53095 D: 101091
Ptnml(0-2): 126, 21986, 59389, 22041, 114
https://tests.stockfishchess.org/tests/view/68c241e359efc3c96b6113ef

Bench: 2657664