### PR TITLE
Simplify best move effort

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -478,19 +478,16 @@ void Search::Worker::iterative_deepening() {
             double reduction =
               (1.455 + mainThread->previousTimeReduction) / (2.2375 * timeReduction);
             double bestMoveInstability = 1.04 + 1.8956 * totBestMoveChanges / threads.size();
+            double highBestMoveEffort          = completedDepth >= 10 && nodesEffort >= 92425 ? 0.666 : 1.0;
 
-            double totalTime =
-              mainThread->tm.optimum() * fallingEval * reduction * bestMoveInstability;
+            double totalTime = mainThread->tm.optimum() * fallingEval * reduction
+                             * bestMoveInstability * highBestMoveEffort;
 
             // Cap used time in case of a single legal move for a better viewer experience
             if (rootMoves.size() == 1)
                 totalTime = std::min(502.0, totalTime);
 
             auto elapsedTime = elapsed();
-
-            if (completedDepth >= 10 && nodesEffort >= 92425 && elapsedTime > totalTime * 0.666
-                && !mainThread->ponder)
-                threads.stop = true;
 
             // Stop the search if we have exceeded the totalTime or maximum
             if (elapsedTime > std::min(totalTime, double(mainThread->tm.maximum())))


### PR DESCRIPTION
Simplify best move effort

Passed non-regression STC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 44224 W: 11614 L: 11403 D: 21207
Ptnml(0-2): 147, 4936, 11726, 5165, 138
https://tests.stockfishchess.org/tests/view/68e9410ed323fd15c04e3a87

Passed non-regression LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 109788 W: 28223 L: 28096 D: 53469
Ptnml(0-2): 60, 11493, 31657, 11628, 56
https://tests.stockfishchess.org/tests/view/68eb5ac0a23744016c14af1d

bench 2343840
