### PR TITLE
Avoid reducing move horizon in cyclic time controls

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -94,8 +94,9 @@ void TimeManagement::init(Search::LimitsType& limits,
     // Maximum move horizon
     int mtg = limits.movestogo ? std::min(limits.movestogo, 50) : 50;
 
-    // If less than one second, gradually reduce mtg
-    if (scaledTime < 1000)
+    // If less than one second, gradually reduce mtg.
+    // In cyclic time controls we keep the actual movestogo as horizon.
+    if (scaledTime < 1000 && limits.movestogo == 0)
         mtg = int(scaledTime * 0.05);
 
     // Make sure timeLeft is > 0 since we may use it as a divisor


### PR DESCRIPTION
Fixes losses on time in cyclic time controls.

Results of master vs fix (40/1, 1t, 64MB, UHO_Lichess_4852_v1.epd): 
Elo: -48.65 +/- 9.84, nElo: -76.63 +/- 15.29
LOS: 0.00 %, DrawRatio: 40.83 %, PairsRatio: 0.48
Games: 1984, Wins: 451, Losses: 727, Draws: 806, Points: 854.0 (43.04 %) 
Ptnml(0-2): [81, 316, 405, 178, 12], WL/DD Ratio: 1.60

Master timeouts: 557, Fix timeouts: 0

Results of master vs fix (40/10, 1t, 64MB, UHO_Lichess_4852_v1.epd): 
Elo: -8.10 +/- 3.45, nElo: -15.98 +/- 6.81
LOS: 0.00 %, DrawRatio: 52.00 %, PairsRatio: 0.84
Games: 10000, Wins: 2463, Losses: 2696, Draws: 4841, Points: 4883.5 (48.84 %) 
Ptnml(0-2): [39, 1268, 2600, 1073, 20], WL/DD Ratio: 1.08

Master timeouts: 116, Fix timeouts: 0

No functional change