### PR TITLE
Remove Secondary TT Aging

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -110,8 +110,6 @@ void TTEntry::save(
         value16   = int16_t(v);
         eval16    = int16_t(ev);
     }
-    else if (depth8 + DEPTH_ENTRY_OFFSET >= 5 && Bound(genBound8 & 0x3) != BOUND_EXACT)
-        depth8--;
 }
 
 


### PR DESCRIPTION
Passed VVLTC w/ STC Bounds:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 107006 W: 27676 L: 27326 D: 52004
Ptnml(0-2): 21, 9505, 34097, 9863, 17
https://tests.stockfishchess.org/tests/view/6939ac5b75b70713ef796f11

Passed VVLTC w/ LTC Bounds:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 263190 W: 67547 L: 66837 D: 128806
Ptnml(0-2): 32, 23939, 82942, 24651, 31
https://tests.stockfishchess.org/tests/view/692165823b03dd3a060e666d

Bench: 2477942