### PR TITLE
Use default signal handler after cleanup

### DIFF
--- a/src/shm_linux.h
+++ b/src/shm_linux.h
@@ -112,7 +112,8 @@ class CleanupHooks {
         sa.sa_handler = SIG_DFL;
         sigemptyset(&sa.sa_mask);
         sa.sa_flags = 0;
-        sigaction(sig, &sa, nullptr);
+        if (sigaction(sig, &sa, nullptr) == -1)
+            _Exit(128 + sig);
 
         raise(sig);
     }


### PR DESCRIPTION
With the current setup, on Linux, SIGILL (and SIGSEGV/SIGBUS etc., in the case of a program bug) lead to no feedback if they occur after the signal handlers are installed, they just exit silently. By invoking the default signal handler, we can still get the appropriate feedback. This is particularly important for feedback if someone downloads the wrong SF binary and runs it on Linux.

Example, running the avxvnni binary on a Zen 2 Linux machine:

```
timothy@xz ~/Stockfish/src (master?) $ ./stockfish bench
Stockfish dev-20260115-71f53b92 by the Stockfish developers (see AUTHORS file)
info string Using 1 thread

Position: 1/50 (rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1)
info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
info string Network replica 1: Shared memory.
info string Network replica 2: No allocation.
timothy@xz ~/Stockfish/src (master?) $ 
```

and this branch:

```
timothy@xz ~/Stockfish/src (print-crash?) $ ./stockfish bench                
Stockfish dev-20260116-6b4542b4 by the Stockfish developers (see AUTHORS file)
info string Using 1 thread

Position: 1/50 (rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1)
info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
info string Network replica 1: Shared memory.
info string Network replica 2: No allocation.
[1]    3708888 illegal hardware instruction  ./stockfish bench
timothy@xz ~/Stockfish/src (print-crash?) $ 
```

The coredump should still be useful in terms of having a backtrace, but the registers will probably be wrong. (here I'm using a purposely introduced segfault in `check_time`):

<img width="1009" height="303" alt="image" src="https://github.com/user-attachments/assets/d73a2df3-6e5b-41cb-8ab2-5507096b9bd7" />

And of course we don't get a coredump upon SIGINT or SIGTERM.
