### PR TITLE
Replace nnueComplexity with simple_eval equivalent

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -37,8 +37,14 @@
 
 namespace Stockfish {
 
-// Evaluate is the evaluator for the outer world. It returns a static evaluation
-// of the position from the point of view of the side to move.
+int Eval::simple_eval(const Position& pos) {
+    const Color c = pos.side_to_move();
+    return PawnValue * (pos.count<PAWN>(c) - pos.count<PAWN>(~c)) + pos.non_pawn_material(c)
+         - pos.non_pawn_material(~c);
+}
+
+Value scale_evaluation(Value nnue, int optimism, const Position& pos);
+
 Value Eval::evaluate(const Eval::NNUE::Network&     network,
                      const Position&                pos,
                      Eval::NNUE::AccumulatorStack&  accumulators,
@@ -46,23 +52,44 @@ Value Eval::evaluate(const Eval::NNUE::Network&     network,
                      int                            optimism) {
 
     assert(!pos.checkers());
+    Value nnue = network.evaluate(pos, accumulators, caches);
+    return scale_evaluation(nnue, optimism, pos);
+}
 
-    auto [psqt, positional] = network.evaluate(pos, accumulators, caches);
+// Applies search-dependent scaling (optimism and rule50) to the raw NNUE eval
+Value scale_evaluation(Value nnue, int optimism, const Position& pos) {
+    int se = Eval::simple_eval(pos);
 
-    Value nnue = psqt + positional;
+    // 1. Normalize the raw evaluations to [-1024, 1024] to measure their correlation.
+    int se_norm   = (se * 1024) / (std::abs(se) + 1024);
+    int nnue_norm = (nnue * 1024) / (std::abs(nnue) + 1024);
 
-    // Blend optimism and eval with nnue complexity
-    int nnueComplexity = std::abs(psqt - positional);
-    optimism += optimism * i64(nnueComplexity) / 476;
-    nnue -= nnue * i64(nnueComplexity) / 18236;
+    // 2. Measure positional difficulty, "alignment". When NNUE and material agree, the position is
+    // straightforward; otherwise, it involves complex compensation. In a representative sample,
+    // raw_alignment averages -1 or so, i.e. well-centered in [-2048, 2048].
+    int raw_alignment = (se_norm * nnue_norm) / 512;
+    // Shift it to a positive range: [hard, average, easy] -> [0, 2048, 4096].
+    int alignment = raw_alignment + 2048;
 
-    int material = 534 * pos.count<PAWN>() + pos.non_pawn_material();
-    int v        = nnue + (nnue * i64(material) + optimism * i64(7675)) / 91000;
+    // 3. Blend optimism and NNUE according to the alignment.
+    // We favor easy positions by heavily boosting optimism when alignment is high.
+    // Conversely, in hard positions, the optimism boost is minimized.
+    // To maintain overall evaluation scale, the static NNUE score is dampened proportionally.
+    // At average alignment of 2047, the optimism boost is around 1.5x.
+    optimism += (optimism * alignment) / 4096;
+    nnue     -= (i64(nnue) * alignment) / 131072;
 
-    // Damp down the evaluation linearly when shuffling
-    v -= v * pos.rule50_count() / 199;
+    int base_eval = nnue + (optimism * 7674) / 90649;
 
-    // Guarantee evaluation does not hit the tablebase range
+    // 4. Scale the combined evaluation by material volume.
+    // Higher material on the board amplifies the final evaluation magnitude.
+    int material = 521 * pos.count<PAWN>() + pos.non_pawn_material();
+    int v = (base_eval * i64(90649 + material)) / 90649;
+
+    // 5. Damp down the evaluation linearly when shuffling
+    v -= v * pos.rule50_count() / 189;
+
+    // 6. Guarantee that the evaluation does not hit the tablebase range
     v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
 
     return v;
@@ -86,17 +113,17 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Network& network) {
 
     ss << std::showpoint << std::showpos << std::fixed << std::setprecision(2) << std::setw(15);
 
-    auto [psqt, positional] = network.evaluate(pos, *accumulators, *caches);
-    Value v                 = psqt + positional;
-    ss << "NNUE evaluation          " << v << " (side to move, internal units)\n";
-    v = pos.side_to_move() == WHITE ? v : -v;
-    ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)\n";
+    Value nnue = network.evaluate(pos, *accumulators, *caches);
+    Value s_v  = scale_evaluation(nnue, VALUE_ZERO, pos); // requires stm perspective
 
-    v = evaluate(network, pos, *accumulators, *caches, VALUE_ZERO);
-    v = pos.side_to_move() == WHITE ? v : -v;
+    ss << "NNUE evaluation          " << nnue << " (side to move, internal units)\n";
 
+    nnue = pos.side_to_move() == WHITE ? nnue : -nnue;
+    s_v  = pos.side_to_move() == WHITE ? s_v : -s_v;
+
+    ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(nnue, pos) << " (white side, pawns)\n";
     ss << "Final evaluation      ";
-    ss << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)";
+    ss << 0.01 * UCIEngine::to_cp(s_v, pos) << " (white side, pawns)";
     ss << " [with scaled NNUE, ...]\n";
 
     return ss.str();

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -43,11 +43,18 @@ class AccumulatorStack;
 
 std::string trace(Position& pos, const Eval::NNUE::Network& network);
 
+// The main function for the outside world. It returns a static evaluation
+// of the position for the side to move perspective.
 Value evaluate(const NNUE::Network&           network,
                const Position&                pos,
                Eval::NNUE::AccumulatorStack&  accumulators,
                Eval::NNUE::AccumulatorCaches& caches,
                int                            optimism);
+
+// Returns the material difference for the side to move.
+// Divide by PawnValue to get a vaguely traditional estimate
+int simple_eval(const Position& pos);
+
 }  // namespace Eval
 
 }  // namespace Stockfish

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -138,7 +138,7 @@ bool Network::save(const EvalFile& evalFile, const std::optional<fs::path>& file
     return saved;
 }
 
