### PR TITLE
Fix UB when passing plain char to <cctype> functions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -115,6 +115,7 @@ Henri Wiechers
 Hiraoka Takuya (HiraokaTakuya)
 homoSapiensSapiens
 Hongzhi Cheng
+IncognitoQuack
 Ivan Ivec (IIvec)
 Jacques B. (Timshel)
 Jake Senne (w1wwwwww)

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -565,7 +565,7 @@ std::optional<usize> str_to_size_t(const std::string& s) {
     errno                           = 0;
     char*                    endptr = nullptr;
     const unsigned long long value  = std::strtoull(s.c_str(), &endptr, 10);
-    if (errno == ERANGE || (*endptr != '\0' && !std::isspace(*endptr))
+    if (errno == ERANGE || (*endptr != '\0' && !std::isspace(static_cast<unsigned char>(*endptr)))
         || value > std::numeric_limits<usize>::max())
         return std::nullopt;
     return static_cast<usize>(value);
@@ -579,11 +579,12 @@ std::optional<std::string> read_file_to_string(const std::string& path) {
 }
 
 void remove_whitespace(std::string& s) {
-    s.erase(std::remove_if(s.begin(), s.end(), [](char c) { return std::isspace(c); }), s.end());
+    s.erase(std::remove_if(s.begin(), s.end(), [](unsigned char c) { return std::isspace(c); }),
+            s.end());
 }
 
 bool is_whitespace(std::string_view s) {
-    return std::all_of(s.begin(), s.end(), [](char c) { return std::isspace(c); });
+    return std::all_of(s.begin(), s.end(), [](unsigned char c) { return std::isspace(c); });
 }
 
 fs::path CommandLine::get_binary_directory(fs::path argv0) {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1590,8 +1590,10 @@ std::optional<PositionSetError> Position::flip() {
     ss >> token;  // Castling availability
     f += token + " ";
 
-    std::transform(f.begin(), f.end(), f.begin(),
-                   [](char c) { return char(islower(c) ? toupper(c) : tolower(c)); });
+    std::transform(f.begin(), f.end(), f.begin(), [](char c) {
+        const unsigned char u = c;
+        return char(islower(u) ? toupper(u) : tolower(u));
+    });
 
     ss >> token;  // En passant square
     f += (token == "-" ? token : token.replace(1, 1, token[1] == '3' ? "6" : "3"));

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1590,10 +1590,8 @@ std::optional<PositionSetError> Position::flip() {
     ss >> token;  // Castling availability
     f += token + " ";
 
-    std::transform(f.begin(), f.end(), f.begin(), [](char c) {
-        const unsigned char u = c;
-        return char(islower(u) ? toupper(u) : tolower(u));
-    });
+    std::transform(f.begin(), f.end(), f.begin(),
+                   [](unsigned char c) { return char(islower(c) ? toupper(c) : tolower(c)); });
 
     ss >> token;  // En passant square
     f += (token == "-" ? token : token.replace(1, 1, token[1] == '3' ? "6" : "3"));

--- a/tests/instrumented.py
+++ b/tests/instrumented.py
@@ -671,13 +671,6 @@ class TestInvalidOptions(metaclass=OrderedClassMembers):
         self.stockfish.send_command("isready")
         self.stockfish.equals("readyok")
 
-    # Non-ASCII bytes must not be passed to <cctype> functions as plain char
-    def test_numa_non_ascii(self):
-        self.stockfish.send_command("setoption name NumaPolicy value 0-1é")
-        self.stockfish.expect("*NumaPolicy: invalid value*keeping previous config.*")
-        self.stockfish.send_command("isready")
-        self.stockfish.equals("readyok")
-
 
 class TestBenchFile(metaclass=OrderedClassMembers):
     def beforeEach(self):

--- a/tests/instrumented.py
+++ b/tests/instrumented.py
@@ -671,6 +671,13 @@ class TestInvalidOptions(metaclass=OrderedClassMembers):
         self.stockfish.send_command("isready")
         self.stockfish.equals("readyok")
 
+    # Non-ASCII bytes must not be passed to <cctype> functions as plain char
+    def test_numa_non_ascii(self):
+        self.stockfish.send_command("setoption name NumaPolicy value 0-1é")
+        self.stockfish.expect("*NumaPolicy: invalid value*keeping previous config.*")
+        self.stockfish.send_command("isready")
+        self.stockfish.equals("readyok")
+
 
 class TestBenchFile(metaclass=OrderedClassMembers):
     def beforeEach(self):


### PR DESCRIPTION

Cast to `unsigned char` before calling these functions, matching the pattern already used elsewhere in the codebase (`UCIEngine::to_lower`, `CaseInsensitiveLess::operator()`).

No functional change.