### PR TITLE
Add test for partially numeric spin option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -137,6 +137,7 @@ Jost Triller (tsoj)
 Julian Willemer (NightlyKing)
 jundery
 Justin Blanchard (UncombedCoconut)
+Justin DeGuzman (jdeguzman11)
 Kazuki Yamashita (KazApps)
 Kelly Wilson
 Ken Takusagawa

--- a/tests/instrumented.py
+++ b/tests/instrumented.py
@@ -610,6 +610,11 @@ class TestInvalidOptions(metaclass=OrderedClassMembers):
         self.stockfish.send_command("isready")
         self.stockfish.equals("readyok")
 
+    def test_spin_partially_numeric(self):
+        self.stockfish.send_command("setoption name Threads value 12abc")
+        self.stockfish.send_command("isready")
+        self.stockfish.equals("readyok")
+
     def test_spin_out_of_range(self):
         self.stockfish.send_command("setoption name Threads value 999999999999")
         self.stockfish.send_command("isready")


### PR DESCRIPTION
Adds regression coverage for partially numeric spin option values such as `12abc`.

The existing invalid option tests cover non-numeric, negative, and out-of-range values, but not values that begin with valid digits and contain trailing non-numeric characters.

Validation:
- `python3 -m py_compile tests/instrumented.py`
- `python3 tests/instrumented.py src/stockfish`
- 74 tests passed, 0 failed

No functional change.