### PR TITLE
Revert "Scale Null Move Pruning reduction"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,7 +37,6 @@ Aron Petkovski (fury)
 Arseniy Surkov (codedeliveryservice)
 Artem Solopiy (EntityFX)
 Auguste Pop
-Ayush (ayushthepiro11-design)
 Balazs Szilagyi
 Balint Pfliegel
 Baptiste Rech (breatn)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -995,8 +995,8 @@ Value Search::Worker::search(
     {
         assert((ss - 1)->currentMove != Move::null());
 
-        // Null move dynamic reduction based on depth and evaluation margin
-        Depth R = 7 + depth / 3 + std::max(0, (ss->staticEval - beta) / 256);
+        // Null move dynamic reduction based on depth
+        Depth R = 7 + depth / 3;
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);


### PR DESCRIPTION

This reverts commit 9d4090e82685cca447265dcd7093d617cb34a107.

causes very poor mate finding performance, ultimately causing a CI hang on a mate in 2

Testcase:

position fen k1B5/2p5/NbN5/P7/3p4/P2p4/P1prp3/2RbK3 b - - 0 1 setoption name Hash value 16
setoption name Threads value 4
go mate 2
ucinewgame

Bench: 2466447