### PR TITLE
Simplify piece threat calculation

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1061,38 +1061,11 @@ void Position::update_piece_threats(Piece pc, Square s, DirtyThreats* const dts)
     const Bitboard kings        = pieces(KING);
     const Bitboard whitePawns   = pieces(WHITE, PAWN);
     const Bitboard blackPawns   = pieces(BLACK, PAWN);
-
+  
+    Bitboard threatened = attacks_bb(pc, s, occupied) & occupied;
+  
     const Bitboard rAttacks = attacks_bb<ROOK>(s, occupied);
     const Bitboard bAttacks = attacks_bb<BISHOP>(s, occupied);
-
-    Bitboard qAttacks = Bitboard(0);
-    if constexpr (ComputeRay)
-        qAttacks = rAttacks | bAttacks;
-    else if (type_of(pc) == QUEEN)
-        qAttacks = rAttacks | bAttacks;
-
-    Bitboard threatened;
-
-    switch (type_of(pc))
-    {
-    case PAWN :
-        threatened = PseudoAttacks[color_of(pc)][s];
-        break;
-    case BISHOP :
-        threatened = bAttacks;
-        break;
-    case ROOK :
-        threatened = rAttacks;
-        break;
-    case QUEEN :
-        threatened = qAttacks;
-        break;
-
-    default :
-        threatened = PseudoAttacks[type_of(pc)][s];
-    }
-
-    threatened &= occupied;
 
     while (threatened)
     {
@@ -1109,6 +1082,7 @@ void Position::update_piece_threats(Piece pc, Square s, DirtyThreats* const dts)
 
     if constexpr (ComputeRay)
     {
+        const Bitboard qAttacks = rAttacks | bAttacks;
         while (sliders)
         {
             Square sliderSq = pop_lsb(sliders);


### PR DESCRIPTION
Simplify piece threat calculation

Passed STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 105984 W: 27206 L: 27067 D: 51711
Ptnml(0-2): 260, 11556, 29245, 11647, 284
https://tests.stockfishchess.org/tests/view/6914798e7ca87818523317cf

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 53028 W: 13635 L: 13456 D: 25937
Ptnml(0-2): 28, 5184, 15908, 5369, 25
https://tests.stockfishchess.org/tests/view/6918c5fc7ca8781852332312

bench: 2523092