### PR TITLE
Adjust main history with every new root position.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -65,6 +65,7 @@ using namespace Search;
 namespace {
 
 constexpr int SEARCHEDLIST_CAPACITY = 32;
+constexpr int mainHistoryDefault = 68;
 using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 
 // (*Scalers):
@@ -311,6 +312,10 @@ void Search::Worker::iterative_deepening() {
     int searchAgainCounter = 0;
 
     lowPlyHistory.fill(97);
+
+    for (Color c: {WHITE, BLACK})
+        for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
+            mainHistory[c][i] = (mainHistory[c][i] - mainHistoryDefault) * 3 / 4 + mainHistoryDefault;
 
     // Iterative deepening loop until requested to stop or the target depth is reached
     while (++rootDepth < MAX_PLY && !threads.stop
@@ -578,7 +583,7 @@ void Search::Worker::undo_null_move(Position& pos) { pos.undo_null_move(); }
 
 // Reset histories, usually before a new game
 void Search::Worker::clear() {
-    mainHistory.fill(68);
+    mainHistory.fill(mainHistoryDefault);
     captureHistory.fill(-689);
 
     // Each thread is responsible for clearing their part of shared history


### PR DESCRIPTION
This patch dampens down main history to 3/4 of it value for all possible moves at the start of ID loop, making it partially refresh with every new root position.
Passed STC:
https://tests.stockfishchess.org/tests/view/694e33ff572093c1986d7234
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 115520 W: 30164 L: 29735 D: 55621
Ptnml(0-2): 395, 13192, 30192, 13551, 430 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6950cbe6572093c1986d816c
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 63672 W: 16480 L: 16114 D: 31078
Ptnml(0-2): 46, 6524, 18329, 6892, 45 
bench 2710946