### PR TITLE
Simplify Away Second Razoring Number

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -997,7 +997,7 @@ Value Search::Worker::search(
     // Step 7. Razoring
     // If eval is really low, skip search entirely and return the qsearch value.
     // For PvNodes, we must have a guard against mates being returned.
-    if (!PvNode && eval < alpha - 483 - 318 * depth * depth)
+    if (!PvNode && eval < alpha - 482 * depth * depth)
         return qsearch<NonPV>(pos, ss, alpha, beta);
 
     // Step 8. Futility pruning: child node


### PR DESCRIPTION
This patch simplifies away the second razoring number and adds a small offset to compensate.

Passed STC non regression:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 169600 W: 43837 L: 43764 D: 81999
Ptnml(0-2): 397, 19909, 44131, 19950, 413
https://tests.stockfishchess.org/tests/view/6a7481672cf557d58a2e20ee

Passed LTC non regression:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 28332 W: 7450 L: 7241 D: 13641
Ptnml(0-2): 5, 2895, 8169, 3080, 17
https://tests.stockfishchess.org/tests/view/6a78946ea7e815d01b56019f

On new master, doesn't hurt matetrack results significantly:

Master results on 1th 1m nodes:
Total FENs: 6554
Found mates: 3160
Best mates: 2218

New results on 1th 1m nodes:
Total FENs: 6554
Found mates: 3180
Best mates: 2215

On new master, doesn't hurt matedtrack results significantly either:

Master results on 1th 1m nodes:
Total FENs: 6536
Found mates: 3500
Best mates: 2856

New results on 1th 1m nodes:
Total FENs: 6536
Found mates: 3506
Best mates: 2859

Maybe even improves matetrack/matedtrack :)

Bench: 2389382