### PR TITLE
Simplify doDeeperSearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1241,7 +1241,7 @@ moves_loop:  // When in check, search starts here
             {
                 // Adjust full-depth search based on LMR results - if the result was
                 // good enough search deeper, if it was bad enough search shallower.
-                const bool doDeeperSearch    = d < newDepth && value > (bestValue + newDepth + 44);
+                const bool doDeeperSearch    = d < newDepth && value > bestValue + 50;
                 const bool doShallowerSearch = value < bestValue + 9;
 
                 newDepth += doDeeperSearch - doShallowerSearch;


### PR DESCRIPTION
Simplify doDeeperSearch

Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 92096 W: 23888 L: 23728 D: 44480
Ptnml(0-2): 336, 10796, 23608, 10988, 320 
https://tests.stockfishchess.org/tests/view/694b6b9d572093c1986d6ae0

Passed simplification LTC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 50064 W: 12789 L: 12598 D: 24677
Ptnml(0-2): 24, 5350, 14103, 5521, 34 
https://tests.stockfishchess.org/tests/view/694d49aa572093c1986d7021

bench 2970339