### PR TITLE
For expected ALL nodes scale up reduction with depth dependent factor.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1221,6 +1221,10 @@ moves_loop:  // When in check, search starts here
         // Decrease/increase reduction for moves with a good/bad history
         r -= ss->statScore * 850 / 8192;
 
+        // Scale up reductions for expected ALL nodes
+        if (allNode)
+            r += r / (depth + 1);
+
         // Step 17. Late moves reduction / extension (LMR)
         if (depth >= 2 && moveCount > 1)
         {


### PR DESCRIPTION
Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 141120 W: 36860 L: 36390 D: 67870
Ptnml(0-2): 470, 16441, 36314, 16819, 516
https://tests.stockfishchess.org/tests/view/694978e93c8768ca45072763

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 66576 W: 17078 L: 16700 D: 32798
Ptnml(0-2): 45, 7093, 18628, 7483, 39
https://tests.stockfishchess.org/tests/view/694bb608572093c1986d6ba6

Bench: 2671592