### PR TITLE
LSX/LASX NNUE paths optimizes

### DIFF
--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -152,11 +152,12 @@ class AffineTransform {
     static constexpr IndexType get_weight_index_scrambled(IndexType i) {
         IndexType inputIndex = i % PaddedInputDimensions;
 
-#if defined(USE_AVX2_PAIR_ACTIVATIONS)
+#if defined(USE_SCRAMBLED_ACTIVATIONS)
         if constexpr (ScrambledInput)
         {
-            // AVX2 packs operate independently on 128-bit lanes. Keep their interleaved output
-            // order and rearrange the following layer's weights instead of issuing VPERMD.
+            // AVX2 and LASX packs operate independently on 128-bit lanes. Keep their interleaved
+            // output order and rearrange the following layer's weights instead of issuing a
+            // runtime permutation.
             const IndexType block = inputIndex / 32;
             const IndexType chunk = (inputIndex % 32) / 4;
             inputIndex            = block * 32 + ((chunk % 2) * 4 + chunk / 2) * 4 + inputIndex % 4;
@@ -240,6 +241,13 @@ class AffineTransform {
         #define vec_add_32 __lsx_vadd_w
         #define vec_add_dpbusd_32 SIMD::lsx_m128_add_dpbusd_epi32
     #endif
+    #if defined(USE_LASX)
+        #define vec_load_32(a) __lasx_xvldrepl_w(reinterpret_cast<const void*>(a), 0)
+    #elif defined(USE_LSX)
+        #define vec_load_32(a) __lsx_vldrepl_w(reinterpret_cast<const void*>(a), 0)
+    #else
+        #define vec_load_32(a) vec_set_32(load_as<i32>(a))
+    #endif
 
             static constexpr IndexType OutputSimdWidth = sizeof(vec_t) / sizeof(OutputType);
 
@@ -265,8 +273,8 @@ class AffineTransform {
     #if defined(USE_VNNI) || defined(USE_NEON_DOTPROD)
             for (; i < NumChunks; i += 2)
             {
-                const vec_t in0 = vec_set_32(load_as<i32>(input + i * sizeof(i32)));
-                const vec_t in1 = vec_set_32(load_as<i32>(input + (i + 1) * sizeof(i32)));
+                const vec_t in0 = vec_load_32(input + i * sizeof(i32));
+                const vec_t in1 = vec_load_32(input + (i + 1) * sizeof(i32));
                 const auto  col0 =
                   reinterpret_cast<const vec_t*>(&weights[i * OutputDimensions * 4]);
                 const auto col1 =
@@ -288,7 +296,7 @@ class AffineTransform {
     #endif
             for (; i < NumChunks; ++i)
             {
-                const vec_t in0 = vec_set_32(load_as<i32>(input + i * sizeof(i32)));
+                const vec_t in0 = vec_load_32(input + i * sizeof(i32));
                 const auto  col0 =
                   reinterpret_cast<const vec_t*>(&weights[i * OutputDimensions * 4]);
 
@@ -301,6 +309,7 @@ class AffineTransform {
                 outptr[k] = acc[k];
 
     #undef vec_set_32
+    #undef vec_load_32
     #undef vec_add_dpbusd_32
         }
         else if constexpr (OutputDimensions == 1)

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -163,6 +163,13 @@ class AffineTransformSparseInput {
         #define vec_set_32 __lsx_vreplgr2vr_w
         #define vec_add_dpbusd_32 SIMD::lsx_m128_add_dpbusd_epi32
     #endif
+    #if defined(USE_LASX)
+        #define vec_load_32(a) __lasx_xvldrepl_w(reinterpret_cast<const void*>(a), 0)
+    #elif defined(USE_LSX)
+        #define vec_load_32(a) __lsx_vldrepl_w(reinterpret_cast<const void*>(a), 0)
+    #else
+        #define vec_load_32(a) vec_set_32(load_as<i32>(a))
+    #endif
         constexpr IndexType OutputSimdWidth = sizeof(outvec_t) / sizeof(OutputType);
         constexpr IndexType NumAccums       = OutputDimensions / OutputSimdWidth;
         // If we're using high-latency dot product instructions, split the accumulators
@@ -204,9 +211,9 @@ class AffineTransformSparseInput {
             const isize   i0  = *start++;
             const isize   i1  = *start++;
             const isize   i2  = *start++;
-            const invec_t in0 = vec_set_32(load_as<i32>(input + i0 * sizeof(i32)));
-            const invec_t in1 = vec_set_32(load_as<i32>(input + i1 * sizeof(i32)));
-            const invec_t in2 = vec_set_32(load_as<i32>(input + i2 * sizeof(i32)));
+            const invec_t in0 = vec_load_32(input + i0 * sizeof(i32));
+            const invec_t in1 = vec_load_32(input + i1 * sizeof(i32));
+            const invec_t in2 = vec_load_32(input + i2 * sizeof(i32));
             const auto    col0 =
               reinterpret_cast<const invec_t*>(&weights_cp[i0 * OutputDimensions * ChunkSize]);
             const auto col1 =
@@ -228,7 +235,7 @@ class AffineTransformSparseInput {
         while (start < end)
         {
             const isize   i  = *start++;
-            const invec_t in = vec_set_32(load_as<i32>(input + i * sizeof(i32)));
+            const invec_t in = vec_load_32(input + i * sizeof(i32));
             const auto    col =
               reinterpret_cast<const invec_t*>(&weights_cp[i * OutputDimensions * ChunkSize]);
             for (IndexType k = 0; k < NumAccums; ++k)
@@ -263,7 +270,7 @@ class AffineTransformSparseInput {
             while (bits)
             {
                 const isize   i0   = pop_lsb(bits);
-                const invec_t in0  = vec_set_32(load_as<i32>(base_addr + i0 * sizeof(i32)));
+                const invec_t in0  = vec_load_32(base_addr + i0 * sizeof(i32));
                 const auto    col0 = reinterpret_cast<const invec_t*>(
                   &weights_base[i0 * OutputDimensions * ChunkSize]);
 
@@ -275,7 +282,7 @@ class AffineTransformSparseInput {
                 }
 
                 const isize   i1   = pop_lsb(bits);
-                const invec_t in1  = vec_set_32(load_as<i32>(base_addr + i1 * sizeof(i32)));
+                const invec_t in1  = vec_load_32(base_addr + i1 * sizeof(i32));
                 const auto    col1 = reinterpret_cast<const invec_t*>(
                   &weights_base[i1 * OutputDimensions * ChunkSize]);
 
@@ -291,7 +298,7 @@ class AffineTransformSparseInput {
                 const isize i0 = pop_lsb(bits);
                 if (!bits)
                 {
-                    const invec_t in0  = vec_set_32(load_as<i32>(base_addr + i0 * sizeof(i32)));
+                    const invec_t in0  = vec_load_32(base_addr + i0 * sizeof(i32));
                     const auto    col0 = reinterpret_cast<const invec_t*>(
                       &weights_base[i0 * OutputDimensions * ChunkSize]);
                     for (IndexType l = 0; l < NumAccums; ++l)
@@ -302,8 +309,8 @@ class AffineTransformSparseInput {
                 const isize i1 = pop_lsb(bits);
                 if (!bits)
                 {
-                    const invec_t in0  = vec_set_32(load_as<i32>(base_addr + i0 * sizeof(i32)));
-                    const invec_t in1  = vec_set_32(load_as<i32>(base_addr + i1 * sizeof(i32)));
+                    const invec_t in0  = vec_load_32(base_addr + i0 * sizeof(i32));
+                    const invec_t in1  = vec_load_32(base_addr + i1 * sizeof(i32));
                     const auto    col0 = reinterpret_cast<const invec_t*>(
                       &weights_base[i0 * OutputDimensions * ChunkSize]);
                     const auto col1 = reinterpret_cast<const invec_t*>(
@@ -317,9 +324,9 @@ class AffineTransformSparseInput {
                 }
 
                 const isize   i2   = pop_lsb(bits);
-                const invec_t in0  = vec_set_32(load_as<i32>(base_addr + i0 * sizeof(i32)));
-                const invec_t in1  = vec_set_32(load_as<i32>(base_addr + i1 * sizeof(i32)));
-                const invec_t in2  = vec_set_32(load_as<i32>(base_addr + i2 * sizeof(i32)));
+                const invec_t in0  = vec_load_32(base_addr + i0 * sizeof(i32));
+                const invec_t in1  = vec_load_32(base_addr + i1 * sizeof(i32));
+                const invec_t in2  = vec_load_32(base_addr + i2 * sizeof(i32));
                 const auto    col0 = reinterpret_cast<const invec_t*>(
                   &weights_base[i0 * OutputDimensions * ChunkSize]);
                 const auto col1 = reinterpret_cast<const invec_t*>(
@@ -346,7 +353,7 @@ class AffineTransformSparseInput {
                 #undef FIX_GCC15_MISOPTIMIZATION
             #endif
 
-                const invec_t in = vec_set_32(load_as<i32>(input_addr));
+                const invec_t in = vec_load_32(input_addr);
                 for (IndexType l = 0; l < NumAccums; ++l)
                     vec_add_dpbusd_32(acc[l], in, col[l]);
             }
@@ -366,6 +373,7 @@ class AffineTransformSparseInput {
             outptr[k] = acc[k];
 
     #undef vec_set_32
+    #undef vec_load_32
     #undef vec_add_dpbusd_32
     #ifdef vec_add_32
         #undef vec_add_32

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -125,11 +125,8 @@ class ClippedReLU {
         {
             const __m256i packed0 = SIMD::lasx_packus_32(in[i * 4 + 0], in[i * 4 + 1]);
             const __m256i packed1 = SIMD::lasx_packus_32(in[i * 4 + 2], in[i * 4 + 3]);
-            const __m256i words0  = __lasx_xvsrli_h(packed0, WeightScaleBitsLocal);
-            const __m256i words1  = __lasx_xvsrli_h(packed1, WeightScaleBitsLocal);
-            const __m256i packed  = __lasx_xvssrani_b_h(words1, words0, 0);
-            const __m256i swaped  = __lasx_xvpermi_d(packed, 0xD8);
-            __lasx_xvst(__lasx_xvshuf4i_w(swaped, 0xD8), out + i, 0);
+            const __m256i packed  = __lasx_xvssrlni_b_h(packed1, packed0, WeightScaleBitsLocal);
+            __lasx_xvst(packed, out + i, 0);
         }
         constexpr IndexType Start = NumChunks * 32;
 
@@ -141,9 +138,7 @@ class ClippedReLU {
         {
             const __m128i packed0 = SIMD::lsx_packus_32(in[i * 4 + 0], in[i * 4 + 1]);
             const __m128i packed1 = SIMD::lsx_packus_32(in[i * 4 + 2], in[i * 4 + 3]);
-            const __m128i words0  = __lsx_vsrli_h(packed0, WeightScaleBitsLocal);
-            const __m128i words1  = __lsx_vsrli_h(packed1, WeightScaleBitsLocal);
-            out[i]                = __lsx_vssrani_b_h(words1, words0, 0);
+            out[i]                = __lsx_vssrlni_b_h(packed1, packed0, WeightScaleBitsLocal);
         }
         constexpr IndexType Start = NumChunks * 16;
 

--- a/src/nnue/layers/sqr_clipped_relu.h
+++ b/src/nnue/layers/sqr_clipped_relu.h
@@ -185,10 +185,8 @@ class SqrClippedReLU {
             const __m256i words1 = __lasx_xvssrani_h_w(in[i * 4 + 3], in[i * 4 + 2], 0);
             const __m256i sqr0   = __lasx_xvmuh_h(words0, words0);
             const __m256i sqr1   = __lasx_xvmuh_h(words1, words1);
-            __m256i       packed;
-            packed               = __lasx_xvssrlni_b_h(sqr1, sqr0, SimdShiftAmount);
-            const __m256i permed = __lasx_xvpermi_d(packed, 0xD8);
-            __lasx_xvst(__lasx_xvshuf4i_w(permed, 0xD8), out + i, 0);
+            const __m256i packed = __lasx_xvssrlni_b_h(sqr1, sqr0, SimdShiftAmount);
+            __lasx_xvst(packed, out + i, 0);
         }
         constexpr IndexType Start = NumChunks * 32;
 

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -241,6 +241,13 @@ void apply_combined(Color                              perspective,
                 acc[k]     = vsubw_s8(acc[k], vget_low_s8(column[k / 2]));
                 acc[k + 1] = vsubw_high_s8(acc[k + 1], column[k / 2]);
             }
+    #elif defined(USE_LSX) && !defined(USE_LASX)
+            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
+            {
+                const __m128i weight = __lsx_vld(reinterpret_cast<const void*>(&column[k]), 0);
+                acc[k]               = vec_sub_16(acc[k], __lsx_vsllwil_h_b(weight, 0));
+                acc[k + 1]           = vec_sub_16(acc[k + 1], __lsx_vexth_h_b(weight));
+            }
     #else
             for (IndexType k = 0; k < Tiling::NumRegs; ++k)
                 acc[k] = vec_sub_16(acc[k], vec_convert_8_16(column[k]));
@@ -257,6 +264,13 @@ void apply_combined(Color                              perspective,
             {
                 acc[k]     = vaddw_s8(acc[k], vget_low_s8(column[k / 2]));
                 acc[k + 1] = vaddw_high_s8(acc[k + 1], column[k / 2]);
+            }
+    #elif defined(USE_LSX) && !defined(USE_LASX)
+            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
+            {
+                const __m128i weight = __lsx_vld(reinterpret_cast<const void*>(&column[k]), 0);
+                acc[k]               = vec_add_16(acc[k], __lsx_vsllwil_h_b(weight, 0));
+                acc[k + 1]           = vec_add_16(acc[k + 1], __lsx_vexth_h_b(weight));
             }
     #else
             for (IndexType k = 0; k < Tiling::NumRegs; ++k)
@@ -743,6 +757,13 @@ void update_accumulator_hybrid(Color                     perspective,
                 acc[k]     = vsubw_s8(acc[k], vget_low_s8(column[k / 2]));
                 acc[k + 1] = vsubw_high_s8(acc[k + 1], column[k / 2]);
             }
+    #elif defined(USE_LSX) && !defined(USE_LASX)
+            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
+            {
+                const __m128i weight = __lsx_vld(reinterpret_cast<const void*>(&column[k]), 0);
+                acc[k]               = vec_sub_16(acc[k], __lsx_vsllwil_h_b(weight, 0));
+                acc[k + 1]           = vec_sub_16(acc[k + 1], __lsx_vexth_h_b(weight));
+            }
     #else
             for (IndexType k = 0; k < Tiling::NumRegs; ++k)
                 acc[k] = vec_sub_16(acc[k], vec_convert_8_16(column[k]));
@@ -759,6 +780,13 @@ void update_accumulator_hybrid(Color                     perspective,
             {
                 acc[k]     = vaddw_s8(acc[k], vget_low_s8(column[k / 2]));
                 acc[k + 1] = vaddw_high_s8(acc[k + 1], column[k / 2]);
+            }
+    #elif defined(USE_LSX) && !defined(USE_LASX)
+            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
+            {
+                const __m128i weight = __lsx_vld(reinterpret_cast<const void*>(&column[k]), 0);
+                acc[k]               = vec_add_16(acc[k], __lsx_vsllwil_h_b(weight, 0));
+                acc[k + 1]           = vec_add_16(acc[k + 1], __lsx_vexth_h_b(weight));
             }
     #else
             for (IndexType k = 0; k < Tiling::NumRegs; ++k)
@@ -1007,6 +1035,13 @@ void update_accumulator_refresh_cache(Color                     perspective,
             {
                 acc[k]     = vaddw_s8(acc[k], vget_low_s8(column[k / 2]));
                 acc[k + 1] = vaddw_high_s8(acc[k + 1], column[k / 2]);
+            }
+    #elif defined(USE_LSX) && !defined(USE_LASX)
+            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
+            {
+                const __m128i weight = __lsx_vld(reinterpret_cast<const void*>(&column[k]), 0);
+                acc[k]               = vec_add_16(acc[k], __lsx_vsllwil_h_b(weight, 0));
+                acc[k + 1]           = vec_add_16(acc[k + 1], __lsx_vexth_h_b(weight));
             }
     #else
             for (IndexType k = 0; k < Tiling::NumRegs; ++k)

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -59,19 +59,19 @@ struct NetworkArchitecture {
     static constexpr IndexType TransformedFeatureDimensions = L1;
     static constexpr int       FC_0_OUTPUTS                 = L2;
     static constexpr int       FC_1_OUTPUTS                 = L3;
-#if defined(USE_AVX2_PAIR_ACTIVATIONS)
-    static constexpr bool UsePairedActivations = true;
+#if defined(USE_SCRAMBLED_ACTIVATIONS)
+    static constexpr bool ScrambledInput = true;
 #else
-    static constexpr bool UsePairedActivations = false;
+    static constexpr bool ScrambledInput = false;
 #endif
 
-    Layers::AffineTransformSparseInput<TransformedFeatureDimensions, FC_0_OUTPUTS>        fc_0;
-    Layers::SqrClippedReLU<FC_0_OUTPUTS, WeightScaleBits + 1>                             ac_sqr_0;
-    Layers::ClippedReLU<FC_0_OUTPUTS, WeightScaleBits + 1>                                ac_0;
-    Layers::AffineTransform<FC_0_OUTPUTS * 2, FC_1_OUTPUTS, UsePairedActivations>         fc_1;
-    Layers::SqrClippedReLU<FC_1_OUTPUTS, WeightScaleBits>                                 ac_sqr_1;
-    Layers::ClippedReLU<FC_1_OUTPUTS, WeightScaleBits>                                    ac_1;
-    Layers::AffineTransform<FC_0_OUTPUTS * 2 + FC_1_OUTPUTS * 2, 1, UsePairedActivations> fc_2;
+    Layers::AffineTransformSparseInput<TransformedFeatureDimensions, FC_0_OUTPUTS>  fc_0;
+    Layers::SqrClippedReLU<FC_0_OUTPUTS, WeightScaleBits + 1>                       ac_sqr_0;
+    Layers::ClippedReLU<FC_0_OUTPUTS, WeightScaleBits + 1>                          ac_0;
+    Layers::AffineTransform<FC_0_OUTPUTS * 2, FC_1_OUTPUTS, ScrambledInput>         fc_1;
+    Layers::SqrClippedReLU<FC_1_OUTPUTS, WeightScaleBits>                           ac_sqr_1;
+    Layers::ClippedReLU<FC_1_OUTPUTS, WeightScaleBits>                              ac_1;
+    Layers::AffineTransform<FC_0_OUTPUTS * 2 + FC_1_OUTPUTS * 2, 1, ScrambledInput> fc_2;
 
     // Hash value embedded in the evaluation file
     static constexpr u32 get_hash_value() {

--- a/src/nnue/simd.h
+++ b/src/nnue/simd.h
@@ -59,6 +59,10 @@ namespace Stockfish::Eval::NNUE::SIMD {
     #define USE_PAIR_ACTIVATIONS
 #endif
 
+#if defined(USE_AVX2_PAIR_ACTIVATIONS) || defined(USE_LASX)
+    #define USE_SCRAMBLED_ACTIVATIONS
+#endif
+
 // If vector instructions are enabled, we update and refresh the
 // accumulator tile by tile such that each tile fits in the CPU's
 // vector registers.


### PR DESCRIPTION
Optimizes the LoongArch NNUE SIMD implementation, avoiding permutation and shuffle operations in `ClippedReLU` and `SqrClippedReLU`.

Adds LSX path that widens and processes both halves of each signed-byte weight vector.

Passed STC:

LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 50528 W: 13459 L: 13130 D: 23939
Ptnml(0-2): 182, 5438, 13706, 5745, 193 
https://tests.stockfishchess.org/tests/view/6a607ab325028d004c922829

No functional change.
