### PR TITLE
Wide char support on Windows

### DIFF
--- a/.github/workflows/avx2_compilers.yml
+++ b/.github/workflows/avx2_compilers.yml
@@ -22,7 +22,6 @@ jobs:
           - { name: gcc-15, comp: gcc, cxx: g++, image: "gcc:15" }
 
           # Using silkeh/clang for older versions
-          - { name: clang-10, comp: clang, cxx: clang++, image: "silkeh/clang:10", is_clang: true, ver: "10" }
           - { name: clang-11, comp: clang, cxx: clang++, image: "silkeh/clang:11", is_clang: true, ver: "11" }
           - { name: clang-12, comp: clang, cxx: clang++, image: "silkeh/clang:12", is_clang: true, ver: "12" }
           - { name: clang-13, comp: clang, cxx: clang++, image: "silkeh/clang:13", is_clang: true, ver: "13" }

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,6 +37,7 @@
 
 #if defined(_WIN32)
     #include <windows.h>
+    #include <shellapi.h>
 #endif
 
 namespace Stockfish {
@@ -483,7 +484,6 @@ void start_logger(const std::string& fname) { Logger::start(fname); }
 
 #ifdef _WIN32
     #include <direct.h>
-    #define GETCWD _getcwd
 #else
     #include <unistd.h>
     #define GETCWD getcwd
@@ -496,13 +496,24 @@ usize str_to_size_t(const std::string& s) {
     return static_cast<usize>(value);
 }
 
+#ifdef _WIN32
+static std::string to_utf8(const std::wstring& wstr) {
+    int len   = static_cast<int>(wstr.size());
+    int u8len = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), len, NULL, 0, NULL, NULL);
+
+    std::string u8str(static_cast<usize>(u8len), '\0');
+    WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), len, u8str.data(), u8len, NULL, NULL);
+    return u8str;
+}
+#endif
+
 std::filesystem::path fixup_path(const std::string& path) {
 #ifdef _WIN32
-    int len  = static_cast<int>(path.size());
-    int wlen = MultiByteToWideChar(CP_UTF8, 0, path.c_str(), len, NULL, 0);
+    int u8len = static_cast<int>(path.size());
+    int wlen  = MultiByteToWideChar(CP_UTF8, 0, path.c_str(), u8len, NULL, 0);
 
     std::wstring wstr(static_cast<usize>(wlen), L'\0');
-    MultiByteToWideChar(CP_UTF8, 0, path.c_str(), len, wstr.data(), wlen);
+    MultiByteToWideChar(CP_UTF8, 0, path.c_str(), u8len, wstr.data(), wlen);
     return {wstr};
 #else
     return {path};
@@ -524,18 +535,38 @@ bool is_whitespace(std::string_view s) {
     return std::all_of(s.begin(), s.end(), [](char c) { return std::isspace(c); });
 }
 
+CommandLine::CommandLine(int _argc, char** _argv) :
+    argc(_argc),
+    argv(_argv) {
+#ifdef _WIN32
+    // Convert any non-ANSI characters passed on the command line to UTF-8
+    int wargc = 0;
+    if (LPWSTR* wargv = CommandLineToArgvW(GetCommandLineW(), &wargc))
+    {
+        args.reserve(static_cast<usize>(wargc));
+        for (int i = 0; i < wargc; ++i)
+            args.push_back(to_utf8(wargv[i]));
+        LocalFree(wargv);
+
+        for (std::string& s : args)
+            argvValues.push_back(s.data());
+        argvValues.push_back(NULL);
+
+        argc = wargc;
+        argv = argvValues.data();
+    }
+#endif
+}
+
 std::string CommandLine::get_binary_directory(std::string argv0) {
     std::string pathSeparator;
 
 #ifdef _WIN32
     pathSeparator = "\\";
-    #ifdef _MSC_VER
-    // Under windows argv[0] may not have the extension. Also _get_pgmptr() had
-    // issues in some Windows 10 versions, so check returned values carefully.
-    char* pgmptr = nullptr;
-    if (!_get_pgmptr(&pgmptr) && pgmptr != nullptr && *pgmptr)
-        argv0 = pgmptr;
-    #endif
+    std::wstring exePath(32768, L'\0');  // big enough
+    DWORD        len = GetModuleFileNameW(NULL, exePath.data(), static_cast<DWORD>(exePath.size()));
+    if (len != 0)
+        argv0 = to_utf8(exePath.substr(0, len));
 #else
     pathSeparator = "/";
 #endif
@@ -559,11 +590,18 @@ std::string CommandLine::get_binary_directory(std::string argv0) {
 }
 
 std::string CommandLine::get_working_directory() {
-    std::string workingDirectory = "";
-    char        buff[40000];
-    char*       cwd = GETCWD(buff, 40000);
+    std::string     workingDirectory = "";
+    constexpr usize CwdMax           = 40000;
+#ifdef _WIN32
+    wchar_t buff[CwdMax];
+    if (_wgetcwd(buff, CwdMax))
+        workingDirectory = to_utf8(buff);
+#else
+    char  buff[CwdMax];
+    char* cwd = GETCWD(buff, CwdMax);
     if (cwd)
         workingDirectory = cwd;
+#endif
 
     return workingDirectory;
 }

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -543,14 +543,13 @@ CommandLine::CommandLine(int _argc, char** _argv) :
     int wargc = 0;
     if (LPWSTR* wargv = CommandLineToArgvW(GetCommandLineW(), &wargc))
     {
-        args.reserve(static_cast<usize>(wargc));
         for (int i = 0; i < wargc; ++i)
             args.push_back(to_utf8(wargv[i]));
         LocalFree(wargv);
 
         for (std::string& s : args)
             argvValues.push_back(s.data());
-        argvValues.push_back(NULL);
+        argvValues.push_back(nullptr);
 
         argc = wargc;
         argv = argvValues.data();

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -35,6 +35,10 @@
 
 #include "types.h"
 
+#if defined(_WIN32)
+    #include <windows.h>
+#endif
+
 namespace Stockfish {
 
 namespace {
@@ -96,7 +100,7 @@ class Logger {
 
         if (!fname.empty())
         {
-            l.file.open(fname, std::ifstream::out);
+            l.file.open(fixup_path(fname), std::ifstream::out);
 
             if (!l.file.is_open())
             {
@@ -492,8 +496,21 @@ usize str_to_size_t(const std::string& s) {
     return static_cast<usize>(value);
 }
 
+std::filesystem::path fixup_path(const std::string& path) {
+#ifdef _WIN32
+    int len  = static_cast<int>(path.size());
+    int wlen = MultiByteToWideChar(CP_UTF8, 0, path.c_str(), len, NULL, 0);
+
+    std::wstring wstr(static_cast<usize>(wlen), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, path.c_str(), len, wstr.data(), wlen);
+    return {wstr};
+#else
+    return {path};
+#endif
+}
+
 std::optional<std::string> read_file_to_string(const std::string& path) {
-    std::ifstream f(path, std::ios_base::binary);
+    std::ifstream f(fixup_path(path), std::ios_base::binary);
     if (!f)
         return std::nullopt;
     return std::string(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>());

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -36,6 +36,9 @@
 #include "types.h"
 
 #if defined(_WIN32)
+    #ifndef NOMINMAX
+        #define NOMINMAX
+    #endif
     #include <windows.h>
     #include <shellapi.h>
 #endif

--- a/src/misc.h
+++ b/src/misc.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <exception>  // IWYU pragma: keep
+#include <filesystem>
 // IWYU pragma: no_include <__exception/terminate.h>
 #include <functional>
 #include <iosfwd>
@@ -148,6 +149,9 @@ struct PipeDeleter {
 };
 
 #endif
+
+// Normalize non-ANSI paths on Windows
+std::filesystem::path fixup_path(const std::string& path);
 
 // Reads the file as bytes.
 // Returns std::nullopt if the file does not exist.

--- a/src/misc.h
+++ b/src/misc.h
@@ -601,15 +601,20 @@ class FixedString {
 
 struct CommandLine {
    public:
-    CommandLine(int _argc, char** _argv) :
-        argc(_argc),
-        argv(_argv) {}
+    CommandLine(int _argc, char** _argv);
 
     static std::string get_binary_directory(std::string argv0);
     static std::string get_working_directory();
 
     int    argc;
     char** argv;
+
+   private:
+#ifdef _WIN32
+    // Backing store for argc/argv
+    std::vector<std::string> args;
+    std::vector<char*>       argvValues;
+#endif
 };
 
 namespace Utility {

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -128,7 +128,7 @@ bool Network::save(const std::optional<std::string>& filename) const {
         actualFilename = evalFile.defaultName;
     }
 
-    std::ofstream stream(actualFilename, std::ios_base::binary);
+    std::ofstream stream(fixup_path(actualFilename), std::ios_base::binary);
     bool          saved = save(stream, evalFile.current, evalFile.netDescription);
 
     msg = saved ? "Network saved successfully to " + actualFilename : "Failed to export a net";
@@ -226,7 +226,7 @@ NnueEvalTrace Network::trace_evaluate(const Position&    pos,
 
 
 void Network::load_user_net(const std::string& dir, const std::string& evalfilePath) {
-    std::ifstream stream(dir + evalfilePath, std::ios::binary);
+    std::ifstream stream(fixup_path(dir + evalfilePath), std::ios::binary);
     auto          description = load(stream);
 
     if (description.has_value())

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -251,7 +251,7 @@ class TBFile: public std::ifstream {
         while (std::getline(ss, path, SepChar))
         {
             fname = path + "/" + f;
-            std::ifstream::open(fname);
+            std::ifstream::open(fixup_path(fname));
             if (is_open())
                 return;
         }
@@ -291,7 +291,7 @@ class TBFile: public std::ifstream {
         }
     #else
         // Note FILE_FLAG_RANDOM_ACCESS is only a hint to Windows and as such may get ignored.
-        HANDLE fd = CreateFileA(fname.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+        HANDLE fd = CreateFileW(fixup_path(fname).c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
                                 OPEN_EXISTING, FILE_FLAG_RANDOM_ACCESS, nullptr);
 
         if (fd == INVALID_HANDLE_VALUE)

--- a/src/types.h
+++ b/src/types.h
@@ -65,8 +65,8 @@
     #endif
 
     // Enforce minimum Clang version
-    #if defined(__clang__) && (__clang_major__ < 10)
-        #error "Stockfish requires Clang 10.0 or later for correct compilation"
+    #if defined(__clang__) && (__clang_major__ < 11)
+        #error "Stockfish requires Clang 11.0 or later for correct compilation"
     #endif
 
     #define ASSERT_ALIGNED(ptr, alignment) assert(reinterpret_cast<uintptr_t>(ptr) % alignment == 0)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -40,6 +40,9 @@
 #include "ucioption.h"
 
 #ifdef _WIN32
+    #ifndef NOMINMAX
+        #define NOMINMAX
+    #endif
     #include <windows.h>
 #endif
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -39,6 +39,10 @@
 #include "types.h"
 #include "ucioption.h"
 
+#ifdef _WIN32
+    #include <windows.h>
+#endif
+
 namespace Stockfish {
 
 constexpr auto BenchmarkCommand = "speedtest";
@@ -85,6 +89,12 @@ void UCIEngine::init_search_update_listeners() {
 }
 
 void UCIEngine::loop() {
+#ifdef _WIN32
+    // Best-effort UTF-8 support
+    (void) SetConsoleCP(CP_UTF8);
+    (void) SetConsoleOutputCP(CP_UTF8);
+#endif
+
     std::string token, cmd;
 
     for (int i = 1; i < cli.argc; ++i)


### PR DESCRIPTION
Fixes #3424. Also remove clang-10 because it needs some extra finagling to support `std::filesystem`. I tested in powershell with `export_net` and works fine. To wit,

Broke (`master`):

<img width="1538" height="614" alt="image" src="https://github.com/user-attachments/assets/7ac9176a-4662-45ef-9b27-b27a26b32352" />

Woke (this branch):

<img width="1598" height="602" alt="image" src="https://github.com/user-attachments/assets/39092edc-521a-4227-8e6b-f06790e0cb7b" />

No functional change