### PR TITLE
Branchless correction history with to_sq_unchecked

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -114,13 +114,14 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    if (m.is_ok())
-    {
-        const Square to = m.to_sq();
-        const Piece  pc = pos.piece_on(m.to_sq());
-        (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus * 127 / 128;
-        (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus * 59 / 128;
-    }
+    // Branchless: use mask to zero bonus when move is not ok
+    const int    mask   = int(m.is_ok());
+    const Square to     = m.to_sq_unchecked();
+    const Piece  pc     = pos.piece_on(to);
+    const int    bonus2 = (bonus * 127 / 128) * mask;
+    const int    bonus4 = (bonus * 59 / 128) * mask;
+    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
+    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness

--- a/src/types.h
+++ b/src/types.h
@@ -449,6 +449,10 @@ class Move {
         return Square(data & 0x3F);
     }
 
+    // Same as to_sq() but without assertion, for branchless code paths
+    // where the result is masked/ignored when move is not ok
+    constexpr Square to_sq_unchecked() const { return Square(data & 0x3F); }
+
     constexpr MoveType type_of() const { return MoveType(data & (3 << 14)); }
 
     constexpr PieceType promotion_type() const { return PieceType(((data >> 12) & 3) + KNIGHT); }


### PR DESCRIPTION
Earlier branch https://github.com/official-stockfish/Stockfish/pull/6567 passed STC but raised assertion in `Move::to_sq` on debug builds. 

STC URL: https://tests.stockfishchess.org/tests/live_elo/6974dfc798dc5fff1dba5b74
```
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 92384 W: 24052 L: 23665 D: 44667
Ptnml(0-2): 265, 10229, 24831, 10588, 279
```

To avoid the assertion, add Move::to_sq_unchecked() that bypasses the is_ok() assertion. This method can be used in branchless code paths where invalid moves are masked out, such as this one.

Bench: 2050811