### PR TITLE
Introduce 6-ply continuation correction history

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -85,6 +85,7 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const auto  cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
+                    + (*(ss - 6)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                  : 8;
 
     return 9536 * pcv + 8494 * micv + 10132 * (wnpcv + bnpcv) + 7156 * cntcv;
@@ -118,6 +119,7 @@ void update_correction_history(const Position& pos,
         const Piece  pc = pos.piece_on(m.to_sq());
         (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus * 137 / 128;
         (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus * 64 / 128;
+        (*(ss - 6)->continuationCorrectionHistory)[pc][to] << bonus * 32 / 128;
     }
 }
 


### PR DESCRIPTION
This extends the continuation correction history mechanism to look back 6 plies in addition to the existing 2-ply and 4-ply terms. Following the proven pattern from the recent 4-ply addition (#6345), this uses a conservative weight (32/128 = 0.25) that decreases with distance.

The regular continuation history already benefits from 6-ply lookback, and this change applies the same principle to correction history.

**Implementation:**
- Adds (ss-6) term to `correction_value()` calculation
- Updates (ss-6) in `update_correction_history()` with weight 32/128
- Follows the same code structure as the successful 4-ply implementation

**Bench Results:**
- Baseline: 2169281
- With changes: 2402955

**Testing:**
This requires Fishtest validation to confirm Elo gains at STC/LTC/VLTC.

bench: 2402955