### PR TITLE
Update castling rights unconditionally.

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -813,13 +813,10 @@ void Position::do_move(Move                      m,
         st->epSquare = SQ_NONE;
     }
 
-    // Update castling rights if needed
-    if (st->castlingRights && (castlingRightsMask[from] | castlingRightsMask[to]))
-    {
-        k ^= Zobrist::castling[st->castlingRights];
-        st->castlingRights &= ~(castlingRightsMask[from] | castlingRightsMask[to]);
-        k ^= Zobrist::castling[st->castlingRights];
-    }
+    // Update castling rights.
+    k ^= Zobrist::castling[st->castlingRights];
+    st->castlingRights &= ~(castlingRightsMask[from] | castlingRightsMask[to]);
+    k ^= Zobrist::castling[st->castlingRights];
 
     // Move the piece. The tricky Chess960 castling is handled earlier
     if (m.type_of() != CASTLING)


### PR DESCRIPTION
Passed non-regression STC: https://tests.stockfishchess.org/tests/view/697e6f4e5f56030af97b5a3c
```
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 163680 W: 42214 L: 42137 D: 79329
Ptnml(0-2): 454, 18054, 44734, 18157, 441
```

No functional change.