### PR TITLE
guarantee PV extension for nodestime and handle MultiPV

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -61,7 +61,8 @@ void syzygy_extend_pv(const OptionsMap&            options,
                       const Search::LimitsType&    limits,
                       Stockfish::Position&         pos,
                       Stockfish::Search::RootMove& rootMove,
-                      Value&                       v);
+                      Value&                       v,
+                      const usize                  multiPV);
 
 using namespace Search;
 
@@ -2127,19 +2128,24 @@ void syzygy_extend_pv(const OptionsMap&         options,
                       const Search::LimitsType& limits,
                       Position&                 pos,
                       RootMove&                 rootMove,
-                      Value&                    v) {
+                      Value&                    v,
+                      const usize               multiPV) {
 
     auto t_start      = std::chrono::steady_clock::now();
     int  moveOverhead = int(options["Move Overhead"]);
     bool rule50       = bool(options["Syzygy50MoveRule"]);
 
-    // Do not use more than moveOverhead / 2 time, if time management is active
-    auto time_abort = [&t_start, &moveOverhead, &limits]() -> bool {
+    // Do not use more than moveOverhead / 2 ms, if time management is active.
+    // Under 'nodestime' the pos.do_move() calls come for free.
+    auto time_abort = [&t_start, &moveOverhead, &limits, &multiPV]() -> bool {
         auto t_end = std::chrono::steady_clock::now();
-        return limits.use_time_management()
-            && 2 * std::chrono::duration<double, std::milli>(t_end - t_start).count()
-                 > moveOverhead;
+        return !limits.npmsec && limits.use_time_management()
+            && 2 * multiPV * std::chrono::duration<double, std::milli>(t_end - t_start).count()
+                 >= moveOverhead;
     };
+
+    if (time_abort())
+        return;
 
     std::list<StateInfo> sts;
 
@@ -2286,7 +2292,7 @@ void SearchManager::output_pv(Search::Worker&           worker,
         // Previous PVs have already been extended. Inexact flags indicate an unreliable PV.
         if (is_decisive(v) && !is_mate_or_mated(v) && !usePreviousScore
             && (!rootMoves[i].is_inexact() || isTBScore))
-            syzygy_extend_pv(worker.options, worker.limits, pos, rootMoves[i], v);
+            syzygy_extend_pv(worker.options, worker.limits, pos, rootMoves[i], v, multiPV);
 
         std::string pv;
         for (Move m : usePreviousScore ? rootMoves[i].previousPV : rootMoves[i].pv)


### PR DESCRIPTION
This PR fixes two minor issues with master's PV extension code.

1. When 'nodestime' is active, master may abort PV extension if it takes too long (as measured in ms), rendering the produced results nondeterministic. The patch always completes the PV extensions. This has no effect on playing strength because the local calls to `pos.do_move()` do not update the global used nodes counter.

2. If standard time management is active, and the game is played with `multiPV > 1`, then extending several PVs may repeatedly use up to `moveOverhead / 2` ms, possibly leading to time losses. The patch fixes this by only extending the PV of the best move during game play.

No functional change.