### PR TITLE
Simplify Futility pruning formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -853,7 +853,6 @@ Value Search::Worker::search(
             return futilityMult * d                                //
                  - 2094 * improving * futilityMult / 1024          //
                  - 1324 * opponentWorsening * futilityMult / 4096  //
-                 + (ss - 1)->statScore / 331                       //
                  + std::abs(correctionValue) / 158105;
         };
 


### PR DESCRIPTION
Simplify Futility pruning formula

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 170112 W: 44266 L: 44193 D: 81653
Ptnml(0-2): 599, 20062, 43611, 20235, 549
https://tests.stockfishchess.org/tests/view/68f50b94637acd2a11e721ad

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 164658 W: 42393 L: 42318 D: 79947
Ptnml(0-2): 120, 18127, 45747, 18228, 107
https://tests.stockfishchess.org/tests/view/68fa6683637acd2a11e72ac3


bench: 2622795