### PR TITLE
Convert movetime when nodestime is in force

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -55,6 +55,9 @@ void TimeManagement::init(Search::LimitsType& limits,
     startTime    = limits.startTime;
     useNodesTime = npmsec != 0;
 
+    if (useNodesTime)
+        limits.movetime *= npmsec;
+
     if (limits.time[us] == 0)
         return;
 


### PR DESCRIPTION
elapsed() returns nodes while nodestime is active, but check_time compared it against limits.movetime in milliseconds without conversion, so movetime silently meant nodes. Convert movetime to nodes before init's early return.

No functional change