### PR TITLE
Simplify threat term in movepick

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -171,9 +171,8 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
 
             // penalty for moving to a square threatened by a lesser piece
             // or bonus for escaping an attack by a lesser piece.
-            static constexpr int bonus[KING + 1] = {0, 0, 144, 144, 256, 517, 10000};
-            int v = threatByLesser[pt] & to ? -95 : 100 * bool(threatByLesser[pt] & from);
-            m.value += bonus[pt] * v;
+            int v = threatByLesser[pt] & to ? -19 : 20 * bool(threatByLesser[pt] & from);
+            m.value += PieceValue[pt] * v;
 
 
             if (ply < LOW_PLY_HISTORY_SIZE)


### PR DESCRIPTION
Simplify threat term in movepick

Passed simplification STC
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 71296 W: 18605 L: 18419 D: 34272
Ptnml(0-2): 250, 8374, 18183, 8622, 219 
https://tests.stockfishchess.org/tests/view/690454c7ea4b268f1fac1bbe

Passed simplification LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 240552 W: 61870 L: 61874 D: 116808
Ptnml(0-2): 113, 26300, 67460, 26284, 119 
https://tests.stockfishchess.org/tests/view/69063956ea4b268f1fac1f66

bench 2388100