### PR TITLE
bigger PAWN_HISTORY_SIZE

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -217,6 +217,7 @@ Ronald de Man (syzygy1, syzygy)
 Ron Britvich (Britvich)
 rqs
 Rui Coelho (ruicoelhopedro)
+rustam-cpp
 Ryan Schmitt
 Ryan Takker
 Sami Kiminki (skiminki)

--- a/src/history.h
+++ b/src/history.h
@@ -33,7 +33,7 @@
 
 namespace Stockfish {
 
-constexpr int PAWN_HISTORY_SIZE        = 1024;   // has to be a power of 2
+constexpr int PAWN_HISTORY_SIZE        = 8192;   // has to be a power of 2
 constexpr int CORRECTION_HISTORY_SIZE  = 32768;  // has to be a power of 2
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;


### PR DESCRIPTION
STC (10+0.1 th1) was accepted:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 75712 W: 19701 L: 19326 D: 36685
Ptnml(0-2): 254, 8738, 19513, 9081, 270
https://tests.stockfishchess.org/tests/view/68e286d5fa806e2e8393d160

LTC (60+0.6 th1) was accepted:
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 108492 W: 28068 L: 27604 D: 52820
Ptnml(0-2): 60, 11639, 30390, 12091, 66
https://tests.stockfishchess.org/tests/view/68e3e564a017f472e763dac0

bench 2128316