### PR TITLE
Report a failed thread creation

### DIFF
--- a/src/thread_native.h
+++ b/src/thread_native.h
@@ -23,7 +23,10 @@
     #include <thread>
 #else
     #include <pthread.h>
+    #include <cstdlib>
+    #include <cstring>
     #include <functional>
+    #include <iostream>
     #include <utility>
 
     #include "misc.h"
@@ -69,7 +72,14 @@ class NativeThread {
             return nullptr;
         };
 
-        pthread_create(&thread, attr, start_routine, func);
+        const int rc = pthread_create(&thread, attr, start_routine, func);
+        pthread_attr_destroy(attr);
+
+        if (rc != 0)
+        {
+            std::cerr << "Failed to create a thread: " << std::strerror(rc) << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
     }
 
     void join() { pthread_join(thread, nullptr); }


### PR DESCRIPTION
pthread_create's return value was ignored, so a failed spawn left the engine hanging forever waiting for a searching flag no thread would clear. Report the error and exit.

No functional change