### PR TITLE
Multi cut pruning correction history

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1264,6 +1264,15 @@ moves_loop:  // When in check, search starts here
             else if (value >= beta && !is_decisive(value))
             {
                 ttMoveHistory << -421 - 110 * depth;
+
+                if (!ss->inCheck && value > ss->staticEval)
+                {
+                    const int bonus = std::clamp(
+                      int(value - ss->staticEval) * singularDepth * 177 / 1024,
+                      -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
+                    update_correction_history(pos, ss, *this, bonus);
+                }
+
                 return value;
             }
 


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/6a596dca5529b8472df81060
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 151072 W: 39154 L: 38677 D: 73241
Ptnml(0-2): 372, 17511, 39320, 17934, 399 

LTC: https://tests.stockfishchess.org/tests/view/6a6508b6c054e285ae028b5f
LLR: 2.96 (-2.94,2.94) <0.50,2.50>
Total: 109866 W: 28697 L: 28240 D: 52929
Ptnml(0-2): 39, 11353, 31686, 11822, 33 

bench: 2148099

As an experiment I pointed some LLMs at other engine github repos to look for ideas to port to SF.  Most failed.  This one by GPT 5.6 from https://github.com/Yoshie2000/PlentyChess passed.  Congrats and credit to PlentyChess!