### PR TITLE
Update main network to nn-f8a759c05f9f.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultName "nn-71d6d32cb962.nnue"
+#define EvalFileDefaultName "nn-f8a759c05f9f.nnue"
 
 namespace NNUE {
 class Network;


### PR DESCRIPTION
This network is further trained on a new BT4 distillation stage, fine tuning on ~2 billion positions relabeled with the value head output of `BT4-tf13tune.pb.gz`. The dataset can be found at https://huggingface.co/datasets/xushawn/test80-bt4-relabel. A modified branch of lc0 was used to derive this data: https://github.com/xu-shawn/lc0/tree/relabel_dual_stream_test

2 billion positions represent a tiny subset of the total training data, and BT4 relabeling is inherently computationally expensive. I expect a lot more gains as more data are relabeled, but it will likely require coordinated community effort. Everyone is welcome to contribute, and yl25946 has made a spreadsheet to track progress: https://docs.google.com/spreadsheets/d/1yanofhusEzDg8ZnurAw799ikoTY6GcqsNMYfpswOIbw/edit.

Special thanks to Viren6, who performed policy/value distillation experiments on Monty, and created the lc0 distillation fork that the current relabeler is based on; yl25946 for proposing the idea of large network distillations back in February 2025, running distillation experiments on the HL4096 network, and working on fine tuning attempts; vondele for nettest and suggesting the fine-tuning approach; and many others on the knowledge distillation thread in the SF Discord #ideas channel.

nettest PR: https://github.com/vondele/nettest/pull/369

Ongoing STC:
 LLR: -0.01 (-2.94,2.94) <0.00,2.00>
Total: 72224 W: 18891 L: 18784 D: 34549
Ptnml(0-2): 336, 8437, 18332, 8798, 209 
https://tests.stockfishchess.org/tests/view/6a3ae7913036e45021aeb4a0

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 25110 W: 6566 L: 6288 D: 12256
Ptnml(0-2): 27, 2625, 6957, 2935, 11
https://tests.stockfishchess.org/tests/view/6a3b73513036e45021aeb51e

Passed VLTC:
 LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 18544 W: 4924 L: 4658 D: 8962
Ptnml(0-2): 5, 1730, 5533, 2002, 2 
https://tests.stockfishchess.org/tests/view/6a3bbe233036e45021aeb56e