### PR TITLE
[bugfix] Guard is_decisive() to avoid assert triggers

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -110,9 +110,13 @@ void TTEntry::save(
     // Secondary aging. Important for elementary mate finding.
     // (*Scaler) Secondary aging on entries relevant to singular extensions
     // generally scales poorly and requires VVLTC verification.
-    else if (depth8 + DEPTH_NONE >= 5 && is_decisive(value16)
+    else if (depth8 + DEPTH_NONE >= 5
              && Bound((genBound8 & BOUND_MASK) >> BOUND_SHIFT) != BOUND_EXACT)
-        depth8--;
+    {
+        auto v16 = value16;
+        if (std::abs(v16) < VALUE_INFINITE && is_decisive(v16))
+            depth8--;
+    }
 }
 
 

--- a/tests/instrumented.py
+++ b/tests/instrumented.py
@@ -31,7 +31,7 @@ def get_prefix():
 
 def get_threads():
     if args.valgrind_thread or args.sanitizer_thread:
-        return 2
+        return 4
     return 1
 
 


### PR DESCRIPTION
This PR fixes an oversight in #6818. At least in multithreaded searches the TT scores can be corrupted, and accessing them is racy.

Passed non-reg STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 61792 W: 15609 L: 15428 D: 30755
Ptnml(0-2): 134, 6534, 17373, 6727, 128
https://tests.stockfishchess.org/tests/view/6a0b15396524d21ee79b868b

We also increase the number of the threads in our instrumented CI tests to make these assert failures for buggy patches more likely in future.

No functional change.