### PR TITLE
CI: test for macOS g++ pretending to be clang++

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -306,6 +306,13 @@ jobs:
           make -j4 ARCH=apple-silicon build
           ../tests/signature.sh $benchref
 
+      - name: Test apple-silicon build with system g++ (macOS g++ == clang++)
+        if: matrix.config.run_m1_tests
+        run: |
+          make clean
+          env -u COMPCXX make -j4 ARCH=apple-silicon build COMP=gcc
+          ../tests/signature.sh $benchref
+
       # armv8 tests
 
       - name: Test armv8 build


### PR DESCRIPTION
Avoids compilation errors on macOS by ensuring flags specific to g++ are applied to actual g++

No functional change