### PR TITLE
Fix technical UB

### DIFF
--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -77,10 +77,9 @@ struct AccumulatorCaches {
             // To initialize a refresh entry, we set all its bitboards empty,
             // so we put the biases in the accumulation, without any weights on top
             void clear(const std::array<BiasType, Size>& biases) {
-
                 accumulation = biases;
-                std::memset((uint8_t*) this + offsetof(Entry, psqtAccumulation), 0,
-                            sizeof(Entry) - offsetof(Entry, psqtAccumulation));
+                std::memset(reinterpret_cast<std::byte*>(this) + offsetof(Entry, psqtAccumulation),
+                            0, sizeof(Entry) - offsetof(Entry, psqtAccumulation));
             }
         };
 


### PR DESCRIPTION
C++ standard does not define `uint8_t` as an allowed pointer alias type. Despite `uint8_t` being `unsigned char` (allowed for type aliasing) on most platforms, this is not enforced by the standard.

https://eel.is/c++draft/basic.lval#11
https://stackoverflow.com/a/16138470