### PR TITLE
Update Release Creation

### DIFF
--- a/.github/workflows/official_release.yml
+++ b/.github/workflows/official_release.yml
@@ -18,7 +18,7 @@ jobs:
       universal_matrix: ${{ steps.set-universal-matrix.outputs.universal_matrix }}
       arm_matrix: ${{ steps.set-arm-matrix.outputs.arm_matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - id: set-universal-matrix

--- a/.github/workflows/official_release.yml
+++ b/.github/workflows/official_release.yml
@@ -1,0 +1,126 @@
+name: Official Release
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Official release tag in the form sf_X or sf_X.Y
+        required: true
+        type: string
+      release_title:
+        description: Official release title
+        required: true
+        type: string
+
+jobs:
+  Matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      universal_matrix: ${{ steps.set-universal-matrix.outputs.universal_matrix }}
+      arm_matrix: ${{ steps.set-arm-matrix.outputs.arm_matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: set-universal-matrix
+        run: |
+          UNIVERSAL_MATRIX=$(jq -c '.' .github/ci/universal_matrix.json)
+          echo "UNIVERSAL_MATRIX=$UNIVERSAL_MATRIX" >> $GITHUB_OUTPUT
+      - id: set-arm-matrix
+        run: |
+          ARM_MATRIX=$(jq -c '.' .github/ci/arm_matrix.json)
+          echo "ARM_MATRIX=$ARM_MATRIX" >> $GITHUB_OUTPUT
+
+  OfficialReleaseDraft:
+    if: github.repository == 'official-stockfish/Stockfish'
+    runs-on: ubuntu-latest
+    needs: [Matrix]
+    outputs:
+      release_tag: ${{ steps.release_metadata.outputs.release_tag }}
+    permissions:
+      contents: write # For creating the official release tag and draft
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Validate release request
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_TITLE: ${{ inputs.release_title }}
+        run: |
+          if [[ "${{ github.ref_name }}" != 'master' ]]; then
+            echo 'Official releases must be dispatched from master.'
+            exit 1
+          fi
+
+          if [[ ! "$RELEASE_TAG" =~ ^sf_[0-9]+(\.[0-9]+)?$ ]]; then
+            echo 'release_tag must match sf_X or sf_X.Y'
+            exit 1
+          fi
+
+          if [[ -z "$RELEASE_TITLE" ]]; then
+            echo 'release_title is required.'
+            exit 1
+          fi
+
+      - name: Compute release metadata
+        id: release_metadata
+        run: echo "release_tag=${{ inputs.release_tag }}" >> $GITHUB_OUTPUT
+
+      - name: Ensure tag does not already exist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release view "${{ inputs.release_tag }}" >/dev/null 2>&1 && { echo 'Release already exists for this tag.'; exit 1; } || true
+
+      - name: Ensure git tag does not already exist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh api "repos/${{ github.repository }}/git/ref/tags/${{ inputs.release_tag }}" >/dev/null 2>&1 && { echo 'Tag already exists.'; exit 1; } || true
+
+      - name: Create official release tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh api "repos/${{ github.repository }}/git/refs" -f ref="refs/tags/${{ inputs.release_tag }}" -f sha="${{ github.sha }}"
+
+      - name: Create draft official release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${{ inputs.release_tag }}" --draft --title "${{ inputs.release_title }}" --notes ''
+
+  UniversalCompilation:
+    needs: [Matrix]
+    uses: ./.github/workflows/universal_compilation.yml
+
+  ARMCompilation:
+    needs: [Matrix]
+    uses: ./.github/workflows/arm_compilation.yml
+    with:
+      matrix: ${{ needs.Matrix.outputs.arm_matrix }}
+
+  OfficialBinaries:
+    if: github.repository == 'official-stockfish/Stockfish'
+    needs: [OfficialReleaseDraft, Matrix, UniversalCompilation]
+    uses: ./.github/workflows/upload_binaries.yml
+    with:
+      matrix: ${{ needs.Matrix.outputs.universal_matrix }}
+      release_tag: ${{ needs.OfficialReleaseDraft.outputs.release_tag }}
+      release_prerelease: false
+    permissions:
+      contents: write # For uploading release assets
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
+  OfficialARMBinaries:
+    if: github.repository == 'official-stockfish/Stockfish'
+    needs: [OfficialReleaseDraft, Matrix, ARMCompilation]
+    uses: ./.github/workflows/upload_binaries.yml
+    with:
+      matrix: ${{ needs.Matrix.outputs.arm_matrix }}
+      release_tag: ${{ needs.OfficialReleaseDraft.outputs.release_tag }}
+      release_prerelease: false
+    permissions:
+      contents: write # For uploading release assets
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -1,8 +1,6 @@
 name: Stockfish
 on:
   push:
-    tags:
-      - "*"
     branches:
       - master
       - tools
@@ -18,32 +16,18 @@ concurrency:
 
 jobs:
   Prerelease:
-    name: Prerelease
-    if: github.repository == 'official-stockfish/Stockfish' && (github.ref == 'refs/heads/master' || (startsWith(github.ref_name, 'sf_') && github.ref_type == 'tag'))
+    if: github.repository == 'official-stockfish/Stockfish' && github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: [Matrix, ARMCompilation, UniversalCompilation]
+    outputs:
+      release_tag: ${{ steps.prerelease_metadata.outputs.release_tag }}
     permissions:
-      contents: write # For deleting/creating a prerelease
+      contents: write # For managing the dev prerelease
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0
-
-      # returns null if no pre-release exists
-      - name: Get Commit SHA of Latest Pre-release
-        run: |
-          # Install required packages
-          sudo apt-get update
-          sudo apt-get install -y curl jq
-
-          echo "COMMIT_SHA_TAG=$(jq -r 'map(select(.prerelease)) | first | .tag_name' <<< $(curl -s https://api.github.com/repos/${{ github.repository_owner }}/Stockfish/releases))" >> $GITHUB_ENV
-
-      # delete old previous pre-release and tag
-      - run: gh release delete ${{ env.COMMIT_SHA_TAG }} --cleanup-tag
-        if: env.COMMIT_SHA_TAG != 'null'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Make sure that an old ci that still runs on master doesn't recreate a prerelease
       - name: Check Pullable Commits
@@ -52,14 +36,6 @@ jobs:
           git fetch
           CHANGES=$(git rev-list HEAD..origin/master --count)
           echo "CHANGES=$CHANGES" >> $GITHUB_ENV
-
-      - name: Get last commit SHA
-        id: last_commit
-        run: echo "COMMIT_SHA=$(git rev-parse HEAD | cut -c 1-8)" >> $GITHUB_ENV
-
-      - name: Get commit date
-        id: commit_date
-        run: echo "COMMIT_DATE=$(git show -s --date=format:'%Y%m%d' --format=%cd HEAD)" >> $GITHUB_ENV
 
       - name: Official Release?
         id: official_release
@@ -71,7 +47,20 @@ jobs:
             echo "OFFICIAL_RELEASE=false" >> $GITHUB_ENV
           fi
 
-      # Get recent commits for release body
+      - name: Compute prerelease metadata
+        id: prerelease_metadata
+        run: |
+          COMMIT_SHA=$(git rev-parse HEAD | cut -c 1-8)
+          COMMIT_DATE=$(git show -s --date=format:'%Y%m%d' --format=%cd HEAD)
+
+          if [[ "${{ github.ref_name }}" == 'master' && "$CHANGES" == '0' && "$OFFICIAL_RELEASE" == 'false' ]]; then
+            echo "release_name=Stockfish dev-$COMMIT_DATE-$COMMIT_SHA" >> $GITHUB_OUTPUT
+            echo "release_tag=stockfish-dev-$COMMIT_DATE-$COMMIT_SHA" >> $GITHUB_OUTPUT
+          else
+            echo "release_name=" >> $GITHUB_OUTPUT
+            echo "release_tag=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Get commits in this push
         id: recent_commits
         run: |
@@ -82,31 +71,44 @@ jobs:
           echo "$COMMITS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      # Create a new pre-release, the other upload_binaries.yml will upload the binaries
-      # to this pre-release.
-      - name: Create Prerelease
-        if: github.ref_name == 'master' && env.CHANGES == '0' && env.OFFICIAL_RELEASE == 'false'
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+      - name: Get Latest Dev Prerelease Tag
+        if: steps.prerelease_metadata.outputs.release_tag != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COMMIT_SHA_TAG=$(gh release list --repo "${{ github.repository }}" --exclude-drafts --limit 100 --json tagName,isPrerelease | jq -r 'map(select(.isPrerelease)) | first | .tagName // "null"')
+          echo "COMMIT_SHA_TAG=$COMMIT_SHA_TAG" >> "$GITHUB_ENV"
+
+      - name: Delete Previous Dev Prerelease
+        if: steps.prerelease_metadata.outputs.release_tag != '' && env.COMMIT_SHA_TAG != 'null'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release delete "${{ env.COMMIT_SHA_TAG }}" --repo "${{ github.repository }}" --cleanup-tag
+
+      - name: Create Draft Prerelease
+        if: steps.prerelease_metadata.outputs.release_tag != ''
+        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
         with:
-          name: Stockfish dev-${{ env.COMMIT_DATE }}-${{ env.COMMIT_SHA }}
-          tag_name: stockfish-dev-${{ env.COMMIT_DATE }}-${{ env.COMMIT_SHA }}
+          name: ${{ steps.prerelease_metadata.outputs.release_name }}
+          tag_name: ${{ steps.prerelease_metadata.outputs.release_tag }}
+          draft: true
           prerelease: true
           body: |
             Precompiled binaries of the latest Stockfish development version, built automatically on every commit.
-            
+
             > [!NOTE]
             > For stable, thoroughly tested builds use the [official releases](https://github.com/official-stockfish/Stockfish/releases).
             > Pre-releases may contain bugs.
-            
+
             *Some platforms ship a **universal binary** that automatically selects the best
             instruction set for your CPU - no manual selection needed.*
-            
+
             ---
-            
+
             ## Commits
-            
+
             ${{ steps.recent_commits.outputs.COMMITS }}
-            
+
             [View all commits →](https://github.com/${{ github.repository }}/commits/master)
   Matrix:
     name: Prepare matrices
@@ -165,25 +167,40 @@ jobs:
     name: "Universal builds"
     needs: [Matrix, Sanitizers, Tests, Matetrack, Games, CompilerCheck]
     uses: ./.github/workflows/universal_compilation.yml
-  ARM_Binaries:
+  DevBinaries:
     if: github.repository == 'official-stockfish/Stockfish'
-    name: Android uploads
-    needs: [Prerelease, Matrix]
-    uses: ./.github/workflows/upload_binaries.yml
-    with:
-      matrix: ${{ needs.Matrix.outputs.arm_matrix }}
-    permissions:
-      contents: write # For deleting/creating a (pre)release
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
-  Universal_Binaries:
-    if: github.repository == 'official-stockfish/Stockfish'
-    name: Universal binaries
-    needs: [Prerelease, Matrix]
+    name: Universal uploads
+    needs: [Prerelease, Matrix, UniversalCompilation]
     uses: ./.github/workflows/upload_binaries.yml
     with:
       matrix: ${{ needs.Matrix.outputs.universal_matrix }}
+      release_tag: ${{ needs.Prerelease.outputs.release_tag }}
+      release_prerelease: true
     permissions:
-      contents: write # For deleting/creating a (pre)release
+      contents: write # For uploading release assets
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+  DevARMBinaries:
+    if: github.repository == 'official-stockfish/Stockfish'
+    name: Android uploads
+    needs: [Prerelease, Matrix, ARMCompilation]
+    uses: ./.github/workflows/upload_binaries.yml
+    with:
+      matrix: ${{ needs.Matrix.outputs.arm_matrix }}
+      release_tag: ${{ needs.Prerelease.outputs.release_tag }}
+      release_prerelease: true
+    permissions:
+      contents: write # For uploading release assets
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+  PublishPrerelease:
+    if: github.repository == 'official-stockfish/Stockfish' && needs.Prerelease.outputs.release_tag != ''
+    needs: [Prerelease, DevBinaries, DevARMBinaries]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # For publishing the draft prerelease
+    steps:
+      - name: Publish Draft Prerelease
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ needs.Prerelease.outputs.release_tag }}" --repo "${{ github.repository }}" --draft=false --prerelease

--- a/.github/workflows/upload_binaries.yml
+++ b/.github/workflows/upload_binaries.yml
@@ -5,6 +5,12 @@ on:
       matrix:
         type: string
         required: true
+      release_tag:
+        type: string
+        required: false
+      release_prerelease:
+        type: boolean
+        required: false
     secrets:
       token:
         required: true
@@ -69,46 +75,12 @@ jobs:
         run: |
           zip -r stockfish-$NAME-$BINARY.zip stockfish
 
-      - name: Release
-        if: startsWith(github.ref_name, 'sf_') && github.ref_type == 'tag'
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+      - name: Upload Draft Release Asset
+        if: inputs.release_tag != ''
+        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
         with:
-          files: stockfish-${{ matrix.config.simple_name }}-${{ matrix.binaries }}.${{ matrix.config.archive_ext }}
-          token: ${{ secrets.token }}
-
-      - name: Get last commit sha
-        id: last_commit
-        run: echo "COMMIT_SHA=$(git rev-parse HEAD | cut -c 1-8)" >> $GITHUB_ENV
-
-      - name: Get commit date
-        id: commit_date
-        run: echo "COMMIT_DATE=$(git show -s --date=format:'%Y%m%d' --format=%cd HEAD)" >> $GITHUB_ENV
-
-      # Make sure that an old ci that still runs on master doesn't recreate a prerelease
-      - name: Check Pullable Commits
-        id: check_commits
-        run: |
-          git fetch
-          CHANGES=$(git rev-list HEAD..origin/master --count)
-          echo "CHANGES=$CHANGES" >> $GITHUB_ENV
-
-      - name: Official Release?
-        id: official_release
-        # Check for "Official release version of Stockfish" in the commit message
-        run: |
-          if git log -1 --pretty=%B | grep -q "Official release version of Stockfish"; then
-            echo "OFFICIAL_RELEASE=true" >> $GITHUB_ENV
-          else
-            echo "OFFICIAL_RELEASE=false" >> $GITHUB_ENV
-          fi
-
-      - name: Prerelease
-        if: github.ref_name == 'master' && env.CHANGES == '0' && env.OFFICIAL_RELEASE == 'false'
-        continue-on-error: true
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          name: Stockfish dev-${{ env.COMMIT_DATE }}-${{ env.COMMIT_SHA }}
-          tag_name: stockfish-dev-${{ env.COMMIT_DATE }}-${{ env.COMMIT_SHA }}
-          prerelease: true
+          tag_name: ${{ inputs.release_tag }}
+          draft: true
+          prerelease: ${{ inputs.release_prerelease }}
           files: stockfish-${{ matrix.config.simple_name }}-${{ matrix.binaries }}.${{ matrix.config.archive_ext }}
           token: ${{ secrets.token }}


### PR DESCRIPTION
Update the release pipeline so that we can create immutable releases.
The problem of the previous pipeline was that the release was created first and only afterwards the binaries were added, which is not possible with immutable releases.

https://github.com/Disservin/Stockfish/actions/runs/32180223600
<img width="1113" height="710" alt="image" src="https://github.com/user-attachments/assets/1e4945f7-3557-4c1f-afe2-7be0ed2b1060" />
