### PR TITLE
Fix one error and all remaining warnings on MSVC 2026

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -454,7 +454,7 @@ BenchmarkSetup setup_benchmark(std::istream& is) {
     int desiredTimeS;
 
     if (!(is >> setup.threads))
-        setup.threads = get_hardware_concurrency();
+        setup.threads = int(get_hardware_concurrency());
     else
         setup.originalInvocation += std::to_string(setup.threads);
 
@@ -486,7 +486,7 @@ BenchmarkSetup setup_benchmark(std::istream& is) {
         int ply = 1;
         for (int i = 0; i < static_cast<int>(game.size()); ++i)
         {
-            const float correctedTime = getCorrectedTime(ply);
+            const float correctedTime = float(getCorrectedTime(ply));
             totalTime += correctedTime;
             ply += 1;
         }

--- a/src/history.h
+++ b/src/history.h
@@ -48,13 +48,13 @@ inline int pawn_history_index(const Position& pos) {
     return pos.pawn_key() & (PAWN_HISTORY_SIZE - 1);
 }
 
-inline uint16_t pawn_correction_history_index(const Position& pos) { return pos.pawn_key(); }
+inline uint16_t pawn_correction_history_index(const Position& pos) { return uint16_t(pos.pawn_key()); }
 
-inline uint16_t minor_piece_index(const Position& pos) { return pos.minor_piece_key(); }
+inline uint16_t minor_piece_index(const Position& pos) { return uint16_t(pos.minor_piece_key()); }
 
 template<Color c>
 inline uint16_t non_pawn_index(const Position& pos) {
-    return pos.non_pawn_key(c);
+    return uint16_t(pos.non_pawn_key(c));
 }
 
 // StatsEntry is the container of various numerical statistics. We use a class

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -171,9 +171,10 @@ class FeatureTransformer {
 
             read_leb_128<WeightType>(stream, *combinedWeights);
 
-            std::copy(combinedWeights->begin(),
-                      combinedWeights->begin() + ThreatInputDimensions * HalfDimensions,
-                      std::begin(threatWeights));
+            std::transform(combinedWeights->begin(),
+                           combinedWeights->begin() + ThreatInputDimensions * HalfDimensions,
+                           std::begin(threatWeights),
+                           [](WeightType w) { return static_cast<ThreatWeightType>(w); });
 
             std::copy(combinedWeights->begin() + ThreatInputDimensions * HalfDimensions,
                       combinedWeights->begin()

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -584,7 +584,7 @@ int decompress_pairs(PairsData* d, uint64_t idx) {
     //       idx = k * d->span + idx % d->span    (2)
     //
     // So from (1) and (2) we can compute idx - I(K):
-    int diff = idx % d->span - d->span / 2;
+    int diff = int(idx % d->span - d->span / 2);
 
     // Sum the above to offset to find the offset corresponding to our idx
     offset += diff;
@@ -1092,7 +1092,7 @@ uint8_t* set_sizes(PairsData* d, uint8_t* data) {
     // See https://web.archive.org/web/20201106232444/http://www.larsson.dogma.net/dcc99.pdf
     std::vector<bool> visited(d->symlen.size());
 
-    for (std::size_t sym = 0; sym < d->symlen.size(); ++sym)
+    for (Sym sym = 0; sym < d->symlen.size(); ++sym)
         if (!visited[sym])
             d->symlen[sym] = set_symlen(d, sym, visited);
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -283,8 +283,8 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
     {
         th->run_custom_job([&]() {
             th->worker->limits = limits;
-            th->worker->nodes = th->worker->tbHits = th->worker->nmpMinPly =
-              th->worker->bestMoveChanges          = 0;
+            th->worker->nodes = th->worker->tbHits = th->worker->bestMoveChanges = 0;
+            th->worker->nmpMinPly = 0;
             th->worker->rootDepth = th->worker->completedDepth = 0;
             th->worker->rootMoves                              = rootMoves;
             th->worker->rootPos.set(pos.fen(), pos.is_chess960(), &th->worker->rootState);

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -91,7 +91,7 @@ void TimeManagement::init(Search::LimitsType& limits,
 
     // If less than one second, gradually reduce mtg
     if (scaledTime < 1000)
-        centiMTG = scaledTime * 5.051;
+        centiMTG = int(scaledTime * 5.051);
 
     // Make sure timeLeft is > 0 since we may use it as a divisor
     TimePoint timeLeft =

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -313,8 +313,8 @@ void UCIEngine::benchmark(std::istream& args) {
 
     Benchmark::BenchmarkSetup setup = Benchmark::setup_benchmark(args);
 
-    const int numGoCommands = count_if(setup.commands.begin(), setup.commands.end(),
-                                       [](const std::string& s) { return s.find("go ") == 0; });
+    const long long numGoCommands = count_if(setup.commands.begin(), setup.commands.end(),
+                                             [](const std::string& s) { return s.find("go ") == 0; });
 
     TimePoint totalTime = 0;
 
@@ -361,13 +361,14 @@ void UCIEngine::benchmark(std::istream& args) {
 
     int           numHashfullReadings = 0;
     constexpr int hashfullAges[]      = {0, 999};  // Only normal hashfull and touched hash.
-    int           totalHashfull[std::size(hashfullAges)] = {0};
-    int           maxHashfull[std::size(hashfullAges)]   = {0};
+    constexpr int hashfullAgeCount    = std::size(hashfullAges);
+    int           totalHashfull[hashfullAgeCount] = {0};
+    int           maxHashfull[hashfullAgeCount]   = {0};
 
     auto updateHashfullReadings = [&]() {
         numHashfullReadings += 1;
 
-        for (int i = 0; i < static_cast<int>(std::size(hashfullAges)); ++i)
+        for (int i = 0; i < hashfullAgeCount; ++i)
         {
             const int hashfull = engine.get_hashfull(hashfullAges[i]);
             maxHashfull[i]     = std::max(maxHashfull[i], hashfull);
@@ -554,7 +555,7 @@ int UCIEngine::to_cp(Value v, const Position& pos) {
 
     auto [a, b] = win_rate_params(pos);
 
-    return std::round(100 * int(v) / a);
+    return int(std::round(100 * int(v) / a));
 }
 
 std::string UCIEngine::wdl(Value v, const Position& pos) {


### PR DESCRIPTION
The error is "C1001: Internal compiler error." in uci.cpp on line 370 of master.  For some reason the compiler can't handle the std::size(hashfullAges) inside the lambda.  Older MSVC versions had no problem.

Most of the warnings are due to implicit type conversions 
"conversion from type A to type B, possible loss of data" 
many of which have been present for a while.

No functional change
bench: 2912398