### PR TITLE
fix syzygy crash on Apple Silicon by unrolling tbprobe adjustment loop

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -781,7 +781,6 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
         assert(type_of(pc) == PAWN);
 
         leadPawns = b = pos.pieces(color_of(pc), PAWN);
-        DISABLE_CLANG_LOOP_VEC
         do
             squares[size++] = pop_lsb(b) ^ flipSquares;
         while (b);
@@ -802,7 +801,6 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
     // Now we are ready to get all the position pieces (but the lead pawns) and
     // directly map them to the correct color and square.
     b = pos.pieces() ^ leadPawns;
-    DISABLE_CLANG_LOOP_VEC
     do
     {
         Square s       = pop_lsb(b);

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -104,8 +104,8 @@ int LeadPawnIdx[6][SQUARE_NB];  // [leadPawnsCnt][SQUARE_NB]
 int LeadPawnsSize[6][4];        // [leadPawnsCnt][FILE_A..FILE_D]
 
 // Comparison function to sort leading pawns in ascending MapPawns[] order
-bool pawns_comp(int i, int j) { return MapPawns[i] < MapPawns[j]; }
-int  off_A1H8(int sq) { return int(rank_of(Square(sq))) - file_of(Square(sq)); }
+bool pawns_comp(Square i, Square j) { return MapPawns[i] < MapPawns[j]; }
+int  off_A1H8(Square sq) { return int(rank_of(sq)) - file_of(sq); }
 
 constexpr Value WDL_to_value[] = {-VALUE_MATE + MAX_PLY + 1, VALUE_DRAW - 2, VALUE_DRAW,
                                   VALUE_DRAW + 2, VALUE_MATE - MAX_PLY - 1};
@@ -744,7 +744,7 @@ int map_score(TBTable<DTZ>* entry, File f, int value, WDLScore wdl) {
 template<typename T, typename Ret = typename T::Ret>
 Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* result) {
 
-    int        squares[TBPIECES];
+    Square     squares[TBPIECES];
     Piece      pieces[TBPIECES];
     uint64_t   idx;
     int        next = 0, size = 0, leadPawnsCnt = 0;
@@ -781,15 +781,16 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
         assert(type_of(pc) == PAWN);
 
         leadPawns = b = pos.pieces(color_of(pc), PAWN);
+        DISABLE_CLANG_LOOP_VEC
         do
-            squares[size++] = int(pop_lsb(b) ^ flipSquares);
+            squares[size++] = pop_lsb(b) ^ flipSquares;
         while (b);
 
         leadPawnsCnt = size;
 
         std::swap(squares[0], *std::max_element(squares, squares + leadPawnsCnt, pawns_comp));
 
-        tbFile = File(edge_distance(file_of(Square(squares[0]))));
+        tbFile = File(edge_distance(file_of(squares[0])));
     }
 
     // DTZ tables are one-sided, i.e. they store positions only for white to
@@ -801,10 +802,11 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
     // Now we are ready to get all the position pieces (but the lead pawns) and
     // directly map them to the correct color and square.
     b = pos.pieces() ^ leadPawns;
+    DISABLE_CLANG_LOOP_VEC
     do
     {
         Square s       = pop_lsb(b);
-        squares[size]  = int(s ^ flipSquares);
+        squares[size]  = s ^ flipSquares;
         pieces[size++] = Piece(pos.piece_on(s) ^ flipColor);
     } while (b);
 
@@ -825,11 +827,11 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
 
     // Now we map again the squares so that the square of the lead piece is in
     // the triangle A1-D1-D4.
-    if (file_of(Square(squares[0])) > FILE_D)
+    if (file_of(squares[0]) > FILE_D)
     {
         DISABLE_CLANG_LOOP_VEC
         for (int i = 0; i < size; ++i)
-            squares[i] = int(flip_file(Square(squares[i])));
+            squares[i] = flip_file(squares[i]);
     }
 
     // Encode leading pawns starting with the one with minimum MapPawns[] and
@@ -848,11 +850,11 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
 
     // In positions without pawns, we further flip the squares to ensure leading
     // piece is below RANK_5.
-    if (rank_of(Square(squares[0])) > RANK_4)
+    if (rank_of(squares[0]) > RANK_4)
     {
         DISABLE_CLANG_LOOP_VEC
         for (int i = 0; i < size; ++i)
-            squares[i] = int(flip_rank(Square(squares[i])));
+            squares[i] = flip_rank(squares[i]);
     }
 
     // Look for the first piece of the leading group not on the A1-D4 diagonal
@@ -867,7 +869,7 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
         {
             DISABLE_CLANG_LOOP_VEC
             for (int j = i; j < size; ++j)
-                squares[j] = ((squares[j] >> 3) | (squares[j] << 3)) & 63;
+                squares[j] = Square(((squares[j] >> 3) | (squares[j] << 3)) & 63);
         }
         break;
     }
@@ -915,19 +917,18 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
         // 6 to differentiate from the above case, rank_of() maps a1-d4 diagonal
         // to 0...3 and finally MapB1H1H7[] maps the b1-h1-h7 triangle to 0..27.
         else if (off_A1H8(squares[1]))
-            idx = (6 * 63 + rank_of(Square(squares[0])) * 28 + MapB1H1H7[squares[1]]) * 62
-                + squares[2] - adjust2;
+            idx = (6 * 63 + rank_of(squares[0]) * 28 + MapB1H1H7[squares[1]]) * 62 + squares[2]
+                - adjust2;
 
         // First two pieces are on a1-h8 diagonal, third below
         else if (off_A1H8(squares[2]))
