### PR TITLE
Reduce depth after failed null move search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1051,6 +1051,9 @@ Value Search::Worker::search(
             if (v >= beta)
                 return nullValue;
         }
+
+        if (depth > 1)
+            --depth;
     }
 
     improving |= ss->staticEval >= beta;


### PR DESCRIPTION
After a null move search fails to reach beta, reduce the remaining search depth by one. This makes the search more selective after an unsuccessful speculative cutoff attempt.

The patch was authored by Stefan Geschwentner (locutus2); the commit preserves the original author metadata.

Bench: `2185399`

STC: https://tests.stockfishchess.org/tests/view/6a881c625b1b38ebda865031
- Accepted: LLR `2.965` (`0.0, 2.0`)
- 48,736 games: 12,620 wins / 12,294 losses / 23,822 draws
- Estimated `+2.157` normalized Elo, 95% CI `[+0.573, +3.724]`

LTC confirmation (ongoing): https://tests.stockfishchess.org/tests/view/6a89eee708c0f6a39c9e7888

Local validation:
- Apple-silicon Clang PGO build
- Bench signature check
- Perft suite
- Reproducible-search suite across 20 node budgets
- Instrumented integration suite: 75/75 passed