### PR TITLE
fix tbb crash on Apple Silicon by excluding tbprobe from LTO

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1111,6 +1111,13 @@ config-sanity: net
 $(EXE): $(OBJS)
 	+$(CXX) -o $@ $(OBJS) $(LDFLAGS)
 
+# tbprobe.o must be compiled without LTO on Apple Silicon due to
+# miscompilation from strict aliasing violations in memory-mapped tablebase access
+ifeq ($(ARCH),apple-silicon)
+tbprobe.o: syzygy/tbprobe.cpp
+	$(CXX) $(filter-out -flto=full -flto=thin -flto,$(CXXFLAGS)) -c -o $@ $<
+endif
+
 # Force recompilation to ensure version info is up-to-date
 misc.o: FORCE
 FORCE:


### PR DESCRIPTION
A bit tricky to identify (any additional insight is appreciated), but in `apple-silicon` builds from the past 2-3 months, specifying a value for `SyzygyPath` would lead to crashes at certain (sometimes very low) depths from a SIGBUS.

Disabling LTO globally fixed the issue, but the disabling can instead be localized to tbprobe.

This PR adjusts `src/Makefile` so that LTO is not applied on `src/tbprobe.o`'s compilation, specifically on `apple-silicon` builds.

No functional change.

bench: 2477446