### PR TITLE
Scale Null Move Pruning reduction dynamically based on evaluation margin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ Aron Petkovski (fury)
 Arseniy Surkov (codedeliveryservice)
 Artem Solopiy (EntityFX)
 Auguste Pop
+Ayush (ayushthepiro11-design)
 Balazs Szilagyi
 Balint Pfliegel
 Baptiste Rech (breatn)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -993,8 +993,8 @@ Value Search::Worker::search(
     {
         assert((ss - 1)->currentMove != Move::null());
 
-        // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        // Null move dynamic reduction based on depth and evaluation margin
+        Depth R = 7 + depth / 3 + std::max(0, (ss->staticEval - beta) / 256);
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);


### PR DESCRIPTION
This patch introduces a dynamic scaling factor for Null Move Pruning (NMP) reductions. By scaling the reduction depth relative to the static evaluation margin against beta, the engine can afford more aggressive reductions in positions that are overwhelmingly favorable, optimizing CPU cycle utilization without compromising search integrity.

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 85504 W: 22383 L: 22000 D: 41121
Ptnml(0-2): 225, 9855, 22218, 10220, 234 
https://tests.stockfishchess.org/tests/view/6a4793daf97ff95f78795812

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 205800 W: 53879 L: 53224 D: 98697
Ptnml(0-2): 98, 21747, 58561, 22390, 104 
https://tests.stockfishchess.org/tests/view/6a4b864ff97ff95f78795e52

Bench: 2997670