### PR TITLE
qsearch: prevent bestValue from going down

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1653,7 +1653,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
                 // we can prune this move.
                 if (!pos.see_ge(move, alpha - futilityBase))
                 {
-                    bestValue = std::min(alpha, futilityBase);
+                    bestValue = std::max(bestValue, std::min(alpha, futilityBase));
                     continue;
                 }
             }


### PR DESCRIPTION
The bestValue can sometimes go down. This happens 2% of the time or so. This fix stops it from decreasing.

Passed Non-regression LTC:

LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 257796 W: 65662 L: 65683 D: 126451
Ptnml(0-2): 164, 28247, 72087, 28246, 154

https://tests.stockfishchess.org/tests/live_elo/69554ff0d844c1ce7cc7e333

closes: #6519

Bench: 2477446