### PR TITLE
Add Pawn Pair accumulator cache

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -912,7 +912,7 @@ void update_accumulator_refresh_cache(Color                     perspective,
 
     ThreatFeatureSet::IndexList active;
     ThreatFeatureSet::append_active_indices(perspective, pos, active);
-    PairFeatureSet::append_active_indices(perspective, pos, active);
+    const auto& pawnEntry = cache.pawn_entry(perspective, pos, featureTransformer);
 
     accumulator.computed[perspective] = true;
 
@@ -930,6 +930,8 @@ void update_accumulator_refresh_cache(Color                     perspective,
 
         acc = apply_threat_features<+1>(j, acc, active, featureTransformer);
 
+        if (pawnEntry.featureCount)
+            acc = apply<+1>(j, acc, pawnEntry.accumulation.data());
         store_tile(j, accumulator.accumulation[perspective].data(), acc);
     }
 
@@ -944,10 +946,49 @@ void update_accumulator_refresh_cache(Color                     perspective,
 
         psqt = apply_psqt<+1>(j, psqt, active, featureTransformer.threatAndPpPsqtWeights.data());
 
+        if (pawnEntry.featureCount)
+            psqt = apply<+1>(j, psqt, pawnEntry.psqtAccumulation.data());
         store_psqt(j, accumulator.psqtAccumulation[perspective].data(), psqt);
     }
 }
 
+}
+
+const AccumulatorCaches::PawnEntry& AccumulatorCaches::pawn_entry(
+  Color perspective, const Position& pos, const FeatureTransformer& featureTransformer) {
+    const Square ksq = pos.square<KING>(perspective);
+    auto&        entry =
+      pawnEntries[pos.pawn_key() & (PawnCacheSize / 4 - 1)][perspective][(int(ksq) >> 2) & 1];
+    const Bitboard white = pos.pieces(WHITE, PAWN);
+    const Bitboard black = pos.pieces(BLACK, PAWN);
+    if (entry.pawns[WHITE] == white && entry.pawns[BLACK] == black)
+        return entry;
+
+    // Comparing actual bitboards makes both hits and collisions exact. The old
+    // entry remains a useful starting point even when its pawn hash differs.
+    DirtyPawnPairs            diff{{entry.pawns[WHITE], entry.pawns[BLACK]}, {white, black}};
+    PairFeatureSet::IndexList removed, added;
+    PairFeatureSet::append_changed_indices(perspective, ksq, diff, removed, added,
+                                           featureTransformer.threatAndPpWeights.data(),
+                                           Dimensions);
+    for (IndexType j = 0; j < Dimensions; increment_index(j))
+    {
+        auto acc = load_tile(j, entry.accumulation.data());
+        acc      = apply_threat_features<-1>(j, acc, removed, featureTransformer);
+        acc      = apply_threat_features<+1>(j, acc, added, featureTransformer);
+        store_tile(j, entry.accumulation.data(), acc);
+    }
+    for (IndexType j = 0; j < PSQTBuckets; increment_psqt_index(j))
+    {
+        auto psqt = load_psqt(j, entry.psqtAccumulation.data());
+        psqt = apply_psqt<-1>(j, psqt, removed, featureTransformer.threatAndPpPsqtWeights.data());
+        psqt = apply_psqt<+1>(j, psqt, added, featureTransformer.threatAndPpPsqtWeights.data());
+        store_psqt(j, entry.psqtAccumulation.data(), psqt);
+    }
+    entry.featureCount = u16(entry.featureCount + added.size() - removed.size());
+    entry.pawns[WHITE] = white;
+    entry.pawns[BLACK] = black;
+    return entry;
 }
 
 }

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -910,9 +910,9 @@ void update_accumulator_refresh_cache(Color                     perspective,
     entry.pieceBB = pos.pieces();
     entry.pieces  = pos.piece_array();
 
-    ThreatFeatureSet::IndexList active;
-    ThreatFeatureSet::append_active_indices(perspective, pos, active);
-    const auto& pawnEntry = cache.pawn_entry(perspective, pos, featureTransformer);
+    ThreatFeatureSet::IndexList activeThreats;
+    ThreatFeatureSet::append_active_indices(perspective, pos, activeThreats);
+    const auto& ppEntry = cache.pp_entry(perspective, pos, featureTransformer);
 
     accumulator.computed[perspective] = true;
 
@@ -928,10 +928,11 @@ void update_accumulator_refresh_cache(Color                     perspective,
 
         store_tile(j, &entry.accumulation[0], acc);
 
-        acc = apply_threat_features<+1>(j, acc, active, featureTransformer);
+        acc = apply_threat_features<+1>(j, acc, activeThreats, featureTransformer);
 
-        if (pawnEntry.featureCount)
-            acc = apply<+1>(j, acc, pawnEntry.accumulation.data());
+        // Avoid loading and adding a zero vector when no PP features are active.
+        if (ppEntry.featureCount)
+            acc = apply<+1>(j, acc, ppEntry.accumulation.data());
         store_tile(j, accumulator.accumulation[perspective].data(), acc);
     }
 
@@ -944,29 +945,32 @@ void update_accumulator_refresh_cache(Color                     perspective,
 
         store_psqt(j, entry.psqtAccumulation.data(), psqt);
 
-        psqt = apply_psqt<+1>(j, psqt, active, featureTransformer.threatAndPpPsqtWeights.data());
+        psqt =
+          apply_psqt<+1>(j, psqt, activeThreats, featureTransformer.threatAndPpPsqtWeights.data());
 
-        if (pawnEntry.featureCount)
-            psqt = apply<+1>(j, psqt, pawnEntry.psqtAccumulation.data());
+        if (ppEntry.featureCount)
+            psqt = apply<+1>(j, psqt, ppEntry.psqtAccumulation.data());
         store_psqt(j, accumulator.psqtAccumulation[perspective].data(), psqt);
     }
 }
 
 }
 
