### PR TITLE
[bugfix] Allow root move PV to be longer than MAX_PLY plies

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -286,9 +286,9 @@ bool Search::Worker::iterative_deepening() {
 
     PVMoves pv;
 
-    PVMoves lastBestMovePV;
-    Depth   lastBestMoveDepth = 0;
-    Value   lastBestMoveScore = -VALUE_INFINITE;
+    RootPVMoves lastBestMovePV;
+    Depth       lastBestMoveDepth = 0;
+    Value       lastBestMoveScore = -VALUE_INFINITE;
 
     Value  alpha, beta;
     Value  bestValue     = -VALUE_INFINITE;

--- a/src/search.h
+++ b/src/search.h
@@ -60,6 +60,11 @@ class Network;
 
 namespace Search {
 
+// syzygy_extend_pv() may lead to PVs longer than MAX_PLY
+struct RootPVMoves: public std::vector<Move> {
+    RootPVMoves() { reserve(MAX_PLY); }
+};
+
 struct PVMoves {
     Move  moves[MAX_PLY + 1];
     usize length = 0;
@@ -98,6 +103,12 @@ struct PVMoves {
 
         moves[0] = move;
         ++length;
+    }
+
+    PVMoves& operator=(const RootPVMoves& rhs) {
+        length = std::min(rhs.size(), usize(MAX_PLY));
+        std::memcpy(moves, rhs.data(), length * sizeof(Move));
+        return *this;
     }
 };
 
@@ -141,19 +152,19 @@ struct RootMove {
         return m.score != score ? m.score < score : m.previousScore < previousScore;
     }
 
-    u64     effort             = 0;
-    Value   score              = -VALUE_INFINITE;
-    Value   previousScore      = -VALUE_INFINITE;
-    Value   averageScore       = -VALUE_INFINITE;
-    Value   meanSquaredScore   = -VALUE_INFINITE * VALUE_INFINITE;
-    Value   uciScore           = -VALUE_INFINITE;
-    bool    scoreLowerbound    = false;
-    bool    scoreUpperbound    = false;
-    bool    previousScoreExact = false;
-    int     selDepth           = 0;
-    int     tbRank             = 0;
-    Value   tbScore;
-    PVMoves pv, previousPV;
+    u64         effort             = 0;
+    Value       score              = -VALUE_INFINITE;
+    Value       previousScore      = -VALUE_INFINITE;
+    Value       averageScore       = -VALUE_INFINITE;
+    Value       meanSquaredScore   = -VALUE_INFINITE * VALUE_INFINITE;
+    Value       uciScore           = -VALUE_INFINITE;
+    bool        scoreLowerbound    = false;
+    bool        scoreUpperbound    = false;
+    bool        previousScoreExact = false;
+    int         selDepth           = 0;
+    int         tbRank             = 0;
+    Value       tbScore;
+    RootPVMoves pv, previousPV;
 };
 
 using RootMoves = std::vector<RootMove>;

--- a/tests/instrumented.py
+++ b/tests/instrumented.py
@@ -474,6 +474,12 @@ class TestSyzygy(metaclass=OrderedClassMembers):
         self.stockfish.check_output(check_output)
         self.stockfish.expect("bestmove *")
 
+    def test_syzygy_position_4(self):
+        self.stockfish.send_command("ucinewgame")
+        self.stockfish.send_command("position fen 8/8/7B/3B3P/7k/8/5K2/3r4 w - - 0 1")
+        self.stockfish.send_command("go depth 1")
+        self.stockfish.expect("bestmove *")
+
 class TestEnPassantSanitization(metaclass=OrderedClassMembers):
     def beforeAll(self):
         self.stockfish = Stockfish()


### PR DESCRIPTION
This PR fixes a bug that was introduced in 45711fceb478d6162399a5dcc2b7d6e825558a89.

For a debug build it can be triggered with these commands on master:
```
setoption name SyzygyPath value /disk1/syzygy/3-4-5-6/WDL/:/disk2/syzygy/3-4-5-6/DTZ/
position fen 8/8/7B/3B3P/7k/8/5K2/3r4 w - - 0 1
go depth 1
```
resulting in:
```
info string Found 510 WDL and 510 DTZ tablebase files (up to 6-man).
info string Available processors: 0-23
info string Using 1 thread
info string NNUE evaluation using nn-ab28990d4ea3.nnue (109MiB, (86896, 1024, 32, 32, 1))
info string Network replica 1: Shared memory.
stockfish: search.h:81: void Stockfish::Search::PVMoves::push_back(Stockfish::Move): Assertion `length < MAX_PLY + 1' failed.
Aborted
```
Patch passes this cleanly:
```
info string Found 510 WDL and 510 DTZ tablebase files (up to 6-man).
info string Available processors: 0-23
info string Using 1 thread
info string NNUE evaluation using nn-ab28990d4ea3.nnue (109MiB, (86896, 1024, 32, 32, 1))
info string Network replica 1: Shared memory.
info depth 1 seldepth 2 multipv 1 score cp 20000 nodes 1 nps 7 hashfull 0 tbhits 24 time 138 pv d5f3 d1d3 f3e2 d3d7 h6c1 d7c7 c1a3 h4g5 e2d1 g5h4 a3b4 c7b7 b4c3 b7b6 f2g2 b6a6 d1e2 a6e6 e2f3 e6h6 c3b4 h4g5 b4e7 g5f4 g2f2 h6a6 e7f8 f4f5 f2g3 a6a4 f3d1 a4d4 d1e2 f5f6 f8a3 d4d2 e2c4 d2c2 c4d3 c2d2 d3g6 d2e2 g3f3 e2h2 a3c5 h2h4 c5b6 h4a4 b6d8 f6g7 f3g3 g7h6 d8b6 a4a3 g3g4 a3a4 g4f5 a4d4 f5e6 d4h4 b6e3 h6g7 e6f5 h4h3 e3c5 h3h2 c5g1 h2h1 g1d4 g7g8 f5g5 h1d1 d4b6 d1d6 b6e3 d6e6 e3f4 e6e1 g6f5 e1f1 f4e3 f1f3 e3d4 f3g3 g5f4 g3g2 h5h6 g2h2 f4g5 h2g2 g5f6 g2h2 d4e3 h2g2 e3c1 g2g1 c1d2 g1d1 d2e3 d1e1 e3b6 e1d1 f6g5 d1d5 b6c7 g8h8 c7h2 d5a5 h2g1 a5d5 g1e3 h8g8 e3f4 g8f7 f4c1 d5b5 c1d2 b5c5 d2b4 c5c1 f5e4 f7g8 b4d6 c1g1 g5h4 g8h8 d6e5 h8g8 h6h7 g8f7 h7h8n f7e6 e5g3 g1a1 h4g5 a1a4 e4c2 a4a5 g5f4 a5a3 g3e1 a3a1 e1h4 a1f1 f4e4 e6d6 c2b3 f1b1 h8f7 d6d7 b3c4 b1a1 e4d5 a1a5 d5d4 a5a1 h4g5 a1a4 f7e5 d7d6 g5d2 d6e7 d4d5 e7f6 d5d6 a4a7 c4d3 a7a3 d2e3 a3a8 e5g4 f6f7 e3g5 a8a7 g4e5 f7g7 d6e6 a7b7 g5f6 g7h6 d3c4 b7a7 e6f5 a7a5 f6d8 a5a3 f5f6 h6h5 f6g7 a3g3 g7h8 h5h6 c4f7 g3g7 d8b6 g7h7 h8g8 h7g7 g8f8 g7g2 b6e3 h6h7 f7c4 g2g7 e3c1 h7h8 e5f7 h8h7 c4d3 g7g6 d3g6 h7g6 f8e7 g6f5 f7d6 f5g4 e7e6 g4f3 d6f5 f3e4 c1e3 e4f3 e6d5 f3g2 d5e4 g2h2 e4f3 h2h3 e3f2 h3h2 f5g3 h2h3 f2g1 h3h4 g3e4 h4h5 g1d4 h5h4 d4e5 h4h3 e4f2 h3h4 e5f6 h4h5 f3f4 h5g6 f2e4 g6h6 f4f5 h6h5 e4g3 h5h6 f6b2 h6h7 f5f6 h7h6 b2a3 h6h7 g3f5 h7g8 f6g6 g8h8 a3b4 h8g8 f5h6 g8h8 b4c3
bestmove d5f3 ponder d1d3
```

Passed STC non-reg:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 45440 W: 11730 L: 11535 D: 22175
Ptnml(0-2): 71, 4723, 12947, 4898, 81
https://tests.stockfishchess.org/tests/view/6a8482b19960adfadf924095

No functional change.