### PR TITLE
Replace constant LMR history divisor with depth-based array

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -52,6 +52,11 @@
 
 namespace Stockfish {
 
+static constexpr int LmrDivisor[16] = {
+    3307, 2930, 2874, 2818, 3215, 3225, 3224, 2782, 2858, 2919,
+    3088, 3275, 3180, 2868, 3006, 3599
+};
+
 namespace TB = Tablebases;
 
 void syzygy_extend_pv(const OptionsMap&            options,
@@ -1097,6 +1102,7 @@ moves_loop:  // When in check, search starts here
             }
             else if (!ss->followPV || !PvNode)
             {
+                int dIndex = std::clamp(int(depth), 1, 16) - 1;
                 int history = (*contHist[0])[movedPiece][move.to_sq()]
                             + (*contHist[1])[movedPiece][move.to_sq()]
                             + sharedHistory.pawn_entry(pos)[movedPiece][move.to_sq()];
@@ -1108,7 +1114,7 @@ moves_loop:  // When in check, search starts here
                 history += 71 * mainHistory[us][move.raw()] / 32;
 
                 // (*Scaler): Generally, lower divisors scales well
-                lmrDepth += history / 2995;
+                lmrDepth += history / LmrDivisor[dIndex];
 
                 Value futilityValue = ss->staticEval + 42 + 151 * !bestMove + 120 * lmrDepth
                                     + 86 * (ss->staticEval > alpha);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -52,7 +52,7 @@
 
 namespace Stockfish {
 
-static constexpr int LmrDivisor[16] = {
+static constexpr std::array<int, 16> lmrDivisor = {
     3307, 2930, 2874, 2818, 3215, 3225, 3224, 2782, 2858, 2919,
     3088, 3275, 3180, 2868, 3006, 3599
 };
@@ -1102,7 +1102,7 @@ moves_loop:  // When in check, search starts here
             }
             else if (!ss->followPV || !PvNode)
             {
-                int dIndex = std::clamp(int(depth), 1, 16) - 1;
+                int dIndex = std::clamp(int(depth), 1, int(lmrDivisor.size())) - 1
                 int history = (*contHist[0])[movedPiece][move.to_sq()]
                             + (*contHist[1])[movedPiece][move.to_sq()]
                             + sharedHistory.pawn_entry(pos)[movedPiece][move.to_sq()];
@@ -1114,7 +1114,7 @@ moves_loop:  // When in check, search starts here
                 history += 71 * mainHistory[us][move.raw()] / 32;
 
                 // (*Scaler): Generally, lower divisors scales well
-                lmrDepth += history / LmrDivisor[dIndex];
+                lmrDepth += history / lmrDivisor[dIndex];
 
                 Value futilityValue = ss->staticEval + 42 + 151 * !bestMove + 120 * lmrDepth
                                     + 86 * (ss->staticEval > alpha);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1102,7 +1102,7 @@ moves_loop:  // When in check, search starts here
             }
             else if (!ss->followPV || !PvNode)
             {
-                int dIndex = std::clamp(int(depth), 1, int(lmrDivisor.size())) - 1
+                int dIndex = std::clamp(int(depth), 1, int(lmrDivisor.size())) - 1;
                 int history = (*contHist[0])[movedPiece][move.to_sq()]
                             + (*contHist[1])[movedPiece][move.to_sq()]
                             + sharedHistory.pawn_entry(pos)[movedPiece][move.to_sq()];


### PR DESCRIPTION
Replace constant LMR history divisor with depth-based array

Passed STC:
LLR: 2.97 (-2.94,2.94) <0.00,2.00>
Total: 677344 W: 175301 L: 174041 D: 328002
Ptnml(0-2): 2018, 79669, 174166, 80673, 2146
https://tests.stockfishchess.org/tests/view/69cfae021668971c9da23b80

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 46470 W: 11988 L: 11651 D: 22831
Ptnml(0-2): 37, 4877, 13055, 5244, 22
https://tests.stockfishchess.org/tests/view/69dcd13c3ca80bdf151d4ab5

Passed VLTC (non-reg.):
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 58986 W: 15120 L: 14947 D: 28919
Ptnml(0-2): 7, 5835, 17636, 6008, 7
https://tests.stockfishchess.org/tests/view/69debc6c5c67bee7d241ffe9

bench: 2723949