### PR TITLE
Quiet depth reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1221,6 +1221,12 @@ moves_loop:  // When in check, search starts here
         // Decrease/increase reduction for moves with a good/bad history
         r -= ss->statScore * 850 / 8192;
 
+        // Quiet moves at high depth are less likely to be critical.
+        // With sufficient search budget, we can afford more aggressive
+        // reduction on non-tactical moves.
+        if (!capture && depth >= 12)
+            r += 256;
+
         // Step 17. Late moves reduction / extension (LMR)
         if (depth >= 2 && moveCount > 1)
         {


### PR DESCRIPTION
Quiet moves at high depth are less likely to be critical. With sufficient search budget, we can afford more aggressive reduction on non-tactical moves. Adds one ply reduction bonus (256) for quiet moves when depth >= 12.

STC: https://tests.stockfishchess.org/tests/view/694926b33c8768ca450726e4
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 50880 W: 13319 L: 12982 D: 24579
Ptnml(0-2): 170, 5863, 13065, 6144, 198 

LTC: https://tests.stockfishchess.org/tests/view/694b8c37572093c1986d6b73
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 132708 W: 34000 L: 33487 D: 65221
Ptnml(0-2): 69, 14262, 37205, 14723, 95 

Bench: 2776381
