### PR TITLE
Set lastIterationPV at the start of the multipv loop

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -187,6 +187,7 @@ void Search::Worker::ensure_network_replicated() {
 void Search::Worker::start_searching() {
 
     accumulatorStack.reset();
+    lastIterationFirstPV.clear();
     lastIterationPV.clear();
 
     // Non-main threads go directly to iterative_deepening()
@@ -341,6 +342,8 @@ bool Search::Worker::iterative_deepening() {
         for (RootMove& rm : rootMoves)
             rm.previousScore = rm.score;
 
+        lastIterationFirstPV = rootMoves[0].pv;
+
         size_t pvFirst = 0;
         pvLast         = 0;
 
@@ -362,6 +365,7 @@ bool Search::Worker::iterative_deepening() {
             selDepth = 0;
 
             // Set lastIterationPV to the current root move's pv
+            // for the followPv idea to work in MultiPV mode, too.
             lastIterationPV = rootMoves[pvIdx].pv;
 
             // Reset aspiration window starting size
@@ -466,7 +470,7 @@ bool Search::Worker::iterative_deepening() {
 
         if (!threads.stop)
         {
-            if (!pvIdx && rootMoves[0].pv[0] != lastIterationPV[0])
+            if (rootMoves[0].pv[0] != lastIterationFirstPV[0])
                 lastBestMoveDepth = rootDepth;
         }
 
@@ -479,9 +483,9 @@ bool Search::Worker::iterative_deepening() {
             // Bring the last best move to the front for best thread selection.
             if (rootDepth > 1)
             {
-                Utility::move_to_front(rootMoves, [&lastPV = std::as_const(lastIterationPV)](
+                Utility::move_to_front(rootMoves, [&lastPV = std::as_const(lastIterationFirstPV)](
                                                     const auto& rm) { return rm == lastPV[0]; });
-                rootMoves[0].pv    = lastIterationPV;
+                rootMoves[0].pv    = lastIterationFirstPV;
                 rootMoves[0].score = rootMoves[0].uciScore = rootMoves[0].previousScore;
 
                 if (mainThread)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -361,6 +361,9 @@ bool Search::Worker::iterative_deepening() {
             // Reset UCI info selDepth for each depth and each PV line
             selDepth = 0;
 
+            // Set lastIterationPV to the current root move's pv
+            lastIterationPV = rootMoves[pvIdx].pv;
+
             // Reset aspiration window starting size
             delta     = 5 + threadIdx % 8 + std::abs(rootMoves[pvIdx].meanSquaredScore) / 10588;
             Value avg = rootMoves[pvIdx].averageScore;
@@ -463,10 +466,8 @@ bool Search::Worker::iterative_deepening() {
 
         if (!threads.stop)
         {
-            if (lastIterationPV.empty() || rootMoves[0].pv[0] != lastIterationPV[0])
+            if (rootMoves[0].pv[0] != lastIterationPV[0])
                 lastBestMoveDepth = rootDepth;
-
-            lastIterationPV = rootMoves[0].pv;
         }
 
         // An exact mated-in/TB-loss score from an aborted search cannot be trusted: the
@@ -476,7 +477,7 @@ bool Search::Worker::iterative_deepening() {
                  && !rootMoves[0].score_is_bound())
         {
             // Bring the last best move to the front for best thread selection.
-            if (!lastIterationPV.empty())
+            if (rootDepth > 1)
             {
                 Utility::move_to_front(rootMoves, [&lastPV = std::as_const(lastIterationPV)](
                                                     const auto& rm) { return rm == lastPV[0]; });

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -466,7 +466,7 @@ bool Search::Worker::iterative_deepening() {
 
         if (!threads.stop)
         {
-            if (rootMoves[0].pv[0] != lastIterationPV[0])
+            if (!pvIdx && rootMoves[0].pv[0] != lastIterationPV[0])
                 lastBestMoveDepth = rootDepth;
         }
 

--- a/src/search.h
+++ b/src/search.h
@@ -385,6 +385,7 @@ class Worker {
     Depth     rootDepth;
     Value     rootDelta;
 
+    PVMoves lastIterationFirstPV;
     PVMoves lastIterationPV;
 
     size_t                    threadIdx, numaThreadIdx, numaTotal;


### PR DESCRIPTION
with the PV of the currently searched PV line.

This allows ss->followPv to also work in MultiPV mode. As a consequence, lastIterationPV will never be empty which makes it necessary to do some reworking.

Overall, this looks a bit more logical to me.
No functional change in single PV mode.

Bench: 2336177