### PR TITLE
Add a standard .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# normalize line endings for all text files
+* text=auto eol=lf


### PR DESCRIPTION
ensures checkouts are by default the same on linux and windows.

No functional change