### PR TITLE
Use capture history for qsearch SEE pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1821,8 +1821,12 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
             if (!capture)
                 continue;
 
-            // Do not search moves with bad enough SEE values
-            if (!pos.see_ge(move, -74))
+            // Let capture history adapt the SEE threshold: reliable tactical patterns
+            // may justify a slightly riskier exchange, while repeatedly bad ones are
+            // pruned earlier. A neutral history preserves the existing threshold.
+            int captHist = captureHistory[pos.moved_piece(move)][move.to_sq()]
+                                         [type_of(pos.piece_on(move.to_sq()))];
+            if (!pos.see_ge(move, -74 - captHist / 256))
                 continue;
         }
 


### PR DESCRIPTION
Quiescence search currently uses a fixed SEE threshold of -74 for every capture, even though the main search already maintains capture history for the same piece/to-square/captured-piece tuple.

This patch uses that existing history to adjust the qsearch SEE threshold. Successful tactical patterns may search a slightly negative exchange, while repeatedly unsuccessful patterns require stronger SEE. A neutral history retains the current -74 threshold. No additional history training or state is introduced.

Local testing against 229f6339, 1 thread, 16 MB, paired randomized openings:

- 2+0.02, nodestime=50, UHO_Lichess_4852_v1, seed 2026082313, 1,200 games: W436 L366 D398; Elo +20.29 +/- 13.93, nElo +28.71 +/- 19.66, LOS 99.79%
- 2+0.02, nodestime=50, UHO_4060_v4, seed 2026082314, 1,200 games: W395 L385 D420; Elo +2.90 +/- 13.67, nElo +4.17 +/- 19.66, LOS 66.10%
- 2+0.02, nodestime=50, UHO_Lichess_4852_v1, seed 2026082318, 1,200 games: W408 L390 D402; Elo +5.21 +/- 13.79, nElo +7.44 +/- 19.66, LOS 77.08%

Combined at that node scale: W1239 L1141 D1220, Elo point estimate +9.46 over 3,600 games.

Larger replication:

- 2+0.02, nodestime=50, UHO_Lichess_4852_v1, seed 2026082319, 5,000 games: W1607 L1659 D1734; Elo -3.61 +/- 6.76, nElo -5.15 +/- 9.63, LOS 14.72%

Pooling all four intended-scale runs gives W2846 L2800 D2954, approximately +1.86 Elo over 8,600 games. The larger replication outweighs the earlier signal and the patch does not meet the +5 Elo target.

Lower-scale control:

- 10+0.1, nodestime=1, UHO_Lichess_4852_v1, seed 2026082315, 1,200 games: W537 L541 D122; Elo -1.16 +/- 11.41, nElo -2.00 +/- 19.66, LOS 42.11%

This experiment is rejected and the draft is closed; an official Fishtest is no longer requested.

Bench: 2601191
