### PR TITLE
Simplify Pawn History Bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1871,7 +1871,7 @@ void update_quiet_histories(
 
     int pIndex = pawn_history_index(pos);
     workerThread.pawnHistory[pIndex][pos.moved_piece(move)][move.to_sq()]
-      << (bonus * (bonus > 0 ? 800 : 500) / 1024) + 70;
+      << bonus * (bonus > 0 ? 850 : 550) / 1024;
 }
 
 }


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.98 (-2.94,2.94) <-1.75,0.25>
Total: 122016 W: 31655 L: 31525 D: 58836
Ptnml(0-2): 388, 14317, 31474, 14435, 394
https://tests.stockfishchess.org/tests/view/68f57e66637acd2a11e7221d

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 81348 W: 21016 L: 20858 D: 39474
Ptnml(0-2): 45, 8793, 22841, 8949, 46
https://tests.stockfishchess.org/tests/view/68f9e2d9637acd2a11e72997

Bench: 2513942