### PR TITLE
Simplify is_ok square validation

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -385,7 +385,7 @@ constexpr Color color_of(Piece pc) {
     return Color(pc >> 3);
 }
 
-constexpr bool is_ok(Square s) { return s >= SQ_A1 && s <= SQ_H8; }
+constexpr bool is_ok(Square s) { return s <= SQ_H8; }
 
 constexpr File file_of(Square s) { return File(s & 7); }
 


### PR DESCRIPTION
Simplify is_ok square validation

Square is defined as an enum : uint8_t. Since SQ_A1 is 0, the condition s >= SQ_A1 is always true for an unsigned type.

No functional change