### PR TITLE
Select only inner squares for avx2 rank attack lookup

### DIFF
--- a/src/attacks.cpp
+++ b/src/attacks.cpp
@@ -78,12 +78,14 @@ static void init_magics(Magic magics[][2]) {
 #elif defined(USE_DUAL_HYPERBOLA_QUINT)
 
 // Sliding attacks within a rank, indexed by the slider's file and the
-// 8-bit rank occupancy, yielding the 8-bit attack set on that rank
+// 6-bit occupancy of non-edge rank squares, yielding the 8-bit attack set
+// on that rank
 constexpr auto RankAttacks = []() {
-    std::array<std::array<uint8_t, 256>, FILE_NB> table{};
+    std::array<std::array<uint8_t, 64>, FILE_NB> table{};
     for (int file = 0; file < 8; ++file)
-        for (int occ = 0; occ < 256; ++occ)
+        for (int occ6 = 0; occ6 < 64; ++occ6)
         {
+            int     occ     = occ6 << 1;
             uint8_t attacks = 0;
             for (int f = file + 1; f <= 7; ++f)
             {
@@ -97,7 +99,7 @@ constexpr auto RankAttacks = []() {
                 if (occ & (1 << f))
                     break;
             }
-            table[file][occ] = attacks;
+            table[file][occ6] = attacks;
         }
     return table;
 }();
@@ -114,6 +116,7 @@ static void init_dual_magics(DualMagic magics[]) {
         m.rr                = square_bb(Square(63 - int(s))) * 2;
         m.rankAttacksLookup = RankAttacks[int(file_of(s))].data();
         m.shift             = 8 * int(rank_of(s));
+        m.indexShift        = m.shift + 1;
     }
 }
 

--- a/src/attacks.h
+++ b/src/attacks.h
@@ -84,8 +84,8 @@ struct DualMagic {
     Bitboard r, rr;
 
     const uint8_t* RESTRICT rankAttacksLookup;
-    // 8 * rank_of(sq)
-    int shift;
+    int                     shift;  // 8 * rank_of(sq), for placing rank attacks back on the board
+    int                     indexShift;  // shift + 1, for extracting the 6-bit rank occupancy index
 
     // We always compute [bishop, rook] attacks at once, then rely on
     // compiler's DCE and CSE to eliminate unneeded re-computations or extractions.
@@ -117,8 +117,8 @@ struct DualMagic {
         __m128i rookBishop =
           _mm_or_si128(_mm256_extracti128_si256(result, 1), _mm256_castsi256_si128(result));
 
-        Bitboard rowOccupancy = rankAttacksLookup[(occupied >> shift) & 0xff];
-        Bitboard rankAttacks  = rowOccupancy << shift;
+        Bitboard firstRankAttacks = rankAttacksLookup[(occupied >> indexShift) & 0x3f];
+        Bitboard rankAttacks      = firstRankAttacks << shift;
 
         // [bishop, rook]
         return {_mm_extract_epi64(rookBishop, 1), _mm_cvtsi128_si64(rookBishop) + rankAttacks};


### PR DESCRIPTION
We can change the rank occupancy mask from 0xff to 0x7f for free,
ignoring the last square of the rank. Halves the size of the RankAttacks
table.

Additionally, DualMagic has 4 padding bytes. Use them to store a shift
that also ignores the first square of the rank. Halves the size of the
RankAttacks table again.

AMD EPYC 7502P

Result of 200 runs
base (...ockfish-base) =     993763  +/- 890
test (...kfish-6bit-p) =     996407  +/- 893
diff                   =      +2644  +/- 1308

speedup        = +0.0027
P(speedup > 0) =  1.0000

No functional change