### PR TITLE
BMI2 PEXT/PDEP sliding-piece attacks (compressed table)

### DIFF
--- a/src/attacks.cpp
+++ b/src/attacks.cpp
@@ -19,6 +19,7 @@
 #include "attacks.h"
 
 #include <array>
+#include <vector>
 
 #include "misc.h"
 
@@ -30,7 +31,7 @@ Bitboard RayPassBB[SQUARE_NB][SQUARE_NB];
 
 namespace {
 
-#ifndef USE_DUAL_HYPERBOLA_QUINT
+#if !defined(USE_DUAL_HYPERBOLA_QUINT) && !defined(USE_PEXT)
 alignas(64) Magic Magics[SQUARE_NB][2];
 #endif
 
@@ -95,6 +96,54 @@ static constexpr auto make_dual_magics() {
 }
 
 alignas(64) extern constexpr std::array<DualMagic, SQUARE_NB> DualMagics = make_dual_magics();
+
+#elif defined(USE_PEXT)
+
+SliderEntry SliderRook[SQUARE_NB];
+SliderEntry SliderBishop[SQUARE_NB];
+
+namespace {
+
+std::vector<u16> SliderTable;  // PEXT-compressed attack codes, rook then bishop, packed
+
+void init_slider_piece(PieceType pt, SliderEntry entries[], size_t& off) {
+    for (Square s = SQ_A1; s <= SQ_H8; ++s)
+    {
+        Bitboard edges = ((Rank1BB | Rank8BB) & ~rank_bb(s)) | ((FileABB | FileHBB) & ~file_bb(s));
+
+        SliderEntry& e = entries[s];
+        e.rayMask      = sliding_attack(pt, s, 0);
+        e.occMask      = e.rayMask & ~edges;
+        e.packed       = &SliderTable[off];
+
+        Bitboard b = 0;
+        do
+        {
+            // Store the attack set compressed onto its ray; slider_attacks() PDEPs it back.
+            SliderTable[off + pext(b, e.occMask)] = u16(pext(sliding_attack(pt, s, b), e.rayMask));
+            b                                     = (b - e.occMask) & e.occMask;
+        } while (b);
+
+        off += size_t(1) << popcount(e.occMask);
+    }
+}
+
+void init_sliders() {
+    size_t total = 0;
+    for (Square s = SQ_A1; s <= SQ_H8; ++s)
+    {
+        Bitboard edges = ((Rank1BB | Rank8BB) & ~rank_bb(s)) | ((FileABB | FileHBB) & ~file_bb(s));
+        for (PieceType pt : {ROOK, BISHOP})
+            total += size_t(1) << popcount(sliding_attack(pt, s, 0) & ~edges);
+    }
+    SliderTable.assign(total, 0);
+
+    size_t off = 0;
+    init_slider_piece(ROOK, SliderRook, off);
+    init_slider_piece(BISHOP, SliderBishop, off);
+}
+
+}  // namespace
 
 #else
 
@@ -165,6 +214,8 @@ void init() {
 
 #ifdef USE_HYPERBOLA_QUINT
     init_magics(Magics);
+#elif defined(USE_PEXT)
+    init_sliders();
 #elif !defined(USE_DUAL_HYPERBOLA_QUINT)
     init_magics(ROOK, RookTable.data(), Magics);
     init_magics(BISHOP, BishopTable.data(), Magics);
@@ -188,7 +239,7 @@ void init() {
     }
 }
 
-#ifndef USE_DUAL_HYPERBOLA_QUINT
+#if !defined(USE_DUAL_HYPERBOLA_QUINT) && !defined(USE_PEXT)
 const Magic& magic(Square s, PieceType pt) {
     assert((pt == BISHOP || pt == ROOK) && is_ok(s));
     return Magics[s][pt - BISHOP];

--- a/src/attacks.h
+++ b/src/attacks.h
@@ -32,7 +32,7 @@
     #define USE_HYPERBOLA_QUINT
 #elif defined(__loongarch__) && __loongarch_grlen == 64
     #define USE_HYPERBOLA_QUINT
-#elif defined(USE_AVX2)
+#elif defined(USE_AVX2) && !defined(USE_PEXT)
     #include <immintrin.h>
     #define USE_DUAL_HYPERBOLA_QUINT
 #endif
@@ -139,6 +139,35 @@ struct alignas(32) DualMagic {
 
 extern const std::array<DualMagic, SQUARE_NB> DualMagics;
 inline const DualMagic&                       dual_magic(Square s) { return DualMagics[s]; }
+
+#elif defined(USE_PEXT)
+
+// BMI2 backend: PEXT the relevant (edges-excluded) occupancy into a compact
+// index, read a PEXT-compressed attack code (<= 14 bits) from this square's
+// table, and PDEP it back onto the square's full ray to rebuild the attack set.
+struct SliderEntry {
+    Bitboard   occMask;  // edges-excluded relevant occupancy (PEXT index)
+    Bitboard   rayMask;  // full ray incl. edges (PDEP target)
+    const u16* packed;   // PEXT-compressed attack codes
+};
+
+extern SliderEntry SliderRook[SQUARE_NB];
+extern SliderEntry SliderBishop[SQUARE_NB];
+
+inline Bitboard slider_attacks(const SliderEntry& e, Bitboard occupied) {
+    return pdep(Bitboard(e.packed[pext(occupied, e.occMask)]), e.rayMask);
+}
+
+// Bishop and rook lookups are independent; interleave their PEXT -> load -> PDEP
+// chains so the CPU can pipeline them. Queen and both_attacks_bb() route here.
+inline std::pair<Bitboard, Bitboard>
+slider_both(const SliderEntry& b, const SliderEntry& r, Bitboard occupied) {
+    const u64 ib = pext(occupied, b.occMask);
+    const u64 ir = pext(occupied, r.occMask);
+    const u16 cb = b.packed[ib];
+    const u16 cr = r.packed[ir];
+    return {pdep(Bitboard(cb), b.rayMask), pdep(Bitboard(cr), r.rayMask)};
+}
 
 #else
 // Magic holds all magic bitboards relevant data for a single square
@@ -302,6 +331,20 @@ inline Bitboard attacks_bb(Square s, Bitboard occupied) {
     default :
         return PseudoAttacks[Pt][s];
     }
+#elif defined(USE_PEXT)
+    switch (Pt)
+    {
+    case BISHOP :
+        return slider_attacks(SliderBishop[s], occupied);
+    case ROOK :
+        return slider_attacks(SliderRook[s], occupied);
+    case QUEEN : {
+        const auto [bishop, rook] = slider_both(SliderBishop[s], SliderRook[s], occupied);
+        return bishop | rook;
+    }
+    default :
+        return PseudoAttacks[Pt][s];
+    }
 #else
     switch (Pt)
     {
@@ -319,6 +362,8 @@ inline Bitboard attacks_bb(Square s, Bitboard occupied) {
 inline std::pair<Bitboard, Bitboard> both_attacks_bb(Square s, Bitboard occupied) {
 #ifdef USE_DUAL_HYPERBOLA_QUINT
     return dual_magic(s).both_attacks_bb(occupied);
+#elif defined(USE_PEXT)
+    return slider_both(SliderBishop[s], SliderRook[s], occupied);
 #else
     return {attacks_bb<BISHOP>(s, occupied), attacks_bb<ROOK>(s, occupied)};
 #endif


### PR DESCRIPTION
On BMI2 targets (USE_PEXT), generate bishop/rook/queen attacks by PEXT-ing the edges-excluded occupancy into a compact index, reading a PEXT-compressed attack code (<= 14 bits, stored u16) from a per-square table, and PDEP-ing it back onto the square's full ray. This quarters the table vs storing full u64 attack sets (~210 KB total). Queen and both_attacks_bb() interleave the two independent bishop/rook PEXT -> load -> PDEP chains for ILP.

The idea comes from:
> From 20 Nanoseconds to One
> Optimizing Bishop, Rook and Queen Move Generation in a Chess Engine

by Aryan Naraghi

I've added pdep-ing back out rather than having a LUT of 64bits bbs.

The implementation was done by Claude.