### PR TITLE
Refine reduction logic based on next-ply cutoff count

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1203,8 +1203,8 @@ moves_loop:  // When in check, search starts here
             r += 1119;
 
         // Increase reduction if next ply has a lot of fail high
-        if ((ss + 1)->cutoffCnt > 2)
-            r += 991 + allNode * 923;
+        if ((ss + 1)->cutoffCnt > 1)
+            r += 120 + 1024 * ((ss + 1)->cutoffCnt > 2) + 100 * ((ss + 1)->cutoffCnt > 3) + 1024 * allNode;
 
         // For first picked move (ttMove) reduce reduction
         if (move == ttData.move)


### PR DESCRIPTION
Refine reduction logic based on next-ply cutoff count

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 38208 W: 10076 L: 9754 D: 18378
Ptnml(0-2): 139, 4390, 9742, 4676, 157
https://tests.stockfishchess.org/tests/view/6945bb6446f342e1ec211d93

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 64086 W: 16529 L: 16157 D: 31400
Ptnml(0-2): 34, 6808, 17990, 7174, 37
https://tests.stockfishchess.org/tests/view/69479d303c8768ca45072446

bench: 2442415