### PR TITLE
Use arm64-universal in ARM universal workflow builds

### DIFF
--- a/.github/workflows/universal_compilation.yml
+++ b/.github/workflows/universal_compilation.yml
@@ -136,7 +136,7 @@ jobs:
           sudo apt-get install -y qemu-user
 
       - name: Build universal binary
-        run: make -j4 -C src ARCH=armv8-universal profile-build
+        run: make -j4 -C src ARCH=arm64-universal profile-build
 
       - name: Strip binary
         run: strip src/stockfish
@@ -185,7 +185,7 @@ jobs:
           install: mingw-w64-clang-aarch64-clang make git zip
 
       - name: Build universal binary
-        run: make -j4 -C src ARCH=armv8-universal profile-build COMP=clang COMPCXX=clang++
+        run: make -j4 -C src ARCH=arm64-universal profile-build COMP=clang COMPCXX=clang++
 
       - name: Strip binary
         run: strip src/stockfish.exe

--- a/AUTHORS
+++ b/AUTHORS
@@ -181,6 +181,7 @@ Mira
 Miroslav Fontán (Hexik)
 Moez Jellouli (MJZ1977)
 Mohammed Li (tthsqe12)
+Mukhammedali Beriktassuly (Berektassuly)
 Muzhen J (XInTheDark)
 Nathan Rugg (nmrugg)
 Nguyen Pham (nguyenpham)


### PR DESCRIPTION
This updates the Linux and Windows ARM universal workflow builds to use ARCH=arm64-universal instead of ARCH=armv8-universal.

The Makefile supported architecture list, help text, and release matrices already use arm64-universal, so this keeps the workflow aligned with the current target name.

Validation:
- git diff --cached --check
- make -C src ARCH=arm64-universal config-sanity

Refs #6798