### PR TITLE
Avoid branching before `ValueList::push_back`

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -201,6 +201,11 @@ class ValueList {
         assert(size_ < MaxSize);
         values_[size_++] = value;
     }
+    inline void        push_back_if_lt(const T& value, T max) {
+        assert(size_ < MaxSize);
+        values_[size_] = value;
+        size_ += (value < max);
+    }
     const T* begin() const { return values_; }
     const T* end() const { return values_ + size_; }
     const T& operator[](int index) const { return values_[index]; }

--- a/src/misc.h
+++ b/src/misc.h
@@ -197,12 +197,12 @@ class ValueList {
    public:
     std::size_t size() const { return size_; }
     int         ssize() const { return int(size_); }
-    void        push_back(const T& value) {
+    void push_back(const T& value) {
         assert(size_ < MaxSize);
         values_[size_++] = value;
     }
     // pushes back value if value < max
-    inline void        push_back_if_lt(const T& value, T max) {
+    void push_back_if_lt(const T& value, const T& max) {
         assert(size_ < MaxSize);
         values_[size_] = value;
         size_ += (value < max);

--- a/src/misc.h
+++ b/src/misc.h
@@ -201,6 +201,7 @@ class ValueList {
         assert(size_ < MaxSize);
         values_[size_++] = value;
     }
+    // pushes back value if value < max
     inline void        push_back_if_lt(const T& value, T max) {
         assert(size_ < MaxSize);
         values_[size_] = value;

--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -236,8 +236,7 @@ void FullThreats::append_active_indices(Color perspective, const Position& pos, 
                     Piece     attacked = pos.piece_on(to);
                     IndexType index    = make_index(perspective, attacker, from, to, attacked, ksq);
 
-                    if (index < Dimensions)
-                        active.push_back(index);
+                    active.push_back_if_lt(index, Dimensions);
                 }
 
                 while (attacks_right)
@@ -247,8 +246,7 @@ void FullThreats::append_active_indices(Color perspective, const Position& pos, 
                     Piece     attacked = pos.piece_on(to);
                     IndexType index    = make_index(perspective, attacker, from, to, attacked, ksq);
 
-                    if (index < Dimensions)
-                        active.push_back(index);
+                    active.push_back_if_lt(index, Dimensions);
                 }
 
                 // Set of pawns which are prevented from movement by a pawn in front of them
@@ -279,8 +277,7 @@ void FullThreats::append_active_indices(Color perspective, const Position& pos, 
                         IndexType index =
                           make_index(perspective, attacker, from, to, attacked, ksq);
 
-                        if (index < Dimensions)
-                            active.push_back(index);
+                        active.push_back_if_lt(index, Dimensions);
                     }
                 }
             }
@@ -342,13 +339,10 @@ void FullThreats::append_changed_indices(Color                   perspective,
         auto&           insert = add ? added : removed;
         const IndexType index  = make_index(perspective, attacker, from, to, attacked, ksq);
 
-        if (index < Dimensions)
-        {
-            if (prefetchBase)
-                prefetch<PrefetchRw::READ, PrefetchLoc::LOW>(
-                  prefetchBase + static_cast<std::ptrdiff_t>(index) * prefetchStride);
-            insert.push_back(index);
-        }
+        if (prefetchBase)
+            prefetch<PrefetchRw::READ, PrefetchLoc::LOW>(
+                prefetchBase + static_cast<std::ptrdiff_t>(index) * prefetchStride);
+        insert.push_back_if_lt(index, Dimensions);
     }
 }
 

--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -22,7 +22,6 @@
 
 #include <array>
 #include <cassert>
-#include <cstddef>
 #include <cstdint>
 #include <initializer_list>
 #include <utility>
@@ -340,8 +339,8 @@ void FullThreats::append_changed_indices(Color                   perspective,
         const IndexType index  = make_index(perspective, attacker, from, to, attacked, ksq);
 
         if (prefetchBase)
-            prefetch<PrefetchRw::READ, PrefetchLoc::LOW>(
-                prefetchBase + static_cast<std::ptrdiff_t>(index) * prefetchStride);
+            prefetch<PrefetchRw::READ, PrefetchLoc::LOW>(reinterpret_cast<const void*>(
+                reinterpret_cast<uintptr_t>(prefetchBase) + index *  prefetchStride));
         insert.push_back_if_lt(index, Dimensions);
     }
 }

--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -258,8 +258,7 @@ void FullThreats::append_active_indices(Color perspective, const Position& pos, 
                     assert(type_of(attacked) == PAWN);
 
                     IndexType index = make_index(perspective, attacker, from, to, attacked, ksq);
-                    if (index < Dimensions)
-                        active.push_back(index);
+                    active.push_back_if_lt(index, Dimensions);
                 }
             }
             else


### PR DESCRIPTION
Instead of checking whether a threat index is valid and then writing to a vector if it isn't, we can instead always write to the buffer of the vector, and only increase the size of the vector if the index is valid. This saves some branch mispredictions.

passed STC: https://tests.stockfishchess.org/tests/view/69ceb1689f7a7e3fdfc9a44b
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 205760 W: 53109 L: 52561 D: 100090
Ptnml(0-2): 603, 22552, 56076, 22992, 657 

local speedtest shows
```
Result of 100 runs (cycles)
===========================
base (...ockfish.orig) =     296886  +/- 1645
test (...kfish.df0822) =     298862  +/- 1662
speedup %              =      +0.67  +/- 0.19
                         [95% CI; t-statistic]

p(speedup > 0)   =  1.0000
p(speedup > .5%) =  0.9562

CPU: 16 x Intel(R) Core(TM) Ultra 9 185H
Hyperthreading: on 
```