### PR TITLE
Simplify Internal Iterative Reductions (IIR) Condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -989,7 +989,7 @@ Value Search::Worker::search(
     // Step 10. Internal iterative reductions
     // At sufficient depth, reduce depth for PV/Cut nodes without a TTMove.
     // (*Scaler) Making IIR more aggressive scales poorly.
-    if (!ss->followPV && !allNode && depth >= 6 && !ttData.move && priorReduction <= 3)
+    if (!ss->followPV && !allNode && depth >= 6 && !ttData.move)
         depth--;
 
     // Step 11. ProbCut


### PR DESCRIPTION
 Simplify Internal Iterative Reductions (IIR) Condition

Passed STC non-reg:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 75840 W: 19367 L: 19192 D: 37281
Ptnml(0-2): 186, 8837, 19710, 8990, 197
https://tests.stockfishchess.org/tests/view/6a0b02ba6524d21ee79b8685

Passed LTC non-reg:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 166920 W: 42039 L: 41967 D: 82914
Ptnml(0-2): 78, 18155, 46919, 18233, 75
https://tests.stockfishchess.org/tests/view/6a0c98fb6524d21ee79b8875

Passed VTC non-reg:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 46390 W: 11914 L: 11729 D: 22747
Ptnml(0-2): 8, 4543, 13911, 4722, 11
https://tests.stockfishchess.org/tests/view/6a143877818cacc1db0ac7c5

[Updated]
Passed also VVLTC non-reg:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 160064 W: 41077 L: 41007 D: 77980
Ptnml(0-2): 12, 14336, 51263, 14412, 9
https://tests.stockfishchess.org/tests/view/6a1711e0818cacc1db0acbc7

bench: 2814421