### PR TITLE
Fix integer overflow in update_continuation_histories

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -2016,7 +2016,7 @@ void update_all_stats(const Position& pos,
 // the current move and the moves played in previous plies.
 void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
     static constexpr std::array<ConthistBonus, 6> conthist_bonuses = {
-      {{1, 1040}, {2, 780}, {3, 290}, {4, 502}, {5, 132}, {6, 418}}};
+      {{1, 520}, {2, 390}, {3, 145}, {4, 251}, {5, 66}, {6, 209}}};
 
     // Multipliers for positive history consistency
     constexpr int CMHCMultipliers[] = {94, 103, 110, 106, 119, 126, 121};
@@ -2035,7 +2035,7 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
                 positiveCount++;
 
             int multiplier = CMHCMultipliers[positiveCount];
-            historyEntry << int(i64(bonus) * weight * multiplier / 131072) + 73 * (i < 2);
+            historyEntry << bonus * weight * multiplier / 65536 + 73 * (i < 2);
         }
     }
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -2035,7 +2035,7 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
                 positiveCount++;
 
             int multiplier = CMHCMultipliers[positiveCount];
-            historyEntry << (bonus * weight * multiplier / 131072) + 73 * (i < 2);
+            historyEntry << int(i64(bonus) * weight * multiplier / 131072) + 73 * (i < 2);
         }
     }
 }


### PR DESCRIPTION
Repro with `-ftrapv`:

```
position fen 4rk2/2r2p2/3R1Bpn/7p/1pPp3P/1P3P2/3p2P1/3R3K w - - 0 36
go
```

```
info depth 27 seldepth 61 multipv 1 score cp 169 nodes 5778888 nps 514090 hashfull 964 tbhits 0 time 11241 pv d1d2 h6f5 d6b6 c7d7 h1g1 f8g8 d2e2 e8a8 e2a2 a
8c8 g1f2 g8h7 f6g5 h7g7 a2e2 c8a8 e2d2 a8e8 g5f6 g7h7 b6b4 e8e6 f6g5 f7f6 g5f4 f5h4 c4c5 g6g5 f4h2 h4f5 b4b6 e6b6 c5b6 f5e7 h2c7 e7c6 f2e2 d7d5             
info depth 28 seldepth 62 multipv 1 score cp 169 nodes 6673438 nps 507833 hashfull 984 tbhits 0 time 13141 pv d1d2 h6f5 d6b6 c7d7 h1g1 f8g8 d2e2 e8a8 e2a2 a
8c8 g1f2 g8h7 f6g5 h7g7 a2d2 c8e8 g5f6 g7h7 b6b4 e8e6 f6g5 f7f6 g5f4 e6c6 g2g3 h7g8 b4b5 d4d3 c4c5 f5d4 d2d3 d4b5 d3d7 c6c5 f4d2 c5c2 f2e3 b5c3             
                                                                                                                                                            
Thread 4 "stockfish" received signal SIGABRT, Aborted.                                                                                
(gdb) bt
[snip]
#5  0x00007ffff7bd8e55 in __mulvsi3 () from /lib/x86_64-linux-gnu/libgcc_s.so.1
#6  0x000000000043b8ce in Stockfish::(anonymous namespace)::update_continuation_histories(Stockfish::Search::Stack*, Stockfish::Piece, Stockfish::Square, in
t) ()
```

After this fix, the worst-case near-overflows across Stockfish that I could find (which are still this one!) still have a healthy margin:

```
MUL closest to overflow, margin: 1086513607 (10300680 x 103 -> 1060970040)
```

No functional change