### PR TITLE
Clang: generate profile with multithreaded benchmark.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -64,7 +64,15 @@ PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds
-PGOBENCH = $(RUN_PREFIX) ./$(EXE) bench
+ifeq ($(COMP),clang)
+# clang/llvm gains speedup with multithreaded benchmark profile
+	ifndef PGO_BENCH_THREADS
+		export PGO_BENCH_THREADS := 4
+	endif
+	PGOBENCH = $(RUN_PREFIX) ./$(EXE) bench 16 $(PGO_BENCH_THREADS)
+else
+	PGOBENCH = $(RUN_PREFIX) ./$(EXE) bench
+endif
 
 ### Source and object files
 SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \


### PR DESCRIPTION
Using multithreaded benchmarking to generate profile gains speedup in Clang/LLVM.  
After some local testing, 4 threads seems to be a good balance and is chosen as the default.  

For GCC to work it needs `-fprofile-update=atomic` (otherwise profiles will be corrupted),  
but the impact is insignificant (~0.1% speedup) thus this change is only for Clang.  
  
<br>  

`PGO_BENCH_THREADS` can be set in case fishtest needs it.

*No Functional Change.*

```
 Result of  20 runs
 ==================
 base (...kfish-master) =     794097  +/- 8951
 test (./stockfish    ) =     821058  +/- 10670
 diff                   =     +26961  +/- 2010
 
 speedup        = +0.0340
 P(speedup > 0) =  1.0000
 
 CPU: 14 x 12th Gen Intel(R) Core(TM) i7-12700H
 Hyperthreading: on
```

```
Result of  20 runs
==================
base (...kfish-master) =     259423  +/- 1365
test (./stockfish    ) =     267394  +/- 1358
diff                   =      +7970  +/- 2039

speedup        = +0.0307
P(speedup > 0) =  1.0000

CPU: 8 x unknown (Note: Cortex-A76@2.3GHz)
Hyperthreading: off
```

```
Result of  20 runs
==================
base (...kfish-master) =    1730672  +/- 10563
test (./stockfish    ) =    1758644  +/- 7942
diff                   =     +27972  +/- 6605

speedup        = +0.0162
P(speedup > 0) =  1.0000

CPU: 16 x AMD Ryzen 9 7945HX with Radeon Graphics
Hyperthreading: on
```