### PR TITLE
avoid modify_and_replicate for first load

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -63,10 +63,7 @@ Engine::Engine(std::optional<std::string> path) :
     numaContext(NumaConfig::from_system(DefaultNumaPolicy)),
     states(new std::deque<StateInfo>(1)),
     threads(),
-    networks(numaContext,
-             // Heap-allocate because sizeof(NN::Networks) is large
-             std::make_unique<NN::Networks>(NN::EvalFile{EvalFileDefaultNameBig, "None", ""},
-                                            NN::EvalFile{EvalFileDefaultNameSmall, "None", ""})) {
+    networks(numaContext, get_default_networks()) {
 
     pos.set(StartFEN, false, &states->back());
 
@@ -147,7 +144,8 @@ Engine::Engine(std::optional<std::string> path) :
           return std::nullopt;
       }));
 
-    load_networks();
+    threads.clear();
+    threads.ensure_network_replicated();
     resize_threads();
 }
 
@@ -294,13 +292,16 @@ void Engine::verify_networks() const {
     }
 }
 
-void Engine::load_networks() {
-    networks.modify_and_replicate([this](NN::Networks& networks_) {
-        networks_.big.load(binaryDirectory, options["EvalFile"]);
-        networks_.small.load(binaryDirectory, options["EvalFileSmall"]);
-    });
-    threads.clear();
-    threads.ensure_network_replicated();
+std::unique_ptr<Eval::NNUE::Networks> Engine::get_default_networks() const {
+
+    auto networks_ =
+      std::make_unique<NN::Networks>(NN::EvalFile{EvalFileDefaultNameBig, "None", ""},
+                                     NN::EvalFile{EvalFileDefaultNameSmall, "None", ""});
+
+    networks_->big.load(binaryDirectory, "");
+    networks_->small.load(binaryDirectory, "");
+
+    return networks_;
 }
 
 void Engine::load_big_network(const std::string& file) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -85,10 +86,10 @@ class Engine {
 
     // network related
 
-    void verify_networks() const;
-    void load_networks();
-    void load_big_network(const std::string& file);
-    void load_small_network(const std::string& file);
+    void                                  verify_networks() const;
+    std::unique_ptr<Eval::NNUE::Networks> get_default_networks() const;
+    void                                  load_big_network(const std::string& file);
+    void                                  load_small_network(const std::string& file);
     void save_network(const std::pair<std::optional<std::string>, std::string> files[2]);
 
     // utility functions


### PR DESCRIPTION
We call `modify_and_replicate` in `load_networks`, but this is quite inefficient.