### PR TITLE
IIR priorReduction threshold simplification

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -929,7 +929,7 @@ Value Search::Worker::search(
     // Step 10. Internal iterative reductions
     // At sufficient depth, reduce depth for PV/Cut nodes without a TTMove.
     // (*Scaler) Making IIR more aggressive scales poorly.
-    if (!allNode && depth >= 6 && !ttData.move && priorReduction <= 3)
+    if (!allNode && depth >= 6 && !ttData.move)
         depth--;
 
     // Step 11. ProbCut


### PR DESCRIPTION
This simplification removes the `priorReduction <= 3` condition from Internal Iterative Reductions, allowing IIR to reduce depth at all qualifying nodes regardless of how much the parent reduced. NNUE-independent: IIR controls search depth allocation, not position evaluation - NNUE is never consulted or affected by this code path.

Passed LTC: https://tests.stockfishchess.org/tests/live_elo/69655bf1d5a3b5895b50f121
```
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 53988 W: 13827 L: 13641 D: 26520
Ptnml(0-2): 20, 5798, 15185, 5958, 33 
```
Passed STC: https://tests.stockfishchess.org/tests/live_elo/696231da24b0f200b0c5555a
```
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 94432 W: 24523 L: 24367 D: 45542
Ptnml(0-2): 304, 11086, 24283, 11236, 307 
```

Bench: 2567885