### PR TITLE
AVX-512 paired activations

### DIFF
--- a/src/nnue/layers/sqr_clipped_relu.h
+++ b/src/nnue/layers/sqr_clipped_relu.h
@@ -67,9 +67,9 @@ class SqrClippedReLU {
         return h;
     }
 
-#if defined(USE_AVX2_PAIR_ACTIVATIONS)
+#if defined(USE_PAIR_ACTIVATIONS)
     // Produce the squared and linear clipped activations together, sharing the input loads and
-    // the initial signed 32-to-16-bit saturating packs.
+    // the initial signed 32-to-16-bit saturating narrowing.
     void propagate_pair(const InputType* input, OutputType* squared, OutputType* clipped) const {
         static_assert(WeightScaleBitsLocal >= 5 && WeightScaleBitsLocal <= 8,
                       "SqrClippedReLU only support WeightScaleBitsLocal between 5 and 8");
@@ -78,6 +78,29 @@ class SqrClippedReLU {
         constexpr IndexType NumChunks       = InputDimensions / 32;
         constexpr int       SimdShiftAmount = WeightScaleBitsLocal * 2 + 7 - 16;
 
+    #if defined(USE_AVX512)
+        const auto in      = reinterpret_cast<const __m512i*>(input);
+        auto       sqrOut  = reinterpret_cast<__m256i*>(squared);
+        auto       clipOut = reinterpret_cast<__m256i*>(clipped);
+
+        const __m512i zero = _mm512_setzero_si512();
+
+        for (IndexType i = 0; i < NumChunks; ++i)
+        {
+            const __m256i words0 = _mm512_cvtsepi32_epi16(_mm512_load_si512(&in[i * 2 + 0]));
+            const __m256i words1 = _mm512_cvtsepi32_epi16(_mm512_load_si512(&in[i * 2 + 1]));
+            const __m512i words  = _mm512_inserti64x4(_mm512_castsi256_si512(words0), words1, 1);
+
+            const __m512i sqrWords =
+              _mm512_srli_epi16(_mm512_mulhi_epi16(words, words), SimdShiftAmount);
+            _mm256_store_si256(&sqrOut[i], _mm512_cvtsepi16_epi8(sqrWords));
+
+            const __m512i clipWords =
+              _mm512_srli_epi16(_mm512_max_epi16(words, zero), WeightScaleBitsLocal);
+            _mm256_store_si256(&clipOut[i], _mm512_cvtsepi16_epi8(clipWords));
+        }
+
+    #elif defined(USE_AVX2_PAIR_ACTIVATIONS)
         const auto in      = reinterpret_cast<const __m256i*>(input);
         auto       sqrOut  = reinterpret_cast<__m256i*>(squared);
         auto       clipOut = reinterpret_cast<__m256i*>(clipped);
@@ -105,6 +128,7 @@ class SqrClippedReLU {
             const __m256i clipPacked = _mm256_packs_epi16(clip0, clip1);
             _mm256_store_si256(&clipOut[i], clipPacked);
         }
+    #endif
     }
 #endif
 

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -117,7 +117,7 @@ struct NetworkArchitecture {
         Buffer buffer;
 
         fc_0.propagate(transformedFeatures, buffer.fc_0_out, nnzInfo);
-#if defined(USE_AVX2_PAIR_ACTIVATIONS)
+#if defined(USE_PAIR_ACTIVATIONS)
         ac_sqr_0.propagate_pair(buffer.fc_0_out, buffer.concat_buffer,
                                 buffer.concat_buffer + FC_0_OUTPUTS);
 #else
@@ -126,7 +126,7 @@ struct NetworkArchitecture {
 #endif
 
         fc_1.propagate(buffer.concat_buffer, buffer.fc_1_out);
-#if defined(USE_AVX2_PAIR_ACTIVATIONS)
+#if defined(USE_PAIR_ACTIVATIONS)
         ac_sqr_1.propagate_pair(buffer.fc_1_out, buffer.concat_buffer + FC_0_OUTPUTS * 2,
                                 buffer.concat_buffer + FC_0_OUTPUTS * 2 + FC_1_OUTPUTS);
 #else

--- a/src/nnue/simd.h
+++ b/src/nnue/simd.h
@@ -55,6 +55,10 @@ namespace Stockfish::Eval::NNUE::SIMD {
     #define USE_AVX2_PAIR_ACTIVATIONS
 #endif
 
+#if defined(USE_AVX512) || defined(USE_AVX2_PAIR_ACTIVATIONS)
+    #define USE_PAIR_ACTIVATIONS
+#endif
+
 // If vector instructions are enabled, we update and refresh the
 // accumulator tile by tile such that each tile fits in the CPU's
 // vector registers.


### PR DESCRIPTION
Speedup measured by @anematode
```
Result of 100 runs
base (...kfish.master) = 1876128 +/- 4698
test (./stockfish ) = 1888088 +/- 3218
diff = +11960 +/- 5722

speedup = +0.0064
P(speedup > 0) = 1.0000
```

Passed STC:
https://tests.stockfishchess.org/tests/view/6a5be3ff5529b8472df81662
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 86752 W: 22568 L: 22209 D: 41975
Ptnml(0-2): 200, 8676, 25260, 9045, 195

No functional change