### PR TITLE
[RFC] Apply a mutating command only when idle

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -170,7 +170,7 @@ void UCIEngine::loop() {
             if (is >> filename)
                 file = path_from_utf8(filename);
 
-            engine.save_network(file);
+            apply_idle([&] { engine.save_network(file); });
         }
         else if (token == "--help" || token == "help" || token == "--license" || token == "license")
             sync_cout
@@ -480,9 +480,14 @@ void UCIEngine::benchmark(std::istream& args) {
     init_search_update_listeners();
 }
 
-void UCIEngine::setoption(std::istringstream& is) {
+void UCIEngine::apply_idle(const std::function<void()>& mutate) {
+    engine.stop();
     engine.wait_for_search_finished();
-    engine.get_options().setoption(is);
+    mutate();
+}
+
+void UCIEngine::setoption(std::istringstream& is) {
+    apply_idle([&] { engine.get_options().setoption(is); });
 }
 
 u64 UCIEngine::perft(const Search::LimitsType& limits) {

--- a/src/uci.h
+++ b/src/uci.h
@@ -19,6 +19,7 @@
 #ifndef UCI_H_INCLUDED
 #define UCI_H_INCLUDED
 
+#include <functional>
 #include <iostream>
 #include <string>
 #include <string_view>
@@ -67,6 +68,7 @@ class UCIEngine {
     void benchmark(std::istream& args);
     void position(std::istringstream& is);
     void setoption(std::istringstream& is);
+    void apply_idle(const std::function<void()>& mutate);
     u64  perft(const Search::LimitsType&);
 
     static void on_update_no_moves(const Engine::InfoShort& info);


### PR DESCRIPTION
Non-conforming GUIs could deadlock or crash SF by sending certain UCI commands while searching. This fix ensures no search is running when they are applied.

No functional change