### PR TITLE
docs: fix typo in comment embeded -> embedded

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -86,6 +86,7 @@ Dubslow
 Eduardo Cáceres (eduherminio)
 Eelco de Groot (KingDefender)
 Ehsan Rashid (erashid)
+Ellie Price (LikeABInnit)
 Elvin Liu (solarlight2)
 erbsenzaehler
 Ernesto Gatti

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -599,7 +599,7 @@ bool is_whitespace(std::string_view s) {
 
 
 // Return the directory where our Stockfish binary sits. This is useful,
-// because when the NNUE network is not embeded in the binary, this directory
+// because when the NNUE network is not embedded in the binary, this directory
 // is one of the locations where we look for the NNUE file.
 fs::path CommandLine::get_binary_directory(fs::path argv0) {
 


### PR DESCRIPTION
Fixed spelling error in src/misc.cpp

Changed "embeded" to "embedded"