### PR TITLE
Reduce LMR less aggressively in loose alpha windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ Hisayori Noda (nodchip)
 
 # All other authors of Stockfish code (in alphabetical order)
 87flowers
+Adarsh Das (Saphereye)
 Aditya (absimaldata)
 Adrian Ladoni (AdrianGHUB15)
 Adrian Petrescu (apetresc)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1358,6 +1358,9 @@ moves_loop:  // When in check, search starts here
         // Decrease/increase reduction for moves with a good/bad history
         r -= ss->statScore * 439 / 4096;
 
+        if (!capture && !is_decisive(alpha))
+            r += 3 * std::clamp(alpha - eval, -64, 96);
+
         // Scale up reductions for expected ALL nodes
         if (allNode)
             r += r * 276 / (256 * depth + 268);


### PR DESCRIPTION
Passed STC
https://tests.stockfishchess.org/tests/view/6a71da2b2cf557d58a2e1c45
LLR: 2.95 (-2.94,2.94) <0.00,2.00>
Total: 90784 W: 23707 L: 23319 D: 43758
Ptnml(0-2): 191, 10444, 23757, 10786, 214

Passed LTC
https://tests.stockfishchess.org/tests/view/6a736ab02cf557d58a2e1f56
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 209640 W: 54841 L: 54179 D: 100620
Ptnml(0-2): 79, 22245, 59512, 22903, 81

Bench: 2396575