### PR TITLE
Remove unused search-layer APIs

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -56,8 +56,6 @@ class MovePicker {
     Move select(Pred);
     template<GenType T>
     ExtMove* score(const MoveList<T>&);
-    ExtMove* begin() { return cur; }
-    ExtMove* end() { return endCur; }
 
     const Position&              pos;
     const ButterflyHistory*      mainHistory;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1832,15 +1832,9 @@ int Search::Worker::reduction(bool i, Depth d, int mn, int delta) const {
 // 'nodestime' option is enabled, it will return the count of nodes searched
 // instead. This function is called to check whether the search should be
 // stopped based on predefined thresholds like time limits or nodes searched.
-//
-// elapsed_time() returns the actual time elapsed since the start of the search.
-// This function is intended for use only when printing PV outputs, and not used
-// for making decisions within the search algorithm itself.
 TimePoint Search::Worker::elapsed() const {
     return main_manager()->tm.elapsed([this]() { return threads.nodes_searched(); });
 }
-
-TimePoint Search::Worker::elapsed_time() const { return main_manager()->tm.elapsed_time(); }
 
 Value Search::Worker::evaluate(const Position& pos) {
     return Eval::evaluate(network[numaAccessToken], pos, accumulatorStack, refreshTable,

--- a/src/search.h
+++ b/src/search.h
@@ -298,8 +298,6 @@ class SearchManager: public ISearchManager {
     Value                bestPreviousAverageScore;
     bool                 stopOnPonderhit;
 
-    usize id;
-
     const UpdateContext& updates;
 };
 
@@ -370,7 +368,6 @@ class Worker {
     }
 
     TimePoint elapsed() const;
-    TimePoint elapsed_time() const;
 
     Value evaluate(const Position&);
 


### PR DESCRIPTION
The following have zero call sites repo-wide:

    SearchManager::id: never read or written (also never initialized, nor was it ever used).
    Search::Worker::elapsed_time(): never called. PV output uses tm.elapsed_time() (TimeManager) directly. (removed callers on 25361e5)
    MovePicker::begin()/end(): unused private accessors. (removed callers on 8c2d21f)

No functional change.