### PR TITLE
Less penalty for quiet late moves that didn't beat the best move.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1822,9 +1822,16 @@ void update_all_stats(const Position& pos,
     {
         update_quiet_histories(pos, ss, workerThread, bestMove, bonus * 910 / 1024);
 
+        int i = 0;
         // Decrease stats for all non-best quiet moves
         for (Move move : quietsSearched)
-            update_quiet_histories(pos, ss, workerThread, move, -malus * 1085 / 1024);
+        {
+            i++;
+            int actualMalus = malus * 1085 / 1024;
+            if (i > 5)
+                actualMalus -= actualMalus * (i - 5) / i;
+            update_quiet_histories(pos, ss, workerThread, move, -actualMalus);
+        }
     }
     else
     {


### PR DESCRIPTION
This moves since they are late in move ordering probably already have pretty bad stats anyway.
Passed STC:
https://tests.stockfishchess.org/tests/view/6943bcd546f342e1ec210e25
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 96704 W: 25206 L: 24798 D: 46700
Ptnml(0-2): 357, 11244, 24767, 11602, 382 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6946a8723c8768ca450722f0
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 89814 W: 23193 L: 22770 D: 43851
Ptnml(0-2): 53, 9532, 25321, 9941, 60 
bench 2717363