### PR TITLE
Update minimum required compiler versions to GCC 10.2 and Clang 11.0

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -58,15 +58,15 @@
 // _WIN32                  Building on Windows (any)
 // _WIN64                  Building on Windows 64 bit
 
-// Enforce minimum GCC version
+    // Enforce minimum GCC version
     #if defined(__GNUC__) && !defined(__clang__) \
-      && (__GNUC__ < 9 || (__GNUC__ == 9 && __GNUC_MINOR__ < 3))
-        #error "Stockfish requires GCC 9.3 or later for correct compilation"
+      && (__GNUC__ < 10 || (__GNUC__ == 10 && __GNUC_MINOR__ < 2))
+        #error "Stockfish requires GCC 10.2 or later for correct compilation"
     #endif
 
     // Enforce minimum Clang version
-    #if defined(__clang__) && (__clang_major__ < 10)
-        #error "Stockfish requires Clang 10.0 or later for correct compilation"
+    #if defined(__clang__) && (__clang_major__ < 11)
+        #error "Stockfish requires Clang 11.0 or later for correct compilation"
     #endif
 
     #define ASSERT_ALIGNED(ptr, alignment) assert(reinterpret_cast<uintptr_t>(ptr) % alignment == 0)


### PR DESCRIPTION
Update minimum required compiler versions to GCC 11.1 and Clang 13.0

It has been roughly one year:
[Update min GCC to 9.3 and Clang to 10.0](https://github.com/official-stockfish/fishtest/pull/2282)
since the compiler baselines were last adjusted (to GCC 9.3 and Clang 10.0).

These versions were selected as a conservative step that advances our baseline while preserving out-of-the-box compatibility with major stable LTS distributions, specifically respecting the lifecycle of Debian 11 Bullseye (LTS until August 31, 2026):
GCC 10.2 is the default compiler on Debian 11 Bullseye (which ships with GCC 10.2.1).
Clang 11.0 is the default Clang version on Debian 11 Bullseye.

An analysis of the current Fishtest active worker pool shows that this update has minimal impact and represents an extremely safe transition:

GCC Status: Almost all active workers currently run GCC 12.2.0 or newer. Notably, (noobftw) upgraded all his machines to GCC 13.3.0. Currently, only a single active contributor (sylvek) runs a compiler older than GCC 12.2.0 (specifically GCC 9.4.0).

Clang Status: The oldest Clang version currently active in the Fishtest pool is Clang 17.0.0. No active testing workers are using older Clang versions.

If agreed by the maintainers, I will later open a corresponding PR in Fishtest to align the testing framework toolchain requirements with this baseline.

No functional change