### PR TITLE
Simplify away the special case for en passant in the legality check

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -673,24 +673,6 @@ bool Position::legal(Move m) const {
     assert(color_of(moved_piece(m)) == us);
     assert(piece_on(square<KING>(us)) == make_piece(us, KING));
 
-    // En passant captures are a tricky special case. Because they are rather
-    // uncommon, we do it simply by testing whether the king is attacked after
-    // the move is made.
-    if (m.type_of() == EN_PASSANT)
-    {
-        Square   ksq      = square<KING>(us);
-        Square   capsq    = to - pawn_push(us);
-        Bitboard occupied = (pieces() ^ from ^ capsq) | to;
-
-        assert(to == ep_square());
-        assert(moved_piece(m) == make_piece(us, PAWN));
-        assert(piece_on(capsq) == make_piece(~us, PAWN));
-        assert(piece_on(to) == NO_PIECE);
-
-        return !(attacks_bb<ROOK>(ksq, occupied) & pieces(~us, QUEEN, ROOK))
-            && !(attacks_bb<BISHOP>(ksq, occupied) & pieces(~us, QUEEN, BISHOP));
-    }
-
     // Castling moves generation does not check if the castling path is clear of
     // enemy attacks, it is delayed at a later time: now!
     if (m.type_of() == CASTLING)


### PR DESCRIPTION
Since as of 94175524b1c06f1a4ce80a5640272a15120dcbbd the en passant square is only set if there is a legal en passant capture, the special handling is redundant

Passed Non-Regression STC:
https://tests.stockfishchess.org/tests/view/696ffb6512ee1f6231b96fe8
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 79072 W: 20380 L: 20210 D: 38482.

No functional change