-NetworkOutput Network::evaluate(const Position&    pos,
+Value Network::evaluate(const Position&    pos,
                                 AccumulatorStack&  accumulatorStack,
                                 AccumulatorCaches& cache) const {
 
@@ -154,7 +154,7 @@ NetworkOutput Network::evaluate(const Position&    pos,
     const auto psqt       = featureTransformer.transform(pos, accumulatorStack, cache,
                                                          transformedFeatures, bucket, nnzInfo);
     const auto positional = network[bucket].propagate(transformedFeatures, nnzInfo);
-    return {static_cast<Value>(psqt / OutputScale), static_cast<Value>(positional / OutputScale)};
+    return static_cast<Value>(psqt / OutputScale) + static_cast<Value>(positional / OutputScale);
 }
 
 

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -25,7 +25,6 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <tuple>
 #include <filesystem>
 
 #include "../types.h"
@@ -42,8 +41,6 @@ namespace Stockfish::Eval::NNUE {
 
 class AccumulatorStack;
 struct AccumulatorCaches;
-
-using NetworkOutput = std::tuple<Value, Value>;
 
 // The network must be a trivial type, i.e. the memory must be in-line.
 // This is required to allow sharing the network via shared memory, as
@@ -65,9 +62,9 @@ class Network {
 
     usize get_content_hash() const;
 
-    NetworkOutput evaluate(const Position&    pos,
-                           AccumulatorStack&  accumulatorStack,
-                           AccumulatorCaches& cache) const;
+    Value evaluate(const Position&    pos,
+                   AccumulatorStack&  accumulatorStack,
+                   AccumulatorCaches& cache) const;
 
 
     void verify(const std::function<void(std::string_view)>& f,


### PR DESCRIPTION
This greatly eases future network arch simplifications, namely removing its `psqt` component.

When we scale the eval for use in search, compare it with simple_eval (rather than nnue psqt) to determine the optimism boost.

Passed STC: https://tests.stockfishchess.org/tests/view/6a72671d2cf557d58a2e1d5b
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 312288 W: 80020 L: 80103 D: 152165
Ptnml(0-2): 473, 37193, 81228, 36444, 806

Passed LTC: https://tests.stockfishchess.org/tests/view/6a7a2a278b9c2482ffa9e00b
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 189792 W: 49500 L: 49452 D: 90840
Ptnml(0-2): 33, 20317, 54212, 20237, 97

bench 2666650