### PR TITLE
Bump minimum GCC version to 10.2 and adopt C++20 std::erase / std::erase_if

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -568,7 +568,7 @@ std::optional<std::string> read_file_to_string(const std::string& path) {
 }
 
 void remove_whitespace(std::string& s) {
-    s.erase(std::remove_if(s.begin(), s.end(), [](char c) { return std::isspace(c); }), s.end());
+    std::erase_if(s, [](unsigned char c) { return std::isspace(c); });
 }
 
 bool is_whitespace(std::string_view s) {

--- a/src/numa.h
+++ b/src/numa.h
@@ -981,11 +981,7 @@ class NumaConfig {
         customAffinity(false) {}
 
     void remove_empty_numa_nodes() {
-        std::vector<std::set<CpuIndex>> newNodes;
-        for (auto&& cpus : nodes)
-            if (!cpus.empty())
-                newNodes.emplace_back(std::move(cpus));
-        nodes = std::move(newNodes);
+        std::erase_if(nodes, [](const auto& cpus) { return cpus.empty(); });
     }
 
     // Returns true if successful

--- a/src/shm_unix.h
+++ b/src/shm_unix.h
@@ -74,8 +74,7 @@ class SharedMemoryRegistry {
     static void unlink_socket_path(const std::string& path) {
         std::scoped_lock lock(socket_paths_mutex_);
         unlink(path.c_str());
-        socket_paths_.erase(std::remove(socket_paths_.begin(), socket_paths_.end(), path),
-                            socket_paths_.end());
+        std::erase(socket_paths_, path);
     }
 
     static void cleanup_at_exit() noexcept {

--- a/src/types.h
+++ b/src/types.h
@@ -59,8 +59,8 @@
 
     // Enforce minimum GCC version
     #if defined(__GNUC__) && !defined(__clang__) \
-      && (__GNUC__ < 9 || (__GNUC__ == 9 && __GNUC_MINOR__ < 3))
-        #error "Stockfish requires GCC 9.3 or later for correct compilation"
+      && (__GNUC__ < 10 || (__GNUC__ == 10 && __GNUC_MINOR__ < 2))
+        #error "Stockfish requires GCC 10.2 or later for correct compilation"
     #endif
 
     // Enforce minimum Clang version


### PR DESCRIPTION
Updating the minimum required GCC version from 9.3 to 10.2 and modernizing container element removal across the codebase using C++20 std::erase and std::erase_if.

GCC 9.3's standard library (libstdc++ 9.x) lacked full C++20 uniform container erasure support (std::erase_if for <string> and <vector>). Bumping the GCC baseline to 10.2 ensures full libstdc++ C++20 feature completeness and allows us to eliminate verbose erase-remove boilerplate.

types.h: Update compile-time GCC version check from 9.3 to 10.2.
misc.cpp: Simplify remove_whitespace() using std::erase_if.
shm_unix.h: Simplify unlink_socket_path() using C++20 std::erase().
numa.h: Replace manual vector filtering/reallocation in remove_empty_numa_nodes() with a single std::erase_if().

No functional change