### PR TITLE
Add iterator header to numa.h

### DIFF
--- a/src/numa.h
+++ b/src/numa.h
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <functional>
 #include <iostream>
+#include <iterator>
 #include <limits>
 #include <map>
 #include <memory>


### PR DESCRIPTION
Fix missing iterator include in numa.h that causes compilation to fail with clang version 23.1.1 and possibly other versions on Windows when using the command line "make -j8 profile-build ARCH=native COMP=clang". A sample of error messages follows, 

./numa.h:121:36:        error:     no member named 'inserter' in namespace 'std'
... 
./numa.h:121:36: ./numa.h:121:36: error: In file included from timeman.cpp:25:
... 
In file included from ./search.h:37:
no member ./numa.h:121:36: error: named 'inserter' in namespace 'std'error: no member named 'inserter' in namespace 
... 
no member named 'inserter' in namespace 'std'In file included from tt.cpp:32:

Adding #include <iterator> to numa.h solves the problem and the compilation completes as expected. 