### PR TITLE
Simplification - Use raw reduction value

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -751,9 +751,9 @@ Value Search::Worker::search(
     opponentWorsening = ss->staticEval > -(ss - 1)->staticEval;
 
     // Hindsight adjustment of reductions based on static evaluation difference.
-    if (priorReduction >= 3 && !opponentWorsening)
+    if (priorReduction >= 3200 && !opponentWorsening)
         depth++;
-    if (priorReduction >= 2 && depth >= 2 && ss->staticEval + (ss - 1)->staticEval > 173)
+    if (priorReduction >= 2000 && depth >= 2 && ss->staticEval + (ss - 1)->staticEval > 173)
         depth--;
 
     // At non-PV nodes we check for an early TT cutoff
@@ -929,7 +929,7 @@ Value Search::Worker::search(
     // Step 10. Internal iterative reductions
     // At sufficient depth, reduce depth for PV/Cut nodes without a TTMove.
     // (*Scaler) Making IIR more aggressive scales poorly.
-    if (!allNode && depth >= 6 && !ttData.move && priorReduction <= 3)
+    if (!allNode && depth >= 6 && !ttData.move && priorReduction <= 3072)
         depth--;
 
     // Step 11. ProbCut
@@ -1237,7 +1237,7 @@ moves_loop:  // When in check, search starts here
             // std::clamp has been replaced by a more robust implementation.
             Depth d = std::max(1, std::min(newDepth - r / 1024, newDepth + 2)) + PvNode;
 
-            ss->reduction = newDepth - d;
+            ss->reduction = r;
             value         = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);
             ss->reduction = 0;
 


### PR DESCRIPTION
Simplification - Use raw reduction value
And at the same time, it also improves tunability due to the increase in granularity.

Passed STC:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 99968 W: 25859 L: 25708 D: 48401
Ptnml(0-2): 296, 11741, 25760, 11890, 297
https://tests.stockfishchess.org/tests/view/697b9de65f56030af97b54ac

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 73326 W: 18709 L: 18542 D: 36075
Ptnml(0-2): 30, 8017, 20401, 8186, 29
https://tests.stockfishchess.org/tests/view/697cbee75f56030af97b56d6

bench: 2638451