### PR TITLE
Simplify material formula in evaluate()

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -77,8 +77,8 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     optimism += optimism * nnueComplexity / 476;
     nnue -= nnue * nnueComplexity / 18236;
 
-    int material = 534 * pos.count<PAWN>() + pos.non_pawn_material();
-    int v        = (nnue * (77871 + material) + optimism * (7191 + material)) / 77871;
+    int material = 560 * pos.count<PAWN>() + pos.non_pawn_material();
+    int v        = nnue + (nnue + optimism) * material / 65536;
 
     // Damp down the evaluation linearly when shuffling
     v -= v * pos.rule50_count() / 199;


### PR DESCRIPTION
Use a simpler formula for the material amplification in evaluation, with only one constant instead of three. Compensate by very slightly tweaking the pawn weight on the previous line.

passed STC:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 34496 W: 8921 L: 8697 D: 16878
Ptnml(0-2): 104, 3933, 8944, 4169, 98
https://tests.stockfishchess.org/tests/view/695853c3d844c1ce7cc7e8d4

passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 239388 W: 60709 L: 60712 D: 117967
Ptnml(0-2): 147, 26271, 66857, 26276, 143
https://tests.stockfishchess.org/tests/view/6958e624d844c1ce7cc7e980

As there was a change of network in the delay between the tests and the pull request, we launched a verification test at STC with the new (post SF18) network:

Verification run (STC):
https://tests.stockfishchess.org/tests/view/6988609db0f3ca5200aafb0e

closes https://github.com/official-stockfish/Stockfish/pull/6604

bench: 2376808