### PR TITLE
Remove unused PieceType::QUEEN case in pseudo_attacks()

### DIFF
--- a/src/attacks.h
+++ b/src/attacks.h
@@ -230,8 +230,6 @@ constexpr Bitboard pseudo_attacks(PieceType pt, Square sq) {
     case PieceType::ROOK :
     case PieceType::BISHOP :
         return sliding_attack(pt, sq, 0);
-    case PieceType::QUEEN :
-        return sliding_attack(PieceType::ROOK, sq, 0) | sliding_attack(PieceType::BISHOP, sq, 0);
     case PieceType::KNIGHT :
         return knight_attack(sq);
     case PieceType::KING :


### PR DESCRIPTION
`pseudo_attacks()` includes a branch for `PieceType::QUEEN`. However, the compile-time `PseudoAttacks` table initializes queen attacks directly by combining the already-computed bishop and rook attack tables:

```cpp
attacks[QUEEN][s1] = attacks[BISHOP][s1] = pseudo_attacks(BISHOP, s1);
attacks[QUEEN][s1] |= attacks[ROOK][s1]  = pseudo_attacks(ROOK, s1);
```

As a result, `pseudo_attacks()` is never called with QUEEN anywhere in the codebase.

No functional change