### PR TITLE
Simplify quadratic depth in Razoring

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -988,7 +988,7 @@ Value Search::Worker::search(
 
     // Step 8. Razoring
     // If eval is really low, skip search entirely and return the qsearch value
-    if (!PvNode && eval < alpha - 482 * depth * depth)
+    if (!PvNode && eval < alpha - 482 * depth && !seekMate)
         return qsearch<NonPV>(pos, ss, alpha, beta);
 
     // Step 9. Futility pruning: child node


### PR DESCRIPTION
This patch simplifies quadratic depth in razoring, and replaces it with seekMate.
Passed gainer STC:

https://tests.stockfishchess.org/tests/view/6a8d8a8608c0f6a39c9e7f96

LLR: 2.94 (-2.94,2.94) <0.00,2.00>
Total: 152064 W: 39102 L: 38631 D: 74331
Ptnml(0-2): 270, 17473, 40064, 17966, 259

Passed gainer LTC:

https://tests.stockfishchess.org/tests/view/6a90cdf708c0f6a39c9e8602

LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 109002 W: 28365 L: 27908 D: 52729
Ptnml(0-2): 29, 11437, 31112, 11894, 29

Master (Peel off one iteration of the halfka incremental update) matetrack:

Total FENs:    6554
Found mates:   3725
Best mates:    2480

New matetrack:

Total FENs:    6554
Found mates:   3692
Best mates:    2487

Master (Peel off one iteration of the halfka incremental update) matedtrack:

Total FENs:    6536
Found mates:   3895
Best mates:    3108

New matedtrack:

Total FENs:    6536
Found mates:   3945
Best mates:    3129

so matedtrack improvement but matetrack loss (not too much tho)

Bench: 2207014