### PR TITLE
Do not terminate process on invalid position and guard search against invalid state

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -144,7 +144,8 @@ void UCIEngine::loop() {
         {
             if (auto err = engine.flip())
             {
-                terminate_on_critical_error(err->what());
+                hasValidPosition = false;
+                report_error(err->what());
             }
         }
         else if (token == "bench")
@@ -152,9 +153,19 @@ void UCIEngine::loop() {
         else if (token == BenchmarkCommand)
             benchmark(is);
         else if (token == "d")
-            sync_cout << engine.visualize() << sync_endl;
+        {
+            if (!hasValidPosition)
+                sync_cout << "info string Error: No valid position set." << sync_endl;
+            else
+                sync_cout << engine.visualize() << sync_endl;
+        }
         else if (token == "eval")
-            engine.trace_eval();
+        {
+            if (!hasValidPosition)
+                sync_cout << "info string Error: No valid position set." << sync_endl;
+            else
+                engine.trace_eval();
+        }
         else if (token == "compiler")
             sync_cout << compiler_info() << sync_endl;
         else if (token == "export_net")
@@ -224,13 +235,23 @@ Search::LimitsType UCIEngine::parse_limits(std::istream& is) {
             limits.ponderMode = true;
 
         if (is.fail())
-            terminate_on_critical_error("Invalid argument for '" + token + "'");
+        {
+            report_error("Invalid argument for '" + token + "'");
+            break;
+        }
     }
 
     return limits;
 }
 
 void UCIEngine::go(std::istringstream& is) {
+
+    if (!hasValidPosition)
+    {
+        sync_cout << "info string Error: No valid position set." << sync_endl;
+        sync_cout << "bestmove (none)" << sync_endl;
+        return;
+    }
 
     Search::LimitsType limits = parse_limits(is);
 
@@ -473,9 +494,18 @@ void UCIEngine::setoption(std::istringstream& is) {
 }
 
 u64 UCIEngine::perft(const Search::LimitsType& limits) {
+    if (!hasValidPosition)
+    {
+        sync_cout << "info string Error: No valid position set." << sync_endl;
+        return 0;
+    }
+
     auto result = engine.perft(engine.fen(), limits.perft, engine.get_options()["UCI_Chess960"]);
     if (auto err = std::get_if<PositionSetError>(&result))
-        terminate_on_critical_error(err->what());
+    {
+        report_error(err->what());
+        return 0;
+    }
 
     auto nodes = std::get<u64>(result);
     sync_cout << "\nNodes searched: " << nodes << "\n" << sync_endl;
@@ -510,7 +540,12 @@ void UCIEngine::position(std::istringstream& is) {
     auto err = engine.set_position(fen, moves);
     if (err.has_value())
     {
-        terminate_on_critical_error(err->what());
+        hasValidPosition = false;
+        report_error(err->what());
+    }
+    else
+    {
+        hasValidPosition = true;
     }
 }
 
@@ -681,11 +716,10 @@ void UCIEngine::on_bestmove(std::string_view bestmove, std::string_view ponder) 
     std::cout << sync_endl;
 }
 
-void UCIEngine::terminate_on_critical_error(const std::string& message) {
+void UCIEngine::report_error(const std::string& message) {
     sync_cout << "info string CRITICAL ERROR: Command `" << currentCmd
               << "` failed. Reason: " << message << '\n'
               << sync_endl;
-    std::exit(1);
 }
 
 }  // namespace Stockfish

--- a/src/uci.h
+++ b/src/uci.h
@@ -59,6 +59,7 @@ class UCIEngine {
     Engine      engine;
     CommandLine cli;
     std::string currentCmd;
+    bool        hasValidPosition = true;
 
     static void print_info_string(std::string_view str);
 
@@ -75,8 +76,7 @@ class UCIEngine {
     static void on_bestmove(std::string_view bestmove, std::string_view ponder);
 
     void init_search_update_listeners();
-
-    [[noreturn]] void terminate_on_critical_error(const std::string& message);
+    void report_error(const std::string& message);
 };
 
 }  // namespace Stockfish


### PR DESCRIPTION
No functional change

Fixes #7000 

This PR addresses an issue where Stockfish calls std::exit(1) upon encountering an illegal move or invalid FEN in a position command. Terminating the process breaks the UCI pipe connection with GUIs (such as Arena GUI), leaving the user with a dead engine process and requiring a full GUI restart.

Summary of Changes:
Prevent Process Termination: Replaced std::exit(1) in terminate_on_critical_error() with a non-fatal report_error() function. This outputs the error info string to the GUI while keeping the engine's main UCI control loop active.
Track Position State Validity: Added a hasValidPosition boolean flag to UCIEngine.
When position or flip fails due to an illegal move or invalid FEN, hasValidPosition is set to false.
When a valid position is successfully processed, hasValidPosition is set to true.

Guard Search Operations:
In go() and perft(), if hasValidPosition is false, the engine outputs info string Error: No valid position set. and bestmove (none) and immediately returns without starting a search. This prevents the engine from analyzing incomplete or invalid positions.
Added guards for non-search diagnostic commands (eval, d) when hasValidPosition is false.

Verification:
Tested via UCI terminal input and inside Arena GUI.
Invalid/illegal move sequences output the critical error string without killing the Stockfish process.
Sending go on an invalid position cleanly returns bestmove (none) without analyzing an incomplete board state.
Sending a subsequent valid position command clears the error flag and restores normal search capability without requiring an engine or GUI restart.