### PR TITLE
Reject invalid perft depths

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -260,6 +260,7 @@ Stephen Touset (stouset)
 Stockfisher69
 Styx (styxdoto)
 Syine Mineta (MinetaS)
+syzygy930
 Taras Vuk (TarasVuk)
 Thanar2
 thaspel

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -222,7 +222,11 @@ Search::LimitsType UCIEngine::parse_limits(std::istream& is) {
         else if (token == "mate")
             is >> limits.mate;
         else if (token == "perft")
+        {
             is >> limits.perft;
+            if (limits.perft <= 0)
+                is.setstate(std::ios::failbit);
+        }
         else if (token == "infinite")
             limits.infinite = 1;
         else if (token == "ponder")

--- a/tests/instrumented.py
+++ b/tests/instrumented.py
@@ -96,6 +96,16 @@ class TestCLI(metaclass=OrderedClassMembers):
         self.stockfish = Stockfish("go perft 4".split(" "), True)
         assert self.stockfish.process.returncode == 0
 
+    def test_go_perft_zero(self):
+        self.stockfish = Stockfish("go perft 0".split(" "), True)
+        assert self.stockfish.process.returncode != 0
+        assert "Invalid argument for 'perft'" in self.stockfish.process.stdout
+
+    def test_go_perft_negative(self):
+        self.stockfish = Stockfish("go perft -1".split(" "), True)
+        assert self.stockfish.process.returncode != 0
+        assert "Invalid argument for 'perft'" in self.stockfish.process.stdout
+
     def test_go_movetime_1000(self):
         self.stockfish = Stockfish("go movetime 1000".split(" "), True)
         assert self.stockfish.process.returncode == 0


### PR DESCRIPTION
Fixes #7035.

`go perft 0` currently leaves `limits.perft` at its sentinel value and starts a normal search. Negative values are also accepted and behave like depth one.

Reject non-positive perft depths through the existing invalid-argument path. Add CLI regression coverage for zero and negative values.

No functional change to engine play.

Tests:
- `python3 ../tests/instrumented.py --none ./stockfish` (77 tests)
- `EXE=./stockfish ../tests/signature.sh 2516158`
