### PR TITLE
Simplify away main history default

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -65,7 +65,6 @@ using namespace Search;
 namespace {
 
 constexpr int SEARCHEDLIST_CAPACITY = 32;
-constexpr int mainHistoryDefault    = 68;
 using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 
 // (*Scalers):
@@ -315,8 +314,7 @@ void Search::Worker::iterative_deepening() {
 
     for (Color c : {WHITE, BLACK})
         for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
-            mainHistory[c][i] =
-              (mainHistory[c][i] - mainHistoryDefault) * 3 / 4 + mainHistoryDefault;
+            mainHistory[c][i] = mainHistory[c][i] * 3 / 4;
 
     // Iterative deepening loop until requested to stop or the target depth is reached
     while (++rootDepth < MAX_PLY && !threads.stop
@@ -584,7 +582,7 @@ void Search::Worker::undo_null_move(Position& pos) { pos.undo_null_move(); }
 
 // Reset histories, usually before a new game
 void Search::Worker::clear() {
-    mainHistory.fill(mainHistoryDefault);
+    mainHistory.fill(0);
     captureHistory.fill(-689);
 
     // Each thread is responsible for clearing their part of shared history


### PR DESCRIPTION
Simplify away main history default

Passed non-regression STC
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 130752 W: 33725 L: 33605 D: 63422
Ptnml(0-2): 421, 15472, 33460, 15612, 411 
https://tests.stockfishchess.org/tests/view/697eb9e35f56030af97b5a9e

Passed non-regression LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 53352 W: 13697 L: 13509 D: 26146
Ptnml(0-2): 36, 5804, 14811, 5986, 39 
https://tests.stockfishchess.org/tests/view/6980e5846362aee5c8a55396

bench 2488430