### PR TITLE
[RFC] Prefer suboptimal moves to time losses

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1952,6 +1952,10 @@ void syzygy_extend_pv(const OptionsMap&         options,
                       RootMove&                 rootMove,
                       Value&                    v) {
 
+    // Do not use nodes budget, if nodestime time management is active
+    if (int(options["nodestime"]) != 0 && limits.use_time_management())
+        return;
+
     auto t_start      = std::chrono::steady_clock::now();
     int  moveOverhead = int(options["Move Overhead"]);
     bool rule50       = bool(options["Syzygy50MoveRule"]);

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1643,8 +1643,15 @@ bool Tablebases::root_probe(Position&                    pos,
 
         pos.undo_move(m.pv[0]);
 
-        if (time_abort() || result == FAIL)
+        if (result == FAIL)
             return false;
+
+        if (time_abort())
+        {
+            sync_cout << "info string Unable to fully probe Syzygy DTZ due to time pressure."
+                      << sync_endl;
+            return false;
+        }
 
         // Better moves are ranked higher. Certain wins are ranked equally.
         // Losing moves are ranked equally unless a 50-move draw is in sight.
@@ -1739,9 +1746,9 @@ Config Tablebases::rank_root_moves(const OptionsMap&            options,
         config.rootInTB =
           root_probe(pos, rootMoves, options["Syzygy50MoveRule"], rankDTZ, time_abort);
 
-        if (!config.rootInTB && !time_abort())
+        if (!config.rootInTB)
         {
-            // DTZ tables are missing; try to rank moves using WDL tables
+            // DTZ tables are missing/slow; try to rank moves using WDL tables
             dtz_available   = false;
             config.rootInTB = root_probe_wdl(pos, rootMoves, options["Syzygy50MoveRule"]);
         }

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -73,12 +73,11 @@ bool     root_probe(Position&                    pos,
                     bool                         rankDTZ,
                     const std::function<bool()>& time_abort);
 bool     root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, bool rule50);
-Config   rank_root_moves(
-    const OptionsMap&            options,
-    Position&                    pos,
-    Search::RootMoves&           rootMoves,
-    bool                         rankDTZ    = false,
-    const std::function<bool()>& time_abort = []() { return false; });
+Config   rank_root_moves(const OptionsMap&            options,
+                         Position&                    pos,
+                         Search::RootMoves&           rootMoves,
+                         bool                         rankDTZ,
+                         const std::function<bool()>& time_abort);
 
 }  // namespace Stockfish::Tablebases
 


### PR DESCRIPTION
This PR is a follow up to #6422. We now also abort DTZ probes at root if we run low on time.

Edit: Apologies about previously published numbers, they were for an old master binary without the pv extension dtz patch. Corrected numbers show no measurable impact at the tested TC.
```
> ./fastchess -engine name="patch" cmd=../stockfish/src/stockfish.patch -engine name="master" cmd=../stockfish/src/stockfish.master -each tc=1+0.05 option.SyzygyPath=/disk1/syzygy/3-4-5-6/WDL:/disk2/syzygy/3-4-5-6/DTZ -openings file=endgames.epd format=epd -rounds 500 -repeat -concurrency
...
Results of patch vs master (1+0.05, 1t, 16MB, endgames.epd):
Elo: -6.60 +/- 10.16, nElo: -14.00 +/- 21.53
LOS: 10.13 %, DrawRatio: 71.00 %, PairsRatio: 0.81
Games: 1000, Wins: 170, Losses: 189, Draws: 641, Points: 490.5 (49.05 %)
Ptnml(0-2): [15, 65, 355, 54, 11], WL/DD Ratio: 0.36
--------------------------------------------------

Player: master
  Timeouts: 22
  Crashed: 0
Player: patch
  Timeouts: 27
  Crashed: 0

Finished match
```

No functional change.
