### PR TITLE
Tweak best move history updates.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -144,7 +144,8 @@ void update_all_stats(const Position& pos,
                       SearchedList&   quietsSearched,
                       SearchedList&   capturesSearched,
                       Depth           depth,
-                      Move            ttMove);
+                      Move            ttMove,
+                      bool            PvNode);
 
 bool is_shuffling(Move move, Stack* const ss, const Position& pos) {
     if (pos.capture_stage(move) || pos.rule50_count() < 10)
@@ -1477,7 +1478,7 @@ moves_loop:  // When in check, search starts here
     else if (bestMove)
     {
         update_all_stats(pos, ss, *this, bestMove, prevSq, quietsSearched, capturesSearched, depth,
-                         ttData.move);
+                         ttData.move, PvNode);
         if (!PvNode)
             ttMoveHistory << (bestMove == ttData.move ? 792 : -779);
     }
@@ -1871,7 +1872,8 @@ void update_all_stats(const Position& pos,
                       SearchedList&   quietsSearched,
                       SearchedList&   capturesSearched,
                       Depth           depth,
-                      Move            ttMove) {
+                      Move            ttMove,
+                      bool            PvNode) {
 
     CapturePieceToHistory& captureHistory = workerThread.captureHistory;
     Piece                  movedPiece     = pos.moved_piece(bestMove);
@@ -1880,6 +1882,11 @@ void update_all_stats(const Position& pos,
     int bonus =
       std::min(134 * depth - 79, 1572) + 382 * (bestMove == ttMove) + (ss - 1)->statScore / 30;
     int malus = std::min(1005 * depth - 205, 2218);
+
+    if (!PvNode)
+        // Important: don't remove the cast to a 64-bit number else the multiplication
+        // can overflow on 32-bit platforms which would change the bench signature
+        bonus += bonus * uint64_t(quietsSearched.size() + capturesSearched.size()) / 256;
 
     if (!pos.capture_stage(bestMove))
     {


### PR DESCRIPTION
If not at an PV node, scale history bonus for the found best move up proportionally to the count of the other moves searched.

Passed STC:
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 219712 W: 56104 L: 55525 D: 108083
Ptnml(0-2): 565, 25482, 57188, 26051, 570
https://tests.stockfishchess.org/tests/view/6a1306fb818cacc1db0ac5b7

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 53988 W: 13851 L: 13498 D: 26639
Ptnml(0-2): 22, 5779, 15051, 6108, 34
https://tests.stockfishchess.org/tests/view/6a1b557e818cacc1db0ad0b8

Bench: 2935474