### PR TITLE
Fix bug in nodestime

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -89,7 +89,7 @@ void TimeManagement::init(Search::LimitsType& limits,
     // These numbers are used where multiplications, divisions,
     // or comparisons with constants are involved.
     const i64       scaleFactor = useNodesTime ? npmsec : 1;
-    const TimePoint scaledTime  = limits.time[us] / scaleFactor;
+    const TimePoint scaledTime  = std::max(TimePoint(1), limits.time[us] / scaleFactor);
 
     // Maximum move horizon
     int mtg = limits.movestogo ? std::min(limits.movestogo, 50) : 50;


### PR DESCRIPTION
When `availableNodes` hits 0 in master, on the next move we hit UB in `TimeManagement::init()`. More generally, the UB can happen whenever `availableNodes < npmsec`.

That is because `limits.time[us] == 0` gets passed into `scaledTime`, which is then used in `log10` to define `logTimeInSec`, leading to `-inf` in `optConstant` and hence `+inf` in `optScale`, if `originalTimeAdjust < 0`. Casting that `+inf` double value to the integer valued `optimumTime` via `TimePoint(std::max(1.0, optScale * timeLeft))` is undefined behavior.

The patch clamps `scaledTime` from below to 1.

No functional change.