### PR TITLE
Simplify FullThreats::append_active_indices()

### DIFF
--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -207,76 +207,60 @@ inline sf_always_inline IndexType FullThreats::make_index(
 // Get a list of indices for active features in ascending order
 
 void FullThreats::append_active_indices(Color perspective, const Position& pos, IndexList& active) {
-    Square   ksq      = pos.square<KING>(perspective);
-    Bitboard occupied = pos.pieces();
-    Bitboard pawns    = pos.pieces(PAWN);
+    const Square   ksq      = pos.square<KING>(perspective);
+    const Bitboard occupied = pos.pieces();
+    const Bitboard pawns    = pos.pieces(PAWN);
 
     for (Color color : {WHITE, BLACK})
     {
-        for (PieceType pt = PAWN; pt < KING; ++pt)
+        const Color c = Color(perspective ^ color);
+
         {
-            Color    c        = Color(perspective ^ color);
-            Piece    attacker = make_piece(c, pt);
-            Bitboard bb       = pos.pieces(c, pt);
+            const Piece     attacker = make_piece(c, PAWN);
+            const Bitboard  cPawns   = pos.pieces(c, PAWN);
+            // Set of pawns which are prevented from movement by a pawn in front of them
+            const Bitboard  pushers  = pawn_single_push_bb(~c, pawns) & cPawns;
 
-            if (pt == PAWN)
+            auto process_pawn_attacks = [&](Bitboard attacks, Direction attkDir) {
+                while (attacks)
+                {
+                    Square    to       = pop_lsb(attacks);
+                    Square    from     = to - attkDir;
+                    Piece     attacked = pos.piece_on(to);
+                    assert(file_of(from) != file_of(to) || type_of(attacked) == PAWN);
+                    IndexType index    = make_index(perspective, attacker, from, to, attacked, ksq);
+                    active.push_back_if_lt(index, Dimensions);
+                }
+            };
+
+            if (c == WHITE)
             {
-                auto right = (c == WHITE) ? NORTH_EAST : SOUTH_WEST;
-                auto left  = (c == WHITE) ? NORTH_WEST : SOUTH_EAST;
-                auto attacks_left =
-                  ((c == WHITE) ? shift<NORTH_EAST>(bb) : shift<SOUTH_WEST>(bb)) & occupied;
-                auto attacks_right =
-                  ((c == WHITE) ? shift<NORTH_WEST>(bb) : shift<SOUTH_EAST>(bb)) & occupied;
-
-                while (attacks_left)
-                {
-                    Square    to       = pop_lsb(attacks_left);
-                    Square    from     = to - right;
-                    Piece     attacked = pos.piece_on(to);
-                    IndexType index    = make_index(perspective, attacker, from, to, attacked, ksq);
-
-                    active.push_back_if_lt(index, Dimensions);
-                }
-
-                while (attacks_right)
-                {
-                    Square    to       = pop_lsb(attacks_right);
-                    Square    from     = to - left;
-                    Piece     attacked = pos.piece_on(to);
-                    IndexType index    = make_index(perspective, attacker, from, to, attacked, ksq);
-
-                    active.push_back_if_lt(index, Dimensions);
-                }
-
-                // Set of pawns which are prevented from movement by a pawn in front of them
-                Bitboard pushers = pawn_single_push_bb(~c, pawns) & pos.pieces(c, PAWN);
-                while (pushers)
-                {
-                    Square from     = pop_lsb(pushers);
-                    Square to       = from + pawn_push(c);
-                    Piece  attacked = pos.piece_on(to);
-                    assert(type_of(attacked) == PAWN);
-
-                    IndexType index = make_index(perspective, attacker, from, to, attacked, ksq);
-                    active.push_back_if_lt(index, Dimensions);
-                }
+                process_pawn_attacks(shift<NORTH_EAST>(cPawns) & occupied, NORTH_EAST);
+                process_pawn_attacks(shift<NORTH_WEST>(cPawns) & occupied, NORTH_WEST);
+                process_pawn_attacks(shift<NORTH>(pushers), NORTH);
             }
             else
             {
-                while (bb)
+                process_pawn_attacks(shift<SOUTH_WEST>(cPawns) & occupied, SOUTH_WEST);
+                process_pawn_attacks(shift<SOUTH_EAST>(cPawns) & occupied, SOUTH_EAST);
+                process_pawn_attacks(shift<SOUTH>(pushers), SOUTH);
+            }
+        }
+
+        for (PieceType pt = KNIGHT; pt < KING; ++pt)
+        {
+            Piece    attacker = make_piece(c, pt);
+            Bitboard bb       = pos.pieces(c, pt);
+            while (bb)
+            {
+                Square   from    = pop_lsb(bb);
+                Bitboard attacks = attacks_bb(pt, from, occupied) & occupied;
+                while (attacks)
                 {
-                    Square   from    = pop_lsb(bb);
-                    Bitboard attacks = (attacks_bb(pt, from, occupied)) & occupied;
-
-                    while (attacks)
-                    {
-                        Square    to       = pop_lsb(attacks);
-                        Piece     attacked = pos.piece_on(to);
-                        IndexType index =
-                          make_index(perspective, attacker, from, to, attacked, ksq);
-
-                        active.push_back_if_lt(index, Dimensions);
-                    }
+                    Square    to       = pop_lsb(attacks);
+                    Piece     attacked = pos.piece_on(to);
+                    IndexType index    = make_index(perspective, attacker, from, to, attacked, ksq);
+                    active.push_back_if_lt(index, Dimensions);
                 }
             }
         }
@@ -318,8 +302,7 @@ void FullThreats::append_changed_indices(Color                   perspective,
                 else if (fusedData->dp2removedOriginBoard & to)
                     continue;
             }
-
-            if (to != SQ_NONE && to == fusedData->dp2removed)
+            else if (to != SQ_NONE && to == fusedData->dp2removed)
             {
                 if (add)
                 {


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/69e71a490e9667dd5a76549f
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 210688 W: 54362 L: 54335 D: 101991
Ptnml(0-2): 613, 23246, 57593, 23285, 607 

Simplify FullThreats::append_active_indices().
Also add an else to FullThreats::append_changed_indices() because dp2removed can't be equal to both from and to simultaneously.

Thanks to @ces42 for an improvement suggestion.

No functional change
bench: 2723949