### PR TITLE
BMI2 PEXT sliding-piece attacks

### DIFF
--- a/src/attacks.cpp
+++ b/src/attacks.cpp
@@ -19,6 +19,7 @@
 #include "attacks.h"
 
 #include <array>
+#include <vector>
 
 #include "misc.h"
 
@@ -30,7 +31,7 @@ Bitboard RayPassBB[SQUARE_NB][SQUARE_NB];
 
 namespace {
 
-#ifndef USE_DUAL_HYPERBOLA_QUINT
+#if !defined(USE_DUAL_HYPERBOLA_QUINT) && !defined(USE_PEXT)
 alignas(64) Magic Magics[SQUARE_NB][2];
 #endif
 
@@ -95,6 +96,52 @@ static constexpr auto make_dual_magics() {
 }
 
 alignas(64) extern constexpr std::array<DualMagic, SQUARE_NB> DualMagics = make_dual_magics();
+
+#elif defined(USE_PEXT)
+
+SliderEntry SliderRook[SQUARE_NB];
+SliderEntry SliderBishop[SQUARE_NB];
+
+namespace {
+
+std::vector<Bitboard> SliderTable;  // full attack sets, rook then bishop, packed
+
+void init_slider_piece(PieceType pt, SliderEntry entries[], size_t& off) {
+    for (Square s = SQ_A1; s <= SQ_H8; ++s)
+    {
+        Bitboard edges = ((Rank1BB | Rank8BB) & ~rank_bb(s)) | ((FileABB | FileHBB) & ~file_bb(s));
+
+        SliderEntry& e = entries[s];
+        e.occMask      = sliding_attack(pt, s, 0) & ~edges;
+        e.attacks      = &SliderTable[off];
+
+        Bitboard b = 0;
+        do
+        {
+            SliderTable[off + pext(b, e.occMask)] = sliding_attack(pt, s, b);
+            b                                     = (b - e.occMask) & e.occMask;
+        } while (b);
+
+        off += size_t(1) << popcount(e.occMask);
+    }
+}
+
+void init_sliders() {
+    size_t total = 0;
+    for (Square s = SQ_A1; s <= SQ_H8; ++s)
+    {
+        Bitboard edges = ((Rank1BB | Rank8BB) & ~rank_bb(s)) | ((FileABB | FileHBB) & ~file_bb(s));
+        for (PieceType pt : {ROOK, BISHOP})
+            total += size_t(1) << popcount(sliding_attack(pt, s, 0) & ~edges);
+    }
+    SliderTable.assign(total, 0);
+
+    size_t off = 0;
+    init_slider_piece(ROOK, SliderRook, off);
+    init_slider_piece(BISHOP, SliderBishop, off);
+}
+
+}  // namespace
 
 #else
 
@@ -165,6 +212,8 @@ void init() {
 
 #ifdef USE_HYPERBOLA_QUINT
     init_magics(Magics);
+#elif defined(USE_PEXT)
+    init_sliders();
 #elif !defined(USE_DUAL_HYPERBOLA_QUINT)
     init_magics(ROOK, RookTable.data(), Magics);
     init_magics(BISHOP, BishopTable.data(), Magics);
@@ -188,7 +237,7 @@ void init() {
     }
 }
 
-#ifndef USE_DUAL_HYPERBOLA_QUINT
+#if !defined(USE_DUAL_HYPERBOLA_QUINT) && !defined(USE_PEXT)
 const Magic& magic(Square s, PieceType pt) {
     assert((pt == BISHOP || pt == ROOK) && is_ok(s));
     return Magics[s][pt - BISHOP];

--- a/src/attacks.h
+++ b/src/attacks.h
@@ -32,7 +32,7 @@
     #define USE_HYPERBOLA_QUINT
 #elif defined(__loongarch__) && __loongarch_grlen == 64
     #define USE_HYPERBOLA_QUINT
-#elif defined(USE_AVX2)
+#elif defined(USE_AVX2) && !defined(USE_PEXT)
     #include <immintrin.h>
     #define USE_DUAL_HYPERBOLA_QUINT
 #endif
@@ -139,6 +139,31 @@ struct alignas(32) DualMagic {
 
 extern const std::array<DualMagic, SQUARE_NB> DualMagics;
 inline const DualMagic&                       dual_magic(Square s) { return DualMagics[s]; }
+
+#elif defined(USE_PEXT)
+
+// BMI2 backend: PEXT the relevant (edges-excluded) occupancy bits into a compact
+// index, then read the full attack bitboard from this square's table.
+struct SliderEntry {
+    Bitboard        occMask;  // edges-excluded relevant occupancy
+    const Bitboard* attacks;  // per-square table of full attack sets
+};
+
+extern SliderEntry SliderRook[SQUARE_NB];
+extern SliderEntry SliderBishop[SQUARE_NB];
+
+inline Bitboard slider_attacks(const SliderEntry& e, Bitboard occupied) {
+    return e.attacks[pext(occupied, e.occMask)];
+}
+
+// Bishop and rook lookups are independent; interleave their PEXT+load chains so
+// the CPU can pipeline them. Queen and both_attacks_bb() route through here.
+inline std::pair<Bitboard, Bitboard>
+slider_both(const SliderEntry& b, const SliderEntry& r, Bitboard occupied) {
+    const u64 ib = pext(occupied, b.occMask);
+    const u64 ir = pext(occupied, r.occMask);
+    return {b.attacks[ib], r.attacks[ir]};
+}
 
 #else
 // Magic holds all magic bitboards relevant data for a single square
@@ -302,6 +327,20 @@ inline Bitboard attacks_bb(Square s, Bitboard occupied) {
     default :
         return PseudoAttacks[Pt][s];
     }
+#elif defined(USE_PEXT)
+    switch (Pt)
+    {
+    case BISHOP :
+        return slider_attacks(SliderBishop[s], occupied);
+    case ROOK :
+        return slider_attacks(SliderRook[s], occupied);
+    case QUEEN : {
+        const auto [bishop, rook] = slider_both(SliderBishop[s], SliderRook[s], occupied);
+        return bishop | rook;
+    }
+    default :
+        return PseudoAttacks[Pt][s];
+    }
 #else
     switch (Pt)
     {
@@ -319,6 +358,8 @@ inline Bitboard attacks_bb(Square s, Bitboard occupied) {
 inline std::pair<Bitboard, Bitboard> both_attacks_bb(Square s, Bitboard occupied) {
 #ifdef USE_DUAL_HYPERBOLA_QUINT
     return dual_magic(s).both_attacks_bb(occupied);
+#elif defined(USE_PEXT)
+    return slider_both(SliderBishop[s], SliderRook[s], occupied);
 #else
     return {attacks_bb<BISHOP>(s, occupied), attacks_bb<ROOK>(s, occupied)};
 #endif


### PR DESCRIPTION
On BMI2 targets (USE_PEXT), generate bishop/rook/queen attacks by PEXT-ing the relevant edges-excluded occupancy into a per-square table of full attack bitboards, replacing the dual hyperbola-quintessence path. Queen and both_attacks_bb() interleave the two independent bishop/rook PEXT+load chains for ILP.

On a Zen3 this is ~+6% perft NPS over dual-HQ.

The idea comes from:
> From 20 Nanoseconds to One
> Optimizing Bishop, Rook and Queen Move Generation in a Chess Engine

by Aryan Naraghi

The implementation was done by Claude.