### PR TITLE
remove simple eval

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -36,15 +36,6 @@
 
 namespace Stockfish {
 
-// Returns a static, purely materialistic evaluation of the position from
-// the point of view of the side to move. It can be divided by PawnValue to get
-// an approximation of the material advantage on the board in terms of pawns.
-int Eval::simple_eval(const Position& pos) {
-    Color c = pos.side_to_move();
-    return PawnValue * (pos.count<PAWN>(c) - pos.count<PAWN>(~c)) + pos.non_pawn_material(c)
-         - pos.non_pawn_material(~c);
-}
-
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
 // of the position from the point of view of the side to move.
 Value Eval::evaluate(const Eval::NNUE::Network&     network,
@@ -99,9 +90,6 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Network& network) {
     ss << "NNUE evaluation          " << v << " (side to move, internal units)\n";
     v = pos.side_to_move() == WHITE ? v : -v;
     ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)\n";
-
-    ss << "SimpleEval                         " << simple_eval(pos)
-       << " (side to move, internal units)\n\n";
 
     v = evaluate(network, pos, *accumulators, *caches, VALUE_ZERO);
     v = pos.side_to_move() == WHITE ? v : -v;

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -43,8 +43,6 @@ class AccumulatorStack;
 
 std::string trace(Position& pos, const Eval::NNUE::Network& network);
 
-int   simple_eval(const Position& pos);
-bool  use_smallnet(const Position& pos);
 Value evaluate(const NNUE::Network&           network,
                const Position&                pos,
                Eval::NNUE::AccumulatorStack&  accumulators,


### PR DESCRIPTION
No longer needed after the removal of smallnet.

Also remove declaration of `use_smallnet()`.

No functional change.