### PR TITLE
Remove unused code from the post NNUE accumulator merge

### DIFF
--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -275,8 +275,6 @@ void FullThreats::append_changed_indices(Color                   perspective,
                                          const DiffType&         diff,
                                          IndexList&              removed,
                                          IndexList&              added,
-                                         FusedUpdateData*        fusedData,
-                                         bool                    first,
                                          const ThreatWeightType* prefetchBase,
                                          IndexType               prefetchStride) {
 
@@ -288,36 +286,6 @@ void FullThreats::append_changed_indices(Color                   perspective,
         auto to       = dirty.threatened_sq();
         auto add      = dirty.add();
 
-        if (fusedData)
-        {
-            if (from == fusedData->dp2removed)
-            {
-                if (add)
-                {
-                    if (first)
-                    {
-                        fusedData->dp2removedOriginBoard |= to;
-                        continue;
-                    }
-                }
-                else if (fusedData->dp2removedOriginBoard & to)
-                    continue;
-            }
-            else if (to != SQ_NONE && to == fusedData->dp2removed)
-            {
-                if (add)
-                {
-                    if (first)
-                    {
-                        fusedData->dp2removedTargetBoard |= from;
-                        continue;
-                    }
-                }
-                else if (fusedData->dp2removedTargetBoard & from)
-                    continue;
-            }
-        }
-
         auto&           insert = add ? added : removed;
         const IndexType index  = make_index(perspective, attacker, from, to, attacked, ksq);
 
@@ -326,10 +294,6 @@ void FullThreats::append_changed_indices(Color                   perspective,
               reinterpret_cast<uintptr_t>(prefetchBase) + index * prefetchStride));
         insert.push_back_if_lt(index, Dimensions);
     }
-}
-
-bool FullThreats::requires_refresh(const DiffType& diff, Color perspective) {
-    return perspective == diff.us && (i8(diff.ksq) & 0b100) != (i8(diff.prevKsq) & 0b100);
 }
 
 }  // namespace Stockfish::Eval::NNUE::Features

--- a/src/nnue/features/full_threats.h
+++ b/src/nnue/features/full_threats.h
@@ -13,7 +13,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-//Definition of input features Simplified_Threats of NNUE evaluation function
+//Definition of input features Full_Threats of NNUE evaluation function
 
 #ifndef NNUE_FEATURES_FULL_THREATS_INCLUDED
 #define NNUE_FEATURES_FULL_THREATS_INCLUDED
@@ -34,9 +34,6 @@ static constexpr int numValidTargets[PIECE_NB] = {0, 6, 10, 8, 8, 10, 0, 0,
 
 class FullThreats {
    public:
-    // Feature name
-    static constexpr const char* Name = "Full_Threats(Friend)";
-
     // Hash value embedded in the evaluation file
     static constexpr u32 HashValue = 0x8f234cb8u;
 
@@ -66,13 +63,6 @@ class FullThreats {
     };
     // clang-format on
 
-    struct FusedUpdateData {
-        Bitboard dp2removedOriginBoard = 0;
-        Bitboard dp2removedTargetBoard = 0;
-
-        Square dp2removed;
-    };
-
     // Maximum number of simultaneously active features.
     static constexpr IndexType MaxActiveDimensions = 128;
     using IndexList                                = ValueList<IndexType, MaxActiveDimensions>;
@@ -90,14 +80,8 @@ class FullThreats {
                                        const DiffType&         diff,
                                        IndexList&              removed,
                                        IndexList&              added,
-                                       FusedUpdateData*        fd             = nullptr,
-                                       bool                    first          = false,
                                        const ThreatWeightType* prefetchBase   = nullptr,
                                        IndexType               prefetchStride = 0);
-
-    // Returns whether the change stored in this DirtyPiece means
-    // that a full accumulator refresh is required.
-    static bool requires_refresh(const DiffType& diff, Color perspective);
 };
 
 }  // namespace Stockfish::Eval::NNUE::Features

--- a/src/nnue/features/half_ka_v2_hm.cpp
+++ b/src/nnue/features/half_ka_v2_hm.cpp
@@ -20,10 +20,12 @@
 
 #include "half_ka_v2_hm.h"
 
-#include "../../bitboard.h"
-#include "../../position.h"
 #include "../../types.h"
 #include "../nnue_common.h"
