### PR TITLE
Fix delayed history updates after castling and promotion

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -224,6 +224,7 @@ Prokop Randáček (ProkopRandacek)
 Rahul Dsilva (silversolver1)
 Ralph Stößer (Ralph Stoesser)
 Raminder Singh
+Remi (ScarletDevilRemi)
 renouve
 Reuven Peleg (R-Peleg)
 Richard Lloyd (Richard-Lloyd)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -2054,7 +2054,7 @@ void update_continuation_histories(Stack* ss, Piece pc, Square to, int bonus) {
                 positiveCount++;
 
             int multiplier = CMHCMultipliers[positiveCount];
-            historyEntry << (bonus * weight * multiplier / 131072) + 73 * (i < 2);
+            historyEntry << int(i64(bonus) * weight * multiplier / 131072) + 73 * (i < 2);
         }
     }
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -81,6 +81,23 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // (*Scaler) All tuned parameters at time controls shorter than
 // optimized for require verifications at longer time controls
 
+// Return the piece that made the previous move. In the current position the
+// destination square does not identify the moving piece for promotions or castling.
+Piece previous_moved_piece(const Position& pos, Move move) {
+    assert(move.is_ok());
+
+    const Color previousSide = ~pos.side_to_move();
+
+    if (move.type_of() == PROMOTION)
+        return make_piece(previousSide, PAWN);
+    if (move.type_of() == CASTLING)
+        return make_piece(previousSide, KING);
+
+    const Piece pc = pos.piece_on(move.to_sq());
+    assert(pc != NO_PIECE && color_of(pc) == previousSide);
+    return pc;
+}
+
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
     const Color us     = pos.side_to_move();
     const auto  m      = (ss - 1)->currentMove;
@@ -812,9 +829,10 @@ Value Search::Worker::search(
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
-    Square prevSq  = ((ss - 1)->currentMove).is_ok() ? ((ss - 1)->currentMove).to_sq() : SQ_NONE;
-    bestMove       = Move::none();
-    priorReduction = (ss - 1)->reduction;
+    const Move priorMove = (ss - 1)->currentMove;
+    Square     prevSq     = priorMove.is_ok() ? priorMove.to_sq() : SQ_NONE;
+    bestMove              = Move::none();
+    priorReduction        = (ss - 1)->reduction;
     (ss - 1)->reduction = 0;
     ss->statScore       = 0;
     (ss + 2)->cutoffCnt = 0;
@@ -894,7 +912,8 @@ Value Search::Worker::search(
 
             // Extra penalty for early quiet moves of the previous ply
             if (prevSq != SQ_NONE && (ss - 1)->moveCount < 5 && !priorCapture)
-                update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq, -2210);
+                update_continuation_histories(ss - 1, previous_moved_piece(pos, priorMove), prevSq,
+                                              -2210);
         }
 
         // Partial workaround for the graph history interaction problem
@@ -988,9 +1007,12 @@ Value Search::Worker::search(
     {
         int evalDiff = std::clamp(-int((ss - 1)->staticEval + ss->staticEval), -189, 194) + 60;
         mainHistory[~us][((ss - 1)->currentMove).raw()] << evalDiff * 11;
-        if (!ttHit && type_of(pos.piece_on(prevSq)) != PAWN
-            && ((ss - 1)->currentMove).type_of() != PROMOTION)
-            sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << evalDiff * 13;
+        if (!ttHit && priorMove.type_of() != PROMOTION)
+        {
+            const Piece prevPc = previous_moved_piece(pos, priorMove);
+            if (type_of(prevPc) != PAWN)
+                sharedHistory.pawn_entry(pos)[prevPc][prevSq] << evalDiff * 13;
+        }
     }
 
 
@@ -1589,14 +1611,14 @@ moves_loop:  // When in check, search starts here
 
         // scaledBonus ranges from 0 to roughly 2.3M, overflows happen for multipliers larger than 900
         const int scaledBonus = std::min(150 * depth - 85, 1337) * bonusScale;
+        const Piece prevPc     = previous_moved_piece(pos, priorMove);
 
-        update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
-                                      scaledBonus * 263 / 16384);
+        update_continuation_histories(ss - 1, prevPc, prevSq, scaledBonus * 263 / 16384);
 
         mainHistory[~us][((ss - 1)->currentMove).raw()] << scaledBonus * 215 / 32768;
 
-        if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
-            sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << scaledBonus * 324 / 8192;
+        if (type_of(prevPc) != PAWN && priorMove.type_of() != PROMOTION)
+            sharedHistory.pawn_entry(pos)[prevPc][prevSq] << scaledBonus * 324 / 8192;
     }
 
     // Bonus for prior capture countermove that caused the fail low
@@ -1604,7 +1626,7 @@ moves_loop:  // When in check, search starts here
     {
         Piece capturedPiece = pos.captured_piece();
         assert(capturedPiece != NO_PIECE);
-        captureHistory[pos.piece_on(prevSq)][prevSq][type_of(capturedPiece)] << 892;
+        captureHistory[previous_moved_piece(pos, priorMove)][prevSq][type_of(capturedPiece)] << 892;
     }
 
     if (PvNode)
@@ -1996,7 +2018,8 @@ void update_all_stats(const Position& pos,
     // Extra penalty for a quiet early move that was not a TT move in
     // previous ply when it gets refuted.
     if (prevSq != SQ_NONE && ((ss - 1)->moveCount == 1 + (ss - 1)->ttHit) && !pos.captured_piece())
-        update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq, -malus * 713 / 1024);
+        update_continuation_histories(ss - 1, previous_moved_piece(pos, (ss - 1)->currentMove),
+                                      prevSq, -malus * 713 / 1024);
 
     // Decrease stats for all non-best capture moves
     for (Move move : capturesSearched)


