### PR TITLE
Scale razoring margin with correction-value uncertainty

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -997,7 +997,7 @@ Value Search::Worker::search(
     // Step 7. Razoring
     // If eval is really low, skip search entirely and return the qsearch value.
     // For PvNodes, we must have a guard against mates being returned.
-    if (!PvNode && eval < alpha - 483 - 318 * depth * depth)
+    if (!PvNode && eval < alpha - 483 - 318 * depth * depth - std::abs(correctionValue) / 262144)
         return qsearch<NonPV>(pos, ss, alpha, beta);
 
     // Step 8. Futility pruning: child node


### PR DESCRIPTION
The absolute correction value is already used as an uncertainty proxy in the child-node futility margin and in the reduction/SEE adjustments, but razoring - the most aggressive eval-based decision in search - ignores it entirely. When |correctionValue| is large the corrected static eval has historically been unreliable in this position class, so dropping straight into qsearch is riskier. Widen the razoring window by |correctionValue| / 262144 (mean ~45, measured over bench nodes) so noisy-eval nodes get a real search.

bench 2131631