### PR TITLE
Update main network to nn-1b6a82263149.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultName "nn-f8a759c05f9f.nnue"
+#define EvalFileDefaultName "nn-1b6a82263149.nnue"
 
 namespace NNUE {
 class Network;


### PR DESCRIPTION
Add `test80-2024-01-jan-2tb7p.min-v2.v6.relabel.binpack` to the distillation fine tuning stage, an additional 3.5B (2.9B non-skipped) positions.

nettest PR: https://github.com/vondele/nettest/pull/375

Passed STC (vs #6924):
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 57952 W: 15000 L: 14656 D: 28296
Ptnml(0-2): 164, 6651, 15003, 6993, 165
https://tests.stockfishchess.org/tests/view/6a3cca103036e45021aeb6f8

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 81456 W: 21265 L: 20858 D: 39333
Ptnml(0-2): 52, 8630, 22958, 9035, 53
https://tests.stockfishchess.org/tests/view/6a3dbe203036e45021aeb828