### PR TITLE
Simplify away unused CorrHistType variants

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -254,6 +254,7 @@ theo77186
 TierynnB
 Timothy Herchen (anematode)
 Ting-Hsuan Huang (fffelix-huang)
+tobi437a
 Tobias Steinmann
 Tomasz Sobczyk (Sopel97)
 Tom Truscott

--- a/src/history.h
+++ b/src/history.h
@@ -158,9 +158,6 @@ using PawnHistory =
 // used by some search heuristics.
 // see https://www.chessprogramming.org/Static_Evaluation_Correction_History
 enum CorrHistType {
-    Pawn,          // By color and pawn structure
-    Minor,         // By color and positions of minor pieces (Knight, Bishop)
-    NonPawn,       // By non-pawn material positions and color
     PieceTo,       // By [piece][to] move
     Continuation,  // Combined history of move pairs
 };
@@ -183,10 +180,7 @@ struct CorrectionBundle {
 namespace Detail {
 
 template<CorrHistType>
-struct CorrHistTypedef {
-    using type =
-      DynStats<Stats<std::int16_t, CORRECTION_HISTORY_LIMIT, COLOR_NB>, CORRHIST_BASE_SIZE>;
-};
+struct CorrHistTypedef;
 
 template<>
 struct CorrHistTypedef<PieceTo> {
@@ -196,12 +190,6 @@ struct CorrHistTypedef<PieceTo> {
 template<>
 struct CorrHistTypedef<Continuation> {
     using type = MultiArray<CorrHistTypedef<PieceTo>::type, PIECE_NB, SQUARE_NB>;
-};
-
-template<>
-struct CorrHistTypedef<NonPawn> {
-    using type = DynStats<Stats<std::int16_t, CORRECTION_HISTORY_LIMIT, COLOR_NB, COLOR_NB>,
-                          CORRHIST_BASE_SIZE>;
 };
 
 }


### PR DESCRIPTION
After the introduction of UnifiedCorrectionHistory, the Pawn, Minor and NonPawn entries in CorrHistType are dead - only PieceTo and Continuation are referenced via CorrectionHistory<T>. Drop them, along with the now unreachable default template and the NonPawn specialization. Reduce the primary CorrHistTypedef template to a forward declaration so that any future stray use of an unsupported tag fails to compile.

No functional change