### PR TITLE
disable PV extension for nodestime

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1983,6 +1983,10 @@ void syzygy_extend_pv(const OptionsMap&         options,
                       RootMove&                 rootMove,
                       Value&                    v) {
 
+    // Do not use nodes budget, if nodestime time management is active
+    if (int(options["nodestime"]) != 0 && limits.use_time_management())
+        return;
+
     auto t_start      = std::chrono::steady_clock::now();
     int  moveOverhead = int(options["Move Overhead"]);
     bool rule50       = bool(options["Syzygy50MoveRule"]);


### PR DESCRIPTION
The overhead measurement in the PV extension code is always in ms, whereas for nodestime the budget given is counted in nodes. Moreover, extending the PVs would eat into the nodes budget. So best to simply disable in this rarely used case.

Prompted by https://github.com/official-stockfish/Stockfish/pull/6424#issuecomment-3536216359.

Bench is unchanged.