### PR TITLE
Make universal Intel macOS binary

### DIFF
--- a/.github/ci/universal_matrix.json
+++ b/.github/ci/universal_matrix.json
@@ -12,6 +12,12 @@
       "simple_name": "windows",
       "ext": ".exe",
       "archive_ext": "zip"
+    },
+    {
+      "name": "macOS 15 Apple Clang Universal",
+      "os": "macos-15-intel",
+      "simple_name": "macos",
+      "archive_ext": "tar.gz"
     }
   ],
   "binaries": ["x86-64-universal"]

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -207,3 +207,39 @@ jobs:
              .
              !.git
              !.output
+
+  UniversalMacOS:
+    name: macOS x86-64 Universal
+    runs-on: macos-15-intel
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      # petarpetrovt/setup-sde has no macOS support yet, so no PGO for now
+      - name: Build universal binary
+        run: make -j4 -C src ARCH=x86-64-universal build
+
+      - name: Strip binary
+        run: strip src/stockfish
+
+      - name: Rename binary
+        run: mv src/stockfish stockfish-macos-x86-64-universal
+
+      - name: Remove non src files
+        run: |
+          rm -fR src/temp_builds
+          git -C src clean -fx
+
+      - name: Upload artifact for (pre)-release
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: macos x86-64-universal
+          path: |
+             .
+             !.git
+             !.output

--- a/src/Makefile
+++ b/src/Makefile
@@ -631,6 +631,7 @@ ifeq ($(COMP),gcc)
 	ifneq ($(gccisclang),)
 		profile_make = clang-profile-make
 		profile_use = clang-profile-use
+		CXXFLAGS += -fconstexpr-steps=500000000
 	else
 		CXXFLAGS += -Wstack-usage=128000 -fno-ipa-cp-clone -fconstexpr-ops-limit=500000000
 	endif
@@ -1043,7 +1044,12 @@ profile-build: net config-sanity objclean profileclean
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) profileclean
 endif
 
-ifeq ($(comp), clang)
+ifeq ($(KERNEL),Darwin)
+# Apple uses ld64 which doesn't have --save-temps, so we need to explicitly
+# specify a location to save the LTOed object
+LTO_OBJ_SUFFIX := .lto.o
+SAVE_TEMPS := -Wl,-object_path_lto,stockfish.lto.o
+else ifeq ($(comp), clang)
 LTO_OBJ_SUFFIX := .lto.o
 SAVE_TEMPS := -Wl,--save-temps
 else
