### PR TITLE
Remove the Redundant ply Variables in Benchmark Calculations

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -483,15 +483,8 @@ BenchmarkSetup setup_benchmark(std::istream& is) {
 
     float totalTime = 0;
     for (const auto& game : BenchmarkPositions)
-    {
-        int ply = 1;
-        for (int i = 0; i < static_cast<int>(game.size()); ++i)
-        {
-            const float correctedTime = float(getCorrectedTime(ply));
-            totalTime += correctedTime;
-            ply += 1;
-        }
-    }
+        for (size_t i = 0; i < game.size(); ++i)
+            totalTime += float(getCorrectedTime(i + 1));
 
     float timeScaleFactor = static_cast<float>(desiredTimeS * 1000) / totalTime;
 
@@ -502,11 +495,8 @@ BenchmarkSetup setup_benchmark(std::istream& is) {
         for (const std::string& fen : game)
         {
             setup.commands.emplace_back("position fen " + fen);
-
-            const int correctedTime = static_cast<int>(getCorrectedTime(ply) * timeScaleFactor);
+            const int correctedTime = static_cast<int>(getCorrectedTime(ply++) * timeScaleFactor);
             setup.commands.emplace_back("go movetime " + std::to_string(correctedTime));
-
-            ply += 1;
         }
     }
 


### PR DESCRIPTION
Remove the Redundant ply Variables in Benchmark Calculations

In setup_benchmark, the variables evaluating the current ply simply mirror the exact iterative progress of the string arrays loop (since ply just increments by 1 with every pass). We can delete the separate integer assignment and execute it securely within the loop declaration.

No functional change