### PR TITLE
Remove rootDepth condition in newDepth setting

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1276,7 +1276,7 @@ moves_loop:  // When in check, search starts here
             // decisive score handling improves mate finding and retrograde analysis.
             if (move == ttData.move
                 && ((is_valid(ttData.value) && is_decisive(ttData.value) && ttData.depth > 0)
-                    || (ttData.depth > 1 && rootDepth > 8)))
+                    || ttData.depth > 1))
                 newDepth = std::max(newDepth, 1);
 
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);


### PR DESCRIPTION
Remove rootDepth condition in newDepth clamping

Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 132256 W: 34462 L: 34347 D: 63447
Ptnml(0-2): 470, 15625, 33833, 15720, 480 
https://tests.stockfishchess.org/tests/view/69325fe0a24a6df719fcca16

Passed simplification LTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 128220 W: 32503 L: 32392 D: 63325
Ptnml(0-2): 94, 13900, 35982, 14069, 65 
https://tests.stockfishchess.org/tests/view/6934c2b3a24a6df719fcdf1e


bench 2926903