### PR TITLE
Allow trailing whitespace in str_to_size_t

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -554,7 +554,8 @@ std::optional<usize> str_to_size_t(const std::string& s) {
     errno                           = 0;
     char*                    endptr = nullptr;
     const unsigned long long value  = std::strtoull(s.c_str(), &endptr, 10);
-    if (errno == ERANGE || *endptr != '\0' || value > std::numeric_limits<usize>::max())
+    if (errno == ERANGE || (*endptr != '\0' && !std::isspace(*endptr))
+        || value > std::numeric_limits<usize>::max())
         return std::nullopt;
     return static_cast<usize>(value);
 }


### PR DESCRIPTION
Fixes #6984, first reported by sqrmax on the Discord, causing incorrect detection of NUMA and L3 domains on Linux due to trailing whitespace when reading from sysfs.

This was introduced by #6844 which made `str_to_size_t` too strict, since `std::stoull` allows trailing characters (and leading whitespace, although this part is not relevant for us).

Before:
$ ./bins/stockfish.master speedtest
Stockfish dev-20260716-ebcea3ef by the Stockfish developers (see AUTHORS file)
info string Using 224 threads with NUMA node thread binding: 64/32:64/32:64/32:32/16

After:
$ ./stockfish speedtest
Stockfish dev-20260718-m-cb702902 by the Stockfish developers (see AUTHORS file)
info string Using 224 threads with NUMA node thread binding: 32/32:32/32:32/32:32/32:32/32:32/32:32/32