### PR TITLE
Simplify fail high reduction formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1206,8 +1206,7 @@ moves_loop:  // When in check, search starts here
 
         // Increase reduction if next ply has a lot of fail high
         if ((ss + 1)->cutoffCnt > 1)
-            r += 120 + 1024 * ((ss + 1)->cutoffCnt > 2) + 100 * ((ss + 1)->cutoffCnt > 3)
-               + 1024 * allNode;
+            r += 256 + 1024 * ((ss + 1)->cutoffCnt > 2) + 1024 * allNode;
 
         // For first picked move (ttMove) reduce reduction
         if (move == ttData.move)


### PR DESCRIPTION
Simplify fail high reduction formula

Passed STC:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 165792 W: 42849 L: 42768 D: 80175
Ptnml(0-2): 512, 19499, 42800, 19566, 519
https://tests.stockfishchess.org/tests/view/695cdd95912b7ff140de60c2

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 80448 W: 20619 L: 20459 D: 39370
Ptnml(0-2): 47, 8693, 22596, 8829, 59
https://tests.stockfishchess.org/tests/view/695f7e84ca95f52e4b852536

bench: 2050811