### PR TITLE
Fix Clang-Format Complaints

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -80,7 +80,7 @@ HEADERS = benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.h history.
 		nnue/layers/clipped_relu.h nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h \
 		nnue/nnue_architecture.h nnue/nnue_common.h nnue/nnue_feature_transformer.h nnue/simd.h \
 		position.h search.h syzygy/tbprobe.h thread.h thread_win32_osx.h timeman.h \
-		tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h engine.h score.h numa.h memory.h
+		tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h engine.h score.h numa.h memory.h shm.h shm_linux.h
 
 OBJS = $(notdir $(SRCS:.cpp=.o))
 

--- a/src/shm.h
+++ b/src/shm.h
@@ -535,7 +535,8 @@ struct SystemWideSharedConstant {
         std::size_t executable_hash = hash_string(getExecutablePathHash());
 
         char buf[1024];
-        std::snprintf(buf, sizeof(buf), "Local\\sf_%zu$%zu$%zu", content_hash, executable_hash, discriminator);
+        std::snprintf(buf, sizeof(buf), "Local\\sf_%zu$%zu$%zu", content_hash, executable_hash,
+                      discriminator);
         std::string shm_name = buf;
 
 #if defined(__linux__) && !defined(__ANDROID__)

--- a/src/shm_linux.h
+++ b/src/shm_linux.h
@@ -20,7 +20,7 @@
 #define SHM_LINUX_H_INCLUDED
 
 #if !defined(__linux__) || defined(__ANDROID__)
-#error shm_linux.h should not be included on this platform.
+    #error shm_linux.h should not be included on this platform.
 #endif
 
 #include <atomic>
@@ -63,14 +63,14 @@ struct ShmHeader {
 
 class SharedMemoryBase {
    public:
-    virtual ~SharedMemoryBase()                      = default;
-    virtual void               close(bool skip_unmap = false) noexcept      = 0;
-    virtual const std::string& name() const noexcept = 0;
+    virtual ~SharedMemoryBase()                                        = default;
+    virtual void               close(bool skip_unmap = false) noexcept = 0;
+    virtual const std::string& name() const noexcept                   = 0;
 };
 
 class SharedMemoryRegistry {
    private:
-    static std::mutex                            registry_mutex_;
+    static std::mutex                     registry_mutex_;
     static std::vector<SharedMemoryBase*> active_instances_;
 
    public:
@@ -82,7 +82,8 @@ class SharedMemoryRegistry {
     static void unregister_instance(SharedMemoryBase* instance) {
         std::scoped_lock lock(registry_mutex_);
         active_instances_.erase(
-            std::remove(active_instances_.begin(), active_instances_.end(), instance), active_instances_.end());
+          std::remove(active_instances_.begin(), active_instances_.end(), instance),
+          active_instances_.end());
     }
 
     static void cleanup_all(bool skip_unmap = false) noexcept {
@@ -93,7 +94,7 @@ class SharedMemoryRegistry {
     }
 };
 
-inline std::mutex                            SharedMemoryRegistry::registry_mutex_;
+inline std::mutex                     SharedMemoryRegistry::registry_mutex_;
 inline std::vector<SharedMemoryBase*> SharedMemoryRegistry::active_instances_;
 
 class CleanupHooks {
@@ -179,7 +180,7 @@ class SharedMemory: public detail::SharedMemoryBase {
     }
 
     static std::string make_sentinel_base(const std::string& name) {
-        char     buf[32];
+        char buf[32];
         // Using std::to_string here causes non-deterministic PGO builds.
         // snprintf, being part of libc, is insensitive to the formatted values.
         std::snprintf(buf, sizeof(buf), "sfshm_%016" PRIu64, hash_string(name));


### PR DESCRIPTION
Somehow we forgot to add `shm.h` & `shm_linux.h` to the headers..