### PR TITLE
Simplify Negative Extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1274,14 +1274,10 @@ moves_loop:  // When in check, search starts here
             // if the ttMove is singular or can do a multi-cut, so we reduce the
             // ttMove in favor of other moves based on some conditions:
 
-            // If the ttMove is assumed to fail high over current beta
-            else if (ttData.value >= beta)
+            // If the ttMove is assumed to fail high over current beta or
+            // if we are on a cutNode
+            else if (ttData.value >= beta || cutNode)
                 extension = -3;
-
-            // If we are on a cutNode but the ttMove is not assumed to fail high
-            // over current beta
-            else if (cutNode)
-                extension = -2;
         }
 
         u64 nodeCount = rootNode ? u64(nodes) : 0;


### PR DESCRIPTION
Simplify Negative Extensions

Passed STC non-reg:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 89280 W: 23332 L: 23169 D: 42779
Ptnml(0-2): 234, 10427, 23159, 10582, 238
https://tests.stockfishchess.org/tests/view/6a5cee545529b8472df81bb2

Passed LTC non-reg:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 71388 W: 18511 L: 18345 D: 34532
Ptnml(0-2): 30, 7531, 20411, 7687, 35
https://tests.stockfishchess.org/tests/view/6a5f6f125529b8472df821f5

Passed VVLTC non-reg:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 82480 W: 21426 L: 21288 D: 39766
Ptnml(0-2): 7, 7001, 27083, 7145, 4
https://tests.stockfishchess.org/tests/view/6a60851f25028d004c922860

bench: 2970409