### PR TITLE
Avoid unnecessary clears of TT and histories

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -141,6 +141,7 @@ Engine::Engine(std::optional<std::filesystem::path> path) :
     threads.clear();
     threads.ensure_network_replicated();
     resize_threads();
+    fresh = true;
 }
 
 std::variant<u64, PositionSetError>
@@ -151,6 +152,7 @@ Engine::perft(const std::string& fen, Depth depth, bool isChess960) {
 }
 
 void Engine::go(Search::LimitsType& limits) {
+    fresh = false;
     assert(limits.perft == 0);
     verify_network();
 
@@ -161,11 +163,15 @@ void Engine::stop() { threads.stop = true; }
 void Engine::search_clear() {
     wait_for_search_finished();
 
-    tt.clear(threads);
-    threads.clear();
-
     // TODO: does not work with multiple instances
     Tablebases::init(options["SyzygyPath"]);  // Free mapped files
+
+    if (fresh) return;
+
+    tt.clear(threads); // initializes TT
+    threads.clear(); // initializes histories
+
+    fresh = true;
 }
 
 void Engine::set_on_update_no_moves(std::function<void(const Engine::InfoShort&)>&& f) {
@@ -190,7 +196,7 @@ void Engine::set_on_verify_network(std::function<void(std::string_view)>&& f) {
     onVerifyNetwork = std::move(f);
 }
 
-void Engine::wait_for_search_finished() { threads.main_thread()->wait_for_search_finished(); }
+void Engine::wait_for_search_finished() const { threads.main_thread()->wait_for_search_finished(); }
 
 std::optional<PositionSetError> Engine::set_position(const std::string&              fen,
                                                      const std::vector<std::string>& moves) {

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -82,14 +82,14 @@ Engine::Engine(std::optional<std::filesystem::path> path) :
 
     options.add(  //
       "Threads", Option(1, 1, MaxThreads, [this](const Option& o) {
-          if ( !(fresh && threads.num_threads() == usize(o)) )
+          if ( dirty || threads.num_threads() != usize(o) )
               resize_threads();
           return thread_allocation_information_as_string();
       }));
 
     options.add(  //
       "Hash", Option(16, 1, MaxHashMB, [this](const Option& o) {
-          if ( !(fresh && tt.size() == usize(o)) )
+          if ( dirty || tt.size() != usize(o) )
               set_tt_size(o);
           return std::nullopt;
       }));
@@ -141,7 +141,7 @@ Engine::Engine(std::optional<std::filesystem::path> path) :
       }));
 
     resize_threads();
-    fresh = true;
+    dirty = false;
 }
 
 std::variant<u64, PositionSetError>
@@ -152,7 +152,7 @@ Engine::perft(const std::string& fen, Depth depth, bool isChess960) {
 }
 
 void Engine::go(Search::LimitsType& limits) {
-    fresh = false;
+    dirty = true;
     assert(limits.perft == 0);
     verify_network();
 
@@ -166,12 +166,12 @@ void Engine::search_clear() {
     // TODO: does not work with multiple instances
     Tablebases::init(options["SyzygyPath"]);  // Free mapped files
 
-    if (fresh) return;
+    if (!dirty) return;
 
     tt.clear(threads); // initializes TT
     threads.clear(); // initializes histories
 
-    fresh = true;
+    dirty = false;
 }
 
 void Engine::set_on_update_no_moves(std::function<void(const Engine::InfoShort&)>&& f) {
@@ -257,7 +257,7 @@ void Engine::resize_threads() {
 
     // Reallocate the hash with the new threadpool size
     set_tt_size(options["Hash"]);
-    fresh = true; // threads.set clears histories, set_tt_size clears tt
+    dirty = false; // threads.set clears histories, set_tt_size clears tt
     threads.ensure_network_replicated();
 }
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -81,14 +81,16 @@ Engine::Engine(std::optional<std::filesystem::path> path) :
       }));
 
     options.add(  //
-      "Threads", Option(1, 1, MaxThreads, [this](const Option&) {
-          resize_threads();
+      "Threads", Option(1, 1, MaxThreads, [this](const Option& o) {
+          if ( !(fresh && threads.num_threads() == usize(o)) )
+              resize_threads();
           return thread_allocation_information_as_string();
       }));
 
     options.add(  //
       "Hash", Option(16, 1, MaxHashMB, [this](const Option& o) {
-          set_tt_size(o);
+          if ( !(fresh && tt.size() == usize(o)) )
+              set_tt_size(o);
           return std::nullopt;
       }));
 
@@ -138,8 +140,6 @@ Engine::Engine(std::optional<std::filesystem::path> path) :
           return std::nullopt;
       }));
 
-    threads.clear();
-    threads.ensure_network_replicated();
     resize_threads();
     fresh = true;
 }
