### PR TITLE
Allow time checking after each DTZ probe

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1980,8 +1980,9 @@ void syzygy_extend_pv(const OptionsMap&         options,
         for (const auto& m : MoveList<LEGAL>(pos))
             legalMoves.emplace_back(m);
 
-        Tablebases::Config config = Tablebases::rank_root_moves(options, pos, legalMoves);
-        RootMove&          rm     = *std::find(legalMoves.begin(), legalMoves.end(), pvMove);
+        Tablebases::Config config =
+          Tablebases::rank_root_moves(options, pos, legalMoves, false, time_abort);
+        RootMove& rm = *std::find(legalMoves.begin(), legalMoves.end(), pvMove);
 
         if (legalMoves[0].tbRank != rm.tbRank)
             break;
@@ -2040,7 +2041,8 @@ void syzygy_extend_pv(const OptionsMap&         options,
           [](const Search::RootMove& a, const Search::RootMove& b) { return a.tbRank > b.tbRank; });
 
         // The winning side tries to minimize DTZ, the losing side maximizes it
-        Tablebases::Config config = Tablebases::rank_root_moves(options, pos, legalMoves, true);
+        Tablebases::Config config =
+          Tablebases::rank_root_moves(options, pos, legalMoves, true, time_abort);
 
         // If DTZ is not available we might not find a mate, so we bail out
         if (!config.rootInTB || config.cardinality > 0)

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1594,10 +1594,11 @@ int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
 // Use the DTZ tables to rank root moves.
 //
 // A return value false indicates that not all probes were successful.
-bool Tablebases::root_probe(Position&          pos,
-                            Search::RootMoves& rootMoves,
-                            bool               rule50,
-                            bool               rankDTZ) {
+bool Tablebases::root_probe(Position&                    pos,
+                            Search::RootMoves&           rootMoves,
+                            bool                         rule50,
+                            bool                         rankDTZ,
+                            const std::function<bool()>& time_abort) {
 
     ProbeState result = OK;
     StateInfo  st;
@@ -1642,7 +1643,7 @@ bool Tablebases::root_probe(Position&          pos,
 
         pos.undo_move(m.pv[0]);
 
-        if (result == FAIL)
+        if (time_abort() || result == FAIL)
             return false;
 
         // Better moves are ranked higher. Certain wins are ranked equally.
@@ -1707,10 +1708,11 @@ bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, boo
     return true;
 }
 
-Config Tablebases::rank_root_moves(const OptionsMap&  options,
-                                   Position&          pos,
-                                   Search::RootMoves& rootMoves,
-                                   bool               rankDTZ) {
+Config Tablebases::rank_root_moves(const OptionsMap&            options,
+                                   Position&                    pos,
+                                   Search::RootMoves&           rootMoves,
+                                   bool                         rankDTZ,
+                                   const std::function<bool()>& time_abort) {
     Config config;
 
     if (rootMoves.empty())
@@ -1733,10 +1735,11 @@ Config Tablebases::rank_root_moves(const OptionsMap&  options,
 
     if (config.cardinality >= popcount(pos.pieces()) && !pos.can_castle(ANY_CASTLING))
     {
-        // Rank moves using DTZ tables
-        config.rootInTB = root_probe(pos, rootMoves, options["Syzygy50MoveRule"], rankDTZ);
+        // Rank moves using DTZ tables, bail out if time_abort flags zeitnot
+        config.rootInTB =
+          root_probe(pos, rootMoves, options["Syzygy50MoveRule"], rankDTZ, time_abort);
 
-        if (!config.rootInTB)
+        if (!config.rootInTB && !time_abort())
         {
             // DTZ tables are missing; try to rank moves using WDL tables
             dtz_available   = false;

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -19,6 +19,7 @@
 #ifndef TBPROBE_H
 #define TBPROBE_H
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -66,12 +67,18 @@ extern int MaxCardinality;
 void     init(const std::string& paths);
 WDLScore probe_wdl(Position& pos, ProbeState* result);
 int      probe_dtz(Position& pos, ProbeState* result);
-bool     root_probe(Position& pos, Search::RootMoves& rootMoves, bool rule50, bool rankDTZ);
+bool     root_probe(Position&                    pos,
+                    Search::RootMoves&           rootMoves,
+                    bool                         rule50,
+                    bool                         rankDTZ,
+                    const std::function<bool()>& time_abort);
 bool     root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, bool rule50);
-Config   rank_root_moves(const OptionsMap&  options,
-                         Position&          pos,
-                         Search::RootMoves& rootMoves,
-                         bool               rankDTZ = false);
+Config   rank_root_moves(
+    const OptionsMap&            options,
+    Position&                    pos,
+    Search::RootMoves&           rootMoves,
+    bool                         rankDTZ    = false,
+    const std::function<bool()>& time_abort = []() { return false; });
 
 }  // namespace Stockfish::Tablebases
 


### PR DESCRIPTION
This PR allows for time checking within `Tablebases::rank_root_moves()`. The principal application for now is `syzygy_extend_pv()`. 

In the past, Stockfish suffered some time losses at e.g. TCEC when the HDD with the DTZ tables was too slow for the chosen move overhead setting, see #5894.

```
> ./fastchess -engine name="patch" cmd=./stockfish.patch -engine name="master" cmd=./stockfish.master -each tc=10+0.1 option.SyzygyPath=/disk1/syzygy/3-4-5-6/WDL:/disk2/syzygy/3-4-5-6/DTZ -draw movenumber=34 movecount=8 score=20 -openings file=UHO_Lichess_4852_v1.epd format=epd -rounds 50 -repeat -concurrency 16
...
Results of patch vs master (10+0.1, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 59.64 +/- 35.35, nElo: 117.61 +/- 68.10
LOS: 99.96 %, DrawRatio: 56.00 %, PairsRatio: 4.50
Games: 100, Wins: 34, Losses: 17, Draws: 49, Points: 58.5 (58.50 %)
Ptnml(0-2): [0, 4, 28, 15, 3], WL/DD Ratio: 0.87
--------------------------------------------------

Player: master
  Timeouts: 19
  Crashed: 0

Finished match
```

No functional change.