### PR TITLE
Simplify threat by lesser

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -171,7 +171,7 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
 
             // penalty for moving to a square threatened by a lesser piece
             // or bonus for escaping an attack by a lesser piece.
-            int v = threatByLesser[pt] & to ? -19 : 20 * bool(threatByLesser[pt] & from);
+            int v = 20 * (bool(threatByLesser[pt] & from) - bool(threatByLesser[pt] & to));
             m.value += PieceValue[pt] * v;
 
 


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/699da988eaae015cd278ede4
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 141184 W: 36647 L: 36541 D: 67996
Ptnml(0-2): 511, 16620, 36237, 16700, 524 

LTC https://tests.stockfishchess.org/tests/view/699f4bee2be03365d5073c71
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 99852 W: 25463 L: 25322 D: 49067
Ptnml(0-2): 47, 10997, 27721, 11090, 71 

Removes a constant and a branch(for the price of a subtract) and treats the from and to squares symmetrically.

bench: 2486227