### PR TITLE
add rbit fallback

### DIFF
--- a/src/attacks.h
+++ b/src/attacks.h
@@ -43,20 +43,24 @@ void init();
 #ifdef USE_HYPERBOLA_QUINT
 
 inline Bitboard reverse_bb(Bitboard bb) {
-    #ifdef __aarch64__
-        #if defined(__GNUC__) && !defined(__clang__) \
-          && (__GNUC__ < 12 || (__GNUC__ == 12 && __GNUC_MINOR__ < 2))
+    #if __has_builtin(__builtin_bitreverse64)
+    return __builtin_bitreverse64(bb);
+    #else
+        #ifdef __aarch64__
+            #if defined(__GNUC__) && !defined(__clang__) \
+              && (__GNUC__ < 12 || (__GNUC__ == 12 && __GNUC_MINOR__ < 2))
     // no rbit in arm_acle.h
     Bitboard out;
     asm("rbit %0, %1" : "=r"(out) : "r"(bb));
     return out;
-        #else
+            #else
     return __rbitll(bb);
-        #endif
-    #else  // loongarch
+            #endif
+        #else  // loongarch
     Bitboard out;
     asm("bitrev.d %0, %1" : "=r"(out) : "r"(bb));
     return out;
+        #endif
     #endif
 }
 

--- a/src/attacks.h
+++ b/src/attacks.h
@@ -44,7 +44,15 @@ void init();
 
 inline Bitboard reverse_bb(Bitboard bb) {
     #ifdef __aarch64__
+        #if defined(__GNUC__) && !defined(__clang__) \
+          && (__GNUC__ < 12 || (__GNUC__ == 12 && __GNUC_MINOR__ < 2))
+    // no rbit in arm_acle.h
+    Bitboard out;
+    asm("rbit %0, %1" : "=r"(out) : "r"(bb));
+    return out;
+        #else
     return __rbitll(bb);
+        #endif
     #else  // loongarch
     Bitboard out;
     asm("bitrev.d %0, %1" : "=r"(out) : "r"(bb));

--- a/src/misc.h
+++ b/src/misc.h
@@ -621,6 +621,10 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
 }
 }
 
+#ifndef __has_builtin
+    #define __has_builtin(x) 0
+#endif
+
 #if defined(__GNUC__)
     #define sf_always_inline __attribute__((always_inline))
 #elif defined(_MSC_VER)


### PR DESCRIPTION
GCC 12.2 added `__rbitll` intrinsic to `arm_acle.h`, so we can add a fallback for older versions

Clang 10 (our new minimum supported version) is unaffected by all this