### PR TITLE
Remove unused constexpr_lsb and lsb_index64

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -185,17 +185,6 @@ inline int popcount(Bitboard b) {
 #endif
 }
 
-inline constexpr int lsb_index64[64] = {
-  0,  47, 1,  56, 48, 27, 2,  60, 57, 49, 41, 37, 28, 16, 3,  61, 54, 58, 35, 52, 50, 42,
-  21, 44, 38, 32, 29, 23, 17, 11, 4,  62, 46, 55, 26, 59, 40, 36, 15, 53, 34, 51, 20, 43,
-  31, 22, 10, 45, 25, 39, 14, 33, 19, 30, 9,  24, 13, 18, 8,  12, 7,  6,  5,  63};
-
-constexpr int constexpr_lsb(u64 bb) {
-    assert(bb != 0);
-    constexpr u64 debruijn64 = 0x03F79D71B4CB0A89ULL;
-    return lsb_index64[((bb ^ (bb - 1)) * debruijn64) >> 58];
-}
-
 // Returns the least significant bit in a non-zero bitboard.
 inline Square lsb(Bitboard b) {
     assert(b);


### PR DESCRIPTION
The de Bruijn constexpr LSB helper and its 64-entry lookup table have zero references repo-wide. Runtime lsb() uses compiler intrinsics (__builtin_ctzll / _BitScanForward64), and compile-time table builds no longer need it. Leftover from earlier refactors, same class as PawnPushOrAttacks removal. Verified with repo-wide grep and syntax check on bitboard.cpp / position.cpp / attacks.cpp.

No functional change