### PR TITLE
docs: fix typo alignement -> alignment

### DIFF
--- a/src/shm_unix.h
+++ b/src/shm_unix.h
@@ -336,7 +336,7 @@ class SharedMemory {
         {
             struct msghdr   msg                = {};
             const usize     space              = CMSG_SPACE(sizeof(int));
-            constexpr usize alignment         = alignof(struct cmsghdr);
+            constexpr usize alignment          = alignof(struct cmsghdr);
             auto            v                  = std::make_unique<std::byte[]>(space + alignment);
             std::byte*      control_msg_buffer = align_ptr_up<alignment>(v.get());
 

--- a/src/shm_unix.h
+++ b/src/shm_unix.h
@@ -336,9 +336,9 @@ class SharedMemory {
         {
             struct msghdr   msg                = {};
             const usize     space              = CMSG_SPACE(sizeof(int));
-            constexpr usize alignement         = alignof(struct cmsghdr);
-            auto            v                  = std::make_unique<std::byte[]>(space + alignement);
-            std::byte*      control_msg_buffer = align_ptr_up<alignement>(v.get());
+            constexpr usize alignment         = alignof(struct cmsghdr);
+            auto            v                  = std::make_unique<std::byte[]>(space + alignment);
+            std::byte*      control_msg_buffer = align_ptr_up<alignment>(v.get());
 
             char         buf[1];
             struct iovec iov[1];
@@ -435,9 +435,9 @@ class SharedMemory {
 
                       struct msghdr   msg        = {};
                       const usize     space      = CMSG_SPACE(sizeof(int));
-                      constexpr usize alignement = alignof(struct cmsghdr);
-                      auto            v = std::make_unique<std::byte[]>(space + alignement);
-                      std::byte*      control_msg_buffer = align_ptr_up<alignement>(v.get());
+                      constexpr usize alignment = alignof(struct cmsghdr);
+                      auto            v = std::make_unique<std::byte[]>(space + alignment);
+                      std::byte*      control_msg_buffer = align_ptr_up<alignment>(v.get());
 
 
                       char  buf[1] = {};


### PR DESCRIPTION
Corrects the misspelling `alignement` -> `alignment` in `src/shm_unix.h`.

Documentation only, no behaviour change.