### PR TITLE
Cache qemu-user deb & syzygy in CI

### DIFF
--- a/.github/workflows/matetrack.yml
+++ b/.github/workflows/matetrack.yml
@@ -43,6 +43,13 @@ jobs:
               matetrack/3-4-5-dtz/
            key: key-syzygy
 
+      - name: cache syzygy test data
+        id: cache-syzygy-test
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+           path: Stockfish/tests/syzygy
+           key: syzygy-test-9b9aa13
+
       - name: download syzygy 3-4-5 if needed
         working-directory: matetrack
         if: steps.cache-syzygy.outputs.cache-hit != 'true'

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -52,6 +52,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Cache syzygy test data
+        id: cache-syzygy-test
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: tests/syzygy
+          key: syzygy-test-9b9aa13
+
       - name: Download required linux packages
         run: |
           sudo apt update

--- a/.github/workflows/universal_compilation.yml
+++ b/.github/workflows/universal_compilation.yml
@@ -276,9 +276,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang-20 lld-20 llvm-20 g++-riscv64-linux-gnu
           echo "/usr/lib/llvm-20/bin" >> "$GITHUB_PATH"
+      - name: Cache qemu-user deb
+        id: cache-qemu
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: /tmp/qemu.deb
+          key: qemu-user-9.2.1+ds-1ubuntu5_amd64
+
       - name: Install qemu
         run: |
-          curl -sL -o /tmp/qemu.deb "$QEMU_DEB"
+          if [ "${{ steps.cache-qemu.outputs.cache-hit }}" != "true" ]; then
+            curl -fsSL -o /tmp/qemu.deb "$QEMU_DEB"
+          fi
           dpkg -x /tmp/qemu.deb /tmp/qemu
           /tmp/qemu/usr/bin/qemu-riscv64 --version
           echo "/tmp/qemu/usr/bin" >> "$GITHUB_PATH"

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -83,6 +83,7 @@ class Syzygy:
                 tarball_path = os.path.join(tmpdirname, f"{file}.tar.gz")
 
                 response = requests.get(url, stream=True)
+                response.raise_for_status()
                 with open(tarball_path, "wb") as f:
                     for chunk in response.iter_content(chunk_size=8192):
                         f.write(chunk)


### PR DESCRIPTION
should fix the common case of downloads not being successful.

Similarly cache the syzygy download.

No functional change