### PR TITLE
Introduce 4-ply continuation correction history

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -83,8 +83,9 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const auto  wnpcv = w.nonPawnCorrectionHistory[non_pawn_index<WHITE>(pos)][WHITE][us];
     const auto  bnpcv = w.nonPawnCorrectionHistory[non_pawn_index<BLACK>(pos)][BLACK][us];
     const auto  cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                 : 8;
+      m.is_ok() ?   (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
+                  + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
+                : 8;
 
     return 9536 * pcv + 8494 * micv + 10132 * (wnpcv + bnpcv) + 7156 * cntcv;
 }
@@ -112,8 +113,12 @@ void update_correction_history(const Position& pos,
       << bonus * nonPawnWeight / 128;
 
     if (m.is_ok())
-        (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-          << bonus * 137 / 128;
+    {
+        const Square to = m.to_sq();
+        const Piece  pc = pos.piece_on(m.to_sq());
+        (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus * 137 / 128;
+        (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus * 64 / 128;
+    }
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness


### PR DESCRIPTION
Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 113984 W: 29752 L: 29323 D: 54909
Ptnml(0-2): 376, 13191, 29435, 13608, 382
https://tests.stockfishchess.org/tests/view/68dc3576fa806e2e8393bd93

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 80154 W: 20823 L: 20417 D: 38914
Ptnml(0-2): 47, 8600, 22383, 8994, 53
https://tests.stockfishchess.org/tests/view/68df83e0fa806e2e8393cbe8

Passed non-regression VLTC (rebased):
LLR: 2.98 (-2.94,2.94) <-1.75,0.25>
Total: 38158 W: 9992 L: 9805 D: 18361
Ptnml(0-2): 3, 3406, 12075, 3591, 4
https://tests.stockfishchess.org/tests/view/68e22f2afa806e2e8393d0ed

bench 2169281