### PR TITLE
avoid duplicate legal move check

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -153,6 +153,7 @@ Leonardo Ljubičić (ICCF World Champion)
 Leonid Pechenik (lp--)
 Li Ying (yl25946)
 Liam Keegan (lkeegan)
+Liang Chenxuan (aba2222)
 Linmiao Xu (linrock)
 Linus Arver (listx)
 loco-loco

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -299,18 +299,17 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
     increaseDepth = true;
 
     Search::RootMoves rootMoves;
-    const auto        legalmoves = MoveList<LEGAL>(pos);
 
     for (const auto& uciMove : limits.searchmoves)
     {
         auto move = UCIEngine::to_move(pos, uciMove);
 
-        if (std::find(legalmoves.begin(), legalmoves.end(), move) != legalmoves.end())
+        if (move != Move::none())
             rootMoves.emplace_back(move);
     }
 
     if (rootMoves.empty())
-        for (const auto& m : legalmoves)
+        for (const auto& m : MoveList<LEGAL>(pos))
             rootMoves.emplace_back(m);
 
     Tablebases::Config tbConfig = Tablebases::rank_root_moves(options, pos, rootMoves);


### PR DESCRIPTION
Remove redundant legal move checks when search moves are limited. Because `UCIEngine::to_move` already performs this check.

Also remove the unused `legalMoves` variable.