### PR TITLE
Replace directory == "<internal>" with a simple "else"

### DIFF
--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -101,14 +101,9 @@ void Network::load(const std::string& rootDirectory, std::string evalfilePath) {
         if (std::string(evalFile.current) != evalfilePath)
         {
             if (directory != "<internal>")
-            {
                 load_user_net(directory, evalfilePath);
-            }
-
-            if (directory == "<internal>" && evalfilePath == std::string(evalFile.defaultName))
-            {
+            else if (evalfilePath == std::string(evalFile.defaultName))
                 load_internal();
-            }
         }
     }
 }


### PR DESCRIPTION
Replace directory == "<internal>" with a simple "else" , since the previous condition was the opposite.

No functional change