### PR TITLE
Yeet psqt weights

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -48,7 +48,7 @@ Value Eval::evaluate(const Eval::NNUE::Network&     network,
 
     auto [psqt, positional] = network.evaluate(pos, accumulators, caches);
 
-    Value nnue = (125 * psqt + 131 * positional) / 128;
+    Value nnue = psqt + positional;
 
     // Blend optimism and eval with nnue complexity
     int nnueComplexity = std::abs(psqt - positional);


### PR DESCRIPTION
Simplifying the ratio in the eval between the psqt and the positional eval to a basic addition

Passed Nonreg STC:
https://tests.stockfishchess.org/tests/view/6a3eaac63036e45021aeb937
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 207392 W: 53521 L: 53489 D: 100382
Ptnml(0-2): 585, 24412, 53748, 24288, 663

Passed Nonreg LTC:
https://tests.stockfishchess.org/tests/view/6a423666f97ff95f7879508e
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 27198 W: 7200 L: 6989 D: 13009
Ptnml(0-2): 12, 2794, 7779, 2999, 15

bench: 2067208
