### PR TITLE
Simplify quiet history bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -881,7 +881,7 @@ Value Search::Worker::search(
         {
             // Bonus for a quiet ttMove that fails high
             if (!ttCapture)
-                update_quiet_histories(pos, ss, *this, ttData.move, std::min(112 * depth, 695));
+                update_quiet_histories(pos, ss, *this, ttData.move, 131 * depth);
 
             // Extra penalty for early quiet moves of the previous ply
             if (prevSq != SQ_NONE && (ss - 1)->moveCount < 5 && !priorCapture)


### PR DESCRIPTION
Passed non-regression STC
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 230240 W: 58691 L: 58684 D: 112865
Ptnml(0-2): 402, 26840, 60621, 26863, 394
https://tests.stockfishchess.org/tests/view/6a95b22608c0f6a39c9e8fbe

Passed non-regression LTC (rebased)
LLR: 2.95 (-2.94,2.94) <-1.75,0.25>
Total: 272106 W: 70243 L: 70278 D: 131585
Ptnml(0-2): 81, 29104, 77725, 29055, 88
https://tests.stockfishchess.org/tests/view/6a9832e308c0f6a39c9e950f

bench 2703249