### PR TITLE
Update NNUE perspectives together

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Ayush (ayushthepiro11-design)
 Balazs Szilagyi
 Balint Pfliegel
 Baptiste Rech (breatn)
+Bartosz Paprzycki (compxed)
 Ben Chaney (Chaneybenjamini)
 Ben Koshy (BKSpurgeon)
 Bill Henry (VoyagerOne)

--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -287,8 +287,45 @@ void FullThreats::append_changed_indices(Color                   perspective,
 
         if (prefetchBase)
             prefetch<PrefetchRw::READ, PrefetchLoc::LOW>(reinterpret_cast<const void*>(
-              reinterpret_cast<uintptr_t>(prefetchBase) + index * prefetchStride));
+              reinterpret_cast<uintptr_t>(prefetchBase) + uintptr_t(index) * prefetchStride));
         insert.push_back_if_lt(index, Dimensions);
+    }
+}
+
+void FullThreats::append_changed_indices_both(Square                  white_ksq,
+                                              Square                  black_ksq,
+                                              const DiffType&         diff,
+                                              IndexList&              white_removed,
+                                              IndexList&              white_added,
+                                              IndexList&              black_removed,
+                                              IndexList&              black_added,
+                                              const ThreatWeightType* prefetchBase,
+                                              IndexType               prefetchStride) {
+
+    for (const auto& dirty : diff.list)
+    {
+        const Piece  attacker = dirty.pc();
+        const Piece  attacked = dirty.threatened_pc();
+        const Square from     = dirty.pc_sq();
+        const Square to       = dirty.threatened_sq();
+        const bool   add      = dirty.add();
+
+        auto& white_insert = add ? white_added : white_removed;
+        auto& black_insert = add ? black_added : black_removed;
+
+        const IndexType white_index = make_index(WHITE, attacker, from, to, attacked, white_ksq);
+        const IndexType black_index = make_index(BLACK, attacker, from, to, attacked, black_ksq);
+
+        if (prefetchBase)
+        {
+            prefetch<PrefetchRw::READ, PrefetchLoc::LOW>(reinterpret_cast<const void*>(
+              reinterpret_cast<uintptr_t>(prefetchBase) + uintptr_t(white_index) * prefetchStride));
+            prefetch<PrefetchRw::READ, PrefetchLoc::LOW>(reinterpret_cast<const void*>(
+              reinterpret_cast<uintptr_t>(prefetchBase) + uintptr_t(black_index) * prefetchStride));
+        }
+
+        white_insert.push_back_if_lt(white_index, Dimensions);
+        black_insert.push_back_if_lt(black_index, Dimensions);
     }
 }
 

--- a/src/nnue/features/full_threats.h
+++ b/src/nnue/features/full_threats.h
@@ -83,6 +83,16 @@ class FullThreats {
                                        IndexList&              added,
                                        const ThreatWeightType* prefetchBase   = nullptr,
                                        IndexType               prefetchStride = 0);
+
+    static void append_changed_indices_both(Square                  white_ksq,
+                                            Square                  black_ksq,
+                                            const DiffType&         diff,
+                                            IndexList&              white_removed,
+                                            IndexList&              white_added,
+                                            IndexList&              black_removed,
+                                            IndexList&              black_added,
+                                            const ThreatWeightType* prefetchBase   = nullptr,
+                                            IndexType               prefetchStride = 0);
 };
 
 }  // namespace Stockfish::Eval::NNUE::Features

--- a/src/nnue/features/pp_3wide.cpp
+++ b/src/nnue/features/pp_3wide.cpp
@@ -146,7 +146,7 @@ void PP_3Wide::append_changed_indices(Color                                    p
         auto push = [&](IndexType index) {
             if (prefetchBase)
                 prefetch<PrefetchRw::READ, PrefetchLoc::LOW>(reinterpret_cast<const void*>(
-                  reinterpret_cast<uintptr_t>(prefetchBase) + index * prefetchStride));
+                  reinterpret_cast<uintptr_t>(prefetchBase) + uintptr_t(index) * prefetchStride));
             out.push_back(index);
         };
         const Bitboard unchanged = (pawnsW | pawnsB) & ~(updatedW | updatedB);
