### PR TITLE
[RFC] AMX(Advanced Matrix Extensions) support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -126,6 +126,7 @@ VPATH = syzygy:nnue:nnue/features
 # avx512 = yes/no     --- -mavx512bw         --- Use Intel Advanced Vector Extensions 512
 # vnni512 = yes/no    --- -mavx512vnni       --- Use Intel Vector Neural Network Instructions 512
 # avx512icl = yes/no  --- ... multiple ...   --- Use All AVX-512 features available on both Intel Ice Lake and AMD Zen 4
+# amx = yes/no        --- -mamx-tile ...     --- Use Intel Advanced Matrix Extensions
 # altivec = yes/no    --- -maltivec          --- Use PowerPC Altivec SIMD extension
 # vsx = yes/no        --- -mvsx              --- Use POWER VSX SIMD extension
 # neon = yes/no       --- -DUSE_NEON         --- Use ARM SIMD architecture
@@ -156,7 +157,7 @@ endif
 # explicitly check for the list of supported architectures (as listed with make help),
 # the user can override with `make ARCH=x86-64-avx512icl SUPPORTED_ARCH=true`
 ifeq ($(ARCH), $(filter $(ARCH), \
-                 x86-64-universal x86-64-avx512icl x86-64-vnni512 x86-64-avx512 x86-64-avxvnni \
+                 x86-64-universal x86-64-amx x86-64-avx512icl x86-64-vnni512 x86-64-avx512 x86-64-avxvnni \
                  x86-64-bmi2 x86-64-avx2 x86-64-sse41-popcnt x86-64-modern x86-64-ssse3 x86-64-sse3-popcnt \
                  x86-64 x86-32-sse41-popcnt x86-32-sse2 x86-32 ppc-64 ppc-64-altivec ppc-64-vsx ppc-32 e2k \
                  armv7 armv7-neon armv8 armv8-dotprod arm64-universal apple-silicon general-64 general-32 riscv64 \
@@ -190,6 +191,7 @@ avxvnni = no
 avx512 = no
 vnni512 = no
 avx512icl = no
+amx = no
 altivec = no
 vsx = no
 neon = no
@@ -329,6 +331,20 @@ ifeq ($(findstring -avx512icl,$(ARCH)),-avx512icl)
 	avx512 = yes
 	vnni512 = yes
 	avx512icl = yes
+endif
+
+ifeq ($(findstring -amx,$(ARCH)),-amx)
+	popcnt = yes
+	sse = yes
+	sse2 = yes
+	ssse3 = yes
+	sse41 = yes
+	avx2 = yes
+	pext = yes
+	avx512 = yes
+	vnni512 = yes
+	avx512icl = yes
+	amx = yes
 endif
 
 ifeq ($(sse),yes)
@@ -815,6 +831,13 @@ ifeq ($(avx512icl),yes)
 	endif
 endif
 
+ifeq ($(amx),yes)
+	CXXFLAGS += -DUSE_AMX
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
+		CXXFLAGS += -mamx-tile -mamx-int8
+	endif
+endif
+
 ifeq ($(sse41),yes)
 	CXXFLAGS += -DUSE_SSE41
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
@@ -1024,6 +1047,7 @@ help:
 	echo "" && \
 	echo "native                  > select the best architecture for the host processor (default)" && \
 	echo "x86-64-universal        > x86 64-bit with automatic runtime selection of the best architecture" && \
+	echo "x86-64-amx              > x86 64-bit with amx support" && \
 	echo "x86-64-avx512icl        > x86 64-bit with minimum avx512 support of Intel Ice Lake or AMD Zen 4" && \
 	echo "x86-64-vnni512          > x86 64-bit with vnni 512bit support" && \
 	echo "x86-64-avx512           > x86 64-bit with avx512 support" && \
@@ -1259,6 +1283,7 @@ config-sanity: net
 	echo "avx512: '$(avx512)'" && \
 	echo "vnni512: '$(vnni512)'" && \
 	echo "avx512icl: '$(avx512icl)'" && \
+	echo "amx: '$(amx)'" && \
 	echo "altivec: '$(altivec)'" && \
 	echo "vsx: '$(vsx)'" && \
 	echo "neon: '$(neon)'" && \
@@ -1297,6 +1322,7 @@ config-sanity: net
 	(test "$(avx512)" = "yes" || test "$(avx512)" = "no") && \
 	(test "$(vnni512)" = "yes" || test "$(vnni512)" = "no") && \
 	(test "$(avx512icl)" = "yes" || test "$(avx512icl)" = "no") && \
+	(test "$(amx)" = "yes" || test "$(amx)" = "no") && \
 	(test "$(altivec)" = "yes" || test "$(altivec)" = "no") && \
 	(test "$(vsx)" = "yes" || test "$(vsx)" = "no") && \
 	(test "$(neon)" = "yes" || test "$(neon)" = "no") && \

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -250,6 +250,9 @@ std::string compiler_info() {
 
     compiler += "\nCompilation settings       : ";
     compiler += (Is64Bit ? "64bit" : "32bit");
+#if defined(USE_AMX)
+    compiler += " AMX";
+#endif
 #if defined(USE_AVX512ICL)
     compiler += " AVX512ICL";
 #endif

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -188,6 +188,9 @@ class AffineTransform {
         for (IndexType i = 0; i < OutputDimensions * PaddedInputDimensions; ++i)
             weights[get_weight_index(i)] = read_little_endian<WeightType>(stream);
 
+#if defined(USE_AMX)
+        SIMD::amxWeightEpoch.fetch_add(1, std::memory_order_relaxed);
+#endif
         return !stream.fail();
     }
 
@@ -216,7 +219,62 @@ class AffineTransform {
 
         if constexpr (OutputDimensions > 1)
         {
-    #if defined(USE_AVX512)
+    #if defined(USE_AMX)
+            // TDPBUSD computes acc[m][n] += dot4(A[m][4k..4k+3], B[k][4n..4n+3]),
+            // and the scrambled weight order used under ENABLE_SEQ_OPT is exactly
+            // this B-matrix (VNNI) layout: dword row k holds, for every output n,
+            // the 4 weights of inputs 4k..4k+3, with a row stride of
+            // OutputDimensions * 4 bytes. Tiles are limited to 16 rows x 64 bytes,
+            // so one weight tile covers 64 inputs x 16 outputs.
+            static_assert(PaddedInputDimensions == 64,
+                          "Resident weight tiles require all inputs to fit one tile chunk.");
+            static_assert(OutputDimensions % 16 == 0 && OutputDimensions / 16 <= 3,
+                          "Outputs must fill 1 to 3 accumulator tiles of 16 i32 each.");
+
+            constexpr IndexType NumBTiles    = OutputDimensions / 16;
+            constexpr IndexType WeightStride = OutputDimensions * 4;
+
+            // Loads the tile configuration on first use in this thread. Must
+            // precede the residency check because LDTILECFG zeroes all tiles.
+            SIMD::amx_thread_init();
+
+            // The weights are constant, so keep them resident in tmm4-tmm6 and
+            // reload only when this thread sees a different or reloaded weight
+            // set (e.g. another NUMA replica). The shared per-thread key also
+            // handles multiple instances clobbering each other's tiles. Note
+            // that nothing else in the process may touch the tile state.
+            const u32 epoch = SIMD::amxWeightEpoch.load(std::memory_order_relaxed);
+            if (SIMD::amxResidentWeights != weights || SIMD::amxResidentEpoch != epoch)
+            {
+                SIMD::amxResidentWeights = weights;
+                SIMD::amxResidentEpoch   = epoch;
+                _tile_loadd(4, &weights[0], WeightStride);
+                if constexpr (NumBTiles > 1)
+                    _tile_loadd(5, &weights[64], WeightStride);
+                if constexpr (NumBTiles > 2)
+                    _tile_loadd(6, &weights[128], WeightStride);
+            }
+
+            // tmm0 holds the 64 inputs, tmm1-tmm3 accumulate 16 outputs each,
+            // seeded with the biases. The loads are independent and overlap in
+            // the out-of-order window.
+            _tile_loadd(0, input, 64);
+            _tile_loadd(1, &biases[0], 64);
+            _tile_dpbusd(1, 0, 4);
+            _tile_stored(1, &output[0], 64);
+            if constexpr (NumBTiles > 1)
+            {
+                _tile_loadd(2, &biases[16], 64);
+                _tile_dpbusd(2, 0, 5);
+                _tile_stored(2, &output[16], 64);
+            }
+            if constexpr (NumBTiles > 2)
+            {
+                _tile_loadd(3, &biases[32], 64);
+                _tile_dpbusd(3, 0, 6);
+                _tile_stored(3, &output[32], 64);
+            }
+    #elif defined(USE_AVX512)
             using vec_t = __m512i;
         #define vec_set_32 _mm512_set1_epi32
         #define vec_add_32 _mm512_add_epi32
@@ -248,6 +306,7 @@ class AffineTransform {
         #define vec_add_dpbusd_32 SIMD::lsx_m128_add_dpbusd_epi32
     #endif
 
+    #if !defined(USE_AMX)
             static constexpr IndexType OutputSimdWidth = sizeof(vec_t) / sizeof(OutputType);
 
             static_assert(OutputDimensions % OutputSimdWidth == 0);
@@ -305,6 +364,7 @@ class AffineTransform {
 
     #undef vec_set_32
     #undef vec_add_dpbusd_32
+    #endif
         }
         else if constexpr (OutputDimensions == 1)
         {

--- a/src/nnue/simd.h
+++ b/src/nnue/simd.h
@@ -19,7 +19,15 @@
 #ifndef NNUE_SIMD_H_INCLUDED
 #define NNUE_SIMD_H_INCLUDED
 
-#if defined(USE_AVX2)
+#if defined(USE_AMX)
+    #include <cstdlib>
+    #include <iostream>
+    #if defined(__linux__)
+        #include <sys/syscall.h>
+        #include <unistd.h>
+    #endif
+
+#elif defined(USE_AVX2)
     #include <immintrin.h>
 
 #elif defined(USE_SSE41)
@@ -584,6 +592,64 @@ dotprod_m128_add_dpbusd_epi32(int32x4_t& acc, int8x16_t a, int8x16_t b) {
 }
 
 #endif  // USE_LSX
+
+#if defined(USE_AMX)
+
+// Memory layout of the tile configuration loaded by LDTILECFG.
+struct alignas(64) AmxTileConfig {
+    u8  paletteId;
+    u8  startRow;
+    u8  reserved[14];
+    u16 colsb[16];
+    u8  rows[16];
+};
+
+// Configure the AMX tiles once per thread; on Linux additionally request the
+// per-process permission to use the AMX tile data state on first use. The
+// operating system preserves the tile configuration across context switches
+// as part of the extended (XSAVE) state, so loading it once per thread is
+// sufficient. Tile shapes (must match their use in AffineTransform::propagate):
+//   tmm0      : 1 row   x 64 bytes (64 u8 inputs)
+//   tmm1-tmm3 : 1 row   x 64 bytes (16 i32 accumulators each)
+//   tmm4-tmm7 : 16 rows x 64 bytes (weights for 64 inputs x 16 outputs, VNNI layout)
+inline void amx_thread_init() {
+    static thread_local bool initialized = [] {
+        #if defined(__linux__)
+        constexpr int ARCH_REQ_XCOMP_PERM = 0x1023;
+        constexpr int XFEATURE_XTILEDATA  = 18;
+
+        static const bool permitted =
+          syscall(SYS_arch_prctl, ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA) == 0;
+
+        if (!permitted)
+        {
+            std::cerr << "Kernel denied permission to use AMX tile data (XTILEDATA)." << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        #endif
+
+        AmxTileConfig cfg{};
+        cfg.paletteId = 1;
+        for (int t = 0; t < 8; ++t)
+        {
+            cfg.colsb[t] = 64;
+            cfg.rows[t]  = t < 4 ? 1 : 16;
+        }
+        _tile_loadconfig(&cfg);
+        return true;
+    }();
+
+    (void) initialized;
+}
+
+// Weight-generation counter, bumped whenever network parameters are (re)loaded,
+// so threads can detect stale resident weight tiles even if a reloaded network
+// reuses the same allocation address. amxResidentWeights tracks which weight
+// matrix this thread currently holds in tmm4-tmm6.
+inline std::atomic<u32> amxWeightEpoch{0};
+inline thread_local const void* amxResidentWeights = nullptr;
+inline thread_local u32         amxResidentEpoch   = 0;
+#endif  // USE_AMX
 
 
 // Compute optimal SIMD register count for feature transformer accumulation.


### PR DESCRIPTION
I was testing Fable 5 and asked it to write an AMX implementation of AffineTransform::propagate().  I verified that it gives the correct bench using the Intel SDE(Software Development Emulator).  Fable thinks it will be slower than the current VNNI implementation but I don't have any Sapphire Rapids+ hardware to test.  Could someone bench this? The new ARCH is x86-64-amx.

No functional change
bench: 2353997