### PR TITLE
Optimize RVV affine transforms

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -199,6 +199,7 @@ Norman Schmidt (FireFather)
 notruck
 Nour Berakdar (Nonlinear)
 Ofek Shochat (OfekShochat, ghostway)
+Olaf Bernstein (camel-cdr)
 Ömer Faruk Tutkun (OmerFarukTutkun)
 Ondřej Mišina (AndrovT)
 Ondrej Mosnáček (WOnder93)

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -105,6 +105,7 @@ affine_transform_non_ssse3(i32* output, const i8* weights, const i32* biases, co
 
         #endif
     }
+    #else
     std::memcpy(output, biases, sizeof(i32) * OutputDimensions);
 
     // Traverse weights in transpose order to take advantage of input sparsity

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -46,7 +46,7 @@ namespace Stockfish::Eval::NNUE::Layers {
 
 // Fallback implementation for older/other architectures.
 // Requires the input to be padded to at least 16 values.
-#ifndef ENABLE_SEQ_OPT
+#if !defined(ENABLE_SEQ_OPT) && !defined(USE_RVV)
 
 template<IndexType InputDimensions, IndexType PaddedInputDimensions, IndexType OutputDimensions>
 static void
@@ -105,27 +105,6 @@ affine_transform_non_ssse3(i32* output, const i8* weights, const i32* biases, co
 
         #endif
     }
-    #elif defined(USE_RVV)
-    for (IndexType i = 0; i < OutputDimensions; ++i)
-    {
-        const i8*  row  = &weights[i * PaddedInputDimensions];
-        vint32m1_t vsum = __riscv_vmv_v_x_i32m1(0, __riscv_vsetvlmax_e32m1());
-
-        for (usize j = 0; j < InputDimensions;)
-        {
-            usize vl = __riscv_vsetvl_e8m4(InputDimensions - j);
-
-            vint8m4_t  w    = __riscv_vle8_v_i8m4(&row[j], vl);
-            vuint8m4_t x    = __riscv_vle8_v_u8m4(&input[j], vl);
-            vint16m8_t prod = __riscv_vwmulsu_vv_i16m8(w, x, vl);
-
-            vsum = __riscv_vwredsum_vs_i16m8_i32m1(prod, vsum, vl);
-            j += vl;
-        }
-
-        output[i] = biases[i] + __riscv_vmv_x_s_i32m1_i32(vsum);
-    }
-    #else
     std::memcpy(output, biases, sizeof(i32) * OutputDimensions);
 
     // Traverse weights in transpose order to take advantage of input sparsity
@@ -364,6 +343,48 @@ class AffineTransform {
     #undef vec_add_dpbusd_32
     #undef vec_hadd
         }
+#elif defined(USE_RVV)
+        const i8* wIt = weights;
+
+    #define RVV_PROPAGATE_SINGLE(m2, m1) \
+        do \
+        { \
+            vint32m1_t     zero = __riscv_vmv_s_x_i32m1(0, 1); \
+            usize          vl   = __riscv_vsetvl_e8##m1(InputDimensions); \
+            vuint8##m1##_t in   = __riscv_vle8_v_u8##m1(input, vl); \
+            for (IndexType i = 0; i < OutputDimensions; ++i, wIt += PaddedInputDimensions) \
+            { \
+                vint8##m1##_t  w    = __riscv_vle8_v_i8##m1(wIt, vl); \
+                vint16##m2##_t prod = __riscv_vwmulsu(w, in, vl); \
+                output[i]           = biases[i] + __riscv_vmv_x(__riscv_vwredsum(prod, zero, vl)); \
+            } \
+        } while (0)
+
+        static usize VL1 = __riscv_vsetvlmax_e16m1();
+        if (InputDimensions <= VL1)
+            RVV_PROPAGATE_SINGLE(m1, mf2);
+        else if (InputDimensions <= VL1 * 2)
+            RVV_PROPAGATE_SINGLE(m2, m1);
+        else if (InputDimensions <= VL1 * 4)
+            RVV_PROPAGATE_SINGLE(m4, m2);
+        else
+        {
+            for (IndexType i = 0; i < OutputDimensions; ++i, wIt += PaddedInputDimensions)
+            {
+                vint32m1_t sum = __riscv_vmv_s_x_i32m1(0, 1);
+                for (IndexType vl, j = 0; j < InputDimensions; j += vl)
+                {
+                    vl              = __riscv_vsetvl_e8m2(InputDimensions - j);
+                    vuint8m2_t in   = __riscv_vle8_v_u8m2(input + j, vl);
+                    vint8m2_t  w    = __riscv_vle8_v_i8m2(wIt + j, vl);
+                    vint16m4_t prod = __riscv_vwmulsu(w, in, vl);
+                    sum             = __riscv_vwredsum(prod, sum, vl);
+                }
+                output[i] = biases[i] + __riscv_vmv_x(sum);
+            }
+        }
+
+    #undef RVV_PROPAGATE_SINGLE
 #else
         // Use old implementation for the other architectures.
         affine_transform_non_ssse3<InputDimensions, PaddedInputDimensions, OutputDimensions>(

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -59,8 +59,7 @@ class AffineTransformSparseInput {
     static constexpr IndexType PaddedOutputDimensions =
       ceil_to_multiple<IndexType>(OutputDimensions, MaxSimdWidth);
 
-#if (defined(USE_SSSE3) || defined(USE_LSX) || defined(USE_LASX) || (USE_NEON >= 8) \
-     || defined(USE_RVV))
+#if (defined(USE_SSSE3) || defined(USE_LSX) || defined(USE_LASX) || (USE_NEON >= 8))
     static constexpr IndexType ChunkSize = 4;
 #else
     static constexpr IndexType ChunkSize = 1;
@@ -372,48 +371,50 @@ class AffineTransformSparseInput {
         #undef vec_add_32
     #endif
 #elif defined(USE_RVV)
-        static_assert(InputDimensions % 256 == 0);
+        // we don't support larger for now
+        static_assert(OutputDimensions <= 128 * 8 / 32);
 
-        const i8* weights_cp = weights;
-
-    #define RVV_SPARSE_PROPAGATE(LMUL) \
+    #define RVV_SPARSE_PROPAGATE(m1, m2, m4) \
         do \
         { \
-            const usize blk = __riscv_vsetvlmax_e32m##LMUL(); \
-            for (IndexType ob = 0; ob < OutputDimensions; ob += blk) \
+            usize          vl  = OutputDimensions; \
+            vint32##m4##_t acc = __riscv_vle32_v_i32##m4(biases, vl); \
+            IndexType      i   = 0; \
+            for (; i + 2 <= nnzInfo.count; i += 2) \
             { \
-                const usize       vl  = __riscv_vsetvl_e32m##LMUL(OutputDimensions - ob); \
-                vint32m##LMUL##_t acc = __riscv_vle32_v_i32m##LMUL(biases + ob, vl); \
-                for (IndexType k = 0; k < InputDimensions / 256; ++k) \
-                { \
-                    u64   bits         = load_as<u64>(nnzInfo.bitset + k * 8); \
-                    isize base         = k * 64; \
-                    auto* base_addr    = input + base * sizeof(i32); \
-                    auto* weights_base = &weights_cp[base * OutputDimensions * ChunkSize]; \
-                    while (bits) \
-                    { \
-                        isize             i = pop_lsb(bits); \
-                        vuint8m##LMUL##_t a = __riscv_vreinterpret_v_u32m##LMUL##_u8m##LMUL( \
-                          __riscv_vmv_v_x_u32m##LMUL(load_as<u32>(base_addr + i * sizeof(i32)), \
-                                                     vl)); \
-                        vint8m##LMUL##_t b = __riscv_vle8_v_i8m##LMUL( \
-                          &weights_base[i * OutputDimensions * ChunkSize + ob * ChunkSize], \
-                          vl * ChunkSize); \
-                        acc = \
-                          __riscv_vadd_vv_i32m##LMUL(acc, SIMD::rvv_dpbusd_m##LMUL(a, b, vl), vl); \
-                    } \
-                } \
-                __riscv_vse32_v_i32m##LMUL(output + ob, acc, vl); \
+                usize         idx0 = nnzInfo.nnz[i + 0]; \
+                usize         idx1 = nnzInfo.nnz[i + 1]; \
+                uint8_t       in0  = input[idx0]; \
+                uint8_t       in1  = input[idx1]; \
+                vint8##m1##_t w0   = __riscv_vle8_v_i8##m1(&weights[idx0 * OutputDimensions], vl); \
+                vint8##m1##_t w1   = __riscv_vle8_v_i8##m1(&weights[idx1 * OutputDimensions], vl); \
+                /* input is in [0:127], weights is in [-128:127], \
+                 * so it's safe to accumulate into 16-bit twice */ \
+                vint16##m2##_t prod = __riscv_vwmulsu(w0, in0, vl); \
+                prod                = __riscv_vwmaccus(prod, in1, w1, vl); \
+                acc                 = __riscv_vwadd_wv(acc, prod, vl); \
             } \
+            if (i < nnzInfo.count) \
+            { \
+                usize          idx  = nnzInfo.nnz[i]; \
+                uint8_t        in   = input[idx]; \
+                vint8##m1##_t  w    = __riscv_vle8_v_i8##m1(&weights[idx * OutputDimensions], vl); \
+                vint16##m2##_t prod = __riscv_vwmulsu(w, in, vl); \
+                acc                 = __riscv_vwadd_wv(acc, prod, vl); \
+            } \
+            __riscv_vse32(output, acc, vl); \
         } while (0)
 
         // Select LMUL
