### PR TITLE
prefetch earlier if checKEP is false

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -858,9 +858,9 @@ DirtyPiece Position::do_move(Move                      m,
             st->minorPieceKey ^= Zobrist::psq[pc][from] ^ Zobrist::psq[pc][to];
     }
 
-    st->key = k;
+    // If en passant is impossible, then k will not change and we can prefetch earlier
     if (tt && !checkEP)
-        prefetch(tt->first_entry(key()));
+        prefetch(tt->first_entry(adjust_key50(k)));
 
     // Set capture piece
     st->capturedPiece = captured;


### PR DESCRIPTION
[Passed SMP STC](https://tests.stockfishchess.org/tests/live_elo/68f337c528e6d77fcffa066a):

```
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 65256 W: 16806 L: 16462 D: 31988
Ptnml(0-2): 76, 7386, 17362, 7726, 78 
```

[Single-threaded STC](https://tests.stockfishchess.org/tests/live_elo/68f3378328e6d77fcffa0665) seems to be a wash. 

Only a modest amount of work happens between the transposition table prefetch and the probe, so the probe still often stalls waiting for DRAM. The vast majority of the time (in particular, if `!checkEP`), the key is known much earlier in the `do_move` function and the latency can be better hidden.

In my local tests, the speedup grows with thread count, which I suspect accounts for the difference on fishtest.
