### PR TITLE
Remove redundant <deque> include in thread.cpp

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -20,7 +20,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <deque>
 #include <map>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Remove redundant <deque> include in thread.cpp

thread.cpp includes "thread.h"
thread.h includes "position.h"
position.h includes <deque>

No functional change