### PR TITLE
Clamp speedtest inputs to valid ranges

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -17,12 +17,15 @@
 */
 
 #include "benchmark.h"
+#include "engine.h"
 #include "numa.h"
 #include "misc.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <vector>
 
 namespace {
@@ -450,25 +453,45 @@ BenchmarkSetup setup_benchmark(std::istream& is) {
 
     static constexpr int DEFAULT_DURATION_S = 150;
 
+    static constexpr int MaxDurationS = std::numeric_limits<int>::max() / 1000;
+
     BenchmarkSetup setup{};
 
-    // Assign default values to missing arguments
-    int desiredTimeS;
+    auto clamped = [](const char* what, i64 value, i64 lo, i64 hi) {
+        const i64 fixed = std::clamp(value, lo, hi);
+        if (fixed != value)
+            std::cerr << "info string speedtest: " << what << ' ' << value << " is outside [" << lo
+                      << ", " << hi << "]; using " << fixed << std::endl;
+        return int(fixed);
+    };
 
-    if (!(is >> setup.threads))
+    // Assign default values to missing arguments
+    i64 desiredTimeS;
+    i64 requested;
+
+    if (!(is >> requested))
         setup.threads = int(get_hardware_concurrency());
     else
+    {
+        setup.threads = clamped("threads", requested, 1, MaxThreads);
         setup.originalInvocation += std::to_string(setup.threads);
+    }
 
-    if (!(is >> setup.ttSize))
-        setup.ttSize = TT_SIZE_PER_THREAD * setup.threads;
+    if (!(is >> requested))
+        setup.ttSize = clamped("hash", i64(TT_SIZE_PER_THREAD) * setup.threads, 1, MaxHashMB);
     else
+    {
+        setup.ttSize = clamped("hash", requested, 1, MaxHashMB);
         setup.originalInvocation += " " + std::to_string(setup.ttSize);
+    }
 
     if (!(is >> desiredTimeS))
         desiredTimeS = DEFAULT_DURATION_S;
     else
+    {
+        desiredTimeS = clamped("seconds", desiredTimeS, 1, MaxDurationS);
         setup.originalInvocation += " " + std::to_string(desiredTimeS);
+    }
 
     setup.filledInvocation += std::to_string(setup.threads) + " " + std::to_string(setup.ttSize)
                             + " " + std::to_string(desiredTimeS);

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -48,8 +48,7 @@ namespace Stockfish {
 
 namespace NN = Eval::NNUE;
 
-constexpr int MaxHashMB  = Is64Bit ? 33554432 : 2048;
-int           MaxThreads = std::max(1024, 4 * int(get_hardware_concurrency()));
+int MaxThreads = std::max(1024, 4 * int(get_hardware_concurrency()));
 
 // The default configuration will attempt to group L3 domains up to 32 threads.
 // This size was found to be a good balance between the Elo gain of increased

--- a/src/engine.h
+++ b/src/engine.h
@@ -40,9 +40,13 @@
 #include "syzygy/tbprobe.h"  // for Stockfish::Depth
 #include "thread.h"
 #include "tt.h"
+#include "types.h"
 #include "ucioption.h"
 
 namespace Stockfish {
+
+constexpr int MaxHashMB = Is64Bit ? 33554432 : 2048;
+extern int    MaxThreads;
 
 class Engine {
    public:


### PR DESCRIPTION
speedtest multiplied user-supplied seconds and threads in int, which could overflow and produce negative movetime or Hash values. Clamp each input to the range the option layer accepts and report corrections.

No functional change