### PR TITLE
Initialise time budgets on every path

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -56,7 +56,10 @@ void TimeManagement::init(Search::LimitsType& limits,
     useNodesTime = npmsec != 0;
 
     if (limits.time[us] == 0)
+    {
+        optimumTime = maximumTime = NoBound;
         return;
+    }
 
     TimePoint moveOverhead = TimePoint(options["Move Overhead"]);
 

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -20,6 +20,8 @@
 #define TIMEMAN_H_INCLUDED
 
 
+#include <limits>
+
 #include "misc.h"
 
 namespace Stockfish {
@@ -53,9 +55,11 @@ class TimeManagement {
     void advance_nodes_time(i64 nodes);
 
    private:
+    static constexpr TimePoint NoBound = std::numeric_limits<TimePoint>::max() / 2;
+
     TimePoint startTime;
-    TimePoint optimumTime;
-    TimePoint maximumTime;
+    TimePoint optimumTime = NoBound;
+    TimePoint maximumTime = NoBound;
 
     i64  availableNodes = -1;     // When in 'nodes as time' mode
     bool useNodesTime   = false;  // True if we are in 'nodes as time' mode

--- a/tests/instrumented.py
+++ b/tests/instrumented.py
@@ -288,6 +288,28 @@ class TestInteractive(metaclass=OrderedClassMembers):
 
         self.stockfish.check_output(callback)
 
+    def test_go_depth_3_with_mismatched_clock(self):
+        self.stockfish.send_command("ucinewgame")
+        self.stockfish.send_command("position startpos")
+        self.stockfish.send_command("go depth 3 btime 1000")
+
+        max_depth = 0
+
+        def callback(output):
+            nonlocal max_depth
+            if output.startswith("info depth"):
+                match = re.search(r"info depth (\d+)", output)
+                if match:
+                    max_depth = max(max_depth, int(match.group(1)))
+
+            if output.startswith("bestmove"):
+                assert max_depth == 3
+                return True
+
+            return False
+
+        self.stockfish.check_output(callback)
+
     def test_clear_hash(self):
         self.stockfish.send_command("setoption name Clear Hash")
 


### PR DESCRIPTION
TimeManagement::init returned early when the side to move had no clock, before optimumTime and maximumTime were assigned. The guard still let the search read them, so a mismatched-colour clock used uninitialised values. Reproduce with:

  position startpos
  go depth 3 btime 1000

Add a CI test for this case and initialise the budgets to NoBound, writing NoBound on the early-return path.

No functional change