### PR TITLE
Avoid throwing spin options

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -391,7 +391,8 @@ Position::set(const string& fenStr, bool isChess960, StateInfo* si) {
     // Ignore if square is invalid or not on side to move relative rank 6.
     bool          enpassant = false, legalEP = false;
     unsigned char col = '-', row;
-    ss >> col;
+    if (!(ss >> col))
+        return PositionSetError("Invalid FEN. Expected en-passant square.");
     if (col != '-')
     {
         if (!(ss >> row))

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -20,10 +20,12 @@
 
 #include <algorithm>
 #include <cassert>
+#include <charconv>
 #include <cctype>
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
+#include <system_error>
 #include <utility>
 
 #include "misc.h"
@@ -86,7 +88,7 @@ void OptionsMap::add(const std::string& name, const Option& option) {
 usize OptionsMap::count(const std::string& name) const { return options_map.count(name); }
 
 Option::Option(const OptionsMap* map) :
-    parent(map) {}
+    parent(map) { }
 
 Option::Option(const char* v, OnChange f) :
     type("string"),
@@ -108,7 +110,7 @@ Option::Option(OnChange f) :
     type("button"),
     min(0),
     max(0),
-    on_change(std::move(f)) {}
+    on_change(std::move(f)) { }
 
 Option::Option(int v, int minv, int maxv, OnChange f) :
     type("spin"),
@@ -152,9 +154,24 @@ Option& Option::operator=(const std::string& v) {
 
     assert(!type.empty());
 
+    if (type == "spin")
+    {
+        int         value = 0;
+        const char* begin = v.data();
+        const char* end   = begin + v.size();
+
+        // Match std::stoi() in accepting an explicit plus sign.
+        if (begin != end && *begin == '+')
+            ++begin;
+
+        auto [ptr, ec] = std::from_chars(begin, end, value);
+
+        if (ec != std::errc() || ptr != end || value < min || value > max)
+            return *this;
+    }
+
     if ((type != "button" && type != "string" && v.empty())
-        || (type == "check" && v != "true" && v != "false")
-        || (type == "spin" && (std::stoi(v) < min || std::stoi(v) > max)))
+        || (type == "check" && v != "true" && v != "false"))
         return *this;
 
     if (type == "combo")


### PR DESCRIPTION
Invalid values for `spin` options supplied through `setoption` could throw from `std::stoi` before the value was rejected.

Reproducer before this patch:

```text
uci
setoption name Threads value abc
```

Current behavior:

```text
terminate called after throwing an instance of 'std::invalid_argument'
  what():  stoi
```

This patch parses spin option values with `std::from_chars` instead. Invalid, partially parsed, or out-of-range values are rejected without changing the current option value.

Checked locally:

```text
setoption name Threads value abc
setoption name Threads value 999999999999999999999999999999
setoption name Threads value 4abc
setoption name Threads value +1
setoption name Threads value 1
isready
```

After the patch, malformed values no longer terminate the engine, valid values are still accepted, and the engine replies with `readyok`.

No functional change