### PR TITLE
Remove a prefetch call in do_move

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -36,7 +36,6 @@
 #include "misc.h"
 #include "movegen.h"
 #include "syzygy/tbprobe.h"
-#include "tt.h"
 #include "uci.h"
 
 using std::string;
@@ -704,15 +703,14 @@ bool Position::gives_check(Move m) const {
 // Makes a move, and saves all information necessary
 // to a StateInfo object. The move is assumed to be legal. Pseudo-legal
 // moves should be filtered out before this function is called.
-// If a pointer to the TT table is passed, the entry for the new position
-// will be prefetched, and likewise for shared history.
-void Position::do_move(Move                      m,
-                       StateInfo&                newSt,
-                       bool                      givesCheck,
-                       DirtyPiece&               dp,
-                       DirtyThreats&             dts,
-                       const TranspositionTable* tt      = nullptr,
-                       const SharedHistories*    history = nullptr) {
+// If a pointer to shared history is passed, relevant entries for the new
+// position will be prefetched.
+void Position::do_move(Move                   m,
+                       StateInfo&             newSt,
+                       bool                   givesCheck,
+                       DirtyPiece&            dp,
+                       DirtyThreats&          dts,
+                       const SharedHistories* history = nullptr) {
 
     assert(m.is_ok());
     assert(&newSt != st);
@@ -909,8 +907,6 @@ void Position::do_move(Move                      m,
 
     // Update the key with the final value
     st->key = k;
-    if (tt)
-        prefetch(tt->first_entry(key()));
 
     if (history)
     {

--- a/src/position.h
+++ b/src/position.h
@@ -32,7 +32,6 @@
 
 namespace Stockfish {
 
-class TranspositionTable;
 struct SharedHistories;
 
 // StateInfo struct stores information needed to restore a Position object to
@@ -134,14 +133,13 @@ class Position {
     Piece captured_piece() const;
 
     // Doing and undoing moves
-    void do_move(Move m, StateInfo& newSt, const TranspositionTable* tt);
-    void do_move(Move                      m,
-                 StateInfo&                newSt,
-                 bool                      givesCheck,
-                 DirtyPiece&               dp,
-                 DirtyThreats&             dts,
-                 const TranspositionTable* tt,
-                 const SharedHistories*    worker);
+    void do_move(Move m, StateInfo& newSt);
+    void do_move(Move                   m,
+                 StateInfo&             newSt,
+                 bool                   givesCheck,
+                 DirtyPiece&            dp,
+                 DirtyThreats&          dts,
+                 const SharedHistories* worker);
     void undo_move(Move m);
     void do_null_move(StateInfo& newSt);
     void undo_null_move();
@@ -402,9 +400,9 @@ inline void Position::swap_piece(Square s, Piece pc, DirtyThreats* const dts) {
         update_piece_threats<true, false>(pc, s, dts);
 }
 
-inline void Position::do_move(Move m, StateInfo& newSt, const TranspositionTable* tt = nullptr) {
+inline void Position::do_move(Move m, StateInfo& newSt) {
     new (&scratch_dts) DirtyThreats;
-    do_move(m, newSt, gives_check(m), scratch_dp, scratch_dts, tt, nullptr);
+    do_move(m, newSt, gives_check(m), scratch_dp, scratch_dts, nullptr);
 }
 
 inline StateInfo* Position::state() const { return st; }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -554,7 +554,7 @@ void Search::Worker::do_move(
     nodes.store(nodes.load(std::memory_order_relaxed) + 1, std::memory_order_relaxed);
 
     auto [dirtyPiece, dirtyThreats] = accumulatorStack.push();
-    pos.do_move(move, st, givesCheck, dirtyPiece, dirtyThreats, &tt, &sharedHistory);
+    pos.do_move(move, st, givesCheck, dirtyPiece, dirtyThreats, &sharedHistory);
 
     if (ss != nullptr)
     {
@@ -2192,7 +2192,7 @@ bool RootMove::extract_ponder_from_tt(const TranspositionTable& tt, Position& po
     if (pv[0] == Move::none())
         return false;
 
-    pos.do_move(pv[0], st, &tt);
+    pos.do_move(pv[0], st);
 
     auto [ttHit, ttData, ttWriter] = tt.probe(pos.key());
     if (ttHit)


### PR DESCRIPTION
Passed a non-regression STC:

LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 31072 W: 8128 L: 7910 D: 15034
Ptnml(0-2): 83, 3326, 8508, 3528, 91
https://tests.stockfishchess.org/tests/view/696a0f72fa8ace4d6d448177

Passed a non-regression STC SMP:

sprt @ 5+0.05 th 8, Hash=512

LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 89744 W: 23069 L: 22915 D: 43760
Ptnml(0-2): 101, 10107, 24308, 10249, 107
https://tests.stockfishchess.org/tests/view/696cb5da942b47defb5a9401

No functional change.