### PR TITLE
Simplify malus decay formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1837,14 +1837,11 @@ void update_all_stats(const Position& pos,
     {
         update_quiet_histories(pos, ss, workerThread, bestMove, bonus * 910 / 1024);
 
-        int i = 0;
+        int actualMalus = malus * 1100 / 1024;
         // Decrease stats for all non-best quiet moves
         for (Move move : quietsSearched)
         {
-            i++;
-            int actualMalus = malus * 1085 / 1024;
-            if (i > 5)
-                actualMalus -= actualMalus * (i - 5) / i;
+            actualMalus = actualMalus * 950 / 1024;
             update_quiet_histories(pos, ss, workerThread, move, -actualMalus);
         }
     }


### PR DESCRIPTION
Simplify malus decay formula

Passed non-regression STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 93600 W: 24165 L: 24007 D: 45428
Ptnml(0-2): 325, 11021, 23958, 11163, 333 
https://tests.stockfishchess.org/tests/view/698121d46362aee5c8a55414

Passed non-regression LTC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 83232 W: 21236 L: 21077 D: 40919
Ptnml(0-2): 46, 9147, 23083, 9282, 58 
https://tests.stockfishchess.org/tests/view/698336dc473df9d1d24a90e8

bench 2685102