### PR TITLE
Build: add macOS native arch support and nodiscard to bitboard

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -533,6 +533,10 @@ ifeq ($(KERNEL),Darwin)
 		CXXFLAGS += -arch $(arch)
 		LDFLAGS += -arch $(arch)
 	endif
+	# Add -march=native for optimal CPU-specific optimizations on macOS
+	ifeq ($(ARCH),native)
+		CXXFLAGS += -march=native
+	endif
 	XCRUN = xcrun
 endif
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -75,7 +75,7 @@ struct Magic {
 #endif
 
     // Compute the attack's index using the 'magic bitboards' approach
-    unsigned index(Bitboard occupied) const {
+    [[nodiscard]] inline unsigned index(Bitboard occupied) const {
 
 #ifdef USE_PEXT
         return unsigned(pext(occupied, mask));
@@ -89,7 +89,7 @@ struct Magic {
 #endif
     }
 
-    Bitboard attacks_bb(Bitboard occupied) const { return attacks[index(occupied)]; }
+    [[nodiscard]] inline Bitboard attacks_bb(Bitboard occupied) const { return attacks[index(occupied)]; }
 };
 
 extern Magic Magics[SQUARE_NB][2];


### PR DESCRIPTION
Makefile: Enabled -march=native for macOS builds to unlock CPU-specific optimizations (like AVX2) for improved performance.
Bitboard: Added [[nodiscard]] to index() and attacks_bb() to prevent bugs by ensuring return values are used.
Refactoring: Explicitly marked these critical lookup functions as inline for clarity and correctness.