### PR TITLE
Replacing the futility margin static value with a continuous transition

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -382,7 +382,10 @@ inline uint64_t mul_hi64(uint64_t a, uint64_t b) {
 template<typename T1, typename T2>
 inline constexpr T2 interpolate(T1 x, T1 x0, T1 x1, T2 y0, T2 y1) {
     assert(x0 != x1);
-    return T2(y0 + (y1 - y0) * (x - x0) / (x1 - x0));
+    if constexpr (std::is_floating_point_v<T2>)
+        return T2(y0 + (y1 - y0) * (double(x) - x0) / (double(x1) - x0));
+    else
+        return T2(y0 + (int64_t(y1) - y0) * (x - x0) / (x1 - x0));
 }
 
 uint64_t hash_bytes(const char*, size_t);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -897,7 +897,8 @@ Value Search::Worker::search(
     if (!ss->ttPv && depth < 15 && eval >= beta && (!ttData.move || ttCapture) && !is_loss(beta)
         && !is_win(eval))
     {
-        Value futilityMult   = 76 - 21 * !ss->ttHit;
+        Value futilityMult = std::clamp(interpolate(int(depth), 1, 10, 40, 76), 40, 76);
+        if (!ss->ttHit) futilityMult -= 21;
         Value futilityMargin = futilityMult * depth
                              - (2686 * improving + 362 * opponentWorsening) * futilityMult / 1024
                              + std::abs(correctionValue) / 180600;


### PR DESCRIPTION
Smooth the futility margin by interpolating the multiplier based on depth, replacing the previous static value with a continuous transition between depth 1 and 10.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 208448 W: 53891 L: 53324 D: 101233
Ptnml(0-2): 629, 24426, 53574, 24939, 656
https://tests.stockfishchess.org/tests/view/69e232206f344a19176002f3

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 208938 W: 53432 L: 52765 D: 102741
Ptnml(0-2): 105, 22531, 58550, 23158, 125
https://tests.stockfishchess.org/tests/view/69e8b5d00e9667dd5a7656c6

Bench: 2661424