### PR TITLE
Make sure we don't move a nonexistent piece in SEE

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1105,6 +1105,8 @@ bool Position::see_ge(Move m, int threshold) const {
 
     Square from = m.from_sq(), to = m.to_sq();
 
+    assert(piece_on(from) != NO_PIECE);
+
     int swap = PieceValue[piece_on(to)] - threshold;
     if (swap < 0)
         return false;


### PR DESCRIPTION
Make sure we don't move a nonexistent piece in SEE

I've made a mistake a couple of times where I do SEE on a move after it has been made. This adds an assertion to make sure there is actually a piece on the source square.

No functional change

bench 2746404