### PR TITLE
Speed up find_nnz on neon

### DIFF
--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -31,6 +31,7 @@
 #include "../../memory.h"
 #include "../simd.h"
 #include "../nnue_common.h"
+#include "../nnue_architecture.h"
 
 /*
   This file contains the definition for a fully connected layer (aka affine transform) with block sparse input.
@@ -40,7 +41,8 @@ namespace Stockfish::Eval::NNUE::Layers {
 
 #if (USE_SSSE3 | (USE_NEON >= 8))
 
-#if defined(USE_NEON)
+#if defined(USE_NEON) && defined(L1_SIZE) && L1_SIZE <= 1024
+    #define USE_NEON_NNZ 1
     using NNZOutputType = std::uint8_t;
 #else
     using NNZOutputType = std::uint16_t;
@@ -144,7 +146,7 @@ void find_nnz(const std::uint8_t* RESTRICT input,
     }
     count_out = count;
 
-    #elif defined(USE_NEON)
+    #elif defined(USE_NEON_NNZ)
 
     static_assert(InputDimensions <= 256, "InputDimensions must be <= 256");
 

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -38,6 +38,13 @@
 namespace Stockfish::Eval::NNUE::Layers {
 
 #if (USE_SSSE3 | (USE_NEON >= 8))
+
+#if defined(USE_NEON)
+using NNZOutputType = std::uint8_t;
+#else
+using NNZOutputType = std::uint16_t;
+#endif
+
 static constexpr int lsb_index64[64] = {
   0,  47, 1,  56, 48, 27, 2,  60, 57, 49, 41, 37, 28, 16, 3,  61, 54, 58, 35, 52, 50, 42,
   21, 44, 38, 32, 29, 23, 17, 11, 4,  62, 46, 55, 26, 59, 40, 36, 15, 53, 34, 51, 20, 43,
@@ -51,7 +58,7 @@ constexpr int constexpr_lsb(uint64_t bb) {
 
 alignas(CacheLineSize) static constexpr struct OffsetIndices {
 
-    std::uint16_t offset_indices[256][8];
+    NNZOutputType offset_indices[256][8];
 
     constexpr OffsetIndices() :
         offset_indices() {
@@ -83,7 +90,7 @@ alignas(CacheLineSize) static constexpr struct OffsetIndices {
 // std::uint8_t array.
 template<const IndexType InputDimensions>
 void find_nnz(const std::uint8_t* RESTRICT input,
-              std::uint16_t* RESTRICT      out,
+              NNZOutputType* RESTRICT      out,
               IndexType&                   count_out) {
 
     #if defined(USE_AVX512ICL)
@@ -133,6 +140,27 @@ void find_nnz(const std::uint8_t* RESTRICT input,
         _mm512_mask_cvtepi32_storeu_epi16(out + count, 0xFFFF, nnzV);
         count += popcount(nnzMask);
         base = _mm512_add_epi32(base, increment);
+    }
+    count_out = count;
+
+    #elif defined(USE_NEON)
+
+    static constexpr std::uint16_t nnz_mask[8] = {1, 2, 4, 8, 16, 32, 64, 128};
+    constexpr IndexType NumChunks = InputDimensions / 8;
+    const auto inputVector = reinterpret_cast<const uint32x4_t *>(input);
+
+    IndexType count = 0;
+    uint64_t base = 0ULL;
+    const uint64_t increment = 0x0808080808080808ULL;
+    for (IndexType i = 0; i < NumChunks; ++i) {
+        const uint32x4_t input0 = inputVector[i * 2];
+        const uint32x4_t input1 = inputVector[i * 2 + 1];
+        const uint16x8_t nnz = vcombine_u16(vqmovn_u32(vtstq_u32(input0, input0)), vqmovn_u32(vtstq_u32(input1, input1)));
+        const uint16_t lookup = vaddvq_u16(vandq_u16(nnz, vld1q_u16(nnz_mask)));
+        const uint64_t offsets = *reinterpret_cast<const uint64_t*>(Lookup.offset_indices[lookup]);
+        *reinterpret_cast<uint64_t*>(out + count) = offsets + base;
+        count += popcount(lookup);
+        base += increment;
     }
     count_out = count;
 
@@ -293,7 +321,7 @@ class AffineTransformSparseInput {
     #else
           NumAccums;
     #endif
-        std::uint16_t nnz[NumChunks];
+        NNZOutputType nnz[NumChunks];
         IndexType     count;
 
         // Find indices of nonzero 32-bit blocks

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <iostream>
 
 #include "../../bitboard.h"
@@ -160,8 +161,12 @@ void find_nnz(const std::uint8_t* RESTRICT input,
         const uint16x8_t nnz =
           vcombine_u16(vqmovn_u32(vtstq_u32(v0, v0)), vqmovn_u32(vtstq_u32(v1, v1)));
         const uint16_t lookup = vaddvq_u16(vandq_u16(nnz, vld1q_u16(nnzMask)));
-        const uint64_t offsets = *reinterpret_cast<const uint64_t*>(Lookup.offset_indices[lookup]);
-        *reinterpret_cast<uint64_t*>(out + count) = offsets + base;
+
+        uint64_t offsets;
+        std::memcpy(&offsets, Lookup.offset_indices[lookup], sizeof(offsets));
+        const uint64_t indices = offsets + base;
+        std::memcpy(out + count, &indices, sizeof(indices));
+
         count += popcount(lookup);
         base += increment;
     }

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -40,9 +40,9 @@ namespace Stockfish::Eval::NNUE::Layers {
 #if (USE_SSSE3 | (USE_NEON >= 8))
 
 #if defined(USE_NEON)
-using NNZOutputType = std::uint8_t;
+    using NNZOutputType = std::uint8_t;
 #else
-using NNZOutputType = std::uint16_t;
+    using NNZOutputType = std::uint16_t;
 #endif
 
 static constexpr int lsb_index64[64] = {
@@ -145,7 +145,9 @@ void find_nnz(const std::uint8_t* RESTRICT input,
 
     #elif defined(USE_NEON)
 
-    static constexpr std::uint16_t nnz_mask[8] = {1, 2, 4, 8, 16, 32, 64, 128};
+    static_assert(InputDimensions <= 256, "InputDimensions must be <= 256");
+
+    static constexpr std::uint16_t nnzMask[8] = {1, 2, 4, 8, 16, 32, 64, 128};
     constexpr IndexType NumChunks = InputDimensions / 8;
     const auto inputVector = reinterpret_cast<const uint32x4_t *>(input);
 
@@ -153,10 +155,11 @@ void find_nnz(const std::uint8_t* RESTRICT input,
     uint64_t base = 0ULL;
     const uint64_t increment = 0x0808080808080808ULL;
     for (IndexType i = 0; i < NumChunks; ++i) {
-        const uint32x4_t input0 = inputVector[i * 2];
-        const uint32x4_t input1 = inputVector[i * 2 + 1];
-        const uint16x8_t nnz = vcombine_u16(vqmovn_u32(vtstq_u32(input0, input0)), vqmovn_u32(vtstq_u32(input1, input1)));
-        const uint16_t lookup = vaddvq_u16(vandq_u16(nnz, vld1q_u16(nnz_mask)));
+        const uint32x4_t v0 = inputVector[i * 2];
+        const uint32x4_t v1 = inputVector[i * 2 + 1];
+        const uint16x8_t nnz =
+          vcombine_u16(vqmovn_u32(vtstq_u32(v0, v0)), vqmovn_u32(vtstq_u32(v1, v1)));
+        const uint16_t lookup = vaddvq_u16(vandq_u16(nnz, vld1q_u16(nnzMask)));
         const uint64_t offsets = *reinterpret_cast<const uint64_t*>(Lookup.offset_indices[lookup]);
         *reinterpret_cast<uint64_t*>(out + count) = offsets + base;
         count += popcount(lookup);

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -21,6 +21,8 @@
 #ifndef NNUE_ARCHITECTURE_H_INCLUDED
 #define NNUE_ARCHITECTURE_H_INCLUDED
 
+#define L1_SIZE 1024
+
 #include <cstdint>
 #include <cstring>
 #include <iosfwd>
@@ -40,7 +42,7 @@ using ThreatFeatureSet = Features::FullThreats;
 using PSQFeatureSet    = Features::HalfKAv2_hm;
 
 // Number of input feature dimensions after conversion
-constexpr IndexType TransformedFeatureDimensionsBig = 1024;
+constexpr IndexType TransformedFeatureDimensionsBig = L1_SIZE;
 constexpr int       L2Big                           = 31;
 constexpr int       L3Big                           = 32;
 


### PR DESCRIPTION
Passed STC:
LLR: 2.97 (-2.94,2.94) <0.00,2.00>
Total: 349568 W: 90131 L: 89393 D: 170044
Ptnml(0-2): 725, 37712, 97280, 38234, 833
https://tests.stockfishchess.org/tests/view/69e470510e9667dd5a765046

bench: 2723949

I saw the idea of using uint64_t instead of vectors here from @anematode, who should be a co-author if this gets merged. This would have to be reverted if the accumulator size increases, so maybe it isn’t worth it if that is likely to happen.
