### PR TITLE
Engine: avoid Syzygy reinit in search_clear

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -167,9 +167,6 @@ void Engine::search_clear() {
 
     tt.clear(threads);
     threads.clear();
-
-    // @TODO wont work with multiple instances
-    Tablebases::init(options["SyzygyPath"]);  // Free mapped files
 }
 
 void Engine::set_on_update_no_moves(std::function<void(const Engine::InfoShort&)>&& f) {


### PR DESCRIPTION
This change removes a global Tablebases::init() call from search_clear().

search_clear() should clear per-engine search state (TT and threads) without reinitializing global Syzygy state. The previous call could interfere with multi-instance usage.

Local validation:
- signature/perft/reprosearch pass
- instrumented tests pass

Fishtest:
- https://tests.stockfishchess.org/tests/view/69d69f6e5f8e259c584ace77
- No TB-specific coverage is available there (as discussed).

Bench: 2926703