### PR TITLE
Place continuation history on large pages.

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -195,6 +195,10 @@ using CorrectionHistory = typename Detail::CorrHistTypedef<T>::type;
 
 using TTMoveHistory = StatsEntry<i16, 8192>;
 
+struct ContinuationHistoryBlock {
+    ContinuationHistory table[2][2];
+};
+
 // Set of histories shared between groups of threads. To avoid excessive
 // cross-node data transfer, histories are shared only between threads
 // on a given NUMA node. The passed size must be a power of two to make
@@ -202,11 +206,14 @@ using TTMoveHistory = StatsEntry<i16, 8192>;
 struct SharedHistories {
     SharedHistories(usize threadCount) :
         correctionHistory(threadCount),
+        continuationHistoryBlock(make_unique_large_page<ContinuationHistoryBlock>()),
         pawnHistory(threadCount) {
         assert((threadCount & (threadCount - 1)) == 0 && threadCount != 0);
         sizeMinus1         = correctionHistory.get_size() - 1;
         pawnHistSizeMinus1 = pawnHistory.get_size() - 1;
     }
+
+    auto& continuationHistory() { return continuationHistoryBlock->table; }
 
     usize get_size() const { return sizeMinus1 + 1; }
 
@@ -240,9 +247,9 @@ struct SharedHistories {
         return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
     }
 
-    UnifiedCorrectionHistory correctionHistory;
-    ContinuationHistory      continuationHistory[2][2];
-    PawnHistory              pawnHistory;
+    UnifiedCorrectionHistory               correctionHistory;
+    LargePagePtr<ContinuationHistoryBlock> continuationHistoryBlock;
+    PawnHistory                            pawnHistory;
 
 
    private:

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -168,7 +168,7 @@ Search::Worker::Worker(SharedState&                    sharedState,
                        NumaReplicatedAccessToken       token) :
     // Unpack the SharedState struct into member variables
     sharedHistory(sharedState.sharedHistories.at(token.get_numa_index())),
-    continuationHistory(sharedHistory.continuationHistory),
+    continuationHistory(sharedHistory.continuationHistory()),
     threadIdx(threadId),
     numaThreadIdx(numaThreadId),
     numaTotal(numaTotalThreads),


### PR DESCRIPTION
Requires THP madvise or always. With THP never, MADV_HUGEPAGE is ignored and there is no benefit.

```
Result of  50 runs (nps)
==================
speedup         = +0.0176
paired t-test   = t = 2.320, p = 0.0245

Result of 200 runs (nps)
==================
speedup         = +0.0104
paired t-test   = t = 3.415, p = 0.0008
```

STC passed:
LLR: 3.42 (-2.94,2.94) <0.00,2.00>
Total: 231360 W: 60152 L: 59553 D: 111655
https://tests.stockfishchess.org/tests/view/6a736a122cf557d58a2e1f51
No functional change

Bench: 2829394

Edit: Removed wrong test details
Edit2: Added result for 200 runs