### PR TITLE
Simplify away is_loss(beta) and is_win(eval)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -993,8 +993,7 @@ Value Search::Worker::search(
 
     // Step 9. Futility pruning: child node
     // The depth condition is important for mate finding. It should NOT be tuned.
-    if (!ss->ttPv && depth < (seekMate ? 6 : 19) && eval >= beta && (!ttData.move || ttCapture)
-        && !is_loss(beta) && !is_win(eval))
+    if (!ss->ttPv && depth < (seekMate ? 6 : 19) && eval >= beta && (!ttData.move || ttCapture))
     {
         Value futilityMult = std::min(45 + depth * 4, 85);
         futilityMult -= 20 * !ss->ttHit;


### PR DESCRIPTION
This patch simplifies away !is_loss(beta) and !is_win(eval).

Passed non regression STC:

https://tests.stockfishchess.org/tests/view/6a95508b08c0f6a39c9e8e18

LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 51520 W: 13240 L: 13041 D: 25239
Ptnml(0-2): 79, 5881, 13633, 6096, 71
 
Passed non regression LTC:

https://tests.stockfishchess.org/tests/view/6a964f4408c0f6a39c9e9132

LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 140778 W: 36385 L: 36288 D: 68105
Ptnml(0-2): 40, 14926, 40354, 15035, 34

Master matetrack:

Total FENs:    6554
Found mates:   3722
Best mates:    2485

New matetrack:

Total FENs:    6554
Found mates:   3694
Best mates:    2494

Master matedtrack:

Total FENs:    6536
Found mates:   3892
Best mates:    3104

New matedtrack

Total FENs:    6536
Found mates:   3951
Best mates:    3151

matetrack/matedtrack summary:
matetrack is slightly worse but matedtrack is so much better. in terms of matetrack performance, maybe it might be beneficial to keep !is_win(eval).

Bench: 2367522