@@ -166,6 +166,73 @@ void PP_3Wide::append_changed_indices(Color                                    p
     generate(whiteAfter & ~whiteBefore, blackAfter & ~blackBefore, whiteAfter, blackAfter, added);
     generate(whiteBefore & ~whiteAfter, blackBefore & ~blackAfter, whiteBefore, blackBefore,
              removed);
+}
+
+void PP_3Wide::append_changed_indices_both(Square                  white_ksq,
+                                           Square                  black_ksq,
+                                           const DiffType&         diff,
+                                           IndexList&              white_removed,
+                                           IndexList&              white_added,
+                                           IndexList&              black_removed,
+                                           IndexList&              black_added,
+                                           const ThreatWeightType* prefetchBase,
+                                           IndexType               prefetchStride) {
+
+#ifdef USE_AVX512ICL
+    append_changed_indices(WHITE, white_ksq, diff, white_removed, white_added, prefetchBase,
+                           prefetchStride);
+    append_changed_indices(BLACK, black_ksq, diff, black_removed, black_added, prefetchBase,
+                           prefetchStride);
+#else
+    const Bitboard whiteBefore = diff.before[WHITE];
+    const Bitboard blackBefore = diff.before[BLACK];
+    const Bitboard whiteAfter  = diff.after[WHITE];
+    const Bitboard blackAfter  = diff.after[BLACK];
+
+    if (whiteBefore == whiteAfter && blackBefore == blackAfter)
+        return;
+
+    auto generate = [&](Bitboard updatedW, Bitboard updatedB, Bitboard pawnsW, Bitboard pawnsB,
+                        IndexList& white_out, IndexList& black_out) {
+        auto push = [&](Color color, Square from, Square to, Color pairedColor) {
+            const IndexType white_index =
+              make_index(WHITE, color, from, to, pairedColor, white_ksq);
+            const IndexType black_index =
+              make_index(BLACK, color, from, to, pairedColor, black_ksq);
+
+            if (prefetchBase)
+            {
+                prefetch<PrefetchRw::READ, PrefetchLoc::LOW>(reinterpret_cast<const void*>(
+                  reinterpret_cast<uintptr_t>(prefetchBase)
+                  + uintptr_t(white_index) * prefetchStride));
+                prefetch<PrefetchRw::READ, PrefetchLoc::LOW>(reinterpret_cast<const void*>(
+                  reinterpret_cast<uintptr_t>(prefetchBase)
+                  + uintptr_t(black_index) * prefetchStride));
+            }
+
+            white_out.push_back(white_index);
+            black_out.push_back(black_index);
+        };
+
+        const Bitboard unchanged = (pawnsW | pawnsB) & ~(updatedW | updatedB);
+        for (Bitboard updated = updatedW | updatedB; updated;)
+        {
+            const Square   from  = pop_lsb(updated);
+            const Bitboard mask  = pawn_pair_bb(from) & (unchanged | updated);
+            const Color    color = (pawnsB & from) ? BLACK : WHITE;
+
+            for (Bitboard paired = pawnsB & mask; paired;)
+                push(color, from, pop_lsb(paired), BLACK);
+            for (Bitboard paired = pawnsW & mask; paired;)
+                push(color, from, pop_lsb(paired), WHITE);
+        }
+    };
+
+    generate(whiteAfter & ~whiteBefore, blackAfter & ~blackBefore, whiteAfter, blackAfter,
+             white_added, black_added);
+    generate(whiteBefore & ~whiteAfter, blackBefore & ~blackAfter, whiteBefore, blackBefore,
+             white_removed, black_removed);
+#endif
 }
 
 }  // namespace Stockfish::Eval::NNUE::Features

--- a/src/nnue/features/pp_3wide.h
+++ b/src/nnue/features/pp_3wide.h
@@ -54,6 +54,16 @@ class PP_3Wide {
                                        IndexList&              added,
                                        const ThreatWeightType* prefetchBase   = nullptr,
                                        IndexType               prefetchStride = 0);
+
+    static void append_changed_indices_both(Square                  white_ksq,
+                                            Square                  black_ksq,
+                                            const DiffType&         diff,
+                                            IndexList&              white_removed,
+                                            IndexList&              white_added,
+                                            IndexList&              black_removed,
+                                            IndexList&              black_added,
+                                            const ThreatWeightType* prefetchBase   = nullptr,
+                                            IndexType               prefetchStride = 0);
 };
 
 }  // namespace Stockfish::Eval::NNUE::Features

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -18,6 +18,7 @@
 
 #include "nnue_accumulator.h"
 
