### PR TITLE
Allow cross-compilation of Android version on Mac

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -185,6 +185,7 @@ Moez Jellouli (MJZ1977)
 Mohammed Li (tthsqe12)
 Mukhammedali Beriktassuly (Berektassuly)
 Muzhen J (XInTheDark)
+Mafanwei
 Nathan Rugg (nmrugg)
 Nguyen Pham (nguyenpham)
 Nicklas Persson (NicklasPersson)

--- a/src/Makefile
+++ b/src/Makefile
@@ -588,12 +588,15 @@ ifeq ($(COMP),clang)
 endif
 
 ifeq ($(KERNEL),Darwin)
-	mac_target_flags := -mmacosx-version-min=10.15
-	ifneq ($(arch),any)
-		mac_target_flags += -arch $(arch)
+	# Only add macOS-specific options during non-NDK compilation
+	ifneq ($(COMP),ndk)
+		mac_target_flags := -mmacosx-version-min=10.15
+		ifneq ($(arch),any)
+			mac_target_flags += -arch $(arch)
+		endif
+		CXXFLAGS += $(mac_target_flags)
+		LDFLAGS += $(mac_target_flags)
 	endif
-	CXXFLAGS += $(mac_target_flags)
-	LDFLAGS += $(mac_target_flags)
 	XCRUN = xcrun
 endif
 
@@ -729,14 +732,16 @@ ifeq ($(optimize),yes)
 		endif
 	endif
 
-	ifeq ($(KERNEL),Darwin)
-		ifeq ($(comp),$(filter $(comp),clang icx))
-			CXXFLAGS += -mdynamic-no-pic
-		endif
-
-		ifeq ($(comp),gcc)
-			ifneq ($(arch),arm64)
+	ifneq ($(COMP),ndk)
+		ifeq ($(KERNEL),Darwin)
+			ifeq ($(comp),$(filter $(comp),clang icx))
 				CXXFLAGS += -mdynamic-no-pic
+			endif
+
+			ifeq ($(comp),gcc)
+				ifneq ($(arch),arm64)
+					CXXFLAGS += -mdynamic-no-pic
+				endif
 			endif
 		endif
 	endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,6 +25,13 @@ ifeq ($(KERNEL),Linux)
 	OS := $(shell uname -o)
 endif
 
+### Target operating system (may differ from KERNEL when cross-compiling)
+TARGET_KERNEL := $(KERNEL)
+ifeq ($(COMP),ndk)
+	TARGET_KERNEL := Linux
+	OS := Android
+endif
+
 ### Command prefix to run the built executable (e.g. wine, sde, qemu)
 ### Backward compatible alias: WINE_PATH (deprecated)
 ifneq ($(strip $(WINE_PATH)),)
@@ -516,7 +523,7 @@ ifeq ($(COMP),gcc)
 		LDFLAGS += -latomic
 	endif
 
-	ifneq ($(KERNEL),Darwin)
+	ifneq ($(TARGET_KERNEL),Darwin)
 	ifneq ($(arch),wasm32)
 	   LDFLAGS += -Wl,--no-as-needed
 	endif
@@ -563,7 +570,7 @@ ifeq ($(COMP),clang)
 	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-prototypes \
 	            -Wconditional-uninitialized -flax-vector-conversions=none -fconstexpr-steps=500000000
 
-	ifeq ($(filter $(KERNEL),Darwin OpenBSD FreeBSD),)
+	ifeq ($(filter $(TARGET_KERNEL),Darwin OpenBSD FreeBSD),)
 	ifeq ($(target_windows),)
 	ifneq ($(RTLIB),compiler-rt)
 		LDFLAGS += -latomic
@@ -587,16 +594,13 @@ ifeq ($(COMP),clang)
 	endif
 endif
 
-ifeq ($(KERNEL),Darwin)
-	# Only add macOS-specific options during non-NDK compilation
-	ifneq ($(COMP),ndk)
-		mac_target_flags := -mmacosx-version-min=10.15
-		ifneq ($(arch),any)
-			mac_target_flags += -arch $(arch)
-		endif
-		CXXFLAGS += $(mac_target_flags)
-		LDFLAGS += $(mac_target_flags)
+ifeq ($(TARGET_KERNEL),Darwin)
+	mac_target_flags := -mmacosx-version-min=10.15
+	ifneq ($(arch),any)
+		mac_target_flags += -arch $(arch)
 	endif
+	CXXFLAGS += $(mac_target_flags)
+	LDFLAGS += $(mac_target_flags)
 	XCRUN = xcrun
 endif
 
@@ -660,7 +664,7 @@ else ifeq ($(comp),clang)
 else
 	profile_make = gcc-profile-make
 	profile_use = gcc-profile-use
-	ifeq ($(KERNEL),Darwin)
+	ifeq ($(TARGET_KERNEL),Darwin)
 		EXTRAPROFILEFLAGS = -fvisibility=hidden
 	endif
 endif
@@ -694,7 +698,7 @@ ifneq ($(comp),mingw)
 					add_lrt = no
 				endif
 
