### PR TITLE
Fix RelationCache on Windows 10 compiles

### DIFF
--- a/src/numa.h
+++ b/src/numa.h
@@ -378,7 +378,7 @@ struct HasGroupCount : std::false_type {};
 
 template <typename T>
 struct HasGroupCount<T, 
-    std::void_t<decltype(std::declval<T>()->Cache.GroupCount)>> 
+    std::void_t<decltype(std::declval<T>().Cache.GroupCount)>> 
     : std::true_type {};
 
 template <typename T, typename Pred, std::enable_if_t<HasGroupCount<T>::value, bool> = true>


### PR DESCRIPTION
Windows 10 is missing the GroupMasks and GroupCount members (although this isn't present in the documentation). This breaks compiles on Windows 10; Windows 11 builds, including the official ones, run fine on Windows 10/11. To support developers/testers on Windows 10, fallback conditionally to the Windows 10 struct definition.