### PR TITLE
Always use pthread

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -90,7 +90,7 @@ HEADERS = attacks.h benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.
 		nnue/layers/affine_transform.h nnue/layers/affine_transform_sparse_input.h \
 		nnue/layers/clipped_relu.h nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h \
 		nnue/nnue_architecture.h nnue/nnue_common.h nnue/nnue_feature_transformer.h nnue/simd.h \
-		nnue/nnz_helper.h position.h search.h syzygy/tbprobe.h thread.h thread_win32_osx.h timeman.h \
+		nnue/nnz_helper.h position.h search.h syzygy/tbprobe.h thread.h thread_native.h timeman.h \
 		tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h engine.h score.h numa.h memory.h shm.h shm_linux.h
 
 OBJS = $(notdir $(SRCS:.cpp=.o))
@@ -685,31 +685,27 @@ else ifeq ($(COMP),mingw)
 	CXXFLAGS += -fno-ipa-cp-clone
 endif
 
-### On mingw use Windows threads, otherwise POSIX
-ifneq ($(comp),mingw)
-	CXXFLAGS += -DUSE_PTHREADS
-	# On Android Bionic's C library comes with its own pthread implementation bundled in
-	ifneq ($(OS),Android)
-		# Haiku has pthreads in its libroot, so only link it in on other platforms
-		ifneq ($(KERNEL),Haiku)
-			ifneq ($(COMP),ndk)
-			ifneq ($(arch),wasm32)
-				LDFLAGS += -lpthread
+# On Android Bionic's C library comes with its own pthread implementation bundled in
+ifneq ($(OS),Android)
+	# Haiku has pthreads in its libroot, so only link it in on other platforms
+	ifneq ($(KERNEL),Haiku)
+		ifneq ($(COMP),ndk)
+		ifneq ($(arch),wasm32)
+			LDFLAGS += -lpthread
 
-				add_lrt = yes
-				ifeq ($(target_windows),yes)
-					add_lrt = no
-				endif
-
-				ifeq ($(TARGET_KERNEL),Darwin)
-					add_lrt = no
-				endif
-
-				ifeq ($(add_lrt),yes)
-					LDFLAGS += -lrt
-				endif
+			add_lrt = yes
+			ifeq ($(target_windows),yes)
+				add_lrt = no
 			endif
+
+			ifeq ($(TARGET_KERNEL),Darwin)
+				add_lrt = no
 			endif
+
+			ifeq ($(add_lrt),yes)
+				LDFLAGS += -lrt
+			endif
+		endif
 		endif
 	endif
 endif

--- a/src/thread.h
+++ b/src/thread.h
@@ -31,7 +31,7 @@
 #include "numa.h"
 #include "position.h"
 #include "search.h"
-#include "thread_win32_osx.h"
+#include "thread_native.h"
 
 namespace Stockfish {
 

--- a/src/thread_native.h
+++ b/src/thread_native.h
@@ -16,23 +16,35 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef THREAD_WIN32_OSX_H_INCLUDED
-#define THREAD_WIN32_OSX_H_INCLUDED
+#ifndef THREAD_NATIVE_H_INCLUDED
+#define THREAD_NATIVE_H_INCLUDED
 
-#include <thread>
+#ifdef _MSC_VER
+    #include <thread>
+#else
+    #include <pthread.h>
+    #include <functional>
+    #include <utility>
+
+    #include "misc.h"
+#endif
+
+namespace Stockfish {
+
+#ifdef _MSC_VER
+
+// MSVC-compatible toolchains use std::thread because they do not provide
+// pthreads by default. On all other platforms, pthreads is required and used.
+
+using NativeThread = std::thread;
+
+#else
 
 // On OSX threads other than the main thread are created with a reduced stack
 // size of 512KB by default, this is too low for deep searches, which require
 // somewhat more than 1MB stack, so adjust it to TH_STACK_SIZE.
 // The implementation calls pthread_create() with the stack size parameter
 // equal to the Linux 8MB default, on platforms that support it.
-
-#if defined(__APPLE__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(USE_PTHREADS)
-
-    #include <pthread.h>
-    #include <functional>
-
-namespace Stockfish {
 
 class NativeThread {
     pthread_t thread;
@@ -63,16 +75,8 @@ class NativeThread {
     void join() { pthread_join(thread, nullptr); }
 };
 
-}  // namespace Stockfish
-
-#else  // Default case: use STL classes
-
-namespace Stockfish {
-
-using NativeThread = std::thread;
+#endif  // _MSC_VER
 
 }  // namespace Stockfish
 
-#endif
-
-#endif  // #ifndef THREAD_WIN32_OSX_H_INCLUDED
+#endif  // #ifndef THREAD_NATIVE_H_INCLUDED


### PR DESCRIPTION
After a858defd332bddd828c9280a9e326a0b750b3dda, the pthread implementation of `NativeThread` is always used (except MSVC), as:

1. `-DUSE_PTHREADS` is defined when `comp` is not `mingw`
2. the pthread implementation is used anyways because MinGW defines `__MINGW32__` or `__MINGW64__` macro

No functional change