### PR TITLE
Optimize both_attacks_bb()

### DIFF
--- a/src/attacks.h
+++ b/src/attacks.h
@@ -133,7 +133,7 @@ struct alignas(32) DualMagic {
         Bitboard rankAttacks  = rowOccupancy << shift;
 
         // [bishop, rook]
-        return {_mm_extract_epi64(rookBishop, 1), _mm_cvtsi128_si64(rookBishop) + rankAttacks};
+        return {_mm_extract_epi64(rookBishop, 1), _mm_cvtsi128_si64(_mm256_castsi256_si128(result)) + rankAttacks};
     }
 };
 


### PR DESCRIPTION
STC: https://tests.stockfishchess.org/tests/view/6a9e3aada8284b37a0a04dac
LLR: 2.93 (-2.94,2.94) <0.00,2.00>
Total: 166432 W: 42797 L: 42332 D: 81303
Ptnml(0-2): 262, 17204, 47775, 17757, 218 

Shorten the rook dependency chain.  _mm256_castsi256_si128() compiles away.

No functional change
bench: 2031952