-const AccumulatorCaches::PawnEntry& AccumulatorCaches::pawn_entry(
+const AccumulatorCaches::PpEntry& AccumulatorCaches::pp_entry(
   Color perspective, const Position& pos, const FeatureTransformer& featureTransformer) {
-    const Square ksq = pos.square<KING>(perspective);
-    auto&        entry =
-      pawnEntries[pos.pawn_key() & (PawnCacheSize / 4 - 1)][perspective][(int(ksq) >> 2) & 1];
-    const Bitboard white = pos.pieces(WHITE, PAWN);
-    const Bitboard black = pos.pieces(BLACK, PAWN);
-    if (entry.pawns[WHITE] == white && entry.pawns[BLACK] == black)
+    const Square ksq        = pos.square<KING>(perspective);
+    const usize  bucket     = pos.pawn_key() & (PpCacheBuckets - 1);
+    const bool   kingMirror = file_of(ksq) >= FILE_E;
+    auto&        entry      = ppEntries[bucket][perspective][kingMirror];
+
+    const Bitboard whitePawns = pos.pieces(WHITE, PAWN);
+    const Bitboard blackPawns = pos.pieces(BLACK, PAWN);
+    if (entry.pawns[WHITE] == whitePawns && entry.pawns[BLACK] == blackPawns)
         return entry;
 
     // Comparing actual bitboards makes both hits and collisions exact. The old
     // entry remains a useful starting point even when its pawn hash differs.
-    DirtyPawnPairs            diff{{entry.pawns[WHITE], entry.pawns[BLACK]}, {white, black}};
+    DirtyPawnPairs diff{{entry.pawns[WHITE], entry.pawns[BLACK]}, {whitePawns, blackPawns}};
     PairFeatureSet::IndexList removed, added;
     PairFeatureSet::append_changed_indices(perspective, ksq, diff, removed, added,
                                            featureTransformer.threatAndPpWeights.data(),
@@ -986,8 +990,8 @@ const AccumulatorCaches::PawnEntry& AccumulatorCaches::pawn_entry(
         store_psqt(j, entry.psqtAccumulation.data(), psqt);
     }
     entry.featureCount = u16(entry.featureCount + added.size() - removed.size());
-    entry.pawns[WHITE] = white;
-    entry.pawns[BLACK] = black;
+    entry.pawns[WHITE] = whitePawns;
+    entry.pawns[BLACK] = blackPawns;
     return entry;
 }
 

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -76,35 +76,33 @@ struct AccumulatorCaches {
         }
     };
 
-    // Total number of cached perspective/mirror accumulations.
-    static constexpr usize PawnCacheSize = 64;
+    // Sixteen pawn-key buckets, each with one PP entry per perspective and
+    // king-file orientation, hold 64 entries in total.
+    static constexpr usize PpCacheBuckets = 16;
 
-    struct alignas(CacheLineSize) PawnEntry {
+    struct alignas(CacheLineSize) PpEntry {
         std::array<i16, L1>            accumulation;
         std::array<i32, PSQTBuckets>   psqtAccumulation;
         std::array<Bitboard, COLOR_NB> pawns;
         u16                            featureCount;
     };
 
-    const PawnEntry& pawn_entry(Color                     perspective,
-                                const Position&           pos,
-                                const FeatureTransformer& featureTransformer);
+    const PpEntry& pp_entry(Color, const Position&, const FeatureTransformer&);
 
     template<typename Network>
     void clear(const Network& network) {
         for (auto& entries1D : entries)
             for (auto& entry : entries1D)
                 entry.clear(network.featureTransformer.biases);
-        std::memset(pawnEntries.data(), 0, sizeof(pawnEntries));
+        std::memset(ppEntries.data(), 0, sizeof(ppEntries));
     }
 
     std::array<Entry, COLOR_NB>& operator[](Square sq) { return entries[sq]; }
 
     std::array<std::array<Entry, COLOR_NB>, SQUARE_NB> entries;
 
-    // Fixed perspective/mirror lanes make pawn bitboards sufficient hit tags.
-    static_assert(PawnCacheSize >= 4 && (PawnCacheSize & (PawnCacheSize - 1)) == 0);
-    std::array<std::array<std::array<PawnEntry, 2>, COLOR_NB>, PawnCacheSize / 4> pawnEntries;
+    static_assert(PpCacheBuckets > 0 && (PpCacheBuckets & (PpCacheBuckets - 1)) == 0);
+    std::array<std::array<std::array<PpEntry, 2>, COLOR_NB>, PpCacheBuckets> ppEntries;
 };
 
 

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -76,16 +76,35 @@ struct AccumulatorCaches {
         }
     };
 
