### PR TITLE
Non Atomic Stats

### DIFF
--- a/tests/testing.py
+++ b/tests/testing.py
@@ -53,6 +53,7 @@ race:Stockfish::TTEntry::read
 race:Stockfish::TTEntry::save
 race:Stockfish::TranspositionTable::probe
 race:Stockfish::TranspositionTable::hashfull
+race:Stockfish::StatsEntry
 """
             )
 


### PR DESCRIPTION
https://tests.stockfishchess.org/tests/view/6962c4fde5fe6bcb18aeb375
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 76832 W: 19774 L: 19420 D: 37638
Ptnml(0-2): 85, 8468, 20952, 8830, 81 

It looks like the theoretical benefit of having atomic stats isn't worth the practical performance impact.  If other testing with say higher thread counts is desired please specify what exact tests you would like to see and I will schedule.

No functional change
bench: 2050811