### PR TITLE
Simplify Triple Margin Formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1143,7 +1143,7 @@ moves_loop:  // When in check, search starts here
                 int doubleMargin = -4 + 199 * PvNode - 201 * !ttCapture - corrValAdj
                                  - 897 * ttMoveHistory / 127649 - (ss->ply > rootDepth) * 42;
                 int tripleMargin = 73 + 302 * PvNode - 248 * !ttCapture + 90 * ss->ttPv - corrValAdj
-                                 - (ss->ply * 2 > rootDepth * 3) * 50;
+                                 - (ss->ply > rootDepth) * 48;
 
                 extension =
                   1 + (value < singularBeta - doubleMargin) + (value < singularBeta - tripleMargin);


### PR DESCRIPTION
Simplify Triple Margin Formula

Passed STC:
LLR: 3.01 (-2.94,2.94) <-1.75,0.25>
Total: 517472 W: 133271 L: 133575 D: 250626
Ptnml(0-2): 1628, 61366, 133032, 61102, 1608
https://tests.stockfishchess.org/tests/view/69590175d844c1ce7cc7e9a2

Passed LTC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 95430 W: 24242 L: 24098 D: 47090
Ptnml(0-2): 42, 10289, 26926, 10399, 59
https://tests.stockfishchess.org/tests/view/695f7f03ca95f52e4b85253c

Passed VVLTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 58828 W: 15299 L: 15135 D: 28394
Ptnml(0-2): 4, 5277, 18687, 5443, 3
https://tests.stockfishchess.org/tests/view/6961686c8709a8d27c0383f6

bench: 2258355