### PR TITLE
Use NNUE threat delta count to inform LMR

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -138,6 +138,11 @@ void AccumulatorStack::pop() noexcept {
     size--;
 }
 
+std::size_t AccumulatorStack::threatDeltaCount() const noexcept {
+    assert(size > 0);
+    return threat_accumulators[size - 1].diff.list.size();
+}
+
 template<IndexType Dimensions>
 void AccumulatorStack::evaluate(const Position&                       pos,
                                 const FeatureTransformer<Dimensions>& featureTransformer,

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -160,6 +160,8 @@ class AccumulatorStack {
     std::pair<DirtyPiece&, DirtyThreats&> push() noexcept;
     void                                  pop() noexcept;
 
+    [[nodiscard]] std::size_t threatDeltaCount() const noexcept;
+
     template<IndexType Dimensions>
     void evaluate(const Position&                       pos,
                   const FeatureTransformer<Dimensions>& featureTransformer,

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1239,6 +1239,13 @@ moves_loop:  // When in check, search starts here
         // Decrease/increase reduction for moves with a good/bad history
         r -= ss->statScore * 428 / 4096;
 
+        // Reduce less for moves that create/destroy many NNUE threat features.
+        // Baseline subtraction (~6) neutralizes typical quiet moves; only moves
+        // with above-average tactical impact get reduced less. Scaled by depth
+        // so the effect grows proportionally with search depth.
+        int threatDelta = std::clamp(int(accumulatorStack.threatDeltaCount()) - 6, 0, 20);
+        r -= threatDelta * depth * 2;
+
         // Scale up reductions for expected ALL nodes
         if (allNode)
             r += r * 273 / (256 * depth + 260);


### PR DESCRIPTION
## Idea

The NNUE threat feature accumulator already computes a `DirtyThreatList` for every move — an exact count of how many attack relationships are created or destroyed. This information has **never been used by the search**.

This patch exposes `AccumulatorStack::threatDeltaCount()` and uses it as an LMR reduction signal:

```cpp
int threatDelta = std::clamp(int(accumulatorStack.threatDeltaCount()) - 6, 0, 20);
r -= threatDelta * depth * 2;
```

## Design decisions

| Parameter | Value | Justification |
|-----------|-------|---------------|
| Baseline subtraction | 6 | A typical quiet move changes ~6 threat features. Subtracting this makes the signal neutral for ordinary moves — only above-average tactical moves benefit. |
| Cap | 20 | Theoretical max is ~80, but capping at 20 above baseline prevents outlier positions from dominating. |
| Depth scaling | `* depth * 2` | Effect grows proportionally with search depth, matching other LMR terms. |

All three constants (6, 20, 2) are SPSA-tunable.

## Effect magnitude

| Scenario | threatDelta | depth 8 | depth 16 | depth 24 |
|----------|-------------|---------|----------|----------|
| Typical quiet (~6 threats) | 0 | 0 | 0 | 0 |
| Moderate tactical (~14) | 8 | 128 (~0.12 ply) | 256 (~0.25 ply) | 384 (~0.38 ply) |
| High tactical (26+) | 20 (cap) | 320 (~0.31 ply) | 640 (~0.63 ply) | 960 (~0.94 ply) |

For reference: `r -= moveCount * 65` at moveCount=5 is 325. The moderate-tactical case is comparable.

## Why this is different from existing signals

| Signal | Source | Nature |
|--------|--------|--------|
| mainHistory | Learned from search | Backward-looking (what worked before) |
| contHistory | Learned from search | Backward-looking |
| captureHistory | Learned from search | Backward-looking |
| **threatDeltaCount** | **NNUE accumulator** | **Forward-looking** (static property of the move) |

## Properties

- **Zero additional computation** — `DirtyThreatList` is already computed during incremental accumulator updates
- **+14 lines, 3 files** — surgical patch
- **Bench: 3082861** (master: 2984258, +3.3% nodes — subtle effect)

## Testing needed

STC and LTC fishtest required.