### PR TITLE
Simplify static eval bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -818,12 +818,11 @@ Value Search::Worker::search(
     // Use static evaluation difference to improve quiet move ordering
     if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture)
     {
-        int bonus = std::clamp(-10 * int((ss - 1)->staticEval + ss->staticEval), -2023, 1563) + 583;
-        mainHistory[~us][((ss - 1)->currentMove).from_to()] << bonus * 944 / 1024;
+        int evalDiff = std::clamp(-int((ss - 1)->staticEval + ss->staticEval), -200, 156) + 58;
+        mainHistory[~us][((ss - 1)->currentMove).from_to()] << evalDiff * 9;
         if (!ttHit && type_of(pos.piece_on(prevSq)) != PAWN
             && ((ss - 1)->currentMove).type_of() != PROMOTION)
-            pawnHistory[pawn_history_index(pos)][pos.piece_on(prevSq)][prevSq]
-              << bonus * 1438 / 1024;
+            pawnHistory[pawn_history_index(pos)][pos.piece_on(prevSq)][prevSq] << evalDiff * 14;
     }
 
     // Set up the improving flag, which is true if current static evaluation is


### PR DESCRIPTION
Simplify static eval bonus

Passed non-regression STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 176896 W: 45998 L: 45933 D: 84965
Ptnml(0-2): 609, 20845, 45451, 20958, 585 
https://tests.stockfishchess.org/tests/view/68e5e48ba017f472e763dd21

Passed non-regression LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 77682 W: 20046 L: 19884 D: 37752
Ptnml(0-2): 41, 8404, 21786, 8572, 38 
https://tests.stockfishchess.org/tests/view/68ee71e328e6d77fcff9fd68

bench 2463055