### PR TITLE
Clear capturedPiece in do_null_move

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1371,6 +1371,8 @@ void Position::do_null_move(StateInfo& newSt) {
 
     st->pliesFromNull = 0;
 
+    st->capturedPiece = NO_PIECE;
+
     sideToMove = ~sideToMove;
 
     set_check_info();


### PR DESCRIPTION
do_null_move copies the whole StateInfo from the previous state, which leaves capturedPiece holding the piece captured by the last real move, so inside the null-move subtree captured_piece() reports a stale capture. The priorCapture consumers in search are all guarded by prevSq != SQ_NONE or (ss-1)->currentMove.is_ok(), which are false at the null-move child, but the stalemate verification gate in qsearch reads captured_piece() unguarded and can be spuriously triggered by the stale value. 

Clear the field, since a null move captures nothing.

Passed non-regression STC:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 82784 W: 21172 L: 21011 D: 40601
Ptnml(0-2): 194, 8976, 22923, 9073, 226
https://tests.stockfishchess.org/tests/view/6a2b5b356b4aa63ddbf31518

Passed non-regression LTC:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 118134 W: 30007 L: 29891 D: 58236
Ptnml(0-2): 66, 11856, 35108, 11970, 67
https://tests.stockfishchess.org/tests/view/6a2c4c9c0d5d4b19d0805301

No functional change.