### PR TITLE
Decrease time usage if engine has time disadvantage.

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -23,6 +23,7 @@
 #include <cmath>
 
 #include "search.h"
+#include "types.h"
 #include "ucioption.h"
 
 namespace Stockfish {
@@ -129,6 +130,20 @@ void TimeManagement::init(Search::LimitsType& limits,
     {
         optScale = std::min((0.88 + ply / 116.4) / mtg, 0.88 * limits.time[us] / timeLeft);
         maxScale = 1.3 + 0.11 * mtg;
+    }
+
+    // Decrease time usage if behind in time.
+    // This is skipped in two cases:
+    // - if the nodestime option is used we can't calculate the opponent nodes budget in a deterministic way.
+    // - if we use a cyclic time management (like 40/10) calculating time advantage for the last move (movestogo = 1)
+    //   can be vastly off, because if the opponent had done his last move before us his time budget includes already
+    //   the next cycle time increment but our not. This leads to a unnecessary big decrease in time usage which favors blunders.
+    // Warning: don't remove this conditions.
+    if (!useNodesTime && limits.movestogo != 1)
+    {
+        double timeAdvantage =
+          (limits.time[us] - limits.time[~us]) / (1.0 + limits.time[us] + limits.time[~us]);
+        optScale *= 1 + 0.9 * std::min(timeAdvantage, 0.0);
     }
 
     // Limit the maximum possible time for this move


### PR DESCRIPTION
 This is skipped in two cases:
    1. if the nodestime option is used we can't calculate the opponent nodes budget in a deterministic way.
    2. if we use a cyclic time management (like 40/10) calculating time advantage for the last move (movestogo = 1)
       can be vastly off, because if the opponent had done his last move before us his time budget includes already
       the next cycle time increment but our not. This leads to a unnecessary big decrease in time usage which favors blunders.

Passed STC 10+0.1:
LLR: 2.97 (-2.94,2.94) <0.00,2.00>
Total: 127360 W: 32487 L: 32071 D: 62802
Ptnml(0-2): 169, 13235, 36487, 13589, 200
https://tests.stockfishchess.org/tests/view/6a8738495b1b38ebda864ed0

Passed LTC 60+0.6:
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 191328 W: 49624 L: 49029 D: 92675
Ptnml(0-2): 44, 18455, 58077, 19038, 50
https://tests.stockfishchess.org/tests/view/6a8ade7a08c0f6a39c9e79cc

Passed non-regression sudden death STC 15+0:
LLR: 2.98 (-2.94,2.94) <-1.75,0.25>
Total: 33984 W: 8802 L: 8584 D: 16598
Ptnml(0-2): 111, 3503, 9589, 3635, 154
https://tests.stockfishchess.org/tests/view/6a94002a08c0f6a39c9e8b31

Passed non-regression STC 40/10 (test includes vondeles cyclic tm fix PR 7117):
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 47872 W: 12288 L: 12090 D: 23494
Ptnml(0-2): 83, 5181, 13255, 5289, 128
https://tests.stockfishchess.org/tests/view/6a967e3408c0f6a39c9e91

Bench: 2497913