### PR TITLE
simplify FullThreats::append_active_indices

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -100,19 +100,18 @@ constexpr Bitboard file_bb(Square s) { return file_bb(file_of(s)); }
 
 
 // Moves a bitboard one or two steps as specified by the direction D
-template<Direction D>
-constexpr Bitboard shift(Bitboard b) {
-    return D == NORTH         ? b << 8
-         : D == SOUTH         ? b >> 8
-         : D == NORTH + NORTH ? b << 16
-         : D == SOUTH + SOUTH ? b >> 16
-         : D == EAST          ? (b & ~FileHBB) << 1
-         : D == WEST          ? (b & ~FileABB) >> 1
-         : D == NORTH_EAST    ? (b & ~FileHBB) << 9
-         : D == NORTH_WEST    ? (b & ~FileABB) << 7
-         : D == SOUTH_EAST    ? (b & ~FileHBB) >> 7
-         : D == SOUTH_WEST    ? (b & ~FileABB) >> 9
-                              : 0;
+inline constexpr Bitboard shift(Bitboard b, Direction dir) {
+    return dir == NORTH         ? b << 8
+         : dir == SOUTH         ? b >> 8
+         : dir == NORTH + NORTH ? b << 16
+         : dir == SOUTH + SOUTH ? b >> 16
+         : dir == EAST          ? (b & ~FileHBB) << 1
+         : dir == WEST          ? (b & ~FileABB) >> 1
+         : dir == NORTH_EAST    ? (b & ~FileHBB) << 9
+         : dir == NORTH_WEST    ? (b & ~FileABB) << 7
+         : dir == SOUTH_EAST    ? (b & ~FileHBB) >> 7
+         : dir == SOUTH_WEST    ? (b & ~FileABB) >> 9
+                                : 0;
 }
 
 
@@ -120,12 +119,12 @@ constexpr Bitboard shift(Bitboard b) {
 // from the squares in the given bitboard.
 template<Color C>
 constexpr Bitboard pawn_attacks_bb(Bitboard b) {
-    return C == WHITE ? shift<NORTH_WEST>(b) | shift<NORTH_EAST>(b)
-                      : shift<SOUTH_WEST>(b) | shift<SOUTH_EAST>(b);
+    return C == WHITE ? shift(b, NORTH_WEST) | shift(b, NORTH_EAST)
+                      : shift(b, SOUTH_WEST) | shift(b, SOUTH_EAST);
 }
 
 constexpr Bitboard pawn_single_push_bb(Color c, Bitboard b) {
-    return c == WHITE ? shift<NORTH>(b) : shift<SOUTH>(b);
+    return shift(b, c == WHITE ? NORTH : SOUTH);
 }
 
 inline constexpr auto PawnPairBB = []() {
@@ -133,7 +132,7 @@ inline constexpr auto PawnPairBB = []() {
     for (Square s = SQ_A1; s <= SQ_H8; ++s)
     {
         Bitboard file  = file_bb(s);
-        Bitboard files = file | shift<EAST>(file) | shift<WEST>(file);
+        Bitboard files = file | shift(file, EAST) | shift(file, WEST);
         result[s]      = files & ~(Rank1BB | Rank8BB) & ~square_bb(s);
     }
     return result;

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -122,8 +122,8 @@ Move* generate_pawn_moves(const Position& pos, Move* moveList, Bitboard target) 
     // Single and double pawn pushes, no promotions
     if constexpr (Type != CAPTURES)
     {
-        Bitboard b1 = shift<Up>(pawnsNotOn7) & emptySquares;
-        Bitboard b2 = shift<Up>(b1 & TRank3BB) & emptySquares;
+        Bitboard b1 = shift(pawnsNotOn7, Up) & emptySquares;
+        Bitboard b2 = shift(b1 & TRank3BB, Up) & emptySquares;
 
         if constexpr (Type == EVASIONS)  // Consider only blocking squares
         {
@@ -138,9 +138,9 @@ Move* generate_pawn_moves(const Position& pos, Move* moveList, Bitboard target) 
     // Promotions and underpromotions
     if (pawnsOn7)
     {
-        Bitboard b1 = shift<UpRight>(pawnsOn7) & enemies;
-        Bitboard b2 = shift<UpLeft>(pawnsOn7) & enemies;
-        Bitboard b3 = shift<Up>(pawnsOn7) & emptySquares;
+        Bitboard b1 = shift(pawnsOn7, UpRight) & enemies;
+        Bitboard b2 = shift(pawnsOn7, UpLeft) & enemies;
+        Bitboard b3 = shift(pawnsOn7, Up) & emptySquares;
 
         if constexpr (Type == EVASIONS)
             b3 &= target;
@@ -158,8 +158,8 @@ Move* generate_pawn_moves(const Position& pos, Move* moveList, Bitboard target) 
     // Standard and en passant captures
     if constexpr (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS)
     {
-        Bitboard b1 = shift<UpRight>(pawnsNotOn7) & enemies;
-        Bitboard b2 = shift<UpLeft>(pawnsNotOn7) & enemies;
+        Bitboard b1 = shift(pawnsNotOn7, UpRight) & enemies;
+        Bitboard b2 = shift(pawnsNotOn7, UpLeft) & enemies;
 
         moveList = splat_pawn_moves<UpRight>(moveList, b1);
         moveList = splat_pawn_moves<UpLeft>(moveList, b2);

--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -213,36 +213,28 @@ void FullThreats::append_active_indices(Color perspective, const Position& pos, 
     const Bitboard minorSliderTargets = pos.pieces(PAWN, KNIGHT, BISHOP, ROOK);
     const Bitboard queenTargets       = pos.pieces(PAWN, KNIGHT, BISHOP, ROOK, QUEEN);
 
-    for (Color color : {WHITE, BLACK})
-    {
-        const Color c = Color(perspective ^ color);
-
+    auto process_pawn_attacks = [&](Color c, Direction attkDir) {
+        const Bitboard cPawns = pos.pieces(c, PAWN);
+        Bitboard attacks = shift(cPawns, attkDir) & pawnTargets;
+        while (attacks)
         {
-            const Piece    attacker             = make_piece(c, PAWN);
-            const Bitboard cPawns               = pos.pieces(c, PAWN);
-            auto           process_pawn_attacks = [&](Bitboard attacks, Direction attkDir) {
-                while (attacks)
-                {
-                    Square    to       = pop_lsb(attacks);
-                    Square    from     = to - attkDir;
-                    Piece     attacked = pos.piece_on(to);
-                    IndexType index = make_index(perspective, attacker, from, to, attacked, ksq);
-                    active.push_back_if_lt(index, Dimensions);
-                }
-            };
-
-            if (c == WHITE)
-            {
-                process_pawn_attacks(shift<NORTH_EAST>(cPawns) & pawnTargets, NORTH_EAST);
-                process_pawn_attacks(shift<NORTH_WEST>(cPawns) & pawnTargets, NORTH_WEST);
-            }
-            else
-            {
-                process_pawn_attacks(shift<SOUTH_WEST>(cPawns) & pawnTargets, SOUTH_WEST);
-                process_pawn_attacks(shift<SOUTH_EAST>(cPawns) & pawnTargets, SOUTH_EAST);
-            }
+            Square to       = pop_lsb(attacks);
+            Square from     = to - attkDir;
+            Piece attacked  = pos.piece_on(to);
+            Piece attacker  = make_piece(c, PAWN);
+            IndexType index = make_index(perspective, attacker, from, to, attacked, ksq);
+            active.push_back_if_lt(index, Dimensions);
         }
+    };
 
+    process_pawn_attacks(WHITE, NORTH_EAST);
+    process_pawn_attacks(WHITE, NORTH_WEST);
+
+    process_pawn_attacks(BLACK, SOUTH_WEST);
+    process_pawn_attacks(BLACK, SOUTH_EAST);
+
+    for (Color c : {WHITE, BLACK})
+    {
         for (PieceType pt = KNIGHT; pt < KING; ++pt)
         {
             Piece    attacker = make_piece(c, pt);


### PR DESCRIPTION
also requires de-templating shift

passed STC: https://tests.stockfishchess.org/tests/view/6a78a8c1a7e815d01b5601c4
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 67904 W: 17662 L: 17490 D: 32752
Ptnml(0-2): 135, 7037, 19416, 7249, 115 

A benchmark also shows no regression:
```
Result of 100 runs (counting nodes/1B cycles)
=============================================
base (...tockfish.5062ae) =  275495 +/- 3270
test (...tockfish.978b83) =  275951 +/- 3308
speedup %                 =   +0.16 +/- 0.07
                             [95% CI; t-test]

likelihood(speedup > 0)   =  1.0000

CPU: 16 x Intel(R) Core(TM) Ultra 9 185H
```

No functional change