### PR TITLE
Reintroduce Secondary TT Aging

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -107,6 +107,12 @@ void TTEntry::save(
         value16   = int16_t(v);
         eval16    = int16_t(ev);
     }
+    // Secondary aging. Important for elementary mate finding.
+    // (*Scaler) Secondary aging on entries relevant to singular extensions
+    // generally scales poorly and requires VVLTC verification.
+    else if (depth8 + DEPTH_NONE >= 5 && is_decisive(value16)
+             && Bound((genBound8 & BOUND_MASK) >> BOUND_SHIFT) != BOUND_EXACT)
+        depth8--;
 }
 
 


### PR DESCRIPTION
Restricted secondary aging in TT to evict stale high-depth entries that could not cutoff.

Passed Non-regression STC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 189792 W: 48752 L: 48702 D: 92338
Ptnml(0-2): 428, 21147, 51711, 21167, 443
https://tests.stockfishchess.org/tests/view/69fae7b6c91f9625ce3253c8

Passed Non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 234792 W: 59743 L: 59741 D: 115308
Ptnml(0-2): 98, 24714, 67772, 24712, 100
https://tests.stockfishchess.org/tests/view/69ff3aa39392f0c317213e31

See #6742 for information and test results
```
Using ./stockfish_fix1 on KRvK_1000pv.epd with --nodes 1000000 --mate 0
Engine ID:     Stockfish dev-20260505-1429d98e
Total FENs:    1000
Found mates:   620
Best mates:    159

Using ./stockfish_fix1 on KRvK_1000pv.epd with --nodes 10000000 --mate 0
Engine ID:     Stockfish dev-20260505-1429d98e
Total FENs:    1000
Found mates:   1000
Best mates:    709
```

Closes #6576
Closes #6742

Bench: 2821162