### PR TITLE
Remove redundant TT miss data reassignments

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -756,10 +756,13 @@ Value Search::Worker::search(
     excludedMove                   = ss->excludedMove;
     posKey                         = pos.key();
     auto [ttHit, ttData, ttWriter] = tt.probe(posKey);
+
+    assert(ttHit || (ttData.move == Move::none() && ttData.value == VALUE_NONE));
+
     // Need further processing of the saved data
     ss->ttHit    = ttHit;
-    ttData.move  = rootNode ? rootMoves[pvIdx].pv[0] : ttHit ? ttData.move : Move::none();
-    ttData.value = ttHit ? value_from_tt(ttData.value, ss->ply, pos.rule50_count()) : VALUE_NONE;
+    ttData.move  = rootNode ? rootMoves[pvIdx].pv[0] : ttData.move;
+    ttData.value = value_from_tt(ttData.value, ss->ply, pos.rule50_count());
     ss->ttPv     = excludedMove ? ss->ttPv : PvNode || (ttHit && ttData.is_pv);
     ttCapture    = ttData.move && pos.capture_stage(ttData.move);
 
@@ -1605,10 +1608,12 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
     // Step 3. Transposition table lookup
     posKey                         = pos.key();
     auto [ttHit, ttData, ttWriter] = tt.probe(posKey);
+
+    assert(ttHit || (ttData.move == Move::none() && ttData.value == VALUE_NONE));
+
     // Need further processing of the saved data
     ss->ttHit    = ttHit;
-    ttData.move  = ttHit ? ttData.move : Move::none();
-    ttData.value = ttHit ? value_from_tt(ttData.value, ss->ply, pos.rule50_count()) : VALUE_NONE;
+    ttData.value = value_from_tt(ttData.value, ss->ply, pos.rule50_count());
     pvHit        = ttHit && ttData.is_pv;
 
     // At non-PV nodes we check for an early TT cutoff

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -236,9 +236,15 @@ std::tuple<bool, TTData, TTWriter> TranspositionTable::probe(const Key key) cons
 
     for (int i = 0; i < ClusterSize; ++i)
         if (tte[i].key16 == key16)
-            // This gap is the main place for read races.
-            // After `read()` completes that copy is final, but may be self-inconsistent.
-            return {tte[i].is_occupied(), tte[i].read(), TTWriter(&tte[i])};
+        {
+            if (tte[i].is_occupied())
+                // This gap is the main place for read races.
+                // After `read()` completes that copy is final, but may be self-inconsistent.
+                return {true, tte[i].read(), TTWriter(&tte[i])};
+
+            return {false, TTData{Move::none(), VALUE_NONE, VALUE_NONE, DEPTH_NONE, BOUND_NONE, false},
+                    TTWriter(&tte[i])};
+        }
 
     // Find an entry to be replaced according to the replacement strategy
     TTEntry* replace = tte;


### PR DESCRIPTION
Currently, in both the main search() and qsearch(), we manually guard ttData.move and ttData.value against ttHit.

However, looking at the TT implementation, if tt.probe() misses, it is guaranteed to return a TTData object already safely initialized with Move::none() and VALUE_NONE. Furthermore, the value_from_tt() helper natively handles VALUE_NONE by immediately passing it back out.

Because of these internal guarantees, I think we can safely drop them in both search functions?!

I'm not very expert in this part of the code, if there is anything wrong with my logic, or any drawback that I didn't think about, please just let me know.

New Update:
Passed non-reg STC test:
LLR: 5.07 (-2.94,2.94) <-1.75,0.25>
Total: 645408 W: 164134 L: 164382 D: 316892
Ptnml(0-2): 1574, 69580, 180635, 69350, 1565
https://tests.stockfishchess.org/tests/view/6a10d1c6818cacc1db0ac08e

No functional change