### PR TITLE
Native thread fixes

### DIFF
--- a/src/numa.h
+++ b/src/numa.h
@@ -956,10 +956,16 @@ class NumaConfig {
 
     template<typename FuncT>
     void execute_on_numa_node(NumaIndex n, FuncT&& f) const {
-        std::thread th([this, &f, n]() {
+        NativeThread th = create_native_thread({/*.largeStack=*/false}, [this, &f, n]() {
             bind_current_thread_to_numa_node(n);
             std::forward<FuncT>(f)();
         });
+
+        if (!th.joinable())
+        {
+            std::cerr << "Failed to execute function on NUMA node\n";
+            std::exit(EXIT_FAILURE);
+        }
 
         th.join();
     }

--- a/src/numa.h
+++ b/src/numa.h
@@ -957,7 +957,7 @@ class NumaConfig {
 
     template<typename FuncT>
     void execute_on_numa_node(NumaIndex n, FuncT&& f) const {
-        NativeThread th = create_native_thread({/*.largeStack=*/false}, [this, &f, n]() {
+        NativeThread th = create_native_thread(NativeThreadOptions{}, [this, &f, n]() {
             bind_current_thread_to_numa_node(n);
             std::forward<FuncT>(f)();
         });

--- a/src/numa.h
+++ b/src/numa.h
@@ -300,7 +300,7 @@ inline WindowsAffinity get_process_affinity() {
 
         if (GetThreadSelectedCpuSetMasks_f != nullptr)
         {
-            std::thread th([&]() {
+            NativeThread th = create_native_thread(NativeThreadOptions{}, [&]() {
                 std::set<CpuIndex> cpus;
                 bool               isAffinityFull = true;
 

--- a/src/numa.h
+++ b/src/numa.h
@@ -71,6 +71,7 @@ using GetThreadSelectedCpuSetMasks_t = BOOL (*)(HANDLE, PGROUP_AFFINITY, USHORT,
 #endif
 
 #include "misc.h"
+#include "thread_native.h"
 
 namespace Stockfish {
 

--- a/src/shm_unix.h
+++ b/src/shm_unix.h
@@ -51,6 +51,7 @@
 #define SF_MAX_SEM_NAME_LEN NAME_MAX
 
 #include "misc.h"
+#include "thread_native.h"
 
 namespace Stockfish::shm {
 
@@ -206,9 +207,9 @@ class SharedMemory {
     std::string init_lock_path_;
 
     // serve requests for the shared segment on this .sock
-    std::string socket_path_;
-    std::thread server_thread_;
-    UniqueFd    shutdown_;  // close to signal server thread shutdown
+    std::string  socket_path_;
+    NativeThread server_thread_;
+    UniqueFd     shutdown_;  // close to signal server thread shutdown
 
     static std::string make_sentinel_base(const std::string& name) {
         char buf[32];
@@ -375,10 +376,13 @@ class SharedMemory {
     //  - Forwards the file descriptor fd
     //  - Exits when shutdown_receiver is hung up on
     //  - Listens on server_fd
-    static std::thread
+    static NativeThread
     make_server_thread(UniqueFd fd, UniqueFd shutdown_receiver, UniqueFd server_fd) {
-        return std::thread([fd = std::move(fd), shutdown_receiver = std::move(shutdown_receiver),
-                            server_fd = std::move(server_fd)]() {
+        NativeThreadOptions options{/*.largeStack=*/false};
+
+        return create_native_thread(options, [fd                = std::move(fd),
+                                              shutdown_receiver = std::move(shutdown_receiver),
+                                              server_fd         = std::move(server_fd)]() {
             enum {
                 FdServer,
                 FdShutdown,
@@ -562,6 +566,10 @@ class SharedMemory {
             // other fishes can use.
             server_thread_ = make_server_thread(std::move(memfd), std::move(shutdown_receiver),
                                                 std::move(server_fd));
+            if (!server_thread_.joinable())
+            {
+                return false;
+            }
         }
 
         return true;

--- a/src/shm_unix.h
+++ b/src/shm_unix.h
@@ -378,11 +378,10 @@ class SharedMemory {
     //  - Listens on server_fd
     static NativeThread
     make_server_thread(UniqueFd fd, UniqueFd shutdown_receiver, UniqueFd server_fd) {
-        NativeThreadOptions options{/*.largeStack=*/false};
-
-        return create_native_thread(options, [fd                = std::move(fd),
-                                              shutdown_receiver = std::move(shutdown_receiver),
-                                              server_fd         = std::move(server_fd)]() {
+        return create_native_thread(NativeThreadOptions{}, [fd = std::move(fd),
+                                                            shutdown_receiver =
+                                                              std::move(shutdown_receiver),
+                                                            server_fd = std::move(server_fd)]() {
             enum {
                 FdServer,
                 FdShutdown,

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -23,6 +23,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <deque>
+#include <iostream>
 #include <map>
 #include <memory>
 #include <string>

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -55,7 +55,14 @@ Thread::Thread(Search::SharedState&                    sharedState,
     idxInNuma(numaN),
     totalNuma(totalNumaCount),
     nthreads(sharedState.options["Threads"]),
-    stdThread(&Thread::idle_loop, this) {
+    stdThread(
+      create_native_thread(NativeThreadOptions{/*.largeStack=*/true}, &Thread::idle_loop, this)) {
+
+    if (!stdThread.joinable())
+    {
+        std::cerr << "Failed to create search thread\n";
+        std::exit(EXIT_FAILURE);
+    }
 
     wait_for_search_finished();
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -57,7 +57,7 @@ Thread::Thread(Search::SharedState&                    sharedState,
     totalNuma(totalNumaCount),
     nthreads(sharedState.options["Threads"]),
     stdThread(
-      create_native_thread(NativeThreadOptions{/*.largeStack=*/true}, &Thread::idle_loop, this)) {
+      create_native_thread(NativeThreadOptions{}.setLargeStack(true), &Thread::idle_loop, this)) {
 
     if (!stdThread.joinable())
     {

--- a/src/thread_native.h
+++ b/src/thread_native.h
@@ -34,6 +34,10 @@
 
 namespace Stockfish {
 
+struct NativeThreadOptions {
+    bool largeStack{};
+};
+
 #ifdef _MSC_VER
 
 // MSVC-compatible toolchains use std::thread because they do not provide
@@ -41,7 +45,27 @@ namespace Stockfish {
 
 using NativeThread = std::thread;
 
+template<class Function, class... Args>
+NativeThread create_native_thread(NativeThreadOptions options, Function&& fun, Args&&... args) {
+    // TODO: implement for MSVC
+    (void) options;
+    return NativeThread(options, std::forward<Function>(fun), std::forward<Args>(args)...);
+}
+
 #else
+
+struct ThreadCallableBase {  // type erase F
+    virtual ~ThreadCallableBase() = default;
+    virtual void run()            = 0;
+};
+
+template<typename F>
+struct ThreadCallable final: ThreadCallableBase {
+    F func;
+    ThreadCallable(F&& f) :
+        func(std::move(f)) {}
+    void run() override { func(); }
+};
 
 // On OSX threads other than the main thread are created with a reduced stack
 // size of 512KB by default, this is too low for deep searches, which require
@@ -51,23 +75,22 @@ using NativeThread = std::thread;
 
 class NativeThread {
     pthread_t thread;
+    bool      running_ = false;
 
     static constexpr usize TH_STACK_SIZE = 8 * 1024 * 1024;
 
-   public:
-    template<class Function, class... Args>
-    explicit NativeThread(Function&& fun, Args&&... args) {
-        auto func = new std::function<void()>(
-          std::bind(std::forward<Function>(fun), std::forward<Args>(args)...));
-
+    void start(NativeThreadOptions options, ThreadCallableBase* func) {
         pthread_attr_t attr_storage, *attr = &attr_storage;
         pthread_attr_init(attr);
-        pthread_attr_setstacksize(attr, TH_STACK_SIZE);
+        if (options.largeStack)
+        {
+            pthread_attr_setstacksize(attr, TH_STACK_SIZE);
+        }
 
         auto start_routine = [](void* ptr) -> void* {
-            auto f = reinterpret_cast<std::function<void()>*>(ptr);
+            auto f = reinterpret_cast<ThreadCallableBase*>(ptr);
             // Call the function
-            (*f)();
+            f->run();
             delete f;
             return nullptr;
         };
@@ -76,14 +99,40 @@ class NativeThread {
         pthread_attr_destroy(attr);
 
         if (rc != 0)
+            delete func;
+        else
+            running_ = true;
+    }
+
+   public:
+    bool joinable() const { return running_; }
+    void join() {
+        if (running_)
         {
-            std::cerr << "Failed to create a thread: " << std::strerror(rc) << std::endl;
-            std::exit(EXIT_FAILURE);
+            pthread_join(thread, nullptr);
+            running_ = false;
         }
     }
 
-    void join() { pthread_join(thread, nullptr); }
+    template<class Function, class... Args>
+    friend NativeThread create_native_thread(NativeThreadOptions, Function&&, Args&&...);
 };
+
+template<class Function, class... Args>
+inline NativeThread
+create_native_thread(NativeThreadOptions options, Function&& fun, Args&&... args) {
+    NativeThread thread{};
+    auto         bound_lambda = [f   = std::forward<Function>(fun),
+                         tup = std::make_tuple(std::forward<Args>(args)...)]() mutable {
+        std::apply(std::move(f), std::move(tup));
+    };
+    auto func = new (std::nothrow) ThreadCallable<decltype(bound_lambda)>(std::move(bound_lambda));
+    if (func != nullptr)
+    {
+        thread.start(options, func);
+    }
+    return thread;
+}
 
 #endif  // _MSC_VER
 

--- a/src/thread_native.h
+++ b/src/thread_native.h
@@ -27,6 +27,7 @@
     #include <cstring>
     #include <functional>
     #include <iostream>
+    #include <tuple>
     #include <utility>
 
     #include "misc.h"
@@ -125,12 +126,15 @@ class NativeThread {
     NativeThread& operator=(NativeThread&& other) noexcept {
         if (&other != this)
         {
+            assert(!running_ && "Thread was not joined");
             thread         = other.thread;
             running_       = other.running_;
             other.running_ = false;
         }
         return *this;
     }
+
+    ~NativeThread() { assert(!running_ && "Thread was not joined"); }
 
     bool joinable() const { return running_; }
     void join() {

--- a/src/thread_native.h
+++ b/src/thread_native.h
@@ -36,6 +36,11 @@ namespace Stockfish {
 
 struct NativeThreadOptions {
     bool largeStack{};
+
+    NativeThreadOptions& setLargeStack(bool value) {
+        largeStack = value;
+        return *this;
+    }
 };
 
 #ifdef _MSC_VER
@@ -47,9 +52,9 @@ using NativeThread = std::thread;
 
 template<class Function, class... Args>
 NativeThread create_native_thread(NativeThreadOptions options, Function&& fun, Args&&... args) {
-    // TODO: implement for MSVC
+    // TODO: implement fallible thread creation for MSVC
     (void) options;
-    return NativeThread(options, std::forward<Function>(fun), std::forward<Args>(args)...);
+    return NativeThread(std::forward<Function>(fun), std::forward<Args>(args)...);
 }
 
 #else
@@ -59,12 +64,14 @@ struct ThreadCallableBase {  // type erase F
     virtual void run()            = 0;
 };
 
-template<typename F>
+template<typename F, typename... Args>
 struct ThreadCallable final: ThreadCallableBase {
-    F func;
-    ThreadCallable(F&& f) :
-        func(std::move(f)) {}
-    void run() override { func(); }
+    F                   func_;
+    std::tuple<Args...> args_;
+    ThreadCallable(F&& f, Args&&... args) :
+        func_(std::forward<F>(f)),
+        args_(std::make_tuple(std::forward<Args>(args)...)) {}
+    void run() override { std::apply(func_, args_); }
 };
 
 // On OSX threads other than the main thread are created with a reduced stack
@@ -105,6 +112,26 @@ class NativeThread {
     }
 
    public:
+    NativeThread()                               = default;
+    NativeThread(const NativeThread&)            = delete;
+    NativeThread& operator=(const NativeThread&) = delete;
+
+    NativeThread(NativeThread&& other) noexcept {
+        thread         = other.thread;
+        running_       = other.running_;
+        other.running_ = false;
+    }
+
+    NativeThread& operator=(NativeThread&& other) noexcept {
+        if (&other != this)
+        {
+            thread         = other.thread;
+            running_       = other.running_;
+            other.running_ = false;
+        }
+        return *this;
+    }
+
     bool joinable() const { return running_; }
     void join() {
         if (running_)
@@ -122,15 +149,10 @@ template<class Function, class... Args>
 inline NativeThread
 create_native_thread(NativeThreadOptions options, Function&& fun, Args&&... args) {
     NativeThread thread{};
-    auto         bound_lambda = [f   = std::forward<Function>(fun),
-                         tup = std::make_tuple(std::forward<Args>(args)...)]() mutable {
-        std::apply(std::move(f), std::move(tup));
-    };
-    auto func = new (std::nothrow) ThreadCallable<decltype(bound_lambda)>(std::move(bound_lambda));
-    if (func != nullptr)
-    {
+    using Callable = ThreadCallable<std::decay_t<Function>, std::decay_t<Args>...>;
+    if (auto func =
+          new (std::nothrow) Callable(std::forward<Function>(fun), std::forward<Args>(args)...))
         thread.start(options, func);
-    }
     return thread;
 }
 

--- a/src/thread_native.h
+++ b/src/thread_native.h
@@ -23,7 +23,10 @@
     #include <thread>
 #else
     #include <pthread.h>
+    #include <cstdlib>
+    #include <cstring>
     #include <functional>
+    #include <iostream>
     #include <utility>
 
     #include "misc.h"
@@ -69,7 +72,14 @@ class NativeThread {
             return nullptr;
         };
 
-        pthread_create(&thread, attr, start_routine, func);
+        const int rc = pthread_create(&thread, attr, start_routine, func);
+        pthread_attr_destroy(attr);
+
+        if (rc != 0)
+        {
+            std::cerr << "Failed to create a thread: " << std::strerror(rc) << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
     }
 
     void join() { pthread_join(thread, nullptr); }


### PR DESCRIPTION
pthread_create's return value was ignored, so a failed spawn left the engine hanging forever waiting for a searching flag no thread would clear. Report the error and exit. Avoid using std::thread. Intends to consolidate #7060 and #7065 by making `NativeThread` more customizable.

No functional change