@@ -257,6 +257,7 @@ void Engine::resize_threads() {
 
     // Reallocate the hash with the new threadpool size
     set_tt_size(options["Hash"]);
+    fresh = true; // threads.set clears histories, set_tt_size clears tt
     threads.ensure_network_replicated();
 }
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -130,7 +130,7 @@ class Engine {
     TranspositionTable                                tt;
     Eval::NNUE::EvalFile                              networkFile;
     LazyNumaReplicatedSystemWide<Eval::NNUE::Network> network;
-    bool fresh; // have histories and tt been modified since the last clear?
+    bool dirty; // have histories and tt been modified since the last clear?
 
     Search::SearchManager::UpdateContext  updateContext;
     std::function<void(std::string_view)> onVerifyNetwork;

--- a/src/engine.h
+++ b/src/engine.h
@@ -72,7 +72,7 @@ class Engine {
     void stop();
 
     // blocking call to wait for search to finish
-    void wait_for_search_finished();
+    void wait_for_search_finished() const;
     // set a new position, moves are in UCI format
     std::optional<PositionSetError> set_position(const std::string&              fen,
                                                  const std::vector<std::string>& moves);
@@ -130,6 +130,7 @@ class Engine {
     TranspositionTable                                tt;
     Eval::NNUE::EvalFile                              networkFile;
     LazyNumaReplicatedSystemWide<Eval::NNUE::Network> network;
+    bool fresh; // have histories and tt been modified since the last clear?
 
     Search::SearchManager::UpdateContext  updateContext;
     std::function<void(std::string_view)> onVerifyNetwork;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -2137,6 +2137,17 @@ void SearchManager::check_time(Search::Worker& worker) {
         worker.threads.stop = true;
 }
 
+void SearchManager::clear() {
+    // These two affect the time taken on the first move of a game:
+    bestPreviousAverageScore = VALUE_INFINITE;
+    previousTimeReduction    = 0.85;
+
+    callsCnt           = 0;
+    bestPreviousScore  = VALUE_INFINITE;
+    originalTimeAdjust = -1;
+    tm.clear();
+}
+
 // Used to correct and extend PVs for moves that have a TB (but not a mate) score.
 // Keeps the search based PV for as long as it is verified to maintain the game
 // outcome, truncates afterwards. Finally, extends to mate the PV, providing a

--- a/src/search.h
+++ b/src/search.h
@@ -294,6 +294,8 @@ class SearchManager {
                    const TranspositionTable& tt,
                    Depth                     depth);
 
+    void clear();
+
     Stockfish::TimeManagement tm;
     double                    originalTimeAdjust;
     int                       callsCnt;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -37,7 +37,6 @@
 #include "movegen.h"
 #include "search.h"
 #include "syzygy/tbprobe.h"
-#include "timeman.h"
 #include "types.h"
 #include "uci.h"
 #include "ucioption.h"

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -222,6 +222,8 @@ void ThreadPool::set(const NumaConfig&                           numaConfig,
         auto threadsPerNode = counts;
         counts.clear();
 
+        assert(threads.size() == 0);
+
         while (threads.size() < requested)
         {
             const usize     threadId      = threads.size();
@@ -238,8 +240,8 @@ void ThreadPool::set(const NumaConfig&                           numaConfig,
                                                        : OptionalThreadToNumaNodeBinder(numaId);
 
                 threads.emplace_back(std::make_unique<Thread>(sharedState, std::move(manager),
-                                                                         threadId, counts[numaId]++,
-                                                                         threadsPerNode[numaId], binder));
+                                                              threadId, counts[numaId]++,
+                                                              threadsPerNode[numaId], binder));
             };
 
             // Ensure the worker thread inherits the intended NUMA affinity at creation.
@@ -248,8 +250,6 @@ void ThreadPool::set(const NumaConfig&                           numaConfig,
             else
                 create_thread();
         }
-
-        clear();
 
         main_thread()->wait_for_search_finished();
     }

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -251,6 +251,7 @@ void ThreadPool::set(const NumaConfig&                           numaConfig,
                 create_thread();
         }
 
+        main_manager()->clear();
         main_thread()->wait_for_search_finished();
     }
 }
