### PR TITLE
Simplify en passant square update in Position::do_move().

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -205,6 +205,7 @@ Patrick Jansen (mibere)
 Patrick Leonhardt (Yoshie2000)
 Peter Schneider (pschneider1968)
 Peter Zsifkovits (CoffeeOne)
+Pieter te Brake (pieterteb)
 PikaCat
 Praveen Kumar Tummala (praveentml)
 Prokop Randáček (ProkopRandacek)


### PR DESCRIPTION
Passed non-regression STC:

LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 119680 W: 31011 L: 30884 D: 57785
Ptnml(0-2): 354, 13231, 32575, 13294, 386
https://tests.stockfishchess.org/tests/view/6973b06c6cd60a8e97ca62e5

Bench: 2050811