### PR TITLE
Improve retrograde analisys and matefinding capability

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1259,7 +1259,7 @@ moves_loop:  // When in check, search starts here
             (ss + 1)->pv[0] = Move::none();
 
             // Extend move from transposition table if we are about to dive into qsearch.
-            if (move == ttData.move && ( (is_valid(value) && is_decisive(ttData.value) && ttData.depth > 0) || (ttData.depth > 1 && rootDepth > 8) ))
+            if (move == ttData.move && ( (is_valid(ttData.value) && is_decisive(ttData.value) && ttData.depth > 0) || (ttData.depth > 1 && rootDepth > 8) ))
                 newDepth = std::max(newDepth, 1);
 
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);


### PR DESCRIPTION
This is an alternative PR to #6365 targeting to fix issue #6328

Passed STC
https://tests.stockfishchess.org/tests/view/68fa3fa7637acd2a11e72a79
LLR: 3.55 (-2.94,2.94) <0.00,2.00>
Total: 134144 W: 34960 L: 34471 D: 64713
Ptnml(0-2): 376, 14199, 37459, 14636, 402

Failed LTC
https://tests.stockfishchess.org/tests/view/68ffc1b5637acd2a11e73377
LLR: -3.10 (-2.94,2.94) <0.50,2.50>
Total: 75360 W: 19423 L: 19519 D: 36418
Ptnml(0-2): 38, 7553, 22605, 7435, 49

1. **Improves retrograde analisys capability.**

   on difficult to detect mates like on the folloving game this patch turns out to be a real game changer:

PGN:
```
[FEN "6br/1KNp1n1r/2p2p2/P1ppRP2/1kP3pP/3PBB2/PN1P4/8 w - - 0 1"]

1. Bxc5+ Kxc5 2. d4+ Kxd4 3. Nb5+ Kxe5 4. Nd3+ Kxf5 5. Nd4+ Kg6 6. Nf4+ Kg7 7. Nf5+ Kf8 8. Ng6+ Ke8 9. Kc8 
```

Please use any standard chess GUI to analyze the final position from the PGN above. Both the Stockfish master and the patched version will find a mate in 13 (−M13) in approximately 10 seconds.
Now stop the analysis, go back one or two half-moves, and restart infinite analysis without clearing the hash. The patched version will rediscover the mate almost instantly (around depth 11), while the master version struggles—taking over 10 seconds on average when going back two half-moves. If you go back just one half-move, the master takes significantly longer to reestablish the mate.
You can repeat this process step-by-step all the way back to the starting position. The master version repeatedly loses track of the mating sequence, while the patch maintains/regains it consistently.
This behavior is reproducible with other mating positions as well.

The patch just adds a condition in an already existing if-condition, so I believe it’s worth committing—even if it doesn’t improve playing strength. 

2. **improves matefinding**

Using ..\sf\patch.exe on matetrack.epd with --nodes 1000000
Engine ID:     Stockfish dev-20251015-nogit
Total FENs:    6554
Found mates:   3437
Best mates:    2438

Using ..\sf\master.exe on matetrack.epd with --nodes 1000000
Engine ID:     Stockfish dev-20251015-nogit
Total FENs:    6554
Found mates:   3337
Best mates:    2407

How this patch works:
Before calling search<PV>(depth), the patch ensures that depth is at least 1 whenever we encounter a decisive score in the transposition table (TT). This prevents search<PV>(depth) from being executed by qsearch<PV>, which would otherwise ignore that information.
Typically, decisive TT hits occur when analyzing a mating sequence backward. Due to the nature of Iterative Deepening (IID), such scores are usually first found at depth 0. Without this patch, valuable information can be lost because qsearch may overwrite the TT entry by replacing the value with a static evaluation, even though the node was already processed at a higher depth. This is also why the engine sometimes loses track of an already discovered mate.


bench: 2343840