### PR TITLE
 Simplify TT move extension formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1281,10 +1281,7 @@ moves_loop:  // When in check, search starts here
             (ss + 1)->pv[0] = Move::none();
 
             // Extend move from transposition table if we are about to dive into qsearch.
-            // decisive score handling improves mate finding and retrograde analysis.
-            if (move == ttData.move
-                && ((is_valid(ttData.value) && is_decisive(ttData.value) && ttData.depth > 0)
-                    || ttData.depth > 1))
+            if (move == ttData.move && ttData.depth > 1)
                 newDepth = std::max(newDepth, 1);
 
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);


### PR DESCRIPTION
 Simplify TT move extension formula

Passed STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 110560 W: 28603 L: 28469 D: 53488
Ptnml(0-2): 303, 12146, 30254, 12268, 309
https://tests.stockfishchess.org/tests/view/6958ed4dd844c1ce7cc7e98e

No functional change