### PR TITLE
Avoid perft to display move twice

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -537,6 +537,12 @@ bool Position::legal(Move m) const {
     // enemy attacks, it is delayed at a later time: now!
     if (m.type_of() == CASTLING)
     {
+
+      	if (!chess960)  {
+         if (from != (us == WHITE) ? SQ_E1 : SQ_E8)
+            return false;  
+          }
+
         // After castling, the rook and king final positions are the same in
         // Chess960 as they would be in standard chess.
         to             = relative_square(us, to > from ? SQ_G1 : SQ_C1);


### PR DESCRIPTION
Running perft on some positions causes moves to be listed multiple times in standard chess:
```
Stockfish 17.1 by the Stockfish developers (see AUTHORS file)
position fen rnbqBk1r/1p1Pb1pp/2p5/p7/8/8/PPP1NnPP/RNBQK2R b KQkq - 1 9
go perft 1
info string Available processors: 0-31
info string Using 1 thread
info string NNUE evaluation using nn-1c0000000000.nnue (133MiB, (22528, 3072, 15, 32, 1))
info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
a5a4: 1
c6c5: 1
b7b6: 1
g7g6: 1
h7h6: 1
b7b5: 1
g7g5: 1
h7h5: 1
f2d1: 1
f2h1: 1
f2d3: 1
f2h3: 1
f2e4: 1
f2g4: 1
b8a6: 1
b8d7: 1
e7a3: 1
e7b4: 1
e7h4: 1
e7c5: 1
e7g5: 1
e7d6: 1
e7f6: 1
c8d7: 1
a8a6: 1
a8a7: 1
h8g8: 1
d8b6: 1
d8c7: 1
d8d7: 1
d8e8: 1
f8g8: 1
f8g8: 1

Nodes searched: 33
```

Fix https://github.com/official-stockfish/Stockfish/issues/6290

