### PR TITLE
Simplify attackers_to_exist function (code optimization and simplification change by removing code)

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -513,13 +513,10 @@ Bitboard Position::attackers_to(Square s, Bitboard occupied) const {
 
 bool Position::attackers_to_exist(Square s, Bitboard occupied, Color c) const {
 
-    return ((attacks_bb<ROOK>(s) & pieces(c, ROOK, QUEEN))
-            && (attacks_bb<ROOK>(s, occupied) & pieces(c, ROOK, QUEEN)))
-        || ((attacks_bb<BISHOP>(s) & pieces(c, BISHOP, QUEEN))
-            && (attacks_bb<BISHOP>(s, occupied) & pieces(c, BISHOP, QUEEN)))
-        || (((attacks_bb<PAWN>(s, ~c) & pieces(PAWN)) | (attacks_bb<KNIGHT>(s) & pieces(KNIGHT))
-             | (attacks_bb<KING>(s) & pieces(KING)))
-            & pieces(c));
+    return (attacks_bb<ROOK>(s, occupied) & pieces(c, ROOK, QUEEN))
+        || (attacks_bb<BISHOP>(s, occupied) & pieces(c, BISHOP, QUEEN))
+        || (attacks_bb<PAWN>(s, ~c) & pieces(c, PAWN))
+        || (attacks_bb<KNIGHT>(s) & pieces(c, KNIGHT)) || (attacks_bb<KING>(s) & pieces(c, KING));
 }
 
 // Tests whether a pseudo-legal move is legal


### PR DESCRIPTION
!!! Note: need to pass sanity check after implementing Copilots's suggestion: https://tests.stockfishchess.org/tests/view/6988a215b0f3ca5200aafbb9
!!! Another sanity check after implementing suggestion by @mstembera https://github.com/maximmasiutin/Stockfish/commit/bca2483a35cc30e6b7ea2d4e067e6f3e724925a8#commitcomment-176778292:
https://tests.stockfishchess.org/tests/view/698b716c56863066050fb346


This pull request is code optimization and simplification change by removing code.

There were two checks. First check was faster to avoid executing code of the second check, which was slower and combined both checks. On modern CPUs, branching is expensive. As such avoiding branch overhead may be more beneficial.

Passed STC: https://tests.stockfishchess.org/tests/view/697a7e6e5f56030af97b52c9
```
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 169504 W: 43652 L: 43581 D: 82271
Ptnml(0-2): 456, 18775, 46230, 18824, 467
```

Passed LTC: https://tests.stockfishchess.org/tests/view/697de0325f56030af97b5958
```
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 148812 W: 38084 L: 37996 D: 72732
Ptnml(0-2): 87, 14910, 44318, 15010, 81
```