### PR TITLE
Compress Linux universal release package

### DIFF
--- a/.github/ci/universal_matrix.json
+++ b/.github/ci/universal_matrix.json
@@ -4,7 +4,7 @@
       "name": "Ubuntu 22.04 GCC Universal",
       "os": "ubuntu-22.04",
       "simple_name": "ubuntu",
-      "archive_ext": "tar"
+      "archive_ext": "tar.gz"
     },
     {
       "name": "Windows 2022 Mingw-w64 GCC Universal",

--- a/.github/workflows/upload_binaries.yml
+++ b/.github/workflows/upload_binaries.yml
@@ -59,13 +59,13 @@ jobs:
           cp CONTRIBUTING.md ../stockfish/
 
       - name: Create tar
-        if: ${{ !startsWith(matrix.config.os, 'windows') }}
+        if: ${{ startsWith(matrix.config.archive_ext, 'tar') }}
         run: |
           chmod +x ./stockfish/stockfish-$NAME-$BINARY$EXT
-          tar -cvf stockfish-$NAME-$BINARY.tar stockfish
+          tar -cavf stockfish-$NAME-$BINARY."${{ matrix.config.archive_ext }}" stockfish
 
       - name: Create zip
-        if: ${{ startsWith(matrix.config.os, 'windows') }}
+        if: ${{ matrix.config.archive_ext == 'zip' }}
         run: |
           zip -r stockfish-$NAME-$BINARY.zip stockfish
 


### PR DESCRIPTION
`stockfish-ubuntu-x86-64-universal.tar` goes from 94.8MiB to 67.4MiB (tar.gz)

Note that the CI code is written such that it easy to select other compression schemes in the future (e.g. tar.xz) by simply changing the `archive_ext` parameter.