### PR TITLE
Using De Morgan's Law for ProbCut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -957,7 +957,7 @@ Value Search::Worker::search(
         && !is_decisive(beta)
         // If value from transposition table is lower than probCutBeta, don't attempt
         // probCut there
-        && !(is_valid(ttData.value) && ttData.value < probCutBeta))
+        && (!is_valid(ttData.value) || ttData.value >= probCutBeta))
     {
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 


### PR DESCRIPTION
Using De Morgan's Law, making the logic immediately transparent to the reader.

No functional change