### PR TITLE
Don't store stand pat return value in TT

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1610,9 +1610,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
                 bestValue = (bestValue + beta) / 2;
 
             if (!ss->ttHit)
-                ttWriter.write(posKey, value_to_tt(bestValue, ss->ply), false, BOUND_LOWER,
-                               DEPTH_UNSEARCHED, Move::none(), unadjustedStaticEval,
-                               tt.generation());
+                ttWriter.write(posKey, VALUE_NONE, false, BOUND_LOWER, DEPTH_UNSEARCHED,
+                               Move::none(), unadjustedStaticEval, tt.generation());
             return bestValue;
         }
 


### PR DESCRIPTION
Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/69d2d3de61a12cebe17ede38
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 68384 W: 17646 L: 17459 D: 33279
Ptnml(0-2): 200, 8058, 17496, 8231, 207

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/69d4293433584dad27b3c8cb
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 37290 W: 9582 L: 9380 D: 18328
Ptnml(0-2): 18, 3915, 10579, 4113, 20

bench 2983099