### PR TITLE
use nullptr instead of Null object pattern for SearchManager

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -160,12 +160,12 @@ bool is_shuffling(Move move, Stack* const ss, const Position& pos) {
 
 }  // namespace
 
-Search::Worker::Worker(SharedState&                    sharedState,
-                       std::unique_ptr<ISearchManager> sm,
-                       usize                           threadId,
-                       usize                           numaThreadId,
-                       usize                           numaTotalThreads,
-                       NumaReplicatedAccessToken       token) :
+Search::Worker::Worker(SharedState&                   sharedState,
+                       std::unique_ptr<SearchManager> sm,
+                       usize                          threadId,
+                       usize                          numaThreadId,
+                       usize                          numaTotalThreads,
+                       NumaReplicatedAccessToken      token) :
     // Unpack the SharedState struct into member variables
     sharedHistory(sharedState.sharedHistories.at(token.get_numa_index())),
     continuationHistory(sharedHistory.continuationHistory()),

--- a/src/search.h
+++ b/src/search.h
@@ -212,14 +212,6 @@ struct SharedState {
 
 class Worker;
 
-// Null Object Pattern, implement a common interface for the SearchManagers.
-// A Null Object will be given to non-mainthread workers.
-class ISearchManager {
-   public:
-    virtual ~ISearchManager() {}
-    virtual void check_time(Search::Worker&) = 0;
-};
-
 struct InfoShort {
     int   depth;
     Score score;
@@ -274,7 +266,7 @@ struct Skill {
 
 // SearchManager manages the search from the main thread. It is responsible for
 // keeping track of the time, and storing data strictly related to the main thread.
-class SearchManager: public ISearchManager {
+class SearchManager {
    public:
     using UpdateShort    = std::function<void(const InfoShort&)>;
     using UpdateFull     = std::function<void(const InfoFull&)>;
@@ -294,7 +286,7 @@ class SearchManager: public ISearchManager {
     SearchManager(const UpdateContext& updateContext) :
         updates(updateContext) {}
 
-    void check_time(Search::Worker& worker) override;
+    void check_time(Search::Worker& worker);
 
     void output_pv(Search::Worker&           worker,
                    const ThreadPool&         threads,
@@ -315,18 +307,13 @@ class SearchManager: public ISearchManager {
     const UpdateContext& updates;
 };
 
-class NullSearchManager: public ISearchManager {
-   public:
-    void check_time(Search::Worker&) override {}
-};
-
 // Search::Worker is the class that does the actual search.
 // It is instantiated once per thread, and it is responsible for keeping track
 // of the search history, and storing data required for the search.
 class Worker {
    public:
     Worker(SharedState&,
-           std::unique_ptr<ISearchManager>,
+           std::unique_ptr<SearchManager>,
            usize,
            usize,
            usize,
@@ -379,7 +366,8 @@ class Worker {
     // Pointer to the search manager, only allowed to be called by the main thread
     SearchManager* main_manager() const {
         assert(threadIdx == 0);
-        return static_cast<SearchManager*>(manager.get());
+        assert(manager.get() != nullptr);
+        return manager.get();
     }
 
     TimePoint elapsed() const;
@@ -408,8 +396,8 @@ class Worker {
     // Reductions lookup table initialized at startup
     std::array<int, MAX_MOVES> reductions;  // [depth or moveNumber]
 
-    // The main thread has a SearchManager, the others have a NullSearchManager
-    std::unique_ptr<ISearchManager> manager;
+    // The main thread has a SearchManager, the others have a nullptr
+    std::unique_ptr<SearchManager> manager;
 
     Tablebases::Config tbConfig;
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -46,12 +46,12 @@ namespace Stockfish {
 
 // Constructor launches the thread and waits until it goes to sleep
 // in idle_loop(). Note that 'searching' and 'exit' should be already set.
-Thread::Thread(Search::SharedState&                    sharedState,
-               std::unique_ptr<Search::ISearchManager> sm,
-               usize                                   n,
-               usize                                   numaN,
-               usize                                   totalNumaCount,
-               OptionalThreadToNumaNodeBinder          binder) :
+Thread::Thread(Search::SharedState&                   sharedState,
+               std::unique_ptr<Search::SearchManager> sm,
+               usize                                  n,
+               usize                                  numaN,
+               usize                                  totalNumaCount,
+               OptionalThreadToNumaNodeBinder         binder) :
     idx(n),
     idxInNuma(numaN),
     totalNuma(totalNumaCount),
@@ -227,10 +227,9 @@ void ThreadPool::set(const NumaConfig&                           numaConfig,
             const usize     threadId      = threads.size();
             const NumaIndex numaId        = doBindThreads ? boundThreadToNumaNode[threadId] : 0;
             auto            create_thread = [&]() {
-                auto manager = threadId == 0
-                                          ? std::unique_ptr<Search::ISearchManager>(
-                                   std::make_unique<Search::SearchManager>(updateContext))
-                                          : std::make_unique<Search::NullSearchManager>();
+                auto manager = threadId == 0 ?
+                                     std::make_unique<Search::SearchManager>(updateContext)
+                                   : nullptr;
 
                 // When not binding threads we want to force all access to happen
                 // from the same NUMA node, because in case of NUMA replicated memory
@@ -240,8 +239,8 @@ void ThreadPool::set(const NumaConfig&                           numaConfig,
                                                        : OptionalThreadToNumaNodeBinder(numaId);
 
                 threads.emplace_back(std::make_unique<Thread>(sharedState, std::move(manager),
-                                                                         threadId, counts[numaId]++,
-                                                                         threadsPerNode[numaId], binder));
+                                                              threadId, counts[numaId]++,
+                                                              threadsPerNode[numaId], binder));
             };
 
             // Ensure the worker thread inherits the intended NUMA affinity at creation.

--- a/src/thread.h
+++ b/src/thread.h
@@ -73,7 +73,7 @@ class OptionalThreadToNumaNodeBinder {
 class Thread {
    public:
     Thread(Search::SharedState&,
-           std::unique_ptr<Search::ISearchManager>,
+           std::unique_ptr<Search::SearchManager>,
            usize,
            usize,
            usize,


### PR DESCRIPTION
There might be a reason for this, or maybe it's a historical artifact, but wit seems to me that we can simplify Workers by using nullptr for the `std::unique_ptr<SearchManager>` of non-main threads.