### PR TITLE
update the WDL model

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -507,8 +507,8 @@ WinRateParams win_rate_params(const Position& pos) {
     double m = std::clamp(material, 17, 78) / 58.0;
 
     // Return a = p_a(material) and b = p_b(material), see github.com/official-stockfish/WDL_model
-    constexpr double as[] = {-13.50030198, 40.92780883, -36.82753545, 386.83004070};
-    constexpr double bs[] = {96.53354896, -165.79058388, 90.89679019, 49.29561889};
+    constexpr double as[] = {-72.32565836, 185.93832038, -144.58862193, 416.44950446};
+    constexpr double bs[] = {83.86794042, -136.06112997, 69.98820887, 47.62901433};
 
     double a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
     double b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];


### PR DESCRIPTION
This PR updates the internal WDL model, using data from 3.1M games played by the revisions since 44d5467bbe06789e8a3cbaee87e699e033b3081a. Note that the normalizing constant increases only moderately from 377 to 385.

```
> ./updateWDL.sh --firstrev 44d5467bbe06789e8a3cbaee87e699e033b3081a
Running: ./updateWDL.sh --firstrev 44d5467bbe06789e8a3cbaee87e699e033b3081a --lasttrev HEAD --materialMin 17 --EloDiffMax 5
started at:  Thu 15 Jan 08:49:52 CET 2026
Look recursively in directory pgns for games with max nElo difference 5 using books matching "UHO_Lichess_4852_v..epd" for SF revisions between 44d5467bbe06789e8a3cbaee87e699e033b3081a (from 2025-12-28 14:59:26 +0100) and HEAD (from 2026-01-11 09:13:37 +0100).
Based on 171587003 positions from 3074130 games, NormalizeToPawnValue should change from 377 to 385.
ended at:  Thu 15 Jan 08:54:28 CET 2026
```

```
> cat scoreWDL.log
Converting evals with NormalizeData = {'momType': 'material', 'momMin': 17, 'momMax': 78, 'momTarget': 58, 'as': [-13.50030198, 40.92780883, -36.82753545, 386.8300407]}.
Reading eval stats from updateWDL.json.
Retained (W,D,L) = (41837518, 87045865, 42703620) positions.
Saved distribution plot to updateWDLdistro.png.
Fit WDL model based on material.
Initial objective function:  0.3571045003575733
Final objective function:    0.35710268710203236
Optimization terminated successfully.
const int NormalizeToPawnValue = 385;
Corresponding spread = 65;
Corresponding normalized spread = 0.16972379706320478;
Draw rate at 0.0 eval at material 58 = 0.9944919044779984;
Parameters in internal value units: 
p_a = ((-72.326 * x / 58 + 185.938) * x / 58 + -144.589) * x / 58 + 416.450
p_b = ((83.868 * x / 58 + -136.061) * x / 58 + 69.988) * x / 58 + 47.629
    constexpr double as[] = {-72.32565836, 185.93832038, -144.58862193, 416.44950446};
    constexpr double bs[] = {83.86794042, -136.06112997, 69.98820887, 47.62901433};
Preparing plots.
Saved graphics to updateWDL.png.
Total elapsed time = 79.37s.
```

Bench is unchanged.