### PR TITLE
Use the number of prior NMP Fail High in search 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -805,9 +805,10 @@ Value Search::Worker::search(
     Square prevSq  = ((ss - 1)->currentMove).is_ok() ? ((ss - 1)->currentMove).to_sq() : SQ_NONE;
     bestMove       = Move::none();
     priorReduction = (ss - 1)->reduction;
-    (ss - 1)->reduction = 0;
-    ss->statScore       = 0;
-    (ss + 2)->cutoffCnt = 0;
+    (ss - 1)->reduction        = 0;
+    ss->statScore              = 0;
+    (ss + 2)->cutoffCnt        = 0;
+    (ss + 1)->priorNMPFailHigh = 0;
 
     const auto correctionValue = correction_value(*this, pos, ss);
 
@@ -1008,7 +1009,7 @@ Value Search::Worker::search(
     }
 
     // Step 10. Null move search with verification search
-    if (cutNode && ss->staticEval >= beta - 13 * depth - 47 * improving + 365 && !excludedMove
+    if (cutNode && ss->staticEval + 50 * ss->priorNMPFailHigh >= beta - 13 * depth - 47 * improving + 365 && !excludedMove
         && pos.non_pawn_material(us) && ss->ply >= nmpMinPly && beta >= -2000)
     {
         assert((ss - 1)->currentMove != Move::null());
@@ -1025,7 +1026,10 @@ Value Search::Worker::search(
         if (nullValue >= beta && !is_win(nullValue))
         {
             if (nmpMinPly || depth < 16)
+            {
+                ++ss->priorNMPFailHigh;
                 return nullValue;
+            }
 
             // Recursive verification is not allowed
             assert(!nmpMinPly);
@@ -1039,7 +1043,10 @@ Value Search::Worker::search(
             nmpMinPly = 0;
 
             if (v >= beta)
+            {
+                ++ss->priorNMPFailHigh;
                 return nullValue;
+            }
         }
     }
 

--- a/src/search.h
+++ b/src/search.h
@@ -129,6 +129,7 @@ struct Stack {
     bool                        followPV;
     int                         cutoffCnt;
     int                         reduction;
+    int                         priorNMPFailHigh;
 };
 
 


### PR DESCRIPTION
Passed STC:
LLR: 2.97 (-2.94,2.94) <0.00,2.00>
Total: 111680 W: 28682 L: 28265 D: 54733
Ptnml(0-2): 199, 12828, 29391, 13201, 221
https://tests.stockfishchess.org/tests/view/6a8b1bec08c0f6a39c9e7a4e

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 144576 W: 37740 L: 37212 D: 69624
Ptnml(0-2): 26, 15228, 41268, 15724, 42
https://tests.stockfishchess.org/tests/view/6a8d1c7808c0f6a39c9e7f0b

bench: 1997148