### PR TITLE
Compute simplified HQ r/rr at runtime

### DIFF
--- a/src/attacks.cpp
+++ b/src/attacks.cpp
@@ -69,9 +69,6 @@ static void init_magics(Magic magics[][2]) {
         Magic& bishop = magics[s][BISHOP - BISHOP];
         bishop.mask1  = line_mask(s, NORTH_EAST, SOUTH_WEST);
         bishop.mask2  = line_mask(s, NORTH_WEST, SOUTH_EAST);
-
-        rook.r = bishop.r = square_bb(s) * 2;
-        rook.rr = bishop.rr = square_bb(Square(63 - int(s))) * 2;
     }
 }
 

--- a/src/attacks.h
+++ b/src/attacks.h
@@ -58,18 +58,16 @@ inline Bitboard reverse_bb(Bitboard bb) {
 struct Magic {
     // For rooks: file attacks, rank attacks. For bishops: diagonal/antidiagonal
     Bitboard mask1, mask2;
-    // Precomputed 2 * square_bb(sq), 2 * reverse(square_bb(sq))
-    Bitboard r, rr;
 
-    Bitboard hyperbola(Bitboard occupied, Bitboard mask) const {
+    Bitboard hyperbola(Square s, Bitboard occupied, Bitboard mask) const {
         Bitboard o   = occupied & mask;
-        Bitboard fwd = o - r;
-        Bitboard rev = reverse_bb(o) - rr;
+        Bitboard fwd = o - square_bb(s);
+        Bitboard rev = reverse_bb(o) - square_bb(Square(63 - int(s)));
         return (fwd ^ reverse_bb(rev)) & mask;
     }
 
-    Bitboard attacks_bb(Bitboard occupied) const {
-        return hyperbola(occupied, mask1) | hyperbola(occupied, mask2);
+    Bitboard attacks_bb(Square s, Bitboard occupied) const {
+        return hyperbola(s, occupied, mask1) | hyperbola(s, occupied, mask2);
     }
 };
 
@@ -155,7 +153,7 @@ struct Magic {
     #endif
     }
 
-    Bitboard attacks_bb(Bitboard occupied) const {
+    Bitboard attacks_bb([[maybe_unused]] Square s, Bitboard occupied) const {
     #ifdef USE_PEXT
         return pdep(attacks[index(occupied)], pseudoAttacks);
     #else
@@ -299,7 +297,7 @@ inline Bitboard attacks_bb(Square s, Bitboard occupied) {
     {
     case BISHOP :
     case ROOK :
-        return magic(s, Pt).attacks_bb(occupied);
+        return magic(s, Pt).attacks_bb(s, occupied);
     case QUEEN :
         return attacks_bb<BISHOP>(s, occupied) | attacks_bb<ROOK>(s, occupied);
     default :


### PR DESCRIPTION
Hyperbola Quintessence works out without the "... * 2" in r and rr. This then is cheap enough to compute at runtime, instead of looking it up, for a minor speedup.

Passed apple-silicon|armv8|loongarch64 STC:
https://tests.stockfishchess.org/tests/view/6a15f031818cacc1db0aca49
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 410208 W: 104369 L: 103556 D: 202283
Ptnml(0-2): 758, 43951, 114883, 44744, 768

Verified attacks_bb<ROOK>() and attacks_bb<BISHOP>() assembly remains unchanged on x86 (gcc 16.1.1).

No functional change