### PR TITLE
Revert f8aa78e0a7e8853370e5989fc23783f3b244ac42

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1268,7 +1268,7 @@ moves_loop:  // When in check, search starts here
 
         // For first picked move (ttMove) reduce reduction
         else if (move == ttData.move)
-            r -= 2016 + 150 * cutNode;
+            r = std::max(-10, r - 2016 + 150 * cutNode);
 
         if (capture)
             ss->statScore = 809 * int(PieceValue[pos.captured_piece()]) / 128


### PR DESCRIPTION
The two links given in the PR description for #6826 are not for the same code changes. The code that was eventually committed passed LTC non-reg, but not STC non-reg. However, it was a meaningful code change and so would have needed gainer bounds.

See https://tests.stockfishchess.org/tests/view/69fa69c83a3c3e525bb2b645 and https://tests.stockfishchess.org/tests/view/6a00a2549392f0c317214085.

Bench: 2821162