### PR TITLE
Simplify futility pruning.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -875,9 +875,8 @@ Value Search::Worker::search(
         auto futility_margin = [&](Depth d) {
             Value futilityMult = 76 - 23 * !ss->ttHit;
 
-            return futilityMult * d                               //
-                 - 2474 * improving * futilityMult / 1024         //
-                 - 331 * opponentWorsening * futilityMult / 1024  //
+            return futilityMult * d
+                 - (2474*improving + 331*opponentWorsening)*futilityMult/1024 //
                  + std::abs(correctionValue) / 174665;
         };
 


### PR DESCRIPTION
bench: 2877902

Passed non regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 107968 W: 28080 L: 27937 D: 51951
Ptnml(0-2): 381, 12708, 27626, 12925, 344

https://tests.stockfishchess.org/tests/view/693e642c46f342e1ec20f68d

Passed non regression LTC:

LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 334266 W: 85271 L: 85370 D: 163625
Ptnml(0-2): 179, 36395, 94086, 36292, 181

https://tests.stockfishchess.org/tests/view/693ff10c46f342e1ec20fa6a

Appears to lose elo a bit at LTC but is probably just statistical noise. Minimal functional change. 