### PR TITLE
Avoid unnecessary allocations in AccumulatorStack

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
 namespace NNUE {
 struct Networks;
 struct AccumulatorCaches;
-struct AccumulatorStack;
+class AccumulatorStack;
 }
 
 std::string trace(Position& pos, const Eval::NNUE::Networks& networks);

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -139,7 +139,7 @@ struct AccumulatorState {
 };
 
 
-struct AccumulatorStack {
+class AccumulatorStack {
    public:
     [[nodiscard]] const AccumulatorState& latest() const noexcept;
 


### PR DESCRIPTION
replacing the vector with an array resulted in a .45+-.10 % speedup on my machine.
Do people think this should go on fishtest?

EDIT: By removing the constructor call to `std::vector<Accumulator>` we no longer zero-initialize 200-ish accumulators (each of which is 12KB).