### PR TITLE
skip setting threatByLesser[KING]

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -136,7 +136,7 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
         threatByLesser[ROOK] =
           pos.attacks_by<KNIGHT>(~us) | pos.attacks_by<BISHOP>(~us) | threatByLesser[KNIGHT];
         threatByLesser[QUEEN] = pos.attacks_by<ROOK>(~us) | threatByLesser[ROOK];
-        threatByLesser[KING]  = pos.attacks_by<QUEEN>(~us) | threatByLesser[QUEEN];
+        threatByLesser[KING]  = 0;
     }
 
     ExtMove* it = cur;


### PR DESCRIPTION
It doesn't make sense for a king to move to a square threatened by a lesser piece, since that move would be illegal.

No functional change