### PR TITLE
Fix shared memory recovery across platforms

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -396,6 +396,14 @@ jobs:
 
       # Other tests
 
+      - name: Test Unix shared memory
+        if: runner.os != 'Windows' && matrix.config.run_64bit_tests
+        run: bash ../tests/shm_unix.sh
+
+      - name: Test Windows shared memory
+        if: runner.os == 'Windows' && matrix.config.run_64bit_tests
+        run: bash ../tests/shm_windows.sh
+
       - name: Check perft and search reproducibility
         if: matrix.config.run_64bit_tests
         run: |

--- a/src/shm.h
+++ b/src/shm.h
@@ -335,7 +335,9 @@ class SharedMemoryBackend {
         }
 
         DWORD wait_result = WaitForSingleObject(hMutex, INFINITE);
-        if (wait_result != WAIT_OBJECT_0)
+        // WAIT_ABANDONED also grants ownership. In that case the initialization
+        // flag below determines whether the previous owner completed its work.
+        if (wait_result != WAIT_OBJECT_0 && wait_result != WAIT_ABANDONED)
         {
             const DWORD err    = GetLastError();
             last_error_message = GetLastErrorAsString(err);

--- a/src/shm_unix.h
+++ b/src/shm_unix.h
@@ -110,6 +110,13 @@ class CleanupHooks {
 
 inline std::once_flag CleanupHooks::register_once_;
 
+inline uint64_t next_socket_id() noexcept {
+    // A process may own several SharedMemory instances for the same segment.
+    // Give every server its own endpoint instead of relying on the PID alone.
+    static std::atomic_uint64_t sequence{0};
+    return sequence.fetch_add(1, std::memory_order_relaxed);
+}
+
 }  // namespace detail
 
 
@@ -246,7 +253,8 @@ class SharedMemory: public detail::SharedMemoryBase {
         name_(name),
         shared_dir_(tempRoot.prefix + "/" + make_sentinel_base(name)),
         init_lock_path_(shared_dir_ + "/init_lock"),
-        socket_path_(shared_dir_ + "/" + std::to_string(getpid()) + ".sock"),
+        socket_path_(shared_dir_ + "/" + std::to_string(getpid()) + "."
+                     + std::to_string(detail::next_socket_id()) + ".sock"),
         server_thread_(std::nullopt) {}
 
     ~SharedMemory() noexcept override {

--- a/tests/shm_unix.cpp
+++ b/tests/shm_unix.cpp
@@ -1,0 +1,95 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2026 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+*/
+
+#include "../src/shm_unix.h"
+
+#include <cinttypes>
+#include <cstdio>
+#include <optional>
+#include <string>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace {
+
+using Stockfish::shm::SharedMemory;
+
+int run_child(const std::string& name) {
+    auto shared = Stockfish::shm::create_shared<int>(name, 333);
+    if (!shared)
+        return 20;
+    return shared->get() == 111 ? 0 : 21;
+}
+
+struct TempDirectoryCleanup {
+    explicit TempDirectoryCleanup(const std::string& name) {
+        const auto& root = Stockfish::shm::TempRoot::get_temp_root();
+        if (!root)
+            return;
+
+        char sentinel[32];
+        std::snprintf(sentinel, sizeof(sentinel), "sfshm_%016" PRIu64,
+                      Stockfish::hash_string(name));
+        directory = root->prefix + "/" + sentinel;
+    }
+
+    ~TempDirectoryCleanup() {
+        if (!directory.empty())
+        {
+            unlink((directory + "/init_lock").c_str());
+            rmdir(directory.c_str());
+        }
+    }
+
+    std::string directory;
+};
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc == 3 && std::string(argv[1]) == "--child")
+        return run_child(argv[2]);
+    if (argc != 1)
+        return 1;
+
+    const std::string    name = "stockfish-shm-unix-test-" + std::to_string(getpid());
+    TempDirectoryCleanup cleanup(name);
+
+    std::optional<SharedMemory<int>> first = Stockfish::shm::create_shared<int>(name, 111);
+    if (!first)
+        return 2;
+
+    auto second = Stockfish::shm::create_shared<int>(name, 222);
+    if (!second)
+        return 3;
+    if (second->get() != 111)
+        return 4;
+
+    // Closing one same-process handle must not make the still-live first handle
+    // undiscoverable to a newly launched process.
+    second.reset();
+
+    const pid_t child = fork();
+    if (child == -1)
+        return 5;
+    if (child == 0)
+    {
+        execl(argv[0], argv[0], "--child", name.c_str(), nullptr);
+        _exit(127);
+    }
+
+    int status = 0;
+    if (waitpid(child, &status, 0) != child)
+        return 6;
+    if (!WIFEXITED(status))
+        return 7;
+    return WEXITSTATUS(status);
+}

--- a/tests/shm_unix.sh
+++ b/tests/shm_unix.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TEST_BINARY=$(mktemp)
+trap 'rm -f "$TEST_BINARY"' EXIT
+
+"${COMPCXX:-g++}" \
+  -std=c++17 \
+  -O2 \
+  -pthread \
+  -fno-exceptions \
+  -Wall \
+  -Wextra \
+  -Werror \
+  ../tests/shm_unix.cpp \
+  misc.cpp \
+  -o "$TEST_BINARY"
+
+"$TEST_BINARY"

--- a/tests/shm_windows.cpp
+++ b/tests/shm_windows.cpp
@@ -1,0 +1,115 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2026 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+*/
+
+#include "../src/shm.h"
+
+#include <string>
+#include <vector>
+
+#include <windows.h>
+
+namespace {
+
+class ChildProcess {
+   public:
+    ~ChildProcess() {
+        if (info.hProcess)
+        {
+            TerminateProcess(info.hProcess, 0);
+            WaitForSingleObject(info.hProcess, 5000);
+            CloseHandle(info.hProcess);
+        }
+        if (info.hThread)
+            CloseHandle(info.hThread);
+    }
+
+    PROCESS_INFORMATION info{};
+};
+
+int run_child(const char* mutexName, const char* eventName) {
+    HANDLE mutex = CreateMutexA(nullptr, TRUE, mutexName);
+    HANDLE event = OpenEventA(EVENT_MODIFY_STATE, FALSE, eventName);
+    if (!mutex || !event)
+        return 20;
+
+    if (!SetEvent(event))
+        return 21;
+
+    Sleep(INFINITE);
+    return 22;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc == 4 && std::string(argv[1]) == "--child")
+        return run_child(argv[2], argv[3]);
+    if (argc != 1)
+        return 1;
+
+    const std::string mappingName =
+      "Local\\stockfish_shm_abandoned_test_" + std::to_string(GetCurrentProcessId());
+    const std::string mutexName = mappingName + "$mutex";
+    const std::string eventName = mappingName + "$ready";
+
+    HANDLE ready = CreateEventA(nullptr, TRUE, FALSE, eventName.c_str());
+    if (!ready)
+        return 2;
+
+    char  executable[MAX_PATH];
+    DWORD executableLength = GetModuleFileNameA(nullptr, executable, sizeof(executable));
+    if (executableLength == 0 || executableLength == sizeof(executable))
+    {
+        CloseHandle(ready);
+        return 3;
+    }
+
+    std::string command =
+      "\"" + std::string(executable) + "\" --child \"" + mutexName + "\" \"" + eventName + "\"";
+    std::vector<char> commandBuffer(command.begin(), command.end());
+    commandBuffer.push_back('\0');
+
+    STARTUPINFOA startup{};
+    startup.cb = sizeof(startup);
+    ChildProcess child;
+    if (!CreateProcessA(nullptr, commandBuffer.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr,
+                        &startup, &child.info))
+    {
+        CloseHandle(ready);
+        return 4;
+    }
+
+    if (WaitForSingleObject(ready, 5000) != WAIT_OBJECT_0)
+    {
+        CloseHandle(ready);
+        return 5;
+    }
+    CloseHandle(ready);
+
+    // Keep the mutex object alive after terminating its owning process so the
+    // next waiter deterministically receives WAIT_ABANDONED.
+    HANDLE keepAlive = OpenMutexA(SYNCHRONIZE | MUTEX_MODIFY_STATE, FALSE, mutexName.c_str());
+    if (!keepAlive)
+        return 6;
+
+    if (!TerminateProcess(child.info.hProcess, 0)
+        || WaitForSingleObject(child.info.hProcess, 5000) != WAIT_OBJECT_0)
+    {
+        CloseHandle(keepAlive);
+        return 7;
+    }
+
+    Stockfish::SharedMemoryBackend<int> shared(mappingName, 1234);
+    CloseHandle(keepAlive);
+
+    if (!shared.is_valid())
+        return 8;
+    return *static_cast<int*>(shared.get()) == 1234 ? 0 : 9;
+}

--- a/tests/shm_windows.sh
+++ b/tests/shm_windows.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TEST_BINARY=$(mktemp --suffix=.exe)
+trap 'rm -f "$TEST_BINARY"' EXIT
+
+"${COMPCXX:-g++}" \
+  -std=c++17 \
+  -O2 \
+  -pthread \
+  -fno-exceptions \
+  -Wall \
+  -Wextra \
+  -Werror \
+  ../tests/shm_windows.cpp \
+  -o "$TEST_BINARY"
+
+"$TEST_BINARY"


### PR DESCRIPTION
## Summary

- give every Unix shared-memory server a unique per-process endpoint, preventing multiple `Engine` instances in one process from unlinking each other's sockets
- recover Windows mappings after an initializer dies by treating `WAIT_ABANDONED` as acquired ownership and consulting the shared initialization flag
- add deterministic Unix and Windows regression tests to the corresponding platform CI jobs

## Failure modes covered

On Unix, constructing a second engine in the same process previously reused and unlinked the first engine's socket path; the baseline regression exits 21. On Windows, an initializer dying while owning the mutex leaves it abandoned; `WaitForSingleObject()` still grants ownership, but the old code rejected that result and the baseline regression exits 8.

## Validation

- Unix regression: 100/100 passes, including a `-fno-exceptions` build
- Windows regression: 100/100 passes, including a `-fno-exceptions` build
- real two-Engine integration with the 115 MiB NNUE network
- strict optimized Linux engine build
- focused macOS and Windows backend compilation
- clang-format, ShellCheck, actionlint, and `git diff --check`
- canonical bench: 2829394 nodes

Bench: 2829394