### PR TITLE
refactor `update_piece_threats` to reduce branching

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1153,7 +1153,6 @@ void Position::update_piece_threats(Piece                     pc,
     write_multiple_dirties<DirtyThreat::PcSqOffset, DirtyThreat::PcOffset>(*this, all_attackers,
                                                                            dt_template, dts);
 #else
-#error "AVX512ICL only"
     while (threatened)
     {
         Square threatenedSq = pop_lsb(threatened);


### PR DESCRIPTION
According to benchmarks measured by @Torom (AMD Ryzen 9 9950X3D)

1 thread bench
```
sf_base =  2238429 +/-   1221 (95%)
sf_test =  2248298 +/-   1371 (95%)
diff    =     9869 +/-   1571 (95%)
speedup = 0.44090% +/- 0.070% (95%)
```
32 threads speedtest
```
sf_base = 41016996 +/-  83654 (95%)
sf_test = 41185801 +/-  84269 (95%)
diff    =   168805 +/-  79986 (95%)
speedup = 0.41155% +/- 0.195% (95%)
```

Passed STC Non-Regression:
https://tests.stockfishchess.org/tests/view/696f1a398b64097dacd231c3
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 122272 W: 31587 L: 31466 D: 59219
Ptnml(0-2): 301, 13358, 33750, 13373, 354

No functional change.