### PR TITLE
fix missing condition

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1159,8 +1159,11 @@ void Position::update_piece_threats(Piece               pc,
     if (!all_attackers)
         return;  // Square s is threatened iff there's at least one attacker
 
-    dts->threatenedSqs |= square_bb(s);
-    dts->threateningSqs |= all_attackers;
+    if constexpr (PutPiece)
+    {
+        dts->threatenedSqs |= square_bb(s);
+        dts->threateningSqs |= all_attackers;
+    }
 
     DirtyThreat dt_template{NO_PIECE, pc, Square(0), s, PutPiece};
     write_multiple_dirties<DirtyThreat::PcSqOffset, DirtyThreat::PcOffset>(*this, all_attackers,


### PR DESCRIPTION
The modifications to the DirtyThreats bitboards should only happen if `PutPiece` is true. This somehow didn't affect bench at the default parameters until Mineta's recent test which failed on ICL: [link](https://tests.stockfishchess.org/tests/live_elo/692f6b6ab23dfeae38d01b28). Sorry about this; I should have tested more extensively. Probably worth either merging this soon or reverting the `update_piece_threats` PR as it'll cause intermittent wrong benches against master...

```
Reference AVX2:
./stockfish.killdeer-fix.avx2 bench 64 1 23
Nodes searched  : 178140156
Nodes/second    : 1503152

before patch:
./stockfish.master.avx512icl  bench 64 1 23
Nodes searched  : 218349728
Nodes/second    : 1743450

after patch:
./stockfish.killdeer-fix.avx512icl bench 64 1 23
Nodes searched  : 178140156
Nodes/second    : 1727520
```