### PR TITLE
Improve matefinding & Retrograde analysis capability

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1553,8 +1553,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
             if (is_valid(ttData.value) && !is_decisive(ttData.value)
                 && (ttData.bound & (ttData.value > bestValue ? BOUND_LOWER : BOUND_UPPER)))
                 bestValue = ttData.value;
-            else if (PvNode && hasMateDistance(std::abs(ttData.value)))
-                // to the mate building up the complete PV
+            else if (PvNode && has_mate_distance(ttData.value))
+                //  Prevent valuable TT information being overwritten, useful for mate finding & retrograde analysis
                 return search<PV>(pos, ss, alpha, beta, 1, false);
         }
         else

--- a/src/types.h
+++ b/src/types.h
@@ -39,6 +39,7 @@
     #include <cassert>
     #include <cstddef>
     #include <cstdint>
+    #include <cstdlib>
     #include <type_traits>
 
     #if defined(_MSC_VER)
@@ -178,8 +179,9 @@ constexpr bool is_loss(Value value) {
 
 constexpr bool is_decisive(Value value) { return is_win(value) || is_loss(value); }
 
-constexpr bool hasMateDistance(Value absValue) {
-    return  absValue >= VALUE_MATE_IN_MAX_PLY && absValue < VALUE_MATE;
+constexpr bool has_mate_distance(Value value) {
+    Value absValue = std::abs(value);
+    return absValue >= VALUE_MATE_IN_MAX_PLY && absValue < VALUE_MATE;
 }
 
 // In the code, we make the assumption that these values


### PR DESCRIPTION
- Improves matefinding:

```
Using ..\sf\patch.exe on matetrack.epd with --nodes 1000000
Engine ID:     Stockfish dev-20251015-nogit
Total FENs:    6554
Found mates:   3504
Best mates:    2461

Using ..\sf\master.exe on matetrack.epd with --nodes 1000000
Engine ID:     Stockfish dev-20251015-nogit
Total FENs:    6554
Found mates:   3337
Best mates:    2407
```

- Improves Retrograde analysis capability:

on certain positions like on the final one of following PGN this patch turns out to be a real game changer

```
[FEN "6br/1KNp1n1r/2p2p2/P1ppRP2/1kP3pP/3PBB2/PN1P4/8 w - - 0 1"]

1. Bxc5+ Kxc5 2. d4+ Kxd4 3. Nb5+ Kxe5 4. Nd3+ Kxf5 5. Nd4+ Kg6 6. Nf4+ Kg7 7. Nf5+ Kf8 8. Ng6+ Ke8 9. Kc8 
```

Please use any standard chess GUI to analyze the final position from the PGN above. Both the Stockfish master and the patched version will find a mate in 13 (−M13) in approximately 10 seconds.
Now stop the analysis, go back one or two half-moves, and restart infinite analysis without clearing the hash. The patched version will rediscover the mate almost instantly (around depth 11), while the master version struggles—taking over 10 seconds on average when going back two half-moves. If you go back just one half-move, the master takes significantly longer to reestablish the mate.
You can repeat this process step-by-step all the way back to the starting position. The master version repeatedly loses track of the mating sequence, while the patch maintains/regains it consistently.
This behavior is reproducible with other mating positions as well.

The patch just adds few lines of code, so I believe it’s worth committing—even if it doesn’t directly improve playing strength. The current [STC test](https://tests.stockfishchess.org/tests/view/68e7a8d7a017f472e763e37e) on Fishtest (with gain bounds requested by @vondele), along with similar tests in my experiment33 series, suggests that this patch doesn't introduce a regression.

- Prevents SF from throwing away precious information when hitting a mate-score on the PV out from qsearch.  Current master not only ignores that information, it also can overide that info with a less valuable information by equalizing value with eval although the node were already processed with a higher depth. This is also the cause why it sometimes looses track of an already found mate.

Note: Prior CI-checks (see #6360) have unveiled that this patch can't take advantage of tb-scores (without complicating the code). This because if we consider a tthit (TTEntry) with a tbScore we cannot be sure if it's the very first position in the PV that hits the Tablebases (qsearch don't probes Tablebases). This can lead the engine to report tbscores at root with longer distances that actually are needed to hit the TB.    

P.S: Special thanks to RobbyRobbyRob helping to bissect the problem with wrong tbscores in the pior PR

Solves https://github.com/official-stockfish/Stockfish/issues/6328

bench: 2267656