### PR TITLE
Remove an incorrect AVX512 comment

### DIFF
--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -314,8 +314,6 @@ class AffineTransform {
         }
         else if constexpr (OutputDimensions == 1)
         {
-    // We cannot use AVX512 for the last layer because there are only 32 inputs
-    // and the buffer is not padded to 64 elements.
     #if defined(USE_AVX2)
             using vec_t = __m256i;
         #define vec_setzero() _mm256_setzero_si256()


### PR DESCRIPTION
I don't know if this used to be true but it's not now.  I would have preferred to add the AVX512 version since we usually care more about modern versions than old ones like USE_SSSE3 which this has but it didn't pass as an elo gainer.
https://tests.stockfishchess.org/tests/view/6a631032c054e285ae0286e0

No functional change
bench: 2829394