### PR TITLE
Simplify thread selection

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -350,22 +350,17 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
 Thread* ThreadPool::get_best_thread() const {
 
     Thread* bestThread = threads.front().get();
-    Value   minScore   = VALUE_NONE;
+    Value   minScore   = VALUE_INFINITE;
 
     std::unordered_map<Move, i64, Move::MoveHash> votes(
       2 * std::min(size(), bestThread->worker->rootMoves.size()));
 
-    // Find the minimum score of all threads
     for (auto&& th : threads)
         minScore = std::min(minScore, th->worker->rootMoves[0].score);
 
-    // Vote according to score and depth, and select the best thread
-    auto thread_voting_value = [minScore](Thread* th) {
-        return (th->worker->rootMoves[0].score - minScore + 14) * int(th->worker->rootDepth);
-    };
-
+    // Vote according to score, and select the best thread
     for (auto&& th : threads)
-        votes[th->worker->rootMoves[0].pv[0]] += thread_voting_value(th.get());
+        votes[th->worker->rootMoves[0].pv[0]] += th->worker->rootMoves[0].score - minScore + 14;
 
     for (auto&& th : threads)
     {
@@ -383,11 +378,6 @@ Thread* ThreadPool::get_best_thread() const {
                                     && is_decisive(newThreadMove.score)
                                     && !newThreadMove.score_is_bound();
 
-        // We make sure not to pick a thread with a truncated principal variation.
-        const bool betterVotingValue =
-          thread_voting_value(th.get()) * int(newThreadMove.pv.size() > 2)
-          > thread_voting_value(bestThread) * int(bestThreadMove.pv.size() > 2);
-
         if (bestThreadDecisive)
         {
             // Make sure we pick the shortest mate / TB conversion.
@@ -402,7 +392,8 @@ Thread* ThreadPool::get_best_thread() const {
         else if (newThreadDecisive
                  || (!is_loss(newThreadMove.score)
                      && (newThreadMoveVote > bestThreadMoveVote
-                         || (newThreadMoveVote == bestThreadMoveVote && betterVotingValue))))
+                         || (newThreadMoveVote == bestThreadMoveVote
+                             && newThreadMove.pv.size() > bestThreadMove.pv.size()))))
             bestThread = th.get();
     }
 


### PR DESCRIPTION
The depth dependency in best thread selection no longer seems to gain sufficiently and so can be simplified away.

Passed non-reg STC SMP:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 437904 W: 111841 L: 112051 D: 214012
Ptnml(0-2): 485, 49454, 119332, 49148, 533
https://tests.stockfishchess.org/tests/view/6a3158590d5d4b19d08055cd

Passed non-reg LTC SMP:
LLR: 3.11 (-2.94,2.94) <-1.75,0.25>
Total: 484778 W: 123864 L: 124093 D: 236821
Ptnml(0-2): 121, 49237, 143920, 48972, 139
https://tests.stockfishchess.org/tests/view/6a377f3ba4f63d3271af0920

No functional change.