-        if (__riscv_vsetvlmax_e32m1() >= OutputDimensions)
-            RVV_SPARSE_PROPAGATE(1);
-        else if (__riscv_vsetvlmax_e32m2() >= OutputDimensions)
-            RVV_SPARSE_PROPAGATE(2);
+        const usize VL1 = __riscv_vsetvlmax_e32m1();
+        if (VL1 >= OutputDimensions)
+            RVV_SPARSE_PROPAGATE(mf4, mf2, m1);
+        else if (VL1 * 2 >= OutputDimensions)
+            RVV_SPARSE_PROPAGATE(mf2, m1, m2);
+        else if (VL1 * 4 >= OutputDimensions)
+            RVV_SPARSE_PROPAGATE(m1, m2, m4);
         else
-            RVV_SPARSE_PROPAGATE(4);
+            RVV_SPARSE_PROPAGATE(m2, m4, m8);
 
     #undef RVV_SPARSE_PROPAGATE
 #else

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -196,12 +196,12 @@ class FeatureTransformer {
     }
 
     // Convert input features
-    i32 transform(const Position&            pos,
-                  AccumulatorStack&          accumulatorStack,
-                  AccumulatorCaches&         cache,
-                  OutputType*                output,
-                  int                        bucket,
-                  NNZInfo<OutputDimensions>& nnzInfo) const {
+    i32 transform(const Position&                             pos,
+                  AccumulatorStack&                           accumulatorStack,
+                  AccumulatorCaches&                          cache,
+                  OutputType*                                 output,
+                  int                                         bucket,
+                  [[maybe_unused]] NNZInfo<OutputDimensions>& nnzInfo) const {
 
         using namespace SIMD;
         accumulatorStack.evaluate(pos, *this, cache);
@@ -219,9 +219,9 @@ class FeatureTransformer {
         {
             const IndexType offset = (HalfDimensions / 2) * p;
 
-            [[maybe_unused]] auto cursor = nnzInfo.make_cursor(p);
-
 #if defined(VECTOR)
+
+            [[maybe_unused]] auto cursor = nnzInfo.make_cursor(p);
 
             constexpr IndexType OutputChunkSize = MaxChunkSize;
             static_assert((HalfDimensions / 2) % OutputChunkSize == 0);
@@ -344,36 +344,44 @@ class FeatureTransformer {
 
 #elif defined(USE_RVV)
 
-            usize j = 0;
+            usize       j  = 0;
+            usize       VL = __riscv_vsetvlmax_e8m1();
+            vuint8m1_t  vid8;
+            vuint16m2_t vid16;
+            if (VL <= 256)
+                vid8 = __riscv_vid_v_u8m1(VL);
+            else
+                vid16 = __riscv_vid_v_u16m2(VL);
+            const auto& accp = accumulation[perspectives[p]];
 
-            while (j < HalfDimensions / 2)
+            for (usize vl; j < HalfDimensions / 2; j += vl)
             {
-                usize vl = __riscv_vsetvl_e16m8(HalfDimensions / 2 - j);
+                vl = __riscv_vsetvl_e16m2(HalfDimensions / 2 - j);
 
-                vint16m8_t acc0 = __riscv_vle16_v_i16m8(&accumulation[perspectives[p]][j], vl);
-                vint16m8_t acc1 =
-                  __riscv_vle16_v_i16m8(&accumulation[perspectives[p]][j + HalfDimensions / 2], vl);
+                vint16m2_t acc0 = __riscv_vle16_v_i16m2(&accp[j], vl);
+                vint16m2_t acc1 = __riscv_vle16_v_i16m2(&accp[j + HalfDimensions / 2], vl);
 
-                acc0 = __riscv_vmax_vx_i16m8(acc0, 0, vl);
-                acc1 = __riscv_vmax_vx_i16m8(acc1, 0, vl);
+                acc0 = __riscv_vmax(acc0, 0, vl);
+                acc1 = __riscv_vmax(acc1, 0, vl);
 
-                vuint8m4_t pa = __riscv_vnclipu_wx_u8m4(__riscv_vreinterpret_v_i16m8_u16m8(acc0), 0,
-                                                        __RISCV_VXRM_RDN, vl);
-                vuint8m4_t pb = __riscv_vnclipu_wx_u8m4(__riscv_vreinterpret_v_i16m8_u16m8(acc1), 0,
-                                                        __RISCV_VXRM_RDN, vl);
+                vuint8m1_t pa = __riscv_vnclipu(__riscv_vreinterpret_u16m2(acc0), 0, 0, vl);
+                vuint8m1_t pb = __riscv_vnclipu(__riscv_vreinterpret_u16m2(acc1), 0, 0, vl);
 
-                vuint8m4_t hi     = __riscv_vmulhu_vv_u8m4(pa, pb, vl);
-                vuint8m4_t result = __riscv_vsrl_vx_u8m4(hi, 1, vl);
+                vuint8m1_t hi     = __riscv_vmulhu(pa, pb, vl);
+                vuint8m1_t result = __riscv_vsrl(hi, 1, vl);
 
-                __riscv_vse8_v_u8m4(&output[offset + j], result, vl);
-                j += vl;
+                __riscv_vse8(&output[offset + j], result, vl);
 
-                // Record NNZ
-                usize    vl32 = vl / 4;
-                vbool8_t nnzMask =
-                  __riscv_vmsne_vx_u32m4_b8(__riscv_vreinterpret_v_u8m4_u32m4(result), 0, vl32);
-                __riscv_vsm_v_b8(cursor.out, nnzMask, vl32);
-                cursor.out += vl32 / 8;
+                vbool8_t    m   = __riscv_vmsne(result, 0, vl);
+                usize       cnt = __riscv_vcpop(m, vl);
+                vuint16m2_t vidx;
+                if (VL <= 256)
+                    vidx = __riscv_vzext_vf2(__riscv_vcompress(vid8, m, vl), cnt);
+                else
+                    vidx = __riscv_vcompress(vid16, m, vl);
+                __riscv_vse16(&nnzInfo.nnz[nnzInfo.count], __riscv_vadd(vidx, offset + j, cnt),
+                              cnt);
+                nnzInfo.count += cnt;
             }
 
 #else

--- a/src/nnue/nnz_helper.h
+++ b/src/nnue/nnz_helper.h
@@ -104,6 +104,9 @@ struct NNZInfo {
     };
 
     NNZCursor make_cursor(bool perspective) { return {*this, perspective, count}; }
+#elif defined(USE_RVV)
+    usize count = 0;
+    u16   nnz[Dimensions];  // indices of non-zero chunks
 #else
     // Each 8-bit chunk
     alignas(8) u8 bitset[(Dimensions + 31) / 32];

--- a/src/nnue/simd.h
+++ b/src/nnue/simd.h
@@ -581,34 +581,6 @@ class SIMDTiling {
 #endif
 };
 
-#if defined(USE_RVV)
-
-    #define RVV_DEFINE_DPBUSD(A, W, H) \
-        inline vint32##A##_t rvv_dpbusd_##A(vuint8##A##_t a, vint8##A##_t b, usize n) { \
-            vint16##W##_t  prod   = __riscv_vwmulsu_vv_i16##W(b, a, 4 * n); \
-            vuint32##W##_t prod32 = __riscv_vreinterpret_v_u16##W##_u32##W( \
-              __riscv_vreinterpret_v_i16##W##_u16##W(prod)); \
-            vint16##A##_t even = \
-              __riscv_vreinterpret_v_u16##A##_i16##A(__riscv_vnsrl_wx_u16##A(prod32, 0, 2 * n)); \
-            vint16##A##_t odd = \
-              __riscv_vreinterpret_v_u16##A##_i16##A(__riscv_vnsrl_wx_u16##A(prod32, 16, 2 * n)); \
-            vuint32##A##_t pairs = __riscv_vreinterpret_v_u16##A##_u32##A( \
-              __riscv_vreinterpret_v_i16##A##_u16##A(__riscv_vadd_vv_i16##A(even, odd, 2 * n))); \
-            vint16##H##_t lo = \
-              __riscv_vreinterpret_v_u16##H##_i16##H(__riscv_vnsrl_wx_u16##H(pairs, 0, n)); \
-            vint16##H##_t hi = \
-              __riscv_vreinterpret_v_u16##H##_i16##H(__riscv_vnsrl_wx_u16##H(pairs, 16, n)); \
-            return __riscv_vwadd_vv_i32##A(lo, hi, n); \
-        }
-
-RVV_DEFINE_DPBUSD(m1, m2, mf2)
-RVV_DEFINE_DPBUSD(m2, m4, m1)
-RVV_DEFINE_DPBUSD(m4, m8, m2)
-
-    #undef RVV_DEFINE_DPBUSD
-
-#endif
-
 }
 
 #endif


### PR DESCRIPTION
This PR optimize the RVV implementations of the affine transforms.

For the dense transform it adds special cases, when the entire inner loop fits into a vector register, which gave a small speedup.

The sparse transform was optimized to use ChunkSize=1, because RVV currently  doesn't have a dpbusd like instruction and it makes sure we don't operate on zero inputs.

SpacemiT X100 benchmarks of the changes:
```py
# pyshbench orig XXX 30
dense: +0.0137x
sparse +0.2898x
both:  +0.3204x
```

```py
# stockfish bench
X100: orig: 170061 nodes/second both: 206581 nodes/second 
A100: orig: 112999 nodes/second both: 128794 nodes/second
```