### PR TITLE
Raise inline threshold for clang/llvm.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -267,6 +267,7 @@ Wencey Wang
 windfishballad
 xefoci7612
 Xiang Wang (KatyushaScarlet)
+Yen-Chao Shen (lemteay)
 zz4032
 
 # Additionally, we acknowledge the authors and maintainers of fishtest,

--- a/src/Makefile
+++ b/src/Makefile
@@ -892,6 +892,13 @@ ifeq ($(OS), Android)
 	LDFLAGS += -fPIE -pie
 endif
 
+### 3.11 Inline settings
+ifeq ($(optimize), yes)
+	ifeq ($(comp), clang)
+		CXXFLAGS += -Xclang -mllvm -Xclang -inline-threshold=500
+	endif
+endif
+
 ### ==========================================================================
 ### Section 4. Public Targets
 ### ==========================================================================


### PR DESCRIPTION
Passed STC:  
https://tests.stockfishchess.org/tests/view/696884a56d118e46e1731473  
LLR: 2.93 (-2.94,2.94) <0.00,2.00>  
Total: 29952 W: 7843 L: 7549 D: 14560  
Ptnml(0-2): 72, 3215, 8118, 3489, 82  

*No functional change*  

<br>  

.text area size:
```
master(eb5a65a): 455490
pr:              453250
```

Bench (clang 21.1.8):  
```
Result of 100 runs
==================
base (...kfish-master) =    1719708  +/- 3473
test (./stockfish    ) =    1770555  +/- 3284
diff                   =     +50846  +/- 3949

speedup        = +0.0296
P(speedup > 0) =  1.0000

CPU: 16 x AMD Ryzen 9 7945HX with Radeon Graphics
Hyperthreading: on
```