### PR TITLE
Add support for UCI mirror command 

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -304,6 +304,7 @@ OptionsMap&       Engine::get_options() { return options; }
 std::string Engine::fen() const { return pos.fen(); }
 
 void Engine::flip() { pos.flip(); }
+void Engine::mirror() { pos.mirror(); }
 
 std::string Engine::visualize() const {
     std::stringstream ss;

--- a/src/engine.h
+++ b/src/engine.h
@@ -100,6 +100,7 @@ class Engine {
 
     std::string                            fen() const;
     void                                   flip();
+    void                                   mirror();
     std::string                            visualize() const;
     std::vector<std::pair<size_t, size_t>> get_bound_thread_count_by_numa_node() const;
     std::string                            get_numa_config_as_string() const;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1308,6 +1308,34 @@ void Position::flip() {
     assert(pos_is_ok());
 }
 
+void Position::mirror() {
+
+    string            f, token;
+    std::stringstream ss(fen());
+
+    // Mirror piece placement (horizontal flip)
+    for (Rank r = RANK_8; r >= RANK_1; --r) {
+        std::getline(ss, token, r > RANK_1 ? '/' : ' ');
+        std::reverse(token.begin(), token.end());
+        f += token + (r > RANK_1 ? "/" : " ");
+    }
+
+    ss >> token;   // Active color
+    f += token + " ";  // Color remains the same
+
+    ss >> token;                        
+    f += "- ";    // Disable all castling
+
+    ss >> token;                        
+    f += "- ";   // Disable en passant
+
+    std::getline(ss, token);   // Half and full moves
+    f += token;
+
+    set(f, is_chess960(), st);
+
+    assert(pos_is_ok());
+}
 
 // Performs some consistency checks for the position object
 // and raise an assert if something wrong is detected.

--- a/src/position.h
+++ b/src/position.h
@@ -162,6 +162,7 @@ class Position {
     // Position consistency check, for debugging
     bool pos_is_ok() const;
     void flip();
+    void mirror();
 
     StateInfo* state() const;
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -140,6 +140,8 @@ void UCIEngine::loop() {
         // These commands must not be used during a search!
         else if (token == "flip")
             engine.flip();
+        else if (token == "mirror")
+            engine.mirror();
         else if (token == "bench")
             bench(is);
         else if (token == BenchmarkCommand)


### PR DESCRIPTION
_UCI mirror command reverses the position **horizontally**:_

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/9e7b822c-6a69-4598-a067-76f3aaf9c9f8" />
<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/8914d4ae-0963-44f4-9a96-dfdc919fb23a" />


_UCI flip command reverses the position **vertically**:_

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/9e7b822c-6a69-4598-a067-76f3aaf9c9f8" />
<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/dfdc7664-ac4c-4d0e-85b3-63b78c38c938" />

This command is useful for finding evaluation symmetry bugs.
