### PR TITLE
Simplify singular extension doubleMargin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1139,9 +1139,9 @@ moves_loop:  // When in check, search starts here
 
             if (value < singularBeta)
             {
-                int corrValAdj   = std::abs(correctionValue) / 230673;
-                int doubleMargin = -4 + 199 * PvNode - 201 * !ttCapture - corrValAdj
-                                 - 897 * ttMoveHistory / 127649 - (ss->ply > rootDepth) * 42;
+                int corrValAdj = std::abs(correctionValue) / 230673;
+                int doubleMargin =
+                  -4 + 199 * PvNode - 201 * !ttCapture - corrValAdj - 897 * ttMoveHistory / 127649;
                 int tripleMargin = 73 + 302 * PvNode - 248 * !ttCapture + 90 * ss->ttPv - corrValAdj
                                  - (ss->ply * 2 > rootDepth * 3) * 50;
 


### PR DESCRIPTION
Bench: 2698840

Please accept this simplification change that used simplification bounds elo0=-1.75, elo1=0.25

Passed LTC: https://tests.stockfishchess.org/tests/live_elo/69603ff8d5d22d0c78738219
Passed STC: https://tests.stockfishchess.org/tests/live_elo/695f4a1dca95f52e4b8524d1