### PR TITLE
Shared continuation correction history between threads without atomics

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -263,6 +263,18 @@ struct SharedHistories {
     UnifiedCorrectionHistory correctionHistory;
     PawnHistory              pawnHistory;
 
+    static constexpr int DefaultContCorrFill = 7;
+
+    CorrectionHistory<Continuation> continuationCorrectionHistory;
+
+    void clear_contcorr_range(size_t threadIdx, size_t numaTotal) {
+        constexpr size_t total = PIECE_NB * SQUARE_NB;
+        size_t           start = uint64_t(threadIdx) * total / numaTotal;
+        size_t           end =
+          threadIdx + 1 == numaTotal ? total : uint64_t(threadIdx + 1) * total / numaTotal;
+        for (size_t i = start; i < end; i++)
+            continuationCorrectionHistory[i / SQUARE_NB][i % SQUARE_NB].fill(DefaultContCorrFill);
+    }
 
    private:
     size_t sizeMinus1, pawnHistSizeMinus1;

--- a/src/search.h
+++ b/src/search.h
@@ -290,9 +290,8 @@ class Worker {
     ButterflyHistory mainHistory;
     LowPlyHistory    lowPlyHistory;
 
-    CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
-    CorrectionHistory<Continuation> continuationCorrectionHistory;
+    CapturePieceToHistory captureHistory;
+    ContinuationHistory   continuationHistory[2][2];
 
     TTMoveHistory    ttMoveHistory;
     SharedHistories& sharedHistory;


### PR DESCRIPTION
Shared continuation correction history without atomics.

Passed STC SMP: https://tests.stockfishchess.org/tests/view/699df372eaae015cd278ee81
```
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 132752 W: 34402 L: 33968 D: 64382
Ptnml(0-2): 152, 14808, 36044, 15198, 174
```

Passed LTC SMP: https://tests.stockfishchess.org/tests/view/699fca9744b9136df1165df6
```
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 448314 W: 115636 L: 114520 D: 218158
Ptnml(0-2): 161, 45435, 131846, 46557, 158
```

Bench: 2288704

---

Test URL of the atomic version: https://tests.stockfishchess.org/tests/view/69972692d885742f179a7d0b
