### PR TITLE
Change ttmove reduction logic, and values

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1226,8 +1226,8 @@ moves_loop:  // When in check, search starts here
 
         // Decrease reduction for PvNodes (*Scaler)
         if (ss->ttPv)
-            r -= 2819 + PvNode * 973 + (ttData.value > alpha) * 905
-               + (ttData.depth >= depth) * (935 + cutNode * 959);
+            r -= 2617 + PvNode * 912 + (ttData.value > alpha) * 934
+               + (ttData.depth >= depth) * (988 + cutNode * 889);
 
         r += 691;  // Base reduction offset to compensate for other tweaks
         r -= moveCount * 65;
@@ -1235,7 +1235,7 @@ moves_loop:  // When in check, search starts here
 
         // Increase reduction for cut nodes
         if (cutNode)
-            r += 3611 + 985 * !ttData.move;
+            r += 3274 + 1006 * !ttData.move;
 
         // Increase reduction if ttMove is a capture
         if (ttCapture)
@@ -1246,8 +1246,8 @@ moves_loop:  // When in check, search starts here
             r += 251 + 1124 * ((ss + 1)->cutoffCnt > 2) + 1042 * allNode;
 
         // For first picked move (ttMove) reduce reduction
-        if (move == ttData.move)
-            r -= 2239;
+        else if (move == ttData.move)
+            r = std::max(-10, r - 2016 + 150 * cutNode);
 
         if (capture)
             ss->statScore = 863 * int(PieceValue[pos.captured_piece()]) / 128


### PR DESCRIPTION
Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 38112 W: 10024 L: 9708 D: 18380
Ptnml(0-2): 104, 4365, 9830, 4625, 132
https://tests.stockfishchess.org/tests/view/69dd25a33ca80bdf151d4b33

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 256926 W: 65744 L: 64977 D: 126205
Ptnml(0-2): 126, 27919, 71612, 28674, 132
https://tests.stockfishchess.org/tests/view/69de48645c67bee7d241ff4e

Passed VLTC non-reg:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 174386 W: 44640 L: 44578 D: 85168
Ptnml(0-2): 26, 17847, 51384, 17911, 25
https://tests.stockfishchess.org/tests/view/69e767370e9667dd5a76551b

bench: 2727950