### PR TITLE
Simplify USE_PAIR_ACTIVATIONS / SqrClippedReLU::propagate_pair()

### DIFF
--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -122,7 +122,7 @@ affine_transform_non_ssse3(i32* output, const i8* weights, const i32* biases, co
 
 #endif  // !ENABLE_SEQ_OPT
 
-template<IndexType InDims, IndexType OutDims, bool ScrambledInput = false>
+template<IndexType InDims, IndexType OutDims>
 class AffineTransform {
    public:
     // Input/output type
@@ -152,18 +152,18 @@ class AffineTransform {
     static constexpr IndexType get_weight_index_scrambled(IndexType i) {
         IndexType inputIndex = i % PaddedInputDimensions;
 
-#if defined(USE_SCRAMBLED_ACTIVATIONS)
-        if constexpr (ScrambledInput)
-        {
-            // AVX2 and LASX packs operate independently on 128-bit lanes. Keep their interleaved
-            // output order and rearrange the following layer's weights instead of issuing a
-            // runtime permutation.
-            const IndexType block = inputIndex / 32;
-            const IndexType chunk = (inputIndex % 32) / 4;
-            inputIndex            = block * 32 + ((chunk % 2) * 4 + chunk / 2) * 4 + inputIndex % 4;
-        }
+#if defined(USE_PAIR_ACTIVATIONS) || defined(USE_LASX)
+        // At load time, pre-permute the weights to match the per-128-bit-lane interleaving that
+        // the previous layer produces, either via SqrClippedReLU::propagate_pair() or via the
+        // separate SqrClippedReLU/ClippedReLU propagate() calls, so no shuffle is needed at runtime.
+        const IndexType block = inputIndex / 32;
+        const IndexType chunk = (inputIndex % 32) / 4;
+    #if defined(USE_AVX512)
+        inputIndex = block * 32 + ((chunk % 4) * 2 + chunk / 4) * 4 + inputIndex % 4;
+    #else
+        inputIndex = block * 32 + ((chunk % 2) * 4 + chunk / 2) * 4 + inputIndex % 4;
+    #endif
 #endif
-
         return inputIndex / 4 * OutputDimensions * 4 + i / PaddedInputDimensions * 4
              + inputIndex % 4;
     }

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -66,9 +66,9 @@ class ClippedReLU {
         return h;
     }
 
+#if !defined(USE_PAIR_ACTIVATIONS)
     // Forward propagation
     void propagate(const InputType* input, OutputType* output) const {
-
 
 #if defined(USE_SSE2)
         constexpr IndexType NumChunks = InputDimensions / 16;
@@ -170,6 +170,7 @@ class ClippedReLU {
               static_cast<OutputType>(std::clamp(input[i] >> WeightScaleBitsLocal, 0, 127));
         }
     }
+#endif
 };
 
 }  // namespace Stockfish::Eval::NNUE::Layers

--- a/src/nnue/layers/sqr_clipped_relu.h
+++ b/src/nnue/layers/sqr_clipped_relu.h
@@ -68,12 +68,15 @@ class SqrClippedReLU {
     }
 
 #if defined(USE_PAIR_ACTIVATIONS)
-    // Produce the squared and linear clipped activations together, sharing the input loads and
-    // the initial signed 32-to-16-bit saturating narrowing.
+    // Produce the squared and linear clipped activations together, sharing the input loads and 
+    // the initial signed 32-to-16-bit saturating narrowing. No shuffle is needed to fix up the
+    // pack lane order because the next layer's weights were already reverse pre-permuted to match
+    // by AffineTransform::get_weight_index_scrambled().
     void propagate_pair(const InputType* input, OutputType* squared, OutputType* clipped) const {
         static_assert(WeightScaleBitsLocal >= 5 && WeightScaleBitsLocal <= 8,
                       "SqrClippedReLU only support WeightScaleBitsLocal between 5 and 8");
-        static_assert(InputDimensions % 32 == 0);
+        static_assert(InputDimensions % 32 == 0,
+                      "propagate_pair() needs a tail path if L2/L3 change to multiple of 16");
 
         constexpr IndexType NumChunks       = InputDimensions / 32;
         constexpr int       SimdShiftAmount = WeightScaleBitsLocal * 2 + 7 - 16;
@@ -87,10 +90,8 @@ class SqrClippedReLU {
 
         for (IndexType i = 0; i < NumChunks; ++i)
         {
-            const __m256i words0 = _mm512_cvtsepi32_epi16(_mm512_load_si512(&in[i * 2 + 0]));
-            const __m256i words1 = _mm512_cvtsepi32_epi16(_mm512_load_si512(&in[i * 2 + 1]));
-            const __m512i words  = _mm512_inserti64x4(_mm512_castsi256_si512(words0), words1, 1);
-
+            const __m512i words = _mm512_packs_epi32(_mm512_load_si512(&in[i * 2 + 0]),
+                                                     _mm512_load_si512(&in[i * 2 + 1]));
             const __m512i sqrWords =
               _mm512_srli_epi16(_mm512_mulhi_epi16(words, words), SimdShiftAmount);
             _mm256_store_si256(&sqrOut[i], _mm512_cvtsepi16_epi8(sqrWords));
@@ -100,7 +101,7 @@ class SqrClippedReLU {
             _mm256_store_si256(&clipOut[i], _mm512_cvtsepi16_epi8(clipWords));
         }
 
-    #elif defined(USE_AVX2_PAIR_ACTIVATIONS)
+    #elif defined(USE_AVX2)
         const auto in      = reinterpret_cast<const __m256i*>(input);
         auto       sqrOut  = reinterpret_cast<__m256i*>(squared);
         auto       clipOut = reinterpret_cast<__m256i*>(clipped);
@@ -128,10 +129,13 @@ class SqrClippedReLU {
             const __m256i clipPacked = _mm256_packs_epi16(clip0, clip1);
             _mm256_store_si256(&clipOut[i], clipPacked);
         }
+    #else
+        #error "propagate_pair() requires AVX2 or AVX512"
     #endif
     }
 #endif
 
+#if !defined(USE_PAIR_ACTIVATIONS)
     // Forward propagation
     void propagate(const InputType* input, OutputType* output) const {
         static_assert(WeightScaleBitsLocal >= 5 && WeightScaleBitsLocal <= 8,
@@ -140,24 +144,7 @@ class SqrClippedReLU {
         // MulHi strips the lower 16 bits (i.e. shift by 16) so we need to shift out the remaining.
         [[maybe_unused]] constexpr int SimdShiftAmount = WeightScaleBitsLocal * 2 + 7 - 16;
 
-#if defined(USE_AVX512)
-        static_assert(InputDimensions % 32 == 0);
-        constexpr IndexType NumChunks = InputDimensions / 32;
-        const auto          in        = reinterpret_cast<const __m512i*>(input);
-        const auto          out       = reinterpret_cast<__m256i*>(output);
-        for (IndexType i = 0; i < NumChunks; ++i)
-        {
-            const __m256i words0 = _mm512_cvtsepi32_epi16(_mm512_load_si512(&in[i * 2 + 0]));
-            const __m256i words1 = _mm512_cvtsepi32_epi16(_mm512_load_si512(&in[i * 2 + 1]));
-            __m512i       words  = _mm512_inserti64x4(_mm512_castsi256_si512(words0), words1, 1);
-
-            words = _mm512_srli_epi16(_mm512_mulhi_epi16(words, words), SimdShiftAmount);
-
-            _mm256_store_si256(&out[i], _mm512_cvtsepi16_epi8(words));
-        }
-        constexpr IndexType Start = NumChunks * 32;
-
-#elif defined(USE_SSE2)
+#if defined(USE_SSE2)
         constexpr IndexType NumChunks = InputDimensions / 16;
         const auto          in        = reinterpret_cast<const __m128i*>(input);
         const auto          out       = reinterpret_cast<__m128i*>(output);
@@ -252,6 +239,7 @@ class SqrClippedReLU {
                        ((long long) (input[i]) * input[i]) >> (2 * WeightScaleBitsLocal + 7)));
         }
     }
+#endif
 };
 
 }  // namespace Stockfish::Eval::NNUE::Layers

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -59,19 +59,14 @@ struct NetworkArchitecture {
     static constexpr IndexType TransformedFeatureDimensions = L1;
     static constexpr int       FC_0_OUTPUTS                 = L2;
     static constexpr int       FC_1_OUTPUTS                 = L3;
-#if defined(USE_SCRAMBLED_ACTIVATIONS)
-    static constexpr bool ScrambledInput = true;
-#else
-    static constexpr bool ScrambledInput = false;
-#endif
 
-    Layers::AffineTransformSparseInput<TransformedFeatureDimensions, FC_0_OUTPUTS>  fc_0;
-    Layers::SqrClippedReLU<FC_0_OUTPUTS, WeightScaleBits + 1>                       ac_sqr_0;
-    Layers::ClippedReLU<FC_0_OUTPUTS, WeightScaleBits + 1>                          ac_0;
-    Layers::AffineTransform<FC_0_OUTPUTS * 2, FC_1_OUTPUTS, ScrambledInput>         fc_1;
-    Layers::SqrClippedReLU<FC_1_OUTPUTS, WeightScaleBits>                           ac_sqr_1;
-    Layers::ClippedReLU<FC_1_OUTPUTS, WeightScaleBits>                              ac_1;
-    Layers::AffineTransform<FC_0_OUTPUTS * 2 + FC_1_OUTPUTS * 2, 1, ScrambledInput> fc_2;
+    Layers::AffineTransformSparseInput<TransformedFeatureDimensions, FC_0_OUTPUTS> fc_0;
+    Layers::SqrClippedReLU<FC_0_OUTPUTS, WeightScaleBits + 1>                      ac_sqr_0;
+    Layers::ClippedReLU<FC_0_OUTPUTS, WeightScaleBits + 1>                         ac_0;
+    Layers::AffineTransform<FC_0_OUTPUTS * 2, FC_1_OUTPUTS>                        fc_1;
+    Layers::SqrClippedReLU<FC_1_OUTPUTS, WeightScaleBits>                          ac_sqr_1;
+    Layers::ClippedReLU<FC_1_OUTPUTS, WeightScaleBits>                             ac_1;
+    Layers::AffineTransform<FC_0_OUTPUTS * 2 + FC_1_OUTPUTS * 2, 1>                fc_2;
 
     // Hash value embedded in the evaluation file
     static constexpr u32 get_hash_value() {

--- a/src/nnue/simd.h
+++ b/src/nnue/simd.h
@@ -51,16 +51,8 @@
 
 namespace Stockfish::Eval::NNUE::SIMD {
 
-#if defined(USE_AVX2) && !defined(USE_VNNI) && !defined(USE_AVX512)
-    #define USE_AVX2_PAIR_ACTIVATIONS
-#endif
-
-#if defined(USE_AVX512) || defined(USE_AVX2_PAIR_ACTIVATIONS)
+#if defined(USE_AVX2)
     #define USE_PAIR_ACTIVATIONS
-#endif
-
-#if defined(USE_AVX2_PAIR_ACTIVATIONS) || defined(USE_LASX)
-    #define USE_SCRAMBLED_ACTIVATIONS
 #endif
 
 // If vector instructions are enabled, we update and refresh the


### PR DESCRIPTION
STC https://tests.stockfishchess.org/tests/view/6a66bbd3c054e285ae028e0d
LLR: 3.19 (-2.94,2.94) <-1.75,0.25>
Total: 733184 W: 189246 L: 189739 D: 354199
Ptnml(0-2): 1721, 77704, 208246, 77189, 1732 

No functional change
bench: 2829394

Besides the cleanups,  AVX512 now does the correct permutations at load time instead of using the AVX2 ones and then having to permute again at run time.  AVXVNNI now also uses propagate_pair() (just like AVX2) which for some unknown reason it wasn't before.  An argument could be made for keeping the AVX512 version of SqrClippedReLU::propagate() if we think it may be useful again in the future?