### PR TITLE
Typographical Fixes

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -169,7 +169,7 @@ void Engine::search_clear() {
     tt.clear(threads);
     threads.clear();
 
-    // @TODO wont work with multiple instances
+    // @TODO won't work with multiple instances
     Tablebases::init(options["SyzygyPath"]);  // Free mapped files
 }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -2084,7 +2084,7 @@ void syzygy_extend_pv(const OptionsMap&         options,
     // Finding a draw in this function is an exceptional case, that cannot happen when rule50 is false or
     // during engine game play, since we have a winning score, and play correctly
     // with TB support. However, it can be that a position is draw due to the 50 move
-    // rule if it has been been reached on the board with a non-optimal 50 move counter
+    // rule if it has been reached on the board with a non-optimal 50 move counter
     // (e.g. 8/8/6k1/3B4/3K4/4N3/8/8 w - - 54 106 ) which TB with dtz counter rounding
     // cannot always correctly rank. See also
     // https://github.com/official-stockfish/Stockfish/issues/5175#issuecomment-2058893495


### PR DESCRIPTION
## Summary
- Fix comment typos: "wont" -> "won't" and removed double "been".

## Type
- Non-functional (comments only). No fishtest needed.

## Testing
- Not applicable (no functional changes).


![steepled-hands.png](https://raw.githubusercontent.com/THE-Spellchecker/THE-Website/refs/heads/main/steeple.png)