-            idx = 6 * 63 * 62 + 4 * 28 * 62 + rank_of(Square(squares[0])) * 7 * 28
-                + (rank_of(Square(squares[1])) - adjust1) * 28 + MapB1H1H7[squares[2]];
+            idx = 6 * 63 * 62 + 4 * 28 * 62 + rank_of(squares[0]) * 7 * 28
+                + (rank_of(squares[1]) - adjust1) * 28 + MapB1H1H7[squares[2]];
 
         // All 3 pieces on the diagonal a1-h8
         else
-            idx = 6 * 63 * 62 + 4 * 28 * 62 + 4 * 7 * 28 + rank_of(Square(squares[0])) * 7 * 6
-                + (rank_of(Square(squares[1])) - adjust1) * 6
-                + (rank_of(Square(squares[2])) - adjust2);
+            idx = 6 * 63 * 62 + 4 * 28 * 62 + 4 * 7 * 28 + rank_of(squares[0]) * 7 * 6
+                + (rank_of(squares[1]) - adjust1) * 6 + (rank_of(squares[2]) - adjust2);
     }
     else
         // We don't have at least 3 unique pieces, like in KRRvKBB, just map
@@ -936,7 +937,7 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
 
 encode_remaining:
     idx *= d->groupIdx[0];
-    int* groupSq = squares + d->groupLen[0];
+    Square* groupSq = squares + d->groupLen[0];
 
     // Encode remaining pawns and then pieces according to square, in ascending order
     bool remainingPawns = entry->hasPawns && entry->pawnCount[1];
@@ -950,8 +951,10 @@ encode_remaining:
         // groups (similar to what was done earlier for leading group pieces).
         for (int i = 0; i < d->groupLen[next]; ++i)
         {
-            auto f      = [&](int s) { return groupSq[i] > s; };
-            auto adjust = std::count_if(squares, groupSq, f);
+            int adjust = 0;
+            DISABLE_CLANG_LOOP_VEC
+            for (Square* sq = squares; sq != groupSq; ++sq)
+                adjust += groupSq[i] > *sq;
             n += Binomial[i + 1][groupSq[i] - adjust - 8 * remainingPawns];
         }
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -70,6 +70,10 @@ constexpr int TBPIECES = 7;  // Max number of supported pieces
 constexpr int MAX_DTZ =
   1 << 18;  // Max DTZ supported times 2, large enough to deal with the syzygy TB limit.
 
