### PR TITLE
[bugfix] Apply cyclic TCs when in nodestime

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -31,7 +31,8 @@ TimePoint TimeManagement::optimum() const { return optimumTime; }
 TimePoint TimeManagement::maximum() const { return maximumTime; }
 
 void TimeManagement::clear() {
-    availableNodes = -1;  // When in 'nodes as time' mode
+    availableNodes    = -1;  // When in 'nodes as time' mode
+    previousMovesToGo = 0;
 }
 
 void TimeManagement::advance_nodes_time(i64 nodes) {
@@ -76,8 +77,16 @@ void TimeManagement::init(Search::LimitsType& limits,
     // must be much lower than the real engine speed.
     if (useNodesTime)
     {
-        if (availableNodes == -1)                       // Only once at game start
-            availableNodes = npmsec * limits.time[us];  // Time is in msec
+        if (availableNodes == -1)  // Only once at game start
+        {
+            // First time limit includes increment (both are in milliseconds)
+            availableNodes = npmsec * limits.time[us];
+            cyclicBudget   = npmsec * (limits.time[us] - limits.inc[us]);
+        }
+        else if (limits.movestogo > 0 && limits.movestogo > previousMovesToGo && cyclicBudget > 0)
+            availableNodes += cyclicBudget;
+
+        previousMovesToGo = limits.movestogo;
 
         // Convert from milliseconds to nodes
         limits.time[us] = TimePoint(availableNodes);

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -61,8 +61,11 @@ class TimeManagement {
     TimePoint optimumTime = NoBound;
     TimePoint maximumTime = NoBound;
 
-    i64  availableNodes = -1;     // When in 'nodes as time' mode
-    bool useNodesTime   = false;  // True if we are in 'nodes as time' mode
+    // Related to 'nodes as time' mode:
+    bool useNodesTime      = false;
+    i64  availableNodes    = -1;
+    int  previousMovesToGo = 0;
+    i64  cyclicBudget      = 0;
 };
 
 }  // namespace Stockfish


### PR DESCRIPTION
When using `nodestime`, master does not correctly apply cyclic time controls like 40/10. This patch fixes that.

Details of how game managers deal with these time controls can be found [here](https://github.com/Disservin/fastchess/blob/ccb85325b1db322658687b8be8cfe9f54c495840/app/src/game/timecontrol/timecontrol.cpp).

No functional change.