### PR TITLE
Fix Clang 22 codegen regression

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -346,7 +346,13 @@ inline bool Position::is_chess960() const { return chess960; }
 
 inline bool Position::capture(Move m) const {
     assert(m.is_ok());
-    return (!empty(m.to_sq()) && m.type_of() != CASTLING) || m.type_of() == EN_PASSANT;
+
+    const MoveType mt = m.type_of();
+
+    if (mt == NORMAL || mt == PROMOTION)
+        return !empty(m.to_sq());
+
+    return mt == EN_PASSANT;
 }
 
 // Returns true if a move is generated from the capture stage, having also
@@ -354,7 +360,16 @@ inline bool Position::capture(Move m) const {
 // generation is needed to avoid the generation of duplicate moves.
 inline bool Position::capture_stage(Move m) const {
     assert(m.is_ok());
-    return capture(m) || m.promotion_type() == QUEEN;
+
+    const MoveType mt = m.type_of();
+
+    if (mt == NORMAL)
+        return !empty(m.to_sq());
+
+    if (mt == PROMOTION)
+        return !empty(m.to_sq()) || m.promotion_type() == QUEEN;
+
+    return mt == EN_PASSANT;
 }
 
 inline Piece Position::captured_piece() const { return st->capturedPiece; }


### PR DESCRIPTION
Clang 22 apparently has a codegen regression in capture() and capture_stage() functions. GCC and the other versions of Clang also showed a marginal speedup which however could be due to noise.

Combined results of two STC tests:
https://tests.stockfishchess.org/tests/view/6a45b104f97ff95f78795570
https://tests.stockfishchess.org/tests/view/6a474aaff97ff95f787957a9

STC (clang++ 22):
LLR: 2.811 (-2.944,2.944) <0.00,2.00>
Ptnml(0-2): 67, 3094, 7975, 3306, 102

Non-regression STC (g++, clang++ ~21):
LLR: 6.617 (-2.944,2.944) <-1.75,0.25>
Ptnml(0-2): 428, 22211, 56555, 22553, 429

Local test results (Zen 4, x86-64-avx512icl, bench 512 1 16, 50 runs):

Clang (22.1.2): PASSED: speedup = +0.0169, P(speedup > 0) = 1.0000
GCC (15.2.0):   FAILED: speedup = +0.0031, P(speedup > 0) = 0.9597

No functional change