### PR TITLE
Initialize shared continuation history once per NUMA node

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -703,21 +703,23 @@ void Search::Worker::clear() {
     mainHistory.fill(-5);
     captureHistory.fill(-742);
 
-    // Each thread is responsible for clearing their part of shared history
+    // Each thread clears its part of the dynamically-sized shared histories.
+    // The constant-size continuation history is initialized by thread 0 of each NUMA node.
     sharedHistory.correctionHistory.clear_range(-5, numaThreadIdx, numaTotal);
     sharedHistory.pawnHistory.clear_range(-1338, numaThreadIdx, numaTotal);
+
+    if (numaThreadIdx == 0)
+        for (bool inCheck : {false, true})
+            for (StatsType c : {NoCaptures, Captures})
+                for (auto& to : continuationHistory[inCheck][c])
+                    for (auto& h : to)
+                        h.fill(-586);
 
     ttMoveHistory = 0;
 
     for (auto& to : continuationCorrectionHistory)
         for (auto& h : to)
             h.fill(5);
-
-    for (bool inCheck : {false, true})
-        for (StatsType c : {NoCaptures, Captures})
-            for (auto& to : continuationHistory[inCheck][c])
-                for (auto& h : to)
-                    h.fill(-586);
 
     for (usize i = 1; i < reductions.size(); ++i)
         reductions[i] = int(2872 / 128.0 * std::log(i));


### PR DESCRIPTION
Worker::clear partitioned correctionHistory and pawnHistory by NUMA thread
index, but then filled the shared continuationHistory from every worker.
Since continuationHistory is constant-size and shared only within a NUMA
node, have only thread 0 of each node initialize it

No functional change