### PR TITLE
Simplify Corrhist Bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1454,8 +1454,7 @@ moves_loop:  // When in check, search starts here
         auto bonus =
           std::clamp(int(bestValue - ss->staticEval) * depth / (8 + (bestValue > ss->staticEval)),
                      -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
-        update_correction_history(pos, ss, *this,
-                                  (1088 - 180 * (bestValue > ss->staticEval)) * bonus / 1024);
+        update_correction_history(pos, ss, *this, bonus);
     }
 
     assert(bestValue > -VALUE_INFINITE && bestValue < VALUE_INFINITE);


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 187776 W: 48687 L: 48631 D: 90458
Ptnml(0-2): 570, 22327, 48090, 22279, 622
https://tests.stockfishchess.org/tests/view/68f58019637acd2a11e72233

Passed Non-regression LTC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 159378 W: 41027 L: 40946 D: 77405
Ptnml(0-2): 122, 17645, 44078, 17718, 126
https://tests.stockfishchess.org/tests/view/68fe7492637acd2a11e73090

Bench: 2249582