### PR TITLE
Fix unintended consequences of race-like conditions in shm_linux.h

### DIFF
--- a/src/shm_linux.h
+++ b/src/shm_linux.h
@@ -43,6 +43,7 @@
 #include <sys/file.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
 #include <limits.h>
 #define SF_MAX_SEM_NAME_LEN NAME_MAX
@@ -140,6 +141,10 @@ class CleanupHooks {
 
 inline std::once_flag CleanupHooks::register_once_;
 
+// How long to wait for a racing creator to finish initializing a region
+// before treating it as a crash leftover, and the polling interval.
+constexpr int STALE_WAIT_BUDGET_MS = 1000;
+constexpr int STALE_WAIT_POLL_MS   = 10;
 
 }  // namespace detail
 
@@ -225,7 +230,9 @@ class SharedMemory: public detail::SharedMemoryBase {
     [[nodiscard]] bool open(const T& initial_value) noexcept {
         detail::CleanupHooks::ensure_registered();
 
-        bool retried_stale = false;
+        int  stale_waited_ms = 0;
+        bool unlinked_stale  = false;
+        bool retried_mutex   = false;
 
         while (true)
         {
@@ -257,35 +264,57 @@ class SharedMemory: public detail::SharedMemoryBase {
 
             if (!success)
             {
-                if (created_new || invalid_header)
-                    shm_unlink(name_.c_str());
+                bool wait_for_creator = false;
+                bool retry_create     = false;
+
+                if (created_new)
+                    unlink_if_same_inode();
+                else if (invalid_header)
+                {
+                    // Uninitialized region: a racing creator or a crash
+                    // leftover. Wait for a live creator first; reclaim
+                    // only after the budget expires, and only once.
+                    if (stale_waited_ms < detail::STALE_WAIT_BUDGET_MS)
+                        wait_for_creator = true;
+                    else if (!unlinked_stale)
+                    {
+                        unlink_if_same_inode();
+                        unlinked_stale = true;
+                        retry_create   = true;
+                    }
+                }
+
                 if (mapped_ptr_)
                     unmap_region();
                 unlock_file();
                 ::close(fd_);
                 reset();
 
-                if (!created_new && invalid_header && !retried_stale)
+                if (wait_for_creator)
                 {
-                    retried_stale = true;
+                    struct timespec ts{0, detail::STALE_WAIT_POLL_MS * 1000000L};
+                    nanosleep(&ts, nullptr);
+                    stale_waited_ms += detail::STALE_WAIT_POLL_MS;
                     continue;
                 }
+                if (retry_create)
+                    continue;
                 return false;
             }
 
             if (!lock_shared_mutex())
             {
                 if (created_new)
-                    shm_unlink(name_.c_str());
+                    unlink_if_same_inode();
                 if (mapped_ptr_)
                     unmap_region();
                 unlock_file();
                 ::close(fd_);
                 reset();
 
-                if (!created_new && !retried_stale)
+                if (!created_new && !retried_mutex)
                 {
-                    retried_stale = true;
+                    retried_mutex = true;
                     continue;
                 }
                 return false;
@@ -296,7 +325,7 @@ class SharedMemory: public detail::SharedMemoryBase {
                 unlock_shared_mutex();
                 unmap_region();
                 if (created_new)
-                    shm_unlink(name_.c_str());
+                    unlink_if_same_inode();
                 unlock_file();
                 ::close(fd_);
                 reset();
@@ -345,7 +374,7 @@ class SharedMemory: public detail::SharedMemoryBase {
             unmap_region();
 
         if (remove_region)
-            shm_unlink(name_.c_str());
+            unlink_if_same_inode();
 
         if (file_locked)
             unlock_file();
@@ -397,6 +426,27 @@ class SharedMemory: public detail::SharedMemoryBase {
             data_ptr_   = nullptr;
             header_ptr_ = nullptr;
         }
+    }
+
+    // Unlink the shm name only if it still refers to the inode behind fd_,
+    // so we never delete a region re-created under our name by another process.
+    void unlink_if_same_inode() noexcept {
+        if (fd_ == -1 || name_.empty())
+            return;
+
+        struct stat fd_st;
+        if (fstat(fd_, &fd_st) != 0)
+            return;
+
+        const std::string path =
+          name_.front() == '/' ? "/dev/shm" + name_ : "/dev/shm/" + name_;
+
+        struct stat name_st;
+        if (::stat(path.c_str(), &name_st) != 0)
+            return;
+
+        if (fd_st.st_dev == name_st.st_dev && fd_st.st_ino == name_st.st_ino)
+            shm_unlink(name_.c_str());
     }
 
     [[nodiscard]] bool lock_file(int operation) noexcept {


### PR DESCRIPTION
Attempts to resolve https://github.com/official-stockfish/Stockfish/issues/6977

`SharedMemory::open()` has a window between the creator's `shm_open(O_CREAT | O_EXCL)` and its `flock()` where the region is visible but still empty. An attacher that wins the lock in this window finds `st_size == 0`, concludes the region is a stale crash leftover, unlinks it, and re-creates it — orphaning the original creator's inode. Two copies of the region now exist simultaneously.

This is aggravated by all failure/cleanup paths unlinking **by name** (`shm_unlink(name_)`) while their fd may refer to a different (orphaned) inode — deleting a healthy region that another process re-created under the same name. Observed in production (10 engines, 256MB `/dev/shm`, ~131MiB region): the transient second copy hits `ENOSPC`, failing processes unlink each other's regions, and the end state is most engines silently falling back to private memory (~131MiB PSS each) plus mappings of nameless `(deleted)` regions that block sharing for all future processes.

The race window is normally sub-microsecond, but under container CPU throttling (CFS) a creator can be descheduled between the two syscalls for a full scheduling period, making this reproducible in practice. 

### Fix

Two changes to `shm_linux.h`, no behavior change on the happy path:

1. **Wait for a racing creator before reclaiming.** On finding an existing-but-uninitialized region, release everything and poll (10ms interval, 1s budget) instead of immediately unlinking. A live    creator finishes within the budget and the attacher takes the normal attach path; a genuinely stale region is reclaimed once after the budget expires.

2. **Inode-checked unlinks.** All `shm_unlink(name_)` sites (three failure paths in `open()`, last-closer in `close()`) go through `unlink_if_same_inode()`, which only unlinks if the name still refers to the inode behind our fd. A process can no longer delete a region it didn't examine or create.

---

Most of the work here is produced by Claude, after pointing it where I thought the problem was. I stepped through mentally and the problem makes sense to me, as does the solution. But the author(s) of such code should verify things closely.

Bench 2466447

No functional change

---

I do not know if 1s budget is a generally sufficient window for this. The "sleep to solve race condition" paradigm is almost never actually a good idea. But I leaned to it here, over having multiple copies in `/dev/shm` as an alternative. The reason is that I am specifically setting the size of the shm to handle Stockfish's networks. I don't want to size it such that there _could_ be 10 copies at once. 

External to Stockfish, I am going to do my own solution in my use case. I will spawn one Stockfish copy first, await a response to `isready`. Now, I will spawn the other nine, knowing that the shm should have been populated.

cc @Sopel97 since I roped you into this, although this is Linux not Windows. 
cc @Disservin and @anematode as the principle authors of the Linux portion AFAIK.