### PR TITLE
Optimize IsLittleEndian for compiler DCE

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -124,9 +124,17 @@ std::ostream& operator<<(std::ostream&, SyncCout);
 void sync_cout_start();
 void sync_cout_end();
 
-// True if and only if the binary is compiled on a little-endian machine
-static inline const std::uint16_t Le             = 1;
-static inline const bool          IsLittleEndian = *reinterpret_cast<const char*>(&Le) == 1;
+// True if and only if the binary is compiled on a little-endian machine.
+static inline const bool IsLittleEndian = []() {
+#if defined(__GNUC__) || defined(__clang__)
+    return __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__;
+#elif defined(_MSC_VER)
+    return true;
+#else
+    const std::uint16_t Le = 1;
+    return *reinterpret_cast<const char*>(&Le) == 1;
+#endif
+}();
 
 
 template<typename T, std::size_t MaxSize>


### PR DESCRIPTION
Optimize IsLittleEndian for compiler DCE

Update the definition of IsLittleEndian to use compiler-specific macros where available (GCC, Clang, MSVC). This allows the optimizer to resolve the value at compile-time and perform Dead Code Elimination (DCE) on endian-dependent branches without requiring C++20. A portable fallback is maintained for other compilers.

No functional change