### PR TITLE
Revert "Adjustment of the aspiration window after fail high/low."

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -344,8 +344,7 @@ void Search::Worker::iterative_deepening() {
                 // effective increment for every four searchAgain steps (see issue #2717).
                 Depth adjustedDepth =
                   std::max(1, rootDepth - failedHighCnt - 3 * (searchAgainCounter + 1) / 4);
-                rootDelta                      = beta - alpha;
-                size_t previousBestMoveChanges = bestMoveChanges;
+                rootDelta = beta - alpha;
                 bestValue = search<Root>(rootPos, ss, alpha, beta, adjustedDepth, false);
 
                 // Bring the best move to the front. It is critical that sorting
@@ -373,9 +372,7 @@ void Search::Worker::iterative_deepening() {
                 // otherwise exit the loop.
                 if (bestValue <= alpha)
                 {
-                    beta =
-                      (alpha * 123 + beta * 9 + std::min(bestValue + delta, VALUE_INFINITE) * 12)
-                      / 144;
+                    beta  = alpha;
                     alpha = std::max(bestValue - delta, -VALUE_INFINITE);
 
                     failedHighCnt = 0;
@@ -384,15 +381,6 @@ void Search::Worker::iterative_deepening() {
                 }
                 else if (bestValue >= beta)
                 {
-                    if (bestMoveChanges > previousBestMoveChanges)
-                        alpha =
-                          (alpha * 116 + beta + std::max(bestValue - delta, -VALUE_INFINITE) * 7)
-                          / 124;
-                    else
-                        alpha = (alpha * 119 + beta * 6
-                                 + std::max(bestValue - delta, -VALUE_INFINITE) * 16)
-                              / 141;
-
                     beta = std::min(bestValue + delta, VALUE_INFINITE);
                     ++failedHighCnt;
                 }


### PR DESCRIPTION
This reverts commit bfc7000597b8b5b0899e99bc911f6120a75c6297.

Fixes https://github.com/official-stockfish/Stockfish/issues/6296

After this commit a bug has been reported when the position is close to mate or being mated. Since no workarounds have been suggested yet, it is best to revert this commit until a better solution is found.

Bench: 2493363