### PR TITLE
Use mmap() for large aligned allocations to avoid cross-NUMA arena reuse

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -128,11 +128,13 @@ void* aligned_large_pages_alloc_with_hint(usize allocSize, bool) {
 
 #else
 
+    #if defined(__linux__) && !defined(__ANDROID__)
+static std::map<void*, usize> large_page_sizes;
+static std::mutex             large_page_sizes_mtx;
+    #endif
+
     #if defined(__linux__) && defined(MAP_HUGE_SHIFT) && defined(__x86_64__)
         #define HAS_HUGE_PAGES
-
-static std::map<void*, usize> huge_pages;
-static std::mutex             huge_pages_mtx;
 
 static void* try_huge_pages_alloc(usize allocSize) {
     usize size = ((allocSize + HugePageSize - 1) / HugePageSize) * HugePageSize;
@@ -142,8 +144,8 @@ static void* try_huge_pages_alloc(usize allocSize) {
     if (mem == MAP_FAILED)
         return nullptr;
 
-    std::lock_guard lg(huge_pages_mtx);
-    huge_pages[mem] = size;
+    std::lock_guard lg(large_page_sizes_mtx);
+    large_page_sizes[mem] = size;
     return mem;
 }
     #endif  // defined(__linux__) && defined(MAP_HUGE_SHIFT) && defined(__x86_64__)
@@ -158,19 +160,31 @@ void* aligned_large_pages_alloc_with_hint(usize allocSize, [[maybe_unused]] bool
     }
     #endif
 
-    #if defined(__linux__)
+    #if defined(__linux__) && !defined(__ANDROID__)
     constexpr usize alignment = 2 * 1024 * 1024;  // 2MB page size assumed
-    #else
-    constexpr usize alignment = 4096;  // small page size assumed
-    #endif
 
     // Round up to multiples of alignment
     usize size = ((allocSize + alignment - 1) / alignment) * alignment;
-    void* mem  = std_aligned_alloc(alignment, size);
+    void* mem  = mmap_huge_aligned(size, MAP_PRIVATE | MAP_ANONYMOUS);
+    #if defined(MADV_HUGEPAGE)
+    madvise(mem, size, MADV_HUGEPAGE);
+    #endif
+
+    if (mem)
+    {
+        std::lock_guard lg(large_page_sizes_mtx);
+        large_page_sizes[mem] = size;
+    }
+    return mem;
+    #else
+    constexpr usize alignment = 4096;  // small page size assumed
+    usize           size = ((allocSize + alignment - 1) / alignment) * alignment;
+    void*           mem  = std_aligned_alloc(alignment, size);
     #if defined(MADV_HUGEPAGE)
     madvise(mem, size, MADV_HUGEPAGE);
     #endif
     return mem;
+    #endif
 }
 
 #endif
@@ -233,17 +247,19 @@ void aligned_large_pages_free(void* mem) {
     if (!mem)
         return;
 
-    #ifdef HAS_HUGE_PAGES
-    std::lock_guard lg(huge_pages_mtx);
-    if (auto it = huge_pages.find(mem); it != huge_pages.end())
+    #if defined(__linux__) && !defined(__ANDROID__)
     {
-        if (munmap(mem, it->second) != 0)
+        std::lock_guard lg(large_page_sizes_mtx);
+        if (auto it = large_page_sizes.find(mem); it != large_page_sizes.end())
         {
-            std::cerr << "munmap failed: " << strerror(errno) << std::endl;
-            exit(EXIT_FAILURE);
+            if (munmap(mem, it->second) != 0)
+            {
+                std::cerr << "munmap failed: " << strerror(errno) << std::endl;
+                exit(EXIT_FAILURE);
+            }
+            large_page_sizes.erase(it);
+            return;
         }
-        huge_pages.erase(it);
-        return;
     }
     #endif
 

--- a/src/memory.h
+++ b/src/memory.h
@@ -62,6 +62,11 @@ using AdjustTokenPrivileges_t =
 }
 #endif
 
+#if defined(__linux__) && !defined(__ANDROID__)
+    #include <sys/mman.h>
+    #include <unistd.h>
+#endif
+
 
 namespace Stockfish {
 
@@ -256,6 +261,51 @@ T* align_ptr_up(T* ptr) {
     return reinterpret_cast<T*>(
       reinterpret_cast<char*>((ptrint + (Alignment - 1)) / Alignment * Alignment));
 }
+
+#if defined(__linux__) && !defined(__ANDROID__)
+
+// Allocate size bytes aligned to a 2 MB boundary using mmap.
+// On success the returned pointer can be freed with munmap(ptr, size).
+inline void* mmap_huge_aligned(usize size, int flags, int fd = -1, off_t offset = 0) {
+    constexpr usize Alignment = 2 * 1024 * 1024;
+    const long      pageSize  = sysconf(_SC_PAGESIZE);
+
+    if (size >= Alignment && pageSize > 0)
+    {
+        const usize mappingSize =
+          ((size + static_cast<usize>(pageSize) - 1) / static_cast<usize>(pageSize))
+          * static_cast<usize>(pageSize);
+        const usize reservationSize = mappingSize + Alignment;
+        void*       reservation =
+          mmap(nullptr, reservationSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+        if (reservation != MAP_FAILED)
+        {
+            char* const base        = static_cast<char*>(reservation);
+            char* const alignedBase = align_ptr_up<Alignment>(base);
+
+            void* mapped =
+              mmap(alignedBase, size, PROT_READ | PROT_WRITE, flags | MAP_FIXED, fd, offset);
+
+            if (mapped != MAP_FAILED)
+            {
+                const usize prefixSize = static_cast<usize>(alignedBase - base);
+                const usize suffixSize = reservationSize - prefixSize - mappingSize;
+                if (prefixSize)
+                    munmap(reservation, prefixSize);
+                if (suffixSize)
+                    munmap(alignedBase + mappingSize, suffixSize);
+                return mapped;
+            }
+
+            munmap(reservation, reservationSize);
+        }
+    }
+
+    return mmap(nullptr, size, PROT_READ | PROT_WRITE, flags, fd, offset);
+}
+
+#endif
 
 #if defined(_WIN32)
 

--- a/src/shm_unix.h
+++ b/src/shm_unix.h
@@ -63,45 +63,11 @@ namespace Stockfish::shm {
 namespace detail {
 
 inline void* map_shared(int fd, usize size) noexcept {
-#if defined(__linux__)
-    constexpr usize Alignment = 2 * 1024 * 1024;
-    const long      pageSize  = sysconf(_SC_PAGESIZE);
-
-    if (size >= Alignment && pageSize > 0)
-    {
-        // File-backed huge pages require matching virtual-address and file-offset alignment.
-        // Reserve the address range first so MAP_FIXED cannot replace an unrelated mapping.
-        const usize mappingSize =
-          ((size + static_cast<usize>(pageSize) - 1) / static_cast<usize>(pageSize))
-          * static_cast<usize>(pageSize);
-        const usize reservationSize = mappingSize + Alignment;
-        void*       reservation =
-          mmap(nullptr, reservationSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-
-        if (reservation != MAP_FAILED)
-        {
-            char* const base        = static_cast<char*>(reservation);
-            char* const alignedBase = align_ptr_up<Alignment>(base);
-            void*       mapped =
-              mmap(alignedBase, size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, fd, 0);
-
-            if (mapped != MAP_FAILED)
-            {
-                const usize prefixSize = static_cast<usize>(alignedBase - base);
-                const usize suffixSize = reservationSize - prefixSize - mappingSize;
-                if (prefixSize)
-                    munmap(reservation, prefixSize);
-                if (suffixSize)
-                    munmap(alignedBase + mappingSize, suffixSize);
-                return mapped;
-            }
-
-            munmap(reservation, reservationSize);
-        }
-    }
-#endif
-
+#if defined(__linux__) && !defined(__ANDROID__)
+    return Stockfish::mmap_huge_aligned(size, MAP_SHARED, fd);
+#else
     return mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+#endif
 }
 
 class SharedMemoryRegistry {


### PR DESCRIPTION
Worker/SharedHistories allocations on Linux were served by glibc malloc arenas, which survive thread destruction and can be reused by threads bound to a different NUMA node. This caused non-deterministic remote memory and lower NPS when Threads was set multiple times.

Route aligned_large_pages_alloc_with_hint() through direct mmap() on Linux, storing the base/size so aligned_large_pages_free() can munmap() the original mapping. Merge the existing x86_64 MAP_HUGETLB bookkeeping into the same registry.

fixes https://github.com/official-stockfish/Stockfish/issues/6516

Benchmark: 288 threads, 36864 MB hash, depth 15 (10 runs per config)

```
| Build  | Case                     | Avg NPS     | Min NPS     | Max NPS     | Range     |
|--------|--------------------------|-------------|-------------|-------------|-----------|
| master | Case1 (Threads set x2)   | 253,196,264 | 252,034,443 | 254,396,860 | 2,362,417 |
| master | Case2 (Threads set x1)   | 248,224,546 | 247,304,918 | 249,306,273 | 2,001,355 |
| fix    | Case1 (Threads set x2)   | 254,675,607 | 253,991,054 | 255,600,403 | 1,609,349 |
| fix    | Case2 (Threads set x1)   | 254,931,057 | 253,979,373 | 256,334,683 | 2,355,310 |
```

No functional change