### PR TITLE
Added material-keyed correction history.

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -171,12 +171,14 @@ struct CorrectionBundle {
     StatsEntry<T, D, true> minor;
     StatsEntry<T, D, true> nonPawnWhite;
     StatsEntry<T, D, true> nonPawnBlack;
+    StatsEntry<T, D, true> material;
 
     void operator=(T val) {
         pawn         = val;
         minor        = val;
         nonPawnWhite = val;
         nonPawnBlack = val;
+        material     = val;
     }
 };
 
@@ -258,6 +260,13 @@ struct SharedHistories {
     template<Color c>
     const auto& nonpawn_correction_entry(const Position& pos) const {
         return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
+    }
+
+    auto& material_correction_entry(const Position& pos) {
+        return correctionHistory[pos.material_key() & sizeMinus1];
+    }
+    const auto& material_correction_entry(const Position& pos) const {
+        return correctionHistory[pos.material_key() & sizeMinus1];
     }
 
     UnifiedCorrectionHistory correctionHistory;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -85,12 +85,13 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
     const int   micv   = shared.minor_piece_correction_entry(pos).at(us).minor;
     const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite;
     const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack;
+    const int   matcv  = shared.material_correction_entry(pos).at(us).material;
     const int   cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                   : 8;
 
-    return 10347 * pcv + 8821 * micv + 11665 * (wnpcv + bnpcv) + 7841 * cntcv;
+    return 10347 * pcv + 8821 * micv + 11665 * (wnpcv + bnpcv) + 7841 * cntcv + 8500 * matcv;
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -106,13 +107,15 @@ void update_correction_history(const Position& pos,
     const Move  m  = (ss - 1)->currentMove;
     const Color us = pos.side_to_move();
 
-    constexpr int nonPawnWeight = 178;
-    auto&         shared        = workerThread.sharedHistory;
+    constexpr int nonPawnWeight   = 178;
+    constexpr int materialWeight  = 165;
+    auto&         shared          = workerThread.sharedHistory;
 
     shared.pawn_correction_entry(pos).at(us).pawn << bonus;
     shared.minor_piece_correction_entry(pos).at(us).minor << bonus * 156 / 128;
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
+    shared.material_correction_entry(pos).at(us).material<< bonus * materialWeight / 128;
 
     // Branchless: use mask to zero bonus when move is not ok
     const int    mask   = int(m.is_ok());


### PR DESCRIPTION
The material key captures info orthogonal to all existing correction keys so added a new correction history term keyed by material_key, which encodes the exact piece config on the board (ex : KQR vs KRB).

The nnue evaluation can have systematic biases for certain material configurations --for example, consistently over- or under-evaluating positions with queen vs two rook. We might need something to learn these biases during search and correct the static evaluation accordingly.



The material_key already written in Position and is maintained incrementally in do_move / undo_move. 


