### PR TITLE
Make extensions and futility pruning depend on new seekMate variable

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -158,19 +158,6 @@ bool is_shuffling(Move move, Stack* const ss, const Position& pos) {
         && (ss - 2)->currentMove.from_sq() == (ss - 4)->currentMove.to_sq();
 }
 
-// Look up the futility pruning cutoff depth. This function is important for mate finding.
-inline int futility_depth(Value eval, Value beta) {
-    // LUT values obtained from:
-    //      depth = 13 + int(0.5 + 6 / int(1 + pow(abs(eval) + abs(beta), 3) / 50'000'000'000))
-    static constexpr std::array Lut{Value(1657), 2555, 3294, 4122, 5314, 8194, VALUE_INFINITE * 2};
-    const Value                 prob  = std::abs(eval) + std::abs(beta);
-    int                         depth = 0;
-    while (Lut[depth] < prob)
-        ++depth;
-
-    return 19 - depth;
-}
-
 }  // namespace
 
 Search::Worker::Worker(SharedState&                    sharedState,
@@ -736,6 +723,7 @@ Value Search::Worker::search(
     constexpr bool PvNode   = nodeType != NonPV;
     constexpr bool rootNode = nodeType == Root;
     const bool     allNode  = !(PvNode || cutNode);
+    const bool     seekMate = rootDepth >= 16 && std::abs(rootMoves[pvIdx].score) >= 2000;
 
     // Dive into quiescence search when the depth reaches zero
     if (depth <= 0)
@@ -1004,8 +992,8 @@ Value Search::Worker::search(
 
     // Step 8. Futility pruning: child node
     // The depth condition is important for mate finding. It shouldn't be tuned.
-    if (!ss->ttPv && eval >= beta && (!ttData.move || ttCapture) && !is_loss(beta) && !is_win(eval)
-        && depth < futility_depth(eval, beta))
+    if (!ss->ttPv && depth < (seekMate ? 6 : 19) && eval >= beta && (!ttData.move || ttCapture)
+        && !is_loss(beta) && !is_win(eval))
     {
         Value futilityMult = std::min(45 + depth * 4, 85);
         futilityMult -= 20 * !ss->ttHit;
@@ -1258,7 +1246,7 @@ moves_loop:  // When in check, search starts here
         // and lower extension margins scale well.
         if (!rootNode && move == ttData.move && !excludedMove && depth >= 6 + ss->ttPv
             && is_valid(ttData.value) && !is_decisive(ttData.value) && (ttData.bound & BOUND_LOWER)
-            && ttData.depth >= depth - 3 && !is_shuffling(move, ss, pos))
+            && ttData.depth >= depth - 3 && !is_shuffling(move, ss, pos) && !seekMate)
         {
             Value singularBeta  = ttData.value - (59 + 66 * (ss->ttPv && !PvNode)) * depth / 63;
             Depth singularDepth = newDepth / 2;


### PR DESCRIPTION
This PR simplifies the recent patch https://github.com/official-stockfish/Stockfish/pull/7040, while still allowing Stockfish to consistently pass the CI `go mate` run involving 61 positions with DTM from 1 to 4 plies. 

Results of a deterministic th1 run covering these 61 positions are as follows.
```
Loaded 61 FENs with 61 bm values, with |bm| (min avg max): 1 2 2.

Matetrack started for ./sf.master on matetrack.epd matedtrack.epd with --bmMax 2 --mate 0 ...
100%|███████████████████████████████████████████| 61/61 [00:17<00:00,  3.54it/s]


Using ./sf.master on matetrack.epd matedtrack.epd with --bmMax 2 --mate 0
Engine ID:     Stockfish dev-20260819-229f6339
Total FENs:    61
Found mates:   61
Best mates:    61

Best mate statistics:
|bm| = 1 - mates found: 21 = 100.0% of 21; nodes (min avg max): 4 343 1372, depth (min avg max): 1 4 12
|bm| = 2 - mates found: 40 = 100.0% of 40; nodes (min avg max): 16 402441 15454156, depth (min avg max): 1 10 24
All best mates found: 61 = 100.0% of 61; nodes (min avg max): 4 264014 15454156, depth (min avg max): 1 8 24
```
```
Loaded 61 FENs with 61 bm values, with |bm| (min avg max): 1 2 2.

Matetrack started for ./sf.patch on matetrack.epd matedtrack.epd with --bmMax 2 --mate 0 ...
100%|███████████████████████████████████████████| 61/61 [00:02<00:00, 24.64it/s]


Using ./sf.patch on matetrack.epd matedtrack.epd with --bmMax 2 --mate 0
Engine ID:     Stockfish dev-20260824-1a3ceee9
Total FENs:    61
Found mates:   61
Best mates:    61

Best mate statistics:
|bm| = 1 - mates found: 21 = 100.0% of 21; nodes (min avg max): 4 343 1372, depth (min avg max): 1 4 12
|bm| = 2 - mates found: 40 = 100.0% of 40; nodes (min avg max): 16 20068 255722, depth (min avg max): 1 9 21
All best mates found: 61 = 100.0% of 61; nodes (min avg max): 4 13277 255722, depth (min avg max): 1 8 21
```
The above shows that patch outperforms master 2s:17s, and 13277:264014 nodes.

In addition, patch shows a healthy increase in (best) mates found on matetrack:
```
Using ./sf.patch on matetrack.epd with --nodes 1000000
Engine ID:     Stockfish dev-20260824-1a3ceee9
Total FENs:    6554
Found mates:   3700
Best mates:    2457
```
This compares with 3202, 2263 for master, see https://github.com/vondele/matetrack/blob/c88991a2558b326e2119ca0e5cc9554d60e559ab/matetrack1000000.csv#L4530.

The numbers for the classic mate suite are:
```
Loaded 280 FENs with 280 bm values, with |bm| (min avg max): 10 15 21.

Matetrack started for ./sf.patch on classic280.epd with --nodes 1000000 ...
100%|███████████████████████████████████████████| 56/56 [00:26<00:00,  2.13it/s]


Using ./sf.patch on classic280.epd with --nodes 1000000
Engine ID:     Stockfish dev-20260824-1a3ceee9
Total FENs:    280
Found mates:   128
Best mates:    31
```
This compares with 165, 24 for master, see https://github.com/vondele/matetrack/blob/c88991a2558b326e2119ca0e5cc9554d60e559ab/classic1000000.csv#L4530.

Passed STC non-reg:
LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 41504 W: 10764 L: 10559 D: 20181
Ptnml(0-2): 61, 4620, 11196, 4803, 72
https://tests.stockfishchess.org/tests/view/6a85b5af9960adfadf924292

Passed LTC non-reg:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 111234 W: 28827 L: 28702 D: 53705
Ptnml(0-2): 32, 11680, 32064, 11813, 28
https://tests.stockfishchess.org/tests/view/6a86ef485b1b38ebda864e69

Bench: 2502027