### PR TITLE
Limit memcpy in do_null_move to pre-key fields

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1360,26 +1360,25 @@ void Position::do_null_move(StateInfo& newSt) {
     assert(!checkers());
     assert(&newSt != st);
 
-    std::memcpy(&newSt, st, sizeof(StateInfo));
+    std::memcpy(&newSt, st, offsetof(StateInfo, key));
 
     newSt.previous = st;
-    st             = &newSt;
+    newSt.key = st->key ^ Zobrist::side;
 
     if (st->epSquare != SQ_NONE)
-    {
-        st->key ^= Zobrist::enpassant[file_of(st->epSquare)];
-        st->epSquare = SQ_NONE;
-    }
+        newSt.key ^= Zobrist::enpassant[file_of(st->epSquare)];
 
-    st->key ^= Zobrist::side;
+    st = &newSt;
 
+    st->epSquare      = SQ_NONE;
+    st->checkersBB    = 0;
+    st->capturedPiece = NO_PIECE;
     st->pliesFromNull = 0;
+    st->repetition    = 0;
 
     sideToMove = ~sideToMove;
 
     set_check_info();
-
-    st->repetition = 0;
 
     assert(pos_is_ok());
 }


### PR DESCRIPTION
Problem: The `Position::do_null_move()` function was copying the entire current `StateInfo` structure to a new `StateInfo` before performing a “null move”. The `set_check_info()` function, which runs immediately after the `do_null_move` call, **completely recalculates** the `blockersForKing[2]`, `pinners[2]`, and `checkSquares[PIECE_TYPE_NB]` fields. Therefore, copying this ~128-byte region is a completely unnecessary memory write operation.

Change memcpy in Position::do_null_move to copy only the StateInfo bytes up to the 'key' field (offsetof(StateInfo, key)) instead of the entire struct. Compute newSt.key from the previous state's key (toggling side and applying en-passant) before switching st to &newSt, and explicitly reset fields (epSquare, checkersBB, capturedPiece, pliesFromNull, repetition). This avoids overwriting fields that must be reinitialized and ensures the zobrist key is derived from the old state correctly.