### PR TITLE
Add -fno-ipa-cp-clone for mingw

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -681,6 +681,8 @@ ifeq ($(COMP),gcc)
 	else
 		CXXFLAGS += -Wstack-usage=128000 -fno-ipa-cp-clone -fconstexpr-ops-limit=500000000
 	endif
+else ifeq ($(COMP),mingw)
+	CXXFLAGS += -fno-ipa-cp-clone
 endif
 
 ### On mingw use Windows threads, otherwise POSIX


### PR DESCRIPTION
Add -fno-ipa-cp-clone for mingw just as we do for gcc.  I get about a 1% speedup.  My machine is pretty unreliable for bench so maybe someone can verify.

No functional change
bench: 2466447