### PR TITLE
Remove redundant std::skipws from fresh string streams

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -100,7 +100,7 @@ void UCIEngine::loop() {
         std::istringstream is(cmd);
 
         token.clear();  // Avoid a stale if getline() returns nothing or a blank line
-        is >> std::skipws >> token;
+        is >> token;
 
         if (token == "quit" || token == "stop")
             engine.stop();
@@ -154,10 +154,10 @@ void UCIEngine::loop() {
         {
             std::pair<std::optional<std::string>, std::string> files[2];
 
-            if (is >> std::skipws >> files[0].second)
+            if (is >> files[0].second)
                 files[0].first = files[0].second;
 
-            if (is >> std::skipws >> files[1].second)
+            if (is >> files[1].second)
                 files[1].first = files[1].second;
 
             engine.save_network(files);
@@ -248,7 +248,7 @@ void UCIEngine::bench(std::istream& args) {
     for (const auto& cmd : list)
     {
         std::istringstream is(cmd);
-        is >> std::skipws >> token;
+        is >> token;
 
         if (token == "go" || token == "eval")
         {
@@ -330,7 +330,7 @@ void UCIEngine::benchmark(std::istream& args) {
     for (const auto& cmd : setup.commands)
     {
         std::istringstream is(cmd);
-        is >> std::skipws >> token;
+        is >> token;
 
         if (token == "go")
         {
@@ -381,7 +381,7 @@ void UCIEngine::benchmark(std::istream& args) {
     for (const auto& cmd : setup.commands)
     {
         std::istringstream is(cmd);
-        is >> std::skipws >> token;
+        is >> token;
 
         if (token == "go")
         {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -100,7 +100,7 @@ void UCIEngine::loop() {
         std::istringstream is(cmd);
 
         token.clear();  // Avoid a stale if getline() returns nothing or a blank line
-        is >> token;
+        is >> std::skipws >> token;
 
         if (token == "quit" || token == "stop")
             engine.stop();
@@ -154,10 +154,10 @@ void UCIEngine::loop() {
         {
             std::pair<std::optional<std::string>, std::string> files[2];
 
-            if (is >> files[0].second)
+            if (is >> std::skipws >> files[0].second)
                 files[0].first = files[0].second;
 
-            if (is >> files[1].second)
+            if (is >> std::skipws >> files[1].second)
                 files[1].first = files[1].second;
 
             engine.save_network(files);
@@ -248,7 +248,7 @@ void UCIEngine::bench(std::istream& args) {
     for (const auto& cmd : list)
     {
         std::istringstream is(cmd);
-        is >> token;
+        is >> std::skipws >> token;
 
         if (token == "go" || token == "eval")
         {
@@ -330,7 +330,7 @@ void UCIEngine::benchmark(std::istream& args) {
     for (const auto& cmd : setup.commands)
     {
         std::istringstream is(cmd);
-        is >> token;
+        is >> std::skipws >> token;
 
         if (token == "go")
         {
@@ -381,7 +381,7 @@ void UCIEngine::benchmark(std::istream& args) {
     for (const auto& cmd : setup.commands)
     {
         std::istringstream is(cmd);
-        is >> token;
+        is >> std::skipws >> token;
 
         if (token == "go")
         {


### PR DESCRIPTION
Remove redundant std::skipws from fresh string streams

In C++, all standard input streams (including std::istringstream) are initialized with the skipws format flag enabled by default. Because these stream objects are scoped locally and freshly constructed on each loop iteration, we are guaranteed that skipws is already active.

No functional change