### PR TITLE
Simplify futility multiplier

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -976,7 +976,7 @@ Value Search::Worker::search(
     if (!ss->ttPv && depth < 17 && eval >= beta && (!ttData.move || ttCapture) && !is_loss(beta)
         && !is_win(eval))
     {
-        Value futilityMult = interpolate(std::min(int(depth), 10), 1, 10, 40, 80);
+        Value futilityMult = std::min(40 + depth * 4, 80);
         futilityMult -= 20 * !ss->ttHit;
 
         Value futilityMargin = futilityMult * depth


### PR DESCRIPTION
this patch simplifies the Value futility multiplier and changes pruning behaviour

passed stc: https://tests.stockfishchess.org/tests/live_elo/6a462265f97ff95f78795600
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 38112 W: 10071 L: 9758 D: 18283
Ptnml(0-2): 88, 4341, 9903, 4618, 106

passed ltc: https://tests.stockfishchess.org/tests/live_elo/6a470bc5f97ff95f7879576a
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 67482 W: 17738 L: 17363 D: 32381
Ptnml(0-2): 36, 7061, 19164, 7452, 28

patch rebased to latest master

Bench: 2353997