### PR TITLE
Guard tt depth edits from racy underflows

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -119,7 +119,7 @@ void TTEntry::save(
     {
         auto v16 = value16;
         if (std::abs(v16) < VALUE_INFINITE && is_decisive(v16))
-            depth8--;
+            depth8 = std::max(int(depth8) - 1, 0); // guard against racy underflows, default to "unoccupied"
     }
 }
 
@@ -141,7 +141,10 @@ void TTWriter::write(
     entry->save(k, v, pv, b, d, m, ev, curr_generation);
 }
 
-void TTWriter::penalize(int penalty) { entry->depth8 -= penalty; }
+void TTWriter::penalize(int penalty) {
+    // guard against racy underflows, default to "unoccupied"
+    entry->depth8 = std::max(int(entry->depth8) - penalty, 0);
+}
 
 
 // A TranspositionTable is an array of Cluster, of size clusterCount. Each cluster consists of ClusterSize number


### PR DESCRIPTION
Two recent patches, involving editing TTEs, introduced potential racy underflows. Guarding against these doesn't appear to gain elo but does improve sanity.

fixes https://github.com/official-stockfish/Stockfish/issues/6847

STC: https://tests.stockfishchess.org/tests/view/6a1c8c4b818cacc1db0ad158
LLR: 3.85 (-2.94,2.94) <-1.75,0.25>
Total: 125984 W: 32248 L: 32055 D: 61681
Ptnml(0-2): 292, 13678, 34866, 13857, 299

SMP STC: https://tests.stockfishchess.org/tests/view/6a1fb2ba818cacc1db0ad2e2
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 104272 W: 26524 L: 26385 D: 51363
Ptnml(0-2): 103, 11650, 28494, 11783, 106

bench 2814421