### PR TITLE
Class Default Member Initializers for Option

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -88,24 +88,18 @@ usize OptionsMap::count(const std::string& name) const { return options_map.coun
 
 Option::Option(const char* v, OnChange f) :
     type("string"),
-    min(0),
-    max(0),
     on_change(std::move(f)) {
     defaultValue = currentValue = v;
 }
 
 Option::Option(bool v, OnChange f) :
     type("check"),
-    min(0),
-    max(0),
     on_change(std::move(f)) {
     defaultValue = currentValue = (v ? "true" : "false");
 }
 
 Option::Option(OnChange f) :
     type("button"),
-    min(0),
-    max(0),
     on_change(std::move(f)) {}
 
 Option::Option(int v, int minv, int maxv, OnChange f) :
@@ -118,8 +112,6 @@ Option::Option(int v, int minv, int maxv, OnChange f) :
 
 Option::Option(const char* v, const char* cur, OnChange f) :
     type("combo"),
-    min(0),
-    max(0),
     on_change(std::move(f)) {
     defaultValue = v;
     currentValue = cur;

--- a/src/ucioption.h
+++ b/src/ucioption.h
@@ -63,8 +63,8 @@ class Option {
 
 
     std::string       defaultValue, currentValue, type;
-    int               min, max;
-    usize             idx;
+    int               min = 0, max = 0;
+    usize             idx = 0;
     OnChange          on_change;
     const OptionsMap* parent = nullptr;
 };


### PR DESCRIPTION
The Option class in ucioption.h contains several members (min, max, idx) that are initialized to 0 in initializer lists across multiple constructors in ucioption.cpp. Moving these default values directly into member declarations inside ucioption.h eliminates redundant constructor initializer list entries.

No functional change