### PR TITLE
Simplify probCutDepth term

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -944,7 +944,7 @@ Value Search::Worker::search(
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
         MovePicker mp(pos, ttData.move, probCutBeta - ss->staticEval, &captureHistory);
-        Depth      probCutDepth = std::clamp(depth - 5 - (ss->staticEval - beta) / 315, 0, depth);
+        Depth      probCutDepth = depth - 5;
 
         while ((move = mp.next_move()) != Move::none())
         {


### PR DESCRIPTION
Simplify probCutDepth term

Passed STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 139392 W: 36003 L: 35897 D: 67492
Ptnml(0-2): 451, 16383, 35911, 16511, 440 
https://tests.stockfishchess.org/tests/view/697ebb4d5f56030af97b5aa5

Passed LTC
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 266934 W: 67822 L: 67851 D: 131261
Ptnml(0-2): 175, 29579, 73955, 29616, 142 
https://tests.stockfishchess.org/tests/view/6980e5a26362aee5c8a55398

bench 2539232