### PR TITLE
Prefetch continuation correction histories

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -638,11 +638,22 @@ void Search::Worker::do_move(Position& pos, const Move move, StateInfo& st, Stac
 
 void Search::Worker::do_move(
   Position& pos, const Move move, StateInfo& st, const bool givesCheck, Stack* const ss) {
-    // prefetch_key does not model castling, en passant or promotion keys
-    // exactly; for rare moves the prefetch lands on an unused line.
+    // prefetch_key does not model castling, en passant or promotion exactly.
+    // The correction-history prefetches also approximate castling and promotion;
+    // for these rare moves the prefetches land on unused lines.
     prefetch(tt.first_entry(pos.prefetch_key(move)));
 
     bool capture = pos.capture_stage(move);
+
+    if (ss != nullptr)
+    {
+        const Piece  pc = pos.moved_piece(move);
+        const Square to = move.to_sq();
+
+        prefetch(&(*(ss - 1)->continuationCorrectionHistory)[pc][to]);
+        prefetch(&(*(ss - 3)->continuationCorrectionHistory)[pc][to]);
+    }
+
     ++nodes;
 
     Dirties& dirties = accumulatorStack.push();


### PR DESCRIPTION
Prefetch the two continuation-correction history entries read by the child before updating the position, hiding part of their latency. The prefetched addresses exactly match the later reads for normal moves; castling and promotions may issue a harmless approximate prefetch.

No functional change.

Passed STC:
https://tests.stockfishchess.org/tests/view/6a6c4b56c054e285ae0298ee

LLR: 3.35 (-2.94,2.94) <0.00,2.00>
Total: 480448 W: 124828 L: 123878 D: 231742
Ptnml(0-2): 1147, 51094, 134829, 51970, 1184

Architecture spot checks were positive on Graviton 3 (about 1.0% lower elapsed time) and Zen 3 AVX2 (about 0.5% lower), and neutral on Ice Lake AVX-512 (about +0.03% elapsed time). A fresh Graviton 3 bench after rebasing on current master reproduced about 1.0% lower elapsed time with identical nodes.

Bench: 2829394