### PR TITLE
Fixup RelaxedAtomic operator Types

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -381,7 +381,7 @@ class RelaxedAtomic {
             return inner;
     }
 
-    RelaxedAtomic& operator+=(int val) {
+    RelaxedAtomic& operator+=(T val) {
         T res = this->load(std::memory_order_relaxed) + val;
         this->store(res, std::memory_order_relaxed);
         return *this;
@@ -411,7 +411,7 @@ class RelaxedAtomic {
         return val;
     }
 
-    RelaxedAtomic& operator-=(int val) {
+    RelaxedAtomic& operator-=(T val) {
         T res = this->load(std::memory_order_relaxed) - val;
         this->store(res, std::memory_order_relaxed);
         return *this;


### PR DESCRIPTION
As pointed out in https://github.com/official-stockfish/Stockfish/commit/0111d11e2356147bad21c1f890b271a30d10a580#r188197707, the parameter type should be `T` not `int` 