### PR TITLE
Post-NNUEv10 tune

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -65,7 +65,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     Value nnue = (125 * psqt + 131 * positional) / 128;
 
     // Re-evaluate the position when higher eval accuracy is worth the time spent
-    if (smallNet && (std::abs(nnue) < 236))
+    if (smallNet && (std::abs(nnue) < 277))
     {
         std::tie(psqt, positional) = networks.big.evaluate(pos, accumulators, caches.big);
         nnue                       = (125 * psqt + 131 * positional) / 128;
@@ -74,14 +74,14 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 
     // Blend optimism and eval with nnue complexity
     int nnueComplexity = std::abs(psqt - positional);
-    optimism += optimism * nnueComplexity / 468;
-    nnue -= nnue * nnueComplexity / 18000;
+    optimism += optimism * nnueComplexity / 476;
+    nnue -= nnue * nnueComplexity / 18236;
 
-    int material = 535 * pos.count<PAWN>() + pos.non_pawn_material();
-    int v        = (nnue * (77777 + material) + optimism * (7777 + material)) / 77777;
+    int material = 534 * pos.count<PAWN>() + pos.non_pawn_material();
+    int v        = (nnue * (77871 + material) + optimism * (7191 + material)) / 77871;
 
     // Damp down the evaluation linearly when shuffling
-    v -= v * pos.rule50_count() / 212;
+    v -= v * pos.rule50_count() / 199;
 
     // Guarantee evaluation does not hit the tablebase range
     v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);


### PR DESCRIPTION
Tune search parameters after the switch to NNUEv10.

The change is neutral at STC but increases with the TC. The main changes are more aggressive corrections, futility pruning, and extensions.


Failed STC
LLR: -2.96 (-2.94,2.94) <0.00,2.00>
Total: 108320 W: 27616 L: 27719 D: 52985
Ptnml(0-2): 332, 12833, 27884, 12828, 283 
https://tests.stockfishchess.org/tests/view/69212e623b03dd3a060e6114

Passed LTC
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 43272 W: 11117 L: 10788 D: 21367
Ptnml(0-2): 20, 4543, 12180, 4874, 19 
https://tests.stockfishchess.org/tests/view/692130813b03dd3a060e6123

Passed VLTC
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 22714 W: 5840 L: 5581 D: 11293
Ptnml(0-2): 2, 2152, 6795, 2401, 7 
https://tests.stockfishchess.org/tests/view/6921387b3b03dd3a060e6191

Passed VLTC SMP
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 11868 W: 3142 L: 2896 D: 5830
Ptnml(0-2): 0, 1007, 3676, 1249, 2 
https://tests.stockfishchess.org/tests/view/69212e953b03dd3a060e611b

bench 2907929