### PR TITLE
Simplify RFP return value

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -868,7 +868,7 @@ Value Search::Worker::search(
 
         if (!ss->ttPv && depth < 14 && eval - futility_margin(depth) >= beta && eval >= beta
             && (!ttData.move || ttCapture) && !is_loss(beta) && !is_win(eval))
-            return beta + (eval - beta) / 3;
+            return (2 * beta + eval) / 3;
     }
 
     // Step 9. Null move search with verification search


### PR DESCRIPTION
Passed non-regression STC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 220800 W: 57351 L: 57332 D: 106117
Ptnml(0-2): 726, 26200, 56548, 26181, 745
https://tests.stockfishchess.org/tests/view/68b1db6e6217b8721dca9c67

Passed gainer LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 257820 W: 66286 L: 65523 D: 126011
Ptnml(0-2): 118, 27586, 72779, 28269, 158
https://tests.stockfishchess.org/tests/view/68c1d40859efc3c96b610e3d

bench: 2507596