### PR TITLE
 Simplify is_pv condition checks after TT probe

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -721,7 +721,7 @@ Value Search::Worker::search(
     ss->ttHit    = ttHit;
     ttData.move  = rootNode ? rootMoves[pvIdx].pv[0] : ttHit ? ttData.move : Move::none();
     ttData.value = ttHit ? value_from_tt(ttData.value, ss->ply, pos.rule50_count()) : VALUE_NONE;
-    ss->ttPv     = excludedMove ? ss->ttPv : PvNode || (ttHit && ttData.is_pv);
+    ss->ttPv     = excludedMove ? ss->ttPv : PvNode || ttData.is_pv;
     ttCapture    = ttData.move && pos.capture_stage(ttData.move);
 
     // Step 5. Static evaluation of the position
@@ -1562,7 +1562,6 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
     ss->ttHit    = ttHit;
     ttData.move  = ttHit ? ttData.move : Move::none();
     ttData.value = ttHit ? value_from_tt(ttData.value, ss->ply, pos.rule50_count()) : VALUE_NONE;
-    pvHit        = ttHit && ttData.is_pv;
 
     // At non-PV nodes we check for an early TT cutoff
     if (!PvNode && ttData.depth >= DEPTH_QS
@@ -1737,7 +1736,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
 
     // Save gathered info in transposition table. The static evaluation
     // is saved as it was before adjustment by correction history.
-    ttWriter.write(posKey, value_to_tt(bestValue, ss->ply), pvHit,
+    ttWriter.write(posKey, value_to_tt(bestValue, ss->ply), ttData.is_pv,
                    bestValue >= beta ? BOUND_LOWER : BOUND_UPPER, DEPTH_QS, bestMove,
                    unadjustedStaticEval, tt.generation());
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1531,7 +1531,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
     Key   posKey;
     Move  move, bestMove;
     Value bestValue, value, futilityBase;
-    bool  pvHit, givesCheck, capture;
+    bool  givesCheck, capture;
     int   moveCount;
 
     // Step 1. Initialize node

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -100,7 +100,7 @@ void UCIEngine::loop() {
         std::istringstream is(cmd);
 
         token.clear();  // Avoid a stale if getline() returns nothing or a blank line
-        is >> std::skipws >> token;
+        is >> token;
 
         if (token == "quit" || token == "stop")
             engine.stop();
@@ -154,10 +154,10 @@ void UCIEngine::loop() {
         {
             std::pair<std::optional<std::string>, std::string> files[2];
 
-            if (is >> std::skipws >> files[0].second)
+            if (is >> files[0].second)
                 files[0].first = files[0].second;
 
-            if (is >> std::skipws >> files[1].second)
+            if (is >> files[1].second)
                 files[1].first = files[1].second;
 
             engine.save_network(files);
@@ -248,7 +248,7 @@ void UCIEngine::bench(std::istream& args) {
     for (const auto& cmd : list)
     {
         std::istringstream is(cmd);
-        is >> std::skipws >> token;
+        is >> token;
 
         if (token == "go" || token == "eval")
         {
@@ -330,7 +330,7 @@ void UCIEngine::benchmark(std::istream& args) {
     for (const auto& cmd : setup.commands)
     {
         std::istringstream is(cmd);
-        is >> std::skipws >> token;
+        is >> token;
 
         if (token == "go")
         {
@@ -381,7 +381,7 @@ void UCIEngine::benchmark(std::istream& args) {
     for (const auto& cmd : setup.commands)
     {
         std::istringstream is(cmd);
-        is >> std::skipws >> token;
+        is >> token;
 
         if (token == "go")
         {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -100,7 +100,7 @@ void UCIEngine::loop() {
         std::istringstream is(cmd);
 
         token.clear();  // Avoid a stale if getline() returns nothing or a blank line
-        is >> token;
+        is >> std::skipws >> token;
 
         if (token == "quit" || token == "stop")
             engine.stop();
@@ -154,10 +154,10 @@ void UCIEngine::loop() {
         {
             std::pair<std::optional<std::string>, std::string> files[2];
 
-            if (is >> files[0].second)
+            if (is >> std::skipws >> files[0].second)
                 files[0].first = files[0].second;
 
-            if (is >> files[1].second)
+            if (is >> std::skipws >> files[1].second)
                 files[1].first = files[1].second;
 
             engine.save_network(files);
@@ -248,7 +248,7 @@ void UCIEngine::bench(std::istream& args) {
     for (const auto& cmd : list)
     {
         std::istringstream is(cmd);
-        is >> token;
+        is >> std::skipws >> token;
 
         if (token == "go" || token == "eval")
         {
@@ -330,7 +330,7 @@ void UCIEngine::benchmark(std::istream& args) {
     for (const auto& cmd : setup.commands)
     {
         std::istringstream is(cmd);
-        is >> token;
+        is >> std::skipws >> token;
 
         if (token == "go")
         {
@@ -381,7 +381,7 @@ void UCIEngine::benchmark(std::istream& args) {
     for (const auto& cmd : setup.commands)
     {
         std::istringstream is(cmd);
-        is >> token;
+        is >> std::skipws >> token;
 
         if (token == "go")
         {


### PR DESCRIPTION
 Simplify is_pv condition checks after TT probe

Currently, in both search() and qsearch(), the code checks ttHit && ttData.is_pv. However, the ttHit condition is redundant. When tt.probe() registers a miss (ttHit is false), it returns a newly initialized TTData struct where is_pv is already natively set to false. Therefore, evaluating ttData.is_pv alone is completely safe and functionally identical.
Additionally, this change allows us to eliminate the local pvHit variable entirely in qsearch(), passing ttData.is_pv directly to ttWriter.write().

No functional change