-				ifeq ($(KERNEL),Darwin)
+				ifeq ($(TARGET_KERNEL),Darwin)
 					add_lrt = no
 				endif
 
@@ -732,16 +736,14 @@ ifeq ($(optimize),yes)
 		endif
 	endif
 
-	ifneq ($(COMP),ndk)
-		ifeq ($(KERNEL),Darwin)
-			ifeq ($(comp),$(filter $(comp),clang icx))
-				CXXFLAGS += -mdynamic-no-pic
-			endif
+	ifeq ($(TARGET_KERNEL),Darwin)
+		ifeq ($(comp),$(filter $(comp),clang icx))
+			CXXFLAGS += -mdynamic-no-pic
+		endif
 
-			ifeq ($(comp),gcc)
-				ifneq ($(arch),arm64)
-					CXXFLAGS += -mdynamic-no-pic
-				endif
+		ifeq ($(comp),gcc)
+			ifneq ($(arch),arm64)
+				CXXFLAGS += -mdynamic-no-pic
 			endif
 		endif
 	endif
@@ -855,7 +857,7 @@ endif
 
 ifeq ($(neon),yes)
 	CXXFLAGS += -DUSE_NEON=$(arm_version)
-	ifeq ($(KERNEL),Linux)
+	ifeq ($(TARGET_KERNEL),Linux)
 	ifneq ($(COMP),ndk)
 	ifneq ($(arch),armv8)
 		CXXFLAGS += -mfpu=neon
@@ -935,7 +937,7 @@ endif
 ifeq ($(optimize),yes)
 ifeq ($(debug),no)
 	ifeq ($(arch),wasm32)
-	else ifneq ($(KERNEL),Darwin)
+	else ifneq ($(TARGET_KERNEL),Darwin)
 		LLD_BIN := $(shell command -v ld.lld 2>/dev/null)
 		ifeq ($(LLD_BIN),)
 			LLD_BIN := $(shell command -v lld 2>/dev/null)
@@ -1128,7 +1130,7 @@ macos-lipo:
 	@rm -f $(EXE)-x86_64 $(EXE)-arm64
 	@echo "Universal macOS binary built: $(EXE)"
 
-ifeq ($(KERNEL),Darwin)
+ifeq ($(TARGET_KERNEL),Darwin)
 # Apple uses ld64 which doesn't have --save-temps
   LTO_OBJ_SUFFIX := .lto.o
   SAVE_TEMPS := -Wl,-object_path_lto,stockfish.lto.o
@@ -1399,9 +1401,9 @@ ARCH_OBJS := $(TEMP_DIR)/$(BASELINE_ARCH)/stockfish.o \
 UNIVERSAL_FINAL_FLAGS := -fno-exceptions -Os \
 			 -Wno-c++26-extensions -Wno-c23-extensions # suppress #embed warnings
 
-ifeq ($(KERNEL),Darwin)
+ifeq ($(TARGET_KERNEL),Darwin)
   UNIVERSAL_FINAL_FLAGS += $(mac_target_flags)
-else ifeq ($(KERNEL),Linux)
+else ifeq ($(TARGET_KERNEL),Linux)
   UNIVERSAL_FINAL_FLAGS += -static-libstdc++ -static-libgcc
   ifeq ($(COMP),ndk)
     UNIVERSAL_FINAL_FLAGS += -static
@@ -1424,7 +1426,7 @@ arch-mangled    = _ZN$(shell printf %s '$(call arch-namespace,$(1))' | wc -c | t
 # (Mach-O section names are restricted to <=16 chars, hence this naming scheme)
 arch-mac-section = _i_$(subst -,_,$(patsubst x86-64,,$(patsubst x86-64-%,%,$(1))))
 
-ifeq ($(KERNEL),Darwin)
+ifeq ($(TARGET_KERNEL),Darwin)
   arch-defmain = -Wl,-alias,_$(call arch-mangled,$(1)),_main
 # lld-link, used on Windows+clang, doesn't accept --defsym, so
 # we define main directly in main.cpp instead and delete it later.
@@ -1487,7 +1489,7 @@ $(TEMP_DIR)/%/stockfish.o: $(TEMP_DIR)/%/.setup $(NNUE_EMBED_OBJ) $(NET_SENTINEL
 	    $(MAKE) -C $(TEMP_DIR)/$* $(UOBJ_TGT) \
 	        ARCH=$* CXX=$(CXX) COMP=$(COMP) \
 	        NNUE_EMBED_OBJ=$(NNUE_EMBED_OBJ)
-ifeq ($(KERNEL),Darwin)
+ifeq ($(TARGET_KERNEL),Darwin)
 # Rename the initializer section
 	ld -r -rename_section __DATA __mod_init_func __DATA $(call arch-mac-section,$*) $@ -o $@.tmp
 	mv $@.tmp $@


### PR DESCRIPTION
When compiling for Android (COMP=ndk) on macOS, the build fails because the
NDK's LLVM toolchain does not recognize the macOS-specific flags
-mdynamic-no-pic and -mmacosx-version-min.
﻿
This PR wraps these flags with ifneq ($(COMP),ndk) condition to skip them
during Android cross-compilation.

Please squash and merge this PR.