### PR TITLE
Fail high recovery depth adjustement

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -321,6 +321,7 @@ bool Search::Worker::iterative_deepening() {
     multiPV = std::min(multiPV, rootMoves.size());
 
     int  searchAgainCounter = 0;
+    int  failHighRecovery   = 0;
     bool uciPvSent          = false;
 
     lowPlyHistory.fill(102);
@@ -385,12 +386,14 @@ bool Search::Worker::iterative_deepening() {
             // Start with a small aspiration window and, in the case of a fail
             // high/low, enlarge the window progressively.
             int failedHighCnt = 0;
+            if (!pvIdx)
+                failHighRecovery = std::max(0, failHighRecovery - 2);
             while (true)
             {
                 // Adjust the effective depth searched, but ensure at least one
                 // effective increment for every four searchAgain steps (see issue #2717).
                 Depth adjustedDepth =
-                  std::max(1, rootDepth - failedHighCnt - 3 * (searchAgainCounter + 1) / 4);
+                  std::max(1, rootDepth - failedHighCnt - failHighRecovery - 3 * (searchAgainCounter + 1) / 4);
                 rootDelta = beta - alpha;
                 bestValue = search<Root>(rootPos, ss, alpha, beta, adjustedDepth, false);
 
@@ -439,6 +442,10 @@ bool Search::Worker::iterative_deepening() {
 
                 assert(alpha >= -VALUE_INFINITE && beta <= VALUE_INFINITE);
             }
+
+            // Gradually increase depth after reduced depth search
+            if (failedHighCnt > 0 && !pvIdx)
+                failHighRecovery = (failedHighCnt + 1) / 2 + 2;
 
             if (threads.stop && pvIdx)
             {


### PR DESCRIPTION
Gradually increaese depth after fail high instead of jumping to normal depth directly.

Passed STC
https://tests.stockfishchess.org/tests/view/6a8c1d4008c0f6a39c9e7d21
```
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 163200 W: 41862 L: 41374 D: 79964
Ptnml(0-2): 270, 18918, 42755, 19368, 289
```

Passed LTC
https://tests.stockfishchess.org/tests/view/6a913e4708c0f6a39c9e86bb
```
LLR: 2.94 (-2.94,2.94) <0.50,2.50>
Total: 172530 W: 44924 L: 44339 D: 83267
Ptnml(0-2): 43, 18265, 49070, 18838, 49
```

Bench 1649498