### PR TITLE
remove -Wstack-usage

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -435,7 +435,7 @@ endif
 ifeq ($(COMP),gcc)
 	comp=gcc
 	CXX=g++
-	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-declarations -Wstack-usage=128000
+	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-declarations
 
 	ifeq ($(arch),$(filter $(arch),armv7 armv8 riscv64))
 		ifeq ($(OS),Android)


### PR DESCRIPTION
If I'm not mistaken, this flag shouldn't be necessary anymore now that the network is directly constructed on-heap