### PR TITLE
Improve matefinding & Retrograde analysis capability

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -587,13 +587,9 @@ Value Search::Worker::search(
     constexpr bool PvNode   = nodeType != NonPV;
     constexpr bool rootNode = nodeType == Root;
     const bool     allNode  = !(PvNode || cutNode);
-    bool tbProbe = true;
-
-    if (depth == -1000)
-      depth = 1, tbProbe = false;
 
     // Dive into quiescence search when the depth reaches zero
-    else if (depth <= 0)
+    if (depth <= 0)
         return qsearch<PvNode ? PV : NonPV>(pos, ss, alpha, beta);
 
     // Limit the depth if extensions made it too large
@@ -731,7 +727,7 @@ Value Search::Worker::search(
     }
 
     // Step 5. Tablebases probe
-    if (!rootNode && !excludedMove && tbConfig.cardinality && tbProbe)
+    if (!rootNode && !excludedMove && tbConfig.cardinality)
     {
         int piecesCount = pos.count<ALL_PIECES>();
 
@@ -1559,7 +1555,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
                 bestValue = ttData.value;
             else if (PvNode && is_valid(ttData.value) && is_decisive(ttData.value) && std::abs(ttData.value) != VALUE_MATE)
                 // navigate to the mate to avoid truncated PV's (turn off TB-probing while doing it)
-                return  search<PV>(pos, ss, alpha, beta, -1000, false);
+                return  search<PV>(pos, ss, alpha, beta, 1, false);
         }
         else
         {


### PR DESCRIPTION
Improves matefinding:

```
Using master.exe on matetrack.epd with --nodes 1000000 
Total FENs: 6554
Found mates: 3314
Best mates: 2393

Using patch.exe on matetrack.epd with --nodes 1000000 
Total FENs: 6554
Found mates: 3510
Best mates: 2450
```

Improves Retrograde analysis capability:
on certain positions like on the final one of following PGN this patch turns out to be a real game changer
```
[FEN "6br/1KNp1n1r/2p2p2/P1ppRP2/1kP3pP/3PBB2/PN1P4/8 w - - 0 1"]

1. Bxc5+ Kxc5 2. d4+ Kxd4 3. Nb5+ Kxe5 4. Nd3+ Kxf5 5. Nd4+ Kg6 6. Nf4+ Kg7 7. Nf5+ Kf8 8. Ng6+ Ke8 9. Kc8 
```
Please use any standard chess GUI to analyze the final position from the PGN above. Both the Stockfish master and the patched version will find a mate in 13 (−M13) in approximately 10 seconds.
Now stop the analysis, go back one or two half-moves, and restart infinite analysis without clearing the hash. The patched version will rediscover the mate almost instantly (around depth 11), while the master version struggles—taking over 10 seconds on average when going back two half-moves. If you go back just one half-move, the master takes significantly longer to reestablish the mate.
You can repeat this process step-by-step all the way back to the starting position. The master version repeatedly loses track of the mating sequence, while the patch maintains/regains it consistently.
This behavior is reproducible with other mating positions as well.

The patch consists of just two lines of code, so I believe it’s worth committing—even if it doesn’t directly improve playing strength. The current [STC test](https://tests.stockfishchess.org/tests/view/68e7a8d7a017f472e763e37e) on Fishtest (with gain bounds requested by @vondele), along with similar tests in my experiment33 series, suggests that this patch does not introduce a regression.

Note: I believe the is_decisive(ttData.value) condition was added in the logic for using TT values as improved evaluations—not because we distrust TT hits with decisive scores, but to avoid the engine outputting truncated PVs when mate scores are involved. This patch addresses that issue by applying a normal search to such TT hits.

Solves #6328

bench: 2232472