### PR TITLE
Simplify futilityValue formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1198,8 +1198,8 @@ moves_loop:  // When in check, search starts here
                 // (*Scaler): Generally, lower divisors scale well
                 lmrDepth += history / lmrDivisor[dIndex];
 
-                Value futilityValue = ss->staticEval + 39 + 127 * !bestMove + 119 * lmrDepth
-                                    + 90 * (ss->staticEval > alpha);
+                Value futilityValue = ss->staticEval + 119 * lmrDepth
+                                    + 90 * (ss->staticEval > alpha) + 164;
 
                 // Futility pruning: parent node
                 // (*Scaler): Generally, more frequent futility pruning


### PR DESCRIPTION
Simplify futilityValue formula

Passed STC non-reg:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 51616 W: 13479 L: 13279 D: 24858
Ptnml(0-2): 134, 5897, 13530, 6129, 118
https://tests.stockfishchess.org/tests/view/6a6524b7c054e285ae028b92

Passed LTC non-reg:
LLR: 2.97 (-2.94,2.94) <-1.75,0.25>
Total: 400380 W: 103781 L: 103944 D: 192655
Ptnml(0-2): 178, 43099, 113790, 42954, 169
https://tests.stockfishchess.org/tests/view/6a6673d4c054e285ae028d93

bench: 2829394