### PR TITLE
Move the memcpy case into the threats feature only

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -577,26 +577,27 @@ void update_accumulator_incremental(
         FeatureSet::template append_changed_indices<Perspective>(ksq, computed.diff, added,
                                                                  removed);
 
-    if (!added.size() && !removed.size())
-    {
-        auto&       targetAcc = target_state.template acc<TransformedFeatureDimensions>();
-        const auto& sourceAcc = computed.template acc<TransformedFeatureDimensions>();
-
-        std::memcpy(targetAcc.accumulation[Perspective], sourceAcc.accumulation[Perspective],
-                    sizeof(targetAcc.accumulation[Perspective]));
-        std::memcpy(targetAcc.psqtAccumulation[Perspective],
-                    sourceAcc.psqtAccumulation[Perspective],
-                    sizeof(targetAcc.psqtAccumulation[Perspective]));
-
-        targetAcc.computed[Perspective] = true;
-        return;
-    }
-
     auto updateContext =
       make_accumulator_update_context<Perspective>(featureTransformer, computed, target_state);
 
     if constexpr (std::is_same_v<FeatureSet, ThreatFeatureSet>)
+    {
+        if (!added.size() && !removed.size())
+        {
+            auto&       targetAcc = target_state.template acc<TransformedFeatureDimensions>();
+            const auto& sourceAcc = computed.template acc<TransformedFeatureDimensions>();
+
+            std::memcpy(targetAcc.accumulation[Perspective], sourceAcc.accumulation[Perspective],
+                        sizeof(targetAcc.accumulation[Perspective]));
+            std::memcpy(targetAcc.psqtAccumulation[Perspective],
+                        sourceAcc.psqtAccumulation[Perspective],
+                        sizeof(targetAcc.psqtAccumulation[Perspective]));
+
+            targetAcc.computed[Perspective] = true;
+            return;
+        }
         updateContext.apply(added, removed);
+    }
     else
     {
         assert(added.size() == 1 || added.size() == 2);


### PR DESCRIPTION
Passed non-regression STC: https://tests.stockfishchess.org/tests/live_elo/69181ee17ca87818523321ed

LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 99712 W: 25699 L: 25554 D: 48459
Ptnml(0-2): 288, 10945, 27222, 11136, 265

Merging threat inputs has led to a warning on GCC profile builds, noted by Torom and others. This patch fixes the issue by putting the no-change case into the `FullThreats` branch of `update_accumulator_incremental`. The case is never taken for the king buckets features, so this should have no performance impact.

No functional change