### PR TITLE
Fix shell escaping in misc.o rule

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1143,16 +1143,8 @@ $(EXE): $(OBJS)
 %.o: %.cpp
 	$(strip $(CXX) $(CPPFLAGS) $(CXXFLAGS)) -c -o $@ $<
 
-# Cache git metadata when available, otherwise cache the compiler date.
 misc.o: misc.cpp $(BUILD_SHA_FILE) $(BUILD_DATE_FILE)
-	@sha="$$(cat $(BUILD_SHA_FILE))"; \
-	set -- $(CXX) $(CPPFLAGS) $(CXXFLAGS); \
-	test -n "$$sha"  && set -- "$$@" -DGIT_SHA=$$sha; \
-	test -n "$(GIT_DATE)" && set -- "$$@" -DGIT_DATE=$(GIT_DATE); \
-	set -- "$$@" -c $< -o $@; \
-	printf '%s ' "$$@"; \
-	printf '\n'; \
-	"$$@"
+	$(strip $(CXX) $(CPPFLAGS) $(CXXFLAGS) $(if $(GIT_SHA),-DGIT_SHA=$(GIT_SHA)) $(if $(GIT_DATE),-DGIT_DATE=$(GIT_DATE))) -c -o $@ $<
 
 clang-profile-make:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \


### PR DESCRIPTION
After 415f2ef1. Now works again with CXX paths like `A:\path\to\g++` under MSYS2. The cache files are no longer read in the rule itself and only used as markers for change detection.

No functional change