### PR TITLE
Lint for fixed-width integer types

### DIFF
--- a/.github/workflows/lint-integer-types.yml
+++ b/.github/workflows/lint-integer-types.yml
@@ -1,0 +1,31 @@
+name: Lint integer types
+on:
+  pull_request:
+    branches:
+      - master
+      - tools
+    paths:
+      - "**.cpp"
+      - "**.h"
+      - "scripts/lint_integer_types.py"
+      - ".github/workflows/lint-integer-types.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Lint-Integer-Types:
+    name: No new fixed-width integer types
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check for fixed-width types
+        run: |
+          python3 scripts/lint_integer_types.py \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/lint-integer-types.yml
+++ b/.github/workflows/lint-integer-types.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Check for fixed-width types
-        run: |
-          python3 scripts/lint_integer_types.py \
-            "${{ github.event.pull_request.base.sha }}" \
+        run: >
+          python3 scripts/lint_integer_types.py
+            "${{ github.event.pull_request.base.sha }}"
             "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/lint-integer-types.yml
+++ b/.github/workflows/lint-integer-types.yml
@@ -5,10 +5,10 @@ on:
       - master
       - tools
     paths:
-      - "**.cpp"
-      - "**.h"
-      - "scripts/lint_integer_types.py"
-      - ".github/workflows/lint-integer-types.yml"
+      - '**.cpp'
+      - '**.h'
+      - scripts/lint_integer_types.py
+      - .github/workflows/lint-integer-types.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/scripts/lint_integer_types.py
+++ b/scripts/lint_integer_types.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import re
+import subprocess
+import sys
+
+BANNED_RE = re.compile('\\b(size_t|ptrdiff_t|int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|int_least8_t|int_least16_t|int_least32_t|int_least64_t|uint_least8_t|uint_least16_t|uint_least32_t|uint_least64_t|int_fast8_t|int_fast16_t|int_fast32_t|int_fast64_t|uint_fast8_t|uint_fast16_t|uint_fast32_t|uint_fast64_t|intmax_t|uintmax_t|intptr_t|uintptr_t)\\b')
+
+
+def do_check(path):
+    if not path.endswith(".cpp") and not path.endswith(".h"):
+        return False
+    return "universal" not in path
+
+
+def parse_diff(diff_text):
+    violations = []
+    hunk_re = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+    path = None
+    checked = False
+    new_lineno = 0
+
+    for line in diff_text.splitlines():
+        if line.startswith("+++ "):
+            p = line[4:]
+            if p.startswith("b/"):
+                p = p[2:]
+            path = p
+            checked = do_check(path)
+            continue
+        if line.startswith("--- ") or line.startswith("diff ") or line.startswith("index "):
+            continue
+        if line.startswith("@@"):
+            m = hunk_re.match(line)
+            if m:
+                new_lineno = int(m.group(1))
+            continue
+        if not checked or line.startswith("\\"):
+            continue
+
+        if line.startswith("+"):
+            content = line[1:]
+            m = BANNED_RE.search(content)
+            if m:
+                violations.append((path, new_lineno, m.group(1), content.strip()))
+            new_lineno += 1
+        elif line.startswith("-"):
+            pass
+        else:
+            new_lineno += 1
+
+    return violations
+
+
+def main(argv):
+    diff_text = subprocess.run(
+        ["git", "diff", "--unified=0", "--no-color", f"{argv[1]}...{argv[2]}"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+
+    violations = parse_diff(diff_text)
+
+    for path, lineno, token, _line in violations:
+        print(
+            f"::error file={path},line={lineno}::"
+            f"'{token}' is not allowed in new code, instead use the alias from misc.h"
+        )
+
+    if violations:
+        return 1
+
+    return 0
+
+sys.exit(main(sys.argv))

--- a/scripts/lint_integer_types.py
+++ b/scripts/lint_integer_types.py
@@ -4,7 +4,7 @@ import re
 import subprocess
 import sys
 
-BANNED_RE = re.compile('\\b(size_t|ptrdiff_t|int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|int_least8_t|int_least16_t|int_least32_t|int_least64_t|uint_least8_t|uint_least16_t|uint_least32_t|uint_least64_t|int_fast8_t|int_fast16_t|int_fast32_t|int_fast64_t|uint_fast8_t|uint_fast16_t|uint_fast32_t|uint_fast64_t|intmax_t|uintmax_t|intptr_t|uintptr_t)\\b')
+BANNED_RE = re.compile('\\b(size_t|ptrdiff_t|int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|int_least8_t|int_least16_t|int_least32_t|int_least64_t|uint_least8_t|uint_least16_t|uint_least32_t|uint_least64_t|int_fast8_t|int_fast16_t|int_fast32_t|int_fast64_t|uint_fast8_t|uint_fast16_t|uint_fast32_t|uint_fast64_t)\\b')
 
 
 def do_check(path):
@@ -52,6 +52,12 @@ def parse_diff(diff_text):
     return violations
 
 
+def get_alias(token):
+    s = { "size_t": "usize", "ptrdiff_t": "isize" }.get(token, None)
+    return s if s else token[0] + "".join(filter(str.isdigit, token))
+
+
+
 def main(argv):
     diff_text = subprocess.run(
         ["git", "diff", "--unified=0", "--no-color", f"{argv[1]}...{argv[2]}"],
@@ -61,9 +67,10 @@ def main(argv):
     violations = parse_diff(diff_text)
 
     for path, lineno, token, _line in violations:
+        alias = get_alias(token)
         print(
             f"::error file={path},line={lineno}::"
-            f"'{token}' is not allowed in new code, instead use the alias from misc.h"
+            f"'{token}' is not allowed in new code, instead use the alias '{alias}' from misc.h"
         )
 
     if violations:

--- a/src/history.h
+++ b/src/history.h
@@ -132,7 +132,7 @@ using LowPlyHistory = Stats<i16, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZ
 using CapturePieceToHistory = Stats<i16, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;
 
 // PieceToHistory is like ButterflyHistory but is addressed by a move's [piece][to]
-using PieceToHistory = Stats<int16_t, 30000, PIECE_NB, SQUARE_NB>;
+using PieceToHistory = Stats<i16, 30000, PIECE_NB, SQUARE_NB>;
 
 // ContinuationHistory is the combined history of a given pair of moves, usually
 // the current one given a previous one. The nested history table is based on

--- a/src/history.h
+++ b/src/history.h
@@ -132,7 +132,7 @@ using LowPlyHistory = Stats<i16, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZ
 using CapturePieceToHistory = Stats<i16, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;
 
 // PieceToHistory is like ButterflyHistory but is addressed by a move's [piece][to]
-using PieceToHistory = Stats<i16, 30000, PIECE_NB, SQUARE_NB>;
+using PieceToHistory = Stats<int16_t, 30000, PIECE_NB, SQUARE_NB>;
 
 // ContinuationHistory is the combined history of a given pair of moves, usually
 // the current one given a previous one. The nested history table is based on


### PR DESCRIPTION
After https://github.com/official-stockfish/Stockfish/pull/6874 we use Rust-style type aliases (almost) everywhere. This CI check guards for new instances of the old types

No functional change