### PR TITLE
remove -Wstack-usage on apple clang

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -436,7 +436,7 @@ endif
 ifeq ($(COMP),gcc)
 	comp=gcc
 	CXX=g++
-	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-declarations -Wstack-usage=128000
+	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-declarations
 
 	ifeq ($(arch),$(filter $(arch),armv7 armv8 riscv64))
 		ifeq ($(OS),Android)
@@ -607,6 +607,8 @@ ifeq ($(COMP),gcc)
 	ifneq ($(gccisclang),)
 		profile_make = clang-profile-make
 		profile_use = clang-profile-use
+	else
+		CXXFLAGS += -Wstack-usage=128000
 	endif
 endif
 


### PR DESCRIPTION
Apple clang pretends to be GCC, but is enraged by `-Wstack-usage`:

<img width="955" height="456" alt="image" src="https://github.com/user-attachments/assets/9483cf58-bec4-4e26-936d-a4ebd67ce8c3" />

```
% gcc -v
Homebrew clang version 19.1.6
Target: arm64-apple-darwin24.3.0
Thread model: posix
```