### PR TITLE
MovePicker: prefer contHist[4] over [5] for quiet scoring

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -164,7 +164,9 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
             m.value += (*continuationHistory[1])[pc][to];
             m.value += (*continuationHistory[2])[pc][to];
             m.value += (*continuationHistory[3])[pc][to];
-            m.value += (*continuationHistory[5])[pc][to];
+            // Prefer a contiguous, nearer context window 0..4 over skipping 4 and using 5.
+            // This reduces stale context influence in quiet ordering.
+            m.value += (*continuationHistory[4])[pc][to];
 
             // bonus for checks
             m.value += (bool(pos.check_squares(pt) & to) && pos.see_ge(m, -75)) * 16384;


### PR DESCRIPTION
## Summary
Quiet move ordering currently sums continuation histories for indices 0,1,2,3,5 (skipping 4). This change replaces the deepest index [5] with the nearer [4], forming a contiguous window 0..4.

Rationale:
- nearer contexts are typically more predictive than stale ones;
- using a contiguous short-horizon window reduces noise and avoids overcounting distant patterns;
- change is minimal and isolated to quiet ordering.

## Change
- Replace continuationHistory[5] with [4] for QUIETS scoring in MovePicker.

## Testing
- [ ] STC (10+0.1), target 30k–50k games, nodestime off
- [ ] If positive, LTC (60+0.6) for confirmation

_(patch conceived with AI assistance)_
