### PR TITLE
Updated main network to nn-83a0d6daf7e5.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultName "nn-c7fbe3c71c42.nnue"
+#define EvalFileDefaultName "nn-83a0d6daf7e5.nnue"
 
 namespace NNUE {
 class Network;

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultName "nn-fcf986aea78a.nnue"
+#define EvalFileDefaultName "nn-c7fbe3c71c42.nnue"
 
 namespace NNUE {
 class Network;


### PR DESCRIPTION
Passed STC:
https://tests.stockfishchess.org/tests/live_elo/69f902413a3c3e525bb2b465
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 27264 W: 7199 L: 6895 D: 13170
Ptnml(0-2): 80, 3139, 6903, 3417, 93

Passed LTC:
https://tests.stockfishchess.org/tests/live_elo/69f98b103a3c3e525bb2b4f7
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 32352 W: 8509 L: 8200 D: 15643
Ptnml(0-2): 10, 3439, 8979, 3728, 20

Nettest Run
https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/5137461961076608/2926829081096545/-/pipelines/2496280249

Nettest PR:
https://github.com/vondele/nettest/pull/329

Makes quite a few changes to the trainer. In particular recipe does not use a lambda (game score + outcome blending parameter) schedule for the most part.

Accidentally dropped loss weighing parameters. Unclear how big the effect of that is