### PR TITLE
Add constexpr specifier back to conthist_bonuses

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1873,7 +1873,7 @@ void update_all_stats(const Position& pos,
 // Updates histories of the move pairs formed by moves
 // at ply -1, -2, -3, -4, and -6 with current move.
 void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
-    static std::array<ConthistBonus, 6> conthist_bonuses = {
+    static constexpr std::array<ConthistBonus, 6> conthist_bonuses = {
       {{1, 1133}, {2, 683}, {3, 312}, {4, 582}, {5, 149}, {6, 474}}};
 
     for (const auto [i, weight] : conthist_bonuses)


### PR DESCRIPTION
Passed STC
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 60288 W: 15668 L: 15331 D: 29289
Ptnml(0-2): 159, 6490, 16532, 6781, 182
https://tests.stockfishchess.org/tests/view/698c835762a8f472da3a88e1

No functional change