### PR TITLE
Tweak nnue_accumulator indexing

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -134,6 +134,7 @@ class ValueList {
 
    public:
     std::size_t size() const { return size_; }
+    int         ssize() const { return int(size_); }
     void        push_back(const T& value) {
         assert(size_ < MaxSize);
         values_[size_++] = value;

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -370,7 +370,7 @@ struct AccumulatorUpdateContext {
             for (IndexType k = 0; k < Tiling::NumRegs; ++k)
                 acc[k] = fromTile[k];
 
-            for (int i = 0; i < int(removed.size()); ++i)
+            for (int i = 0; i < removed.ssize(); ++i)
             {
                 size_t       index  = removed[i];
                 const size_t offset = Dimensions * index;
@@ -388,7 +388,7 @@ struct AccumulatorUpdateContext {
     #endif
             }
 
-            for (int i = 0; i < int(added.size()); ++i)
+            for (int i = 0; i < added.ssize(); ++i)
             {
                 size_t       index  = added[i];
                 const size_t offset = Dimensions * index;
@@ -422,7 +422,7 @@ struct AccumulatorUpdateContext {
             for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
                 psqt[k] = fromTilePsqt[k];
 
-            for (int i = 0; i < int(removed.size()); ++i)
+            for (int i = 0; i < removed.ssize(); ++i)
             {
                 size_t       index      = removed[i];
                 const size_t offset     = PSQTBuckets * index + j * Tiling::PsqtTileHeight;
@@ -433,7 +433,7 @@ struct AccumulatorUpdateContext {
                     psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
             }
 
-            for (int i = 0; i < int(added.size()); ++i)
+            for (int i = 0; i < added.ssize(); ++i)
             {
                 size_t       index      = added[i];
                 const size_t offset     = PSQTBuckets * index + j * Tiling::PsqtTileHeight;
@@ -705,7 +705,7 @@ void update_accumulator_refresh_cache(Color                                 pers
             acc[k] = entryTile[k];
 
         int i = 0;
-        for (; i < int(std::min(removed.size(), added.size())); ++i)
+        for (; i < std::min(removed.ssize(), added.ssize()); ++i)
         {
             size_t       indexR  = removed[i];
             const size_t offsetR = Dimensions * indexR;
@@ -717,7 +717,7 @@ void update_accumulator_refresh_cache(Color                                 pers
             for (IndexType k = 0; k < Tiling::NumRegs; ++k)
                 acc[k] = fused<Vec16Wrapper, Add, Sub>(acc[k], columnA[k], columnR[k]);
         }
-        for (; i < int(removed.size()); ++i)
+        for (; i < removed.ssize(); ++i)
         {
             size_t       index  = removed[i];
             const size_t offset = Dimensions * index;
@@ -726,7 +726,7 @@ void update_accumulator_refresh_cache(Color                                 pers
             for (IndexType k = 0; k < Tiling::NumRegs; ++k)
                 acc[k] = vec_sub_16(acc[k], column[k]);
         }
-        for (; i < int(added.size()); ++i)
+        for (; i < added.ssize(); ++i)
         {
             size_t       index  = added[i];
             const size_t offset = Dimensions * index;
@@ -754,7 +754,7 @@ void update_accumulator_refresh_cache(Color                                 pers
         for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
             psqt[k] = entryTilePsqt[k];
 
-        for (int i = 0; i < int(removed.size()); ++i)
+        for (int i = 0; i < removed.ssize(); ++i)
         {
             size_t       index  = removed[i];
             const size_t offset = PSQTBuckets * index + j * Tiling::PsqtTileHeight;
@@ -764,7 +764,7 @@ void update_accumulator_refresh_cache(Color                                 pers
             for (std::size_t k = 0; k < Tiling::NumPsqtRegs; ++k)
                 psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
         }
-        for (int i = 0; i < int(added.size()); ++i)
+        for (int i = 0; i < added.ssize(); ++i)
         {
             size_t       index  = added[i];
             const size_t offset = PSQTBuckets * index + j * Tiling::PsqtTileHeight;
@@ -838,7 +838,7 @@ void update_threats_accumulator_full(Color                                 persp
 
         int i = 0;
 
-        for (; i < int(active.size()); ++i)
+        for (; i < active.ssize(); ++i)
         {
             size_t       index  = active[i];
             const size_t offset = Dimensions * index;
@@ -870,7 +870,7 @@ void update_threats_accumulator_full(Color                                 persp
         for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
             psqt[k] = vec_zero_psqt();
 
-        for (int i = 0; i < int(active.size()); ++i)
+        for (int i = 0; i < active.ssize(); ++i)
         {
             size_t       index  = active[i];
             const size_t offset = PSQTBuckets * index + j * Tiling::PsqtTileHeight;


### PR DESCRIPTION
[Passed STC](https://tests.stockfishchess.org/tests/live_elo/692fd98ab23dfeae38d01d98):

```
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 92736 W: 24149 L: 23764 D: 44823
Ptnml(0-2): 280, 10056, 25334, 10395, 303 
```

The use of `IndexType` in the loops is suboptimal because it requires truncation to 32 bits, and thereby defeats some optimizations. Using `size_t` for the loop body works nicely, and a signed index into the index lists allows the compiler to assume the case `added.size() == UINT_MAX`, which would be an infinite loop, to not happen.

<details>
<summary>Loop comparison, threats feature set, AVX2 build</summary>

```
master:
   23733:   movsxd rcx,r13d
   23736:   add    r13d,0x1
   2373a:   mov    ecx,DWORD PTR [rbp+rcx*4-0x8a0]  
   23741:   lea    ecx,[r10+rcx*8]
   23745:   shl    ecx,0x7
   23748:   lea    rcx,[r15+rcx*1+0x2c00800]
   23750:   vpmovsxbw ymm15,XMMWORD PTR [rcx]
   23755:   vpmovsxbw ymm8,XMMWORD PTR [rcx+0x10]
   2375b:   vpmovsxbw ymm9,XMMWORD PTR [rcx+0x20]
   23761:   vpmovsxbw ymm10,XMMWORD PTR [rcx+0x30]
   23767:   vpmovsxbw ymm11,XMMWORD PTR [rcx+0x40]
   2376d:   vpmovsxbw ymm12,XMMWORD PTR [rcx+0x50]
   23773:   vpsubw ymm7,ymm7,ymm15
   23778:   vpsubw ymm6,ymm6,ymm8
   2377d:   vpmovsxbw ymm13,XMMWORD PTR [rcx+0x60]
   23783:   vpmovsxbw ymm14,XMMWORD PTR [rcx+0x70]
   23789:   mov    ecx,r13d
   2378c:   vpsubw ymm5,ymm5,ymm9
   23791:   vpsubw ymm4,ymm4,ymm10
   23796:   vpsubw ymm3,ymm3,ymm11
   2379b:   vpsubw ymm2,ymm2,ymm12
   237a0:   vpsubw ymm1,ymm1,ymm13
   237a5:   vpsubw ymm0,ymm0,ymm14
   237aa:   cmp    rcx,r11
   237ad:   jb     23733

patch:
   2373b:   mov    ecx,DWORD PTR [r11]
   2373e:   add    r11,0x4
   23742:   shl    rcx,0xa
   23746:   vpmovsxbw ymm15,XMMWORD PTR [rax+rcx*1]
   2374c:   vpmovsxbw ymm8,XMMWORD PTR [rax+rcx*1+0x10]
   23753:   vpmovsxbw ymm9,XMMWORD PTR [rax+rcx*1+0x20]
   2375a:   vpmovsxbw ymm10,XMMWORD PTR [rax+rcx*1+0x30]
   23761:   vpmovsxbw ymm11,XMMWORD PTR [rax+rcx*1+0x40]
   23768:   vpsubw ymm7,ymm7,ymm15
   2376d:   vpsubw ymm6,ymm6,ymm8
   23772:   vpmovsxbw ymm12,XMMWORD PTR [rax+rcx*1+0x50]
   23779:   vpmovsxbw ymm13,XMMWORD PTR [rax+rcx*1+0x60]
   23780:   vpmovsxbw ymm14,XMMWORD PTR [rax+rcx*1+0x70]
   23787:   vpsubw ymm5,ymm5,ymm9
   2378c:   vpsubw ymm4,ymm4,ymm10
   23791:   vpsubw ymm3,ymm3,ymm11
   23796:   vpsubw ymm2,ymm2,ymm12
   2379b:   vpsubw ymm1,ymm1,ymm13
   237a0:   vpsubw ymm0,ymm0,ymm14
   237a5:   cmp    r11,r9
   237a8:   jne    2373b
```
</details>