### PR TITLE
Two small simplifications

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -323,7 +323,7 @@ bool Search::Worker::iterative_deepening() {
 
     for (Color c : {WHITE, BLACK})
         for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
-            mainHistory[c][i] = (mainHistory[c][i] + 5) * 789 / 1024;
+            mainHistory[c][i] = mainHistory[c][i] * 789 / 1024;
 
     // Iterative deepening loop until requested to stop or the target depth is reached
     while (rootDepth + 1 < MAX_PLY && !threads.stop
@@ -1306,7 +1306,7 @@ moves_loop:  // When in check, search starts here
 
         // For first picked move (ttMove) reduce reduction
         else if (move == ttData.move)
-            r = std::max(-10, r - 2016 + 150 * cutNode);
+            r = std::max(0, r - 2016);
 
         if (capture)
             ss->statScore = 809 * int(PieceValue[pos.captured_piece()]) / 128


### PR DESCRIPTION
Two small simplifications

Passed simplification STC
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 206368 W: 52592 L: 52560 D: 101216
Ptnml(0-2): 537, 24201, 53669, 24247, 530 
https://tests.stockfishchess.org/tests/view/6a2c5ab00d5d4b19d0805326

Passed simplification LTC
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 109944 W: 27839 L: 27709 D: 54396
Ptnml(0-2): 61, 11938, 30844, 12068, 61 
https://tests.stockfishchess.org/tests/view/6a2dc6e70d5d4b19d08053aa

bench 2901895