### PR TITLE
Enable MoveSorter for AVX512

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -56,7 +56,7 @@ enum Stages {
     QCAPTURE
 };
 
-#ifdef USE_AVX512ICL
+#ifdef USE_AVX512
 // Load the Move, and the ExtMove value, into all lanes of 512-bit registers
 static void splat_extmove(const ExtMove& m, __m512i& move, __m512i& value) {
     move  = _mm512_set1_epi32(m.raw());
@@ -111,7 +111,7 @@ struct MoveSorter {
 void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
     ExtMove *sortedEnd = begin, *p = begin + 1;
 
-#ifdef USE_AVX512ICL
+#ifdef USE_AVX512
     if (begin == end)
         return;
 


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/6a42f773f97ff95f7879518a
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 132992 W: 34679 L: 34248 D: 64065
Ptnml(0-2): 318, 14004, 37436, 14405, 333 

No functional change
bench: 2067208

Credit to @anematode for the original PR!
 