### PR TITLE
Further simplify low ply history in evasions

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -188,7 +188,7 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
             {
                 m.value = (*mainHistory)[us][m.from_to()] + (*continuationHistory[0])[pc][to];
                 if (ply < LOW_PLY_HISTORY_SIZE)
-                    m.value += 2 * (*lowPlyHistory)[ply][m.from_to()];
+                    m.value += (*lowPlyHistory)[ply][m.from_to()];
             }
         }
     }


### PR DESCRIPTION
Passed Non-regression STC (vs #6308):
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 174208 W: 45414 L: 45343 D: 83451
Ptnml(0-2): 633, 20324, 45095, 20443, 609
https://tests.stockfishchess.org/tests/view/68c24be359efc3c96b611487

Passed Non-regression LTC (vs #6308):
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 110070 W: 28099 L: 27969 D: 54002
Ptnml(0-2): 56, 11919, 30962, 12035, 63
https://tests.stockfishchess.org/tests/view/68c4efa559efc3c96b611dfc

Bench: 2631701