### PR TITLE
Simplify optimism scaling formula

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -57,7 +57,7 @@ Value Eval::evaluate(const Eval::NNUE::Network&     network,
     nnue -= nnue * i64(nnueComplexity) / 18236;
 
     int material = 534 * pos.count<PAWN>() + pos.non_pawn_material();
-    int v        = (nnue * i64(91000 + material) + optimism * i64(7675)) / 91000;
+    int v        = nnue + (nnue * i64(material) + optimism * i64(7675)) / 91000;
 
     // Damp down the evaluation linearly when shuffling
     v -= v * pos.rule50_count() / 199;


### PR DESCRIPTION
Simplify the optimism scaling formula, keeping the i64 cast for safety.

LLR: 2.93 (-2.94,2.94) <-1.75,0.25>
Total: 506336 W: 129447 L: 129738 D: 247151
Ptnml(0-2): 960, 59384, 132718, 59199, 907
Passed STC non-reg:

https://tests.stockfishchess.org/tests/view/6a79ff99a7e815d01b5603ad

Passed LTC non-reg:
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 138276 W: 35651 L: 35552 D: 67073
Ptnml(0-2): 37, 14851, 39261, 14954, 35
https://tests.stockfishchess.org/tests/view/6a842ae29960adfadf924008

bench: 2497913