### PR TITLE
Remove check term in capture movepick

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -153,7 +153,7 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
 
         if constexpr (Type == CAPTURES)
             m.value = (*captureHistory)[pc][to][type_of(capturedPiece)]
-                    + 7 * int(PieceValue[capturedPiece]) + 1024 * bool(pos.check_squares(pt) & to);
+                    + 7 * int(PieceValue[capturedPiece]);
 
         else if constexpr (Type == QUIETS)
         {


### PR DESCRIPTION
Remove check term in capture movepick

Passed simplification STC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 248448 W: 64697 L: 64708 D: 119043
Ptnml(0-2): 784, 29393, 63971, 29202, 874 
https://tests.stockfishchess.org/tests/view/68fc7afb637acd2a11e72d86

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 193626 W: 49808 L: 49764 D: 94054
Ptnml(0-2): 162, 21415, 53621, 21447, 168 
https://tests.stockfishchess.org/tests/view/6901ad09637acd2a11e73828

bench 2164507