### PR TITLE
Improve Speedtest Speed Timing

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -186,9 +186,7 @@ void Engine::set_on_bestmove(std::function<void(std::string_view, std::string_vi
     updateContext.onBestmove = std::move(f);
 }
 
-void Engine::set_on_start(std::function<void()>&& f) {
-    updateContext.onStart = std::move(f);
-}
+void Engine::set_on_start(std::function<void()>&& f) { updateContext.onStart = std::move(f); }
 
 void Engine::set_on_verify_network(std::function<void(std::string_view)>&& f) {
     onVerifyNetwork = std::move(f);

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -186,6 +186,10 @@ void Engine::set_on_bestmove(std::function<void(std::string_view, std::string_vi
     updateContext.onBestmove = std::move(f);
 }
 
+void Engine::set_on_start(std::function<void()>&& f) {
+    updateContext.onStart = std::move(f);
+}
+
 void Engine::set_on_verify_network(std::function<void(std::string_view)>&& f) {
     onVerifyNetwork = std::move(f);
 }

--- a/src/engine.h
+++ b/src/engine.h
@@ -85,6 +85,7 @@ class Engine {
     void set_on_update_full(std::function<void(const InfoFull&)>&&);
     void set_on_iter(std::function<void(const InfoIter&)>&&);
     void set_on_bestmove(std::function<void(std::string_view, std::string_view)>&&);
+    void set_on_start(std::function<void()>&&);
     void set_on_verify_network(std::function<void(std::string_view)>&&);
 
     // network related

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -202,6 +202,7 @@ void Search::Worker::start_searching() {
     main_manager()->tm.init(limits, rootPos.side_to_move(), rootPos.game_ply(), options,
                             main_manager()->originalTimeAdjust);
     tt.new_search();
+    main_manager()->updates.onStart();
 
     if (rootMoves.empty())
     {

--- a/src/search.h
+++ b/src/search.h
@@ -275,7 +275,7 @@ class SearchManager: public ISearchManager {
         UpdateFull     onUpdateFull;
         UpdateIter     onIter;
         UpdateBestmove onBestmove;
-        UpdateStart onStart;
+        UpdateStart    onStart;
     };
 
 

--- a/src/search.h
+++ b/src/search.h
@@ -268,12 +268,14 @@ class SearchManager: public ISearchManager {
     using UpdateFull     = std::function<void(const InfoFull&)>;
     using UpdateIter     = std::function<void(const InfoIteration&)>;
     using UpdateBestmove = std::function<void(std::string_view, std::string_view)>;
+    using UpdateStart    = std::function<void()>;
 
     struct UpdateContext {
         UpdateShort    onUpdateNoMoves;
         UpdateFull     onUpdateFull;
         UpdateIter     onIter;
         UpdateBestmove onBestmove;
+        UpdateStart onStart;
     };
 
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -321,11 +321,11 @@ void UCIEngine::benchmark(std::istream& args) {
     std::string token;
     u64         cnt = 1;
 
-    engine.set_on_update_full([](const auto&) { });
-    engine.set_on_iter([](const auto&) { });
-    engine.set_on_update_no_moves([](const auto&) { });
-    engine.set_on_bestmove([](const auto&, const auto&) { });
-    engine.set_on_verify_network([](const auto&) { });
+    engine.set_on_update_full([](const auto&) {});
+    engine.set_on_iter([](const auto&) {});
+    engine.set_on_update_no_moves([](const auto&) {});
+    engine.set_on_bestmove([](const auto&, const auto&) {});
+    engine.set_on_verify_network([](const auto&) {});
 
     Benchmark::BenchmarkSetup setup = Benchmark::setup_benchmark(args);
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <cmath>
 #include <cstdlib>
 #include <iterator>
@@ -42,6 +43,9 @@
 #include "ucioption.h"
 
 namespace Stockfish {
+
+using Time = std::chrono::steady_clock;
+using ms   = std::chrono::milliseconds;
 
 constexpr auto BenchmarkCommand = "speedtest";
 
@@ -82,6 +86,7 @@ void UCIEngine::init_search_update_listeners() {
     engine.set_on_update_no_moves([](const auto& i) { on_update_no_moves(i); });
     engine.set_on_update_full(
       [this](const auto& i) { on_update_full(i, engine.get_options()["UCI_ShowWDL"]); });
+    engine.set_on_start([]() {});
     engine.set_on_bestmove([](const auto& bm, const auto& p) { on_bestmove(bm, p); });
     engine.set_on_verify_network([](const auto& s) { print_info_string(s); });
 }
@@ -314,22 +319,19 @@ void UCIEngine::benchmark(std::istream& args) {
     static constexpr int NUM_WARMUP_POSITIONS = 3;
 
     std::string token;
-    u64         nodes = 0, cnt = 1;
-    u64         nodesSearched = 0;
+    u64         cnt = 1;
 
-    engine.set_on_update_full([&](const Engine::InfoFull& i) { nodesSearched = i.nodes; });
-
-    engine.set_on_iter([](const auto&) {});
-    engine.set_on_update_no_moves([](const auto&) {});
-    engine.set_on_bestmove([](const auto&, const auto&) {});
-    engine.set_on_verify_network([](const auto&) {});
+    engine.set_on_update_full([](const auto&) { });
+    engine.set_on_iter([](const auto&) { });
+    engine.set_on_update_no_moves([](const auto&) { });
+    engine.set_on_bestmove([](const auto&, const auto&) { });
+    engine.set_on_verify_network([](const auto&) { });
 
     Benchmark::BenchmarkSetup setup = Benchmark::setup_benchmark(args);
 
     const auto numGoCommands = count_if(setup.commands.begin(), setup.commands.end(),
                                         [](const std::string& s) { return s.find("go ") == 0; });
 
-    TimePoint totalTime = 0;
 
     // Set options once at the start.
     auto ss = std::istringstream("name Threads value " + std::to_string(setup.threads));
@@ -369,8 +371,7 @@ void UCIEngine::benchmark(std::istream& args) {
 
     std::cerr << "\n";
 
-    cnt   = 1;
-    nodes = 0;
+    cnt = 1;
 
     int           numHashfullReadings = 0;
     constexpr int hashfullAges[]      = {0, 999};  // Only normal hashfull and touched hash.
@@ -391,6 +392,24 @@ void UCIEngine::benchmark(std::istream& args) {
 
     engine.search_clear();  // search_clear may take a while
 
+    Time::time_point elapsed;
+    Time::duration   totalTime(0);
+
+    u64 nodes = 0, nodesSearched = 0;
+
+    engine.set_on_update_full([&](const Engine::InfoFull& i) { nodesSearched = i.nodes; });
+
+    engine.set_on_start([&elapsed, &nodesSearched]() {
+        elapsed       = Time::now();
+        nodesSearched = 0;
+    });
+
+    engine.set_on_bestmove(
+      [&totalTime, &elapsed, &nodes, &nodesSearched](const auto&, const auto&) {
+          totalTime += Time::now() - elapsed;
+          nodes += nodesSearched;
+      });
+
     for (const auto& cmd : setup.commands)
     {
         std::istringstream is(cmd);
@@ -403,18 +422,11 @@ void UCIEngine::benchmark(std::istream& args) {
 
             Search::LimitsType limits = parse_limits(is);
 
-            nodesSearched     = 0;
-            TimePoint elapsed = now();
-
             // Run with silenced network verification
             engine.go(limits);
             engine.wait_for_search_finished();
 
-            totalTime += now() - elapsed;
-
             updateHashfullReadings();
-
-            nodes += nodesSearched;
         }
         else if (token == "position")
             position(is);
@@ -424,7 +436,8 @@ void UCIEngine::benchmark(std::istream& args) {
         }
     }
 
-    totalTime = std::max<TimePoint>(totalTime, 1);  // Ensure positivity to avoid a 'divide by zero'
+    // Ensure positivity to avoid a 'divide by zero'
+    const auto totalTimeMs = std::max<i64>(std::chrono::duration_cast<ms>(totalTime).count(), 1LL);
 
     dbg_print();
 
@@ -459,8 +472,8 @@ void UCIEngine::benchmark(std::istream& args) {
               << "\n    single game            : " << maxHashfull[1] << ", "
               << totalHashfull[1] / numHashfullReadings
               << "\nTotal nodes searched       : " << nodes
-              << "\nTotal search time [s]      : " << totalTime / 1000.0
-              << "\nNodes/second               : " << 1000 * nodes / totalTime << std::endl;
+              << "\nTotal search time [s]      : " << totalTimeMs / 1000.0
+              << "\nNodes/second               : " << 1000 * nodes / totalTimeMs << std::endl;
 
     // clang-format on
 


### PR DESCRIPTION
This tries to make the timing of the search function to be a bit more precise and start the timing at the start and right when the bestmove is send and thus avoids including any logic which happens in between (network verification, thread awakening etc.).

It also keeps the timepoint in chrono for the duration of the benchmark and converts to milliseconds only at the end.