### PR TITLE
Capture ordering

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -223,7 +223,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
         if constexpr (Type == CAPTURES)
             m.value = (*captureHistory)[pc][to][type_of(capturedPiece)]
-                    + (6 + (depth > 4 * ONE_PLY)) * int(PieceValue[capturedPiece]);;
+                    + (6 + (depth > 4 * ONE_PLY)) * int(PieceValue[capturedPiece]);
 
         else if constexpr (Type == QUIETS)
         {

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -223,7 +223,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
         if constexpr (Type == CAPTURES)
             m.value = (*captureHistory)[pc][to][type_of(capturedPiece)]
-                    + 7 * int(PieceValue[capturedPiece]);
+                    + (6 + (depth > 4 * ONE_PLY)) * int(PieceValue[capturedPiece]);;
 
         else if constexpr (Type == QUIETS)
         {

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -222,8 +222,12 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
         const Piece     capturedPiece = pos.piece_on(to);
 
         if constexpr (Type == CAPTURES)
+        {
+            int depthMultiplier = (depth > -10000 && depth < 10000) ? (6 + (depth > 4 * ONE_PLY)) : 7;
+        
             m.value = (*captureHistory)[pc][to][type_of(capturedPiece)]
-                    + (6 + (depth > 4 * ONE_PLY)) * int(PieceValue[capturedPiece]);
+                    + depthMultiplier * int(PieceValue[capturedPiece]);
+        }
 
         else if constexpr (Type == QUIETS)
         {

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -223,7 +223,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
         if constexpr (Type == CAPTURES)
         {
-            int depthMultiplier = 6 + (depth > 4 * ONE_PLY);
+            int depthMultiplier = (depth > -10000 && depth < 10000) ? (6 + (depth > 4 * ONE_PLY)) : 7;
         
             m.value = (*captureHistory)[pc][to][type_of(capturedPiece)]
                     + depthMultiplier * int(PieceValue[capturedPiece]);

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -223,7 +223,7 @@ ExtMove* MovePicker::score(const MoveList<Type>& ml) {
 
         if constexpr (Type == CAPTURES)
         {
-            int depthMultiplier = (depth > -10000 && depth < 10000) ? (6 + (depth > 4 * ONE_PLY)) : 7;
+            int depthMultiplier = 6 + (depth > 4 * ONE_PLY);
         
             m.value = (*captureHistory)[pc][to][type_of(capturedPiece)]
                     + depthMultiplier * int(PieceValue[capturedPiece]);


### PR DESCRIPTION
Uses a scaling factor to determine whether a capture should be thought about sooner or not. It looks at what level of search the engine is performing and applies it.


Local Test Results
Cutechess-CLI verification tournament using an unbalanced opening book (8moves_v3.pgn):

Score: 28 - 21 - 51 [0.535]

Elo Diff: +24.4 +/- 47.9

LOS: 84.1%

Games: 100 finished