### PR TITLE
Play the optimal DTM move if we can

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1762,6 +1762,12 @@ Config Tablebases::rank_root_moves(const OptionsMap&            options,
 
     if (config.cardinality >= popcount(pos.pieces()) && !pos.can_castle(ANY_CASTLING))
     {
+        // Use DTZ to rank the moves if checkmate is the only zeroing move
+        rankDTZ = rankDTZ
+               || (!pos.pieces(PAWN)
+                   && (popcount(pos.pieces()) == 3
+                       || (popcount(pos.pieces()) == 4 && !(pos.pieces(QUEEN) | pos.pieces(ROOK)))));
+
         // Rank moves using DTZ tables, bail out if time_abort flags zeitnot
         config.rootInTB =
           root_probe(pos, rootMoves, options["Syzygy50MoveRule"], rankDTZ, time_abort);


### PR DESCRIPTION
These days Stockfish at TCEC often plays trivial endgames badly, failing to find a mate score as well. This patch helps Stockfish in those situations, by forcing it to play an optimal DTM move if we can deduce it from the DTZ tables. That is, when the only zeroing move is the checkmate itself.

Hence this PR checks if there are no pawns left to push and if there are no captures or sacrifices possible that would maintain a win. Example positions where this applies are KQvK, KRvK, KBBvK and KNBvK.

The change will also lead to optimal Syzygy PV extensions once the PV enters the "known DTM" territory.

The patch should help mitigate issue #6742.

No functional change.

