### PR TITLE
port get_changed_pieces to ARM NEON

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -645,6 +645,18 @@ Bitboard get_changed_pieces(const std::array<Piece, SQUARE_NB>& oldPieces,
         sameBB |= static_cast<Bitboard>(equalMask) << i;
     }
     return ~sameBB;
+#elif defined(USE_NEON)
+    uint8x16x4_t old_v = vld4q_u8(reinterpret_cast<const uint8_t*>(oldPieces.data()));
+    uint8x16x4_t new_v = vld4q_u8(reinterpret_cast<const uint8_t*>(newPieces.data()));
+    auto         cmp   = [=](const int i) { return vceqq_u8(old_v.val[i], new_v.val[i]); };
+
+    uint8x16_t cmp0_1 = vsriq_n_u8(cmp(1), cmp(0), 1);
+    uint8x16_t cmp2_3 = vsriq_n_u8(cmp(3), cmp(2), 1);
+    uint8x16_t merged = vsriq_n_u8(cmp2_3, cmp0_1, 2);
+    merged            = vsriq_n_u8(merged, merged, 4);
+    uint8x8_t sameBB  = vshrn_n_u16(vreinterpretq_u16_u8(merged), 4);
+
+    return ~vget_lane_u64(vreinterpret_u64_u8(sameBB), 0);
 #else
     Bitboard changed = 0;
 


### PR DESCRIPTION
[Passed STC](https://tests.stockfishchess.org/tests/live_elo/69509e5c572093c1986d7a0a):

```
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 71968 W: 18833 L: 18489 D: 34646
Ptnml(0-2): 192, 7310, 20643, 7640, 199 
```

I measure a modest speedup on Apple M1 and M4, and vondele measured a speedup on his ARM machine.