### PR TITLE
Fix Universal build on Windows

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1260,7 +1260,7 @@ UNIVERSAL_ENTRY_OBJ  := $(TEMP_DIR)/entry_x86.o
 NET_SENTINEL         := $(TEMP_DIR)/.net-done
 
 # Top-level tracked items in src/ (directories and files)
-TRACKED_TOP := $(shell echo "$(SRCS) $(HEADERS) Makefile incbin" | xargs -n1 | awk -F/ '{print $$1}' | sort -u)
+TRACKED_TOP := $(sort $(foreach f,$(SRCS) $(HEADERS) Makefile incbin,$(firstword $(subst /, ,$(f)))))
 
 # Baseline x86-64 must come first in the final link (Windows --allow-multiple-definition
 # uses the first copy of inline duplicates)


### PR DESCRIPTION
No functional change
bench: 2723949

I don't have great Makefile skills so this was actually fixed by Claude.  I asked it to explain the problem and the fix and it said this:

TRACKED_TOP previously used a shell pipeline (xargs, awk, sort) to extract unique top-level directory/file names from SRCS and HEADERS. When invoking make from cmd.exe on Windows, $(shell ...) uses cmd.exe rather than sh.exe, so the pipeline fails because cmd.exe does not support Unix pipe syntax. Other MSYS2 tools (e.g. the compiler) work fine because they are invoked directly as commands, not through a shell pipeline. This caused TRACKED_TOP to be empty, so ln -s never ran and the per-arch temp_builds subdirectories were left without a Makefile symlink, breaking the universal build with: "No rule to make target 'universal-object-nopgo'". Fixed by replacing the shell pipeline with pure GNU make built-in functions (sort, foreach, firstword, subst) which have no shell or PATH dependencies and work identically on Windows, Linux and macOS.