### PR TITLE
Simplify Reduction formula for first picked move (ttMove)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1310,7 +1310,7 @@ moves_loop:  // When in check, search starts here
 
         // For first picked move (ttMove) reduce reduction
         else if (move == ttData.move)
-            r = std::max(0, r - 2016);
+            r -= 2016;
 
         if (capture)
             ss->statScore = 809 * int(PieceValue[pos.captured_piece()]) / 128


### PR DESCRIPTION
Simplify Reduction formula for first picked move (ttMove)

Passed STC non-reg:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 124864 W: 32270 L: 32151 D: 60443
Ptnml(0-2): 273, 13766, 34278, 13799, 316
https://tests.stockfishchess.org/tests/view/6a44f4d9f97ff95f78795463

Passed LTC non-reg:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 335544 W: 87272 L: 87369 D: 160903
Ptnml(0-2): 157, 34355, 98852, 34244, 164
https://tests.stockfishchess.org/tests/view/6a46a188f97ff95f787956a1

bench: 2402830