### PR TITLE
Share continuation history between threads

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -132,7 +132,7 @@ using LowPlyHistory = Stats<i16, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZ
 using CapturePieceToHistory = Stats<i16, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;
 
 // PieceToHistory is like ButterflyHistory but is addressed by a move's [piece][to]
-using PieceToHistory = Stats<i16, 30000, PIECE_NB, SQUARE_NB>;
+using PieceToHistory = AtomicStats<i16, 30000, PIECE_NB, SQUARE_NB>;
 
 // ContinuationHistory is the combined history of a given pair of moves, usually
 // the current one given a previous one. The nested history table is based on

--- a/src/history.h
+++ b/src/history.h
@@ -238,6 +238,7 @@ struct SharedHistories {
     }
 
     UnifiedCorrectionHistory correctionHistory;
+    ContinuationHistory      continuationHistory[2][2];
     PawnHistory              pawnHistory;
 
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -165,6 +165,7 @@ Search::Worker::Worker(SharedState&                    sharedState,
                        NumaReplicatedAccessToken       token) :
     // Unpack the SharedState struct into member variables
     sharedHistory(sharedState.sharedHistories.at(token.get_numa_index())),
+    continuationHistory(sharedHistory.continuationHistory),
     threadIdx(threadId),
     numaThreadIdx(numaThreadId),
     numaTotal(numaTotalThreads),

--- a/src/search.h
+++ b/src/search.h
@@ -336,11 +336,11 @@ class Worker {
     LowPlyHistory    lowPlyHistory;
 
     CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
     CorrectionHistory<Continuation> continuationCorrectionHistory;
 
     TTMoveHistory    ttMoveHistory;
     SharedHistories& sharedHistory;
+    ContinuationHistory             (&continuationHistory)[2][2];
 
    private:
     bool iterative_deepening();


### PR DESCRIPTION
Passed 8th 5+0.05 https://tests.stockfishchess.org/tests/live_elo/6a0bfdb46524d21ee79b879b
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 23472 W: 6103 L: 5823 D: 11546
Ptnml(0-2): 26, 2501, 6403, 2779, 27 

Passed 8th 20+0.2 https://tests.stockfishchess.org/tests/live_elo/6a0c87196524d21ee79b885c
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 44692 W: 11640 L: 11319 D: 21733
Ptnml(0-2): 12, 4418, 13169, 4731, 16 

Passed 16th 5+0.05 https://tests.stockfishchess.org/tests/live_elo/6a20533f818cacc1db0ad32b
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 14720 W: 3910 L: 3642 D: 7168
Ptnml(0-2): 6, 1434, 4223, 1680, 17 

Passed 64th 10+0.1 https://tests.stockfishchess.org/tests/view/6a20ae8e818cacc1db0ad369

LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 34096 W: 8889 L: 8607 D: 16600
Ptnml(0-2): 4, 2974, 10808, 3260, 2

Continuation history is fixed size so there's a much more false sharing and a larger speed loss here at high thread counts, unfortunately.

vondele's machine, 4x70

```
==== master ====
Average (over 3):  294528128
==== shared-conthist ====
Average (over 3):  282364217 (~4% slowdown)
```

my machine, 8x32
```
Nodes/second               : 243157385
Nodes/second               : 228374554 (~6% slowdown)
```

Evidently it still gains at 64th, but a few followup ideas to try get the speed back:
- Add padding in `PieceToHistory` stats so there's less false sharing.
- Subdivide continuation history more finely than shared correction history.
- Scramble the `PieceToHistory` indexing so there's less false sharing