### PR TITLE
Remove the Redundant ply Variables in Benchmark Calculations

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -481,17 +481,10 @@ BenchmarkSetup setup_benchmark(std::istream& is) {
         return 50000.0 / (static_cast<double>(ply) + 15.0);
     };
 
-    float totalTime = 0;
+float totalTime = 0;
     for (const auto& game : BenchmarkPositions)
-    {
-        int ply = 1;
-        for (int i = 0; i < static_cast<int>(game.size()); ++i)
-        {
-            const float correctedTime = float(getCorrectedTime(ply));
-            totalTime += correctedTime;
-            ply += 1;
-        }
-    }
+        for (size_t i = 0; i < game.size(); ++i)
+            totalTime += float(getCorrectedTime(i + 1));
 
     float timeScaleFactor = static_cast<float>(desiredTimeS * 1000) / totalTime;
 
@@ -502,11 +495,8 @@ BenchmarkSetup setup_benchmark(std::istream& is) {
         for (const std::string& fen : game)
         {
             setup.commands.emplace_back("position fen " + fen);
-
-            const int correctedTime = static_cast<int>(getCorrectedTime(ply) * timeScaleFactor);
-            setup.commands.emplace_back("go movetime " + std::to_string(correctedTime));
-
-            ply += 1;
+            setup.commands.emplace_back("go movetime " + 
+                std::to_string(static_cast<int>(getCorrectedTime(ply++) * timeScaleFactor)));
         }
     }
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -481,7 +481,7 @@ BenchmarkSetup setup_benchmark(std::istream& is) {
         return 50000.0 / (static_cast<double>(ply) + 15.0);
     };
 
-float totalTime = 0;
+    float totalTime = 0;
     for (const auto& game : BenchmarkPositions)
         for (size_t i = 0; i < game.size(); ++i)
             totalTime += float(getCorrectedTime(i + 1));

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -495,8 +495,8 @@ BenchmarkSetup setup_benchmark(std::istream& is) {
         for (const std::string& fen : game)
         {
             setup.commands.emplace_back("position fen " + fen);
-            setup.commands.emplace_back("go movetime " + 
-                std::to_string(static_cast<int>(getCorrectedTime(ply++) * timeScaleFactor)));
+            const int correctedTime = static_cast<int>(getCorrectedTime(ply++) * timeScaleFactor);
+            setup.commands.emplace_back("go movetime " + std::to_string(correctedTime));
         }
     }
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -100,7 +100,7 @@ void UCIEngine::loop() {
         std::istringstream is(cmd);
 
         token.clear();  // Avoid a stale if getline() returns nothing or a blank line
-        is >> std::skipws >> token;
+        is >> token;
 
         if (token == "quit" || token == "stop")
             engine.stop();
@@ -154,10 +154,10 @@ void UCIEngine::loop() {
         {
             std::pair<std::optional<std::string>, std::string> files[2];
 
-            if (is >> std::skipws >> files[0].second)
+            if (is >> files[0].second)
                 files[0].first = files[0].second;
 
-            if (is >> std::skipws >> files[1].second)
+            if (is >> files[1].second)
                 files[1].first = files[1].second;
 
             engine.save_network(files);
@@ -248,7 +248,7 @@ void UCIEngine::bench(std::istream& args) {
     for (const auto& cmd : list)
     {
         std::istringstream is(cmd);
-        is >> std::skipws >> token;
+        is >> token;
 
         if (token == "go" || token == "eval")
         {
@@ -330,7 +330,7 @@ void UCIEngine::benchmark(std::istream& args) {
     for (const auto& cmd : setup.commands)
     {
         std::istringstream is(cmd);
-        is >> std::skipws >> token;
+        is >> token;
 
         if (token == "go")
         {
@@ -381,7 +381,7 @@ void UCIEngine::benchmark(std::istream& args) {
     for (const auto& cmd : setup.commands)
     {
         std::istringstream is(cmd);
-        is >> std::skipws >> token;
+        is >> token;
 
         if (token == "go")
         {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -100,7 +100,7 @@ void UCIEngine::loop() {
         std::istringstream is(cmd);
 
         token.clear();  // Avoid a stale if getline() returns nothing or a blank line
-        is >> token;
+        is >> std::skipws >> token;
 
         if (token == "quit" || token == "stop")
             engine.stop();
@@ -154,10 +154,10 @@ void UCIEngine::loop() {
         {
             std::pair<std::optional<std::string>, std::string> files[2];
 
-            if (is >> files[0].second)
+            if (is >> std::skipws >> files[0].second)
                 files[0].first = files[0].second;
 
-            if (is >> files[1].second)
+            if (is >> std::skipws >> files[1].second)
                 files[1].first = files[1].second;
 
             engine.save_network(files);
@@ -248,7 +248,7 @@ void UCIEngine::bench(std::istream& args) {
     for (const auto& cmd : list)
     {
         std::istringstream is(cmd);
-        is >> token;
+        is >> std::skipws >> token;
 
         if (token == "go" || token == "eval")
         {
@@ -330,7 +330,7 @@ void UCIEngine::benchmark(std::istream& args) {
     for (const auto& cmd : setup.commands)
     {
         std::istringstream is(cmd);
-        is >> token;
+        is >> std::skipws >> token;
 
         if (token == "go")
         {
@@ -381,7 +381,7 @@ void UCIEngine::benchmark(std::istream& args) {
     for (const auto& cmd : setup.commands)
     {
         std::istringstream is(cmd);
-        is >> token;
+        is >> std::skipws >> token;
 
         if (token == "go")
         {


### PR DESCRIPTION
Remove the Redundant ply Variables in Benchmark Calculations

In setup_benchmark, the variables evaluating the current ply simply mirror the exact iterative progress of the string arrays loop (since ply just increments by 1 with every pass). We can delete the separate integer assignment and execute it securely within the loop declaration.

No functional change