### PR TITLE
Assume check in Position::do_move if check info missing

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -696,7 +696,7 @@ bool Position::gives_check(Move m) const {
 // will be prefetched, and likewise for shared history.
 void Position::do_move(Move                      m,
                        StateInfo&                newSt,
-                       bool                      givesCheck,
+                       bool                      maybeGivesCheck,
                        DirtyPiece&               dp,
                        DirtyThreats&             dts,
                        const TranspositionTable* tt      = nullptr,
@@ -896,7 +896,7 @@ void Position::do_move(Move                      m,
     st->capturedPiece = captured;
 
     // Calculate checkers bitboard (if move gives check)
-    st->checkersBB = givesCheck ? attackers_to(square<KING>(them)) & pieces(us) : 0;
+    st->checkersBB = maybeGivesCheck ? attackers_to(square<KING>(them)) & pieces(us) : 0;
 
     sideToMove = ~sideToMove;
 

--- a/src/position.h
+++ b/src/position.h
@@ -137,7 +137,7 @@ class Position {
     void do_move(Move m, StateInfo& newSt, const TranspositionTable* tt);
     void do_move(Move                      m,
                  StateInfo&                newSt,
-                 bool                      givesCheck,
+                 bool                      maybeGivesCheck,
                  DirtyPiece&               dp,
                  DirtyThreats&             dts,
                  const TranspositionTable* tt,
@@ -404,7 +404,7 @@ inline void Position::swap_piece(Square s, Piece pc, DirtyThreats* const dts) {
 
 inline void Position::do_move(Move m, StateInfo& newSt, const TranspositionTable* tt = nullptr) {
     new (&scratch_dts) DirtyThreats;
-    do_move(m, newSt, gives_check(m), scratch_dp, scratch_dts, tt, nullptr);
+    do_move(m, newSt, true, scratch_dp, scratch_dts, tt, nullptr);
 }
 
 inline StateInfo* Position::state() const { return st; }


### PR DESCRIPTION
`Position::do_move` assumes that the move gives check if no check information is provided.

Passed STC Non-Regression:
https://tests.stockfishchess.org/tests/view/6954f736d844c1ce7cc7e263
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 90656 W: 23554 L: 23396 D: 43706
Ptnml(0-2): 302, 10013, 24546, 10159, 308

No functional change.