### PR TITLE
Remove Redundant Cast in MovePicker

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -167,7 +167,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
             m.value += (*continuationHistory[5])[pc][to];
 
             // bonus for checks
-            m.value += (bool(pos.check_squares(pt) & to) && pos.see_ge(m, -75)) * 16384;
+            m.value += ((pos.check_squares(pt) & to) && pos.see_ge(m, -75)) * 16384;
 
             // penalty for moving to a square threatened by a lesser piece
             // or bonus for escaping an attack by a lesser piece.


### PR DESCRIPTION
Remove Redundant Cast in MovePicker

No functional change