### PR TITLE
Don't store go commands in the bench list

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -392,10 +392,12 @@ namespace Stockfish::Benchmark {
 // bench 64 1 100000 default nodes  : search default positions for 100K nodes each
 // bench 64 4 5000 current movetime : search current position with 4 threads for 5 sec
 // bench 16 1 5 blah perft          : run a perft 5 on positions in file "blah"
-std::vector<std::string> setup_bench(const std::string& currentFen, std::istream& is) {
+//
+// The return values are the list of commands-or-FENs and the go command to be looped.
+std::tuple<std::vector<std::string>, std::string> setup_bench(const std::string& currentFen, std::istream& is) {
 
-    std::vector<std::string> fens, list;
-    std::string              go, token;
+    std::vector<std::string> list;
+    std::string              goCmd, token;
 
     // Assign default values to missing arguments
     std::string ttSize    = (is >> token) ? token : "16";
@@ -404,13 +406,16 @@ std::vector<std::string> setup_bench(const std::string& currentFen, std::istream
     std::string fenFile   = (is >> token) ? token : "default";
     std::string limitType = (is >> token) ? token : "depth";
 
-    go = limitType == "eval" ? "eval" : "go " + limitType + " " + limit;
+    list.emplace_back("setoption name Threads value " + threads);
+    list.emplace_back("setoption name Hash value " + ttSize);
+    list.emplace_back("ucinewgame");
+    goCmd = limitType == "eval" ? "eval" : "go " + limitType + " " + limit;
 
     if (fenFile == "default")
-        fens = Defaults;
+        list.insert(list.end(), Defaults.begin(), Defaults.end());
 
     else if (fenFile == "current")
-        fens.push_back(currentFen);
+        list.push_back(currentFen);
 
     else
     {
@@ -425,25 +430,12 @@ std::vector<std::string> setup_bench(const std::string& currentFen, std::istream
 
         while (getline(file, fen))
             if (!fen.empty())
-                fens.push_back(fen);
+                list.push_back(fen);
 
         file.close();
     }
 
-    list.emplace_back("setoption name Threads value " + threads);
-    list.emplace_back("setoption name Hash value " + ttSize);
-    list.emplace_back("ucinewgame");
-
-    for (const std::string& fen : fens)
-        if (fen.find("setoption") != std::string::npos)
-            list.emplace_back(fen);
-        else
-        {
-            list.emplace_back("position fen " + fen);
-            list.emplace_back(go);
-        }
-
-    return list;
+    return {list, goCmd};
 }
 
 BenchmarkSetup setup_benchmark(std::istream& is) {

--- a/src/benchmark.h
+++ b/src/benchmark.h
@@ -21,11 +21,14 @@
 
 #include <iosfwd>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace Stockfish::Benchmark {
 
-std::vector<std::string> setup_bench(const std::string&, std::istream&);
+// Bench input accepts either one FEN per line, or a "setoption" UCI command per line.
+// The returned list contains the initialization and input; the goCmd is parsed from the args.
+std::tuple<std::vector<std::string>, std::string> setup_bench(const std::string&, std::istream& args);
 
 struct BenchmarkSetup {
     int                      ttSize;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -150,7 +150,7 @@ Engine::perft(const std::string& fen, Depth depth, bool isChess960) {
     return Benchmark::perft(fen, depth, isChess960);
 }
 
-void Engine::go(Search::LimitsType& limits) {
+void Engine::go(const Search::LimitsType& limits) {
     assert(limits.perft == 0);
     verify_network();
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -67,7 +67,7 @@ class Engine {
     std::variant<u64, PositionSetError> perft(const std::string& fen, Depth depth, bool isChess960);
 
     // non blocking call to start searching
-    void go(Search::LimitsType&);
+    void go(const Search::LimitsType&);
     // non blocking call to stop searching
     void stop();
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -256,10 +256,15 @@ void UCIEngine::bench(std::istream& args) {
         on_update_full(i, options["UCI_ShowWDL"]);
     });
 
-    std::vector<std::string> list = Benchmark::setup_bench(engine.fen(), args);
+    auto [list, goCmd] = Benchmark::setup_bench(engine.fen(), args);
+
+    const bool eval = goCmd.find("eval") != std::string::npos;
+    std::istringstream go(goCmd);
+    const Search::LimitsType limits = eval ? Search::LimitsType() : parse_limits(go);
 
     num = count_if(list.begin(), list.end(),
-                   [](const std::string& s) { return s.find("go ") == 0 || s.find("eval") == 0; });
+                   [](const std::string& s) { return    s.find("setoption")  == std::string::npos
+                                                     && s.find("ucinewgame") == std::string::npos; });
 
     TimePoint elapsed = now();
 
@@ -268,14 +273,23 @@ void UCIEngine::bench(std::istream& args) {
         std::istringstream is(cmd);
         is >> token;
 
-        if (token == "go" || token == "eval")
+        if (token == "setoption")
+            setoption(is);
+        else if (token == "ucinewgame")
         {
+            engine.search_clear();  // search_clear may take a while
+            elapsed = now();
+        }
+        else // non-options are assumed to be FENs
+        {
+            std::istringstream fenCmd("fen " + is.str());
+            position(fenCmd);
+
             std::cerr << "\nPosition: " << cnt++ << '/' << num << " (" << engine.fen() << ")"
                       << std::endl;
-            if (token == "go")
-            {
-                Search::LimitsType limits = parse_limits(is);
 
+            if (!eval)
+            {
                 if (limits.perft)
                     nodesSearched = perft(limits);
                 else
@@ -289,15 +303,6 @@ void UCIEngine::bench(std::istream& args) {
             }
             else
                 engine.trace_eval();
-        }
-        else if (token == "setoption")
-            setoption(is);
-        else if (token == "position")
-            position(is);
-        else if (token == "ucinewgame")
-        {
-            engine.search_clear();  // search_clear may take a while
-            elapsed = now();
         }
     }
 


### PR DESCRIPTION
Saves a couple LOC and a lot of memory for large inputs to bench. On a 1 GiB input, master uses 3.8 GiB of memory, but this uses 3.1 GiB of memory.

no functional change