### PR TITLE
simplify delta-based reductions to constant PvNode discount

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -391,7 +391,6 @@ bool Search::Worker::iterative_deepening() {
                 // effective increment for every four searchAgain steps (see issue #2717).
                 Depth adjustedDepth =
                   std::max(1, rootDepth - failedHighCnt - 3 * (searchAgainCounter + 1) / 4);
-                rootDelta = beta - alpha;
                 bestValue = search<Root>(rootPos, ss, alpha, beta, adjustedDepth, false);
 
                 // Bring the best move to the front. It is critical that sorting
@@ -1160,9 +1159,11 @@ moves_loop:  // When in check, search starts here
         // Calculate new depth for this move
         newDepth = depth - 1;
 
-        int delta = beta - alpha;
+        int r = reduction(improving, depth, moveCount);
 
-        int r = reduction(improving, depth, moveCount, delta);
+        // Decrease reduction for PvNodes
+        if (PvNode)
+            r -= 512;
 
         // Increase reduction for ttPv nodes
         // (*Scaler) Larger values scale well.
@@ -1890,9 +1891,9 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
     return bestValue;
 }
 
-int Search::Worker::reduction(bool i, Depth d, int mn, int delta) const {
+int Search::Worker::reduction(bool i, Depth d, int mn) const {
     int reductionScale = reductions[d] * reductions[mn];
-    return reductionScale - delta * 577 / rootDelta + !i * reductionScale * 197 / 512 + 982;
+    return reductionScale + !i * reductionScale * 197 / 512 + 948;
 }
 
 // elapsed() returns the time elapsed since the search started. If the

--- a/src/search.h
+++ b/src/search.h
@@ -358,7 +358,7 @@ class Worker {
     template<NodeType nodeType>
     Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta);
 
-    int reduction(bool i, Depth d, int mn, int delta) const;
+    int reduction(bool i, Depth d, int mn) const;
 
     // Pointer to the search manager, only allowed to be called by the main thread
     SearchManager* main_manager() const {
@@ -383,7 +383,6 @@ class Worker {
     StateInfo rootState;
     RootMoves rootMoves;
     Depth     rootDepth;
-    Value     rootDelta;
 
     PVMoves lastIterationIdxPV;
 


### PR DESCRIPTION
Removing dependence on delta and rootDelta for LMR calculation. The idea is to reduce unintended side effects like aspiration failures decreasing search effort.

Passed non-reg STC
https://tests.stockfishchess.org/tests/live_elo/6a9aa810a8284b37a0a047a3

```
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 119584 W: 30430 L: 30304 D: 58850
Ptnml(0-2): 211, 14017, 31183, 14197, 184
```

Passed non-reg LTC
https://tests.stockfishchess.org/tests/live_elo/6a9db9d2a8284b37a0a04cb7
```
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 32832 W: 8581 L: 8376 D: 15875
Ptnml(0-2): 8, 3428, 9337, 3637, 6
```

In progress non-reg STC SMP
https://tests.stockfishchess.org/tests/live_elo/6aaeb754dbd128aac8fd58bd


Bench 1700273

