### PR TITLE
Compiler optimization: cache occupied bitboard in set_check_info

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -326,11 +326,16 @@ void Position::set_check_info() const {
 
     Square ksq = square<KING>(~sideToMove);
 
+    // Cache pieces() call for bishop and rook attacks
+    const Bitboard occupied = pieces();
+    const Bitboard bishopAtk = attacks_bb<BISHOP>(ksq, occupied);
+    const Bitboard rookAtk   = attacks_bb<ROOK>(ksq, occupied);
+
     st->checkSquares[PAWN]   = attacks_bb<PAWN>(ksq, ~sideToMove);
     st->checkSquares[KNIGHT] = attacks_bb<KNIGHT>(ksq);
-    st->checkSquares[BISHOP] = attacks_bb<BISHOP>(ksq, pieces());
-    st->checkSquares[ROOK]   = attacks_bb<ROOK>(ksq, pieces());
-    st->checkSquares[QUEEN]  = st->checkSquares[BISHOP] | st->checkSquares[ROOK];
+    st->checkSquares[BISHOP] = bishopAtk;
+    st->checkSquares[ROOK]   = rookAtk;
+    st->checkSquares[QUEEN]  = bishopAtk | rookAtk;
     st->checkSquares[KING]   = 0;
 }
 


### PR DESCRIPTION
This is a compiler optimization where values are stored in variable and than reused, which allows compilers to use larger registers: 256 bits instead of 64 bits. This gives small but statistically significant gains on avx512icl clang, with no benefit on gcc and mixed results on other architectures. Still, the source code change provides simpler and easier to understand refactoring where a value is calculated once and stored in a variable for reuse instead of calculated in-place several times.

## Local Speedtest Results (Multi-threaded)

| Platform | Architecture | Compiler | Threads | Branch NPS | Master NPS | Delta |
|----------|--------------|----------|---------|------------|------------|-------|
| Ryzen Zen 4 | x86-64-avx512icl | clang++ 22.0.0 | 32 | 33,798,219 | 33,676,610 | **+0.36%** |
| Arrow Lake | x86-64-avxvnni | clang++ 22.0.0 | 20 | 22,694,573 | 22,731,284 | -0.16% |
| Cascade Lake | x86-64-vnni512 | clang++ 22.0.0 | 36 | 17,085,515 | 17,173,417 | -0.51% |
| Sapphire Rapids  | x86-64-avx512icl | clang++ 22.0.0 | 48 | 25,740,272 | 25,721,679 | **+0.07%** |

**Summary:** Mixed results in multi-threaded speedtest. Positive on Ryzen (+0.36%) and Rapids (+0.07%), negative on Arrow (-0.16%) and Cascade (-0.51%). Mean: -0.06%. Multi-threaded speedtest results often don't correlate with single-threaded Fishtest Elo.

---

## Fishtest Results (Single-threaded)

