### PR TITLE
Fail reproducibility checks on engine errors or missing node output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -195,6 +195,7 @@ Mohammed Li (tthsqe12)
 Mukhammedali Beriktassuly (Berektassuly)
 Muzhen J (XInTheDark)
 Mafanwei
+Naman Jain (jainaman-umich)
 Nathan Rugg (nmrugg)
 Nguyen Pham (nguyenpham)
 Nick Pelling (nickpelling)

--- a/tests/reprosearch.sh
+++ b/tests/reprosearch.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # verify reproducible search
 
+set -o pipefail
+
 error()
 {
   echo "reprosearch testing failed on line $1"
@@ -52,7 +54,7 @@ do
   echo "reprosearch testing with $nodes nodes"
 
   # each line should appear exactly an even number of times
-  expect repeat.exp $nodes 2>&1 | grep -o "nodes [0-9]*" | sort | uniq -c | awk '{if ($1%2!=0) exit(1)}'
+  expect repeat.exp $nodes 2>&1 | grep '^info ' | grep -o "nodes [0-9]*" | sort | uniq -c | awk '{if ($1%2!=0) exit(1)}'
 
 done
 


### PR DESCRIPTION
Enable pipefail so Expect failures and grep's no-match status reach the existing error trap instead of being hidden by a successful final awk.

Only extract node counts from info lines. Expect echoes go nodes commands, which otherwise let a run without node reports pass even with pipefail.

No functional change