### PR TITLE
Validate UCI numeric arguments strictly

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -19,6 +19,7 @@
 #include "uci.h"
 
 #include <algorithm>
+#include <charconv>
 #include <cctype>
 #include <chrono>
 #include <cmath>
@@ -48,6 +49,20 @@ using Time = std::chrono::steady_clock;
 using ms   = std::chrono::milliseconds;
 
 constexpr auto BenchmarkCommand = "speedtest";
+
+template<typename T>
+bool parse_nonnegative(std::istream& is, T& value) {
+    std::string token;
+
+    if (!(is >> token))
+        return false;
+
+    if (token.empty() || token.front() == '-')
+        return false;
+
+    auto [end, error] = std::from_chars(token.data(), token.data() + token.size(), value);
+    return error == std::errc{} && end == token.data() + token.size();
+}
 
 template<typename... Ts>
 struct overload: Ts... {
@@ -204,32 +219,60 @@ Search::LimitsType UCIEngine::parse_limits(std::istream& is) {
         }
 
         else if (token == "wtime")
-            is >> limits.time[WHITE];
+        {
+            if (!parse_nonnegative(is, limits.time[WHITE]))
+                terminate_on_critical_error("Invalid argument for 'wtime'");
+        }
         else if (token == "btime")
-            is >> limits.time[BLACK];
+        {
+            if (!parse_nonnegative(is, limits.time[BLACK]))
+                terminate_on_critical_error("Invalid argument for 'btime'");
+        }
         else if (token == "winc")
-            is >> limits.inc[WHITE];
+        {
+            if (!parse_nonnegative(is, limits.inc[WHITE]))
+                terminate_on_critical_error("Invalid argument for 'winc'");
+        }
         else if (token == "binc")
-            is >> limits.inc[BLACK];
+        {
+            if (!parse_nonnegative(is, limits.inc[BLACK]))
+                terminate_on_critical_error("Invalid argument for 'binc'");
+        }
         else if (token == "movestogo")
-            is >> limits.movestogo;
+        {
+            if (!parse_nonnegative(is, limits.movestogo))
+                terminate_on_critical_error("Invalid argument for 'movestogo'");
+        }
         else if (token == "depth")
-            is >> limits.depth;
+        {
+            if (!parse_nonnegative(is, limits.depth))
+                terminate_on_critical_error("Invalid argument for 'depth'");
+        }
         else if (token == "nodes")
-            is >> limits.nodes;
+        {
+            if (!parse_nonnegative(is, limits.nodes))
+                terminate_on_critical_error("Invalid argument for 'nodes'");
+        }
         else if (token == "movetime")
-            is >> limits.movetime;
+        {
+            if (!parse_nonnegative(is, limits.movetime))
+                terminate_on_critical_error("Invalid argument for 'movetime'");
+        }
         else if (token == "mate")
-            is >> limits.mate;
+        {
+            if (!parse_nonnegative(is, limits.mate))
+                terminate_on_critical_error("Invalid argument for 'mate'");
+        }
         else if (token == "perft")
-            is >> limits.perft;
+        {
+            if (!parse_nonnegative(is, limits.perft))
+                terminate_on_critical_error("Invalid argument for 'perft'");
+        }
         else if (token == "infinite")
             limits.infinite = 1;
         else if (token == "ponder")
             limits.ponderMode = true;
 
-        if (is.fail())
-            terminate_on_critical_error("Invalid argument for '" + token + "'");
     }
 
     return limits;


### PR DESCRIPTION
Fixes #7131

## Summary

Validate numeric arguments to the UCI `go` command as complete, non-negative integer tokens.

Previously, formatted stream extraction could accept a valid numeric prefix and ignore trailing characters. For example, `go depth 12x` could be interpreted as `depth 12`.

This change reads each numeric argument as a complete token and rejects malformed values such as:

- `go depth 12x`
- `go movetime 100ms`
- `go nodes 1000abc`
- `go depth -1`

The existing critical-error reporting mechanism is used when validation fails.

## Testing

- Compiled `src/uci.cpp` successfully.
- Verified that parsing requires the complete token and rejects a leading minus sign.

## Note
PR #7083 independently addresses the separate `go perft 0` behavior reported in #7035. This PR focuses on strict validation of malformed numeric tokens such as `12x` and `100ms` across UCI `go` limits.