### PR TITLE
Simplify make_index return value

### DIFF
--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -142,11 +142,8 @@ inline sf_always_inline IndexType FullThreats::make_index(
     if ((piecePairData.excluded_pair_info() + less_than) & 2)
         return FullThreats::Dimensions;
 
-    const IndexType index =
-      piecePairData.feature_index_base() + offsets[attacker][from] + index_lut2[attacker][from][to];
-
-    sf_assume(index != FullThreats::Dimensions);
-    return index;
+    return piecePairData.feature_index_base() + offsets[attacker][from]
+         + index_lut2[attacker][from][to];
 }
 
 // Get a list of indices for active features in ascending order


### PR DESCRIPTION
No functional change

Passed STC nonreg:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 272832 W: 70102 L: 70139 D: 132591
Ptnml(0-2): 824, 30049, 74716, 29994, 833 
https://tests.stockfishchess.org/tests/view/69127ea9ec1d00d2c195caec