**Test ID:** [69760ace98dc5fff1dba5d88](https://tests.stockfishchess.org/tests/view/69760ace98dc5fff1dba5d88)
**Status:** Running
**TC:** 10+0.1 (1 thread)

### Overall Statistics

| Metric | Value |
|--------|-------|
| LLR | 1.01 (-2.94, 2.94) |
| SPRT Bounds | <0.00, 2.00> |
| Total Games | 207,264 |
| Win-Loss-Draw | 53,484 - 53,101 - 100,391 (25.8% - 25.7% - 48.5%) |
| Pentanomial | [602, 22,923, 56,258, 23,182, 667] |
| Elo | **+0.63** [-0.16, +1.39] (95% CI) |
| LOS | 94.2% |

### Pentanomial Analysis

| Category | Count | Percentage | Meaning |
|----------|-------|------------|---------|
| LL (0) | 602 | 0.58% | Both games lost |
| LD (1) | 22,923 | 22.06% | One loss, one draw |
| DD/WL (2) | 56,258 | 54.15% | Two draws or split |
| WD (3) | 23,182 | 22.31% | One win, one draw |
| WW (4) | 667 | 0.64% | Both games won |

**Win Bias:** (WW+WD) - (LL+LD) = (667+23,182) - (602+22,923) = 23,849 - 23,525 = **+324 pairs**

The slight positive bias in the pentanomial supports the +0.63 Elo estimate.

---

## Fishtest Results by Architecture

Based on worker data (274 completed tasks):

### x86-64-avx512icl (VNNI + AVX-512)

| Compiler | Games | Ptnml [0-4] | Win Pairs | Loss Pairs | Net |
|----------|-------|-------------|-----------|------------|-----|
| clang++ 17-22 | 73,728 | [179, 7,847, 20,102, 8,160, 176] | 8,336 | 8,026 | **+310** |
| g++ 13-15 | 25,408 | [60, 2,654, 6,857, 2,721, 60] | 2,781 | 2,714 | **+67** |
| **Subtotal** | 99,136 | | | | **+377** |

**Estimated Elo (avx512icl):** ~+0.8 Elo (based on win pair surplus)

### x86-64-avx512 (AVX-512 without VNNI)

| Compiler | Games | Ptnml [0-4] | Win Pairs | Loss Pairs | Net |
|----------|-------|-------------|-----------|------------|-----|
| g++ 13-15 | 35,040 | [53, 3,839, 9,580, 3,694, 94] | 3,788 | 3,892 | **-104** |

**Estimated Elo (avx512):** ~-0.6 Elo (slightly negative)

### x86-64-bmi2 (Haswell/Zen)

| Compiler | Games | Ptnml [0-4] | Win Pairs | Loss Pairs | Net |
|----------|-------|-------------|-----------|------------|-----|
| g++ 9-15 | 26,304 | [79, 2,866, 7,111, 2,990, 110] | 3,100 | 2,945 | **+155** |
| clang++ 20-21 | 4,928 | [7, 492, 1,329, 520, 11] | 531 | 499 | **+32** |
| **Subtotal** | 31,232 | | | | **+187** |

**Estimated Elo (bmi2):** ~+1.2 Elo (positive)

### x86-64-avx2 (Zen1/Skylake without BMI2)

| Compiler | Games | Ptnml [0-4] | Win Pairs | Loss Pairs | Net |
|----------|-------|-------------|-----------|------------|-----|
| g++ 12-15 | 26,432 | [73, 2,960, 6,924, 2,859, 92] | 2,951 | 3,033 | **-82** |

**Estimated Elo (avx2):** ~-0.6 Elo (slightly negative)

### x86-64-avxvnni (Arrow Lake/Alder Lake)

| Compiler | Games | Ptnml [0-4] | Win Pairs | Loss Pairs | Net |
|----------|-------|-------------|-----------|------------|-----|
| g++ 14-15 | 8,288 | [26, 904, 2,308, 859, 18] | 877 | 930 | **-53** |
| clang++ 17-21 | 3,328 | [9, 339, 899, 372, 5] | 377 | 348 | **+29** |
| **Subtotal** | 11,616 | | | | **-24** |

**Estimated Elo (avxvnni):** ~-0.4 Elo (slightly negative)

### apple-silicon (ARM NEON with DotProd)

| Compiler | Games | Ptnml [0-4] | Win Pairs | Loss Pairs | Net |
|----------|-------|-------------|-----------|------------|-----|
| clang++ 17 | 1,824 | [2, 196, 481, 158, 3] | 161 | 198 | **-37** |

**Estimated Elo (apple-silicon):** ~-4 Elo (negative, small sample)

### x86-64-sse41-popcnt (Legacy)

| Games | Ptnml [0-4] | Win Pairs | Loss Pairs | Net |
|-------|-------------|-----------|------------|-----|
| 160 | [2, 19, 46, 13, 0] | 13 | 21 | **-8** |

**Estimated Elo (sse41):** ~-10 Elo (very small sample, unreliable)

### armv8-dotprod (Raspberry Pi)

| Games | Ptnml [0-4] | Win Pairs | Loss Pairs | Net |
|-------|-------------|-----------|------------|-----|
| 64 | [0, 8, 18, 6, 0] | 6 | 8 | **-2** |

**Estimated Elo (armv8):** Insufficient data

---

## Architecture Distribution and Weights

### Architecture Summary Table

| # | Architecture | Games | Weight | Game Pairs | Net Pairs | Est. Elo | Weighted Elo |
|---|--------------|-------|--------|------------|-----------|----------|--------------|
| 1 | x86-64-avx512icl | 99,136 | **47.8%** | 49,568 | +377 | +0.8 | +0.38 |
| 2 | x86-64-avx512 | 35,040 | **16.9%** | 17,520 | -104 | -0.6 | -0.10 |
| 3 | x86-64-bmi2 | 31,232 | **15.1%** | 15,616 | +187 | +1.2 | +0.18 |
| 4 | x86-64-avx2 | 26,432 | **12.7%** | 13,216 | -82 | -0.6 | -0.08 |
| 5 | x86-64-avxvnni | 11,616 | **5.6%** | 5,808 | -24 | -0.4 | -0.02 |
| 6 | apple-silicon | 1,824 | **0.9%** | 912 | -37 | -4.0 | -0.04 |
| 7 | x86-64-sse41-popcnt | 160 | 0.1% | 80 | -8 | -10.0 | -0.01 |
| 8 | armv8-dotprod | 64 | 0.0% | 32 | -2 | -- | -- |
| | **Total** | **207,264** | **100%** | **103,632** | **+324** | -- | **+0.31** |

### Weight Distribution Visualization

```
x86-64-avx512icl  [########################::::::::::::::::::::] 47.8%
x86-64-avx512     [########::::::::::::::::::::::::::::::::::::] 16.9%
x86-64-bmi2       [#######:::::::::::::::::::::::::::::::::::::] 15.1%
x86-64-avx2       [######::::::::::::::::::::::::::::::::::::::] 12.7%
x86-64-avxvnni    [##::::::::::::::::::::::::::::::::::::::::::] 5.6%
apple-silicon     [::::::::::::::::::::::::::::::::::::::::::::] 0.9%
other             [::::::::::::::::::::::::::::::::::::::::::::] 0.1%
```

### Weighted Elo Contribution

The overall +0.63 Elo is composed of:

| Architecture | Weight | Arch Elo | Contribution |
|--------------|--------|----------|--------------|
| x86-64-avx512icl | 47.8% | +0.8 | **+0.38** |
| x86-64-bmi2 | 15.1% | +1.2 | **+0.18** |
| x86-64-avx512 | 16.9% | -0.6 | -0.10 |
| x86-64-avx2 | 12.7% | -0.6 | -0.08 |
| x86-64-avxvnni | 5.6% | -0.4 | -0.02 |
| apple-silicon | 0.9% | -4.0 | -0.04 |
| other | 0.1% | -10.0 | -0.01 |
| **Sum** | 100% | -- | **+0.31** |


## Compiler Distribution and Performance

### Overall by Compiler

| Compiler | Games | % of Total | Ptnml [0-4] | Win Pairs | Loss Pairs | Net | Est. Elo |
|----------|-------|------------|-------------|-----------|------------|-----|----------|
| **clang++** | 83,680 | 40.4% | [197, 8,874, 22,811, 9,210, 195] | 9,405 | 9,071 | **+334** | **+0.8** |
| **g++** | 123,584 | 59.6% | [405, 14,049, 33,447, 13,972, 472] | 14,444 | 14,454 | **-10** | **0.0** |

### Clang++ Version Breakdown

| Version | Games | Ptnml [0-4] | Net Win Pairs | Est. Elo |
|---------|-------|-------------|---------------|----------|
| clang++ 22.0.0 | 55,680 | [113, 5,870, 15,203, 6,109, 125] | +251 | **+0.9** |
| clang++ 20.1.x | 8,096 | [14, 827, 2,189, 912, 20] | +91 | **+2.2** |
| clang++ 17.0.x | 17,856 | [61, 1,983, 4,873, 1,990, 45] | -9 | -0.1 |
| clang++ 21.1.8 | 2,048 | [9, 194, 546, 199, 5] | +1 | +0.1 |

### GCC Version Breakdown

| Version | Games | Ptnml [0-4] | Net Win Pairs | Est. Elo |
|---------|-------|-------------|---------------|----------|
| g++ 15.2.x | 42,112 | [130, 4,632, 11,302, 4,768, 162] | +168 | **+0.8** |
| g++ 14.2.x | 14,208 | [39, 1,566, 3,864, 1,545, 38] | -22 | -0.3 |
| g++ 13.3.x | 55,680 | [190, 6,242, 15,034, 6,036, 218] | -178 | **-0.6** |
| g++ 12.2.0 | 4,576 | [15, 496, 1,224, 504, 17] | +10 | +0.4 |
| g++ 9.4.0 | 288 | [1, 14, 81, 48, 0] | +33 | +22.9 (unreliable) |

### Compiler x Architecture Cross-Analysis

| Architecture | clang++ Games | clang++ Elo | g++ Games | g++ Elo | Delta |
|--------------|---------------|-------------|-----------|---------|-------|
| x86-64-avx512icl | 73,728 | **+0.8** | 25,408 | +0.5 | clang +0.3 |
| x86-64-avx512 | 0 | -- | 35,040 | -0.6 | -- |
| x86-64-bmi2 | 4,928 | +1.3 | 26,304 | **+1.2** | similar |
| x86-64-avx2 | 0 | -- | 26,432 | -0.6 | -- |
| x86-64-avxvnni | 3,328 | **+1.7** | 8,288 | -1.3 | clang +3.0 |
| apple-silicon | 1,824 | -4.0 | 0 | -- | -- |


## Assembly differences caused by the change (clang 22.0.0)
### Master (scalar stores):
```asm
mov    %rax,0x80(%r8)      # checkSquares[PAWN]
mov    %r10,0x88(%r8)      # checkSquares[KNIGHT]
mov    %r11,0x90(%r8)      # checkSquares[BISHOP]
mov    %r9,0x98(%r8)       # checkSquares[ROOK]
or     %r11,%r9
mov    %r9,0xa0(%r8)       # checkSquares[QUEEN]
```

### inline-check-squares (AVX-512 vector stores):
```asm
vmovq  %r9,%xmm2
vmovq  (%r11,%rax,8),%xmm0
vpinsrq $0x1,0x400(%r11,%r10,8),%xmm0,%xmm3
vpinsrq $0x1,%rdx,%xmm2,%xmm1
or     %r9,%rdx
mov    %rdx,0xa0(%rcx)              # checkSquares[QUEEN]
vinserti64x2 $0x1,%xmm1,%ymm3,%ymm4 # pack 4 values
vmovdqu %ymm4,0x80(%rcx)            # single 256-bit store for PAWN,KNIGHT,BISHOP,ROOK
vzeroupper
```