+
+#if defined(USE_AVX512ICL)
+    #include "../../bitboard.h"
+#endif
 
 namespace Stockfish::Eval::NNUE::Features {
 
@@ -89,18 +91,6 @@ IndexType HalfKAv2_hm::make_index(Color perspective, Square s, Piece pc, Square 
     const IndexType flip = 56 * perspective;
     return (IndexType(s) ^ OrientTBL[ksq] ^ flip) + PieceSquareIndex[perspective][pc]
          + KingBuckets[int(ksq) ^ flip];
-}
-
-// Get a list of indices for active features
-
-void HalfKAv2_hm::append_active_indices(Color perspective, const Position& pos, IndexList& active) {
-    Square   ksq = pos.square<KING>(perspective);
-    Bitboard bb  = pos.pieces();
-    while (bb)
-    {
-        Square s = pop_lsb(bb);
-        active.push_back(make_index(perspective, s, pos.piece_on(s), ksq));
-    }
 }
 
 // Get a list of indices for recently changed features

--- a/src/nnue/features/half_ka_v2_hm.h
+++ b/src/nnue/features/half_ka_v2_hm.h
@@ -16,7 +16,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-//Definition of input features HalfKP of NNUE evaluation function
+//Definition of input features HalfKAv2_hm of NNUE evaluation function
 
 #ifndef NNUE_FEATURES_HALF_KA_V2_HM_H_INCLUDED
 #define NNUE_FEATURES_HALF_KA_V2_HM_H_INCLUDED
@@ -24,10 +24,6 @@
 #include "../../misc.h"
 #include "../../types.h"
 #include "../nnue_common.h"
-
-namespace Stockfish {
-class Position;
-}
 
 namespace Stockfish::Eval::NNUE::Features {
 
@@ -61,9 +57,6 @@ class HalfKAv2_hm {
        PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_KING, PS_NONE}};
 
    public:
-    // Feature name
-    static constexpr const char* Name = "HalfKAv2_hm(Friend)";
-
     // Hash value embedded in the evaluation file
     static constexpr u32 HashValue = 0x7f234cb8u;
 
@@ -119,10 +112,6 @@ class HalfKAv2_hm {
     // Index of a feature for a given king position and another piece on some square
 
     static IndexType make_index(Color perspective, Square s, Piece pc, Square ksq);
-
-    // Get a list of indices for active features
-
-    static void append_active_indices(Color perspective, const Position& pos, IndexList& active);
 
     // Get a list of indices for recently changed features
     static void append_changed_indices(

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -358,13 +358,13 @@ void update_accumulator_incremental(Color                     perspective,
     if constexpr (Forward)
     {
         ThreatFeatureSet::append_changed_indices(perspective, ksq, dirtyThreats, thrRemoved,
-                                                 thrAdded, nullptr, false, pfBase, pfStride);
+                                                 thrAdded, pfBase, pfStride);
         PSQFeatureSet::append_changed_indices(perspective, ksq, dirtyPiece, psqRemoved, psqAdded);
     }
     else
     {
         ThreatFeatureSet::append_changed_indices(perspective, ksq, dirtyThreats, thrAdded,
-                                                 thrRemoved, nullptr, false, pfBase, pfStride);
+                                                 thrRemoved, pfBase, pfStride);
         PSQFeatureSet::append_changed_indices(perspective, ksq, dirtyPiece, psqAdded, psqRemoved);
     }
 

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -67,10 +67,8 @@ constexpr u32 Version = 0x6A448AFAu;
 // Constant used in evaluation value calculation
 constexpr int OutputScale     = 16;
 constexpr int WeightScaleBits = 6;
-constexpr int FtOneVal        = 256;
 constexpr int FtMaxVal        = 255;
 constexpr int HiddenOneVal    = 128;
-constexpr int HiddenMaxVal    = 127;
 
 // Size of cache line (in bytes)
 constexpr usize CacheLineSize = 64;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -866,8 +866,6 @@ void Position::do_move(Move                      m,
     dp.from     = from;
     dp.to       = to;
     dp.add_sq   = SQ_NONE;
-    dts.us      = us;
-    dts.prevKsq = square<KING>(us);
 
     assert(color_of(pc) == us);
     assert(captured == NO_PIECE || color_of(captured) == (m.type_of() != CASTLING ? them : us));
@@ -1079,8 +1077,6 @@ void Position::do_move(Move                      m,
             }
         }
     }
-
-    dts.ksq = square<KING>(us);
 
     assert(pos_is_ok());
 

--- a/src/types.h
+++ b/src/types.h
@@ -339,8 +339,6 @@ using DirtyThreatList = ValueList<DirtyThreat, 96>;
 
 struct DirtyThreats {
     DirtyThreatList list;
-    Color           us;
-    Square          prevKsq, ksq;
 };
 
     #define ENABLE_INCR_OPERATORS_ON(T) \


### PR DESCRIPTION
After merging the HalfKA and Threats accumulators (7c7fe322) and the subsequent removal of the double-incremental/fused update, a number of NNUE helpers and fields became unreachable. Each was verified to have zero callers/readers across the source tree:

- FusedUpdateData logic in FullThreats: the fused-update branch of append_changed_indices and the FusedUpdateData parameter are unused; the accumulator update no longer passes fused data.
- FullThreats::requires_refresh: never called. The live king-bucket refresh check is HalfKAv2_hm::requires_refresh (PSQFeatureSet), used in nnue_accumulator.
- HalfKAv2_hm::append_active_indices: never called. The live active-index builder is FullThreats::append_active_indices (ThreatFeatureSet).
- DirtyThreats::us, prevKsq and ksq: written in do_move but only read by the now-removed FullThreats::requires_refresh. Removing them also drops three stores from the do_move path.
- Unused feature Name constants and the unused FtOneVal / HiddenMaxVal constants in nnue_common.h.
- Two stale feature-header banner comments.

No functional change