### PR TITLE
Simplify mtg in time management

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -81,23 +81,21 @@ void TimeManagement::init(Search::LimitsType& limits,
         moveOverhead *= npmsec;
     }
 
-    // These numbers are used where multiplications, divisions or comparisons
-    // with constants are involved.
+    // These numbers are used where multiplications, divisions,
+    // or comparisons with constants are involved.
     const int64_t   scaleFactor = useNodesTime ? npmsec : 1;
     const TimePoint scaledTime  = limits.time[us] / scaleFactor;
 
     // Maximum move horizon
-    int centiMTG = limits.movestogo ? std::min(limits.movestogo * 100, 5000) : 5051;
+    int mtg = limits.movestogo ? std::min(limits.movestogo, 50) : 50;
 
     // If less than one second, gradually reduce mtg
     if (scaledTime < 1000)
-        centiMTG = int(scaledTime * 5.051);
+        mtg = int(scaledTime * 0.05);
 
     // Make sure timeLeft is > 0 since we may use it as a divisor
-    TimePoint timeLeft =
-      std::max(TimePoint(1),
-               limits.time[us]
-                 + (limits.inc[us] * (centiMTG - 100) - moveOverhead * (200 + centiMTG)) / 100);
+    TimePoint timeLeft = std::max(TimePoint(1), limits.time[us] + limits.inc[us] * (mtg - 1)
+                                                  - moveOverhead * (2 + mtg));
 
     // x basetime (+ z increment)
     // If there is a healthy increment, timeLeft can exceed the actual available
@@ -124,8 +122,8 @@ void TimeManagement::init(Search::LimitsType& limits,
     else
     {
         optScale =
-          std::min((0.88 + ply / 116.4) / (centiMTG / 100.0), 0.88 * limits.time[us] / timeLeft);
-        maxScale = 1.3 + 0.11 * (centiMTG / 100.0);
+          std::min((0.88 + ply / 116.4) / mtg, 0.88 * limits.time[us] / timeLeft);
+        maxScale = 1.3 + 0.11 * mtg;
     }
 
     // Limit the maximum possible time for this move


### PR DESCRIPTION
Simplify mtg in time management

Passed Stc:
LLR: 3.05 (-2.94,2.94) <-1.75,0.25>
Total: 289088 W: 74727 L: 74773 D: 139588
Ptnml(0-2): 903, 30974, 80841, 30918, 908
https://tests.stockfishchess.org/tests/view/699d9093eaae015cd278eda3

Passed Ltc:
LLR: 3.02 (-2.94,2.94) <-1.75,0.25>
Total: 144438 W: 36859 L: 36766 D: 70813
Ptnml(0-2): 62, 13391, 45235, 13454, 77
https://tests.stockfishchess.org/tests/view/699f02913ece4c464328a264

Passed Sudden death:
LLR: 2.99 (-2.94,2.94) <-1.75,0.25>
Total: 53406 W: 13960 L: 13753 D: 25693
Ptnml(0-2): 265, 5848, 14253, 6089, 248
https://tests.stockfishchess.org/tests/view/69a47548a70d5f3736be6482

No functional change