### PR TITLE
Simplify doDeeperSearch formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1232,7 +1232,7 @@ moves_loop:  // When in check, search starts here
             {
                 // Adjust full-depth search based on LMR results - if the result was
                 // good enough search deeper, if it was bad enough search shallower.
-                const bool doDeeperSearch = d < newDepth && value > (bestValue + 43 + 2 * newDepth);
+                const bool doDeeperSearch = d < newDepth && value > (bestValue + newDepth + 44);
                 const bool doShallowerSearch = value < bestValue + 9;
 
                 newDepth += doDeeperSearch - doShallowerSearch;


### PR DESCRIPTION
Simplify doDeeperSearch formula

Passed STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 211776 W: 54939 L: 54911 D: 101926
Ptnml(0-2): 714, 24971, 54484, 25011, 708
https://tests.stockfishchess.org/tests/view/6938971875b70713ef796b70

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 216774 W: 55346 L: 55326 D: 106102
Ptnml(0-2): 105, 23599, 60980, 23577, 126
https://tests.stockfishchess.org/tests/view/693fc91f46f342e1ec20f9f6

bench: 2664473