### PR TITLE
Fix Clang Tbprobe Miscompilation

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -711,9 +711,9 @@ int map_score(TBTable<DTZ>* entry, File f, int value, WDLScore wdl) {
 
 // A temporary fix for the compiler bug with vectorization. (#4450)
 #if defined(__clang__) && defined(__clang_major__) && __clang_major__ >= 15
-    #define CLANG_BUG_FIX _Pragma("clang loop vectorize(disable)")
+    #define DISABLE_CLANG_LOOP_VEC _Pragma("clang loop vectorize(disable)")
 #else
-    #define CLANG_BUG_FIX
+    #define DISABLE_CLANG_LOOP_VEC
 #endif
 
 // Compute a unique index out of a position and use it to probe the TB file. To
@@ -808,7 +808,7 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
     // the triangle A1-D1-D4.
     if (file_of(squares[0]) > FILE_D)
     {
-        CLANG_BUG_FIX
+        DISABLE_CLANG_LOOP_VEC
         for (int i = 0; i < size; ++i)
             squares[i] = flip_file(squares[i]);
     }
@@ -831,14 +831,14 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
     // piece is below RANK_5.
     if (rank_of(squares[0]) > RANK_4)
     {
-        CLANG_BUG_FIX
+        DISABLE_CLANG_LOOP_VEC
         for (int i = 0; i < size; ++i)
             squares[i] = flip_rank(squares[i]);
     }
 
     // Look for the first piece of the leading group not on the A1-D4 diagonal
     // and ensure it is mapped below the diagonal.
-    CLANG_BUG_FIX
+    DISABLE_CLANG_LOOP_VEC
     for (int i = 0; i < d->groupLen[0]; ++i)
     {
         if (!off_A1H8(squares[i]))
@@ -846,7 +846,7 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
 
         if (off_A1H8(squares[i]) > 0)  // A1-H8 diagonal flip: SQ_A3 -> SQ_C1
         {
-            CLANG_BUG_FIX
+            DISABLE_CLANG_LOOP_VEC
             for (int j = i; j < size; ++j)
                 squares[j] = Square(((squares[j] >> 3) | (squares[j] << 3)) & 63);
         }


### PR DESCRIPTION
Recent changes to the Square enum (reducing it from int32_t to int8_t) now allow the compiler to vectorize loops that were previously too wide for targets below AVX-512. However, this vectorization which Clang performs is not sane and causes a miscompilation.
Disable this vectorization.

This particular issue was noticable with Clang 15 and Clang 19

Ref: https://github.com/official-stockfish/Stockfish/pull/6063
Original Clang Issue: https://github.com/llvm/llvm-project/issues/80494

First reported by https://github.com/official-stockfish/Stockfish/pull/6528, though misinterpreted.

closes https://github.com/official-stockfish/Stockfish/pull/6529

No functional change