### PR TITLE
Simplify r50 condition in cutoff

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -685,10 +685,7 @@ Value Search::Worker::search(
     if (!PvNode && !excludedMove && ttData.depth > depth - (ttData.value <= beta)
         && is_valid(ttData.value)  // Can happen when !ttHit or when access race in probe()
         && (ttData.bound & (ttData.value >= beta ? BOUND_LOWER : BOUND_UPPER))
-        && (cutNode == (ttData.value >= beta) || depth > 5)
-        // avoid a TT cutoff if the rule50 count is high and the TT move is zeroing
-        && (depth > 8 || ttData.move == Move::none() || pos.rule50_count() < 80
-            || (!ttCapture && type_of(pos.moved_piece(ttData.move)) != PAWN)))
+        && (cutNode == (ttData.value >= beta) || depth > 5))
     {
         // If ttMove is quiet, update move sorting heuristics on TT hit
         if (ttData.move && ttData.value >= beta)


### PR DESCRIPTION
Simplify r50 condition in cutoff

Passed non-regression STC
LLR: 3.11 (-2.94,2.94) <-1.75,0.25>
Total: 114560 W: 29832 L: 29689 D: 55039
Ptnml(0-2): 332, 12302, 31869, 12445, 332 
https://tests.stockfishchess.org/tests/view/68e38587fa806e2e8393d4a9

Passed non-regression LTC
LLR: 2.99 (-2.94,2.94) <-1.75,0.25>
Total: 256272 W: 65817 L: 65832 D: 124623
Ptnml(0-2): 137, 25528, 76817, 25521, 133 
https://tests.stockfishchess.org/tests/view/68e69b47a017f472e763e065

bench 2529051