### PR TITLE
Simplify Incremental Updates

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -584,21 +584,6 @@ void update_accumulator_incremental(
     else
         FeatureSet::append_changed_indices(perspective, ksq, computed.diff, added, removed);
 
-    if (!added.size() && !removed.size())
-    {
-        auto&       targetAcc = target_state.template acc<TransformedFeatureDimensions>();
-        const auto& sourceAcc = computed.template acc<TransformedFeatureDimensions>();
-
-        std::memcpy(targetAcc.accumulation[perspective], sourceAcc.accumulation[perspective],
-                    sizeof(targetAcc.accumulation[perspective]));
-        std::memcpy(targetAcc.psqtAccumulation[perspective],
-                    sourceAcc.psqtAccumulation[perspective],
-                    sizeof(targetAcc.psqtAccumulation[perspective]));
-
-        targetAcc.computed[perspective] = true;
-        return;
-    }
-
     auto updateContext =
       make_accumulator_update_context(perspective, featureTransformer, computed, target_state);
 


### PR DESCRIPTION
Passed Non-regression STC:
LLR: 3.03 (-2.94,2.94) <-1.75,0.25>
Total: 277856 W: 71575 L: 71611 D: 134670
Ptnml(0-2): 842, 30719, 75836, 30695, 836
https://tests.stockfishchess.org/tests/view/69169dc17ca8781852331d76

Supersedes #6430

No functional change