### PR TITLE
Fix MSVC warning C4141 ('inline' used more than once)

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -1,0 +1,56 @@
+name: MSVC
+
+on:
+  workflow_call:
+
+jobs:
+  msvc:
+    name: ${{ matrix.name }} (msvc)
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Runners cannot execute AVX-512, so avx512icl is build-only.
+          - { name: avx2, flags: "/arch:AVX2", bench: true }
+          - { name: avx512icl, flags: "/arch:AVX512 /DUSE_AVX512 /DUSE_VNNI /DUSE_AVX512ICL /DUSE_PEXT", bench: false }
+
+    defaults:
+      run:
+        working-directory: src
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download network
+        if: matrix.bench
+        run: make net
+
+      - name: Extract the bench number from the commit history
+        if: matrix.bench
+        run: |
+          for hash in $(git rev-list -100 HEAD); do
+            benchref=$(git show -s $hash | tac | grep -m 1 -o -x '[[:space:]]*\b[Bb]ench[ :]\+[1-9][0-9]\{5,7\}\b[[:space:]]*' | sed 's/[^0-9]//g') && break || true
+          done
+          [[ -n "$benchref" ]] && echo "benchref=$benchref" >> $GITHUB_ENV && echo "From commit: $hash" && echo "Reference bench: $benchref" || echo "No bench found"
+
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      - name: Build ${{ matrix.name }} binary
+        shell: cmd
+        run: >-
+          cl /nologo /std:c++17 /MT /EHsc /O2 /MP /W3 /WX /permissive-
+          /DUSE_POPCNT /DUSE_SSE2 /DUSE_SSSE3 /DUSE_SSE41 /DUSE_AVX2 ${{ matrix.flags }}
+          /Fe:stockfish.exe *.cpp nnue\*.cpp nnue\features\*.cpp syzygy\*.cpp
+          /link /STACK:8388608 shell32.lib
+
+      - name: Verify bench signature
+        if: matrix.bench
+        run: EXE=./stockfish.exe ../tests/signature.sh $benchref

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -152,6 +152,10 @@ jobs:
     name: Compiler check
     if: ${{ always() }}
     uses: ./.github/workflows/avx2_compilers.yml
+  MSVC:
+    name: MSVC
+    if: ${{ always() }}
+    uses: ./.github/workflows/msvc.yml
   WASMCompilation:
     name: WASM compilation
     if: ${{ always() }}

--- a/src/misc.h
+++ b/src/misc.h
@@ -552,12 +552,12 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
 #endif
 
 #if defined(__GNUC__)
-    #define sf_always_inline __attribute__((always_inline))
+    #define sf_always_inline inline __attribute__((always_inline))
 #elif defined(_MSC_VER)
     #define sf_always_inline __forceinline
 #else
-    // do nothing for other compilers
-    #define sf_always_inline
+    // plain inline for other compilers
+    #define sf_always_inline inline
 #endif
 
 #if defined(__clang__)

--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -189,7 +189,7 @@ constexpr auto index_lut1 = init_index_luts();
 constexpr auto index_lut2 = index_lut2_array();
 
 // Index of a feature for a given king position and another piece on some square
