### PR TITLE
[RFC] remove non-VECTOR code path in nnue_accumulator.cpp

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -180,6 +180,68 @@ void AccumulatorStack::backward_update_incremental(Color                     per
 
 namespace {
 
+constexpr IndexType Dimensions = FeatureTransformer::OutputDimensions;
+
+#ifdef VECTOR
+
+using Tiling = SIMDTiling<Dimensions, Dimensions, PSQTBuckets>;
+
+template<int sign>
+sf_always_inline inline void apply_psq_features(IndexType j,
+                                                vec_t acc[],
+                                                const PSQFeatureSet::IndexList& list,
+                                                const FeatureTransformer& ft) {
+    static_assert(sign == 1 || sign == -1);
+
+    const usize tileOff    = j * Tiling::TileHeight;
+    for (int i = 0; i < list.ssize(); ++i)
+    {
+        auto* column = reinterpret_cast<const vec_t*>(&ft.weights[list[i] * Dimensions + tileOff]);
+        for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+            if constexpr (sign == +1)
+                acc[k] = vec_add_16(acc[k], column[k]);
+            else
+                acc[k] = vec_sub_16(acc[k], column[k]);
+    }
+}
+
+template<int sign>
+sf_always_inline inline void apply_threat_features(IndexType j,
+                                                   vec_t acc[],
+                                                   const ThreatFeatureSet::IndexList& list,
+                                                   const FeatureTransformer& ft) {
+    static_assert(sign == 1 || sign == -1);
+
+    const usize tileOff    = j * Tiling::TileHeight;
+    for (int i = 0; i < list.ssize(); ++i)
+    {
+        auto* column = reinterpret_cast<const vec_i8_t*>(&ft.threatAndPpWeights[list[i] * Dimensions + tileOff]);
+#ifdef USE_NEON
+        for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
+        {
+            if constexpr (sign == +1)
+            {
+                acc[k]     = vaddw_s8(acc[k], vget_low_s8(column[k / 2]));
+                acc[k + 1] = vaddw_high_s8(acc[k + 1], column[k / 2]);
+            }
+            else
+            {
+                acc[k]     = vsubw_s8(acc[k], vget_low_s8(column[k / 2]));
+                acc[k + 1] = vsubw_high_s8(acc[k + 1], column[k / 2]);
+            }
+        }
+#else
+        for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+            if constexpr (sign == +1)
+                acc[k] = vec_add_16(acc[k], vec_convert_8_16(column[k]));
+            else
+                acc[k] = vec_sub_16(acc[k], vec_convert_8_16(column[k]));
+#endif
+    }
+}
+
+#endif
+
 void apply_combined(Color                              perspective,
                     const FeatureTransformer&          featureTransformer,
                     const AccumulatorState&            from,
@@ -188,7 +250,6 @@ void apply_combined(Color                              perspective,
                     const PSQFeatureSet::IndexList&    psqRemoved,
                     const ThreatFeatureSet::IndexList& thrAdded,
                     const ThreatFeatureSet::IndexList& thrRemoved) {
-    constexpr IndexType Dimensions = FeatureTransformer::OutputDimensions;
 
     const auto& fromAcc = from.accumulation[perspective];
     auto&       toAcc   = to.accumulation[perspective];
@@ -197,13 +258,9 @@ void apply_combined(Color                              perspective,
     auto&       toPsqtAcc   = to.psqtAccumulation[perspective];
 
 #ifdef VECTOR
-    using Tiling = SIMDTiling<Dimensions, Dimensions, PSQTBuckets>;
 
     vec_t      acc[Tiling::NumRegs];
     psqt_vec_t psqt[Tiling::NumPsqtRegs];
-
-    const auto* psqWeights         = &featureTransformer.weights[0];
-    const auto* threatAndPpWeights = &featureTransformer.threatAndPpWeights[0];
 
     for (IndexType j = 0; j < Dimensions / Tiling::TileHeight; ++j)
     {
@@ -214,55 +271,11 @@ void apply_combined(Color                              perspective,
         for (IndexType k = 0; k < Tiling::NumRegs; ++k)
             acc[k] = fromTile[k];
 
-        for (int i = 0; i < psqRemoved.ssize(); ++i)
-        {
-            auto* row =
-              reinterpret_cast<const vec_t*>(&psqWeights[psqRemoved[i] * Dimensions + tileOff]);
-            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = vec_sub_16(acc[k], row[k]);
-        }
+        apply_psq_features<-1>(j, acc, psqRemoved, featureTransformer);
+        apply_psq_features<+1>(j, acc, psqAdded, featureTransformer);
 
-        for (int i = 0; i < psqAdded.ssize(); ++i)
-        {
-            auto* row =
-              reinterpret_cast<const vec_t*>(&psqWeights[psqAdded[i] * Dimensions + tileOff]);
-            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = vec_add_16(acc[k], row[k]);
-        }
-
-        for (int i = 0; i < thrRemoved.ssize(); ++i)
-        {
-            auto* column = reinterpret_cast<const vec_i8_t*>(
-              &threatAndPpWeights[thrRemoved[i] * Dimensions + tileOff]);
-
-    #ifdef USE_NEON
-            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
-            {
-                acc[k]     = vsubw_s8(acc[k], vget_low_s8(column[k / 2]));
-                acc[k + 1] = vsubw_high_s8(acc[k + 1], column[k / 2]);
-            }
-    #else
-            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = vec_sub_16(acc[k], vec_convert_8_16(column[k]));
-    #endif
-        }
-
-        for (int i = 0; i < thrAdded.ssize(); ++i)
-        {
-            auto* column = reinterpret_cast<const vec_i8_t*>(
-              &threatAndPpWeights[thrAdded[i] * Dimensions + tileOff]);
-
-    #ifdef USE_NEON
-            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
-            {
-                acc[k]     = vaddw_s8(acc[k], vget_low_s8(column[k / 2]));
-                acc[k + 1] = vaddw_high_s8(acc[k + 1], column[k / 2]);
-            }
-    #else
-            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = vec_add_16(acc[k], vec_convert_8_16(column[k]));
-    #endif
-        }
+        apply_threat_features<-1>(j, acc, thrRemoved, featureTransformer);
+        apply_threat_features<+1>(j, acc, thrAdded, featureTransformer);
 
         for (IndexType k = 0; k < Tiling::NumRegs; k++)
             vec_store(&toTile[k], acc[k]);
@@ -662,8 +675,6 @@ void update_accumulator_hybrid(Color                     perspective,
     PairFeatureSet::append_changed_indices(perspective, newKsq, target.dirtyPawnPairs, thrRemoved,
                                            thrAdded, threatPpBase, pfStride);
 
-    constexpr IndexType Dimensions = FeatureTransformer::OutputDimensions;
-
     const auto& fromAcc = computed.accumulation[perspective];
     auto&       toAcc   = target.accumulation[perspective];
 
@@ -671,13 +682,8 @@ void update_accumulator_hybrid(Color                     perspective,
     auto&       toPsqtAcc   = target.psqtAccumulation[perspective];
 
 #ifdef VECTOR
-    using Tiling = SIMDTiling<Dimensions, Dimensions, PSQTBuckets>;
-
     vec_t      acc[Tiling::NumRegs];
     psqt_vec_t psqt[Tiling::NumPsqtRegs];
-
-    const auto* weights            = &featureTransformer.weights[0];
-    const auto* threatAndPpWeights = &featureTransformer.threatAndPpWeights[0];
 
     for (IndexType j = 0; j < Dimensions / Tiling::TileHeight; ++j)
     {
@@ -690,20 +696,8 @@ void update_accumulator_hybrid(Color                     perspective,
         for (IndexType k = 0; k < Tiling::NumRegs; ++k)
             acc[k] = newEntryTile[k];
 
-        for (int i = 0; i < newRemove.ssize(); ++i)
-        {
-            auto* column =
-              reinterpret_cast<const vec_t*>(&weights[newRemove[i] * Dimensions + tileOff]);
-            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = vec_sub_16(acc[k], column[k]);
-        }
-        for (int i = 0; i < newAdd.ssize(); ++i)
-        {
-            auto* column =
-              reinterpret_cast<const vec_t*>(&weights[newAdd[i] * Dimensions + tileOff]);
-            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = vec_add_16(acc[k], column[k]);
-        }
+        apply_psq_features<-1>(j, acc, newRemove, featureTransformer);
+        apply_psq_features<+1>(j, acc, newAdd, featureTransformer);
 
         for (IndexType k = 0; k < Tiling::NumRegs; ++k)
         {
@@ -717,54 +711,11 @@ void update_accumulator_hybrid(Color                     perspective,
         }
 
         // ... then we adjust
-        for (int i = 0; i < oldRemove.ssize(); ++i)
-        {
-            auto* column =
-              reinterpret_cast<const vec_t*>(&weights[oldRemove[i] * Dimensions + tileOff]);
-            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = vec_add_16(acc[k], column[k]);
-        }
-        for (int i = 0; i < oldAdd.ssize(); ++i)
-        {
-            auto* column =
-              reinterpret_cast<const vec_t*>(&weights[oldAdd[i] * Dimensions + tileOff]);
-            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = vec_sub_16(acc[k], column[k]);
-        }
+        apply_psq_features<+1>(j, acc, oldRemove, featureTransformer);
+        apply_psq_features<-1>(j, acc, oldAdd, featureTransformer);
 
-        for (int i = 0; i < thrRemoved.ssize(); ++i)
-        {
-            auto* column = reinterpret_cast<const vec_i8_t*>(
-              &threatAndPpWeights[thrRemoved[i] * Dimensions + tileOff]);
-
-    #ifdef USE_NEON
-            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
-            {
-                acc[k]     = vsubw_s8(acc[k], vget_low_s8(column[k / 2]));
-                acc[k + 1] = vsubw_high_s8(acc[k + 1], column[k / 2]);
-            }
-    #else
-            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = vec_sub_16(acc[k], vec_convert_8_16(column[k]));
-    #endif
-        }
-
-        for (int i = 0; i < thrAdded.ssize(); ++i)
-        {
-            auto* column = reinterpret_cast<const vec_i8_t*>(
-              &threatAndPpWeights[thrAdded[i] * Dimensions + tileOff]);
-
-    #ifdef USE_NEON
-            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
-            {
-                acc[k]     = vaddw_s8(acc[k], vget_low_s8(column[k / 2]));
-                acc[k + 1] = vaddw_high_s8(acc[k + 1], column[k / 2]);
-            }
-    #else
-            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = vec_add_16(acc[k], vec_convert_8_16(column[k]));
-    #endif
-        }
+        apply_threat_features<-1>(j, acc, thrRemoved, featureTransformer);
+        apply_threat_features<+1>(j, acc, thrAdded, featureTransformer);
 
         for (IndexType k = 0; k < Tiling::NumRegs; k++)
             vec_store(&toTile[k], acc[k]);
@@ -926,9 +877,6 @@ void update_accumulator_refresh_cache(Color                     perspective,
                                       const Position&           pos,
                                       AccumulatorState&         accumulator,
                                       AccumulatorCaches&        cache) {
-    constexpr auto Dimensions = FeatureTransformer::OutputDimensions;
-
-    using Tiling [[maybe_unused]] = SIMDTiling<Dimensions, Dimensions, PSQTBuckets>;
 
     const Square             ksq   = pos.square<KING>(perspective);
     auto&                    entry = cache[ksq][perspective];
@@ -967,9 +915,6 @@ void update_accumulator_refresh_cache(Color                     perspective,
     vec_t      acc[Tiling::NumRegs];
     psqt_vec_t psqt[Tiling::NumPsqtRegs];
 
-    const auto* weights            = &featureTransformer.weights[0];
-    const auto* threatAndPpWeights = &featureTransformer.threatAndPpWeights[0];
-
     for (IndexType j = 0; j < Dimensions / Tiling::TileHeight; ++j)
     {
         const usize tileOff = j * Tiling::TileHeight;
@@ -979,40 +924,13 @@ void update_accumulator_refresh_cache(Color                     perspective,
         for (IndexType k = 0; k < Tiling::NumRegs; ++k)
             acc[k] = entryTile[k];
 
-        for (int i = 0; i < removed.ssize(); ++i)
-        {
-            auto* column =
-              reinterpret_cast<const vec_t*>(&weights[removed[i] * Dimensions + tileOff]);
-            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = vec_sub_16(acc[k], column[k]);
-        }
-        for (int i = 0; i < added.ssize(); ++i)
-        {
-            auto* column =
-              reinterpret_cast<const vec_t*>(&weights[added[i] * Dimensions + tileOff]);
-            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = vec_add_16(acc[k], column[k]);
-        }
+        apply_psq_features<-1>(j, acc, removed, featureTransformer);
+        apply_psq_features<+1>(j, acc, added, featureTransformer);
 
         for (IndexType k = 0; k < Tiling::NumRegs; k++)
             vec_store(&entryTile[k], acc[k]);
 
-        for (int i = 0; i < active.ssize(); ++i)
-        {
-            auto* column = reinterpret_cast<const vec_i8_t*>(
-              &threatAndPpWeights[active[i] * Dimensions + tileOff]);
-
-    #ifdef USE_NEON
-            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
-            {
-                acc[k]     = vaddw_s8(acc[k], vget_low_s8(column[k / 2]));
-                acc[k + 1] = vaddw_high_s8(acc[k + 1], column[k / 2]);
-            }
-    #else
-            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = vec_add_16(acc[k], vec_convert_8_16(column[k]));
-    #endif
-        }
+        apply_threat_features<+1>(j, acc, active, featureTransformer);
 
         for (IndexType k = 0; k < Tiling::NumRegs; k++)
             vec_store(&accTile[k], acc[k]);

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -196,7 +196,8 @@ sf_always_inline inline void apply_psq_features(IndexType j,
     const usize tileOff    = j * Tiling::TileHeight;
     for (int i = 0; i < list.ssize(); ++i)
     {
-        auto* column = reinterpret_cast<const vec_t*>(&ft.weights[list[i] * Dimensions + tileOff]);
+        auto* column = reinterpret_cast<const vec_t*>(
+            &ft.weights[list[i] * Dimensions + tileOff]);
         for (IndexType k = 0; k < Tiling::NumRegs; ++k)
             if constexpr (sign == +1)
                 acc[k] = vec_add_16(acc[k], column[k]);
@@ -207,7 +208,7 @@ sf_always_inline inline void apply_psq_features(IndexType j,
 
 template<int sign>
 sf_always_inline inline void apply_threat_features(IndexType j,
-                                                   vec_t acc[],
+                                                   vec_t acc[Tiling::NumRegs],
                                                    const ThreatFeatureSet::IndexList& list,
                                                    const FeatureTransformer& ft) {
     static_assert(sign == 1 || sign == -1);
@@ -215,7 +216,8 @@ sf_always_inline inline void apply_threat_features(IndexType j,
     const usize tileOff    = j * Tiling::TileHeight;
     for (int i = 0; i < list.ssize(); ++i)
     {
-        auto* column = reinterpret_cast<const vec_i8_t*>(&ft.threatAndPpWeights[list[i] * Dimensions + tileOff]);
+        auto* column = reinterpret_cast<const vec_i8_t*>(
+            &ft.threatAndPpWeights[list[i] * Dimensions + tileOff]);
 #ifdef USE_NEON
         for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
         {
@@ -237,6 +239,26 @@ sf_always_inline inline void apply_threat_features(IndexType j,
             else
                 acc[k] = vec_sub_16(acc[k], vec_convert_8_16(column[k]));
 #endif
+    }
+}
+
+template<int sign, usize MaxLen, typename IdxType>
+sf_always_inline inline void apply_psqt(IndexType j,
+                                        psqt_vec_t psqt[Tiling::NumPsqtRegs],
+                                        const ValueList<IdxType, MaxLen>& list,
+                                        const PSQTWeightType* weights) {
+    static_assert(sign == 1 || sign == -1);
+
+    const usize psqtTileOff    = j * Tiling::PsqtTileHeight;
+    for (int i = 0; i < list.ssize(); ++i)
+    {
+        auto* column = reinterpret_cast<const psqt_vec_t*>(
+            &weights[list[i] * PSQTBuckets + psqtTileOff]);
+        for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
+            if constexpr (sign == +1)
+                psqt[k] = vec_add_psqt_32(psqt[k], column[k]);
+            else
+                psqt[k] = vec_sub_psqt_32(psqt[k], column[k]);
     }
 }
 
@@ -290,38 +312,11 @@ void apply_combined(Color                              perspective,
         for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
             psqt[k] = fromTilePsqt[k];
 
-        for (int i = 0; i < psqRemoved.ssize(); ++i)
-        {
-            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer.psqtWeights[psqRemoved[i] * PSQTBuckets + psqtTileOff]);
-            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
-        }
+        apply_psqt<-1>(j, psqt, psqRemoved, featureTransformer.psqtWeights.data());
+        apply_psqt<+1>(j, psqt, psqAdded, featureTransformer.psqtWeights.data());
 
-        for (int i = 0; i < psqAdded.ssize(); ++i)
-        {
-            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer.psqtWeights[psqAdded[i] * PSQTBuckets + psqtTileOff]);
-            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
-        }
-
-        for (int i = 0; i < thrRemoved.ssize(); ++i)
-        {
-            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer
-                 .threatAndPpPsqtWeights[thrRemoved[i] * PSQTBuckets + psqtTileOff]);
-            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
-        }
-
-        for (int i = 0; i < thrAdded.ssize(); ++i)
-        {
-            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer.threatAndPpPsqtWeights[thrAdded[i] * PSQTBuckets + psqtTileOff]);
-            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
-        }
+        apply_psqt<-1>(j, psqt, thrRemoved, featureTransformer.threatAndPpPsqtWeights.data());
+        apply_psqt<+1>(j, psqt, thrAdded, featureTransformer.threatAndPpPsqtWeights.data());
 
         for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
             vec_store_psqt(&toTilePsqt[k], psqt[k]);
@@ -471,8 +466,8 @@ void update_accumulator_incremental(Color                     perspective,
         PSQFeatureSet::append_changed_indices(perspective, ksq, dirtyPiece, psqAdded, psqRemoved);
     }
 
-    apply_combined(perspective, featureTransformer, computed, target_state, psqAdded, psqRemoved,
-                   thrAdded, thrRemoved);
+    apply_combined(perspective, featureTransformer, computed, target_state, psqAdded,
+                   psqRemoved, thrAdded, thrRemoved);
 
     target_state.computed[perspective] = true;
 }
@@ -734,20 +729,8 @@ void update_accumulator_hybrid(Color                     perspective,
         for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
             psqt[k] = newEntryTilePsqt[k];
 
-        for (int i = 0; i < newRemove.ssize(); ++i)
-        {
-            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer.psqtWeights[newRemove[i] * PSQTBuckets + psqtTileOff]);
-            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
-        }
-        for (int i = 0; i < newAdd.ssize(); ++i)
-        {
-            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer.psqtWeights[newAdd[i] * PSQTBuckets + psqtTileOff]);
-            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
-        }
+        apply_psqt<-1>(j, psqt, newRemove, featureTransformer.psqtWeights.data());
+        apply_psqt<+1>(j, psqt, newAdd, featureTransformer.psqtWeights.data());
 
         for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
         {
@@ -756,37 +739,11 @@ void update_accumulator_hybrid(Color                     perspective,
             psqt[k] = vec_sub_psqt_32(psqt[k], oldEntryTilePsqt[k]);
         }
 
-        for (int i = 0; i < oldRemove.ssize(); ++i)
-        {
-            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer.psqtWeights[oldRemove[i] * PSQTBuckets + psqtTileOff]);
-            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
-        }
-        for (int i = 0; i < oldAdd.ssize(); ++i)
-        {
-            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer.psqtWeights[oldAdd[i] * PSQTBuckets + psqtTileOff]);
-            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
-        }
+        apply_psqt<+1>(j, psqt, oldRemove, featureTransformer.psqtWeights.data());
+        apply_psqt<-1>(j, psqt, oldAdd, featureTransformer.psqtWeights.data());
 
-        for (int i = 0; i < thrRemoved.ssize(); ++i)
-        {
-            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer
-                 .threatAndPpPsqtWeights[thrRemoved[i] * PSQTBuckets + psqtTileOff]);
-            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
-        }
-
-        for (int i = 0; i < thrAdded.ssize(); ++i)
-        {
-            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer.threatAndPpPsqtWeights[thrAdded[i] * PSQTBuckets + psqtTileOff]);
-            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
-        }
+        apply_psqt<-1>(j, psqt, thrRemoved, featureTransformer.threatAndPpPsqtWeights.data());
+        apply_psqt<+1>(j, psqt, thrAdded, featureTransformer.threatAndPpPsqtWeights.data());
 
         for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
             vec_store_psqt(&toTilePsqt[k], psqt[k]);
@@ -946,31 +903,13 @@ void update_accumulator_refresh_cache(Color                     perspective,
         for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
             psqt[k] = entryTilePsqt[k];
 
-        for (int i = 0; i < removed.ssize(); ++i)
-        {
-            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer.psqtWeights[removed[i] * PSQTBuckets + psqtTileOff]);
-            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
-        }
-        for (int i = 0; i < added.ssize(); ++i)
-        {
-            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer.psqtWeights[added[i] * PSQTBuckets + psqtTileOff]);
-            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
-        }
+        apply_psqt<-1>(j, psqt, removed, featureTransformer.psqtWeights.data());
+        apply_psqt<+1>(j, psqt, added, featureTransformer.psqtWeights.data());
 
         for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
             vec_store_psqt(&entryTilePsqt[k], psqt[k]);
 
-        for (int i = 0; i < active.ssize(); ++i)
-        {
-            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer.threatAndPpPsqtWeights[active[i] * PSQTBuckets + psqtTileOff]);
-            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
-        }
+        apply_psqt<+1>(j, psqt, active, featureTransformer.threatAndPpPsqtWeights.data());
 
         for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
             vec_store_psqt(&accTilePsqt[k], psqt[k]);

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -182,7 +182,7 @@ namespace {
 
 constexpr IndexType Dimensions = FeatureTransformer::OutputDimensions;
 
-#ifdef VECTOR
+#ifndef USE_RVV
 
 using Tiling = SIMDTiling<Dimensions, Dimensions, PSQTBuckets>;
 
@@ -279,7 +279,7 @@ void apply_combined(Color                              perspective,
     const auto& fromPsqtAcc = from.psqtAccumulation[perspective];
     auto&       toPsqtAcc   = to.psqtAccumulation[perspective];
 
-#ifdef VECTOR
+#ifndef USE_RVV
 
     vec_t      acc[Tiling::NumRegs];
     psqt_vec_t psqt[Tiling::NumPsqtRegs];
@@ -322,7 +322,7 @@ void apply_combined(Color                              perspective,
             vec_store_psqt(&toTilePsqt[k], psqt[k]);
     }
 
-#elif defined(USE_RVV)
+#else
 
     usize tileOffset = 0;
 
@@ -378,47 +378,6 @@ void apply_combined(Color                              perspective,
         __riscv_vse32_v_i32m1(&toPsqtAcc[tileOffset], accum, vl);
 
         tileOffset += vl;
-    }
-
-#else
-
-    toAcc     = fromAcc;
-    toPsqtAcc = fromPsqtAcc;
-
-    for (const auto index : psqRemoved)
-    {
-        const IndexType offset = Dimensions * index;
-        for (IndexType j = 0; j < Dimensions; ++j)
-            toAcc[j] -= featureTransformer.weights[offset + j];
-        for (usize k = 0; k < PSQTBuckets; ++k)
-            toPsqtAcc[k] -= featureTransformer.psqtWeights[index * PSQTBuckets + k];
-    }
-
-    for (const auto index : psqAdded)
-    {
-        const IndexType offset = Dimensions * index;
-        for (IndexType j = 0; j < Dimensions; ++j)
-            toAcc[j] += featureTransformer.weights[offset + j];
-        for (usize k = 0; k < PSQTBuckets; ++k)
-            toPsqtAcc[k] += featureTransformer.psqtWeights[index * PSQTBuckets + k];
-    }
-
-    for (const auto index : thrRemoved)
-    {
-        const IndexType offset = Dimensions * index;
-        for (IndexType j = 0; j < Dimensions; ++j)
-            toAcc[j] -= featureTransformer.threatAndPpWeights[offset + j];
-        for (usize k = 0; k < PSQTBuckets; ++k)
-            toPsqtAcc[k] -= featureTransformer.threatAndPpPsqtWeights[index * PSQTBuckets + k];
-    }
-
-    for (const auto index : thrAdded)
-    {
-        const IndexType offset = Dimensions * index;
-        for (IndexType j = 0; j < Dimensions; ++j)
-            toAcc[j] += featureTransformer.threatAndPpWeights[offset + j];
-        for (usize k = 0; k < PSQTBuckets; ++k)
-            toPsqtAcc[k] += featureTransformer.threatAndPpPsqtWeights[index * PSQTBuckets + k];
     }
 
 #endif
@@ -676,7 +635,7 @@ void update_accumulator_hybrid(Color                     perspective,
     const auto& fromPsqtAcc = computed.psqtAccumulation[perspective];
     auto&       toPsqtAcc   = target.psqtAccumulation[perspective];
 
-#ifdef VECTOR
+#ifndef USE_RVV
     vec_t      acc[Tiling::NumRegs];
     psqt_vec_t psqt[Tiling::NumPsqtRegs];
 
@@ -748,77 +707,8 @@ void update_accumulator_hybrid(Color                     perspective,
         for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
             vec_store_psqt(&toTilePsqt[k], psqt[k]);
     }
-
 #else
-    for (const auto index : newRemove)
-    {
-        const IndexType offset = Dimensions * index;
-        for (IndexType j = 0; j < Dimensions; ++j)
-            newEntry.accumulation[j] -= featureTransformer.weights[offset + j];
-
-        for (usize k = 0; k < PSQTBuckets; ++k)
-            newEntry.psqtAccumulation[k] -= featureTransformer.psqtWeights[index * PSQTBuckets + k];
-    }
-    for (const auto index : newAdd)
-    {
-        const IndexType offset = Dimensions * index;
-        for (IndexType j = 0; j < Dimensions; ++j)
-            newEntry.accumulation[j] += featureTransformer.weights[offset + j];
-
-        for (usize k = 0; k < PSQTBuckets; ++k)
-            newEntry.psqtAccumulation[k] += featureTransformer.psqtWeights[index * PSQTBuckets + k];
-    }
-
-    toAcc     = newEntry.accumulation;
-    toPsqtAcc = newEntry.psqtAccumulation;
-
-    for (IndexType j = 0; j < Dimensions; ++j)
-    {
-        toAcc[j] += fromAcc[j];
-        toAcc[j] -= oldEntry.accumulation[j];
-    }
-    for (usize k = 0; k < PSQTBuckets; ++k)
-    {
-        toPsqtAcc[k] += fromPsqtAcc[k];
-        toPsqtAcc[k] -= oldEntry.psqtAccumulation[k];
-    }
-
-    for (const auto index : oldRemove)
-    {
-        const IndexType offset = Dimensions * index;
-        for (IndexType j = 0; j < Dimensions; ++j)
-            toAcc[j] += featureTransformer.weights[offset + j];
-
-        for (usize k = 0; k < PSQTBuckets; ++k)
-            toPsqtAcc[k] += featureTransformer.psqtWeights[index * PSQTBuckets + k];
-    }
-    for (const auto index : oldAdd)
-    {
-        const IndexType offset = Dimensions * index;
-        for (IndexType j = 0; j < Dimensions; ++j)
-            toAcc[j] -= featureTransformer.weights[offset + j];
-
-        for (usize k = 0; k < PSQTBuckets; ++k)
-            toPsqtAcc[k] -= featureTransformer.psqtWeights[index * PSQTBuckets + k];
-    }
-
-    for (const auto index : thrRemoved)
-    {
-        const IndexType offset = Dimensions * index;
-        for (IndexType j = 0; j < Dimensions; ++j)
-            toAcc[j] -= featureTransformer.threatAndPpWeights[offset + j];
-        for (usize k = 0; k < PSQTBuckets; ++k)
-            toPsqtAcc[k] -= featureTransformer.threatAndPpPsqtWeights[index * PSQTBuckets + k];
-    }
-    for (const auto index : thrAdded)
-    {
-        const IndexType offset = Dimensions * index;
-        for (IndexType j = 0; j < Dimensions; ++j)
-            toAcc[j] += featureTransformer.threatAndPpWeights[offset + j];
-        for (usize k = 0; k < PSQTBuckets; ++k)
-            toPsqtAcc[k] += featureTransformer.threatAndPpPsqtWeights[index * PSQTBuckets + k];
-    }
-
+// TODO
 #endif
 
     newEntry.pieces  = currentPieces;
@@ -868,7 +758,7 @@ void update_accumulator_refresh_cache(Color                     perspective,
 
     accumulator.computed[perspective] = true;
 
-#ifdef VECTOR
+#ifndef USE_RVV
     vec_t      acc[Tiling::NumRegs];
     psqt_vec_t psqt[Tiling::NumPsqtRegs];
 
@@ -915,7 +805,7 @@ void update_accumulator_refresh_cache(Color                     perspective,
             vec_store_psqt(&accTilePsqt[k], psqt[k]);
     }
 
-#elif defined(USE_RVV)
+#else
 
     const auto* weights           = &featureTransformer.weights[0];
     const auto* threatWeights     = &featureTransformer.threatAndPpWeights[0];
@@ -972,46 +862,6 @@ void update_accumulator_refresh_cache(Color                     perspective,
 
         tileOffset += vl;
     }
-
-#else
-
-    for (const auto index : removed)
-    {
-        const IndexType offset = Dimensions * index;
-        for (IndexType j = 0; j < Dimensions; ++j)
-            entry.accumulation[j] -= featureTransformer.weights[offset + j];
-
-        for (usize k = 0; k < PSQTBuckets; ++k)
-            entry.psqtAccumulation[k] -= featureTransformer.psqtWeights[index * PSQTBuckets + k];
-    }
-    for (const auto index : added)
-    {
-        const IndexType offset = Dimensions * index;
-        for (IndexType j = 0; j < Dimensions; ++j)
-            entry.accumulation[j] += featureTransformer.weights[offset + j];
-
-        for (usize k = 0; k < PSQTBuckets; ++k)
-            entry.psqtAccumulation[k] += featureTransformer.psqtWeights[index * PSQTBuckets + k];
-    }
-
-    // The accumulator of the refresh entry has been updated.
-    // Now copy its content to the actual accumulator we were refreshing.
-    accumulator.accumulation[perspective]     = entry.accumulation;
-    accumulator.psqtAccumulation[perspective] = entry.psqtAccumulation;
-
-    for (const auto index : active)
-    {
-        const IndexType offset = Dimensions * index;
-
-        for (IndexType j = 0; j < Dimensions; ++j)
-            accumulator.accumulation[perspective][j] +=
-              featureTransformer.threatAndPpWeights[offset + j];
-
-        for (usize k = 0; k < PSQTBuckets; ++k)
-            accumulator.psqtAccumulation[perspective][k] +=
-              featureTransformer.threatAndPpPsqtWeights[index * PSQTBuckets + k];
-    }
-
 #endif
 }
 

--- a/src/nnue/simd.h
+++ b/src/nnue/simd.h
@@ -340,6 +340,17 @@ inline __m128i vec_convert_8_16(u64 x) {
     #define MaxChunkSize 16
 
 #else
+using vec_t      = WeightType;
+using vec_i8_t   = ThreatWeightType;
+using psqt_vec_t = PSQTWeightType;
+    #define vec_store(a, b) *(a) = (b)
+    #define vec_convert_8_16(a) static_cast<vec_t>(a)
+    #define vec_add_16(a, b) ((a) + (b))
+    #define vec_sub_16(a, b) ((a) - (b))
+    #define vec_store_psqt(a, b) *(a) = (b)
+    #define vec_add_psqt_32(a, b) ((a) + (b))
+    #define vec_sub_psqt_32(a, b) ((a) - (b))
+
     #undef VECTOR
 
 #endif
@@ -523,12 +534,16 @@ class SIMDTiling {
     static constexpr int NumPsqtRegs =
       BestRegisterCount<psqt_vec_t, PSQTWeightType, PSQTBuckets, NumRegistersSIMD>();
 
-    static constexpr IndexType TileHeight     = NumRegs * sizeof(vec_t) / 2;
-    static constexpr IndexType PsqtTileHeight = NumPsqtRegs * sizeof(psqt_vec_t) / 4;
+#else
+   public:
+    static constexpr int       NumRegs       = HalfDimensions;
+    static constexpr int       NumPsqtRegs   = PSQTBuckets;
+#endif
+    static constexpr IndexType TileHeight     = NumRegs * sizeof(vec_t) / sizeof(WeightType);
+    static constexpr IndexType PsqtTileHeight = NumPsqtRegs * sizeof(psqt_vec_t) / sizeof(PSQTWeightType);
 
     static_assert(HalfDimensions % TileHeight == 0, "TileHeight must divide HalfDimensions");
     static_assert(PSQTBuckets % PsqtTileHeight == 0, "PsqtTileHeight must divide PSQTBuckets");
-#endif
 };
 
 }


### PR DESCRIPTION
this is a PR on top of #7013.
This might be a slight slowdown for binaries without vectorization. E.g. x86-32 running on Redwood Cove:
```
Result of 80 runs (counting nodes/1B cycles)
=============================================
base (...ckfish.mmx.orig) =   37369 +/- 1136
test (...sh.mmx.tile1024) =   37039 +/- 1109
speedup %                 =   -0.85 +/- 0.08
                             [95% CI; t-test]

likelihood(speedup > 0)   =  0.0000

CPU: 16 x Intel(R) Core(TM) Ultra 9 185H
```
Should result in exactly the same code after pre-processing for any uarch that has `defined(VECTOR) || defined(USE_RVV)`. 

No functional change