### PR TITLE
Remove the limit from the formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1196,7 +1196,7 @@ moves_loop:  // When in check, search starts here
             // subtree by returning a softbound.
             else if (value >= beta && !is_decisive(value))
             {
-                ttMoveHistory << std::max(-424 - 107 * depth, -3375);
+                ttMoveHistory << -424 - 107 * depth;
                 return value;
             }
 


### PR DESCRIPTION
Remove the limit from the formula

Passed STC:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 364768 W: 94115 L: 94250 D: 176403
Ptnml(0-2): 1101, 40158, 99989, 40047, 1089
https://tests.stockfishchess.org/tests/view/69e7ca530e9667dd5a7655a7

Passed LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 146382 W: 37335 L: 37247 D: 71800
Ptnml(0-2): 64, 14682, 43630, 14732, 83
https://tests.stockfishchess.org/tests/view/69eeaf551e5788938e86a1e6

Passed VLTC:
LLR: 3.00 (-2.94,2.94) <-1.75,0.25>
Total: 48308 W: 12350 L: 12172 D: 23786
Ptnml(0-2): 4, 4303, 15362, 4481, 4
https://tests.stockfishchess.org/tests/view/69f25adb1e5788938e86a794

No functional change