### PR TITLE
Tune LMR reduction for non-improving nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1711,7 +1711,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
 
 Depth Search::Worker::reduction(bool i, Depth d, int mn, int delta) const {
     int reductionScale = reductions[d] * reductions[mn];
-    return reductionScale - delta * 757 / rootDelta + !i * reductionScale * 218 / 512 + 1200;
+    return reductionScale - delta * 757 / rootDelta + !i * reductionScale * 224 / 512 + 1200;
 }
 
 // elapsed() returns the time elapsed since the search started. If the


### PR DESCRIPTION
## Summary
- increase the non-improving LMR weight from 218/512 to 224/512
- slightly deepen reductions when positions stagnate while keeping improving nodes unchanged

## Testing
- [ ] fishtest STC
- [ ] fishtest LTC

_(patch conceived with AI assistance)_
