### PR TITLE
Simplify Mated Conditions in Iterative Deepening

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -508,10 +508,8 @@ bool Search::Worker::iterative_deepening() {
         }
 
         // Have we found a "mate in x" after a completed iteration?
-        if (limits.mate && !threads.stop
-            && ((is_mate(rootMoves[0].score) && VALUE_MATE - rootMoves[0].score <= 2 * limits.mate)
-                || (is_mated(rootMoves[0].score)
-                    && VALUE_MATE + rootMoves[0].score <= 2 * limits.mate)))
+        if (limits.mate && !threads.stop && is_mate_or_mated(rootMoves[0].score)
+            && VALUE_MATE - std::abs(rootMoves[0].score) <= 2 * limits.mate)
             threads.stop = true;
 
         if (!mainThread)


### PR DESCRIPTION
Simplify Mated Conditions in Iterative Deepening

Follow-up to #6785 

After completing an iteration, the engine verifies if a "mate in x" condition is met to stop searching. Currently, it checks is_mate() and is_mated() independently using two separate bulky logic branches. However, VALUE_MATE equals 32000, so both a mate (e.g., 31998) and a mated score (e.g., -31998) satisfy VALUE_MATE - std::abs(score) == 2. By utilizing is_mate_or_mated() and applying std::abs(), we mathematically combine these checks into a single concise expression.

Can someone please help run a matetrack with a --mate 100 limit for this?

No functional change