### PR TITLE
Tweak Correction History Bonus Asymmetrically

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1448,9 +1448,9 @@ moves_loop:  // When in check, search starts here
         && ((bestValue < ss->staticEval && bestValue < beta)  // negative correction & no fail high
             || (bestValue > ss->staticEval && bestMove)))     // positive correction & no fail low
     {
-        auto bonus = std::clamp(int(bestValue - ss->staticEval) * depth / 8,
+        auto bonus = std::clamp(int(bestValue - ss->staticEval) * depth / (8 + (bestValue > ss->staticEval)),
                                 -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
-        update_correction_history(pos, ss, *this, bonus);
+        update_correction_history(pos, ss, *this, (1088 - 180 * (bestValue > ss->staticEval)) * bonus/ 1024);
     }
 
     assert(bestValue > -VALUE_INFINITE && bestValue < VALUE_INFINITE);


### PR DESCRIPTION
Tweak Correction History Bonus Asymmetrically

Refine the correction history update by applying an asymmetric bonus based on the type of evaluation error. It differentiates between negative corrections and positive corrections.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 165184 W: 43314 L: 42807 D: 79063
Ptnml(0-2): 551, 19391, 42261, 19778, 611
https://tests.stockfishchess.org/tests/view/68cae49902c43c969fe7f008

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 243234 W: 62765 L: 62029 D: 118440
Ptnml(0-2): 163, 25996, 68551, 26756, 151
https://tests.stockfishchess.org/tests/view/68d1c50dfa806e2e8393aa1f

bench: 2236377