### PR TITLE
Further binary releases fixes

### DIFF
--- a/.github/ci/arm_matrix.json
+++ b/.github/ci/arm_matrix.json
@@ -8,7 +8,7 @@
       "emu": "qemu-aarch64",
       "comp": "ndk",
       "shell": "bash",
-      "archive_ext": "tar"
+      "archive_ext": "tar.gz"
     },
     {
       "name": "Android NDK arm",
@@ -18,21 +18,18 @@
       "emu": "qemu-arm",
       "comp": "ndk",
       "shell": "bash",
-      "archive_ext": "tar"
+      "archive_ext": "tar.gz"
     }
   ],
-  "binaries": ["armv8-universal", "armv7", "armv7-neon"],
+  "binaries": [
+    "armv8-universal",
+    "armv7-neon"
+  ],
   "exclude": [
     {
       "binaries": "armv8-universal",
       "config": {
         "compiler": "armv7a-linux-androideabi29-clang++"
-      }
-    },
-    {
-      "binaries": "armv7",
-      "config": {
-        "compiler": "aarch64-linux-android29-clang++"
       }
     },
     {

--- a/.github/ci/macos_matrix.json
+++ b/.github/ci/macos_matrix.json
@@ -8,7 +8,7 @@
         "compiler": "clang++",
         "comp": "clang",
         "shell": "bash",
-        "archive_ext": "tar"
+        "archive_ext": "tar.gz"
       },
       "binaries": "x86-64-bmi2"
     },
@@ -20,7 +20,7 @@
         "compiler": "clang++",
         "comp": "clang",
         "shell": "bash",
-        "archive_ext": "tar"
+        "archive_ext": "tar.gz"
       },
       "binaries": "apple-silicon"
     }


### PR DESCRIPTION
* .tar -> .tar.gz: save a few more MB in distribution.
* drop android armv7 without NEON support: there should be almost no devices around that do not support this.

No functional change