### PR TITLE
Simplify retrograde analysis capability condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1282,9 +1282,7 @@ moves_loop:  // When in check, search starts here
 
             // Extend move from transposition table if we are about to dive into qsearch.
             // decisive score handling improves mate finding and retrograde analysis.
-            if (move == ttData.move
-                && ((is_valid(ttData.value) && is_decisive(ttData.value) && ttData.depth > 0)
-                    || ttData.depth > 1))
+            if (move == ttData.move && ((is_valid(ttData.value) && is_decisive(ttData.value)) || ttData.depth > 1))
                 newDepth = std::max(newDepth, 1);
 
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);


### PR DESCRIPTION
by simplifying according condition in search.cpc

Passed STC and LTC non-reg bounds:
https://tests.stockfishchess.org/tests/view/695ce092912b7ff140de60c6
LLR: 3.17 (-2.94,2.94) <-1.75,0.25>
Total: 121728 W: 31439 L: 31298 D: 58991
Ptnml(0-2): 305, 13281, 33554, 13416, 308

https://tests.stockfishchess.org/tests/view/695dfc9702d0182a589fe8e8
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 56220 W: 14472 L: 14299 D: 27449
Ptnml(0-2): 30, 5326, 17219, 5511, 24

Superseeds PR #6521

N.B.:
Since current implementation relies completely on TT and relevant pv entries might get overriden by other positions
it is not very robust and depends on hash-size, threads, minimum search depth, and other parameters used.
A robust implementation might be possible but requires additional code.

bench: 2477446