### PR TITLE
Split accumulator

### DIFF
--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -295,7 +295,7 @@ class AffineTransformSparseInput {
 
         const outvec_t* biasvec = reinterpret_cast<const outvec_t*>(biases);
         outvec_t        acc[NumRegs];
-        for (IndexType k = 0; k < NumRegs; ++k)
+        for (IndexType k = 0; k < NumAccums; ++k)
             acc[k] = biasvec[k];
 
         auto* start = nnz;
@@ -335,7 +335,7 @@ class AffineTransformSparseInput {
         }
 
         outvec_t* outptr = reinterpret_cast<outvec_t*>(output);
-        for (IndexType k = 0; k < NumRegs; ++k)
+        for (IndexType k = 0; k < NumAccums; ++k)
             outptr[k] = acc[k];
     #undef vec_set_32
     #undef vec_add_dpbusd_32

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -284,7 +284,6 @@ class AffineTransformSparseInput {
 #else
             false;
 #endif
-        static_assert(SplitAccums && "Test not intended to run on this arch");
         constexpr IndexType NumRegs     = SplitAccums ? 2 * NumAccums : NumAccums;
         std::uint16_t       nnz[NumChunks];
         IndexType           count;

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -278,13 +278,13 @@ class AffineTransformSparseInput {
         constexpr IndexType NumAccums = OutputDimensions / OutputSimdWidth;
         // If there's only one accumulator and we're using high-latency dot product instructions,
         // split it to create two dependency chains and merge at the end
-        constexpr bool      SplitAccums =
-#if defined(USE_VNNI)
-            NumAccums == 1;
-#else
-            false;
-#endif
-        constexpr IndexType NumRegs     = SplitAccums ? 2 * NumAccums : NumAccums;
+        constexpr bool SplitAccums =
+    #if defined(USE_VNNI)
+          NumAccums == 1;
+    #else
+          false;
+    #endif
+        constexpr IndexType NumRegs = SplitAccums ? 2 * NumAccums : NumAccums;
         std::uint16_t       nnz[NumChunks];
         IndexType           count;
 

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -248,6 +248,7 @@ class AffineTransformSparseInput {
     #if defined(USE_AVX512)
         using invec_t  = __m512i;
         using outvec_t = __m512i;
+        #define vec_add_32 _mm512_add_epi32
         #define vec_set_32 _mm512_set1_epi32
         #define vec_add_dpbusd_32 SIMD::m512_add_dpbusd_epi32
     #elif defined(USE_AVX2)
@@ -274,11 +275,14 @@ class AffineTransformSparseInput {
         static constexpr IndexType OutputSimdWidth = sizeof(outvec_t) / sizeof(OutputType);
 
         constexpr IndexType NumChunks = ceil_to_multiple<IndexType>(InputDimensions, 8) / ChunkSize;
-        constexpr IndexType NumRegs   = OutputDimensions / OutputSimdWidth;
+        constexpr IndexType NumAccums = OutputDimensions / OutputSimdWidth;
+        // If there's only one accumulator, split it to create two dependency chains and merge at the end
+        constexpr bool      SplitAccums = NumAccums == 1;
+        constexpr IndexType NumRegs     = SplitAccums ? 2 * NumAccums : NumAccums;
         std::uint16_t       nnz[NumChunks];
         IndexType           count;
 
-        const auto input32 = reinterpret_cast<const std::int32_t*>(input);
+        auto input32 = reinterpret_cast<const std::int32_t*>(input);
 
         // Find indices of nonzero 32-bit blocks
         find_nnz<NumChunks>(input32, nnz, count);
@@ -294,13 +298,33 @@ class AffineTransformSparseInput {
         // convince GCC to not do weird pointer arithmetic in the following loop
         const std::int8_t* weights_cp = weights;
 
+        if constexpr (SplitAccums)
+        {
+            acc[1] = vec_set_32(0);
+            while (start + 1 < end)
+            {
+                std::ptrdiff_t i1  = *start++;
+                std::ptrdiff_t i2  = *start++;
+                const invec_t  in1 = vec_set_32(input32[i1]);
+                const invec_t  in2 = vec_set_32(input32[i2]);
+                const auto     col1 =
+                  reinterpret_cast<const invec_t*>(&weights_cp[i1 * OutputDimensions * ChunkSize]);
+                const auto col2 =
+                  reinterpret_cast<const invec_t*>(&weights_cp[i2 * OutputDimensions * ChunkSize]);
+                vec_add_dpbusd_32(acc[0], in1, *col1);
+                vec_add_dpbusd_32(acc[1], in2, *col2);
+            }
+            acc[0] = vec_add_32(acc[0], acc[1]);
+        }
+
         while (start < end)
         {
             const std::ptrdiff_t i = *start;
             start++;
-            const invec_t in  = vec_set_32(input32[i]);
-            const auto    col = (const invec_t*) (&weights_cp[i * OutputDimensions * ChunkSize]);
-            for (IndexType k = 0; k < NumRegs; ++k)
+            const invec_t in = vec_set_32(input32[i]);
+            const auto    col =
+              reinterpret_cast<const invec_t*>(&weights_cp[i * OutputDimensions * ChunkSize]);
+            for (IndexType k = 0; k < NumAccums; ++k)
                 vec_add_dpbusd_32(acc[k], in, col[k]);
         }
 

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -288,7 +288,7 @@ class AffineTransformSparseInput {
         std::uint16_t       nnz[NumChunks];
         IndexType           count;
 
-        auto input32 = reinterpret_cast<const std::int32_t*>(input);
+        const auto input32 = reinterpret_cast<const std::int32_t*>(input);
 
         // Find indices of nonzero 32-bit blocks
         find_nnz<NumChunks>(input32, nnz, count);

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -325,8 +325,7 @@ class AffineTransformSparseInput {
 
         while (start < end)
         {
-            const std::ptrdiff_t i = *start;
-            start++;
+            const std::ptrdiff_t i = *start++;
             const invec_t in = vec_set_32(input32[i]);
             const auto    col =
               reinterpret_cast<const invec_t*>(&weights_cp[i * OutputDimensions * ChunkSize]);


### PR DESCRIPTION
Passed STC: https://tests.stockfishchess.org/tests/live_elo/68dcd6defa806e2e8393be67

LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 24224 W: 6453 L: 6165 D: 11606
Ptnml(0-2): 56, 2627, 6467, 2897, 65 

While we're at it I replaced the ugly C-style cast with a beautiful `reinterpret_cast` like the rest of SF.

Only applies to AVX512 + VNNI, but we see a broad uplift now, not just on Zen 5. I totally didn't realize that the fallback dotprod implementation didn't have a latency issue. 🤦  Might be worth trying this trick on 256-bit AVX-VNNI.

I have another idea for the non-VNNI case that I'll try out soon.