### PR TITLE
Deprecate VNNI256

### DIFF
--- a/.github/ci/matrix.json
+++ b/.github/ci/matrix.json
@@ -61,7 +61,6 @@
     "x86-64-bmi2",
     "x86-64-avxvnni",
     "x86-64-avx512",
-    "x86-64-vnni256",
     "x86-64-vnni512",
     "x86-64-avx512icl",
     "apple-silicon",
@@ -106,12 +105,6 @@
       }
     },
     {
-      "binaries": "x86-64-vnni256",
-      "config": {
-        "os": "macos-14"
-      }
-    },
-    {
       "binaries": "x86-64-vnni512",
       "config": {
         "os": "macos-14"
@@ -131,12 +124,6 @@
     },
     {
       "binaries": "x86-64-avx512",
-      "config": {
-        "os": "macos-15-intel"
-      }
-    },
-    {
-      "binaries": "x86-64-vnni256",
       "config": {
         "os": "macos-15-intel"
       }
@@ -185,12 +172,6 @@
     },
     {
       "binaries": "x86-64-avx512",
-      "config": {
-        "os": "windows-11-arm"
-      }
-    },
-    {
-      "binaries": "x86-64-vnni256",
       "config": {
         "os": "windows-11-arm"
       }

--- a/scripts/get_native_properties.sh
+++ b/scripts/get_native_properties.sh
@@ -42,7 +42,7 @@ set_arch_x86_64() {
   if check_flags 'avx512f' 'avx512cd' 'avx512vl' 'avx512dq' 'avx512bw' 'avx512ifma' 'avx512vbmi' 'avx512vbmi2' 'avx512vpopcntdq' 'avx512bitalg' 'avx512vnni' 'vpclmulqdq' 'gfni' 'vaes'; then
     true_arch='x86-64-avx512icl'
   elif check_flags 'avx512vnni' 'avx512dq' 'avx512f' 'avx512bw' 'avx512vl'; then
-    true_arch='x86-64-vnni256'
+    true_arch='x86-64-vnni512'
   elif check_flags 'avx512f' 'avx512bw'; then
     true_arch='x86-64-avx512'
   elif [ -z "${znver_1_2+1}" ] && check_flags 'bmi2'; then
@@ -83,7 +83,7 @@ case $uname_s in
       'x86_64')
         flags=$(sysctl -n machdep.cpu.features machdep.cpu.leaf7_features | tr '\n' ' ' | tr '[:upper:]' '[:lower:]' | tr -d '_.')
         set_arch_x86_64
-        if [ "$true_arch" = 'x86-64-vnni256' ] || [ "$true_arch" = 'x86-64-avx512' ]; then
+        if [ "$true_arch" = 'x86-64-avx512' ]; then
            file_arch='x86-64-bmi2'
         fi
         ;;

--- a/src/Makefile
+++ b/src/Makefile
@@ -97,7 +97,6 @@ VPATH = syzygy:nnue:nnue/features
 # avx2 = yes/no       --- -mavx2             --- Use Intel Advanced Vector Extensions 2
 # avxvnni = yes/no    --- -mavxvnni          --- Use Intel Vector Neural Network Instructions AVX
 # avx512 = yes/no     --- -mavx512bw         --- Use Intel Advanced Vector Extensions 512
-# vnni256 = yes/no    --- -mavx256vnni       --- Use Intel Vector Neural Network Instructions 512 with 256bit operands
 # vnni512 = yes/no    --- -mavx512vnni       --- Use Intel Vector Neural Network Instructions 512
 # avx512icl = yes/no  --- ... multiple ...   --- Use All AVX-512 features available on both Intel Ice Lake and AMD Zen 4
 # altivec = yes/no    --- -maltivec          --- Use PowerPC Altivec SIMD extension
@@ -128,7 +127,7 @@ endif
 # explicitly check for the list of supported architectures (as listed with make help),
 # the user can override with `make ARCH=x86-64-avx512icl SUPPORTED_ARCH=true`
 ifeq ($(ARCH), $(filter $(ARCH), \
-                 x86-64-avx512icl x86-64-vnni512 x86-64-vnni256 x86-64-avx512 x86-64-avxvnni \
+                 x86-64-avx512icl x86-64-vnni512 x86-64-avx512 x86-64-avxvnni \
                  x86-64-bmi2 x86-64-avx2 x86-64-sse41-popcnt x86-64-modern x86-64-ssse3 x86-64-sse3-popcnt \
                  x86-64 x86-32-sse41-popcnt x86-32-sse2 x86-32 ppc-64 ppc-64-altivec ppc-64-vsx ppc-32 e2k \
                  armv7 armv7-neon armv8 armv8-dotprod apple-silicon general-64 general-32 riscv64 \
@@ -153,7 +152,6 @@ sse41 = no
 avx2 = no
 avxvnni = no
 avx512 = no
-vnni256 = no
 vnni512 = no
 avx512icl = no
 altivec = no
@@ -267,17 +265,6 @@ ifeq ($(findstring -avx512,$(ARCH)),-avx512)
 	avx2 = yes
 	pext = yes
 	avx512 = yes
-endif
-
-ifeq ($(findstring -vnni256,$(ARCH)),-vnni256)
-	popcnt = yes
-	sse = yes
-	sse2 = yes
-	ssse3 = yes
-	sse41 = yes
-	avx2 = yes
-	pext = yes
-	vnni256 = yes
 endif
 
 ifeq ($(findstring -vnni512,$(ARCH)),-vnni512)
@@ -724,17 +711,10 @@ ifeq ($(avx512),yes)
 	endif
 endif
 
-ifeq ($(vnni256),yes)
-	CXXFLAGS += -DUSE_VNNI
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
-		CXXFLAGS += -mavx512f -mavx512bw -mavx512vnni -mavx512dq -mavx512vl -mprefer-vector-width=256
-	endif
-endif
-
 ifeq ($(vnni512),yes)
 	CXXFLAGS += -DUSE_VNNI
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
-		CXXFLAGS += -mavx512f -mavx512bw -mavx512vnni -mavx512dq -mavx512vl -mprefer-vector-width=512
+		CXXFLAGS += -mavx512f -mavx512bw -mavx512vnni -mavx512dq -mavx512vl
 	endif
 endif
 
@@ -905,7 +885,6 @@ help:
 	echo "native                  > select the best architecture for the host processor (default)" && \
 	echo "x86-64-avx512icl        > x86 64-bit with minimum avx512 support of Intel Ice Lake or AMD Zen 4" && \
 	echo "x86-64-vnni512          > x86 64-bit with vnni 512bit support" && \
-	echo "x86-64-vnni256          > x86 64-bit with vnni 512bit support, limit operands to 256bit wide" && \
 	echo "x86-64-avx512           > x86 64-bit with avx512 support" && \
 	echo "x86-64-avxvnni          > x86 64-bit with vnni 256bit support" && \
 	echo "x86-64-bmi2             > x86 64-bit with bmi2 support" && \
@@ -1050,7 +1029,6 @@ config-sanity: net
 	echo "avx2: '$(avx2)'" && \
 	echo "avxvnni: '$(avxvnni)'" && \
 	echo "avx512: '$(avx512)'" && \
-	echo "vnni256: '$(vnni256)'" && \
 	echo "vnni512: '$(vnni512)'" && \
 	echo "avx512icl: '$(avx512icl)'" && \
 	echo "altivec: '$(altivec)'" && \
@@ -1087,7 +1065,6 @@ config-sanity: net
 	(test "$(sse41)" = "yes" || test "$(sse41)" = "no") && \
 	(test "$(avx2)" = "yes" || test "$(avx2)" = "no") && \
 	(test "$(avx512)" = "yes" || test "$(avx512)" = "no") && \
-	(test "$(vnni256)" = "yes" || test "$(vnni256)" = "no") && \
 	(test "$(vnni512)" = "yes" || test "$(vnni512)" = "no") && \
 	(test "$(avx512icl)" = "yes" || test "$(avx512icl)" = "no") && \
 	(test "$(altivec)" = "yes" || test "$(altivec)" = "no") && \


### PR DESCRIPTION
As suggested https://github.com/official-stockfish/Stockfish/issues/6167#issuecomment-3092356458
When vnni256 was first introduced https://github.com/official-stockfish/Stockfish/pull/3038 it was very slightly faster than vnni512 on some machines.  We have since sped up vnni512 significantly (https://github.com/official-stockfish/Stockfish/pull/4796 over 10% alone, https://github.com/official-stockfish/Stockfish/pull/6139, and probably others I'm forgetting).  Since any machine that can run vnni256 can run vnni512 this arch is no longer useful.

No functional change
bench: 2515619