### PR TITLE
Fix opening files with non-ASCII characters in their path

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -412,7 +412,8 @@ std::vector<std::string> setup_bench(const std::string& currentFen, std::istream
     else
     {
         std::string   fen;
-        std::ifstream file(fenFile);
+        std::ifstream file;
+        open_fstream(file, fenFile, std::ios_base::in);
 
         if (!file.is_open())
         {

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -19,11 +19,9 @@
 #include "misc.h"
 
 #ifdef _WIN32
-    #if !defined(WIN32_LEAN_AND_MEAN)
-        #define WIN32_LEAN_AND_MEAN
-    #endif
-    #if !defined(NOMINMAX)
-        #define NOMINMAX
+    #define WIN32_LEAN_AND_MEAN
+    #ifndef NOMINMAX
+        #define NOMINMAX  // Disable macros min() and max()
     #endif
     #include <windows.h>
 #endif

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -18,6 +18,16 @@
 
 #include "misc.h"
 
+#ifdef _WIN32
+    #if !defined(WIN32_LEAN_AND_MEAN)
+        #define WIN32_LEAN_AND_MEAN
+    #endif
+    #if !defined(NOMINMAX)
+        #define NOMINMAX
+    #endif
+    #include <windows.h>
+#endif
+
 #include <array>
 #include <atomic>
 #include <cassert>
@@ -96,7 +106,7 @@ class Logger {
 
         if (!fname.empty())
         {
-            l.file.open(fname, std::ifstream::out);
+            open_fstream(l.file, fname, std::ios_base::out);
 
             if (!l.file.is_open())
             {
@@ -493,11 +503,24 @@ usize str_to_size_t(const std::string& s) {
 }
 
 std::optional<std::string> read_file_to_string(const std::string& path) {
-    std::ifstream f(path, std::ios_base::binary);
+    std::ifstream f;
+    open_fstream(f, path, std::ios_base::in | std::ios_base::binary);
     if (!f)
         return std::nullopt;
     return std::string(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>());
 }
+
+#ifdef _WIN32
+std::wstring utf8_to_wide(const std::string& str) {
+    if (str.empty())
+        return std::wstring();
+
+    const int size = MultiByteToWideChar(CP_UTF8, 0, str.data(), int(str.size()), nullptr, 0);
+    std::wstring wstr(size, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, str.data(), int(str.size()), wstr.data(), size);
+    return wstr;
+}
+#endif
 
 void remove_whitespace(std::string& s) {
     s.erase(std::remove_if(s.begin(), s.end(), [](char c) { return std::isspace(c); }), s.end());

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -21,7 +21,7 @@
 #ifdef _WIN32
     #define WIN32_LEAN_AND_MEAN
     #ifndef NOMINMAX
-        #define NOMINMAX  // Disable macros min() and max()
+        #define NOMINMAX
     #endif
     #include <windows.h>
 #endif

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -515,7 +515,7 @@ std::wstring utf8_to_wide(const std::string& str) {
     if (str.empty())
         return std::wstring();
 
-    const int size = MultiByteToWideChar(CP_UTF8, 0, str.data(), int(str.size()), nullptr, 0);
+    const int    size = MultiByteToWideChar(CP_UTF8, 0, str.data(), int(str.size()), nullptr, 0);
     std::wstring wstr(size, L'\0');
     MultiByteToWideChar(CP_UTF8, 0, str.data(), int(str.size()), wstr.data(), size);
     return wstr;

--- a/src/misc.h
+++ b/src/misc.h
@@ -155,17 +155,9 @@ struct PipeDeleter {
 std::optional<std::string> read_file_to_string(const std::string& path);
 
 #ifdef _WIN32
-// Converts a UTF-8 encoded string to a UTF-16 wide string. Needed on Windows
-// because the narrow std::fstream and WinAPI overloads interpret paths using
-// the active code page rather than UTF-8.
 std::wstring utf8_to_wide(const std::string& str);
 #endif
 
-// Opens a file stream from a UTF-8 encoded path. On Windows the narrow
-// std::fstream overloads interpret the path with the active code page instead
-// of UTF-8, which prevents opening files whose path contains non-ASCII
-// characters. To avoid this we convert the path to UTF-16 and use the wide
-// open() overload. On other platforms the UTF-8 byte string is used directly.
 template<typename Stream>
 void open_fstream(Stream& stream, const std::string& path, std::ios_base::openmode mode) {
 #ifdef _WIN32

--- a/src/misc.h
+++ b/src/misc.h
@@ -30,6 +30,7 @@
 #include <exception>  // IWYU pragma: keep
 // IWYU pragma: no_include <__exception/terminate.h>
 #include <functional>
+#include <ios>
 #include <iosfwd>
 #include <optional>
 #include <cstring>
@@ -152,6 +153,27 @@ struct PipeDeleter {
 // Reads the file as bytes.
 // Returns std::nullopt if the file does not exist.
 std::optional<std::string> read_file_to_string(const std::string& path);
+
+#ifdef _WIN32
+// Converts a UTF-8 encoded string to a UTF-16 wide string. Needed on Windows
+// because the narrow std::fstream and WinAPI overloads interpret paths using
+// the active code page rather than UTF-8.
+std::wstring utf8_to_wide(const std::string& str);
+#endif
+
+// Opens a file stream from a UTF-8 encoded path. On Windows the narrow
+// std::fstream overloads interpret the path with the active code page instead
+// of UTF-8, which prevents opening files whose path contains non-ASCII
+// characters. To avoid this we convert the path to UTF-16 and use the wide
+// open() overload. On other platforms the UTF-8 byte string is used directly.
+template<typename Stream>
+void open_fstream(Stream& stream, const std::string& path, std::ios_base::openmode mode) {
+#ifdef _WIN32
+    stream.open(utf8_to_wide(path).c_str(), mode);
+#else
+    stream.open(path, mode);
+#endif
+}
 
 void dbg_hit_on(bool cond, int slot = 0);
 void dbg_mean_of(i64 value, int slot = 0);

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -128,8 +128,9 @@ bool Network::save(const std::optional<std::string>& filename) const {
         actualFilename = evalFile.defaultName;
     }
 
-    std::ofstream stream(actualFilename, std::ios_base::binary);
-    bool          saved = save(stream, evalFile.current, evalFile.netDescription);
+    std::ofstream stream;
+    open_fstream(stream, actualFilename, std::ios_base::out | std::ios_base::binary);
+    bool saved = save(stream, evalFile.current, evalFile.netDescription);
 
     msg = saved ? "Network saved successfully to " + actualFilename : "Failed to export a net";
 
@@ -226,8 +227,9 @@ NnueEvalTrace Network::trace_evaluate(const Position&    pos,
 
 
 void Network::load_user_net(const std::string& dir, const std::string& evalfilePath) {
-    std::ifstream stream(dir + evalfilePath, std::ios::binary);
-    auto          description = load(stream);
+    std::ifstream stream;
+    open_fstream(stream, dir + evalfilePath, std::ios_base::in | std::ios_base::binary);
+    auto description = load(stream);
 
     if (description.has_value())
     {

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -251,7 +251,7 @@ class TBFile: public std::ifstream {
         while (std::getline(ss, path, SepChar))
         {
             fname = path + "/" + f;
-            std::ifstream::open(fname);
+            open_fstream(*this, fname, std::ios_base::in);
             if (is_open())
                 return;
         }
@@ -291,7 +291,7 @@ class TBFile: public std::ifstream {
         }
     #else
         // Note FILE_FLAG_RANDOM_ACCESS is only a hint to Windows and as such may get ignored.
-        HANDLE fd = CreateFileA(fname.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+        HANDLE fd = CreateFileW(utf8_to_wide(fname).c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
                                 OPEN_EXISTING, FILE_FLAG_RANDOM_ACCESS, nullptr);
 
         if (fd == INVALID_HANDLE_VALUE)

--- a/tests/instrumented.py
+++ b/tests/instrumented.py
@@ -397,10 +397,7 @@ class TestInteractive(metaclass=OrderedClassMembers):
         self.stockfish.send_command("go depth 5")
         self.stockfish.starts_with("bestmove")
 
-    def test_load_nnue_from_non_ascii_path(self):
-        # Regression test for issue #3424: on Windows the narrow file APIs
-        # interpret paths using the active code page, so exporting/loading a
-        # network through a path with non-ASCII characters used to fail.
+    def test_issue_3424_non_ascii_path(self):
         nnue_dir = os.path.join(os.path.abspath(os.getcwd()), "tëst_тест_目录")
         os.makedirs(nnue_dir, exist_ok=True)
         nnue_path = os.path.join(nnue_dir, "verify.nnue")

--- a/tests/instrumented.py
+++ b/tests/instrumented.py
@@ -397,19 +397,6 @@ class TestInteractive(metaclass=OrderedClassMembers):
         self.stockfish.send_command("go depth 5")
         self.stockfish.starts_with("bestmove")
 
-    def test_issue_3424_non_ascii_path(self):
-        nnue_dir = os.path.join(os.path.abspath(os.getcwd()), "tëst_тест_目录")
-        os.makedirs(nnue_dir, exist_ok=True)
-        nnue_path = os.path.join(nnue_dir, "verify.nnue")
-
-        export = Stockfish(["export_net", nnue_path], True)
-        assert export.process.returncode == 0
-
-        self.stockfish.send_command(f"setoption name EvalFile value {nnue_path}")
-        self.stockfish.send_command("position startpos")
-        self.stockfish.send_command("go depth 5")
-        self.stockfish.starts_with("bestmove")
-
     def test_multipv_setting(self):
         self.stockfish.send_command("setoption name MultiPV value 4")
         self.stockfish.send_command("position startpos")

--- a/tests/instrumented.py
+++ b/tests/instrumented.py
@@ -397,6 +397,22 @@ class TestInteractive(metaclass=OrderedClassMembers):
         self.stockfish.send_command("go depth 5")
         self.stockfish.starts_with("bestmove")
 
+    def test_load_nnue_from_non_ascii_path(self):
+        # Regression test for issue #3424: on Windows the narrow file APIs
+        # interpret paths using the active code page, so exporting/loading a
+        # network through a path with non-ASCII characters used to fail.
+        nnue_dir = os.path.join(os.path.abspath(os.getcwd()), "tëst_тест_目录")
+        os.makedirs(nnue_dir, exist_ok=True)
+        nnue_path = os.path.join(nnue_dir, "verify.nnue")
+
+        export = Stockfish(["export_net", nnue_path], True)
+        assert export.process.returncode == 0
+
+        self.stockfish.send_command(f"setoption name EvalFile value {nnue_path}")
+        self.stockfish.send_command("position startpos")
+        self.stockfish.send_command("go depth 5")
+        self.stockfish.starts_with("bestmove")
+
     def test_multipv_setting(self):
         self.stockfish.send_command("setoption name MultiPV value 4")
         self.stockfish.send_command("position startpos")


### PR DESCRIPTION
## Root cause

On Windows the narrow `std::fstream` constructors/`open()` and the WinAPI
`CreateFileA()` interpret a path using the process *active code page* (ANSI),
not UTF-8. When the UCI input arrives as UTF-8 (as it does from UTF-8 capable
consoles/GUIs), a path containing non-ASCII characters cannot be opened. This is
what is reported in #3424:

```
setoption name EvalFile value C:\Users\Owner\Desktop\русский\nn-62ef826d1a6d.nnue
```

fails, while ASCII-only paths work.

## Fix

Add a small `open_fstream()` helper plus a `utf8_to_wide()` conversion in
`misc.{h,cpp}`:

- On Windows the UTF-8 path is converted to UTF-16 via `MultiByteToWideChar(CP_UTF8, ...)`
  and the wide `open()` overload (resp. `CreateFileW`) is used.
- On all other platforms the UTF-8 byte string is passed through unchanged, so
  behaviour there is identical to before.

This mirrors the approach used by other engines (e.g. lc0, linked in the issue).

## File-open sites covered

All user-supplied path open sites are routed through the helper:

- `nnue/network.cpp` — `EvalFile` load (`load_user_net`) and save
- `misc.cpp` — debug log file (`Logger::start`) and `read_file_to_string`
- `benchmark.cpp` — bench EPD file
- `syzygy/tbprobe.cpp` — tablebase existence check (`std::ifstream`) and the
  memory-mapped open (`CreateFileA` → `CreateFileW`) on Windows

No search/eval logic is changed.

## Verification

- Builds cleanly on macOS (`make build ARCH=apple-silicon`, GCC, `-Wall -Wextra
  -Wshadow -pedantic`), no new warnings.
- Functional test on a non-ASCII path: `export_net` to and `setoption name
  EvalFile value` from a directory named `русский` both succeed (file written
  and net loaded, `readyok`). On Unix paths are byte-transparent; the Windows
  wide-path conversion provides the equivalent behaviour and could not be
  compiled/run in this environment, so the Windows code path is verified by
  review only.

Closes #3424
