### PR TITLE
Update main network to nn-45ab3bb38b12.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultName "nn-0ee0657fb25e.nnue"
+#define EvalFileDefaultName "nn-45ab3bb38b12.nnue"
 
 namespace NNUE {
 class Network;


### PR DESCRIPTION
Using net with mate optimized training.

Performs significantly better on classic matetrack while playing around same strength.

using: python matecheck.py --engine ./stockfish --epdFile classic280.epd

master:
Found mates:   95
Best mates:    9

patch:
Found mates:   138
Best mates:    25

See https://github.com/vondele/nettest/pull/416 for recipe.

passed non-reg STC
https://tests.stockfishchess.org/tests/live_elo/6a51fe8c5529b8472df80373
```
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 96416 W: 25217 L: 25063 D: 46136
Ptnml(0-2): 292, 11399, 24632, 11633, 252
```

passed non-reg LTC
https://tests.stockfishchess.org/tests/live_elo/6a52c7c45529b8472df80587

```
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 122100 W: 31619 L: 31502 D: 58979
Ptnml(0-2): 64, 13255, 34309, 13344, 78
```

Bench 2786872