### PR TITLE
Remove Unused Option Constructor

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -86,9 +86,6 @@ void OptionsMap::add(const std::string& name, const Option& option) {
 
 usize OptionsMap::count(const std::string& name) const { return options_map.count(name); }
 
-Option::Option(const OptionsMap* map) :
-    parent(map) {}
-
 Option::Option(const char* v, OnChange f) :
     type("string"),
     min(0),

--- a/src/ucioption.h
+++ b/src/ucioption.h
@@ -40,7 +40,6 @@ class Option {
    public:
     using OnChange = std::function<std::optional<std::string>(const Option&)>;
 
-    Option(const OptionsMap*);
     Option(OnChange = nullptr);
     Option(bool v, OnChange = nullptr);
     Option(const char* v, OnChange = nullptr);


### PR DESCRIPTION
The constructor overload Option::Option(const OptionsMap* map) is never invoked. Options are constructed independently and assigned their parent pointers later during registration inside the OptionsMap::add function.

Leftover from rework in https://github.com/official-stockfish/Stockfish/commit/c12dbdedd9366bc7ffb29b355038bc7dea5f9c48

No functional change