### PR TITLE
Simplify optimism scaling formula

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -57,7 +57,7 @@ Value Eval::evaluate(const Eval::NNUE::Network&     network,
     nnue -= nnue * i64(nnueComplexity) / 18236;
 
     int material = 534 * pos.count<PAWN>() + pos.non_pawn_material();
-    int v        = (nnue * i64(77871 + material) + optimism * i64(7191 + material)) / 77871;
+    int v        = (nnue * i64(91000 + material) + optimism * i64(7675)) / 91000;
 
     // Damp down the evaluation linearly when shuffling
     v -= v * pos.rule50_count() / 199;


### PR DESCRIPTION
Simplify optimism scaling formula

Passed STC non-reg:
LLR: 2.92 (-2.94,2.94) <-1.75,0.25>
Total: 110624 W: 28564 L: 28429 D: 53631
Ptnml(0-2): 169, 13076, 28801, 12983, 283
https://tests.stockfishchess.org/tests/view/6a6dd611c054e285ae029b86

Passed LTC non-reg:
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 153366 W: 39831 L: 39746 D: 73789
Ptnml(0-2): 36, 16358, 43841, 16381, 67
https://tests.stockfishchess.org/tests/view/6a6f96c82cf557d58a2e188b

bench: 2119477