+enum {
+    BigEndian,
+    LittleEndian
+};
 enum TBType {
     WDL,
     DTZ
@@ -106,26 +110,29 @@ int  off_A1H8(int sq) { return int(rank_of(Square(sq))) - file_of(Square(sq)); }
 constexpr Value WDL_to_value[] = {-VALUE_MATE + MAX_PLY + 1, VALUE_DRAW - 2, VALUE_DRAW,
                                   VALUE_DRAW + 2, VALUE_MATE - MAX_PLY - 1};
 
-template<typename T>
-T read_le(const uint8_t* bytes) {
-    static_assert(std::is_unsigned_v<T>, "read_le expects an unsigned type");
+template<typename T, int Half = sizeof(T) / 2, int End = sizeof(T) - 1>
+inline void swap_endian(T& x) {
+    static_assert(std::is_unsigned_v<T>, "Argument of swap_endian not unsigned");
 
-    T value = 0;
-    for (size_t i = 0; i < sizeof(T); ++i)
-        value |= T(bytes[i]) << (i * 8);
-
-    return value;
+    uint8_t tmp, *c = (uint8_t*) &x;
+    for (int i = 0; i < Half; ++i)
+        tmp = c[i], c[i] = c[End - i], c[End - i] = tmp;
 }
+template<>
+inline void swap_endian<uint8_t>(uint8_t&) {}
 
-template<typename T>
-T read_be(const uint8_t* bytes) {
-    static_assert(std::is_unsigned_v<T>, "read_be expects an unsigned type");
+template<typename T, int LE>
+T number(void* addr) {
+    T v;
 
-    T value = 0;
-    for (size_t i = 0; i < sizeof(T); ++i)
-        value = T((value << 8) | bytes[i]);
+    if (uintptr_t(addr) & (alignof(T) - 1))  // Unaligned pointer (very rare)
+        std::memcpy(&v, addr, sizeof(T));
+    else
+        v = *((T*) addr);
 
-    return value;
+    if (LE != IsLittleEndian)
+        swap_endian(v);
+    return v;
 }
 
 // DTZ tables don't store valid scores for moves that reset the rule50 counter
@@ -147,8 +154,8 @@ int sign_of(T val) {
 
 // Numbers in little-endian used by sparseIndex[] to point into blockLength[]
 struct SparseEntry {
-    uint8_t block[4];   // Number of block
-    uint8_t offset[2];  // Offset within the block
+    char block[4];   // Number of block
+    char offset[2];  // Offset within the block
 };
 
 static_assert(sizeof(SparseEntry) == 6, "SparseEntry must be 6 bytes");
@@ -165,7 +172,7 @@ struct LR {
                     // bits is the right-hand symbol. If the symbol has length 1,
                     // then the left-hand symbol is the stored value.
     template<Side S>
-    Sym get() const {
+    Sym get() {
         return S == Left  ? ((lr[1] & 0xF) << 8) | lr[0]
              : S == Right ? (lr[2] << 4) | (lr[1] >> 4)
                           : (assert(false), Sym(-1));
@@ -314,19 +321,19 @@ std::string TBFile::Paths;
 // There are 8, 4, or 2 PairsData records for each TBTable, according to the type
 // of table and if positions have pawns or not. It is populated at first access.
 struct PairsData {
-    uint8_t        flags;        // Table flags, see enum TBFlag
-    uint8_t        maxSymLen;    // Maximum length in bits of the Huffman symbols
-    uint8_t        minSymLen;    // Minimum length in bits of the Huffman symbols
-    uint32_t       blocksNum;    // Number of blocks in the TB file
-    size_t         sizeofBlock;  // Block size in bytes
-    size_t         span;         // About every span values there is a SparseIndex[] entry
-    const uint8_t* lowestSym;    // lowestSym[l] is the symbol of length l with the lowest value
-    const LR*      btree;        // btree[sym] stores the left and right symbols that expand sym
-    const uint8_t* blockLength;  // Little-endian uint16_t block lengths
-    uint32_t blockLengthSize;  // Size of blockLength[] table: padded so it's bigger than blocksNum
-    const uint8_t* sparseIndex;      // SparseEntry bytes pointing into blockLength[]
-    size_t         sparseIndexSize;  // Size of SparseIndex[] table
-    const uint8_t* data;             // Start of Huffman compressed data
+    uint8_t   flags;            // Table flags, see enum TBFlag
+    uint8_t   maxSymLen;        // Maximum length in bits of the Huffman symbols
+    uint8_t   minSymLen;        // Minimum length in bits of the Huffman symbols
+    uint32_t  blocksNum;        // Number of blocks in the TB file
+    size_t    sizeofBlock;      // Block size in bytes
+    size_t    span;             // About every span values there is a SparseIndex[] entry
+    Sym*      lowestSym;        // lowestSym[l] is the symbol of length l with the lowest value
+    LR*       btree;            // btree[sym] stores the left and right symbols that expand sym
+    uint16_t* blockLength;      // Number of stored positions (minus one) for each block: 1..65536
+    uint32_t  blockLengthSize;  // Size of blockLength[] table: padded so it's bigger than blocksNum
+    SparseEntry* sparseIndex;   // Partial indices into blockLength[]
+    size_t       sparseIndexSize;  // Size of SparseIndex[] table
+    uint8_t*     data;             // Start of Huffman compressed data
     std::vector<uint64_t>
       base64;  // base64[l - min_sym_len] is the 64bit-padded lowest symbol of length l
     std::vector<uint8_t>
@@ -349,7 +356,7 @@ struct TBTable {
 
     std::atomic_bool ready;
     void*            baseAddress;
-    const uint8_t*   map;
+    uint8_t*         map;
     uint64_t         mapping;
     Key              key;
     Key              key2;
@@ -363,8 +370,7 @@ struct TBTable {
 
     TBTable() :
         ready(false),
-        baseAddress(nullptr),
-        map(nullptr) {}
+        baseAddress(nullptr) {}
     explicit TBTable(const std::string& code);
     explicit TBTable(const TBTable<WDL>& wdl);
 
@@ -432,24 +438,6 @@ TBTable<DTZ>::TBTable(const TBTable<WDL>& wdl) :
     hasUniquePieces = wdl.hasUniquePieces;
     pawnCount[0]    = wdl.pawnCount[0];
     pawnCount[1]    = wdl.pawnCount[1];
-}
-
-const uint8_t* sparse_entry_at(const PairsData* d, size_t index) {
-    assert(index < d->sparseIndexSize);
-    return d->sparseIndex + index * sizeof(SparseEntry);
-}
-
-uint16_t block_length_at(const PairsData* d, uint32_t block) {
-    assert(block < d->blockLengthSize);
-    return read_le<uint16_t>(d->blockLength + size_t(block) * sizeof(uint16_t));
-}
-
-Sym lowest_sym_at(const PairsData* d, size_t index) {
-    return read_le<Sym>(d->lowestSym + index * sizeof(Sym));
-}
-
-uint16_t wide_dtz_map_at(const uint8_t* map, size_t index) {
-    return read_le<uint16_t>(map + index * sizeof(uint16_t));
 }
 
 // class TBTables creates and keeps ownership of the TBTable objects, one for
@@ -584,7 +572,7 @@ void TBTables::add(const std::vector<PieceType>& pieces) {
 // Huffman codes are the same for all blocks in the table. A non-symmetric pawnless TB file
 // will have one table for wtm and one for btm, a TB file with pawns will have tables per
 // file a,b,c,d also, in this case, one set for wtm and one for btm.
-int decompress_pairs(const PairsData* d, uint64_t idx) {
+int decompress_pairs(PairsData* d, uint64_t idx) {
 
     // Special case where all table positions store the same value
     if (d->flags & TBFlag::SingleValue)
@@ -608,9 +596,8 @@ int decompress_pairs(const PairsData* d, uint64_t idx) {
     uint32_t k = uint32_t(idx / d->span);
 
     // Then we read the corresponding SparseIndex[] entry
-    const uint8_t* sparseEntry = sparse_entry_at(d, k);
-    uint32_t       block       = read_le<uint32_t>(sparseEntry);
-    int            offset      = read_le<uint16_t>(sparseEntry + sizeof(uint32_t));
+    uint32_t block  = number<uint32_t, LittleEndian>(&d->sparseIndex[k].block);
+    int      offset = number<uint16_t, LittleEndian>(&d->sparseIndex[k].offset);
 
     // Now compute the difference idx - I(k). From the definition of k, we know that
     //
@@ -625,19 +612,19 @@ int decompress_pairs(const PairsData* d, uint64_t idx) {
     // Move to the previous/next block, until we reach the correct block that contains idx,
     // that is when 0 <= offset <= d->blockLength[block]
     while (offset < 0)
-        offset += block_length_at(d, --block) + 1;
+        offset += d->blockLength[--block] + 1;
 
-    while (offset > block_length_at(d, block))
-        offset -= block_length_at(d, block++) + 1;
+    while (offset > d->blockLength[block])
+        offset -= d->blockLength[block++] + 1;
 
     // Finally, we find the start address of our block of canonical Huffman symbols
-    const uint8_t* ptr = d->data + (uint64_t(block) * d->sizeofBlock);
+    uint32_t* ptr = (uint32_t*) (d->data + (uint64_t(block) * d->sizeofBlock));
 
     // Read the first 64 bits in our block, this is a (truncated) sequence of
     // unknown number of symbols of unknown length but we know the first one
     // is at the beginning of this 64-bit sequence.
-    uint64_t buf64 = read_be<uint64_t>(ptr);
-    ptr += sizeof(uint64_t);
+    uint64_t buf64 = number<uint64_t, BigEndian>(ptr);
+    ptr += 2;
     int buf64Size = 64;
     Sym sym;
 
@@ -657,7 +644,7 @@ int decompress_pairs(const PairsData* d, uint64_t idx) {
         sym = Sym((buf64 - d->base64[len]) >> (64 - len - d->minSymLen));
 
         // Now add the value of the lowest symbol of length len to get our symbol
-        sym += lowest_sym_at(d, len);
+        sym += number<Sym, LittleEndian>(&d->lowestSym[len]);
 
         // If our offset is within the number of values represented by symbol sym,
         // we are done.
@@ -673,8 +660,7 @@ int decompress_pairs(const PairsData* d, uint64_t idx) {
         if (buf64Size <= 32)
         {  // Refill the buffer
             buf64Size += 32;
-            buf64 |= uint64_t(read_be<uint32_t>(ptr)) << (64 - buf64Size);
-            ptr += sizeof(uint32_t);
+            buf64 |= uint64_t(number<uint32_t, BigEndian>(ptr++)) << (64 - buf64Size);
         }
     }
 
@@ -722,15 +708,14 @@ int map_score(TBTable<DTZ>* entry, File f, int value, WDLScore wdl) {
 
     auto flags = entry->get(0, f)->flags;
 
-    const uint8_t* map = entry->map;
-    uint16_t*      idx = entry->get(0, f)->map_idx;
+    uint8_t*  map = entry->map;
+    uint16_t* idx = entry->get(0, f)->map_idx;
     if (flags & TBFlag::Mapped)
     {
-        const auto mapIndex = size_t(idx[WDLMap[wdl + 2]] + value);
         if (flags & TBFlag::Wide)
-            value = wide_dtz_map_at(map, mapIndex);
+            value = ((uint16_t*) map)[idx[WDLMap[wdl + 2]] + value];
         else
-            value = map[mapIndex];
+            value = map[idx[WDLMap[wdl + 2]] + value];
     }
 
     // DTZ tables store distance to zero in number of moves or plies. We
@@ -1083,14 +1068,14 @@ uint8_t* set_sizes(PairsData* d, uint8_t* data) {
     d->sizeofBlock     = 1ULL << *data++;
     d->span            = 1ULL << *data++;
     d->sparseIndexSize = size_t((tbSize + d->span - 1) / d->span);  // Round up
-    auto padding       = *data++;
-    d->blocksNum       = read_le<uint32_t>(data);
+    auto padding       = number<uint8_t, LittleEndian>(data++);
+    d->blocksNum       = number<uint32_t, LittleEndian>(data);
     data += sizeof(uint32_t);
     d->blockLengthSize = d->blocksNum + padding;  // Padded to ensure SparseIndex[]
                                                   // does not point out of range.
     d->maxSymLen = *data++;
     d->minSymLen = *data++;
-    d->lowestSym = data;
+    d->lowestSym = (Sym*) data;
     d->base64.resize(d->maxSymLen - d->minSymLen + 1);
 
     // See https://en.wikipedia.org/wiki/Huffman_coding
@@ -1107,7 +1092,9 @@ uint8_t* set_sizes(PairsData* d, uint8_t* data) {
     int base64_size = static_cast<int>(d->base64.size());
     for (int i = base64_size - 2; i >= 0; --i)
     {
-        d->base64[i] = (d->base64[i + 1] + lowest_sym_at(d, i) - lowest_sym_at(d, i + 1)) / 2;
+        d->base64[i] = (d->base64[i + 1] + number<Sym, LittleEndian>(&d->lowestSym[i])
+                        - number<Sym, LittleEndian>(&d->lowestSym[i + 1]))
+                     / 2;
 
         assert(d->base64[i] * 2 >= d->base64[i + 1]);
     }
@@ -1120,9 +1107,9 @@ uint8_t* set_sizes(PairsData* d, uint8_t* data) {
         d->base64[i] <<= 64 - i - d->minSymLen;  // Right-padding to 64 bits
 
     data += base64_size * sizeof(Sym);
-    d->symlen.resize(read_le<uint16_t>(data));
+    d->symlen.resize(number<uint16_t, LittleEndian>(data));
     data += sizeof(uint16_t);
-    d->btree = reinterpret_cast<const LR*>(data);
+    d->btree = (LR*) data;
 
     // The compression scheme used is "Recursive Pairing", that replaces the most
     // frequent adjacent pair of symbols in the source message by a new symbol,
@@ -1154,8 +1141,8 @@ uint8_t* set_dtz_map(TBTable<DTZ>& e, uint8_t* data, File maxFile) {
                 data += uintptr_t(data) & 1;  // Word alignment, we may have a mixed table
                 for (int i = 0; i < 4; ++i)
                 {  // Sequence like 3,x,x,x,1,x,0,2,x,x
-                    e.get(0, f)->map_idx[i] = uint16_t((data - e.map) / sizeof(uint16_t) + 1);
-                    data += 2 * read_le<uint16_t>(data) + 2;
+                    e.get(0, f)->map_idx[i] = uint16_t((uint16_t*) data - (uint16_t*) e.map + 1);
+                    data += 2 * number<uint16_t, LittleEndian>(data) + 2;
                 }
             }
             else
@@ -1225,14 +1212,14 @@ void set(T& e, uint8_t* data) {
     for (File f = FILE_A; f <= maxFile; ++f)
         for (int i = 0; i < sides; i++)
         {
-            (d = e.get(i, f))->sparseIndex = data;
+            (d = e.get(i, f))->sparseIndex = (SparseEntry*) data;
             data += d->sparseIndexSize * sizeof(SparseEntry);
         }
 
     for (File f = FILE_A; f <= maxFile; ++f)
         for (int i = 0; i < sides; i++)
         {
-            (d = e.get(i, f))->blockLength = data;
+            (d = e.get(i, f))->blockLength = (uint16_t*) data;
             data += d->blockLengthSize * sizeof(uint16_t);
         }
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -70,10 +70,6 @@ constexpr int TBPIECES = 7;  // Max number of supported pieces
 constexpr int MAX_DTZ =
   1 << 18;  // Max DTZ supported times 2, large enough to deal with the syzygy TB limit.
 
-enum {
-    BigEndian,
-    LittleEndian
-};
 enum TBType {
     WDL,
     DTZ
@@ -104,35 +100,32 @@ int LeadPawnIdx[6][SQUARE_NB];  // [leadPawnsCnt][SQUARE_NB]
 int LeadPawnsSize[6][4];        // [leadPawnsCnt][FILE_A..FILE_D]
 
 // Comparison function to sort leading pawns in ascending MapPawns[] order
-bool pawns_comp(Square i, Square j) { return MapPawns[i] < MapPawns[j]; }
-int  off_A1H8(Square sq) { return int(rank_of(sq)) - file_of(sq); }
+bool pawns_comp(int i, int j) { return MapPawns[i] < MapPawns[j]; }
+int  off_A1H8(int sq) { return int(rank_of(Square(sq))) - file_of(Square(sq)); }
 
 constexpr Value WDL_to_value[] = {-VALUE_MATE + MAX_PLY + 1, VALUE_DRAW - 2, VALUE_DRAW,
                                   VALUE_DRAW + 2, VALUE_MATE - MAX_PLY - 1};
 
-template<typename T, int Half = sizeof(T) / 2, int End = sizeof(T) - 1>
-inline void swap_endian(T& x) {
-    static_assert(std::is_unsigned_v<T>, "Argument of swap_endian not unsigned");
+template<typename T>
+T read_le(const uint8_t* bytes) {
+    static_assert(std::is_unsigned_v<T>, "read_le expects an unsigned type");
 
-    uint8_t tmp, *c = (uint8_t*) &x;
-    for (int i = 0; i < Half; ++i)
-        tmp = c[i], c[i] = c[End - i], c[End - i] = tmp;
+    T value = 0;
+    for (size_t i = 0; i < sizeof(T); ++i)
+        value |= T(bytes[i]) << (i * 8);
+
+    return value;
 }
-template<>
-inline void swap_endian<uint8_t>(uint8_t&) {}
 
-template<typename T, int LE>
-T number(void* addr) {
-    T v;
+template<typename T>
+T read_be(const uint8_t* bytes) {
+    static_assert(std::is_unsigned_v<T>, "read_be expects an unsigned type");
 
-    if (uintptr_t(addr) & (alignof(T) - 1))  // Unaligned pointer (very rare)
-        std::memcpy(&v, addr, sizeof(T));
-    else
-        v = *((T*) addr);
+    T value = 0;
+    for (size_t i = 0; i < sizeof(T); ++i)
+        value = T((value << 8) | bytes[i]);
 
-    if (LE != IsLittleEndian)
-        swap_endian(v);
-    return v;
+    return value;
 }
 
 // DTZ tables don't store valid scores for moves that reset the rule50 counter
@@ -154,8 +147,8 @@ int sign_of(T val) {
 
 // Numbers in little-endian used by sparseIndex[] to point into blockLength[]
 struct SparseEntry {
-    char block[4];   // Number of block
-    char offset[2];  // Offset within the block
+    uint8_t block[4];   // Number of block
+    uint8_t offset[2];  // Offset within the block
 };
 
 static_assert(sizeof(SparseEntry) == 6, "SparseEntry must be 6 bytes");
@@ -172,7 +165,7 @@ struct LR {
                     // bits is the right-hand symbol. If the symbol has length 1,
                     // then the left-hand symbol is the stored value.
     template<Side S>
-    Sym get() {
+    Sym get() const {
         return S == Left  ? ((lr[1] & 0xF) << 8) | lr[0]
              : S == Right ? (lr[2] << 4) | (lr[1] >> 4)
                           : (assert(false), Sym(-1));
@@ -321,19 +314,19 @@ std::string TBFile::Paths;
 // There are 8, 4, or 2 PairsData records for each TBTable, according to the type
 // of table and if positions have pawns or not. It is populated at first access.
 struct PairsData {
-    uint8_t   flags;            // Table flags, see enum TBFlag
-    uint8_t   maxSymLen;        // Maximum length in bits of the Huffman symbols
-    uint8_t   minSymLen;        // Minimum length in bits of the Huffman symbols
-    uint32_t  blocksNum;        // Number of blocks in the TB file
-    size_t    sizeofBlock;      // Block size in bytes
-    size_t    span;             // About every span values there is a SparseIndex[] entry
-    Sym*      lowestSym;        // lowestSym[l] is the symbol of length l with the lowest value
-    LR*       btree;            // btree[sym] stores the left and right symbols that expand sym
-    uint16_t* blockLength;      // Number of stored positions (minus one) for each block: 1..65536
-    uint32_t  blockLengthSize;  // Size of blockLength[] table: padded so it's bigger than blocksNum
-    SparseEntry* sparseIndex;   // Partial indices into blockLength[]
-    size_t       sparseIndexSize;  // Size of SparseIndex[] table
-    uint8_t*     data;             // Start of Huffman compressed data
+    uint8_t        flags;        // Table flags, see enum TBFlag
+    uint8_t        maxSymLen;    // Maximum length in bits of the Huffman symbols
+    uint8_t        minSymLen;    // Minimum length in bits of the Huffman symbols
+    uint32_t       blocksNum;    // Number of blocks in the TB file
+    size_t         sizeofBlock;  // Block size in bytes
+    size_t         span;         // About every span values there is a SparseIndex[] entry
+    const uint8_t* lowestSym;    // lowestSym[l] is the symbol of length l with the lowest value
+    const LR*      btree;        // btree[sym] stores the left and right symbols that expand sym
+    const uint8_t* blockLength;  // Little-endian uint16_t block lengths
+    uint32_t blockLengthSize;  // Size of blockLength[] table: padded so it's bigger than blocksNum
+    const uint8_t* sparseIndex;      // SparseEntry bytes pointing into blockLength[]
+    size_t         sparseIndexSize;  // Size of SparseIndex[] table
+    const uint8_t* data;             // Start of Huffman compressed data
     std::vector<uint64_t>
       base64;  // base64[l - min_sym_len] is the 64bit-padded lowest symbol of length l
     std::vector<uint8_t>
@@ -356,7 +349,7 @@ struct TBTable {
 
     std::atomic_bool ready;
     void*            baseAddress;
-    uint8_t*         map;
+    const uint8_t*   map;
     uint64_t         mapping;
     Key              key;
     Key              key2;
@@ -370,7 +363,8 @@ struct TBTable {
 
     TBTable() :
         ready(false),
-        baseAddress(nullptr) {}
+        baseAddress(nullptr),
+        map(nullptr) {}
     explicit TBTable(const std::string& code);
     explicit TBTable(const TBTable<WDL>& wdl);
 
@@ -438,6 +432,24 @@ TBTable<DTZ>::TBTable(const TBTable<WDL>& wdl) :
     hasUniquePieces = wdl.hasUniquePieces;
     pawnCount[0]    = wdl.pawnCount[0];
     pawnCount[1]    = wdl.pawnCount[1];
+}
+
+const uint8_t* sparse_entry_at(const PairsData* d, size_t index) {
+    assert(index < d->sparseIndexSize);
+    return d->sparseIndex + index * sizeof(SparseEntry);
+}
+
+uint16_t block_length_at(const PairsData* d, uint32_t block) {
+    assert(block < d->blockLengthSize);
+    return read_le<uint16_t>(d->blockLength + size_t(block) * sizeof(uint16_t));
+}
+
+Sym lowest_sym_at(const PairsData* d, size_t index) {
+    return read_le<Sym>(d->lowestSym + index * sizeof(Sym));
+}
+
+uint16_t wide_dtz_map_at(const uint8_t* map, size_t index) {
+    return read_le<uint16_t>(map + index * sizeof(uint16_t));
 }
 
 // class TBTables creates and keeps ownership of the TBTable objects, one for
@@ -572,7 +584,7 @@ void TBTables::add(const std::vector<PieceType>& pieces) {
 // Huffman codes are the same for all blocks in the table. A non-symmetric pawnless TB file
 // will have one table for wtm and one for btm, a TB file with pawns will have tables per
 // file a,b,c,d also, in this case, one set for wtm and one for btm.
-int decompress_pairs(PairsData* d, uint64_t idx) {
+int decompress_pairs(const PairsData* d, uint64_t idx) {
 
     // Special case where all table positions store the same value
     if (d->flags & TBFlag::SingleValue)
@@ -596,8 +608,9 @@ int decompress_pairs(PairsData* d, uint64_t idx) {
     uint32_t k = uint32_t(idx / d->span);
 
     // Then we read the corresponding SparseIndex[] entry
-    uint32_t block  = number<uint32_t, LittleEndian>(&d->sparseIndex[k].block);
-    int      offset = number<uint16_t, LittleEndian>(&d->sparseIndex[k].offset);
+    const uint8_t* sparseEntry = sparse_entry_at(d, k);
+    uint32_t       block       = read_le<uint32_t>(sparseEntry);
+    int            offset      = read_le<uint16_t>(sparseEntry + sizeof(uint32_t));
 
     // Now compute the difference idx - I(k). From the definition of k, we know that
     //
@@ -612,19 +625,19 @@ int decompress_pairs(PairsData* d, uint64_t idx) {
     // Move to the previous/next block, until we reach the correct block that contains idx,
     // that is when 0 <= offset <= d->blockLength[block]
     while (offset < 0)
-        offset += d->blockLength[--block] + 1;
+        offset += block_length_at(d, --block) + 1;
 
-    while (offset > d->blockLength[block])
-        offset -= d->blockLength[block++] + 1;
+    while (offset > block_length_at(d, block))
+        offset -= block_length_at(d, block++) + 1;
 
     // Finally, we find the start address of our block of canonical Huffman symbols
-    uint32_t* ptr = (uint32_t*) (d->data + (uint64_t(block) * d->sizeofBlock));
+    const uint8_t* ptr = d->data + (uint64_t(block) * d->sizeofBlock);
 
     // Read the first 64 bits in our block, this is a (truncated) sequence of
     // unknown number of symbols of unknown length but we know the first one
     // is at the beginning of this 64-bit sequence.
-    uint64_t buf64 = number<uint64_t, BigEndian>(ptr);
-    ptr += 2;
+    uint64_t buf64 = read_be<uint64_t>(ptr);
+    ptr += sizeof(uint64_t);
     int buf64Size = 64;
     Sym sym;
 
@@ -644,7 +657,7 @@ int decompress_pairs(PairsData* d, uint64_t idx) {
         sym = Sym((buf64 - d->base64[len]) >> (64 - len - d->minSymLen));
 
         // Now add the value of the lowest symbol of length len to get our symbol
-        sym += number<Sym, LittleEndian>(&d->lowestSym[len]);
+        sym += lowest_sym_at(d, len);
 
         // If our offset is within the number of values represented by symbol sym,
         // we are done.
@@ -660,7 +673,8 @@ int decompress_pairs(PairsData* d, uint64_t idx) {
         if (buf64Size <= 32)
         {  // Refill the buffer
             buf64Size += 32;
-            buf64 |= uint64_t(number<uint32_t, BigEndian>(ptr++)) << (64 - buf64Size);
+            buf64 |= uint64_t(read_be<uint32_t>(ptr)) << (64 - buf64Size);
+            ptr += sizeof(uint32_t);
         }
     }
 
@@ -708,14 +722,15 @@ int map_score(TBTable<DTZ>* entry, File f, int value, WDLScore wdl) {
 
     auto flags = entry->get(0, f)->flags;
 
-    uint8_t*  map = entry->map;
-    uint16_t* idx = entry->get(0, f)->map_idx;
+    const uint8_t* map = entry->map;
+    uint16_t*      idx = entry->get(0, f)->map_idx;
     if (flags & TBFlag::Mapped)
     {
+        const auto mapIndex = size_t(idx[WDLMap[wdl + 2]] + value);
         if (flags & TBFlag::Wide)
-            value = ((uint16_t*) map)[idx[WDLMap[wdl + 2]] + value];
+            value = wide_dtz_map_at(map, mapIndex);
         else
-            value = map[idx[WDLMap[wdl + 2]] + value];
+            value = map[mapIndex];
     }
 
     // DTZ tables store distance to zero in number of moves or plies. We
@@ -744,7 +759,7 @@ int map_score(TBTable<DTZ>* entry, File f, int value, WDLScore wdl) {
 template<typename T, typename Ret = typename T::Ret>
 Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* result) {
 
-    Square     squares[TBPIECES];
+    int        squares[TBPIECES];
     Piece      pieces[TBPIECES];
     uint64_t   idx;
     int        next = 0, size = 0, leadPawnsCnt = 0;
@@ -782,14 +797,14 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
 
         leadPawns = b = pos.pieces(color_of(pc), PAWN);
         do
-            squares[size++] = pop_lsb(b) ^ flipSquares;
+            squares[size++] = int(pop_lsb(b) ^ flipSquares);
         while (b);
 
         leadPawnsCnt = size;
 
         std::swap(squares[0], *std::max_element(squares, squares + leadPawnsCnt, pawns_comp));
 
-        tbFile = File(edge_distance(file_of(squares[0])));
+        tbFile = File(edge_distance(file_of(Square(squares[0]))));
     }
 
     // DTZ tables are one-sided, i.e. they store positions only for white to
@@ -804,7 +819,7 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
     do
     {
         Square s       = pop_lsb(b);
-        squares[size]  = s ^ flipSquares;
+        squares[size]  = int(s ^ flipSquares);
         pieces[size++] = Piece(pos.piece_on(s) ^ flipColor);
     } while (b);
 
@@ -825,11 +840,11 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
 
     // Now we map again the squares so that the square of the lead piece is in
     // the triangle A1-D1-D4.
-    if (file_of(squares[0]) > FILE_D)
+    if (file_of(Square(squares[0])) > FILE_D)
     {
         DISABLE_CLANG_LOOP_VEC
         for (int i = 0; i < size; ++i)
-            squares[i] = flip_file(squares[i]);
+            squares[i] = int(flip_file(Square(squares[i])));
     }
 
     // Encode leading pawns starting with the one with minimum MapPawns[] and
@@ -848,11 +863,11 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
 
     // In positions without pawns, we further flip the squares to ensure leading
     // piece is below RANK_5.
-    if (rank_of(squares[0]) > RANK_4)
+    if (rank_of(Square(squares[0])) > RANK_4)
     {
         DISABLE_CLANG_LOOP_VEC
         for (int i = 0; i < size; ++i)
-            squares[i] = flip_rank(squares[i]);
+            squares[i] = int(flip_rank(Square(squares[i])));
     }
 
     // Look for the first piece of the leading group not on the A1-D4 diagonal
@@ -867,7 +882,7 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
         {
             DISABLE_CLANG_LOOP_VEC
             for (int j = i; j < size; ++j)
-                squares[j] = Square(((squares[j] >> 3) | (squares[j] << 3)) & 63);
+                squares[j] = ((squares[j] >> 3) | (squares[j] << 3)) & 63;
         }
         break;
     }
@@ -915,18 +930,19 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
         // 6 to differentiate from the above case, rank_of() maps a1-d4 diagonal
         // to 0...3 and finally MapB1H1H7[] maps the b1-h1-h7 triangle to 0..27.
         else if (off_A1H8(squares[1]))
-            idx = (6 * 63 + rank_of(squares[0]) * 28 + MapB1H1H7[squares[1]]) * 62 + squares[2]
-                - adjust2;
+            idx = (6 * 63 + rank_of(Square(squares[0])) * 28 + MapB1H1H7[squares[1]]) * 62
+                + squares[2] - adjust2;
 
         // First two pieces are on a1-h8 diagonal, third below
         else if (off_A1H8(squares[2]))
-            idx = 6 * 63 * 62 + 4 * 28 * 62 + rank_of(squares[0]) * 7 * 28
-                + (rank_of(squares[1]) - adjust1) * 28 + MapB1H1H7[squares[2]];
+            idx = 6 * 63 * 62 + 4 * 28 * 62 + rank_of(Square(squares[0])) * 7 * 28
+                + (rank_of(Square(squares[1])) - adjust1) * 28 + MapB1H1H7[squares[2]];
 
         // All 3 pieces on the diagonal a1-h8
         else
-            idx = 6 * 63 * 62 + 4 * 28 * 62 + 4 * 7 * 28 + rank_of(squares[0]) * 7 * 6
-                + (rank_of(squares[1]) - adjust1) * 6 + (rank_of(squares[2]) - adjust2);
+            idx = 6 * 63 * 62 + 4 * 28 * 62 + 4 * 7 * 28 + rank_of(Square(squares[0])) * 7 * 6
+                + (rank_of(Square(squares[1])) - adjust1) * 6
+                + (rank_of(Square(squares[2])) - adjust2);
     }
     else
         // We don't have at least 3 unique pieces, like in KRRvKBB, just map
@@ -935,7 +951,7 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
 
 encode_remaining:
     idx *= d->groupIdx[0];
-    Square* groupSq = squares + d->groupLen[0];
+    int* groupSq = squares + d->groupLen[0];
 
     // Encode remaining pawns and then pieces according to square, in ascending order
     bool remainingPawns = entry->hasPawns && entry->pawnCount[1];
@@ -949,7 +965,7 @@ encode_remaining:
         // groups (similar to what was done earlier for leading group pieces).
         for (int i = 0; i < d->groupLen[next]; ++i)
         {
-            auto f      = [&](Square s) { return groupSq[i] > s; };
+            auto f      = [&](int s) { return groupSq[i] > s; };
             auto adjust = std::count_if(squares, groupSq, f);
             n += Binomial[i + 1][groupSq[i] - adjust - 8 * remainingPawns];
         }
@@ -1067,14 +1083,14 @@ uint8_t* set_sizes(PairsData* d, uint8_t* data) {
     d->sizeofBlock     = 1ULL << *data++;
     d->span            = 1ULL << *data++;
     d->sparseIndexSize = size_t((tbSize + d->span - 1) / d->span);  // Round up
-    auto padding       = number<uint8_t, LittleEndian>(data++);
-    d->blocksNum       = number<uint32_t, LittleEndian>(data);
+    auto padding       = *data++;
+    d->blocksNum       = read_le<uint32_t>(data);
     data += sizeof(uint32_t);
     d->blockLengthSize = d->blocksNum + padding;  // Padded to ensure SparseIndex[]
                                                   // does not point out of range.
     d->maxSymLen = *data++;
     d->minSymLen = *data++;
-    d->lowestSym = (Sym*) data;
+    d->lowestSym = data;
     d->base64.resize(d->maxSymLen - d->minSymLen + 1);
 
     // See https://en.wikipedia.org/wiki/Huffman_coding
@@ -1091,9 +1107,7 @@ uint8_t* set_sizes(PairsData* d, uint8_t* data) {
     int base64_size = static_cast<int>(d->base64.size());
     for (int i = base64_size - 2; i >= 0; --i)
     {
-        d->base64[i] = (d->base64[i + 1] + number<Sym, LittleEndian>(&d->lowestSym[i])
-                        - number<Sym, LittleEndian>(&d->lowestSym[i + 1]))
-                     / 2;
+        d->base64[i] = (d->base64[i + 1] + lowest_sym_at(d, i) - lowest_sym_at(d, i + 1)) / 2;
 
         assert(d->base64[i] * 2 >= d->base64[i + 1]);
     }
@@ -1106,9 +1120,9 @@ uint8_t* set_sizes(PairsData* d, uint8_t* data) {
         d->base64[i] <<= 64 - i - d->minSymLen;  // Right-padding to 64 bits
 
     data += base64_size * sizeof(Sym);
-    d->symlen.resize(number<uint16_t, LittleEndian>(data));
+    d->symlen.resize(read_le<uint16_t>(data));
     data += sizeof(uint16_t);
-    d->btree = (LR*) data;
+    d->btree = reinterpret_cast<const LR*>(data);
 
     // The compression scheme used is "Recursive Pairing", that replaces the most
     // frequent adjacent pair of symbols in the source message by a new symbol,
@@ -1140,8 +1154,8 @@ uint8_t* set_dtz_map(TBTable<DTZ>& e, uint8_t* data, File maxFile) {
                 data += uintptr_t(data) & 1;  // Word alignment, we may have a mixed table
                 for (int i = 0; i < 4; ++i)
                 {  // Sequence like 3,x,x,x,1,x,0,2,x,x
-                    e.get(0, f)->map_idx[i] = uint16_t((uint16_t*) data - (uint16_t*) e.map + 1);
-                    data += 2 * number<uint16_t, LittleEndian>(data) + 2;
+                    e.get(0, f)->map_idx[i] = uint16_t((data - e.map) / sizeof(uint16_t) + 1);
+                    data += 2 * read_le<uint16_t>(data) + 2;
                 }
             }
             else
@@ -1211,14 +1225,14 @@ void set(T& e, uint8_t* data) {
     for (File f = FILE_A; f <= maxFile; ++f)
         for (int i = 0; i < sides; i++)
         {
-            (d = e.get(i, f))->sparseIndex = (SparseEntry*) data;
+            (d = e.get(i, f))->sparseIndex = data;
             data += d->sparseIndexSize * sizeof(SparseEntry);
         }
 
     for (File f = FILE_A; f <= maxFile; ++f)
         for (int i = 0; i < sides; i++)
         {
-            (d = e.get(i, f))->blockLength = (uint16_t*) data;
+            (d = e.get(i, f))->blockLength = data;
             data += d->blockLengthSize * sizeof(uint16_t);
         }
 


### PR DESCRIPTION
A bit tricky to identify, but in `apple-silicon` builds, specifying a value for `SyzygyPath` could still lead to crashes at certain depths from a SIGBUS/SIGSEGV.

This PR replaces the `std::count_if()` adjustment in `tbprobe.cpp`'s `do_probe_table()` with an annotated handwritten loop, avoiding the clang/LTO miscompilation behind the crash.

No functional change.

bench: 2923401
