### PR TITLE
Interpolate highBestMoveEffort

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -373,6 +373,12 @@ inline uint64_t mul_hi64(uint64_t a, uint64_t b) {
 #endif
 }
 
+template<typename T1, typename T2>
+inline constexpr T2 interpolate(T1 x, T1 x0, T1 x1, T2 y0, T2 y1) {
+    assert(x0 != x1);
+    return T2(y0 + (y1 - y0) * (x - x0) / (x1 - x0));
+}
+
 uint64_t hash_bytes(const char*, size_t);
 
 template<typename T>

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -511,7 +511,8 @@ bool Search::Worker::iterative_deepening() {
 
             double bestMoveInstability = 1.088 + 2.315 * totBestMoveChanges / threads.size();
 
-            double highBestMoveEffort = nodesEffort > 86000 ? 0.74 : 0.96;
+            double highBestMoveEffort = std::clamp(
+              interpolate(int64_t(nodesEffort), int64_t(78000), int64_t(94000), 0.96, 0.74), 0.74, 0.96);
 
             double totalTime = mainThread->tm.optimum() * fallingEval * reduction
                              * bestMoveInstability * highBestMoveEffort;


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/69d586a64088e069540a22aa
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 63520 W: 16579 L: 16233 D: 30708
Ptnml(0-2): 138, 7179, 16825, 7435, 183 

LTC: https://tests.stockfishchess.org/tests/view/69d6ddd79ffee997bab13a98
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 227100 W: 58279 L: 57591 D: 111230
Ptnml(0-2): 95, 23435, 65828, 24071, 121  

bench: 2923401

Transition highBestMoveEffort smoothly instead of abruptly. May also be more amenable to future tuning.