### PR TITLE
Unify do_move & do_null_move workload

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -299,7 +299,7 @@ class Worker {
     void do_move(Position& pos, const Move move, StateInfo& st, Stack* const ss);
     void
     do_move(Position& pos, const Move move, StateInfo& st, const bool givesCheck, Stack* const ss);
-    void do_null_move(Position& pos, StateInfo& st);
+    void do_null_move(Position& pos, StateInfo& st, Stack* const ss);
     void undo_move(Position& pos, const Move move);
     void undo_null_move(Position& pos);
 


### PR DESCRIPTION
Unifies the assignment of stacks' currentMove & continuationHistories of both methods into their helper methods.
This seems more consistent and readable.

While being there also remove an unused continuationHistory assignment for qsearch.

Tested for non regression at STC:
https://tests.stockfishchess.org/tests/view/69060d81ea4b268f1fac1f36
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 94496 W: 24570 L: 24421 D: 45505
Ptnml(0-2): 264, 10145, 26275, 10306, 258

no functional change