### PR TITLE
Remove non-functional board updates in do_castling

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1252,8 +1252,6 @@ void Position::do_castling(Color               us,
     // Remove both pieces first since squares could overlap in Chess960
     remove_piece(Do ? from : to, dts);
     remove_piece(Do ? rfrom : rto, dts);
-    board[Do ? from : to] = board[Do ? rfrom : rto] =
-      NO_PIECE;  // remove_piece does not do this for us
     put_piece(make_piece(us, KING), Do ? to : from, dts);
     put_piece(make_piece(us, ROOK), Do ? rto : rfrom, dts);
 }


### PR DESCRIPTION
Contrary to what the comment says, `remove_piece` does in fact set the relevant `board` elements to `NO_PIECE`.

No functional change

bench 2912398