### PR TITLE
Update get_native_properties.sh for AVXVNNI

### DIFF
--- a/scripts/get_native_properties.sh
+++ b/scripts/get_native_properties.sh
@@ -45,6 +45,8 @@ set_arch_x86_64() {
     true_arch='x86-64-vnni512'
   elif check_flags 'avx512f' 'avx512bw'; then
     true_arch='x86-64-avx512'
+  elif check_flags 'avxvnni'; then
+    true_arch='x86-64-avxvnni'
   elif [ -z "${znver_1_2+1}" ] && check_flags 'bmi2'; then
     true_arch='x86-64-bmi2'
   elif check_flags 'avx2'; then


### PR DESCRIPTION
Update get_native_properties.sh to detect and report 'x86-64-avxvnni' when the CPU supports it.

No functional change