-inline sf_always_inline IndexType FullThreats::make_index(
+sf_always_inline IndexType FullThreats::make_index(
   Color perspective, Piece attacker, Square from, Square to, Piece attacked, Square ksq) {
     const i8 orientation   = OrientTBL[ksq] ^ (56 * perspective);
     unsigned from_oriented = u8(from) ^ orientation;

--- a/src/nnue/features/pp_3wide.cpp
+++ b/src/nnue/features/pp_3wide.cpp
@@ -46,7 +46,7 @@ static inline __m256i pp_idx_epi16(__m256i a, __m256i b) {
 }
 #endif
 
-inline sf_always_inline IndexType PP_3Wide::make_index(
+sf_always_inline IndexType PP_3Wide::make_index(
   Color perspective, Color color, Square from, Square to, Color pairedColor, Square ksq) {
     const i8 orientation   = FullThreats::OrientTBL[ksq] ^ (56 * perspective);
     unsigned from_oriented = u8(from) ^ orientation;

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -236,36 +236,36 @@ struct Tiling {
 using Tile     = vint16m8_t;
 using PsqtTile = vint32m1_t;
 
-sf_always_inline inline Tile load_tile(IndexType j, const i16* data) {
+sf_always_inline Tile load_tile(IndexType j, const i16* data) {
     usize vl = __riscv_vsetvl_e16m8(Dimensions - j);
     return __riscv_vle16_v_i16m8(data + j, vl);
 }
 
-sf_always_inline inline void store_tile(IndexType j, i16* dest, Tile acc) {
+sf_always_inline void store_tile(IndexType j, i16* dest, Tile acc) {
     usize vl = __riscv_vsetvl_e16m8(Dimensions - j);
     __riscv_vse16_v_i16m8(dest + j, acc, vl);
 }
 
-sf_always_inline inline PsqtTile load_psqt(IndexType j, const i32* data) {
+sf_always_inline PsqtTile load_psqt(IndexType j, const i32* data) {
     usize vl = __riscv_vsetvl_e32m1(PSQTBuckets - j);
     return __riscv_vle32_v_i32m1(data + j, vl);
 }
 
-sf_always_inline inline void store_psqt(IndexType j, i32* dest, PsqtTile psqt) {
+sf_always_inline void store_psqt(IndexType j, i32* dest, PsqtTile psqt) {
     usize vl = __riscv_vsetvl_e32m1(PSQTBuckets - j);
     __riscv_vse32_v_i32m1(dest + j, psqt, vl);
 }
 
-sf_always_inline inline void increment_index(IndexType& j) {
+sf_always_inline void increment_index(IndexType& j) {
     j += __riscv_vsetvl_e16m8(Dimensions - j);
 }
 
-sf_always_inline inline void increment_psqt_index(IndexType& j) {
+sf_always_inline void increment_psqt_index(IndexType& j) {
     j += __riscv_vsetvl_e32m1(PSQTBuckets - j);
 }
 
 template<int sign>
-sf_always_inline inline Tile apply(IndexType j, Tile acc, const i16* data) {
+sf_always_inline Tile apply(IndexType j, Tile acc, const i16* data) {
     static_assert(sign == 1 || sign == -1);
     usize      vl       = __riscv_vsetvl_e16m8(Dimensions - j);
     vint16m8_t data_vec = __riscv_vle16_v_i16m8(data + j, vl);
@@ -277,7 +277,7 @@ sf_always_inline inline Tile apply(IndexType j, Tile acc, const i16* data) {
 }
 
 template<int sign>
-sf_always_inline inline PsqtTile apply(IndexType j, PsqtTile acc, const i32* data) {
+sf_always_inline PsqtTile apply(IndexType j, PsqtTile acc, const i32* data) {
     static_assert(sign == 1 || sign == -1);
     usize      vl       = __riscv_vsetvl_e32m1(PSQTBuckets - j);
     vint32m1_t data_vec = __riscv_vle32_v_i32m1(data + j, vl);
@@ -289,10 +289,10 @@ sf_always_inline inline PsqtTile apply(IndexType j, PsqtTile acc, const i32* dat
 }
 
 template<int sign>
-sf_always_inline inline Tile apply_threat_features(IndexType                          j,
-                                                   Tile                               acc,
-                                                   const ThreatFeatureSet::IndexList& list,
-                                                   const FeatureTransformer&          ft) {
+sf_always_inline Tile apply_threat_features(IndexType                          j,
+                                            Tile                               acc,
+                                            const ThreatFeatureSet::IndexList& list,
+                                            const FeatureTransformer&          ft) {
     static_assert(sign == 1 || sign == -1);
     usize vl = __riscv_vsetvl_e16m8(Dimensions - j);
     for (int i = 0; i < list.ssize(); ++i)
@@ -346,7 +346,7 @@ struct Tile {
     auto& operator[](int i) { return inner[i]; }
 };
 
-sf_always_inline inline Tile load_tile(IndexType j, const i16* data) {
+sf_always_inline Tile load_tile(IndexType j, const i16* data) {
     Tile  acc;
     auto* column = reinterpret_cast<const vec_t*>(&data[j]);
     for (IndexType k = 0; k < Tiling::NumRegs; ++k)
@@ -354,13 +354,13 @@ sf_always_inline inline Tile load_tile(IndexType j, const i16* data) {
     return acc;
 }
 
-sf_always_inline inline void store_tile(IndexType j, i16* dest, Tile acc) {
+sf_always_inline void store_tile(IndexType j, i16* dest, Tile acc) {
     auto* column = reinterpret_cast<vec_t*>(&dest[j]);
     for (IndexType k = 0; k < Tiling::NumRegs; ++k)
         column[k] = acc[k];
 }
 
-sf_always_inline inline PsqtTile load_psqt(IndexType j, const i32* data) {
+sf_always_inline PsqtTile load_psqt(IndexType j, const i32* data) {
     PsqtTile psqt;
     auto*    column = reinterpret_cast<const psqt_vec_t*>(&data[j]);
     for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
@@ -368,21 +368,21 @@ sf_always_inline inline PsqtTile load_psqt(IndexType j, const i32* data) {
     return psqt;
 }
 
-sf_always_inline inline void store_psqt(IndexType j, i32* dest, PsqtTile psqt) {
+sf_always_inline void store_psqt(IndexType j, i32* dest, PsqtTile psqt) {
     auto* column = reinterpret_cast<psqt_vec_t*>(&dest[j]);
     for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
         column[k] = psqt[k];
 }
 
-sf_always_inline inline void increment_index(IndexType& j) { j += Tiling::TileHeight; }
+sf_always_inline void increment_index(IndexType& j) { j += Tiling::TileHeight; }
 
-sf_always_inline inline void increment_psqt_index(IndexType& j) { j += Tiling::PsqtTileHeight; }
+sf_always_inline void increment_psqt_index(IndexType& j) { j += Tiling::PsqtTileHeight; }
 
 template<int sign>
-sf_always_inline inline Tile apply_threat_features(IndexType                          j,
-                                                   Tile                               acc,
-                                                   const ThreatFeatureSet::IndexList& list,
-                                                   const FeatureTransformer&          ft) {
+sf_always_inline Tile apply_threat_features(IndexType                          j,
+                                            Tile                               acc,
+                                            const ThreatFeatureSet::IndexList& list,
+                                            const FeatureTransformer&          ft) {
     static_assert(sign == 1 || sign == -1);
 
     for (int i = 0; i < list.ssize(); ++i)
@@ -432,7 +432,7 @@ sf_always_inline inline Tile apply_threat_features(IndexType                    
 }
 
 template<int sign>
-sf_always_inline inline Tile apply(IndexType j, Tile acc, const i16* data) {
+sf_always_inline Tile apply(IndexType j, Tile acc, const i16* data) {
     const auto* column = reinterpret_cast<const vec_t*>(data + j);
     for (IndexType k = 0; k < Tiling::NumRegs; ++k)
         if constexpr (sign == +1)
@@ -443,7 +443,7 @@ sf_always_inline inline Tile apply(IndexType j, Tile acc, const i16* data) {
 }
 
 template<int sign>
-sf_always_inline inline PsqtTile apply(IndexType j, PsqtTile acc, const i32* data) {
+sf_always_inline PsqtTile apply(IndexType j, PsqtTile acc, const i32* data) {
     const auto* column = reinterpret_cast<const psqt_vec_t*>(data + j);
     for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
         if constexpr (sign == +1)
@@ -456,10 +456,10 @@ sf_always_inline inline PsqtTile apply(IndexType j, PsqtTile acc, const i32* dat
 #endif
 
 template<int sign>
-sf_always_inline inline Tile apply_psq_features(IndexType                       j,
-                                                Tile                            acc,
-                                                const PSQFeatureSet::IndexList& list,
-                                                const FeatureTransformer&       ft) {
+sf_always_inline Tile apply_psq_features(IndexType                       j,
+                                         Tile                            acc,
+                                         const PSQFeatureSet::IndexList& list,
+                                         const FeatureTransformer&       ft) {
     static_assert(sign == 1 || sign == -1);
     for (int i = 0; i < list.ssize(); ++i)
         acc = apply<sign>(j, acc, &ft.weights[list[i] * Dimensions]);
@@ -467,10 +467,10 @@ sf_always_inline inline Tile apply_psq_features(IndexType                       
 }
 
 template<int sign, typename IdxType, usize MaxLen>
-sf_always_inline inline PsqtTile apply_psqt(IndexType                         j,
-                                            PsqtTile                          acc,
-                                            const ValueList<IdxType, MaxLen>& list,
-                                            const PSQTWeightType*             weights) {
+sf_always_inline PsqtTile apply_psqt(IndexType                         j,
+                                     PsqtTile                          acc,
+                                     const ValueList<IdxType, MaxLen>& list,
+                                     const PSQTWeightType*             weights) {
     static_assert(sign == 1 || sign == -1);
     for (int i = 0; i < list.ssize(); ++i)
         acc = apply<sign>(j, acc, &weights[list[i] * PSQTBuckets]);


### PR DESCRIPTION
Bug: On MSVC sf_always_inline expands to ```__forceinline```, which already implies ```inline```, so definitions writing both triggered "warning C4141 ('inline' used more than once)".

Fix: Moved ```inline``` into the macro and removed it from all definition sites.
GCC/Clang still get ```inline __attribute__((always_inline))```.   ```inline``` is in the macro since the attribute alone would not set linkage.

[Edit]
Also adds MSVC coverage to CI as requested.

No functional change
bench: 2516158