### PR TITLE
Reduce ProbCut depth near balanced scores

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -259,6 +259,7 @@ Stéphane Nicolet (snicolet)
 Stephen Touset (stouset)
 Stockfisher69
 Styx (styxdoto)
+Suleiman Sheikh (syzygy930)
 Syine Mineta (MinetaS)
 Taras Vuk (TarasVuk)
 Thanar2

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1074,7 +1074,7 @@ Value Search::Worker::search(
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
         MovePicker mp(pos, ttData.move, probCutBeta - ss->staticEval, &captureHistory);
-        Depth      probCutDepth = depth - (improving ? 5 : 3);
+        Depth      probCutDepth = depth - (improving ? 5 : 3) - (std::abs(beta) < 1000);
 
         while ((move = mp.next_move()) != Move::none())
         {


### PR DESCRIPTION
ProbCut currently selects its verification depth from depth and the binary improving flag. This patch makes the verification search one ply shallower when beta is within 1000 centipawns of a balanced score. The intent is to spend fewer verification nodes on speculative captures in the broad non-decisive score range while retaining the existing depth in clearly winning or losing positions.

Local fixed-node testing against 229f6339, 1 thread, 16 MB, paired UHO openings:

- 5k nodes, UHO_Lichess_4852_v1, 1,200 games: W423 L395 D382; nElo +10.99 +/- 19.66
- 10k nodes, UHO_Lichess_4852_v1, 1,200 games: W372 L334 D494; nElo +17.26 +/- 19.66
- 10k nodes, UHO_Lichess_4852_v1, 5,000 games: W1502 L1466 D2032; nElo +3.95 +/- 9.63
- 10k nodes, UHO_4060_v4, stopped at 556 games: W156 L172 D228; nElo -15.31 +/- 28.88

Local time-managed testing against the same baseline, 1 thread, 16 MB, paired UHO openings:

- 2+0.02 with nodestime=50, UHO_Lichess_4852_v1, 1,200 games: W426 L397 D377; Elo +8.40 +/- 15.30, nElo +10.80 +/- 19.66, LOS 85.92%

Vizvezdenec has launched an official STC Fishtest run of the exact one-line patch:
https://tests.stockfishchess.org/tests/view/6a8a97bd08c0f6a39c9e797d

The time-managed point estimate is above 5 Elo, but its confidence interval is wide. The longer fixed-node estimate is mildly positive but below 5 nElo, and the alternate-suite run did not replicate. The official result is therefore the relevant acceptance evidence; this PR was closed while that test continues.

Bench: 2415259
