### PR TITLE
Fix integer overflow.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1432,6 +1432,7 @@ moves_loop:  // When in check, search starts here
 
         bonusScale = std::max(bonusScale, 0);
 
+        // scaledBonus ranges from 0 to roughly 2.3M, overflows happen for multipliers larger than 900
         const int scaledBonus = std::min(141 * depth - 87, 1351) * bonusScale;
 
         update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
@@ -1440,8 +1441,7 @@ moves_loop:  // When in check, search starts here
         mainHistory[~us][((ss - 1)->currentMove).raw()] << scaledBonus * 243 / 32768;
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
-            sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq]
-              << scaledBonus * 1160 / 32768;
+            sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << scaledBonus * 290 / 8192;
     }
 
     // Bonus for prior capture countermove that caused the fail low


### PR DESCRIPTION
scaledBonus can reach rather large values,
which lead to an int overflow as detected anematode using ubsan. (see https://github.com/official-stockfish/Stockfish/issues/6505#issuecomment-3696988889)

It can be fixed by scaling nominator and denominator appropriately, which doesn't change the bench, as long as there is no overflow.

First overflow/bench change happens at depth 26

Bench: 2050811