### PR TITLE
Simplify HalfKAv2_hm::write_indices()

### DIFF
--- a/src/nnue/features/half_ka_v2_hm.cpp
+++ b/src/nnue/features/half_ka_v2_hm.cpp
@@ -71,13 +71,8 @@ void HalfKAv2_hm::write_indices(const std::array<Piece, SQUARE_NB>& oldPieces,
     const __m512i added_indices =
       _mm512_xor_si512(added_squares, _mm512_permutexvar_epi16(added_pieces, psi_plus_offset));
 
-    _mm512_storeu_si512(write_removed,
-                        _mm512_cvtepu16_epi32(_mm512_castsi512_si256(removed_indices)));
-    _mm512_storeu_si512(write_removed + 16,
-                        _mm512_cvtepu16_epi32(_mm512_extracti64x4_epi64(removed_indices, 1)));
-    _mm512_storeu_si512(write_added, _mm512_cvtepu16_epi32(_mm512_castsi512_si256(added_indices)));
-    _mm512_storeu_si512(write_added + 16,
-                        _mm512_cvtepu16_epi32(_mm512_extracti64x4_epi64(added_indices, 1)));
+    _mm512_storeu_si512(write_removed, removed_indices);
+    _mm512_storeu_si512(write_added, added_indices);
 }
 #endif
 

--- a/src/nnue/features/half_ka_v2_hm.h
+++ b/src/nnue/features/half_ka_v2_hm.h
@@ -94,7 +94,7 @@ class HalfKAv2_hm {
 
     // Maximum number of simultaneously active features.
     static constexpr IndexType MaxActiveDimensions = 32;
-    using IndexList                                = ValueList<IndexType, MaxActiveDimensions>;
+    using IndexList                                = ValueList<u16, MaxActiveDimensions>;
     using DiffType                                 = DirtyPiece;
 
 #if defined(USE_AVX512ICL)


### PR DESCRIPTION
passed STC: 
https://tests.stockfishchess.org/tests/view/6a8d043108c0f6a39c9e7eba
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 289440 W: 73563 L: 73617 D: 142260
Ptnml(0-2): 356, 30896, 82225, 30932, 311 

No functional change