### PR TITLE
Simplify Evasion Logic

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -752,26 +752,8 @@ bool Position::pseudo_legal(const Move m) const {
     else if (!(attacks_bb(type_of(pc), from, pieces()) & to))
         return false;
 
-    // Evasions generator already takes care to avoid some kind of illegal moves
-    // and legal() relies on this. We therefore have to take care that the same
-    // kind of moves are filtered out here.
     if (checkers())
-    {
-        if (type_of(pc) != KING)
-        {
-            // Double check? In this case, a king move is required
-            if (more_than_one(checkers()))
-                return false;
-
-            // Our move must be a blocking interposition or a capture of the checking piece
-            if (!(between_bb(square<KING>(us), lsb(checkers())) & to))
-                return false;
-        }
-        // In case of king moves under check we have to remove the king so as to catch
-        // invalid moves like b1a1 when opposite queen is on c1.
-        else if (attackers_to_exist(to, pieces() ^ from, ~us))
-            return false;
-    }
+        return MoveList<EVASIONS>(*this).contains(m);
 
     return true;
 }


### PR DESCRIPTION
Simplify Evasion Logic
When the king is in check, a pseudo-legal move must be a valid evasion. Instead of duplicating the checking rules for king and non-king moves, we can leverage the existing MoveList<EVASIONS> class. 

Passed non-reg STC:
LLR: 2.98 (-2.94,2.94) <-1.75,0.25>
Total: 187360 W: 47579 L: 47524 D: 92257
Ptnml(0-2): 418, 20266, 52263, 20309, 424
https://tests.stockfishchess.org/tests/view/6a28aa5b7c758d82accea13c

No functional change