### PR TITLE
[CI] Upgrade SDE action

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -43,10 +43,10 @@ jobs:
 
       - name: Download SDE package
         if: ${{ matrix.config.sde }}
-        uses: petarpetrovt/setup-sde@2a27a21f27212e473f3cc59a6dac97d8dffe8970 # v3.0
+        uses: petarpetrovt/setup-sde@d230e06df0ca06ced70000e4a7fa62afc9a2001e # v4.0
         with:
           environmentVariableName: SDE_DIR
-          sdeVersion: 9.33.0
+          sdeVersion: 9.58.0
 
       - name: Download the used network from the fishtest framework
         run: make net

--- a/.github/workflows/universal_compilation.yml
+++ b/.github/workflows/universal_compilation.yml
@@ -20,10 +20,10 @@ jobs:
           version: 15
 
       - name: Download SDE package
-        uses: petarpetrovt/setup-sde@2a27a21f27212e473f3cc59a6dac97d8dffe8970 # v3.0
+        uses: petarpetrovt/setup-sde@d230e06df0ca06ced70000e4a7fa62afc9a2001e # v4.0
         with:
           environmentVariableName: SDE_DIR
-          sdeVersion: 9.33.0
+          sdeVersion: 9.58.0
 
       - name: Build universal binary
         run: make -j4 -C src ARCH=x86-64-universal profile-build RUN_PREFIX="$SDE_DIR/sde -future --"
@@ -77,10 +77,10 @@ jobs:
           install: mingw-w64-x86_64-gcc make git zip
 
       - name: Download SDE package
-        uses: petarpetrovt/setup-sde@2a27a21f27212e473f3cc59a6dac97d8dffe8970 # v3.0
+        uses: petarpetrovt/setup-sde@d230e06df0ca06ced70000e4a7fa62afc9a2001e # v4.0
         with:
           environmentVariableName: SDE_DIR
-          sdeVersion: 9.33.0
+          sdeVersion: 9.58.0
 
       - name: Build universal binary
         run: |


### PR DESCRIPTION
fix Node.js version dependency, update SDE.
    
This upgrades to 9.58, upgrade to 10.8 failed with:
Invalid file name and base dir combination: Pin root DLL: pincrt4.dll
    
Also adjusts Makefile to show PGO bench output on failure

No functional change