### PR TITLE
Fix for SF getting stuck during search (issue #5023)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -141,6 +141,14 @@ void update_all_stats(const Position& pos,
                       Move            TTMove,
                       int             moveCount);
 
+bool isShuffling(Move move, Stack* const ss, const Position& pos) {
+    if (type_of(pos.moved_piece(move)) == PAWN || pos.capture_stage(move) || pos.rule50_count() < 10)
+        return false;
+    if (pos.state()->pliesFromNull <= 6 || ss->ply < 20)
+        return false;
+    return move.from_sq() == (ss-2)->currentMove.to_sq() && (ss-2)->currentMove.from_sq() == (ss-4)->currentMove.to_sq();
+}
+
 }  // namespace
 
 Search::Worker::Worker(SharedState&                    sharedState,
@@ -1114,7 +1122,7 @@ moves_loop:  // When in check, search starts here
         // and lower extension margins scale well.
         if (!rootNode && move == ttData.move && !excludedMove && depth >= 6 + ss->ttPv
             && is_valid(ttData.value) && !is_decisive(ttData.value) && (ttData.bound & BOUND_LOWER)
-            && ttData.depth >= depth - 3)
+            && ttData.depth >= depth - 3 && !isShuffling(move, ss, pos))
         {
             Value singularBeta  = ttData.value - (53 + 75 * (ss->ttPv && !PvNode)) * depth / 60;
             Depth singularDepth = newDepth / 2;


### PR DESCRIPTION
I believe the patch fixes the open issue in a substantial way (i.e. not just the one case with KBvK and few pieces), at least it copes with all FENS reported in the issue (tested with 1 th, 512 MB hash).

Among several passed similar versions this is the simpliest one.

Passed STC non-regression
https://tests.stockfishchess.org/tests/view/691f3b4aacb6dbdf23d07d11
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 126368 W: 32607 L: 32489 D: 61272
Ptnml(0-2): 408, 13974, 34298, 14100, 404

Passed LTC non-regression
https://tests.stockfishchess.org/tests/view/69209712acb6dbdf23d0836a
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 114786 W: 29097 L: 28976 D: 56713
Ptnml(0-2): 53, 11841, 33488, 11954, 57

bench: 2941767