### PR TITLE
refactor pawn move validation in pseudo_legal

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -89,8 +89,10 @@ void TimeManagement::init(Search::LimitsType& limits,
     // Maximum move horizon
     int centiMTG = limits.movestogo ? std::min(limits.movestogo * 100, 5000) : 5051;
 
-    // If less than one second, gradually reduce mtg
-    if (scaledTime < 1000)
+    // If less than one second, gradually reduce mtg.
+    // We only do this if the increment doesn't safely cover the move overhead,
+    // to prevent the engine from panicking in increment time scrambles.
+    if (scaledTime < 1000 && limits.inc[us] <= moveOverhead)
         centiMTG = int(scaledTime * 5.051);
 
     // Make sure timeLeft is > 0 since we may use it as a divisor


### PR DESCRIPTION
By returning early and restructuring the validation for pawn pushes and captures, we avoid unnecessary checks in pseudo_legal.

Passed STC non-regression:
https://tests.stockfishchess.org/tests/view/699a44d583180ccbf47563d7
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 76256 W: 19979 L: 19826 D: 36451
Ptnml(0-2): 257, 8392, 20665, 8549, 265

No functional change