### PR TITLE
Threat accumulator: 2-way unroll for AVX-512 ICL (optimization only)

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -370,22 +370,71 @@ struct AccumulatorUpdateContext {
             for (IndexType k = 0; k < Tiling::NumRegs; ++k)
                 acc[k] = fromTile[k];
 
+    #if defined(USE_AVX512ICL)
+            // AVX-512 ICL: 2-way unroll to break dependency chains
+            {
+                int i = 0;
+                for (; i + 1 < removed.ssize(); i += 2)
+                {
+                    const size_t offset0 = Dimensions * removed[i];
+                    const size_t offset1 = Dimensions * removed[i + 1];
+                    auto*        col0 = reinterpret_cast<const vec_i8_t*>(&threatWeights[offset0]);
+                    auto*        col1 = reinterpret_cast<const vec_i8_t*>(&threatWeights[offset1]);
+
+                    for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+                    {
+                        acc[k] = vec_sub_16(acc[k], vec_convert_8_16(col0[k]));
+                        acc[k] = vec_sub_16(acc[k], vec_convert_8_16(col1[k]));
+                    }
+                }
+                for (; i < removed.ssize(); ++i)
+                {
+                    const size_t offset = Dimensions * removed[i];
+                    auto*        column = reinterpret_cast<const vec_i8_t*>(&threatWeights[offset]);
+                    for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+                        acc[k] = vec_sub_16(acc[k], vec_convert_8_16(column[k]));
+                }
+            }
+            {
+                int i = 0;
+                for (; i + 1 < added.ssize(); i += 2)
+                {
+                    const size_t offset0 = Dimensions * added[i];
+                    const size_t offset1 = Dimensions * added[i + 1];
+                    auto*        col0 = reinterpret_cast<const vec_i8_t*>(&threatWeights[offset0]);
+                    auto*        col1 = reinterpret_cast<const vec_i8_t*>(&threatWeights[offset1]);
+
+                    for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+                    {
+                        acc[k] = vec_add_16(acc[k], vec_convert_8_16(col0[k]));
+                        acc[k] = vec_add_16(acc[k], vec_convert_8_16(col1[k]));
+                    }
+                }
+                for (; i < added.ssize(); ++i)
+                {
+                    const size_t offset = Dimensions * added[i];
+                    auto*        column = reinterpret_cast<const vec_i8_t*>(&threatWeights[offset]);
+                    for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+                        acc[k] = vec_add_16(acc[k], vec_convert_8_16(column[k]));
+                }
+            }
+    #else
             for (int i = 0; i < removed.ssize(); ++i)
             {
                 size_t       index  = removed[i];
                 const size_t offset = Dimensions * index;
                 auto*        column = reinterpret_cast<const vec_i8_t*>(&threatWeights[offset]);
 
-    #ifdef USE_NEON
+        #ifdef USE_NEON
                 for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
                 {
                     acc[k]     = vec_sub_16(acc[k], vmovl_s8(vget_low_s8(column[k / 2])));
                     acc[k + 1] = vec_sub_16(acc[k + 1], vmovl_high_s8(column[k / 2]));
                 }
-    #else
+        #else
                 for (IndexType k = 0; k < Tiling::NumRegs; ++k)
                     acc[k] = vec_sub_16(acc[k], vec_convert_8_16(column[k]));
-    #endif
+        #endif
             }
 
             for (int i = 0; i < added.ssize(); ++i)
@@ -394,17 +443,18 @@ struct AccumulatorUpdateContext {
                 const size_t offset = Dimensions * index;
                 auto*        column = reinterpret_cast<const vec_i8_t*>(&threatWeights[offset]);
 
-    #ifdef USE_NEON
+        #ifdef USE_NEON
                 for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
                 {
                     acc[k]     = vec_add_16(acc[k], vmovl_s8(vget_low_s8(column[k / 2])));
                     acc[k + 1] = vec_add_16(acc[k + 1], vmovl_high_s8(column[k / 2]));
                 }
-    #else
+        #else
                 for (IndexType k = 0; k < Tiling::NumRegs; ++k)
                     acc[k] = vec_add_16(acc[k], vec_convert_8_16(column[k]));
-    #endif
+        #endif
             }
+    #endif
 
             for (IndexType k = 0; k < Tiling::NumRegs; k++)
                 vec_store(&toTile[k], acc[k]);


### PR DESCRIPTION
This is a code optimization: on avx512icl, via IFDEF, native instructions are used to increase performance via dependency-breaking idioms. No program logic changed, bench remains the same as on master from which this pull request is based (Bench: 2050811).

Passed STC: https://tests.stockfishchess.org/tests/view/6976a1f798dc5fff1dba5eb2
```
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 76448 W: 19809 L: 19446 D: 37193
Ptnml(0-2): 204, 8463, 20533, 8814, 210
```

Further tests confirmed that this optimization is for avx512icl, not earlier AVX-512 processor and not for AVX-2 or AVX-VNNI:

https://tests.stockfishchess.org/tests/view/6977a2e0a2c75f923be1e2e6
https://tests.stockfishchess.org/tests/view/6978a7c8a2c75f923be1e442
