### PR TITLE
Refinec constant in differential correction update

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1447,9 +1447,9 @@ moves_loop:  // When in check, search starts here
     if (!ss->inCheck && !(bestMove && pos.capture(bestMove))
         && (bestValue < ss->staticEval) == !bestMove)
     {
-        auto bonus =
-          std::clamp(int(bestValue - ss->staticEval) * depth / (8 + (bestValue > ss->staticEval)),
-                     -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
+        auto bonus = std::clamp(int(bestValue - ss->staticEval) * depth
+                                  / (8 + 2 * (bestValue > ss->staticEval)),
+                                -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
         update_correction_history(pos, ss, *this, bonus);
     }
 


### PR DESCRIPTION
Refinec constant in differential correction update

Passed STC
LLR: 3.04 (-2.94,2.94) <0.00,2.00>
Total: 250112 W: 65277 L: 64635 D: 120200
Ptnml(0-2): 841, 29326, 64134, 29860, 895 
https://tests.stockfishchess.org/tests/view/69096c46ea4b268f1fac2a39

Passed LTC
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 142908 W: 37141 L: 36604 D: 69163
Ptnml(0-2): 100, 15478, 39742, 16053, 81 
https://tests.stockfishchess.org/tests/view/690e7dfbec1d00d2c195c351

bench 2121514