### PR TITLE
Fix compile bug for Mac OS X 10.13.6

### DIFF
--- a/src/shm_unix.h
+++ b/src/shm_unix.h
@@ -368,22 +368,21 @@ class SharedMemory {
 
         if (ret == 0)
         {
-            msghdr msg = {};
+            struct msghdr msg = {};
+            const usize space = CMSG_SPACE(sizeof(int));
+            constexpr usize alignement = alignof(struct cmsghdr);
+            auto v = std::make_unique<std::byte[]>(space + alignement);
+            std::byte* control_msg_buffer = align_ptr_up<alignement>(v.get());
 
             char         buf[1];
             struct iovec iov[1];
             iov[0].iov_base = buf;
             iov[0].iov_len  = 1;
-            msg.msg_iov     = iov;
-            msg.msg_iovlen  = 1;
 
-            union {
-                char           buf[CMSG_SPACE(sizeof(int))];
-                struct cmsghdr align;
-            } control_msg = {};
-
-            msg.msg_control    = control_msg.buf;
-            msg.msg_controllen = sizeof(control_msg.buf);
+            msg.msg_iov        = iov;
+            msg.msg_iovlen     = 1;
+            msg.msg_control    = control_msg_buffer;
+            msg.msg_controllen = space;
 
             ssize_t bytes_recv;
 #ifdef MSG_CMSG_CLOEXEC
@@ -468,21 +467,22 @@ class SharedMemory {
                       if (!client_fd.is_valid())
                           continue;  // including EINTR
 
-                      msghdr msg    = {};
+                      struct msghdr msg    = {};
+                      const usize space = CMSG_SPACE(sizeof(int));
+                      constexpr usize alignement = alignof(struct cmsghdr);
+                      auto v = std::make_unique<std::byte[]>(space + alignement);
+                      std::byte* control_msg_buffer = align_ptr_up<alignement>(v.get());
+                      
+
                       char   buf[1] = {};
                       iovec  iov[1];
                       iov[0].iov_base = buf;
                       iov[0].iov_len  = 1;
-                      msg.msg_iov     = iov;
-                      msg.msg_iovlen  = 1;
 
-                      union {
-                          char           buf[CMSG_SPACE(sizeof(int))];
-                          struct cmsghdr align;
-                      } control_msg = {};
-
-                      msg.msg_control    = control_msg.buf;
-                      msg.msg_controllen = sizeof(control_msg.buf);
+                      msg.msg_iov        = iov;
+                      msg.msg_iovlen     = 1;
+                      msg.msg_control    = control_msg_buffer;
+                      msg.msg_controllen = space;
 
                       // Send over rights to the memfd (SCM_RIGHTS). The fd may be given a different number, but
                       // will refer to the same underlying file. Once it's mmapped then it will share physical memory


### PR DESCRIPTION
Master branch does not compile on some Unix systems since commit d077f9a8154df309b1b715e51d663e4cd6cf8e73 (for instance compilation fails on Mac OS X 10.13.6 using GNUC 10.4.2).

The problem is that on such systems CMSG_SPACE() is not a compile time constant, so it cannot be used to allocate the size of the message buffer we use in shm_unix.h

The fix is to use a dynamic array instead of a stack array for the buffer. We use a standard C++ vector to get automatic memory management, and align it with our utilities in memory.h.

fixes  https://github.com/official-stockfish/Stockfish/issues/7092

No functional change