### PR TITLE
Compute correction_value before TT lookup

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -736,6 +736,8 @@ Value Search::Worker::search(
     ss->statScore       = 0;
     (ss + 2)->cutoffCnt = 0;
 
+    const auto correctionValue = correction_value(*this, pos, ss);
+
     // Step 4. Transposition table lookup
     excludedMove                   = ss->excludedMove;
     posKey                         = pos.key();
@@ -748,8 +750,8 @@ Value Search::Worker::search(
     ttCapture    = ttData.move && pos.capture_stage(ttData.move);
 
     // Step 5. Static evaluation of the position
-    Value      unadjustedStaticEval = VALUE_NONE;
-    const auto correctionValue      = correction_value(*this, pos, ss);
+    Value unadjustedStaticEval = VALUE_NONE;
+
     // Skip early pruning when in check
     if (ss->inCheck)
         ss->staticEval = eval = (ss - 2)->staticEval;


### PR DESCRIPTION
Passed single-threaded STC with 128MB hash 
https://tests.stockfishchess.org/tests/view/6a04a6348d9bd4cd7cd69124
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 103808 W: 26400 L: 26007 D: 51401
Ptnml(0-2): 205, 11212, 28711, 11537, 239 

Passed standard SMP STC 
https://tests.stockfishchess.org/tests/live_elo/6a054f528d9bd4cd7cd69225
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 80392 W: 20580 L: 20221 D: 39591
Ptnml(0-2): 79, 8872, 21942, 9217, 86 

Entering `do_move`, `correction_value` and the TT lookup are always done together, but the TT lookup happens first. Swapping the order allows the execution of `correction_value` to overlap with the in-flight TT prefetch.

No functional change
