### PR TITLE
Remove dead code left over from earlier refactors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -60,6 +60,7 @@ Ciekce
 clefrks
 Clemens L. (rn5f107s2)
 Cody Ho (aesrentai)
+Con Kirby (ConKirby)
 CSTENTOR
 Dale Weiler (graphitemaster)
 Dalton Hanaway (dhanaway)

--- a/src/misc.h
+++ b/src/misc.h
@@ -26,7 +26,6 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <cstdio>
 #include <exception>  // IWYU pragma: keep
 // IWYU pragma: no_include <__exception/terminate.h>
 #include <functional>
@@ -135,19 +134,6 @@ void prefetch(const void* addr) {
 void start_logger(const std::string& fname);
 
 usize str_to_size_t(const std::string& s);
-
-#if defined(__linux__)
-
-struct PipeDeleter {
-    void operator()(FILE* file) const {
-        if (file != nullptr)
-        {
-            pclose(file);
-        }
-    }
-};
-
-#endif
 
 // Reads the file as bytes.
 // Returns std::nullopt if the file does not exist.

--- a/src/types.h
+++ b/src/types.h
@@ -454,10 +454,6 @@ class Move {
         return Square(data & 0x3F);
     }
 
-    // Same as to_sq() but without assertion, for branchless code paths
-    // where the result is masked/ignored when move is not ok
-    constexpr Square to_sq_unchecked() const { return Square(data & 0x3F); }
-
     constexpr MoveType type_of() const { return MoveType(data & (3 << 14)); }
 
     constexpr PieceType promotion_type() const { return PieceType(((data >> 12) & 3) + KNIGHT); }


### PR DESCRIPTION
The following have zero references repo-wide:

    Move::to_sq_unchecked() (types.h): added in 542c30c2 for a
    branchless correction-history update; its only caller was removed
    in 5ae13d2b ("Remove Redundant Branchless Execution"), leaving the
    method unused.

    PipeDeleter (misc.h): the custom deleter for the std::unique_ptr<FILE,
    PipeDeleter> that wrapped popen("lscpu"). That pipe was removed in
    c8375c2f ("On linux use sysfs instead of lscpu"), so the struct has
    been unused since.

Dropping PipeDeleter also removes the last user of <cstdio> in misc.h, so that include is dropped as well.

No functional change