### PR TITLE
Remove Redundant Branchless Execution

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -113,14 +113,13 @@ void update_correction_history(const Position& pos,
     shared.nonpawn_correction_entry<WHITE>(pos).at(us).nonPawnWhite << bonus * nonPawnWeight / 128;
     shared.nonpawn_correction_entry<BLACK>(pos).at(us).nonPawnBlack << bonus * nonPawnWeight / 128;
 
-    // Branchless: use mask to zero bonus when move is not ok
-    const int    mask   = int(m.is_ok());
-    const Square to     = m.to_sq_unchecked();
-    const Piece  pc     = pos.piece_on(to);
-    const int    bonus2 = (bonus * 126 / 128) * mask;
-    const int    bonus4 = (bonus * 63 / 128) * mask;
-    (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus2;
-    (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus4;
+if (m.is_ok())
+    {
+        const Square to = m.to_sq();
+        const Piece  pc = pos.piece_on(to);
+        (*(ss - 2)->continuationCorrectionHistory)[pc][to] << bonus * 126 / 128;
+        (*(ss - 4)->continuationCorrectionHistory)[pc][to] << bonus * 63 / 128;
+    }
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness


### PR DESCRIPTION
Remove Redundant Branchless Execution

Passed STC non-reg:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 102272 W: 26553 L: 26411 D: 49308
Ptnml(0-2): 269, 11212, 28036, 11346, 273
https://tests.stockfishchess.org/tests/view/69d0f1c5e2b443cb2670b710

No functional change