### PR TITLE
Include threat weights in network hash calculation

### DIFF
--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -218,10 +218,19 @@ class FeatureTransformer {
 
     std::size_t get_content_hash() const {
         std::size_t h = 0;
+
         hash_combine(h, get_raw_data_hash(biases));
         hash_combine(h, get_raw_data_hash(weights));
         hash_combine(h, get_raw_data_hash(psqtWeights));
+
+        if constexpr (UseThreats)
+        {
+            hash_combine(h, get_raw_data_hash(threatWeights));
+            hash_combine(h, get_raw_data_hash(threatPsqtWeights));
+        }
+
         hash_combine(h, get_hash_value());
+
         return h;
     }
 


### PR DESCRIPTION
Fix issue where threat weights are not part of network hash calculation.

This issue causes a shared memory collision for networks that only differ in threat weights.

No functional change