### PR TITLE
Fix calculation of searched nodes (effort)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1218,12 +1218,13 @@ moves_loop:  // When in check, search starts here
                 extension = -2;
         }
 
+        uint64_t nodeCount = rootNode ? uint64_t(nodes) : 0;
+
         // Step 16. Make the move
         do_move(pos, move, st, givesCheck, ss);
 
         // Add extension to new depth
         newDepth += extension;
-        uint64_t nodeCount = rootNode ? uint64_t(nodes) : 0;
 
         // Decrease reduction for PvNodes (*Scaler)
         if (ss->ttPv)


### PR DESCRIPTION
by moving it back to its original place right before making the move. See the original patch https://github.com/official-stockfish/Stockfish/commit/bf2c7306ac7f83200ba4d894867e3c0c78c0802c

Only functional with active time-management.

Bench: 2344696