### PR TITLE
NNUE: Bound network description size

### DIFF
--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -63,6 +63,8 @@ namespace Stockfish::Eval::NNUE {
 
 namespace Detail {
 
+constexpr u32 MaxDescriptionSize = 1024 * 1024;
+
 // Read evaluation function parameters
 template<typename T>
 bool read_parameters(std::istream& stream, T& reference) {
@@ -306,20 +308,29 @@ bool Network::read_header(std::istream& stream, u32* hashValue, std::string* des
     version    = read_little_endian<u32>(stream);
     *hashValue = read_little_endian<u32>(stream);
     size       = read_little_endian<u32>(stream);
-    if (!stream || version != Version)
+    if (!stream || version != Version || size > Detail::MaxDescriptionSize)
         return false;
+
     desc->resize(size);
-    stream.read(&(*desc)[0], size);
+
+    if (size)
+        stream.read(desc->data(), size);
     return !stream.fail();
 }
 
 
 // Write network header
 bool Network::write_header(std::ostream& stream, u32 hashValue, const std::string& desc) const {
+    if (desc.size() > Detail::MaxDescriptionSize)
+        return false;
+
     write_little_endian<u32>(stream, Version);
     write_little_endian<u32>(stream, hashValue);
     write_little_endian<u32>(stream, u32(desc.size()));
-    stream.write(&desc[0], desc.size());
+
+    if (!desc.empty())
+        stream.write(desc.data(), desc.size());
+
     return !stream.fail();
 }
 


### PR DESCRIPTION
Limits the NNUE network description length accepted from the file header before resizing the description string.

The description size is stored in the NNUE header and read from the network file. Previously, this value was used directly to resize the description string, so a malformed file could request an excessively large allocation before the loader failed.

This patch adds a conservative upper bound for the description field and applies the same bound when writing network headers.

Verification:

* `make -j build` passed.