### PR TITLE
Simplify LMR divisor

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -52,8 +52,10 @@
 
 namespace Stockfish {
 
-static constexpr std::array<int, 16> lmrDivisor = {3637, 2787, 2761, 2939, 3171, 3347, 3147, 2762,
-                                                   2772, 3106, 3107, 3060, 3112, 2991, 3090, 3542};
+inline int lmr_divisor(int depth) {
+    int d = std::min(depth, 16);
+    return 3000 + 7 * (d - 8) * (d - 8);
+}
 
 namespace TB = Tablebases;
 
@@ -1196,7 +1198,6 @@ moves_loop:  // When in check, search starts here
             }
             else if (!ss->followPV || !PvNode)
             {
-                int dIndex  = std::min(int(depth), int(lmrDivisor.size())) - 1;
                 int history = (*contHist[0])[movedPiece][move.to_sq()]
                             + (*contHist[1])[movedPiece][move.to_sq()]
                             + sharedHistory.pawn_entry(pos)[movedPiece][move.to_sq()];
@@ -1208,7 +1209,7 @@ moves_loop:  // When in check, search starts here
                 history += 69 * mainHistory[us][move.raw()] / 32;
 
                 // (*Scaler): Generally, lower divisors scale well
-                lmrDepth += history / lmrDivisor[dIndex];
+                lmrDepth += history / lmr_divisor(depth);
 
                 Value futilityValue =
                   ss->staticEval + 119 * lmrDepth + 90 * (ss->staticEval > alpha) + 164;


### PR DESCRIPTION
Passed STC non-reg:
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 87072 W: 22323 L: 22161 D: 42588
Ptnml(0-2): 151, 10149, 22797, 10265, 174
https://tests.stockfishchess.org/tests/view/6a842e989960adfadf92400d

Passed LTC non-reg:
LLR: 3.13 (-2.94,2.94) <-1.75,0.25>
Total: 360972 W: 92853 L: 92963 D: 175156
Ptnml(0-2): 113, 38725, 102907, 38641, 100
https://tests.stockfishchess.org/tests/view/6a84f9cc9960adfadf92418b

bench: 2127004