### PR TITLE
Resolve L3 domain detection when invididual cores are marked offline on Linux

### DIFF
--- a/src/numa.h
+++ b/src/numa.h
@@ -1181,7 +1181,12 @@ class NumaConfig {
 
             if (!siblingsStr.has_value() || siblingsStr->empty())
             {
-                break;  // we have read all available CPUs
+                // cpu<next> may be offline; mark it seen and continue rather than
+                // aborting, since later CPUs may still be online.
+                seenCpus.insert(next);
+                if (seenCpus.size() >= SYSTEM_THREADS_NB)
+                    break;
+                continue;
             }
 
             L3Domain domain;


### PR DESCRIPTION
Resolves: https://github.com/official-stockfish/Stockfish/issues/6857

Feel free to close this and the issue above, in favour of anything with @anematode 's stamp of approval instead. I don't know the full consequences of what I've written here. Just was curious to take a quick look since I predicted the disabled cores being related :) 

After this patch on CCC box:

```
Version                    : Stockfish dev-20260526-e6b7c8b1
Compiled by                : g++ (GNUC) 13.3.0 on Linux
Compilation architecture   : x86-64-avx2
Compilation settings       : 64bit AVX2 SSE41 SSSE3 SSE2 POPCNT
Compiler __VERSION__ macro : 13.3.0
Large pages                : yes
User invocation            : speedtest
Filled invocation          : speedtest 254 32512 150
Available processors       : 0-15,128-143:16-31,144-159:32-47,160-175:48-63,176-191:64,66-79,192,194-207:80-95,208-223:96-111,224-239:112-127,240-255
Thread count               : 254
Thread binding             : 32/32:32/32:32/32:32/32:30/30:32/32:32/32:32/32
TT size [MiB]              : 32512
Hash max, avg [per mille]  :
    single search          : 20, 8
    single game            : 282, 177
Total nodes searched       : 20888431459
Total search time [s]      : 150.027
Nodes/second               : 139231148
```

Before this patch on CCC box:
```
Version                    : Stockfish dev-20260525-77a8f6cc
Compiled by                : g++ (GNUC) 13.3.0 on Linux
Compilation architecture   : x86-64-avx2
Compilation settings       : 64bit AVX2 SSE41 SSSE3 SSE2 POPCNT
Compiler __VERSION__ macro : 13.3.0
Large pages                : yes
User invocation            : speedtest
Filled invocation          : speedtest 254 32512 150
Available processors       : 0-15,128-143:16-31,144-159:32-47,160-175:48-63,176-191:64,66-67,192,194-195
Thread count               : 254
Thread binding             : 61/32:61/32:61/32:60/32:11/6
TT size [MiB]              : 32512
Hash max, avg [per mille]  :
    single search          : 11, 4
    single game            : 160, 98
Total nodes searched       : 11447388039
Total search time [s]      : 151.637
Nodes/second               : 75492050
```