### PR TITLE
Simplify the highBestMoveEffort formula in Time management.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -483,7 +483,7 @@ void Search::Worker::iterative_deepening() {
 
             double bestMoveInstability = 1.02 + 2.14 * totBestMoveChanges / threads.size();
 
-            double highBestMoveEffort = completedDepth >= 10 && nodesEffort >= 93337 ? 0.75 : 1.0;
+            double highBestMoveEffort = nodesEffort >= 93340 ? 0.76 : 1.0;
 
             double totalTime = mainThread->tm.optimum() * fallingEval * reduction
                              * bestMoveInstability * highBestMoveEffort;


### PR DESCRIPTION
Simplify the highBestMoveEffort formula in Time management.

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 22272 W: 5885 L: 5655 D: 10732
Ptnml(0-2): 76, 2329, 6108, 2535, 88
https://tests.stockfishchess.org/tests/view/69244d07ba083df4ca63e02b

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 48690 W: 12405 L: 12221 D: 24064
Ptnml(0-2): 29, 4755, 14597, 4931, 33
https://tests.stockfishchess.org/tests/view/6924de9aba083df4ca63e327

No functional change