### PR TITLE
Improve mate finding with a dynamic futility pruning depth cutoff

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -158,6 +158,23 @@ bool is_shuffling(Move move, Stack* const ss, const Position& pos) {
         && (ss - 2)->currentMove.from_sq() == (ss - 4)->currentMove.to_sq();
 }
 
+// Look up the futility pruning cutoff depth. This function is important for mate finding.
+inline int futility_depth(Value eval, Value beta) {
+    // LUT values obtained from:
+    //      depth = 13 + int(0.5 + 6 / int(1 + pow(abs(eval) + abs(beta), 3) / 50'000'000'000))
+    static constexpr std::array Lut{Value(1657), 2555, 3294, 4122, 5314, 8194, VALUE_INFINITE * 2};
+
+    // Values for scale 45'000'000'000:
+    // static constexpr std::array Lut{Value(1600), 2467, 3180, 3980, 5130, 7811, VALUE_INFINITE * 2};
+
+    const Value prob  = std::abs(eval) + std::abs(beta);
+    int         depth = 0;
+    while (Lut[depth] < prob)
+        ++depth;
+
+    return 19 - depth;
+}
+
 }  // namespace
 
 Search::Worker::Worker(SharedState&                    sharedState,
@@ -977,9 +994,9 @@ Value Search::Worker::search(
         return qsearch<NonPV>(pos, ss, alpha, beta);
 
     // Step 8. Futility pruning: child node
-    // The depth condition is important for mate finding.
-    if (!ss->ttPv && depth < 19 && eval >= beta && (!ttData.move || ttCapture) && !is_loss(beta)
-        && !is_win(eval))
+    // The depth condition is important for mate finding. It shouldn't be tuned.
+    if (!ss->ttPv && eval >= beta && (!ttData.move || ttCapture) && !is_loss(beta) && !is_win(eval)
+        && depth < futility_depth(eval, beta))
     {
         Value futilityMult = std::min(45 + depth * 4, 85);
         futilityMult -= 20 * !ss->ttHit;


### PR DESCRIPTION
This PR improves mate finding with a dynamic futility pruning depth cutoff.

The pruning depth is reduced with the following formula:
`depth = 13 + int(0.5 + 6 / (1 + pow(abs(eval) + abs(beta), 3) / 50'000'000'000))`

Threshold values where the depth changes were put into a lookup table to increase performance.

STC non-regression:
> LLR: 3.37 (-2.94,2.94) <-1.75,0.25>
> Total: 203424 W: 52600 L: 52529 D: 98295
> Ptnml(0-2): 402, 22402, 56093, 22353, 462 
https://tests.stockfishchess.org/tests/view/6a6e38fcc054e285ae029c59

LTC non-regression :
> LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
> Total: 253488 W: 65927 L: 65943 D: 121618
> Ptnml(0-2): 95, 27128, 72307, 27126, 88 
https://tests.stockfishchess.org/tests/view/6a71e2be2cf557d58a2e1c60

Matetrack results for default and classic:
```
Using ./stockfish on ../../matetrack/matetrack.epd with --nodes 1000000
Engine ID:     Stockfish dev-20260809-2e5a3739
Total FENs:    6554
Found mates:   3155
Best mates:    2205

Using ./stockfish on ../../matetrack/classic280.epd with --nodes 1000000
Engine ID:     Stockfish dev-20260809-2e5a3739
Total FENs:    280
Found mates:   141
Best mates:    15
```

Matetrack results for master:
```
Using /usr/games/stockfish/stockfish on matetrack.epd with --nodes 1000000
Engine ID:     Stockfish dev-20260803-762dd1da
Total FENs:    6554
Found mates:   3098
Best mates:    2150

Using /usr/games/stockfish/stockfish on classic280.epd with --nodes 1000000
Engine ID:     Stockfish dev-20260803-762dd1da
Total FENs:    280
Found mates:   150
Best mates:    13
```

Bench: 2705338