### PR TITLE
Optimize singular extension with material-based adjustment

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -216,6 +216,7 @@ Ronald de Man (syzygy1, syzygy)
 Ron Britvich (Britvich)
 rqs
 Rui Coelho (ruicoelhopedro)
+Ryan Lefkowitz (rlefko)
 Ryan Schmitt
 Ryan Takker
 Sami Kiminki (skiminki)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1109,7 +1109,10 @@ moves_loop:  // When in check, search starts here
             && is_valid(ttData.value) && !is_decisive(ttData.value) && (ttData.bound & BOUND_LOWER)
             && ttData.depth >= depth - 3)
         {
-            Value singularBeta  = ttData.value - (56 + 81 * (ss->ttPv && !PvNode)) * depth / 60;
+            // Adjust singular extension margin based on material complexity
+            // More material = more complex positions = tighter margins
+            int materialAdjustment = std::min(16, pos.non_pawn_material() / 512);
+            Value singularBeta  = ttData.value - (56 + materialAdjustment + 81 * (ss->ttPv && !PvNode)) * depth / 60;
             Depth singularDepth = newDepth / 2;
 
             ss->excludedMove = move;


### PR DESCRIPTION
This PR optimizes the singular extension search by adjusting the beta margin based on the material complexity of the position.

When there's more non-pawn material on the board, positions tend to be more complex and tactical. In such positions, we should use tighter margins (higher singularBeta, closer to ttValue) for more selective singular extensions. This helps Stockfish better identify truly singular moves in tactically rich positions while avoiding unnecessary extensions in simpler endgames.

The adjustment scales from 0 to 16 centipawns based on total non-pawn material:
```cpp
int materialAdjustment = std::min(16, pos.non_pawn_material() / 512);
Value singularBeta = ttData.value - (56 + materialAdjustment + 81 * (ss->ttPv && !PvNode)) * depth / 60;
```

Passed STC:
[Needs Fishtest validation]

Passed LTC:
[Needs Fishtest validation]

closes https://github.com/official-stockfish/Stockfish/pull/6320

Bench: 2493363