### PR TITLE
Fix rm.exe "Permission denied" errors on Windows

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1221,6 +1221,9 @@ profileclean:
 	@rm -f ./-lstdc++.res
 
 universalclean:
+# On Windows "ln -s" to a directory makes a native directory symlink that rm
+# cannot unlink; rmdir unlinks it without following it. No-op elsewhere.
+	@find $(TEMP_DIR) -type l -exec rmdir {} + 2>/dev/null || true
 	@rm -rf $(TEMP_DIR)
 	@rm -f universal/network_dump.inc
 


### PR DESCRIPTION
I haven't built a universal exe on Windows for a while.  Doing it today produced "Permission denied" errors afterward when running "make clean".  Claude fixed it and produced the following comment:

"On Windows, `ln -s` to a directory creates a native directory symlink that MSYS
rm cannot unlink, so `rm -rf temp_builds` fails with `Permission denied` and
`make clean` breaks after a universal build.

Fix: in universalclean, run `find ... -type l -exec rmdir {} +` first, which
unlinks such a link without following it. On Linux/macOS rmdir refuses POSIX
symlinks; `|| true` absorbs the error and `rm -rf` behaves exactly as before."

No functional change
bench: 2829394