### PR TITLE
Simplify margin formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1134,7 +1134,7 @@ moves_loop:  // When in check, search starts here
 
                 // SEE based pruning for captures and checks
                 // Avoid pruning sacrifices of our last piece for stalemate
-                int margin = std::max(175 * depth + captHist * 34 / 1024, 0);
+                int margin = 175 * depth + captHist * 34 / 1024;
                 if ((alpha >= VALUE_DRAW || pos.non_pawn_material(us) != PieceValue[movedPiece])
                     && !pos.see_ge(move, -margin))
                     continue;


### PR DESCRIPTION
Simplify margin formula

Passed STC non-reg:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 46944 W: 11934 L: 11730 D: 23280
Ptnml(0-2): 95, 5403, 12273, 5605, 96
https://tests.stockfishchess.org/tests/view/6a0b018d6524d21ee79b8680

Passed LTC non-reg:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 535980 W: 135398 L: 135702 D: 264880
Ptnml(0-2): 241, 58385, 151023, 58119, 222
https://tests.stockfishchess.org/tests/view/6a0c3ab86524d21ee79b87f2

Passed VLTC non-reg:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 126632 W: 32068 L: 31961 D: 62603
Ptnml(0-2): 14, 12466, 38244, 12583, 9
https://tests.stockfishchess.org/tests/view/6a1ac130818cacc1db0ad03c

bench: 2301386