### PR TITLE
Validate optional FEN counters

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -391,7 +391,8 @@ Position::set(const string& fenStr, bool isChess960, StateInfo* si) {
     // Ignore if square is invalid or not on side to move relative rank 6.
     bool          enpassant = false, legalEP = false;
     unsigned char col = '-', row;
-    ss >> col;
+    if (!(ss >> col))
+        return PositionSetError("Invalid FEN. Expected en-passant square.");
     if (col != '-')
     {
         if (!(ss >> row))


### PR DESCRIPTION
Position::set() supports shortened FENs, including those used by bench, but malformed optional halfmove/fullmove counters could be silently ignored because stream extraction failures were not checked.

This patch preserves support for shortened FENs while rejecting malformed optional counters and unexpected trailing content.

Local testing:

* make -j build: passed
* ./stockfish.exe bench: passed
