### PR TITLE
Read hash_bytes tail bytes as unsigned

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -478,7 +478,7 @@ u64 hash_bytes(const char* data, usize size) {
     {
         u64 k = 0;
         for (int i = (size & 7) - 1; i >= 0; i--)
-            k = (k << 8) | u64(end[i]);
+            k = (k << 8) | u8(end[i]);
 
         h ^= k;
         h *= m;


### PR DESCRIPTION
The tail byte was read as signed char, so bytes >= 0x80 sign-extended and erased previously accumulated bytes in the hash. Read it as u8.

No functional change