### PR TITLE
disable IIR and quiet shallow pruning in PV lines

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -270,6 +270,7 @@ windfishballad
 xefoci7612
 Xiang Wang (KatyushaScarlet)
 Yen-Chao Shen (lemteay)
+ZlomenyMesic
 zz4032
 
 # Additionally, we acknowledge the authors and maintainers of fishtest,

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -182,6 +182,7 @@ void Search::Worker::ensure_network_replicated() {
 void Search::Worker::start_searching() {
 
     accumulatorStack.reset();
+    lastIterationPV.clear();
 
     // Non-main threads go directly to iterative_deepening()
     if (!is_mainthread())
@@ -438,7 +439,10 @@ void Search::Worker::iterative_deepening() {
         }
 
         if (!threads.stop)
-            completedDepth = rootDepth;
+        {
+            completedDepth  = rootDepth;
+            lastIterationPV = rootMoves[0].pv;
+        }
 
         // We make sure not to pick an unproven mated-in score,
         // in case this thread prematurely stopped search (aborted-search).
@@ -661,6 +665,10 @@ Value Search::Worker::search(
     ss->moveCount = 0;
     bestValue     = -VALUE_INFINITE;
     maxValue      = VALUE_INFINITE;
+
+    ss->followPV  = rootNode || ((ss - 1)->followPV
+                 && static_cast<size_t>(ss->ply - 1) < lastIterationPV.size()
+                 && (ss - 1)->currentMove == lastIterationPV[ss->ply - 1]);
 
     // Check for the available remaining time
     if (is_mainthread())
@@ -929,7 +937,7 @@ Value Search::Worker::search(
     // Step 10. Internal iterative reductions
     // At sufficient depth, reduce depth for PV/Cut nodes without a TTMove.
     // (*Scaler) Making IIR more aggressive scales poorly.
-    if (!allNode && depth >= 6 && !ttData.move && priorReduction <= 3)
+    if (!ss->followPV && !allNode && depth >= 6 && !ttData.move && priorReduction <= 3)
         depth--;
 
     // Step 11. ProbCut
@@ -1079,7 +1087,7 @@ moves_loop:  // When in check, search starts here
                     && !pos.see_ge(move, -margin))
                     continue;
             }
-            else
+            else if (!ss->followPV || !PvNode)
             {
                 int history = (*contHist[0])[movedPiece][move.to_sq()]
                             + (*contHist[1])[movedPiece][move.to_sq()]

--- a/src/search.h
+++ b/src/search.h
@@ -74,6 +74,7 @@ struct Stack {
     bool                        inCheck;
     bool                        ttPv;
     bool                        ttHit;
+    bool                        followPV;
     int                         cutoffCnt;
     int                         reduction;
 };
@@ -341,6 +342,8 @@ class Worker {
     RootMoves rootMoves;
     Depth     rootDepth, completedDepth;
     Value     rootDelta;
+
+    std::vector<Move> lastIterationPV;
 
     size_t                    threadIdx, numaThreadIdx, numaTotal;
     NumaReplicatedAccessToken numaAccessToken;


### PR DESCRIPTION
Disable IIR and quiet shallow pruning in nodes that are part of the PV line from the previous search iteration. This is done by storing the PV in Worker and adding a followPV flag to Stack. The new flag may also be used in other pruning techniques, allowing further improvement.

Passed STC:
```
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 63776 W: 16679 L: 16323 D: 30774
Ptnml(0-2): 169, 7441, 16377, 7667, 234
```
https://tests.stockfishchess.org/tests/view/69aad1a7d0f65de95886e289

Passed LTC:
```
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 87342 W: 22421 L: 22000 D: 42921
Ptnml(0-2): 40, 9443, 24299, 9834, 55
```
https://tests.stockfishchess.org/tests/view/69ab5993cb31ee884aed629d

Bench: 2434614