### PR TITLE
Avoid exceptions in UCI spin option validation

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
 #include <cctype>
 #include <cstdlib>
 #include <iostream>
@@ -153,9 +154,23 @@ Option& Option::operator=(const std::string& v) {
     assert(!type.empty());
 
     if ((type != "button" && type != "string" && v.empty())
-        || (type == "check" && v != "true" && v != "false")
-        || (type == "spin" && (std::stoi(v) < min || std::stoi(v) > max)))
+        || (type == "check" && v != "true" && v != "false"))
         return *this;
+
+    // For spin options, reject values that don't parse as a full int or fall
+    // outside [min, max]. std::strtol is used instead of std::stoi because the
+    // codebase is compiled with -fno-exceptions, so throwing on malformed UCI
+    // input would terminate the engine.
+    if (type == "spin")
+    {
+        errno             = 0;
+        char* end         = nullptr;
+        const char* begin = v.c_str();
+        const long parsed = std::strtol(begin, &end, 10);
+
+        if (begin == end || *end != '\0' || errno == ERANGE || parsed < min || parsed > max)
+            return *this;
+    }
 
     if (type == "combo")
     {


### PR DESCRIPTION
## Summary

Malformed `setoption` input for a `spin` option is validated in `Option::operator=`, but using `std::stoi` for that check can throw `std::invalid_argument` or `std::out_of_range`. Because Stockfish is compiled with `-fno-exceptions`, malformed console input terminates the engine.

Examples on current master:

```text
setoption name Hash value 999999999999999999  # -> std::out_of_range -> crash
setoption name Hash value notanumber          # -> std::invalid_argument -> crash
```

Confirmed live on `stockfish-dev-20260415-b1fb50ae`:

```text
libc++abi: terminating due to uncaught exception of type std::out_of_range: stoi: out of range
```

## Fix

Replace the throwing validation path in `Option::operator=` with `std::strtol`. This keeps validation non-throwing without depending on `std::from_chars` availability on older toolchains. Rejected values return early without mutating the option.

The new validation rejects:

- non-numeric values (no conversion)
- trailing garbage (partial conversion)
- overflow / underflow
- values outside `[min, max]`

## Testing

```text
Bench: 2984258
```

Malformed values are now rejected without terminating the engine.
