### PR TITLE
remove unncessary op in update_piece_threats

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1140,7 +1140,7 @@ void Position::update_piece_threats(Piece                     pc,
             Square sliderSq = pop_lsb(sliders);
             Piece  slider   = piece_on(sliderSq);
 
-            const Bitboard ray        = RayPassBB[sliderSq][s] & ~BetweenBB[sliderSq][s];
+            const Bitboard ray        = RayPassBB[sliderSq][s];
             const Bitboard discovered = ray & (rAttacks | bAttacks) & occupied;
 
             assert(!more_than_one(discovered));


### PR DESCRIPTION
We know *a priori* that there are no pieces between `sliderSq` and `s` because `sliderSq` is taken from a `pop_lsb` loop on the slider attackers of `s`. Thus we may eliminate the exclusion of BetweenBB squares.

Found by Gemini 3.0 Deep Think. Thanks to @arunim1 for running the prompt for me. (Prompt was just the entire SF codebase, plus a request to look for performance improvements in `update_piece_threats` and some other functions.)

(As an aside, I'm wondering whether we could do something more clever here to find discoveries – without going full on with Lily's tech – by somehow using bitboard manipulation and maybe pext to find *pairs* of pieces on opposite sides of `s`.)

No functional change