### PR TITLE
Simplify malus formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1832,7 +1832,7 @@ void update_all_stats(const Position& pos,
 
     int bonus =
       std::min(116 * depth - 81, 1515) + 347 * (bestMove == ttMove) + (ss - 1)->statScore / 32;
-    int malus = std::min(848 * depth - 207, 2446) - 17 * moveCount;
+    int malus = std::min(800 * depth - 207, 2200);
 
     if (!pos.capture_stage(bestMove))
     {


### PR DESCRIPTION
Simplify malus formula

Passed non-regression STC
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 51936 W: 13490 L: 13283 D: 25163
Ptnml(0-2): 161, 6128, 13184, 6333, 162 
https://tests.stockfishchess.org/tests/view/698120e06362aee5c8a55412

Passed non-regression LTC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 233772 W: 59502 L: 59499 D: 114771
Ptnml(0-2): 144, 25753, 65086, 25762, 141 
https://tests.stockfishchess.org/tests/view/69827426889c3a4c31c8db52

bench 2806288