@@ -267,14 +268,7 @@ void ThreadPool::clear() {
     for (auto&& th : threads)
         th->wait_for_search_finished();
 
-    // These two affect the time taken on the first move of a game:
-    main_manager()->bestPreviousAverageScore = VALUE_INFINITE;
-    main_manager()->previousTimeReduction    = 0.85;
-
-    main_manager()->callsCnt           = 0;
-    main_manager()->bestPreviousScore  = VALUE_INFINITE;
-    main_manager()->originalTimeAdjust = -1;
-    main_manager()->tm.clear();
+    main_manager()->clear();
 }
 
 void ThreadPool::run_on_thread(usize threadId, std::function<void()> f) {

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -176,8 +176,8 @@ static_assert(sizeof(Cluster) == 32, "Suboptimal Cluster size");
 
 
 // Sets the size of the transposition table, measured in megabytes.
-// Transposition table consists of clusters and each cluster consists
-// of ClusterSize number of TTEntry.
+// Transposition table consists of clusters and each cluster consists of
+// ClusterSize number of TTEntry.
 void TranspositionTable::resize(usize mbSize, ThreadPool& threads) {
     aligned_large_pages_free(table);
 
@@ -199,8 +199,14 @@ void TranspositionTable::resize(usize mbSize, ThreadPool& threads) {
     clear(threads);
 }
 
+// returns the size of the transposition table, measured in megabytes
+usize TranspositionTable::size() {
+    assert(clusterCount * sizeof(Cluster) % (1024 * 1024) == 0);
+    return clusterCount * sizeof(Cluster) / (1024 * 1024);
+}
 
-// Initializes the entire transposition table to zero, in a multi-threaded way
+// Initializes the entire transposition table to zero,
+// in a multi-threaded way.
 void TranspositionTable::clear(ThreadPool& threads) {
     generation8             = 0;
     const usize threadCount = threads.num_threads();

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -176,8 +176,8 @@ static_assert(sizeof(Cluster) == 32, "Suboptimal Cluster size");
 
 
 // Sets the size of the transposition table, measured in megabytes.
-// Transposition table consists of clusters and each cluster consists of
-// ClusterSize number of TTEntry.
+// Transposition table consists of clusters and each cluster consists
+// of ClusterSize number of TTEntry.
 void TranspositionTable::resize(usize mbSize, ThreadPool& threads) {
     aligned_large_pages_free(table);
 
@@ -199,14 +199,13 @@ void TranspositionTable::resize(usize mbSize, ThreadPool& threads) {
     clear(threads);
 }
 
-// returns the size of the transposition table, measured in megabytes
+// Returns the size of the transposition table, measured in megabytes
 usize TranspositionTable::size() {
     assert(clusterCount * sizeof(Cluster) % (1024 * 1024) == 0);
     return clusterCount * sizeof(Cluster) / (1024 * 1024);
 }
 
-// Initializes the entire transposition table to zero,
-// in a multi-threaded way.
+// Initializes the entire transposition table to zero, in a multi-threaded way
 void TranspositionTable::clear(ThreadPool& threads) {
     generation8             = 0;
     const usize threadCount = threads.num_threads();

--- a/src/tt.h
+++ b/src/tt.h
@@ -88,6 +88,9 @@ class TranspositionTable {
     // Set TT size in MiB
     void resize(usize mbSize, ThreadPool& threads);
 
+    // returns TT size in MiB
+    usize size();
+
     // Re-initialize memory, multithreaded
     void clear(ThreadPool& threads);
 


### PR DESCRIPTION
On master, running `stockfish bench` requires 5 fills of histories and 4 clears of the TT. Especially the pawn history takes long to clear since it is 16MB by now and compilers don't vectorize the writes to atomic i16s.
This patch avoids that by
1. A `dirty=false` flag on `Engine` is set on creation and when calling search_clear(), and search_clear() on clears if dirty is set.
2. don't clear histories `setoption Threads` is passed the current value of `Threads`, same for TT. This is only done when `dirty == false`, because currently these commands clear histories/TT and maybe someone relies on that.
3. The constructor for Worker already calls clear(), so the additional clear() in ThreadPool::set() is 

As a result `bench` also runs ~30ms faster.

btw this patch can be used to report history/TT clears:
```diff
diff --git src/search.cpp src/search.cpp
index d92d5ad5..50b5dc7d 100644
--- src/search.cpp
+++ src/search.cpp
@@ -687,7 +687,6 @@ void Search::Worker::undo_null_move(Position& pos) { pos.undo_null_move(); }
 
 // Reset histories, usually before a new game
 void Search::Worker::clear() {
-    std::cerr << "history clear" << std::endl;
     mainHistory.fill(-5);
     captureHistory.fill(-742);
 
diff --git src/tt.cpp src/tt.cpp
index 337b1400..b06b8233 100644
--- src/tt.cpp
+++ src/tt.cpp
@@ -194,7 +194,6 @@ usize TranspositionTable::size() {
 
 // Initializes the entire transposition table to zero, in a multi-threaded way
 void TranspositionTable::clear(ThreadPool& threads) {
-    std::cerr << "TT clear (" << clusterCount * sizeof(Cluster) / 1024 / 1024 << "MB)" << std::endl;
     generation8             = 0;
     const usize threadCount = threads.num_threads();
 ```

No functional change.