### PR TITLE
Simplify correction update condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1446,10 +1446,10 @@ moves_loop:  // When in check, search starts here
                        moveCount != 0 ? depth : std::min(MAX_PLY - 1, depth + 6), bestMove,
                        unadjustedStaticEval, tt.generation());
 
-    // Adjust correction history
+    // Adjust correction history if the best move is not a capture
+    // and the error direction matches whether we are above/below bounds.
     if (!ss->inCheck && !(bestMove && pos.capture(bestMove))
-        && ((bestValue < ss->staticEval && bestValue < beta)  // negative correction & no fail high
-            || (bestValue > ss->staticEval && bestMove)))     // positive correction & no fail low
+        && (bestValue < ss->staticEval) == !bestMove)    
     {
         auto bonus =
           std::clamp(int(bestValue - ss->staticEval) * depth / (8 + (bestValue > ss->staticEval)),


### PR DESCRIPTION
Simplify correction update condition

Passed non-regression STC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 95136 W: 24722 L: 24564 D: 45850
Ptnml(0-2): 307, 11139, 24522, 11289, 311 
https://tests.stockfishchess.org/tests/view/68e5034ea017f472e763dc5a

Passed non-regression LTC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 256440 W: 65854 L: 65873 D: 124713
Ptnml(0-2): 144, 28287, 71375, 28272, 142 
https://tests.stockfishchess.org/tests/view/68e71ae4a017f472e763e291

bench 2551690