### PR TITLE
Remove Redundant Transposition Table Validity Check in Step 12

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1086,7 +1086,7 @@ moves_loop:  // When in check, search starts here
     // Step 12. A small Probcut idea
     probCutBeta = beta + 428;
     if ((ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4 && ttData.value >= probCutBeta
-        && !is_decisive(beta) && is_valid(ttData.value) && !is_decisive(ttData.value))
+        && !is_decisive(beta) && !is_decisive(ttData.value))
         return probCutBeta;
 
     const PieceToHistory* contHist[] = {


### PR DESCRIPTION
This check is completely redundant because the condition already verifies ttData.bound & BOUND_LOWER, isn't it?

A lower-bound entry is only recorded when a valid transposition table value has been successfully retrieved during a transposition table hit.

No functional change