### PR TITLE
Remove prefetching in Position::do_null_move

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1248,7 +1248,7 @@ void Position::do_castling(Color               us,
 
 // Used to do a "null move": it flips
 // the side to move without executing any move on the board.
-void Position::do_null_move(StateInfo& newSt, const TranspositionTable& tt) {
+void Position::do_null_move(StateInfo& newSt) {
 
     assert(!checkers());
     assert(&newSt != st);
@@ -1265,7 +1265,6 @@ void Position::do_null_move(StateInfo& newSt, const TranspositionTable& tt) {
     }
 
     st->key ^= Zobrist::side;
-    prefetch(tt.first_entry(key()));
 
     st->pliesFromNull = 0;
 

--- a/src/position.h
+++ b/src/position.h
@@ -143,7 +143,7 @@ class Position {
                  const TranspositionTable* tt,
                  const SharedHistories*    worker);
     void undo_move(Move m);
-    void do_null_move(StateInfo& newSt, const TranspositionTable& tt);
+    void do_null_move(StateInfo& newSt);
     void undo_null_move();
 
     // Static Exchange Evaluation

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -568,7 +568,7 @@ void Search::Worker::do_move(
 }
 
 void Search::Worker::do_null_move(Position& pos, StateInfo& st, Stack* const ss) {
-    pos.do_null_move(st, tt);
+    pos.do_null_move(st);
     ss->currentMove                   = Move::null();
     ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
     ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];


### PR DESCRIPTION
Passed STC Non-Regression:

LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 60704 W: 15709 L: 15522 D: 29473
Ptnml(0-2): 169, 6589, 16649, 6776, 169
https://tests.stockfishchess.org/tests/live_elo/6963d381f6d2e8deff76918f

Passed non-regression STC SMP, Hash=512:

LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 313512 W: 80151 L: 80231 D: 153130
Ptnml(0-2): 376, 35492, 85111, 35390, 387
https://tests.stockfishchess.org/tests/view/696e1684e5a70879bd3fe38f

No functional change.