### PR TITLE
prevent unproved mated-in scores in game play

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -519,7 +519,7 @@ void Search::Worker::iterative_deepening() {
                 if (mainThread->ponder)
                     mainThread->stopOnPonderhit = true;
                 else
-                    threads.stop = true;
+                    threads.stop = threads.abortedSearch = true;
             }
             else
                 threads.increaseDepth = mainThread->ponder || elapsedTime <= totalTime * 0.50;


### PR DESCRIPTION
I believe a small oversight from #4990. Only affects multi-threaded searches.

~~Fixes #6293.~~ Makes unproven mated-in scores less likely, but does not seem to prevent them completely.

Just for completeness: this patch will change the bestmove in those very rare situations where the bug occurs in master. This is because bestmove is taken from `rootMoves[0].pv[0]`, which will now no longer contain unproven mated-in PVs. In that sense the patch is "functional". But of course, it does not change bench.

No functional change