### PR TITLE
Print NEON before POPCNT in compilation settings

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -259,12 +259,12 @@ std::string compiler_info() {
 #if defined(USE_SSE2)
     compiler += " SSE2";
 #endif
-    compiler += (HasPopCnt ? " POPCNT" : "");
 #if defined(USE_NEON_DOTPROD)
     compiler += " NEON_DOTPROD";
 #elif defined(USE_NEON)
     compiler += " NEON";
 #endif
+    compiler += (HasPopCnt ? " POPCNT" : "");
 
 #if !defined(NDEBUG)
     compiler += " DEBUG";


### PR DESCRIPTION
Normally, Stockfish outputs the compilation settings from advanced to less advanced, e.g.: `AVX512ICL VNNI AVX512 BMI2 AVX2 SSE41 SSSE3 SSE2 POPCNT`

With NEON, however, POPCNT is printed first, followed by the more advanced NEON options: `POPCNT NEON_DOTPROD`

This PR places POPCNT behind the NEON options as well.

no functional change