### PR TITLE
[CI] Cleanup artifact content (part 2)

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -195,7 +195,9 @@ jobs:
         run: ./scripts/check_universal.sh ./stockfish-windows-x86-64-universal.exe "$SDE_DIR/sde" "$benchref"
 
       - name: Remove non src files
-        run: git -C src clean -fx
+        run: |
+          rm -fR src/temp_builds
+          git -C src clean -fx
 
       - name: Upload artifact for (pre)-release
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
removes temp_builds directory before packaging, even more.

No functional change