### PR TITLE
Branchless correction history update

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -114,13 +114,14 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    if (m.is_ok())
-    {
-        const Square to = m.to_sq();
-        const Piece  pc = pos.piece_on(m.to_sq());
-        (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus * 127 / 128;
-        (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus * 59 / 128;
-    }
+    // Branchless: use mask to zero bonus when move is not ok
+    const int    mask   = int(m.is_ok());
+    const Square to     = m.to_sq();
+    const Piece  pc     = pos.piece_on(to);
+    const int    bonus2 = (bonus * 127 / 128) * mask;
+    const int    bonus4 = (bonus * 59 / 128) * mask;
+    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
+    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness


### PR DESCRIPTION
Bench: 2050811

This is purely a debranching optimization: the bench value is the same as on master. 

Passed STC: https://tests.stockfishchess.org/tests/live_elo/6974dfc798dc5fff1dba5b74
```
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 92384 W: 24052 L: 23665 D: 44667
Ptnml(0-2): 265, 10229, 24831, 10588, 279
```

Shows `stockfish speedtest` mean gains on 4 platforms tested: https://github.com/official-stockfish/Stockfish/discussions/6566
| Platform | Mean NPS | Probes | vs Master |
|----------|----------|--------|-----------|
| Ryzen | 33,612,856 | 10 | +0.24% |
| Arrow | 23,172,319 | 10 | -0.07% |
| Sapphire | 13,241,589 | 3 | +0.45% |
| Cascade  | 17,139,182 | 8 | -0.14% |
| **Mean** | | | **+0.12%** |
