### PR TITLE
Remove featureTransformer biases

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -99,7 +99,7 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
         return "Final evaluation: none (in check)";
 
     auto accumulators = std::make_unique<Eval::NNUE::AccumulatorStack>();
-    auto caches       = std::make_unique<Eval::NNUE::AccumulatorCaches>(networks);
+    auto                         caches = std::make_unique<Eval::NNUE::AccumulatorCaches>();
 
     std::stringstream ss;
     ss << std::showpoint << std::noshowpos << std::fixed << std::setprecision(2);

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -99,7 +99,7 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
         return "Final evaluation: none (in check)";
 
     auto accumulators = std::make_unique<Eval::NNUE::AccumulatorStack>();
-    auto                         caches = std::make_unique<Eval::NNUE::AccumulatorCaches>();
+    auto caches       = std::make_unique<Eval::NNUE::AccumulatorCaches>();
 
     std::stringstream ss;
     ss << std::showpoint << std::noshowpos << std::fixed << std::setprecision(2);

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,8 +33,8 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-1c0000000000.nnue"
-#define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
+#define EvalFileDefaultNameBig "nn-a6d283b0c73c.nnue"
+#define EvalFileDefaultNameSmall "nn-de9d76fd6b0d.nnue"
 
 namespace NNUE {
 struct Networks;

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -53,7 +53,7 @@ using NetworkOutput = std::tuple<Value, Value>;
 
 // The network must be a trivial type, i.e. the memory must be in-line.
 // This is required to allow sharing the network via shared memory, as
-
+// there is no way to run destructors.
 template<typename Arch, typename Transformer>
 class Network {
     static constexpr IndexType FTDimensions = Arch::TransformedFeatureDimensions;
@@ -64,10 +64,10 @@ class Network {
         embeddedType(type) {}
 
     Network(const Network& other) = default;
-    Network(Network&& other) = default;
+    Network(Network&& other)      = default;
 
     Network& operator=(const Network& other) = default;
-    Network& operator=(Network&& other) = default;
+    Network& operator=(Network&& other)      = default;
 
     void load(const std::string& rootDirectory, std::string evalfilePath);
     bool save(const std::optional<std::string>& filename) const;

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -53,7 +53,7 @@ using NetworkOutput = std::tuple<Value, Value>;
 
 // The network must be a trivial type, i.e. the memory must be in-line.
 // This is required to allow sharing the network via shared memory, as
-// there is no way to run destructors.
+
 template<typename Arch, typename Transformer>
 class Network {
     static constexpr IndexType FTDimensions = Arch::TransformedFeatureDimensions;
@@ -64,10 +64,10 @@ class Network {
         embeddedType(type) {}
 
     Network(const Network& other) = default;
-    Network(Network&& other)      = default;
+    Network(Network&& other) = default;
 
     Network& operator=(const Network& other) = default;
-    Network& operator=(Network&& other)      = default;
+    Network& operator=(Network&& other) = default;
 
     void load(const std::string& rootDirectory, std::string evalfilePath);
     bool save(const std::optional<std::string>& filename) const;
@@ -113,8 +113,6 @@ class Network {
     // Hash value of evaluation function structure
     static constexpr std::uint32_t hash = Transformer::get_hash_value() ^ Arch::get_hash_value();
 
-    template<IndexType Size>
-    friend struct AccumulatorCaches::Cache;
 };
 
 // Definitions of the network types

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -59,9 +59,8 @@ struct alignas(CacheLineSize) Accumulator {
 // is commonly referred to as "Finny Tables".
 struct AccumulatorCaches {
 
-    template<typename Networks>
-    AccumulatorCaches(const Networks& networks) {
-        clear(networks);
+    AccumulatorCaches() {
+        clear();
     }
 
     template<IndexType Size>
@@ -75,19 +74,18 @@ struct AccumulatorCaches {
 
             // To initialize a refresh entry, we set all its bitboards empty,
             // so we put the biases in the accumulation, without any weights on top
-            void clear(const BiasType* biases) {
+            void clear() {
 
-                std::memcpy(accumulation, biases, sizeof(accumulation));
+                std::memset(accumulation, 0, sizeof(accumulation));
                 std::memset((uint8_t*) this + offsetof(Entry, psqtAccumulation), 0,
                             sizeof(Entry) - offsetof(Entry, psqtAccumulation));
             }
         };
 
-        template<typename Network>
-        void clear(const Network& network) {
+        void clear() {
             for (auto& entries1D : entries)
                 for (auto& entry : entries1D)
-                    entry.clear(network.featureTransformer.biases);
+                    entry.clear();
         }
 
         std::array<Entry, COLOR_NB>& operator[](Square sq) { return entries[sq]; }
@@ -95,10 +93,9 @@ struct AccumulatorCaches {
         std::array<std::array<Entry, COLOR_NB>, SQUARE_NB> entries;
     };
 
-    template<typename Networks>
-    void clear(const Networks& networks) {
-        big.clear(networks.big);
-        small.clear(networks.small);
+    void clear() {
+        big.clear();
+        small.clear();
     }
 
     Cache<TransformedFeatureDimensionsBig>   big;

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -123,12 +123,10 @@ class FeatureTransformer {
     }
 
     void permute_weights() {
-        // permute<16>(biases, PackusEpi16Order);
         permute<16>(weights, PackusEpi16Order);
     }
 
     void unpermute_weights() {
-        // permute<16>(biases, InversePackusEpi16Order);
         permute<16>(weights, InversePackusEpi16Order);
     }
 
@@ -139,15 +137,11 @@ class FeatureTransformer {
             for (IndexType i = 0; i < HalfDimensions; ++i)
                 w[i] = read ? w[i] * 2 : w[i] / 2;
         }
-
-        // for (IndexType i = 0; i < HalfDimensions; ++i)
-        //     biases[i] = read ? biases[i] * 2 : biases[i] / 2;
     }
 
     // Read network parameters
     bool read_parameters(std::istream& stream) {
 
-        // read_leb_128<BiasType>(stream, biases, HalfDimensions);
         read_leb_128<WeightType>(stream, weights, HalfDimensions * InputDimensions);
         read_leb_128<PSQTWeightType>(stream, psqtWeights, PSQTBuckets * InputDimensions);
 
@@ -163,7 +157,6 @@ class FeatureTransformer {
         copy->unpermute_weights();
         copy->scale_weights(false);
 
-        //write_leb_128<BiasType>(stream, copy->biases, HalfDimensions);
         write_leb_128<WeightType>(stream, copy->weights, HalfDimensions * InputDimensions);
         write_leb_128<PSQTWeightType>(stream, copy->psqtWeights, PSQTBuckets * InputDimensions);
 
@@ -253,15 +246,14 @@ class FeatureTransformer {
             // values being interpreted as negative after the shift.
 
             // There is a way, however, to get around this limitation. When
-            // loading the network, scale accumulator weights and biases by
-            // 2. To get the same pairwise multiplication result as before,
-            // we need to divide the product by 128 * 2 * 2 = 512, which
-            // amounts to a right shift of 9 bits. So now we only have to
-            // shift left by 7 bits, perform mulhi (shifts right by 16 bits)
-            // and net a 9 bit right shift. Since we scaled everything by
-            // two, the values are clipped at 127 * 2 = 254, which occupies
-            // 8 bits. Shifting it by 7 bits left will no longer occupy the
-            // signed bit, so we are safe.
+            // loading the network, scale accumulator weights by 2. To get
+            // the same pairwise multiplication result as before, we need to
+            // divide the product by 128 * 2 * 2 = 512, which amounts to a
+            // right shift of 9 bits. So now we only have to shift left by 7
+            // bits, perform mulhi (shifts right by 16 bits) and net a 9 bit
+            // right shift. Since we scaled everything by two, the values are
+            // clipped at 127 * 2 = 254, which occupies 8 bits. Shifting it
+            // by 7 bits left will no longer occupy the signed bit, so we are safe.
 
             // Note that on NEON processors, we shift left by 6 instead
             // because the instruction "vqdmulhq_s16" also doubles the

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -156,10 +156,10 @@ class FeatureTransformer {
         return !stream.fail();
     }
 
-
+    // Write network parameters
     bool write_parameters(std::ostream& stream) const {
         std::unique_ptr<FeatureTransformer> copy = std::make_unique<FeatureTransformer>(*this);
-    // Write network parameters
+
         copy->unpermute_weights();
         copy->scale_weights(false);
 
@@ -172,7 +172,6 @@ class FeatureTransformer {
 
     std::size_t get_content_hash() const {
         std::size_t h = 0;
-        hash_combine(h, get_raw_data_hash(biases));
         hash_combine(h, get_raw_data_hash(weights));
         hash_combine(h, get_raw_data_hash(psqtWeights));
         hash_combine(h, get_hash_value());

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -301,6 +301,7 @@ class FeatureTransformer {
         return psqt;
     }  // end of function transform()
 
+    alignas(CacheLineSize) BiasType padding[HalfDimensions];
     alignas(CacheLineSize) WeightType weights[HalfDimensions * InputDimensions];
     alignas(CacheLineSize) PSQTWeightType psqtWeights[InputDimensions * PSQTBuckets];
 };

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -123,12 +123,12 @@ class FeatureTransformer {
     }
 
     void permute_weights() {
-        permute<16>(biases, PackusEpi16Order);
+        // permute<16>(biases, PackusEpi16Order);
         permute<16>(weights, PackusEpi16Order);
     }
 
     void unpermute_weights() {
-        permute<16>(biases, InversePackusEpi16Order);
+        // permute<16>(biases, InversePackusEpi16Order);
         permute<16>(weights, InversePackusEpi16Order);
     }
 
@@ -140,14 +140,14 @@ class FeatureTransformer {
                 w[i] = read ? w[i] * 2 : w[i] / 2;
         }
 
-        for (IndexType i = 0; i < HalfDimensions; ++i)
-            biases[i] = read ? biases[i] * 2 : biases[i] / 2;
+        // for (IndexType i = 0; i < HalfDimensions; ++i)
+        //     biases[i] = read ? biases[i] * 2 : biases[i] / 2;
     }
 
     // Read network parameters
     bool read_parameters(std::istream& stream) {
 
-        read_leb_128<BiasType>(stream, biases, HalfDimensions);
+        // read_leb_128<BiasType>(stream, biases, HalfDimensions);
         read_leb_128<WeightType>(stream, weights, HalfDimensions * InputDimensions);
         read_leb_128<PSQTWeightType>(stream, psqtWeights, PSQTBuckets * InputDimensions);
 
@@ -156,14 +156,14 @@ class FeatureTransformer {
         return !stream.fail();
     }
 
-    // Write network parameters
+
     bool write_parameters(std::ostream& stream) const {
         std::unique_ptr<FeatureTransformer> copy = std::make_unique<FeatureTransformer>(*this);
-
+    // Write network parameters
         copy->unpermute_weights();
         copy->scale_weights(false);
 
-        write_leb_128<BiasType>(stream, copy->biases, HalfDimensions);
+        //write_leb_128<BiasType>(stream, copy->biases, HalfDimensions);
         write_leb_128<WeightType>(stream, copy->weights, HalfDimensions * InputDimensions);
         write_leb_128<PSQTWeightType>(stream, copy->psqtWeights, PSQTBuckets * InputDimensions);
 
@@ -310,7 +310,6 @@ class FeatureTransformer {
         return psqt;
     }  // end of function transform()
 
-    alignas(CacheLineSize) BiasType biases[HalfDimensions];
     alignas(CacheLineSize) WeightType weights[HalfDimensions * InputDimensions];
     alignas(CacheLineSize) PSQTWeightType psqtWeights[InputDimensions * PSQTBuckets];
 };

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -154,7 +154,7 @@ Search::Worker::Worker(SharedState&                    sharedState,
     threads(sharedState.threads),
     tt(sharedState.tt),
     networks(sharedState.networks),
-    refreshTable(networks[token]) {
+    refreshTable() {
     clear();
 }
 
@@ -573,7 +573,7 @@ void Search::Worker::clear() {
     for (size_t i = 1; i < reductions.size(); ++i)
         reductions[i] = int(2809 / 128.0 * std::log(i));
 
-    refreshTable.clear(networks[numaAccessToken]);
+    refreshTable.clear();
 }
 
 


### PR DESCRIPTION
Since the feature at index `make_index(king_square, KING, king_square)` is always active, we don't need a bias in the feature transformer. I'm somewhat confused as to why they were there in the first place. The new network was obtained by adding the existing bias to every weight vector at indices `make_index(sq, KING, sq)` for every square `sq`.

There's currently a test on fishtest running for this: https://tests.stockfishchess.org/tests/view/6909b9e7ea4b268f1fac2a91
But I can't really see how this could possibly regress, so I might stop it unless the maintainers feel strongly about it.