### PR TITLE
Scale Null Move Pruning reduction dynamically based on evaluation margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -993,8 +993,8 @@ Value Search::Worker::search(
     {
         assert((ss - 1)->currentMove != Move::null());
 
-        // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        // Null move dynamic reduction based on depth and evaluation margin
+        Depth R = 7 + depth / 3 + std::max(0, (ss->staticEval - beta) / 256);
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);


### PR DESCRIPTION
This patch introduces a dynamic scaling factor for Null Move Pruning (NMP) reductions. By scaling the reduction depth relative to the static evaluation margin against beta, the engine can afford more aggressive reductions in positions that are overwhelmingly favorable, optimizing CPU cycle utilization without compromising search integrity.

Bench: 2997670