### PR TITLE
In shm_linux.h, skip munmap when exiting via a signal

### DIFF
--- a/src/shm_linux.h
+++ b/src/shm_linux.h
@@ -364,7 +364,8 @@ class SharedMemory: public detail::SharedMemoryBase {
             fd_ = -1;
         }
 
-        reset();
+        if (!skip_unmap)
+            reset();
     }
 
     const std::string& name() const noexcept override { return name_; }


### PR DESCRIPTION
Since shared memory was merged, the following sequence of events would occur on Linux when SF receives `SIGINT`:

1. The sigaction handler on the main thread would iterate over the weights instances, `shm_unlink` them and `munmap` them.
2. Any currently running search threads would attempt to access now-invalid memory and SIGSEGV.
3. Those threads would themselves jump to the signal handler.
4. (At some point in all this) the main thread would call `_Exit` which immediately exits the program without invoking any cleanup actions.

While this isn't really a *problem*, it's certainly not intended. The simplest solution is when exiting from a signal or in a `std::atexit` handler, don't `munmap` the instances (but *do* `shm_unlink` them, which doesn't itself invalidate the mappings). The process is about to exit anyway, so the mapped memory will be cleaned up.

Thanks to vondele for helping investigate this.

### Testing

To test, you can compile with `debug=yes sanitize=address,undefined`. Then if build/run speedtest on master, then Ctrl-C, the sanitizers will be enraged:

<img width="1826" height="624" alt="image" src="https://github.com/user-attachments/assets/f86f76f5-2554-49cc-a52f-327a4a3d86e7" />

This branch should be fine.
