### PR TITLE
Simplify NMP reduction formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -872,7 +872,7 @@ Value Search::Worker::search(
         assert((ss - 1)->currentMove != Move::null());
 
         // Null move dynamic reduction based on depth
-        Depth R = 6 + depth / 3 + improving;
+        Depth R = 7 + depth / 3;
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);


### PR DESCRIPTION
Simplify NMP reduction formula

Passed STC:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 178912 W: 46625 L: 46559 D: 85728
Ptnml(0-2): 540, 21167, 45975, 21235, 539
https://tests.stockfishchess.org/tests/view/69060677ea4b268f1fac1f25

Passed LTC:
LLR: 2.99 (-2.94,2.94) <-1.75,0.25>
Total: 140988 W: 36278 L: 36176 D: 68534
Ptnml(0-2): 82, 15520, 39215, 15568, 109
https://tests.stockfishchess.org/tests/view/6908bc32ea4b268f1fac288f

bench: 2959834