### PR TITLE
Peel off one iteration of the halfka incremental update

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -459,7 +459,6 @@ sf_always_inline Tile apply_psq_features(IndexType                       j,
                                          const PSQFeatureSet::IndexList& list,
                                          const FeatureTransformer&       ft) {
     static_assert(sign == 1 || sign == -1);
-#if defined(USE_AVX2) && !defined(USE_AVX512)
     if constexpr (Incremental)
     {
         assert(list.size() == 1 || list.size() == 2);
@@ -468,7 +467,6 @@ sf_always_inline Tile apply_psq_features(IndexType                       j,
             acc = apply<sign>(j, acc, &ft.weights[list[1] * Dimensions]);
         return acc;
     }
-#endif
     for (int i = 0; i < list.ssize(); ++i)
         acc = apply<sign>(j, acc, &ft.weights[list[i] * Dimensions]);
     return acc;

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -453,14 +453,24 @@ sf_always_inline PsqtTile apply(IndexType j, PsqtTile acc, const i32* data) {
 
 #endif
 
-template<int sign>
+template<int sign, bool Incremental = false>
 sf_always_inline Tile apply_psq_features(IndexType                       j,
                                          Tile                            acc,
                                          const PSQFeatureSet::IndexList& list,
                                          const FeatureTransformer&       ft) {
     static_assert(sign == 1 || sign == -1);
-    for (int i = 0; i < list.ssize(); ++i)
-        acc = apply<sign>(j, acc, &ft.weights[list[i] * Dimensions]);
+    if constexpr (Incremental)
+    {
+        assert(list.size() == 1 || list.size() == 2);
+        acc = apply<sign>(j, acc, &ft.weights[list[0] * Dimensions]);
+        if (list.size() > 1)
+            acc = apply<sign>(j, acc, &ft.weights[list[1] * Dimensions]);
+    }
+    else
+    {
+        for (int i = 0; i < list.ssize(); ++i)
+            acc = apply<sign>(j, acc, &ft.weights[list[i] * Dimensions]);
+    }
     return acc;
 }
 
@@ -497,8 +507,8 @@ void apply_combined(Color                              perspective,
     {
         acc = load_tile(j, fromAcc.data());
 
-        acc = apply_psq_features<-1>(j, acc, psqRemoved, featureTransformer);
-        acc = apply_psq_features<+1>(j, acc, psqAdded, featureTransformer);
+        acc = apply_psq_features<-1, true>(j, acc, psqRemoved, featureTransformer);
+        acc = apply_psq_features<+1, true>(j, acc, psqAdded, featureTransformer);
 
         acc = apply_threat_features<-1>(j, acc, thrRemoved, featureTransformer);
         acc = apply_threat_features<+1>(j, acc, thrAdded, featureTransformer);

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -459,18 +459,18 @@ sf_always_inline Tile apply_psq_features(IndexType                       j,
                                          const PSQFeatureSet::IndexList& list,
                                          const FeatureTransformer&       ft) {
     static_assert(sign == 1 || sign == -1);
+#if defined(USE_AVX2) && !defined(USE_AVX512)
     if constexpr (Incremental)
     {
         assert(list.size() == 1 || list.size() == 2);
         acc = apply<sign>(j, acc, &ft.weights[list[0] * Dimensions]);
         if (list.size() > 1)
             acc = apply<sign>(j, acc, &ft.weights[list[1] * Dimensions]);
+        return acc;
     }
-    else
-    {
-        for (int i = 0; i < list.ssize(); ++i)
-            acc = apply<sign>(j, acc, &ft.weights[list[i] * Dimensions]);
-    }
+#endif
+    for (int i = 0; i < list.ssize(); ++i)
+        acc = apply<sign>(j, acc, &ft.weights[list[i] * Dimensions]);
     return acc;
 }
 


### PR DESCRIPTION
Passed STC 
https://tests.stockfishchess.org/tests/live_elo/6a8ab17b08c0f6a39c9e79ae
LLR: 2.96 (-2.94,2.94) <0.00,2.00>
Total: 96192 W: 24637 L: 24264 D: 47291
Ptnml(0-2): 136, 9961, 27552, 10288, 159 

Passed avx2 STC:
https://tests.stockfishchess.org/tests/live_elo/6a8cd16708c0f6a39c9e7e59
LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 61024 W: 15789 L: 15457 D: 29778
Ptnml(0-2): 108, 6534, 16905, 6848, 117 

Failed avx512icl STC:
https://tests.stockfishchess.org/tests/live_elo/6a8cd14d08c0f6a39c9e7e57
LLR: -2.96 (-2.94,2.94) <0.00,2.00>
Total: 90368 W: 22968 L: 23088 D: 44312
Ptnml(0-2): 132, 9707, 25587, 9665, 93 

Context: https://github.com/official-stockfish/Stockfish/pull/7051#issuecomment-5285531017
Credit to bobbypaper for inspiring the idea. Gated to AVX2 because it seems neutral at best on other architectures.

Locally, despite the avx512icl failure:

Result of 500 runs
base (...kfish.master) =    1907788  +/- 1384
test (./stockfish    ) =    1930017  +/- 1426
diff                   =     +22230  +/- 1978

speedup         = +0.0117
P(speedup > 0) =  1.0000

No functional change