### PR TITLE
Increase NMP reduction when improving

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -869,7 +869,7 @@ Value Search::Worker::search(
         assert((ss - 1)->currentMove != Move::null());
 
         // Null move dynamic reduction based on depth
-        Depth R = 6 + depth / 3;
+        Depth R = 6 + depth / 3 + improving;
 
         ss->currentMove                   = Move::null();
         ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];


### PR DESCRIPTION
Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 52896 W: 13904 L: 13565 D: 25427
Ptnml(0-2): 186, 6022, 13706, 6335, 199
https://tests.stockfishchess.org/tests/view/68e67d02a017f472e763dfaf

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 168354 W: 43750 L: 43163 D: 81441
Ptnml(0-2): 81, 18284, 46882, 18827, 103
https://tests.stockfishchess.org/tests/view/68e79d7ba017f472e763e352

bench: 2537382