### PR TITLE
Simplify ttMove reduction formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1250,7 +1250,7 @@ moves_loop:  // When in check, search starts here
 
         // For first picked move (ttMove) reduce reduction
         else if (move == ttData.move)
-            r = std::max(-10, r - 2016 + 150 * cutNode);
+            r -= 2016 + 150 * cutNode;
 
         if (capture)
             ss->statScore = 809 * int(PieceValue[pos.captured_piece()]) / 128


### PR DESCRIPTION
Simplify ttMove reduction formula

Passed STC non-reg:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 110720 W: 28313 L: 28180 D: 54227
Ptnml(0-2): 230, 12259, 30279, 12332, 260
https://tests.stockfishchess.org/tests/view/69fa69c83a3c3e525bb2b645

Passed LTC non-reg:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 307728 W: 77955 L: 78027 D: 151746
Ptnml(0-2): 138, 33481, 86698, 33409, 138
https://tests.stockfishchess.org/tests/view/6a00a2549392f0c317214085

bench: 2740348