### PR TITLE
Remove low ply history for check evasions scoring

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -184,11 +184,7 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
             if (pos.capture_stage(m))
                 m.value = PieceValue[capturedPiece] + (1 << 28);
             else
-            {
                 m.value = (*mainHistory)[us][m.raw()] + (*continuationHistory[0])[pc][to];
-                if (ply < LOW_PLY_HISTORY_SIZE)
-                    m.value += (*lowPlyHistory)[ply][m.raw()];
-            }
         }
     }
     return it;


### PR DESCRIPTION
Remove low ply history for check evasions scoring

Passed STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 81888 W: 21336 L: 21166 D: 39386
Ptnml(0-2): 284, 9438, 21342, 9584, 296
https://tests.stockfishchess.org/tests/view/692ada47b23dfeae38cffce5

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 107328 W: 27534 L: 27404 D: 52390
Ptnml(0-2): 55, 11390, 30659, 11490, 70
https://tests.stockfishchess.org/tests/view/692d7a01b23dfeae38d011ab

bench: 2408630