### PR TITLE
Avoid writing to shm a network that will be erased immediately

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -63,7 +63,7 @@ Engine::Engine(std::optional<std::filesystem::path> path) :
     states(new std::deque<StateInfo>(1)),
     threads(),
     networkFile{std::nullopt, ""},
-    network(numaContext) {
+    network(numaContext, get_default_network()) {
 
     pos.set(StartFEN, false, &states->back());
 
@@ -139,7 +139,6 @@ Engine::Engine(std::optional<std::filesystem::path> path) :
           return std::nullopt;
       }));
 
-    network = get_default_network();
     threads.clear();
     threads.ensure_network_replicated();
     resize_threads();

--- a/src/numa.h
+++ b/src/numa.h
@@ -1511,9 +1511,6 @@ class LazyNumaReplicatedSystemWide: public NumaReplicatedBase {
    public:
     using ReplicatorFuncType = std::function<T(const T&)>;
 
-    // No default-value constructor: publishing a default-constructed T as a
-    // system-wide shared constant would create (and share) a full-size region
-    // of meaningless content. Construct from the real value instead.
     LazyNumaReplicatedSystemWide(NumaReplicationContext& ctx, std::unique_ptr<T>&& source) :
         NumaReplicatedBase(ctx) {
         prepare_replicate_from(std::move(source));

--- a/src/numa.h
+++ b/src/numa.h
@@ -1511,11 +1511,9 @@ class LazyNumaReplicatedSystemWide: public NumaReplicatedBase {
    public:
     using ReplicatorFuncType = std::function<T(const T&)>;
 
-    LazyNumaReplicatedSystemWide(NumaReplicationContext& ctx) :
-        NumaReplicatedBase(ctx) {
-        prepare_replicate_from(std::make_unique<T>());
-    }
-
+    // No default-value constructor: publishing a default-constructed T as a
+    // system-wide shared constant would create (and share) a full-size region
+    // of meaningless content. Construct from the real value instead.
     LazyNumaReplicatedSystemWide(NumaReplicationContext& ctx, std::unique_ptr<T>&& source) :
         NumaReplicatedBase(ctx) {
         prepare_replicate_from(std::move(source));


### PR DESCRIPTION
Fairly simple. The default constructor was prompting us to write a network to shm, which we then immediately remove, as we write a new one. The first is written with a content hash of 0, as it is not initialized. 

Some logging, showing what was happening, in `master`:
```
$ ./stockfish
Stockfish dev-20260711-9a8dd81d by the Stockfish developers (see AUTHORS file)
[shm 289864] request: content_hash=0 disc=7357739359258373277 -> /sf_495f228c7f1a5827 (sizeof(T)=111263808)
[shm 289864] open: creating /sf_495f228c7f1a5827 (111263864 bytes)
[shm 289864] open: created /sf_495f228c7f1a5827 OK, ref_count=1
[shm 289864] request: /sf_495f228c7f1a5827 -> backend=SharedMemory
[shm 289864] close: /sf_495f228c7f1a5827 ref_count=0 remove_region=1
[shm 289864] request: content_hash=6559306200065483470 disc=7357739359258373277 -> /sf_e5671f518743128b (sizeof(T)=111263808)
[shm 289864] open: creating /sf_e5671f518743128b (111263864 bytes)
[shm 289864] open: created /sf_e5671f518743128b OK, ref_count=1
[shm 289864] request: /sf_e5671f518743128b -> backend=SharedMemory
```

It is _possible_ this was done intentionally. I don't currently see or understand the reason, however. This extra write is not of great consequence, although it means doubling shm sizes if explicitly sizing it to handling Stockfish.

If you happened to spawn a bunch of engines at once, I did run into cases where this file was left lingering. i.e, during a running state, _both_ files were present. That should be resolved though already, with https://github.com/official-stockfish/Stockfish/pull/6979

Bench 2466447

No functional change

cc @anematode 