### PR TITLE
Reintroduce static evaluation based NMP reduction

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ Aron Petkovski (fury)
 Arseniy Surkov (codedeliveryservice)
 Artem Solopiy (EntityFX)
 Auguste Pop
+Ayush (ayushthepiro11-design)
 Balazs Szilagyi
 Balint Pfliegel
 Baptiste Rech (breatn)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -993,12 +993,12 @@ Value Search::Worker::search(
 
     // Step 9. Null move search with verification search
     if (cutNode && ss->staticEval >= beta - 13 * depth - 47 * improving + 365 && !excludedMove
-        && pos.non_pawn_material(us) && ss->ply >= nmpMinPly && !is_loss(beta))
+        && pos.non_pawn_material(us) && ss->ply >= nmpMinPly && beta >= -2000)
     {
         assert((ss - 1)->currentMove != Move::null());
 
         // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        Depth R = 7 + depth / 3 + std::max((ss->staticEval - beta) / 256, 0);
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);


### PR DESCRIPTION
Modification of #6963, which was reverted due to poor matetrack performance. This patch uses a stricter beta margin to prevent mate finding issues when beta is in decisive range

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 206720 W: 53724 L: 53166 D: 99830
Ptnml(0-2): 491, 23993, 53815, 24589, 472
https://tests.stockfishchess.org/tests/view/6a54efa65529b8472df808e1

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 106344 W: 27926 L: 27472 D: 50946
Ptnml(0-2): 44, 11265, 30084, 11751, 28
https://tests.stockfishchess.org/tests/view/6a5a3d2c5529b8472df81249

Bench: 2474832