### PR TITLE
Fuse common HalfKA feature pair

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -321,6 +321,56 @@ sf_always_inline inline void apply_psqt(IndexType                         j,
     }
 }
 
+template<bool SinglePsqPair>
+sf_always_inline inline void apply_main_accumulator(const FeatureTransformer& featureTransformer,
+                                                    const PSQFeatureSet::IndexList&    psqAdded,
+                                                    const PSQFeatureSet::IndexList&    psqRemoved,
+                                                    const ThreatFeatureSet::IndexList& thrAdded,
+                                                    const ThreatFeatureSet::IndexList& thrRemoved,
+                                                    const i16*                         fromAcc,
+                                                    i16*                               toAcc) {
+
+    const auto* removedBase =
+      SinglePsqPair ? &featureTransformer.weights[psqRemoved[0] * Dimensions] : nullptr;
+    const auto* addedBase =
+      SinglePsqPair ? &featureTransformer.weights[psqAdded[0] * Dimensions] : nullptr;
+
+    vec_t acc[Tiling::NumRegs];
+
+    for (IndexType j = 0; j < Dimensions / Tiling::TileHeight; ++j)
+    {
+        const usize tileOff  = j * Tiling::TileHeight;
+        auto*       fromTile = reinterpret_cast<const vec_t*>(&fromAcc[tileOff]);
+        auto*       toTile   = reinterpret_cast<vec_t*>(&toAcc[tileOff]);
+
+        for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+            acc[k] = fromTile[k];
+
+        if constexpr (SinglePsqPair)
+        {
+            const auto* removed = reinterpret_cast<const vec_t*>(removedBase + tileOff);
+            const auto* added   = reinterpret_cast<const vec_t*>(addedBase + tileOff);
+
+            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+            {
+                acc[k] = vec_sub_16(acc[k], removed[k]);
+                acc[k] = vec_add_16(acc[k], added[k]);
+            }
+        }
+        else
+        {
+            apply_psq_features<-1>(j, acc, psqRemoved, featureTransformer);
+            apply_psq_features<+1>(j, acc, psqAdded, featureTransformer);
+        }
+
+        apply_threat_features<-1>(j, acc, thrRemoved, featureTransformer);
+        apply_threat_features<+1>(j, acc, thrAdded, featureTransformer);
+
+        for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+            vec_store(&toTile[k], acc[k]);
+    }
+}
+
 #endif
 
 void apply_combined(Color                              perspective,
@@ -340,27 +390,14 @@ void apply_combined(Color                              perspective,
 
 #ifdef VECTOR
 
-    vec_t      acc[Tiling::NumRegs];
     psqt_vec_t psqt[Tiling::NumPsqtRegs];
 
-    for (IndexType j = 0; j < Dimensions / Tiling::TileHeight; ++j)
-    {
-        const usize tileOff  = j * Tiling::TileHeight;
-        auto*       fromTile = reinterpret_cast<const vec_t*>(&fromAcc[tileOff]);
-        auto*       toTile   = reinterpret_cast<vec_t*>(&toAcc[tileOff]);
-
-        for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-            acc[k] = fromTile[k];
-
-        apply_psq_features<-1>(j, acc, psqRemoved, featureTransformer);
-        apply_psq_features<+1>(j, acc, psqAdded, featureTransformer);
-
-        apply_threat_features<-1>(j, acc, thrRemoved, featureTransformer);
-        apply_threat_features<+1>(j, acc, thrAdded, featureTransformer);
-
-        for (IndexType k = 0; k < Tiling::NumRegs; k++)
-            vec_store(&toTile[k], acc[k]);
-    }
+    if (psqRemoved.size() == 1 && psqAdded.size() == 1)
+        apply_main_accumulator<true>(featureTransformer, psqAdded, psqRemoved, thrAdded, thrRemoved,
+                                     fromAcc.data(), toAcc.data());
+    else
+        apply_main_accumulator<false>(featureTransformer, psqAdded, psqRemoved, thrAdded,
+                                      thrRemoved, fromAcc.data(), toAcc.data());
 
     for (IndexType j = 0; j < PSQTBuckets / Tiling::PsqtTileHeight; ++j)
     {


### PR DESCRIPTION
Specialize the common HalfKA accumulator update with exactly one removed
and one added PSQ row.

The generic path walks both dynamic index lists inside each of the eight
accumulator tiles. This patch checks the common `1 + 1` shape once, hoists
both weight-row bases out of the tile loop, and applies the subtraction and
addition together in one fixed-register loop.

The arithmetic order remains unchanged. Dynamic FullThreat and PP updates,
PSQT updates, the scalar implementation, and all other HalfKA shapes continue
to use their existing paths.

An opportunity profile on two independent 500-position banks measured:

| PSQ shape | Noob | UHO |
| --- | ---: | ---: |
| `1 + 1` | 63.695% | 61.786% |
| `2 + 1` | 34.026% | 36.249% |
| `2 + 2` | 1.901% | 1.572% |

Only `1 + 1` is specialized here. A separate `2 + 1` extension showed a
weak, non-portable marginal result and was not retained. The `2 + 2` shape
did not meet the predeclared opportunity threshold. Both remain on the
generic path.

Paired depth-17 exact-speed screens:

| Platform | Pairs | Paired NPS | 95% interval |
| --- | ---: | ---: | ---: |
| Graviton 3 | 36 | +0.624% | [+0.270%, +0.957%] |
| AMD Zen 3 | 32 | +0.037% | [-0.185%, +0.254%] |
| Intel Sapphire Rapids | 24 | +0.321% | [+0.149%, +0.489%] |

The speed effect is architecture-dependent: it was positive on Graviton 3
and Sapphire Rapids and neutral on Zen 3.

STC passed:
LLR: 3.08 (-2.94, 2.94) <0.00, 2.00>
Total: 222912 W: 57835 L: 57274 D: 107803
https://tests.stockfishchess.org/tests/view/6a79a500a7e815d01b560317

The tested source change was rebased without semantic changes.

Bench: 2884956

No functional change.