### PR TITLE
Increase L2Big to 31

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-c0ae49f08b40.nnue"
+#define EvalFileDefaultNameBig "nn-476aadc9a9c2.nnue"
 #define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
 
 namespace NNUE {

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -41,7 +41,7 @@ using PSQFeatureSet    = Features::HalfKAv2_hm;
 
 // Number of input feature dimensions after conversion
 constexpr IndexType TransformedFeatureDimensionsBig = 1024;
-constexpr int       L2Big                           = 15;
+constexpr int       L2Big                           = 31;
 constexpr int       L3Big                           = 32;
 
 constexpr IndexType TransformedFeatureDimensionsSmall = 128;


### PR DESCRIPTION
It has become significantly cheaper to evaluate AffineTransformSparseInput<>::propagate() 
especially on VNNI hardware. As a result increasing L2Big from 15 to 31 is now worth it.
Bit more info here: https://github.com/official-stockfish/Stockfish/pull/6339#issuecomment-3565778532

STC https://tests.stockfishchess.org/tests/view/69222e83ba083df4ca63b7b9
LLR: 3.00 (-2.94,2.94) <0.00,2.00>
Total: 272640 W: 71514 L: 70833 D: 130293
Ptnml(0-2): 1127, 32203, 68955, 32932, 1103 

LTC https://tests.stockfishchess.org/tests/view/69230557ba083df4ca63d05e
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 135324 W: 34707 L: 34181 D: 66436
Ptnml(0-2): 120, 14880, 37148, 15382, 132 

On non VNNI it is close to neutral
https://tests.stockfishchess.org/tests/view/6914c5357ca87818523318c0

Credit to @sscg13 for training the net.  I will make him the author of this PR.

bench: 2739823