### PR TITLE
Simplify quiet history update expression

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ Hisayori Noda (nodchip)
 87flowers
 Aditya (absimaldata)
 Adrian Petrescu (apetresc)
+Adrian (AdrianGHUB15)
 Ahmed Kerimov (wcdbmv)
 Ajith Chandy Jose (ajithcj)
 Alain Savard (Rocky640)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -821,8 +821,7 @@ Value Search::Worker::search(
         {
             // Bonus for a quiet ttMove that fails high
             if (!ttCapture)
-                update_quiet_histories(pos, ss, *this, ttData.move,
-                                       std::min(114 * depth - 73, 797));
+                update_quiet_histories(pos, ss, *this, ttData.move, std::min(114 * depth, 724));
 
             // Extra penalty for early quiet moves of the previous ply
             if (prevSq != SQ_NONE && (ss - 1)->moveCount < 4 && !priorCapture)


### PR DESCRIPTION
This patch simplifies the quiet history update expression in search.cpp.

The change is behaviour‑identical and removes unnecessary complexity from
the update_quiet_histories call.

Passed STC (non‑regression):
https://tests.stockfishchess.org/tests/live_elo/6a14367b818cacc1db0ac7c3
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 52224 W: 13338 L: 13135 D: 25751
Ptnml(0-2): 118, 6065, 13557, 6240, 132

Passed LTC (non‑regression):
https://tests.stockfishchess.org/tests/live_elo/6a155046818cacc1db0ac94d
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 136812 W: 34689 L: 34586 D: 67537
Ptnml(0-2): 51, 14770, 38668, 14859, 58

Both STC and LTC passed. Patch rebased to latest master.

Bench: 2294416
