### PR TITLE
Do more aggressive probCut when improving.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1039,7 +1039,7 @@ Value Search::Worker::search(
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
         MovePicker mp(pos, ttData.move, probCutBeta - ss->staticEval, &captureHistory);
-        Depth      probCutDepth = depth - 4;
+        Depth      probCutDepth = depth - 4 - improving;
 
         while ((move = mp.next_move()) != Move::none())
         {


### PR DESCRIPTION
If improving is true reduce depth of probCut search by 1.
Passed STC:
https://tests.stockfishchess.org/tests/view/6a2a6ceb17167cbe7100a909
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 119136 W: 30591 L: 30158 D: 58387
Ptnml(0-2): 323, 13831, 30845, 14228, 341 
Passed LTC:
https://tests.stockfishchess.org/tests/view/6a2d65a40d5d4b19d080537f
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 186552 W: 47377 L: 46755 D: 92420
Ptnml(0-2): 89, 20047, 52395, 20643, 102 
bench 2422062