### PR TITLE
Update main network to nn-f68ec79f0fe3.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-7bf13f9655c8.nnue"
+#define EvalFileDefaultNameBig "nn-f68ec79f0fe3.nnue"
 #define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 
 namespace NNUE {


### PR DESCRIPTION
Trained with the following yaml definition https://github.com/Disservin/nettest/blob/8da0a21503adb341bc89ca20b4e2f166c7c9720d/threats.yaml

and the following trainer change 
https://github.com/official-stockfish/nnue-pytorch/commit/d87c248fbed584d08df59820ae0dd309e9b35c85

Initially I saw a lot of weird 0 scores in the binpack, since then @linrock has explained to me/us their meaning and mentioned that they are actually mostly skipped.. except a very small percentage, however it seems this change was still beneficial.

Passed STC:
https://tests.stockfishchess.org/tests/view/69db95f43ca80bdf151d4913
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 106272 W: 27916 L: 27489 D: 50867
Ptnml(0-2): 420, 12533, 26841, 12884, 458

Passed LTC:
https://tests.stockfishchess.org/tests/view/69ddd9003ca80bdf151d4c4d
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 29748 W: 7775 L: 7470 D: 14503
Ptnml(0-2): 24, 3136, 8247, 3445, 22

Bench: 3108996