### PR TITLE
Make dbg_* methods return the inspected variable

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -343,27 +343,33 @@ std::array<DebugExtremes, MaxDebugSlots> extremes;
 
 }  // namespace
 
-void dbg_hit_on(bool cond, int slot) {
+bool dbg_hit_on(bool cond, int slot) {
 
     ++hit.at(slot)[0];
     if (cond)
         ++hit.at(slot)[1];
+
+    return cond;
 }
 
-void dbg_mean_of(i64 value, int slot) {
+i64 dbg_mean_of(i64 value, int slot) {
 
     ++mean.at(slot)[0];
     mean.at(slot)[1] += value;
+
+    return value;
 }
 
-void dbg_stdev_of(i64 value, int slot) {
+i64 dbg_stdev_of(i64 value, int slot) {
 
     ++stdev.at(slot)[0];
     stdev.at(slot)[1] += value;
     stdev.at(slot)[2] += value * value;
+
+    return value;
 }
 
-void dbg_extremes_of(i64 value, int slot) {
+i64 dbg_extremes_of(i64 value, int slot) {
     ++extremes.at(slot)[0];
 
     i64 current_max = extremes.at(slot)[1].load();
@@ -373,6 +379,8 @@ void dbg_extremes_of(i64 value, int slot) {
     i64 current_min = extremes.at(slot)[2].load();
     while (current_min > value && !extremes.at(slot)[2].compare_exchange_weak(current_min, value))
     {}
+
+    return value;
 }
 
 void dbg_correl_of(i64 value1, i64 value2, int slot) {

--- a/src/misc.h
+++ b/src/misc.h
@@ -141,10 +141,10 @@ std::filesystem::path path_from_utf8(const std::string& path);
 // Returns std::nullopt if the file does not exist.
 std::optional<std::string> read_file_to_string(const std::string& path);
 
-void dbg_hit_on(bool cond, int slot = 0);
-void dbg_mean_of(i64 value, int slot = 0);
-void dbg_stdev_of(i64 value, int slot = 0);
-void dbg_extremes_of(i64 value, int slot = 0);
+bool dbg_hit_on(bool cond, int slot = 0);
+i64  dbg_mean_of(i64 value, int slot = 0);
+i64  dbg_stdev_of(i64 value, int slot = 0);
+i64  dbg_extremes_of(i64 value, int slot = 0);
 void dbg_correl_of(i64 value1, i64 value2, int slot = 0);
 void dbg_print();
 void dbg_clear();


### PR DESCRIPTION
This is intended as a small QoL improvement for devs: The idea is that if you want to investigate the branching in
```cpp
if (long_complicated_condition)
```
you can just use
```cpp
if (dbg_hit_on(long_complicated_condition))
```
instead of having to do 
```cpp
dbg_hit_on(long_complicated_condition);
if (long_complicated_condition)
```
or something even more complicated if evaluating the condition has side effects.
Same idea for `dbg_mean_of`, `dbg_stdev_of` and `dbg_extremes_of`, 

No functional change