@@ -1275,21 +1281,37 @@ TRACKED_TOP := $(sort $(foreach f,$(SRCS) $(HEADERS) Makefile incbin,$(firstword
 ARCH_OBJS := $(TEMP_DIR)/x86-64/stockfish.o \
              $(patsubst %,$(TEMP_DIR)/%/stockfish.o,$(filter-out x86-64,$(UNIVERSAL_ARCHES)))
 
-UNIVERSAL_FINAL_FLAGS := -fno-exceptions -Os -static-libstdc++ -static-libgcc -Wno-c++26-extensions
-ifeq ($(KERNEL),Linux)
-    UNIVERSAL_FINAL_FLAGS += -lrt -lpthread
+ifeq ($(KERNEL),Darwin)
+    UNIVERSAL_FINAL_FLAGS := -fno-exceptions -Os -mmacosx-version-min=10.15 -arch $(arch) $(EXTRACXXFLAGS)
 else
-    UNIVERSAL_FINAL_FLAGS += -Wl,--allow-multiple-definition -static
+    UNIVERSAL_FINAL_FLAGS := -fno-exceptions -Os -static-libstdc++ -static-libgcc -Wno-c++26-extensions
+    ifeq ($(KERNEL),Linux)
+        UNIVERSAL_FINAL_FLAGS += -lrt -lpthread
+    else
+        UNIVERSAL_FINAL_FLAGS += -Wl,--allow-multiple-definition -static
+    endif
 endif
 
 # $(call arch-namespace,x86-64-avx2) => Stockfish_x86_64_avx2
 arch-suffix     = $(subst -,_,$(1))
 arch-namespace  = Stockfish_$(call arch-suffix,$(1))
-# Itanium ABI mangled name for Stockfish_<suffix>::main(int, char**)
-arch-mangled    = _ZN$(shell printf %s '$(call arch-namespace,$(1))' | wc -c)$(call arch-namespace,$(1))4mainEiPPc
+# Itanium ABI mangled name for Stockfish_<suffix>::main(int, char**).
+# wc -c pads with spaces on BSD/macOS, so unpad.
+arch-mangled    = _ZN$(shell awk 'BEGIN{print length("$(call arch-namespace,$(1))")}')$(call arch-namespace,$(1))4mainEiPPc
+# Mach-O initializer section name: strip "x86-64" or "x86-64-" and prefix with "_i_"
+# n.b. Mach-O section names are restricted to <=16 chars, hence this naming scheme
+arch-mac-section = _i_$(subst -,_,$(patsubst x86-64,,$(patsubst x86-64-%,%,$(1))))
 
-arch-cxxflags   = --embed-dir=$(CURDIR) -DStockfish=$(call arch-namespace,$(1)) -DUNIVERSAL_BINARY \
-                  -Wl,--defsym=main=$(call arch-mangled,$(1)) -Wno-c++26-extensions
+ifeq ($(KERNEL),Darwin)
+    # ld64 uses -alias instead of --defsym, and macOS has a leading underscore
+    # on all symbols
+    arch-cxxflags = --embed-dir=$(CURDIR) -DStockfish=$(call arch-namespace,$(1)) -DUNIVERSAL_BINARY \
+                    -Wl,-alias,_$(call arch-mangled,$(1)),_main \
+                    -Wno-c++26-extensions -Wno-c23-extensions
+else
+    arch-cxxflags = --embed-dir=$(CURDIR) -DStockfish=$(call arch-namespace,$(1)) -DUNIVERSAL_BINARY \
+                    -Wl,--defsym=main=$(call arch-mangled,$(1)) -Wno-c++26-extensions
+endif
 
 UOBJ_TGT ?= universal-object-pgo
 
@@ -1307,11 +1329,17 @@ $(NET_SENTINEL): | $(TEMP_DIR)
 	@cd $(CURDIR) && $(SHELL) ../scripts/net.sh
 	@touch $@
 
+ifeq ($(KERNEL),Darwin)
+    UNIVERSAL_OBJ_FLAGS := -mmacosx-version-min=10.15 -arch $(arch) $(EXTRACXXFLAGS)
+else
+    UNIVERSAL_OBJ_FLAGS := $(EXTRACXXFLAGS)
+endif
+
 $(NNUE_EMBED_OBJ): $(UNIVERSAL_SRC_DIR)/nnue_embed.cpp $(NET_SENTINEL) | $(TEMP_DIR)
-	$(CXX) -O2 -Wno-c++26-extensions --embed-dir=$(CURDIR) -c $< -o $@
+	$(CXX) -std=c++17 -O2 -Wno-c++26-extensions $(UNIVERSAL_OBJ_FLAGS) --embed-dir=$(CURDIR) -c $< -o $@
 
 $(UNIVERSAL_ENTRY_OBJ): $(UNIVERSAL_SRC_DIR)/entry_x86.cpp | $(TEMP_DIR)
-	$(CXX) -O2 -c $< -o $@
+	$(CXX) -std=c++17 -O2 $(UNIVERSAL_OBJ_FLAGS) -c $< -o $@
 
 # Symlink tracked top-level items from src/ into temp_builds/<arch>/.
 $(TEMP_DIR)/%/.setup: | $(TEMP_DIR)
@@ -1323,6 +1351,19 @@ $(TEMP_DIR)/%/.setup: | $(TEMP_DIR)
 # Per-arch stockfish.o
 .SECONDARY: $(patsubst %,$(TEMP_DIR)/%/.setup,$(UNIVERSAL_ARCHES))
 
+ifeq ($(KERNEL),Darwin)
+$(TEMP_DIR)/%/stockfish.o: $(TEMP_DIR)/%/.setup $(NNUE_EMBED_OBJ) $(NET_SENTINEL)
+	+ENV_CXXFLAGS='$(ENV_CXXFLAGS) $(call arch-cxxflags,$*)' \
+	    $(MAKE) -C $(TEMP_DIR)/$* $(UOBJ_TGT) \
+	        ARCH=$* CXX=$(CXX) \
+	        NNUE_EMBED_OBJ=$(NNUE_EMBED_OBJ)
+# Mach-O has no GNU objcopy, so use ld -r to rename __DATA,__mod_init_func (where the ctors live) to
+# a per-arch section name (prefixed with _i_ -- see above).
+# ld64 auto-rewrites the section type from S_MOD_INIT_FUNC_POINTERS to S_REGULAR in the final link,
+# so no special work needed
+	ld -r -rename_section __DATA __mod_init_func __DATA $(call arch-mac-section,$*) $@ -o $@.tmp
+	mv $@.tmp $@
+else
 $(TEMP_DIR)/%/stockfish.o: $(TEMP_DIR)/%/.setup $(NNUE_EMBED_OBJ) $(NET_SENTINEL)
 	+ENV_CXXFLAGS='$(ENV_CXXFLAGS) $(call arch-cxxflags,$*)' \
 	    $(MAKE) -C $(TEMP_DIR)/$* $(UOBJ_TGT) \
@@ -1336,6 +1377,7 @@ $(TEMP_DIR)/%/stockfish.o: $(TEMP_DIR)/%/.setup $(NNUE_EMBED_OBJ) $(NET_SENTINEL
 	objcopy --rename-section .ctors=$(call arch-suffix,$*)_init $@
 # Make the array inert
 	objcopy --set-section-flags $(call arch-suffix,$*)_init=alloc,data $@
+endif
 
 $(UNIVERSAL_EXE): $(UNIVERSAL_ENTRY_OBJ) $(NNUE_EMBED_OBJ) $(ARCH_OBJS)
 	$(CXX) -o $@ $(UNIVERSAL_ENTRY_OBJ) $(NNUE_EMBED_OBJ) $(ARCH_OBJS) $(UNIVERSAL_FINAL_FLAGS)

--- a/src/universal/entry_x86.cpp
+++ b/src/universal/entry_x86.cpp
@@ -2,41 +2,41 @@
 #include <stdint.h>
 
 #ifdef __APPLE__
-// We locate each arch's initializer pointer array at runtime via getsectiondata().
-// Example name is "_i_sse41_popcnt", baseline build is just "_i_"
-#include <stdio.h>
-#include <mach-o/getsect.h>
+    // We locate each arch's initializer pointer array at runtime via getsectiondata().
+    // Example name is "_i_sse41_popcnt", baseline build is just "_i_"
+    #include <stdio.h>
+    #include <mach-o/getsect.h>
 
 extern "C" const struct mach_header_64 _mh_execute_header;
 
-#define DEFINE_BUILD(x) \
-    namespace Stockfish_##x { \
-        extern int main(int argc, char* argv[]); \
-    } \
-    int entry_##x(int argc, char* argv[]) { \
-        char        name[17]; \
-        const char* full = #x; \
-        snprintf(name, sizeof(name), "_i_%s", full[6] ? full + 7 : ""); \
-        unsigned long size = 0; \
-        auto**        fns  = reinterpret_cast<void (**)()>( \
-          getsectiondata(&_mh_execute_header, "__DATA", name, &size)); \
-        for (unsigned long i = 0; i < size / sizeof(*fns); i++) \
-            fns[i](); \
-        return Stockfish_##x::main(argc, argv); \
-    }
+    #define DEFINE_BUILD(x) \
+        namespace Stockfish_##x { \
+            extern int main(int argc, char* argv[]); \
+        } \
+        int entry_##x(int argc, char* argv[]) { \
+            char        name[17]; \
+            const char* full = #x; \
+            snprintf(name, sizeof(name), "_i_%s", full[6] ? full + 7 : ""); \
+            unsigned long size = 0; \
+            auto**        fns  = reinterpret_cast<void (**)()>( \
+              getsectiondata(&_mh_execute_header, "__DATA", name, &size)); \
+            for (unsigned long i = 0; i < size / sizeof(*fns); i++) \
+                fns[i](); \
+            return Stockfish_##x::main(argc, argv); \
+        }
 #else
