### PR TITLE
Disable PEXT on AMD Excavator CPUs

### DIFF
--- a/scripts/get_native_properties.sh
+++ b/scripts/get_native_properties.sh
@@ -138,17 +138,19 @@ match_sse3() {
 	match_any_flags sse3 pni
 }
 
-# AMD Zen1/2 exclusion logic (used for bmi2 tier).
+# AMD Excavator/Zen1/2 exclusion logic (used for bmi2 tier).
 # https://web.archive.org/web/20250821132355/https://en.wikichip.org/wiki/amd/cpuid
-is_znver_1_2() (
+# All of Bulldozer through Excavator are matched here, but pre-Excavator doesn't support bmi2 anyway
+has_slow_bmi2() (
 	[ -r "$cpuinfo_path" ] || exit 1
 	vendor_id=$(awk '/^vendor_id/{print $3; exit}' "$cpuinfo_path" 2>/dev/null)
 	cpu_family=$(awk '/^cpu family/{print $4; exit}' "$cpuinfo_path" 2>/dev/null)
-	[ "$vendor_id" = "AuthenticAMD" ] && [ "$cpu_family" = "23" ]
+	[ "$vendor_id" = "AuthenticAMD" ] \
+		&& { [ "$cpu_family" = "21" ] || [ "$cpu_family" = "23" ]; }
 )
 
-match_not_znver12_and_flags() {
-	is_znver_1_2 && return 1
+match_not_slow_bmi2_and_flags() {
+	has_slow_bmi2 && return 1
 	match_flags "$@"
 }
 
@@ -199,7 +201,7 @@ x86-64-avx512icl|match_flags|avx512f avx512cd avx512vl avx512dq avx512bw avx512i
 x86-64-vnni512|match_flags|avx512vnni avx512dq avx512f avx512bw avx512vl
 x86-64-avx512|match_flags|avx512f avx512bw
 x86-64-avxvnni|match_flags|avxvnni
-x86-64-bmi2|match_not_znver12_and_flags|bmi2
+x86-64-bmi2|match_not_slow_bmi2_and_flags|bmi2
 x86-64-avx2|match_flags|avx2
 x86-64-sse41-popcnt|match_flags|sse41 popcnt
 x86-64-ssse3|match_flags|ssse3

--- a/src/universal/entry_x86.cpp
+++ b/src/universal/entry_x86.cpp
@@ -67,9 +67,10 @@ DEFINE_BUILD(x86_64_avx512)
 DEFINE_BUILD(x86_64_vnni512)
 DEFINE_BUILD(x86_64_avx512icl)
 
-// AMD Zen/Zen+/Zen2 (family 17h) implement pdep/pext via microcode.
+// AMD Excavator (family 15h) and Zen/Zen+/Zen2 (family 17h) implement pdep/pext via microcode.
 static bool has_slow_bmi2() {
-    return __builtin_cpu_is("amd") && (__builtin_cpu_is("znver1") || __builtin_cpu_is("znver2"));
+    return __builtin_cpu_is("amd")
+        && (__builtin_cpu_is("bdver4") || __builtin_cpu_is("znver1") || __builtin_cpu_is("znver2"));
 }
 
 struct CpuFeatures {

--- a/src/universal/entry_x86.cpp
+++ b/src/universal/entry_x86.cpp
@@ -77,7 +77,7 @@ struct CpuFeatures {
     bool sse41;            // SSE4.1
     bool popcnt;           // POPCNT
     bool avx2;             // AVX2
-    bool bmi2;             // BMI2 (may be slow on AMD Zen/Zen+/Zen2)
+    bool bmi2;             // BMI2 (may be slow on AMD Excavator and Zen/Zen+/Zen2)
     bool avx512f;          // AVX-512 Foundation
     bool avx512vl;         // AVX-512 Vector Length extensions
     bool avx512bw;         // AVX-512 Byte and Word instructions


### PR DESCRIPTION
Excavator also supports BMI2, where it has the same microcoded performance implications as on Zen pre-3.

No functional change.