### PR TITLE
Update the WDL model

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -543,8 +543,8 @@ WinRateParams win_rate_params(const Position& pos) {
     double m = std::clamp(material, 17, 78) / 58.0;
 
     // Return a = p_a(material) and b = p_b(material), see github.com/official-stockfish/WDL_model
-    constexpr double as[] = {-72.32565836, 185.93832038, -144.58862193, 416.44950446};
-    constexpr double bs[] = {83.86794042, -136.06112997, 69.98820887, 47.62901433};
+    constexpr double as[] = {-142.72052667, 372.35176398, -340.71073572, 415.23490212};
+    constexpr double bs[] = {5.93832785, 15.61267078, -30.57816876, 69.63866711};
 
     double a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
     double b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];


### PR DESCRIPTION
This PR updates the internal WDL model, using data from 2M games played by the revisions since 229f6339e537a097a79831cd06dbfdb3e623d4ac. The normalizing constant decreases significantly from 385 to 304. That means the current 78cp will roughly map to 100cp.
```
> ./updateWDL.sh --firstrev 229f6339e537a097a79831cd06dbfdb3e623d4ac
Running: ./updateWDL.sh --firstrev 229f6339e537a097a79831cd06dbfdb3e623d4ac --lasttrev HEAD --materialMin 17 --EloDiffMax 5
started at:  Tue 1 Sep 14:31:12 CEST 2026
Look recursively in directory pgns for games with max nElo difference 5 using books matching "UHO_Lichess_4852_v..epd" for SF revisions between 229f6339e537a097a79831cd06dbfdb3e623d4ac (from 2026-08-19 18:48:49 +0200) and HEAD (from 2026-08-29 09:16:46 +0200).
Based on 109147283 positions from 2046412 games, NormalizeToPawnValue should change from 385 to 304.
In the updated WDL model, 78cp would roughly map to 100cp.
ended at:  Tue 1 Sep 14:32:20 CEST 2026
```
```
> cat scoreWDL.log
Converting evals with NormalizeData = {'momType': 'material', 'momMin': 17, 'momMax': 78, 'momTarget': 58, 'as': [-72.32565836, 185.93832038, -144.58862193, 416.44950446]}.
Reading eval stats from updateWDL.json.
Retained (W,D,L) = (26673519, 54948054, 27525710) positions.
Saved distribution plot to updateWDLdistro.png.
Fit WDL model based on material.
Initial objective function:  0.3550415621263458
Final objective function:    0.3550400701834142
Optimization terminated successfully.
const int NormalizeToPawnValue = 304;
Corresponding spread = 61;
Corresponding normalized spread = 0.19927805405945914;
Draw rate at 0.0 eval at material 58 = 0.986853004859315;
Parameters in internal value units: 
p_a = ((-142.721 * x / 58 + 372.352) * x / 58 + -340.711) * x / 58 + 415.235
p_b = ((5.938 * x / 58 + 15.613) * x / 58 + -30.578) * x / 58 + 69.639
    constexpr double as[] = {-142.72052667, 372.35176398, -340.71073572, 415.23490212};
    constexpr double bs[] = {5.93832785, 15.61267078, -30.57816876, 69.63866711};
Preparing plots.
Saved graphics to updateWDL.png.
Total elapsed time = 30.92s.
```
The patch only affects the displayed `cp` and `wdl` values, and nothing else.

No functional change.