### PR TITLE
Simplify time management reduction logic

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -504,10 +504,8 @@ bool Search::Worker::iterative_deepening() {
             fallingEval = std::clamp(fallingEval, 0.581, 1.655);
 
             // If the bestMove is stable over several iterations, reduce time accordingly
-            double k      = 0.476;
-            double center = lastBestMoveDepth + 11.565;
-
-            timeReduction = 0.64 + 0.93 / (0.953 + std::exp(-k * (completedDepth - center)));
+            timeReduction = std::clamp(interpolate(double(completedDepth - lastBestMoveDepth), 
+                                                   5.0, 18.0, 0.65, 1.55), 0.65, 1.55);
 
             double reduction = (1.5 + mainThread->previousTimeReduction) / (2.255 * timeReduction);
 


### PR DESCRIPTION
Simplify the time management reduction logic by replacing the previous sigmoid function with the linear interpolate function introduced in #6729 , resulting in a cleaner and more efficient calculation of move stability that avoids unnecessary exponential operations.

Passed STC non-reg:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 161856 W: 41933 L: 41852 D: 78071
Ptnml(0-2): 418, 18137, 43792, 18108, 473
https://tests.stockfishchess.org/tests/view/69e117a46f344a1917600148

Passed LTC non-reg:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 108726 W: 27819 L: 27692 D: 53215
Ptnml(0-2): 59, 11084, 31942, 11227, 51
https://tests.stockfishchess.org/tests/view/69e563c00e9667dd5a7652ac

This is a follow-up for #6091  #6729 

No functional change