### PR TITLE
Allow AccumulatorStack::size to point to one past the end

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -75,7 +75,7 @@ void AccumulatorStack::reset() noexcept {
 }
 
 void AccumulatorStack::push(const DirtyPiece& dirtyPiece) noexcept {
-    assert(size + 1 < accumulators.size());
+    assert(size < accumulators.size());
     accumulators[size].reset(dirtyPiece);
     size++;
 }


### PR DESCRIPTION
this is guaranteed to be correct since we access the last element with `size - 1`

closes #6367 

no functional change