### PR TITLE
Extend nodes pre qsearch only with deep enough tt entries.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1257,7 +1257,7 @@ moves_loop:  // When in check, search starts here
             (ss + 1)->pv[0] = Move::none();
 
             // Extend move from transposition table if we are about to dive into qsearch.
-            if (move == ttData.move && rootDepth > 8)
+            if (move == ttData.move && ttData.depth > 1 && rootDepth > 8)
                 newDepth = std::max(newDepth, 1);
 
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);


### PR DESCRIPTION
Modification of current pre qsearch extensions - allowing it only for deep enough tt entries.
Passed STC:
https://tests.stockfishchess.org/tests/view/68c954d302c43c969fe7eea5
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 35872 W: 9548 L: 9236 D: 17088
Ptnml(0-2): 101, 4075, 9295, 4341, 124 
Passed LTC:
https://tests.stockfishchess.org/tests/view/68ca4e4f02c43c969fe7ef5f
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 107754 W: 27784 L: 27324 D: 52646
Ptnml(0-2): 47, 11528, 30300, 11922, 80 
bench 2558668