### PR TITLE
fix msvc macro

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -414,7 +414,7 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
 
 #if defined(__GNUC__)
     #define sf_always_inline __attribute__((always_inline))
-#elif defined(__MSVC)
+#elif defined(_MSC_VER)
     #define sf_always_inline __forceinline
 #else
     // do nothign for other compilers


### PR DESCRIPTION
If I'm not mistaken, `_MSC_VER` is the right way to detect MSVC. @mstembera maybe you could test that this works? (The disassembly should contain no reference to `FullThreats::make_index` if it gets inlined everywhere