### PR TITLE
ci: cancel stale workflow runs per PR or ref

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -12,6 +12,10 @@ on:
       - "**.cpp"
       - "**.h"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: "17 18 * * 1"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -11,6 +11,11 @@ on:
     branches:
       - master
       - tools
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Prerelease:
     if: github.repository == 'official-stockfish/Stockfish' && (github.ref == 'refs/heads/master' || (startsWith(github.ref_name, 'sf_') && github.ref_type == 'tag'))


### PR DESCRIPTION
Add workflow-level concurrency to the direct GitHub Actions entrypoints so a newer run for the same pull request or repository ref cancels the older in-progress run.

Keep the reusable workflow graph, release guards, triggers, and permissions unchanged while documenting the concurrency policy and the official GitHub references used for the change.

No functional change.