### PR TITLE
[RfC] Make CI faster

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,7 +165,13 @@ jobs:
 
       - name: Download required macOS packages
         if: runner.os == 'macOS'
-        run: brew install coreutils gcc@11
+        run: brew install coreutils
+
+      - name: Install GCC on macOS
+        if: runner.os == 'macOS' && matrix.config.comp == 'gcc'
+        run: |
+          brew install gcc@11 || true
+          g++-11 --version
 
       - name: Setup msys and install required packages
         if: runner.os == 'Windows'

--- a/scripts/check_universal.sh
+++ b/scripts/check_universal.sh
@@ -44,26 +44,42 @@ if [ "$BINARY_SIZE" -gt "$MAX_SIZE" ]; then
     exit 1
 fi
 
-FAIL=0
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
 i=0
 for pair in $PAIRS; do
     i=$((i + 1))
     cpu=${pair%%:*}
     expected_compiler=${pair##*:}
-    compiler_out=$("$SDE_EXE" "-$cpu" -- "$STOCKFISH_EXE" compiler 2>&1 || true)
-    bench_out=$("$SDE_EXE" "-$cpu" -- "$STOCKFISH_EXE" bench 2>&1 || true)
-    actual_compiler=$(printf '%s\n' "$compiler_out" | awk -F: '/Compilation architecture/ {
-        sub(/^[[:space:]]+/, "", $2); sub(/[[:space:]]+$/, "", $2); print $2; exit
-    }')
-    actual_bench=$(printf '%s\n' "$bench_out" | awk -F: '/Nodes searched/ {
-        sub(/^[[:space:]]+/, "", $2); sub(/[[:space:]]+$/, "", $2); print $2; exit
-    }')
-    if [ "$actual_compiler" != "$expected_compiler" ] || [ "$actual_bench" != "$EXPECTED_BENCH" ]; then
-        printf '===== CPU %s output (expected %s/%s, got %s/%s) =====\n' \
-            "$cpu" "$expected_compiler" "$EXPECTED_BENCH" "${actual_compiler:--}" "$actual_bench" >&2
+    (
+        compiler_out=$("$SDE_EXE" "-$cpu" -- "$STOCKFISH_EXE" compiler 2>&1 || true)
+        bench_out=$("$SDE_EXE" "-$cpu" -- "$STOCKFISH_EXE" bench 2>&1 >/dev/null || true)
+        actual_compiler=$(printf '%s\n' "$compiler_out" | awk -F: '/Compilation architecture/ {
+            sub(/^[[:space:]]+/, "", $2); sub(/[[:space:]]+$/, "", $2); print $2; exit
+        }')
+        actual_bench=$(printf '%s\n' "$bench_out" | awk -F: '/Nodes searched/ {
+            sub(/^[[:space:]]+/, "", $2); sub(/[[:space:]]+$/, "", $2); print $2; exit
+        }')
+        if [ "$actual_compiler" != "$expected_compiler" ] || [ "$actual_bench" != "$EXPECTED_BENCH" ]; then
+            printf '===== CPU %s output (expected %s/%s, got %s/%s) =====\n' \
+                "$cpu" "$expected_compiler" "$EXPECTED_BENCH" "${actual_compiler:--}" "$actual_bench" > "$WORK/$i.fail"
+        else
+            printf 'CPU %s ok\n' "$cpu" > "$WORK/$i.log"
+        fi
+    ) &
+done
+wait
+
+FAIL=0
+i=0
+for pair in $PAIRS; do
+    i=$((i + 1))
+    if [ -f "$WORK/$i.fail" ]; then
+        cat "$WORK/$i.fail" >&2
         FAIL=1
     else
-        printf 'CPU %s ok\n' "$cpu" >&2
+        cat "$WORK/$i.log" >&2
     fi
 done
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,7 @@ PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds
-PGOBENCH = $(RUN_PREFIX) ./$(EXE) bench 16 1 10
+PGOBENCH = $(RUN_PREFIX) ./$(EXE) bench
 
 ### Source and object files
 SRCS = attacks.cpp benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \

--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,7 @@ PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds
-PGOBENCH = $(RUN_PREFIX) ./$(EXE) bench
+PGOBENCH = $(RUN_PREFIX) ./$(EXE) bench 16 1 10
 
 ### Source and object files
 SRCS = attacks.cpp benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \


### PR DESCRIPTION
We can straightforwardly parallelize the `check_universal.sh` script, which takes quite a bit of time for the x86 builds.

No functional change