### PR TITLE
Optimize RankAttacks

### DIFF
--- a/src/attacks.cpp
+++ b/src/attacks.cpp
@@ -24,10 +24,6 @@
 
 namespace Stockfish::Attacks {
 
-#ifdef USE_DUAL_HYPERBOLA_QUINT
-alignas(64) DualMagic DualMagics[SQUARE_NB];
-#endif
-
 Bitboard LineBB[SQUARE_NB][SQUARE_NB];
 Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
 Bitboard RayPassBB[SQUARE_NB][SQUARE_NB];
@@ -40,12 +36,12 @@ alignas(64) Magic Magics[SQUARE_NB][2];
 
 }
 
-[[maybe_unused]] static Bitboard line_mask(Square sq, Direction d1, Direction d2) {
-    Bitboard mask = 0, dest;
+[[maybe_unused]] static constexpr Bitboard line_mask(Square sq, Direction d1, Direction d2) {
+    Bitboard mask = 0;
     for (Direction d : {d1, d2})
     {
         Square s = sq;
-        while ((dest = safe_destination(s, d)))
+        while (Bitboard dest = safe_destination(s, d))
         {
             mask |= dest;
             s += d;
@@ -71,16 +67,18 @@ static void init_magics(Magic magics[][2]) {
 #elif defined(USE_DUAL_HYPERBOLA_QUINT)
 
 // Sliding attacks within a rank, indexed by the slider's file and the
-// 8-bit rank occupancy, yielding the 8-bit attack set on that rank
-constexpr auto RankAttacks = []() {
-    std::array<std::array<u8, 256>, FILE_NB> table{};
+// 6 inner bits of the rank occupancy (edge squares never affect the
+// attack set), yielding the 8-bit attack set on that rank
+alignas(64) constexpr auto RankAttacks = []() {
+    std::array<std::array<u8, 64>, FILE_NB> table{};
     for (int file = 0; file < 8; ++file)
-        for (int occ = 0; occ < 256; ++occ)
-            table[file][occ] = u8(sliding_attack(ROOK, Square(file), occ));
+        for (int occ6 = 0; occ6 < 64; ++occ6)
+            table[file][occ6] = u8(sliding_attack(ROOK, Square(file), occ6 << 1));
     return table;
 }();
 
-static void init_dual_magics(DualMagic magics[]) {
+static constexpr auto make_dual_magics() {
+    std::array<DualMagic, SQUARE_NB> magics{};
     for (Square s = SQ_A1; s <= SQ_H8; ++s)
     {
         DualMagic& m        = magics[s];
@@ -93,7 +91,10 @@ static void init_dual_magics(DualMagic magics[]) {
         m.rankAttacksLookup = RankAttacks[int(file_of(s))].data();
         m.shift             = 8 * int(rank_of(s));
     }
+    return magics;
 }
+
+alignas(64) extern constexpr std::array<DualMagic, SQUARE_NB> DualMagics = make_dual_magics();
 
 #else
 
@@ -164,9 +165,7 @@ void init() {
 
 #ifdef USE_HYPERBOLA_QUINT
     init_magics(Magics);
-#elif defined(USE_DUAL_HYPERBOLA_QUINT)
-    init_dual_magics(DualMagics);
-#else
+#elif !defined(USE_DUAL_HYPERBOLA_QUINT)
     init_magics(ROOK, RookTable.data(), Magics);
     init_magics(BISHOP, BishopTable.data(), Magics);
 #endif

--- a/src/attacks.h
+++ b/src/attacks.h
@@ -104,7 +104,8 @@ struct alignas(32) DualMagic {
     // When using hyperbola quintessence, file, diagonal and antidiagonal attacks
     // can use a byte reversal rather than a full bit reversal (because all squares
     // reside in different bytes). Rank attacks cannot. Thus, for rank attacks
-    // only, we use a compact lookup table indexed by the 8 bits of the rank's occupancy.
+    // only, we use a compact lookup table indexed by the 6 inner bits of the rank's
+    // occupancy (the edge squares never affect the attack set).
     std::pair<Bitboard, Bitboard> both_attacks_bb(Bitboard occupied) const {
         // Byteswap within 128-bit elements
         const auto bswap = [](__m256i v) {
@@ -128,7 +129,7 @@ struct alignas(32) DualMagic {
         __m128i rookBishop =
           _mm_or_si128(_mm256_extracti128_si256(result, 1), _mm256_castsi256_si128(result));
 
-        Bitboard rowOccupancy = rankAttacksLookup[(occupied >> shift) & 0xff];
+        Bitboard rowOccupancy = rankAttacksLookup[(occupied >> (shift + 1)) & 0x3f];
         Bitboard rankAttacks  = rowOccupancy << shift;
 
         // [bishop, rook]
@@ -136,8 +137,7 @@ struct alignas(32) DualMagic {
     }
 };
 
-extern DualMagic DualMagics[SQUARE_NB];
-
+extern const std::array<DualMagic, SQUARE_NB> DualMagics;
 inline const DualMagic& dual_magic(Square s) { return DualMagics[s]; }
 
 #else
@@ -295,7 +295,7 @@ inline Bitboard attacks_bb(Square s, Bitboard occupied) {
     assert(Pt != PAWN && is_ok(s));
 
 #ifdef USE_DUAL_HYPERBOLA_QUINT
-    const auto [bishop, rook] = dual_magic(s).both_attacks_bb(occupied);
+    [[maybe_unused]] const auto [bishop, rook] = dual_magic(s).both_attacks_bb(occupied);
 
     switch (Pt)
     {


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/6a5c1f185529b8472df816fd
LLR: 3.01 (-2.94,2.94) <0.00,2.00>
Total: 212800 W: 55208 L: 54665 D: 102927
Ptnml(0-2): 466, 22131, 60704, 22592, 507 

No functional change
bench: 2718396

Reduce the size of RankAttacks by 4x and generate it at compile time.  Inspired by some @anematode comments about pdep/pext.