### PR TITLE
Update main net to nn-ab28990d4ea3.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultName "nn-89cb98a217f7.nnue"
+#define EvalFileDefaultName "nn-ab28990d4ea3.nnue"
 
 namespace NNUE {
 class Network;


### PR DESCRIPTION

Passed STC
https://tests.stockfishchess.org/tests/view/6a5a05955529b8472df811c6
```
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 35520 W: 9419 L: 9104 D: 16997
Ptnml(0-2): 103, 4119, 9016, 4404, 118
```

Passed LTC
https://tests.stockfishchess.org/tests/view/6a5a4b3a5529b8472df81254
```
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 97590 W: 25549 L: 25108 D: 46933
Ptnml(0-2): 60, 10413, 27405, 10860, 57
```

Trained net with slightly optimized recipe. Instead of completely changing the lambda for the last stages, instead use a smooth transition following a cosine schedule.

Recipe can be found here

https://github.com/vondele/nettest/pull/426

~~Slight regression in classic matetrack that is currently being investigated.~~ Seems like the regression was only there before rebasing... Unclear what caused it exactly


Bench 2467577