### PR TITLE
Incorporate statscore into history bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1815,7 +1815,7 @@ void update_all_stats(const Position& pos,
     Piece                  movedPiece     = pos.moved_piece(bestMove);
     PieceType              capturedPiece;
 
-    int bonus = std::min(116 * depth - 81, 1515) + 347 * (bestMove == ttMove);
+    int bonus = std::min(116 * depth - 81, 1515) + 347 * (bestMove == ttMove) + (ss - 1)->statScore / 32;
     int malus = std::min(848 * depth - 207, 2446) - 17 * moveCount;
 
     if (!pos.capture_stage(bestMove))


### PR DESCRIPTION
Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 80128 W: 20879 L: 20498 D: 38751
Ptnml(0-2): 274, 9318, 20496, 9705, 271
https://tests.stockfishchess.org/tests/view/6945d11f3c8768ca45072218

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 134298 W: 34497 L: 33983 D: 65818
Ptnml(0-2): 81, 14334, 37812, 14834, 88
https://tests.stockfishchess.org/tests/view/6947bf033c8768ca45072491

bench: 2682493