### PR TITLE
Remove condition in qsearch

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -62,7 +62,7 @@ CSTENTOR
 Dale Weiler (graphitemaster)
 Daniel Axtens (daxtens)
 Daniel Dugovic (ddugovic)
-Daniel Monroe (Ergodice)
+Daniel Monroe (daniel-monroe)
 Daniel Samek (DanSamek)
 Dan Schmidt (dfannius)
 Dariusz Orzechowski (dorzechowski)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1634,9 +1634,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
                 }
             }
 
-            // Continuation history based pruning
-            if (!capture
-                && pawnHistory[pawn_history_index(pos)][pos.moved_piece(move)][move.to_sq()] < 7300)
+            // Skip non-captures
+            if (!capture)
                 continue;
 
             // Do not search moves with bad enough SEE values


### PR DESCRIPTION
Remove condition in qsearch

Instead of skipping non-captures when pawn history is exceptionally high, skip all non-captures

Passed non-regression STC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 38016 W: 10018 L: 9795 D: 18203
Ptnml(0-2): 155, 4346, 9755, 4625, 127 
https://tests.stockfishchess.org/tests/view/68e43d4aa017f472e763db2e

Passed rebased non-regression LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 96048 W: 24854 L: 24710 D: 46484
Ptnml(0-2): 47, 10504, 26780, 10644, 49 
https://tests.stockfishchess.org/tests/view/68e59352a017f472e763dcf9

bench 2174210