### PR TITLE
Small cleanups in update_piece_threats and MovePicker

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -56,9 +56,6 @@ class MovePicker {
     Move select(Pred);
     template<GenType T>
     ExtMove* score(const MoveList<T>&);
-    ExtMove* begin() { return cur; }
-    ExtMove* end() { return endCur; }
-
     const Position&              pos;
     const ButterflyHistory*      mainHistory;
     const LowPlyHistory*         lowPlyHistory;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1222,7 +1222,7 @@ void Position::update_piece_threats(Piece               pc,
             const Bitboard discovered = ray & (rAttacks | bAttacks) & occupiedNoK;
 
             assert(!more_than_one(discovered));
-            if (discovered && (ray_pass_bb(sliderSq, s) & noRaysContaining) != noRaysContaining)
+            if (discovered && (ray & noRaysContaining) != noRaysContaining)
             {
                 const Square threatenedSq = lsb(discovered);
                 const Piece  threatenedPc = piece_on(threatenedSq);


### PR DESCRIPTION
Two small cleanups:

In `Position::update_piece_threats()`, the discovered-threat condition calls `ray_pass_bb(sliderSq, s)` a second time even though the identical value had just been computed into the local `ray` variable, which can be reused.

Remove the private `begin()`/`end()` accessors without callers in `MovePicker`.

No functional change