### PR DESCRIPTION
## Status and scope

Draft for correctness discussion, **not a merge-ready Elo claim**. This preserves the exact two-commit candidate used in a paused local fishtest run; no official/community test is being requested at this stage.

The main change is [0d070557](https://github.com/ScarletDevilRemi/Stockfish/commit/0d070557c5b263f63b0e61721f114b686e327d66): recover the original moving piece when applying delayed history updates after castling or promotion. The separate [f7b99807](https://github.com/ScarletDevilRemi/Stockfish/commit/f7b998074e9d460933761fd948dfdddc4a84c2cc) widens a continuation-history intermediate product to `i64`.

No NNUE changes, retuning, or en-passant patch are included.

## Suspected indexing inconsistency

Move ordering and immediate history updates use the **pre-move piece** (`pos.moved_piece(move)`) with the move's encoded `to_sq()`. Several delayed updates instead reconstruct that piece with `pos.piece_on(prevSq)` after the move:

- Promotion: the destination now holds the promoted piece, not the pawn used for the original history key.
- Castling: Stockfish encodes the destination as the rook's origin. In ordinary White kingside castling, for example, the move is internally `e1h1`; the original piece key is `W_KING`, but `h1` is empty afterward. Chess960 can also leave a different piece on the encoded destination.

The helper recovers the pawn/king and its color from the previous move, retaining the encoded destination to match the lookup key. It is used at the affected delayed continuation-, pawn-, and capture-history update sites. Correction history is deliberately unchanged.

Minimal cases for inspecting the key mismatch:

- Castling: `r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1`, play `e1g1` (UCI standard-chess notation).
- Promotion: `7k/P7/8/8/8/8/8/7K w - - 0 1`, play `a7a8q`.

The special-move reconstruction sites remain present in upstream `06675f704049c62e99dac5533fda42fd5c63aef4`, checked September 4, 2026. **The overflow guard needs separate reassessment:** upstream has since halved the continuation-history weights and divisor. This draft does not claim a demonstrated overflow on that newer tree.

## Local validation — inconclusive

Recorded snapshot when voluntarily paused, August 20, 2026:

| Setting/result | Value |
| --- | --- |
| Base | `5062aee519a1ba262d472d8ab139851ced56573e` |
| Candidate | `f7b998074e9d460933761fd948dfdddc4a84c2cc` |
| TC | STC `10+0.1`, worker-speed scaled |
| Threads / Hash | 1 / 16 MiB |
| Book | `UHO_Lichess_4852_v1.epd` |
| Network, both engines | `nn-ab28990d4ea3.nnue` |
| Platform | Apple Silicon, macOS, Clang 21 |
| Games | 37,472 |
| Candidate W / L / D | 9,651 / 9,482 / 18,339 |
| Pentanomial | `[63, 4414, 9639, 4531, 89]` |
| Normalized Elo | +1.57; reported 95% CI [-0.21, +3.34] |
| SPRT | Normalized [0, 2], alpha = beta = 0.05 |
| LLR | +1.306; boundaries ±2.944; **undecided** |
| Crashes / time losses | 0 / 15 |

There is **no public fishtest result link**: this ran on a local server, run ID `6a8437564b6471bd39a884b1`. The server is currently offline; the figures above are the recorded pause snapshot. This is not a passed SPRT, an official fishtest result, or evidence of an LTC gain. The combined result does not isolate either commit's Elo effect. No further long-running local test is planned.

Earlier optimized and ASan/UBSan integration checks reported 73/73 passing, including targeted special-move checks. On September 4, the retained test binaries' bench signatures were rechecked: base **2884956**, candidate **2449838**. The branch also passes `git diff --check`.

<details>
<summary>Bounded search examples, rechecked September 4</summary>

Fresh engine processes, Threads=1, Hash=16, identical network, `go nodes 200000`:

| Position | Base | Overflow-only | Combined candidate |
| --- | --- | --- | --- |
| A, Black to move | `d4d3` | `d4d3` | `e8g8` (O-O) |
| B, White to move | `d2c3` | `d2c3` | `g4g5` |

A:
```text
r1b1k2r/ppp2ppp/2n5/3Nq3/1bPp4/6P1/PP1NPP1P/R2QKB1R b KQkq - 0 9
```

B:
```text
r2qkb1r/pp3pp1/1nn3b1/1N2P2p/6P1/PP6/3QPPBP/R1B2RK1 w kq - 2 16
```

At 1,000,000 nodes, both base and combined candidate choose O-O in A. These positions were selected during analysis of favorable game pairs, not sampled as an unbiased strength test. They demonstrate a reproducible change in search decisions, **not proof that the fix caused the game wins or improves aggregate Elo**.

For reproduction, start a fresh interactive UCI session with each engine, set Threads=1 and Hash=16, send `ucinewgame` and `isready`, set the FEN, then `go nodes 200000`. Wait for `bestmove` before quitting. Overflow-only refers to `84f56a3ff174a41b6b20d071cebbc1096d02d041`.

</details>

## Before any merge-ready submission

The branch is 40 upstream commits behind at opening. It is intentionally not rebased here so the local test remains tied to its exact candidate. Updating to current master, separating the arithmetic guard from the special-move change, and satisfying the applicable testing requirements remain outstanding.

The question for discussion is whether this is recognized as a correctness bug and, if pursued further, which testing path is appropriate. I understand the [guidelines](https://github.com/official-stockfish/fishtest/wiki/Creating-my-first-test#testing-methodology) require advance maintainer approval for bug-fix/non-regression testing; none is claimed here.

Bench: 2449838

