### PR TITLE
Restructure to a simpler and cleaner version

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -891,17 +891,15 @@ Value Search::Worker::search(
 
     // Step 8. Futility pruning: child node
     // The depth condition is important for mate finding.
+    if (!ss->ttPv && depth < 15 && eval >= beta && (!ttData.move || ttCapture)
+        && !is_loss(beta) && !is_win(eval))
     {
-        auto futility_margin = [&](Depth d) {
-            Value futilityMult = 76 - 21 * !ss->ttHit;
+        Value futilityMult = 76 - 21 * !ss->ttHit;
+        Value futilityMargin = futilityMult * depth
+                             - (2686 * improving + 362 * opponentWorsening) * futilityMult / 1024
+                             + std::abs(correctionValue) / 180600;
 
-            return futilityMult * d
-                 - (2686 * improving + 362 * opponentWorsening) * futilityMult / 1024  //
-                 + std::abs(correctionValue) / 180600;
-        };
-
-        if (!ss->ttPv && depth < 15 && eval - futility_margin(depth) >= beta && eval >= beta
-            && (!ttData.move || ttCapture) && !is_loss(beta) && !is_win(eval))
+        if (eval - futilityMargin >= beta)
             return (2 * beta + eval) / 3;
     }
 


### PR DESCRIPTION
Restructure to a simpler and cleaner version

Passed non-reg test:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 175648 W: 45156 L: 45091 D: 85401
Ptnml(0-2): 459, 19228, 48383, 19297, 457
https://tests.stockfishchess.org/tests/view/69d8d9263ca80bdf151d454a

No functional change