+#include <algorithm>
 #include <cassert>
 #include <new>
 
@@ -42,6 +43,12 @@ void update_accumulator_incremental(Color                     perspective,
                                     const Square              ksq,
                                     AccumulatorState&         target_state,
                                     const AccumulatorState&   computed);
+
+void update_accumulator_incremental_both(const FeatureTransformer& featureTransformer,
+                                         Square                    white_ksq,
+                                         Square                    black_ksq,
+                                         AccumulatorState&         target_state,
+                                         const AccumulatorState&   computed);
 
 void update_accumulator_refresh_cache(Color                     perspective,
                                       const FeatureTransformer& featureTransformer,
@@ -88,18 +95,25 @@ void AccumulatorStack::evaluate(const Position&           pos,
                                 const FeatureTransformer& featureTransformer,
                                 // Silence spurious warning on GCC 10
                                 [[maybe_unused]] AccumulatorCaches& cache) noexcept {
-    evaluate_side(WHITE, pos, featureTransformer, cache);
-    evaluate_side(BLACK, pos, featureTransformer, cache);
+    const usize last_white = find_last_usable_accumulator(WHITE);
+    const usize last_black = find_last_usable_accumulator(BLACK);
+
+    if (accumulators[last_white].computed[WHITE] && accumulators[last_black].computed[BLACK])
+        forward_update_incremental_both(pos, featureTransformer, last_white, last_black);
+    else
+    {
+        evaluate_side(WHITE, pos, featureTransformer, cache, last_white);
+        evaluate_side(BLACK, pos, featureTransformer, cache, last_black);
+    }
 }
 
 void AccumulatorStack::evaluate_side(Color                     perspective,
                                      const Position&           pos,
                                      const FeatureTransformer& featureTransformer,
-                                     AccumulatorCaches&        cache) noexcept {
+                                     AccumulatorCaches&        cache,
+                                     usize                     last_usable_accum) noexcept {
 
     constexpr int MIN_PC_COUNT_HYBRID = 15;
-
-    const auto last_usable_accum = find_last_usable_accumulator(perspective);
 
     if (accumulators[last_usable_accum].computed[perspective])
         forward_update_incremental(perspective, pos, featureTransformer, last_usable_accum);
@@ -176,6 +190,36 @@ void AccumulatorStack::backward_update_incremental(Color                     per
                                               accumulators[next], accumulators[next + 1]);
 
     assert(accumulators[end].computed[perspective]);
+}
+
+void AccumulatorStack::forward_update_incremental_both(const Position&           pos,
+                                                       const FeatureTransformer& featureTransformer,
+                                                       usize                     white_begin,
+                                                       usize black_begin) noexcept {
+
+    assert(white_begin < size);
+    assert(black_begin < size);
+    assert(accumulators[white_begin].computed[WHITE]);
+    assert(accumulators[black_begin].computed[BLACK]);
+
+    const Square white_ksq    = pos.square<KING>(WHITE);
+    const Square black_ksq    = pos.square<KING>(BLACK);
+    const usize  shared_begin = std::max(white_begin, black_begin);
+
+    // Catch up the lagging perspective, then traverse the common suffix once.
+    for (usize next = white_begin + 1; next <= shared_begin; ++next)
+        update_accumulator_incremental<true>(WHITE, featureTransformer, white_ksq,
+                                             accumulators[next], accumulators[next - 1]);
+    for (usize next = black_begin + 1; next <= shared_begin; ++next)
+        update_accumulator_incremental<true>(BLACK, featureTransformer, black_ksq,
+                                             accumulators[next], accumulators[next - 1]);
+
+    for (usize next = shared_begin + 1; next < size; ++next)
+        update_accumulator_incremental_both(featureTransformer, white_ksq, black_ksq,
+                                            accumulators[next], accumulators[next - 1]);
+
+    assert(latest().computed[WHITE]);
+    assert(latest().computed[BLACK]);
 }
 
 namespace {
@@ -462,6 +506,43 @@ void update_accumulator_incremental(Color                     perspective,
                    thrAdded, thrRemoved);
 
     target_state.computed[perspective] = true;
+}
+
+void update_accumulator_incremental_both(const FeatureTransformer& featureTransformer,
+                                         Square                    white_ksq,
+                                         Square                    black_ksq,
+                                         AccumulatorState&         target_state,
+                                         const AccumulatorState&   computed) {
+
+    assert(computed.computed[WHITE]);
+    assert(computed.computed[BLACK]);
+    assert(!target_state.computed[WHITE]);
+    assert(!target_state.computed[BLACK]);
+
+    PSQFeatureSet::IndexList    psq_removed[COLOR_NB], psq_added[COLOR_NB];
+    ThreatFeatureSet::IndexList thr_removed[COLOR_NB], thr_added[COLOR_NB];
+
+    const auto* threat_pp_base = &featureTransformer.threatAndPpWeights[0];
+    const auto  pf_stride      = FeatureTransformer::OutputDimensions;
+
+    ThreatFeatureSet::append_changed_indices_both(
+      white_ksq, black_ksq, target_state.dirtyThreats, thr_removed[WHITE], thr_added[WHITE],
+      thr_removed[BLACK], thr_added[BLACK], threat_pp_base, pf_stride);
+    PairFeatureSet::append_changed_indices_both(
+      white_ksq, black_ksq, target_state.dirtyPawnPairs, thr_removed[WHITE], thr_added[WHITE],
+      thr_removed[BLACK], thr_added[BLACK], threat_pp_base, pf_stride);
+    PSQFeatureSet::append_changed_indices(WHITE, white_ksq, target_state.dirtyPiece,
+                                          psq_removed[WHITE], psq_added[WHITE]);
+    PSQFeatureSet::append_changed_indices(BLACK, black_ksq, target_state.dirtyPiece,
+                                          psq_removed[BLACK], psq_added[BLACK]);
+
+    apply_combined(WHITE, featureTransformer, computed, target_state, psq_added[WHITE],
+                   psq_removed[WHITE], thr_added[WHITE], thr_removed[WHITE]);
+    apply_combined(BLACK, featureTransformer, computed, target_state, psq_added[BLACK],
+                   psq_removed[BLACK], thr_added[BLACK], thr_removed[BLACK]);
+
+    target_state.computed[WHITE] = true;
+    target_state.computed[BLACK] = true;
 }
 
 Bitboard get_changed_pieces(const std::array<Piece, SQUARE_NB>& oldPieces,

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -113,7 +113,8 @@ class AccumulatorStack {
                        const Position&           pos,
                        const FeatureTransformer& featureTransformer,
                        // Silence spurious warning on GCC 10
-                       [[maybe_unused]] AccumulatorCaches& cache) noexcept;
+                       [[maybe_unused]] AccumulatorCaches& cache,
+                       usize                               last_usable_accum) noexcept;
 
     [[nodiscard]] usize find_last_usable_accumulator(Color perspective) const noexcept;
 
@@ -126,6 +127,11 @@ class AccumulatorStack {
                                      const Position&           pos,
                                      const FeatureTransformer& featureTransformer,
                                      const usize               end) noexcept;
+
+    void forward_update_incremental_both(const Position&           pos,
+                                         const FeatureTransformer& featureTransformer,
+                                         usize                     white_begin,
+                                         usize                     black_begin) noexcept;
 
     std::array<AccumulatorState, MaxSize> accumulators;
     usize                                 size = 1;


### PR DESCRIPTION
When both perspective accumulators can be updated incrementally, catch up the
lagging perspective and traverse their common suffix once.

During each shared transition:

- decode FullThreats changes once while preserving perspective-specific indices;
- enumerate non-AVX512 PP_3Wide topology once for both perspectives;
- keep HalfKA indices and accumulator arithmetic perspective-specific;
- retain the existing specialized AVX512 PP_3Wide generator.

This preserves feature indices, list ordering, accumulator arithmetic, and the
resulting evaluation.

Passed STC:
https://tests.stockfishchess.org/tests/view/6a63233fc054e285ae028702

LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 69632 W: 18217 L: 17881 D: 33534
Ptnml(0-2): 153, 7022, 20132, 7354, 155

No functional change

Bench: 2718396