### PR TITLE
do not recompute pinners and blockers on null move

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -62,6 +62,7 @@ CSTENTOR
 Dale Weiler (graphitemaster)
 Daniel Axtens (daxtens)
 Daniel Dugovic (ddugovic)
+Daniel Michna (ZlomenyMesic)
 Daniel Monroe (daniel-monroe)
 Daniel Samek (DanSamek)
 Dan Schmidt (dfannius)

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1250,7 +1250,19 @@ void Position::do_null_move(StateInfo& newSt) {
 
     sideToMove = ~sideToMove;
 
-    set_check_info();
+    st->blockersForKing[WHITE] = st->previous->blockersForKing[WHITE];
+    st->blockersForKing[BLACK] = st->previous->blockersForKing[BLACK];
+    st->pinners[WHITE]         = st->previous->pinners[WHITE];
+    st->pinners[BLACK]         = st->previous->pinners[BLACK];
+
+    Square ksq = square<KING>(~sideToMove);
+
+    st->checkSquares[PAWN]   = attacks_bb<PAWN>(ksq, ~sideToMove);
+    st->checkSquares[KNIGHT] = attacks_bb<KNIGHT>(ksq);
+    st->checkSquares[BISHOP] = attacks_bb<BISHOP>(ksq, pieces());
+    st->checkSquares[ROOK]   = attacks_bb<ROOK>(ksq, pieces());
+    st->checkSquares[QUEEN]  = st->checkSquares[BISHOP] | st->checkSquares[ROOK];
+    st->checkSquares[KING]   = 0;
 
     st->repetition = 0;
 


### PR DESCRIPTION
Do not recompute pinners and blockers on a null move, which is done by inlining set_check_info and replacing update_slider_blockers. The first 4 pinner/blocker assignments are logically redundant, but keeping them boosts performance for a reason i cannot really explain.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 304000 W: 78611 L: 77927 D: 147462
Ptnml(0-2): 858, 33354, 82932, 33958, 898
https://tests.stockfishchess.org/tests/view/6994bfbd86e4a3231411635d

Proof that removing the assignments hurts performance: https://tests.stockfishchess.org/tests/view/6997436bd885742f179a7d21

No functional change