### PR TITLE
Simplify piece threat calculation (Rebased)

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1108,34 +1108,7 @@ void Position::update_piece_threats(Piece               pc,
     const Bitboard rAttacks = attacks_bb<ROOK>(s, occupied);
     const Bitboard bAttacks = attacks_bb<BISHOP>(s, occupied);
 
-    Bitboard qAttacks = Bitboard(0);
-    if constexpr (ComputeRay)
-        qAttacks = rAttacks | bAttacks;
-    else if (type_of(pc) == QUEEN)
-        qAttacks = rAttacks | bAttacks;
-
-    Bitboard threatened;
-
-    switch (type_of(pc))
-    {
-    case PAWN :
-        threatened = PseudoAttacks[color_of(pc)][s];
-        break;
-    case BISHOP :
-        threatened = bAttacks;
-        break;
-    case ROOK :
-        threatened = rAttacks;
-        break;
-    case QUEEN :
-        threatened = qAttacks;
-        break;
-
-    default :
-        threatened = PseudoAttacks[type_of(pc)][s];
-    }
-
-    threatened &= occupied;
+    Bitboard threatened = attacks_bb(pc, s, occupied) & occupied;
     Bitboard sliders = (rookQueens & rAttacks) | (bishopQueens & bAttacks);
     Bitboard incoming_threats =
       (PseudoAttacks[KNIGHT][s] & knights) | (attacks_bb<PAWN>(s, WHITE) & blackPawns)
@@ -1186,7 +1159,7 @@ void Position::update_piece_threats(Piece               pc,
             Piece  slider   = piece_on(sliderSq);
 
             const Bitboard ray        = RayPassBB[sliderSq][s] & ~BetweenBB[sliderSq][s];
-            const Bitboard discovered = ray & qAttacks & occupied;
+            const Bitboard discovered = ray & (rAttacks | bAttacks) & occupied;
 
             assert(!more_than_one(discovered));
             if (discovered && (RayPassBB[sliderSq][s] & noRaysContaining) != noRaysContaining)


### PR DESCRIPTION
Simplify piece threat calculation (Rebased)

Passed STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 105984 W: 27206 L: 27067 D: 51711
Ptnml(0-2): 260, 11556, 29245, 11647, 284
https://tests.stockfishchess.org/tests/view/6914798e7ca87818523317cf

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 53028 W: 13635 L: 13456 D: 25937
Ptnml(0-2): 28, 5184, 15908, 5369, 25
https://tests.stockfishchess.org/tests/view/6918c5fc7ca8781852332312

Rebased from #6435 
No Functional Changes