+    // Total number of cached perspective/mirror accumulations.
+    static constexpr usize PawnCacheSize = 64;
+
+    struct alignas(CacheLineSize) PawnEntry {
+        std::array<i16, L1>            accumulation;
+        std::array<i32, PSQTBuckets>   psqtAccumulation;
+        std::array<Bitboard, COLOR_NB> pawns;
+        u16                            featureCount;
+    };
+
+    const PawnEntry& pawn_entry(Color                     perspective,
+                                const Position&           pos,
+                                const FeatureTransformer& featureTransformer);
+
     template<typename Network>
     void clear(const Network& network) {
         for (auto& entries1D : entries)
             for (auto& entry : entries1D)
                 entry.clear(network.featureTransformer.biases);
+        std::memset(pawnEntries.data(), 0, sizeof(pawnEntries));
     }
 
     std::array<Entry, COLOR_NB>& operator[](Square sq) { return entries[sq]; }
 
     std::array<std::array<Entry, COLOR_NB>, SQUARE_NB> entries;
+
+    // Fixed perspective/mirror lanes make pawn bitboards sufficient hit tags.
+    static_assert(PawnCacheSize >= 4 && (PawnCacheSize & (PawnCacheSize - 1)) == 0);
+    std::array<std::array<std::array<PawnEntry, 2>, COLOR_NB>, PawnCacheSize / 4> pawnEntries;
 };
 
 


### PR DESCRIPTION
Functions similarly to finny tables. When a full refresh of PP inputs is required, first look up from cache and apply incremental updates to the difference.

+0.432% +/- 0.544 speedup locally

Passed Fishtest STC:
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 189152 W: 48431 L: 47932 D: 92789
Ptnml(0-2): 255, 19896, 53807, 20331, 287
https://tests.stockfishchess.org/tests/view/6a9e3782a8284b37a0a04d9f

No functional change