### PR TITLE
Fix assert

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -394,12 +394,14 @@ Thread* ThreadPool::get_best_thread() const {
 
         if (bestThreadDecisive)
         {
-            assert((is_win(bestThreadScore) && is_win(newThreadScore))
-                   || (is_loss(bestThreadScore) && is_loss(newThreadScore)));
-
             // Make sure we pick the shortest mate / TB conversion.
             if (newThreadDecisive && std::abs(newThreadScore) > std::abs(bestThreadScore))
+            {
+                assert((is_win(bestThreadScore) && is_win(newThreadScore))
+                       || (is_loss(bestThreadScore) && is_loss(newThreadScore)));
+
                 bestThread = th.get();
+            }
         }
         else if (newThreadDecisive
                  || (!is_loss(newThreadScore)


### PR DESCRIPTION
the assert checks for `bestThreadDecisive && newThreadDecisive`. However `newThreadDecisive` is not guaranteed at this point, leading to assertion failures. This PR rearranges the conditions to ensure correctness.

no functional change