-#define DEFINE_BUILD(x) \
-    namespace Stockfish_##x { \
-        extern int main(int argc, char* argv[]); \
-    } \
-    extern "C" void (*__start_##x##_init[])(void); \
-    extern "C" void (*__stop_##x##_init[])(void); \
-    int entry_##x(int argc, char* argv[]) { \
-        unsigned count = __stop_##x##_init - __start_##x##_init; \
-        for (unsigned i = 0; i < count; i++) \
-            __start_##x##_init[i](); \
-        return Stockfish_##x::main(argc, argv); \
-    }
+    #define DEFINE_BUILD(x) \
+        namespace Stockfish_##x { \
+            extern int main(int argc, char* argv[]); \
+        } \
+        extern "C" void (*__start_##x##_init[])(void); \
+        extern "C" void (*__stop_##x##_init[])(void); \
+        int entry_##x(int argc, char* argv[]) { \
+            unsigned count = __stop_##x##_init - __start_##x##_init; \
+            for (unsigned i = 0; i < count; i++) \
+                __start_##x##_init[i](); \
+            return Stockfish_##x::main(argc, argv); \
+        }
 #endif
 
 DEFINE_BUILD(x86_64)

--- a/src/universal/entry_x86.cpp
+++ b/src/universal/entry_x86.cpp
@@ -1,6 +1,30 @@
 #include <cpuid.h>
 #include <stdint.h>
 
+#ifdef __APPLE__
+// We locate each arch's initializer pointer array at runtime via getsectiondata().
+// Example name is "_i_sse41_popcnt", baseline build is just "_i_"
+#include <stdio.h>
+#include <mach-o/getsect.h>
+
+extern "C" const struct mach_header_64 _mh_execute_header;
+
+#define DEFINE_BUILD(x) \
+    namespace Stockfish_##x { \
+        extern int main(int argc, char* argv[]); \
+    } \
+    int entry_##x(int argc, char* argv[]) { \
+        char        name[17]; \
+        const char* full = #x; \
+        snprintf(name, sizeof(name), "_i_%s", full[6] ? full + 7 : ""); \
+        unsigned long size = 0; \
+        auto**        fns  = reinterpret_cast<void (**)()>( \
+          getsectiondata(&_mh_execute_header, "__DATA", name, &size)); \
+        for (unsigned long i = 0; i < size / sizeof(*fns); i++) \
+            fns[i](); \
+        return Stockfish_##x::main(argc, argv); \
+    }
+#else
 #define DEFINE_BUILD(x) \
     namespace Stockfish_##x { \
         extern int main(int argc, char* argv[]); \
@@ -13,6 +37,7 @@
             __start_##x##_init[i](); \
         return Stockfish_##x::main(argc, argv); \
     }
+#endif
 
 DEFINE_BUILD(x86_64)
 DEFINE_BUILD(x86_64_sse41_popcnt)


### PR DESCRIPTION
WIP, this one def needs some testing. It also might not be worth the technical burden since x86 macs are less common, up to maintainers.

I have an old pre-Haswell Mac in a box somewhere, and a Haswell one, but I don't have access to one of those Xeon Mac Pros that would take the avx512 codepath...

This also fixes a couple oversights in the Makefile (not passing EXTRACXXFLAGS down)