### PR TITLE
Remove unused FusedUpdateData logic in FullThreats

### DIFF
--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -275,8 +275,6 @@ void FullThreats::append_changed_indices(Color                   perspective,
                                          const DiffType&         diff,
                                          IndexList&              removed,
                                          IndexList&              added,
-                                         FusedUpdateData*        fusedData,
-                                         bool                    first,
                                          const ThreatWeightType* prefetchBase,
                                          IndexType               prefetchStride) {
 
@@ -287,36 +285,6 @@ void FullThreats::append_changed_indices(Color                   perspective,
         auto from     = dirty.pc_sq();
         auto to       = dirty.threatened_sq();
         auto add      = dirty.add();
-
-        if (fusedData)
-        {
-            if (from == fusedData->dp2removed)
-            {
-                if (add)
-                {
-                    if (first)
-                    {
-                        fusedData->dp2removedOriginBoard |= to;
-                        continue;
-                    }
-                }
-                else if (fusedData->dp2removedOriginBoard & to)
-                    continue;
-            }
-            else if (to != SQ_NONE && to == fusedData->dp2removed)
-            {
-                if (add)
-                {
-                    if (first)
-                    {
-                        fusedData->dp2removedTargetBoard |= from;
-                        continue;
-                    }
-                }
-                else if (fusedData->dp2removedTargetBoard & from)
-                    continue;
-            }
-        }
 
         auto&           insert = add ? added : removed;
         const IndexType index  = make_index(perspective, attacker, from, to, attacked, ksq);

--- a/src/nnue/features/full_threats.h
+++ b/src/nnue/features/full_threats.h
@@ -66,13 +66,6 @@ class FullThreats {
     };
     // clang-format on
 
-    struct FusedUpdateData {
-        Bitboard dp2removedOriginBoard = 0;
-        Bitboard dp2removedTargetBoard = 0;
-
-        Square dp2removed;
-    };
-
     // Maximum number of simultaneously active features.
     static constexpr IndexType MaxActiveDimensions = 128;
     using IndexList                                = ValueList<IndexType, MaxActiveDimensions>;
@@ -90,8 +83,6 @@ class FullThreats {
                                        const DiffType&         diff,
                                        IndexList&              removed,
                                        IndexList&              added,
-                                       FusedUpdateData*        fd             = nullptr,
-                                       bool                    first          = false,
                                        const ThreatWeightType* prefetchBase   = nullptr,
                                        IndexType               prefetchStride = 0);
 

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -358,13 +358,13 @@ void update_accumulator_incremental(Color                     perspective,
     if constexpr (Forward)
     {
         ThreatFeatureSet::append_changed_indices(perspective, ksq, dirtyThreats, thrRemoved,
-                                                 thrAdded, nullptr, false, pfBase, pfStride);
+                                                 thrAdded, pfBase, pfStride);
         PSQFeatureSet::append_changed_indices(perspective, ksq, dirtyPiece, psqRemoved, psqAdded);
     }
     else
     {
         ThreatFeatureSet::append_changed_indices(perspective, ksq, dirtyThreats, thrAdded,
-                                                 thrRemoved, nullptr, false, pfBase, pfStride);
+                                                 thrRemoved, pfBase, pfStride);
         PSQFeatureSet::append_changed_indices(perspective, ksq, dirtyPiece, psqAdded, psqRemoved);
     }
 


### PR DESCRIPTION
Since the removal of fused updates in 1a882efc, every caller of `FullThreats::append_changed_indices()` passes `nullptr` for the `fusedData` parameter, so the deduplication branch inside the loop is unreachable.

Remove the `FusedUpdateData` struct, the two unused parameters (`fusedData`, `first`) and the dead branch, and simplify the call sites in `nnue_accumulator.cpp` accordingly.

No functional change